### PR TITLE
Material tiles now have inhand sprites

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -1153,6 +1153,7 @@
 	desc = "The ground you walk on."
 	throwforce = 10
 	icon_state = "material_tile"
+	inhand_icon_state = "tile"
 	turf_type = /turf/open/floor/material
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	merge_type = /obj/item/stack/tile/material


### PR DESCRIPTION
## About The Pull Request
Fixes material tiles having no sprites
closes #87346
![dreamseeker_cWKNeQ1vM9](https://github.com/user-attachments/assets/a45e7741-3254-4694-b507-221f10c4f0d9)
## Why It's Good For The Game
It makes the game look bad to have error sprites and messages going around, also color coating is cool.
## Changelog
:cl: Hoolny
fix: fixes material tiles having no inhand sprites
/:cl:
