### PR TITLE
Silicons can now use dropped PDAs (but still cannot access Messenger)

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -79,10 +79,6 @@
 	if(inserted_pai)
 		. += mutable_appearance(initial(icon), "pai_inserted")
 
-/obj/item/modular_computer/pda/attack_ai(mob/user)
-	to_chat(user, span_notice("It doesn't feel right to snoop around like that..."))
-	return // we don't want ais or cyborgs using a private role tablet
-
 /obj/item/modular_computer/pda/interact(mob/user)
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_PDA_MESSAGE_MENU_RIGGED))

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -337,7 +337,7 @@
 
 	static_data["can_spam"] = spam_mode
 	static_data["is_silicon"] = issilicon(user)
-	static_data["remote_silicon"] = [isAI(user) || iscyborg(user)] && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one. Avoiding pAIs in this check.
+	static_data["remote_silicon"] = (isAI(user) || iscyborg(user)) && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one. Avoiding pAIs in this check.
 	static_data["alert_able"] = alert_able
 
 	return static_data

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -337,6 +337,7 @@
 
 	static_data["can_spam"] = spam_mode
 	static_data["is_silicon"] = issilicon(user)
+	static_data["remote_silicon"] = static_data["is_silicon"] && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one
 	static_data["alert_able"] = alert_able
 
 	return static_data

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -337,7 +337,7 @@
 
 	static_data["can_spam"] = spam_mode
 	static_data["is_silicon"] = issilicon(user)
-	static_data["remote_silicon"] = static_data["is_silicon"] && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one
+	static_data["remote_silicon"] = [(isAI(user) || iscyborg(user)] && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one. Avoiding pAIs in this check.
 	static_data["alert_able"] = alert_able
 
 	return static_data

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -337,7 +337,7 @@
 
 	static_data["can_spam"] = spam_mode
 	static_data["is_silicon"] = issilicon(user)
-	static_data["remote_silicon"] = [(isAI(user) || iscyborg(user)] && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one. Avoiding pAIs in this check.
+	static_data["remote_silicon"] = [isAI(user) || iscyborg(user)] && !istype(computer, /obj/item/modular_computer/pda/silicon) //Silicon is accessing a PDA on the ground, not their internal one. Avoiding pAIs in this check.
 	static_data["alert_able"] = alert_able
 
 	return static_data

--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -54,7 +54,7 @@ export const NtosMessenger = (props) => {
 
   let content: JSX.Element;
   if (remote_silicon) {
-      content = <AccessDeniedScreen />;
+    content = <AccessDeniedScreen />;
   } else if (open_chat !== null) {
     const openChat = saved_chats[open_chat];
     const temporaryRecipient = messengers[open_chat];
@@ -89,7 +89,7 @@ export const NtosMessenger = (props) => {
 
 const AccessDeniedScreen = (props: any) => {
   const { act, data } = useBackend<NtosMessengerData>();
-  
+
   return (
     <Stack fill vertical>
       <Stack.Item>
@@ -103,27 +103,21 @@ const AccessDeniedScreen = (props: any) => {
         </Section>
       </Stack.Item>
       <NoticeBox
-        color='white'
+        color="white"
         position="relative"
         top="30%"
         fontSize="30px"
         textAlign="center"
-        >
+      >
         ERROR: CONNECTION REFUSED
       </NoticeBox>
-        <Stack vertical position="relative" top="35%" textAlign="left">
-          <Section>
-          <Box>
-            Message from host:
-          </Box>
-          <Box>
-            -  Remote access of this application has been restricted.
-          </Box>
-          <Box>
-            -  Contact your Administrator for further assistance.
-          </Box>
-          </Section>
-        </Stack>
+      <Stack vertical position="relative" top="35%" textAlign="left">
+        <Section>
+          <Box>Message from host:</Box>
+          <Box>- Remote access of this application has been restricted.</Box>
+          <Box>- Contact your Administrator for further assistance.</Box>
+        </Section>
+      </Stack>
     </Stack>
   );
 };

--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -11,6 +11,7 @@ import {
   Divider,
   Icon,
   Input,
+  NoticeBox,
   Section,
   Stack,
   TextArea,
@@ -22,6 +23,7 @@ import { NtChat, NtMessenger, NtPicture } from './types';
 type NtosMessengerData = {
   can_spam: BooleanLike;
   is_silicon: BooleanLike;
+  remote_silicon: BooleanLike;
   owner?: NtMessenger;
   saved_chats: Record<string, NtChat>;
   messengers: Record<string, NtMessenger>;
@@ -41,6 +43,7 @@ export const NtosMessenger = (props) => {
   const { data } = useBackend<NtosMessengerData>();
   const {
     is_silicon,
+	remote_silicon,
     saved_chats,
     stored_photos,
     selected_photo_path,
@@ -50,7 +53,9 @@ export const NtosMessenger = (props) => {
   } = data;
 
   let content: JSX.Element;
-  if (open_chat !== null) {
+  if (remote_silicon) {
+	  content = <AccessDeniedScreen />;
+  } else if (open_chat !== null) {
     const openChat = saved_chats[open_chat];
     const temporaryRecipient = messengers[open_chat];
 
@@ -79,6 +84,48 @@ export const NtosMessenger = (props) => {
     <NtosWindow width={600} height={850}>
       <NtosWindow.Content>{content}</NtosWindow.Content>
     </NtosWindow>
+  );
+};
+
+const AccessDeniedScreen = (props: any) => {
+  const { act, data } = useBackend<NtosMessengerData>();
+  
+  return (
+    <Stack fill vertical>
+      <Stack.Item>
+	    <Section>
+	      <Stack vertical textAlign="center">
+            <Box bold>
+              <Icon name="address-card" />
+              SpaceMessenger V6.5.3
+            </Box>
+       </Stack>
+	    </Section>
+      </Stack.Item>
+	  
+	  <NoticeBox
+		color='white'
+		position="relative"
+		top="30%"
+		fontSize="30px"
+		textAlign="center"
+	    >
+		ERROR: CONNECTION REFUSED
+	  </NoticeBox>
+	    <Stack vertical position="relative" top="35%" textAlign="left">
+		  <Section>
+		  <Box>
+		    Message from host:
+		  </Box>
+		  <Box>
+		    -  Remote access of this application has been restricted.
+		  </Box>
+		  <Box>
+			-  Contact your Administrator for further assistance.
+    </Box>
+		  </Section>
+     </Stack>
+    </Stack>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -43,7 +43,7 @@ export const NtosMessenger = (props) => {
   const { data } = useBackend<NtosMessengerData>();
   const {
     is_silicon,
-	remote_silicon,
+    remote_silicon,
     saved_chats,
     stored_photos,
     selected_photo_path,
@@ -54,7 +54,7 @@ export const NtosMessenger = (props) => {
 
   let content: JSX.Element;
   if (remote_silicon) {
-	  content = <AccessDeniedScreen />;
+      content = <AccessDeniedScreen />;
   } else if (open_chat !== null) {
     const openChat = saved_chats[open_chat];
     const temporaryRecipient = messengers[open_chat];
@@ -93,38 +93,37 @@ const AccessDeniedScreen = (props: any) => {
   return (
     <Stack fill vertical>
       <Stack.Item>
-	    <Section>
-	      <Stack vertical textAlign="center">
+        <Section>
+          <Stack vertical textAlign="center">
             <Box bold>
               <Icon name="address-card" />
               SpaceMessenger V6.5.3
             </Box>
-       </Stack>
-	    </Section>
+          </Stack>
+        </Section>
       </Stack.Item>
-	  
-	  <NoticeBox
-		color='white'
-		position="relative"
-		top="30%"
-		fontSize="30px"
-		textAlign="center"
-	    >
-		ERROR: CONNECTION REFUSED
-	  </NoticeBox>
-	    <Stack vertical position="relative" top="35%" textAlign="left">
-		  <Section>
-		  <Box>
-		    Message from host:
-		  </Box>
-		  <Box>
-		    -  Remote access of this application has been restricted.
-		  </Box>
-		  <Box>
-			-  Contact your Administrator for further assistance.
-    </Box>
-		  </Section>
-     </Stack>
+      <NoticeBox
+        color='white'
+        position="relative"
+        top="30%"
+        fontSize="30px"
+        textAlign="center"
+        >
+        ERROR: CONNECTION REFUSED
+      </NoticeBox>
+        <Stack vertical position="relative" top="35%" textAlign="left">
+          <Section>
+          <Box>
+            Message from host:
+          </Box>
+          <Box>
+            -  Remote access of this application has been restricted.
+          </Box>
+          <Box>
+            -  Contact your Administrator for further assistance.
+          </Box>
+          </Section>
+        </Stack>
     </Stack>
   );
 };


### PR DESCRIPTION

## About The Pull Request
- Removes the restriction from borgs and AIs opening PDA interfaces.
- Adds a restriction on Messenger if the PDA is being viewed by an AI or Cyborg *and* the PDA is not a silicon-type PDA. Messenger is completely unusable in this case.
- The AI's own PDA is unaffected, due to it being a silicon-type PDA. Downstreams that give Borg PDAs the Messenger app should likewise be unaffected. Though mainly unrelated to the PR, pAIs were also tested and have not been affected.
## Why It's Good For The Game
Back before tablets and PDAs were squished together, silicons could access tablets freely. TGUI PDAs were restricted from Silicons mainly to keep parity with the old PDAs, of which Messenger is the major feature that was ported over. Thus, I'm blocking Messenger specifically while allowing the rest of a PDA's features to be unblocked.

As an aside, the old fluff text `It doesn't feel right to snoop around like that...` was kinda terrible, since there are many times you do, in fact, want to snoop. The AI trying to track down a known killer's accomplice would want to snoop. The Malf AI that's trying to trick the Captain would want to snoop. The prior owner of the PDA before they were borged wouldn't even feel like it's snooping. So now it's a connection refused thing, not an AI's feelings thing.
## Changelog
:cl:
balance: Borgs and AIs can now access dropped PDAs. The Messenger app does not work over a remote connection, however.
/:cl:
Messenger interface when accessed remotely, by the by;
![image](https://github.com/user-attachments/assets/2df8ab39-97be-4472-bb18-528d79028c7b)
