### PR TITLE
Fixing a typo in the typepath for unconsumable doughballs

### DIFF
--- a/code/game/objects/items/food/bait.dm
+++ b/code/game/objects/items/food/bait.dm
@@ -83,7 +83,7 @@
  * Otherwise it'd be hard/impossible to cath some fish with it,
  * making that rod a shoddy choice in the long run.
  */
-/obj/item/food/bait/doughball/syntethic/unconsumable
+/obj/item/food/bait/doughball/synthetic/unconsumable
 
 /obj/item/food/bait/doughball/synthetic/unconsumable/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I've noticed this typographical error during a local test while spawning synthetic doughballs.

## Why It's Good For The Game
Smal gremmar misteak.

## Changelog
N/A