### PR TITLE
Using SiliConnect to send a message to a cyborg now includes the sender's job

### DIFF
--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -161,7 +161,9 @@
 		if(computer.obj_flags & EMAGGED)
 			return "STDERR:UNDF"
 		return FALSE
-	return ID.registered_name
+	. = "[ID.registered_name]"
+	if(ID.assignment)
+		. = "[.], [ID.assignment]"
 
 /datum/computer_file/program/borg_monitor/syndicate
 	filename = "roboverlord"


### PR DESCRIPTION

## About The Pull Request
Does as title says. Doesn't take effect if the ID has no job listed.
## Why It's Good For The Game
Gives a bit more context about who is sending a message.
## Changelog
:cl:
add: Borgs now get the job title of someone sending them a message through SiliConnect.
/:cl:
