### PR TITLE
Fish Tail Filleting (and assorted fish organ tastes) (and allowing organs to define their own foodtypes and tastes)

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -241,7 +241,7 @@
 
 	// Seafood instead of meat, because it's a fish organ. Additionally gross for being gills
 	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
-	tastes = list("gross fish" = 1)
+	food_tastes = list("gross fish" = 1)
 	safe_oxygen_min = 0 //We don't breathe this
 	///The required partial pressure of water_vapor for not suffocating.
 	var/safe_water_level = parent_type::safe_oxygen_min

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -368,7 +368,7 @@
 	disgust_metabolism = 2.5
 
 	// Seafood instead of meat, because it's a fish organ
-	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
+	foodtype_flags = RAW | SEAFOOD | GORE
 	// Salty and putrid like it smells, yum
 	food_tastes = list(
 		"salt" = 1,

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -165,9 +165,26 @@
 	wag_flags = WAG_ABLE
 	organ_traits = list(TRAIT_FLOPPING)
 
+	// Fishlike reagents, you could serve it raw like fish
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment/protein = 10,
+		/datum/reagent/consumable/nutriment/vitamin = 5,
+		/datum/reagent/consumable/nutriment/fat = 10,
+	)
+	// Seafood instead of meat, because it's a fish organ
+	foodtype_flags = RAW | SEAFOOD | GORE
+	// Also just tastes like fish
+	food_tastes = list("fatty fish" = 1)
+	/// The fillet type this fish tail is processable into
+	var/fillet_type = /obj/item/food/fishmeat/fish_tail
+	/// The amount of fillets this gets processed into
+	var/fillet_amount = 5
+
 /obj/item/organ/external/tail/fish/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/fish)
+	var/time_to_fillet = fillet_amount * 0.5 SECONDS
+	AddElement(/datum/element/processable, TOOL_KNIFE, fillet_type, fillet_amount, time_to_fillet, screentip_verb = "Cut")
 
 /obj/item/organ/external/tail/fish/on_mob_insert(mob/living/carbon/owner)
 	. = ..()

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -413,6 +413,11 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/iron = 5, /datum/reagent/toxin/tetrodotoxin = 5)
 	grind_results = list(/datum/reagent/consumable/nutriment/peptides = 5, /datum/reagent/toxin/tetrodotoxin = 5)
 
+	// Seafood instead of meat, because it's a fish organ
+	foodtype_flags = RAW | SEAFOOD | GORE
+	// Just fish, the toxin isn't obvious
+	food_tastes = list("fish" = 1)
+
 /obj/item/organ/internal/liver/fish/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/fish)

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -387,6 +387,14 @@
 	icon_state = "inky_tongue"
 	actions_types = list(/datum/action/cooldown/ink_spit)
 
+	// Seafood instead of meat, because it's a fish organ
+	foodtype_flags = RAW | SEAFOOD | GORE
+	// Squid with a hint of the sea (from the ink)
+	food_tastes = list(
+		"squid" = 1,
+		"the sea" = 0.2,
+	)
+
 /obj/item/organ/internal/tongue/inky/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noticable_organ, "Slick black ink seldom rivulets from %PRONOUN_their mouth.", BODY_ZONE_PRECISE_MOUTH)

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -241,6 +241,7 @@
 
 	// Seafood instead of meat, because it's a fish organ. Additionally gross for being gills
 	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
+	tastes = list("gross fish" = 1)
 	safe_oxygen_min = 0 //We don't breathe this
 	///The required partial pressure of water_vapor for not suffocating.
 	var/safe_water_level = parent_type::safe_oxygen_min

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -239,6 +239,8 @@
 	icon = 'icons/obj/medical/organs/infuser_organs.dmi'
 	icon_state = "gills"
 
+	// Seafood instead of meat, because it's a fish organ. Additionally gross for being gills
+	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
 	safe_oxygen_min = 0 //We don't breathe this
 	///The required partial pressure of water_vapor for not suffocating.
 	var/safe_water_level = parent_type::safe_oxygen_min
@@ -363,6 +365,14 @@
 
 	organ_traits = list(TRAIT_STRONG_STOMACH, TRAIT_FISH_EATER)
 	disgust_metabolism = 2.5
+
+	// Seafood instead of meat, because it's a fish organ
+	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
+	// Salty and putrid like it smells, yum
+	food_tastes = list(
+		"salt" = 1,
+		"putrid fish" = 1,
+	)
 
 /obj/item/organ/internal/stomach/fish/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -153,6 +153,7 @@
 		/datum/reagent/consumable/nutriment/fat = 2,
 	)
 	bite_consumption = 5
+	tastes = list("fatty fish" = 1)
 	crafting_complexity = FOOD_COMPLEXITY_1
 
 /obj/item/food/fishmeat/fish_tail/Initialize(mapload)

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -144,6 +144,21 @@
 /obj/item/food/fishmeat/octopus/make_grillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/grilled_octopus, rand(15 SECONDS, 25 SECONDS), TRUE, TRUE)
 
+/obj/item/food/fishmeat/fish_tail
+	name = "fish tail fillet"
+	desc = "A precious fatty filet cut straight from the tail of a very large fish. Its rarity has it seen as a delicacy in certain spaces."
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment/protein = 2,
+		/datum/reagent/consumable/nutriment/vitamin = 1,
+		/datum/reagent/consumable/nutriment/fat = 2,
+	)
+	bite_consumption = 5
+	crafting_complexity = FOOD_COMPLEXITY_1
+
+/obj/item/food/fishmeat/fish_tail/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/quality_food_ingredient, FOOD_COMPLEXITY_1)
+
 /obj/item/food/fishfingers
 	name = "fish fingers"
 	desc = "A finger of fish."

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -146,7 +146,7 @@
 
 /obj/item/food/fishmeat/fish_tail
 	name = "fish tail fillet"
-	desc = "A precious fatty filet cut straight from the tail of a very large fish. Its rarity has it seen as a delicacy in certain spaces."
+	desc = "A precious fatty filet cut straight from the tail of a very large ...fish? Its rarity has it seen as a delicacy in certain spaces."
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment/protein = 2,
 		/datum/reagent/consumable/nutriment/vitamin = 1,

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -46,6 +46,10 @@
 
 	/// Food reagents if the organ is edible
 	var/list/food_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	/// Foodtypes if the organ is edible
+	var/foodtype_flags = RAW | MEAT | GORE
+	/// Overrides tastes if the organ is edible
+	var/food_tastes
 	/// The size of the reagent container if the organ is edible
 	var/reagent_vol = 10
 
@@ -74,8 +78,9 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(organ_flags & ORGAN_EDIBLE)
 		AddComponent(/datum/component/edible,\
 			initial_reagents = food_reagents,\
-			foodtypes = RAW | MEAT | GORE,\
+			foodtypes = foodtype_flags,\
 			volume = reagent_vol,\
+			tastes = food_tastes,\
 			after_eat = CALLBACK(src, PROC_REF(OnEatFrom)))
 
 	if(bodypart_overlay)


### PR DESCRIPTION

## About The Pull Request

I looked at the code for too long and now I want it to let me fillet the things.

Anyhow, in this pr we simply allow organs to define their own food types and tastes, and use this to make the fish infusion organs count as seafood and have their own tastes.
Additionally, we give fish tails more food reagents, and allow them to be filletable into their own quality fish fillets. These are quality ingredients due to the... rarity of the... fish... they came from.

While it isn't a _hard_ requirement, this requires #87329 to operate at its full potential. As it is, some of the tastes get blocked out by the jank that fixes.
## Why It's Good For The Game

It's funny.
It's basically like, just a really large fish right?
Fish organs being seafood makes more sense.
Special tastes for organs is fun.
I just wanna fillet the fish tail and serve fish tail sashimi.
## Changelog
:cl:
add: Organs can now define their own tastes or food types.
add: Fish tails can now be filleted into quality ingredient fish tail fish fillets, and have a fitting amount of food reagents on the whole.
balance: Fish organs are now counted as seafood, and have specific tastes set.
/:cl:
