### PR TITLE
Evidence bag is a storage now; Detective's scanner now can scan items on their own person

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -30,13 +30,6 @@
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 
-/obj/item/evidencebag/Exited(atom/movable/gone, direction)
-	. = ..()
-	cut_overlays()
-	update_weight_class(initial(w_class))
-	icon_state = initial(icon_state)
-	desc = initial(desc)
-
 /obj/item/evidencebag/update_desc(updates)
 	. = ..()
 	if(!atom_storage.get_total_weight())

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -21,12 +21,12 @@
 /obj/item/evidencebag/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(interacting_with == loc || !isitem(interacting_with) || HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
 		return NONE
-	if(evidencebagEquip(interacting_with, user))
+	if(atom_storage.attempt_insert(interacting_with, user))
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 
 /obj/item/evidencebag/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(evidencebagEquip(tool, user))
+	if(atom_storage.attempt_insert(tool, user))
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 
@@ -36,23 +36,6 @@
 	update_weight_class(initial(w_class))
 	icon_state = initial(icon_state)
 	desc = initial(desc)
-
-/obj/item/evidencebag/proc/evidencebagEquip(obj/item/I, mob/user)
-	if(!istype(I) || I.anchored)
-		return FALSE
-
-	if(I.atom_storage)
-		to_chat(user, span_warning("No matter what way you try, you can't get [I] to fit inside [src]."))
-		return TRUE //begone infinite storage ghosts, begone from me
-
-	if(loc in I.get_all_contents()) // fixes tg #39452, evidence bags could store their own location, causing I to be stored in the bag while being present inworld still, and able to be teleported when removed.
-		to_chat(user, span_warning("You find putting [I] in [src] while it's still inside it quite difficult!"))
-		return TRUE
-
-	if(!atom_storage.attempt_insert(I))
-		return TRUE
-
-	return TRUE
 
 /obj/item/evidencebag/update_desc(updates)
 	. = ..()

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -9,6 +9,15 @@
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = NOBLUDGEON
 
+/obj/item/evidencebag/Initialize(mapload)
+	. = ..()
+	create_storage(
+		max_slots = 1,
+		max_specific_storage = WEIGHT_CLASS_NORMAL,
+	)
+	RegisterSignal(atom_storage, COMSIG_STORAGE_STORED_ITEM, PROC_REF(on_insert))
+	RegisterSignal(atom_storage, COMSIG_STORAGE_REMOVED_ITEM, PROC_REF(on_remove))
+
 /obj/item/evidencebag/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(interacting_with == loc || !isitem(interacting_with) || HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
 		return NONE
@@ -32,72 +41,64 @@
 	if(!istype(I) || I.anchored)
 		return FALSE
 
-	if(loc.atom_storage && I.atom_storage)
+	if(I.atom_storage)
 		to_chat(user, span_warning("No matter what way you try, you can't get [I] to fit inside [src]."))
 		return TRUE //begone infinite storage ghosts, begone from me
-
-	if(HAS_TRAIT(I, TRAIT_NO_STORAGE_INSERT))
-		to_chat(user, span_warning("No matter what way you try, you can't get [I] to fit inside [src]."))
-		return TRUE
-
-	if(istype(I, /obj/item/evidencebag))
-		to_chat(user, span_warning("You find putting an evidence bag in another evidence bag to be slightly absurd."))
-		return TRUE //now this is podracing
 
 	if(loc in I.get_all_contents()) // fixes tg #39452, evidence bags could store their own location, causing I to be stored in the bag while being present inworld still, and able to be teleported when removed.
 		to_chat(user, span_warning("You find putting [I] in [src] while it's still inside it quite difficult!"))
 		return TRUE
 
-	if(I.w_class > WEIGHT_CLASS_NORMAL)
-		to_chat(user, span_warning("[I] won't fit in [src]!"))
+	if(!atom_storage.attempt_insert(I))
 		return TRUE
 
-	if(contents.len)
-		to_chat(user, span_warning("[src] already has something inside it!"))
-		return TRUE
+	return TRUE
 
-	if(!isturf(I.loc)) //If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
-		if(I.loc.atom_storage) //in a container.
-			I.loc.atom_storage.remove_single(user, I, src)
-		if(!user.is_holding(I) || HAS_TRAIT(I, TRAIT_NODROP))
-			return TRUE
+/obj/item/evidencebag/update_desc(updates)
+	. = ..()
+	if(!atom_storage.get_total_weight())
+		desc = src::desc
+		return
+	var/obj/item/inserted = locate(/obj/item) in atom_storage.real_location
+	desc = "An evidence bag containing [inserted]. [inserted.desc]"
 
-	if(QDELETED(I))
-		return TRUE
-
-	user.visible_message(span_notice("[user] puts [I] into [src]."), span_notice("You put [I] inside [src]."),\
-	span_hear("You hear a rustle as someone puts something into a plastic bag."))
-
+/obj/item/evidencebag/update_icon_state()
+	. = ..()
+	if(!atom_storage.get_total_weight())
+		icon_state = "evidenceobj"
+		return
 	icon_state = "evidence"
 
-	var/mutable_appearance/in_evidence = new(I)
+/obj/item/evidencebag/update_overlays()
+	. = ..()
+	if(!atom_storage.get_total_weight())
+		return
+	var/obj/item/inserted = locate(/obj/item) in atom_storage.real_location
+	var/mutable_appearance/in_evidence = new(inserted)
 	in_evidence.plane = FLOAT_PLANE
 	in_evidence.layer = FLOAT_LAYER
 	in_evidence.pixel_x = 0
 	in_evidence.pixel_y = 0
-	add_overlay(in_evidence)
-	add_overlay("evidence") //should look nicer for transparent stuff. not really that important, but hey.
+	. += in_evidence
+	. += "evidence"
 
-	desc = "An evidence bag containing [I]. [I.desc]"
-	I.forceMove(src)
-	update_weight_class(I.w_class)
-	return TRUE
+/obj/item/evidencebag/proc/on_insert(datum/storage/storage, obj/item/to_insert, mob/user, force)
+	SIGNAL_HANDLER
+	update_weight_class(to_insert.w_class)
+
+/obj/item/evidencebag/proc/on_remove(datum/storage/storage, obj/item/to_remove, atom/remove_to_loc, silent)
+	SIGNAL_HANDLER
+	if(!atom_storage.get_total_weight())
+		return
+	update_weight_class(WEIGHT_CLASS_TINY)
 
 /obj/item/evidencebag/attack_self(mob/user)
-	if(contents.len)
-		var/obj/item/I = contents[1]
-		user.visible_message(span_notice("[user] takes [I] out of [src]."), span_notice("You take [I] out of [src]."),\
-		span_hear("You hear someone rustle around in a plastic bag, and remove something."))
-		cut_overlays() //remove the overlays
-		user.put_in_hands(I)
-		update_weight_class(WEIGHT_CLASS_TINY)
-		icon_state = "evidenceobj"
-		desc = "An empty evidence bag."
-
-	else
+	if(!atom_storage.get_total_weight())
 		to_chat(user, span_notice("[src] is empty."))
-		icon_state = "evidenceobj"
-	return
+		return
+	user.visible_message(span_notice("[user] empties [src]."), span_notice("You empty [src]."),\
+	span_hear("You hear someone rustle around in a plastic bag, and remove something."))
+	atom_storage.remove_all()
 
 /obj/item/storage/box/evidence
 	name = "evidence bag box"

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -103,9 +103,13 @@
  * This should always return TRUE barring a runtime
  */
 /obj/item/detective_scanner/proc/scan(mob/user, atom/scanned_atom)
-	// Can remotely scan objects and mobs.
-	if((get_dist(scanned_atom, user) > range) || (!(scanned_atom in view(range, user)) && view_check) || (loc != user))
+	if(loc != user)
 		return TRUE
+	// Can scan items we hold and store
+	if(!(scanned_atom in user.get_all_contents()))
+		// Can remotely scan objects and mobs.
+		if((get_dist(scanned_atom, user) > range) || (!(scanned_atom in view(range, user)) && view_check))
+			return TRUE
 	playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
 	scanner_busy = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Makes Evidence Bag a container - it was already container-ish but never updated with storage code. Now you can open the container and do something with the item inside, like scanning it!

Detective's scanner now can scan items that you hold or store - be it in your backpack or an evidence bag in your another hand!

I was considering just making it drop the item on attack_self() and do some code to make scanning the evidence bag also scan the item inside, but I think making it a container is a better way.

## Why It's Good For The Game
Evidence Bag had you to have no free hands to drop an item to the ground, if you didn't want to add your fibers/prints. That was cumbersome.

Scanning items inside of evidence bag is cool.

## Changelog
:cl:
add: Evidence Bag is now considered a storage container with 1 slot. Allows to use all features storage has, such as drag-and-drop the bag onto a table.
add: Using Evidence Bag in hand now drops the item on the ground instead of putting it in your hands. Don't mess with the evidence!
qol: Detective's scanner can now scan items on your person. You can now pick up an evidence bag, open it like any other container, and scan the item inside without removing it
/:cl:
