### PR TITLE
Fish infusion now prioritizes special organs over the default.

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -100,7 +100,7 @@
 
 /obj/machinery/dna_infuser/proc/end_infuse(fail_explanation, fail_title)
 	var/mob/living/carbon/human/human_occupant = occupant
-	if(human_occupant.infuse_organ(infusing_into, infused_from))
+	if(human_occupant.infuse_organ(infusing_into, infusing_from))
 		check_tier_progression(human_occupant)
 		to_chat(occupant, span_danger("You feel yourself becoming more... [infusing_into.infusion_desc]?"))
 	infusing = FALSE

--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -100,7 +100,7 @@
 
 /obj/machinery/dna_infuser/proc/end_infuse(fail_explanation, fail_title)
 	var/mob/living/carbon/human/human_occupant = occupant
-	if(human_occupant.infuse_organ(infusing_into))
+	if(human_occupant.infuse_organ(infusing_into, infused_from))
 		check_tier_progression(human_occupant)
 		to_chat(occupant, span_danger("You feel yourself becoming more... [infusing_into.infusion_desc]?"))
 	infusing = FALSE

--- a/code/game/machinery/dna_infuser/dna_infusion.dm
+++ b/code/game/machinery/dna_infuser/dna_infusion.dm
@@ -57,10 +57,10 @@
 ///   - or the new organ must be external.
 /// 2. Target's pre-existing organ must be organic / not robotic.
 /// 3. Target must not have the same/identical organ.
-/mob/living/carbon/human/proc/pick_infusion_organ(datum/infuser_entry/entry)
+/mob/living/carbon/human/proc/pick_infusion_organ(datum/infuser_entry/entry, atom/movable/infused_from)
 	if(!entry)
 		return FALSE
-	var/list/obj/item/organ/potential_new_organs = entry.output_organs.Copy()
+	var/list/obj/item/organ/potential_new_organs = entry.get_output_organs(src, infused_from)
 	// Remove organ typepaths from the list if they're incompatible with target.
 	for(var/obj/item/organ/new_organ as anything in entry.output_organs)
 		var/obj/item/organ/old_organ = get_organ_slot(initial(new_organ.slot))

--- a/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_one_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_one_entries.dm
@@ -136,6 +136,32 @@
 	tier = DNA_MUTANT_TIER_ONE
 	status_effect_type = /datum/status_effect/organ_set_bonus/fish
 
+/datum/infuser_entry/fish/get_output_organs(mob/living/carbon/human/target, obj/item/fish/infused_from)
+	if(!istype(infused_from))
+		return ..()
+
+	///Get a list of possible alternatives to the standard fish infusion. We prioritize special infusions over it.
+	var/list/possible_alt_infusions = list()
+	for(var/type in infused_from.fish_traits)
+		var/datum/fish_trait/trait = GLOB.fish_traits[type]
+		if(!trait.infusion_entry)
+			continue
+		var/datum/infuser_entry/entry = GLOB.infuser_entries[trait.infusion_entry]
+		for(var/organ in entry.output_organs)
+			if(!target.get_organ_by_type(organ))
+				possible_alt_infusions |= entry
+				break
+
+	if(length(possible_alt_infusions))
+		var/datum/infuser_entry/chosen = pick(possible_alt_infusions)
+		return chosen.get_output_organs(target, infused_from)
+
+	var/list/organs = ..()
+	if(infused_from.required_fluid_type == AQUARIUM_FLUID_AIR || HAS_TRAIT(infused_from, TRAIT_FISH_AMPHIBIOUS))
+		organs -= /obj/item/organ/internal/lungs/fish
+	return organs
+
+
 /datum/infuser_entry/squid
 	name = "Ink Production"
 	infuse_mob_name = "ink-producing sealife"

--- a/code/game/machinery/dna_infuser/infuser_entry.dm
+++ b/code/game/machinery/dna_infuser/infuser_entry.dm
@@ -48,3 +48,7 @@ GLOBAL_LIST_INIT(infuser_entries, prepare_infuser_entries())
 	var/list/output_organs
 	///message the target gets while being infused
 	var/infusion_desc = "mutant-like"
+
+///Returns a list of organs that can be infused into the target human. Useful for custom behavior for certain entries
+/datum/infuser_entry/proc/get_output_organs(mob/living/carbon/human/target, atom/movable/infused_from)
+	return output_organs.Copy()

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1324,24 +1324,6 @@
 	. = ..()
 	aquarium_vc_color = color || initial(aquarium_vc_color)
 
-/obj/item/fish/get_infusion_entry()
-	var/amphibious = required_fluid_type == AQUARIUM_FLUID_AIR || HAS_TRAIT(src, TRAIT_FISH_AMPHIBIOUS)
-	var/list/possible_infusions = list()
-	for(var/type in fish_traits)
-		var/datum/fish_trait/trait = GLOB.fish_traits[type]
-		if(!trait.infusion_entry)
-			continue
-		possible_infusions |= trait.infusion_entry
-	if(!length(possible_infusions) && !amphibious)
-		return GLOB.infuser_entries[/datum/infuser_entry/fish]
-	var/datum/infuser_entry/fish/entry = new
-	if(amphibious)
-		entry.output_organs -= /obj/item/organ/internal/lungs/fish
-	for(var/key in possible_infusions)
-		var/datum/infuser_entry/infusion = GLOB.infuser_entries[key]
-		entry.output_organs |= infusion.output_organs
-	return entry
-
 /// Returns random fish, using random_case_rarity probabilities.
 /proc/random_fish_type(required_fluid)
 	var/static/probability_table


### PR DESCRIPTION
## About The Pull Request
@carlarctg pointed out a design flaw with fish infusion that can lead to fish with traits that generate special output organs being wasted if the stomach, tail and lung slots haven't been infused yet. To make an example, this means you need to infuse squid last, after infusing three other generic fish, and not before, which is more of an annoying detail than an interesting one in this context...

That said, that should be getting fixed in this PR.

## Why It's Good For The Game
It's a small botherance.

## Changelog

:cl:
fix: Fixed a small botherance with special fish infusions. You no longer need to infuse squids and pufferfish last to reap their special organs.
/:cl:
