### PR TITLE
Big manipulators can no longer pick up anchored, abstract or nodrop/dropdel objects

### DIFF
--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -390,14 +390,20 @@
 /obj/machinery/big_manipulator/proc/finish_rotate_animation(backward)
 	animate(manipulator_hand, transform = matrix(180 * backward, MATRIX_ROTATE), working_speed*0.5)
 
-/obj/machinery/big_manipulator/proc/check_filter(obj/item/what_item)
-	var/filtered_obj = filter_obj?.resolve()
-	if(!istype(what_item, selected_type))
-		return
+/obj/machinery/big_manipulator/proc/check_filter(atom/movable/target)
+	if (target.anchored || HAS_TRAIT(target, TRAIT_NODROP))
+		return FALSE
+	if(!istype(target, selected_type))
+		return FALSE
 	/// We use filter only on items. closets, humans and etc don't need filter check.
-	if(istype(what_item, /obj/item))
-		if((filtered_obj && !istype(what_item, filtered_obj)))
-			return FALSE
+	if(!isitem(target))
+		return TRUE
+	var/obj/item/target_item = target
+	if (target_item.item_flags & (ABSTRACT|DROPDEL))
+		return FALSE
+	var/filtered_obj = filter_obj?.resolve()
+	if((filtered_obj && !istype(target_item, filtered_obj)))
+		return FALSE
 	return TRUE
 
 /// Create dummy to force him use our item and then delete him.


### PR DESCRIPTION
## About The Pull Request

Being able to steal cyborg's weapons or someone's slapper hand is bad
No fun allowed on /tg/
Closes #87353

## Changelog
:cl:
fix: Big manipulators can no longer pick up anchored, abstract or nodrop/dropdel objects
/:cl:
