### PR TITLE
Grammar fixes for produce-based armaments

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -514,7 +514,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	return OXYLOSS
 
 /obj/item/bambostaff
-	name = "Bamboo Staff"
+	name = "bamboo staff"
 	desc = "A long bamboo-made staff with steel-capped ends. It is rumoured that initiates of Spider Clan train with such before getting to learn how to use a katana."
 	force = 10
 	block_chance = 45
@@ -534,6 +534,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/bambostaff/Initialize(mapload)
 	. = ..()
+	// there are too many puns to choose from. ('Bo' is the 'real' name for this kind of weapon.)
+	name = pick("bamboo staff", "bambo staff", "bam-Bo staff", "bam boo staff", "bam-boo staff", "bam Bo", "bambo", "bam-Bo", "bamboo-Bo")
 	AddComponent(/datum/component/two_handed, \
 		force_unwielded = 10, \
 		force_wielded = 14, \

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -677,7 +677,7 @@
 	wound = 5
 
 /obj/item/clothing/head/helmet/durability/holymelon
-	name = "Holymelon Helmet"
+	name = "holymelon helmet"
 	desc = "A helmet from a hollowed out holymelon. Might take a few hits, but don't expect it whitstand much."
 	icon_state = "holymelon"
 	inhand_icon_state = "holymelon"
@@ -713,7 +713,7 @@
 	take_damage(8, BRUTE, 0, 0)
 
 /obj/item/clothing/head/helmet/durability/barrelmelon
-	name = "Barrelmelon Helmet"
+	name = "barrelmelon helmet"
 	desc = "A helmet from hollowed out barrelmelon. As sturdy as if made from actual wood, though its rigid structure makes it break up quicker."
 	icon_state = "barrelmelon"
 	inhand_icon_state = "barrelmelon"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -645,7 +645,7 @@
 	take_damage(1, BRUTE, 0, 0)
 
 /obj/item/clothing/head/helmet/durability/watermelon
-	name = "Watermelon Helmet"
+	name = "watermelon helmet"
 	desc = "A helmet cut out from a watermelon. Might take a few hits, but don't expect it whitstand much."
 	icon_state = "watermelon"
 	inhand_icon_state = "watermelon"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -678,7 +678,7 @@
 
 /obj/item/clothing/head/helmet/durability/holymelon
 	name = "holymelon helmet"
-	desc = "A helmet from a hollowed out holymelon. Might take a few hits, but don't expect it whitstand much."
+	desc = "A helmet from a hollowed out holymelon. Might take a few hits, but don't expect it to withstand much."
 	icon_state = "holymelon"
 	inhand_icon_state = "holymelon"
 	flags_inv = HIDEEARS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -794,7 +794,7 @@
 
 /obj/item/clothing/suit/armor/durability/holymelon
 	name = "holymelon armor"
-	desc = "An armour, made from holymelons. Inspires you to go on some sort of a crusade... Perhaps spreading spinach to children?"
+	desc = "An armor, made from holymelons. Inspires you to go on some sort of a crusade... Perhaps spreading spinach to children?"
 	icon_state = "holymelon"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -833,7 +833,7 @@
 
 /obj/item/clothing/suit/armor/durability/barrelmelon
 	name = "barrelmelon armor"
-	desc = "An armour, made from barrelmelons. Reeks of ale, inspiring to courageous deeds. Or, perhaps, a bar brawl."
+	desc = "An armor, made from barrelmelons. Reeks of ale, inspiring to courageous deeds. Or, perhaps, a bar brawl."
 	icon_state = "barrelmelon"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -759,8 +759,8 @@
 	take_damage(1, BRUTE, 0, 0)
 
 /obj/item/clothing/suit/armor/durability/watermelon
-	name = "watermelon"
-	desc = "An armour, made from watermelons. Propably won't take too many hits, but at least it looks serious... As serious as worn watermelon can be."
+	name = "watermelon armor"
+	desc = "An armor, made from watermelons. Propably won't take too many hits, but at least it looks serious... As serious as worn watermelon can be."
 	icon_state = "watermelon"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -793,7 +793,7 @@
 	wound = 5
 
 /obj/item/clothing/suit/armor/durability/holymelon
-	name = "holymelon"
+	name = "holymelon armor"
 	desc = "An armour, made from holymelons. Inspires you to go on some sort of a crusade... Perhaps spreading spinach to children?"
 	icon_state = "holymelon"
 	inhand_icon_state = null
@@ -832,7 +832,7 @@
 
 
 /obj/item/clothing/suit/armor/durability/barrelmelon
-	name = "barrelmelon"
+	name = "barrelmelon armor"
 	desc = "An armour, made from barrelmelons. Reeks of ale, inspiring to courageous deeds. Or, perhaps, a bar brawl."
 	icon_state = "barrelmelon"
 	inhand_icon_state = null


### PR DESCRIPTION

## About The Pull Request

Bamboo Staff is lowcaps-ed, and also picks between one of various mediocre puns to name itself on initialize

added 'armor' to the melon armors and removed a dirty british spelling of the word in a description

lowcapsed watermelon helmets

## Why It's Good For The Game

normal items should not have caps names, it is both grammatically incorrect, annoying, and inconsistent.

bo staves having may pun based names is funny*

## Changelog

:cl:
spellcheck: Grammar fixes for produce-based armaments
spellcheck: bo staves are very punny
/:cl:

