### PR TITLE
Fixes usage of `\improper` on two donk pocket subtypes

### DIFF
--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -299,7 +299,7 @@
 	foodtypes = GRAIN | MEAT | FRIED
 
 /obj/item/food/donkpocket/deluxe/nocarb
-	name = "/improper Meat-pocket"
+	name = "\improper Meat-pocket"
 	desc = "The food of choice for the carnivorous traitor."
 	icon_state = "donkpocketdeluxenocarb"
 	food_reagents = list(
@@ -332,7 +332,7 @@
 	foodtypes = MEAT
 
 /obj/item/food/donkpocket/deluxe/vegan
-	name = "/improper Donk-roll"
+	name = "\improper Donk-roll"
 	desc = "The classic station snack, now with rice! Certified vegan and cruelty free by the Animal Liberation Front."
 	icon_state = "donkpocketdeluxevegan"
 	food_reagents = list(


### PR DESCRIPTION
## Why It's Good For The Game

Fixes #87342

## Changelog

:cl:
spellcheck: fixed donk-rolls and meat pockets having illegal coderspeak in their name
/:cl: