### PR TITLE
Few spellchecks in fish organs and fish dishes I found

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -338,7 +338,7 @@
 ///Fish infuser organ, allows mobs to safely eat raw fish.
 /obj/item/organ/internal/stomach/fish
 	name = "mutated fish-stomach"
-	desc = "Fish DNA infused into a stomach now parmated by the faint smell of salt and slightly putrified fish."
+	desc = "Fish DNA infused into a stomach now permeated by the faint smell of salt and slightly putrefied fish."
 	icon = 'icons/obj/medical/organs/infuser_organs.dmi'
 	icon_state = "stomach"
 	greyscale_config = /datum/greyscale_config/mutant_organ

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -52,7 +52,7 @@
 
 /obj/item/food/fishmeat/salmon
 	name = "salmon fillet"
-	desc = "a chunky, fatty fillet of salmon meat."
+	desc = "A chunky, fatty fillet of salmon meat."
 	icon_state = "salmon"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment/protein = 4,
@@ -185,7 +185,7 @@
 		/datum/reagent/consumable/nutriment = 6,
 		/datum/reagent/consumable/nutriment/vitamin = 3,
 	)
-	tastes = list("fish" = 1, "pan seared vegtables" = 1)
+	tastes = list("fish" = 1, "pan-seared vegetables" = 1)
 	foodtypes = SEAFOOD | VEGETABLES | FRIED
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_2
@@ -725,7 +725,7 @@
 
 /obj/item/food/sashimi
 	name = "carp sashimi"
-	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself. You sure hope whoever made this is skilled."
+	desc = "Celebrate surviving an attack from hostile alien lifeforms by hospitalising yourself. You sure hope whoever made this is skilled."
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "sashimi"
 	food_reagents = list(


### PR DESCRIPTION

## About The Pull Request

Does what it says on the fin.
## Why It's Good For The Game

mmm speling
## Changelog
:cl:
spellcheck: Fish fry tastes like "pan-seared vegetables" instead of "pan seared vegtables".
spellcheck: Fish liver is now "permeated" by the smell of "putrefied" fish, instead of "parmated" and "putrified".
spellcheck: Salmon fillet description is now capitalized.
spellcheck: Carp sashimi mentions "surviving an attack" instead of "surviving attack".
/:cl:
