### PR TITLE
Outfits that put items in your hand now respect if the outfit is visual only

### DIFF
--- a/code/__HELPERS/dynamic_human_icon_gen.dm
+++ b/code/__HELPERS/dynamic_human_icon_gen.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 			outfit.r_hand = r_hand
 		if(l_hand != NO_REPLACE)
 			outfit.l_hand = l_hand
-		dummy.equipOutfit(outfit, visualsOnly = TRUE)
+		dummy.equipOutfit(outfit, visuals_only = TRUE)
 	else if(mob_spawn_path)
 		var/obj/effect/mob_spawn/spawner = new mob_spawn_path(null, TRUE)
 		spawner.outfit_override = list()

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -235,9 +235,9 @@
 			WARNING("Unable to equip accessory [accessory] in outfit [name]. No uniform present!")
 
 	if(l_hand)
-		user.put_in_l_hand(SSwardrobe.provide_type(l_hand, user))
+		user.put_in_l_hand(SSwardrobe.provide_type(l_hand, user), visuals_only = TRUE)
 	if(r_hand)
-		user.put_in_r_hand(SSwardrobe.provide_type(r_hand, user))
+		user.put_in_r_hand(SSwardrobe.provide_type(r_hand, user), visuals_only = TRUE)
 
 	if(!visuals_only) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -235,9 +235,9 @@
 			WARNING("Unable to equip accessory [accessory] in outfit [name]. No uniform present!")
 
 	if(l_hand)
-		user.put_in_l_hand(SSwardrobe.provide_type(l_hand, user), visuals_only = TRUE)
+		user.put_in_l_hand(SSwardrobe.provide_type(l_hand, user), visuals_only = visuals_only)
 	if(r_hand)
-		user.put_in_r_hand(SSwardrobe.provide_type(r_hand, user), visuals_only = TRUE)
+		user.put_in_r_hand(SSwardrobe.provide_type(r_hand, user), visuals_only = visuals_only)
 
 	if(!visuals_only) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -136,11 +136,11 @@
  * other such sources of change
  *
  * Extra Arguments
- * * visualsOnly true if this is only for display (in the character setup screen)
+ * * visuals_only true if this is only for display (in the character setup screen)
  *
- * If visualsOnly is true, you can omit any work that doesn't visually appear on the character sprite
+ * If visuals_only is true, you can omit any work that doesn't visually appear on the character sprite
  */
-/datum/outfit/proc/pre_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/proc/pre_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	//to be overridden for customization depending on client prefs,species etc
 	return
 
@@ -151,11 +151,11 @@
  * fiddle with id bindings and accesses etc
  *
  * Extra Arguments
- * * visualsOnly true if this is only for display (in the character setup screen)
+ * * visuals_only true if this is only for display (in the character setup screen)
  *
- * If visualsOnly is true, you can omit any work that doesn't visually appear on the character sprite
+ * If visuals_only is true, you can omit any work that doesn't visually appear on the character sprite
  */
-/datum/outfit/proc/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/proc/post_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	//to be overridden for toggling internals, id binding, access etc
 	return
 
@@ -163,7 +163,7 @@
 	user.equip_to_slot_or_del(SSwardrobe.provide_type(##item_path, user), ##slot_name, TRUE, indirect_action = TRUE); \
 	var/obj/item/outfit_item = user.get_item_by_slot(##slot_name); \
 	if (outfit_item && outfit_item.type == ##item_path) { \
-		outfit_item.on_outfit_equip(user, visualsOnly, ##slot_name); \
+		outfit_item.on_outfit_equip(user, visuals_only, ##slot_name); \
 	} \
 }
 
@@ -171,12 +171,12 @@
  * Equips all defined types and paths to the mob passed in
  *
  * Extra Arguments
- * * visualsOnly true if this is only for display (in the character setup screen)
+ * * visuals_only true if this is only for display (in the character setup screen)
  *
- * If visualsOnly is true, you can omit any work that doesn't visually appear on the character sprite
+ * If visuals_only is true, you can omit any work that doesn't visually appear on the character sprite
  */
-/datum/outfit/proc/equip(mob/living/carbon/human/user, visualsOnly = FALSE)
-	pre_equip(user, visualsOnly)
+/datum/outfit/proc/equip(mob/living/carbon/human/user, visuals_only = FALSE)
+	pre_equip(user, visuals_only)
 
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)
@@ -203,7 +203,7 @@
 		EQUIP_OUTFIT_ITEM(back, ITEM_SLOT_BACK)
 	if(id)
 		EQUIP_OUTFIT_ITEM(id, ITEM_SLOT_ID)
-	if(!visualsOnly && id_trim && user.wear_id)
+	if(!visuals_only && id_trim && user.wear_id)
 		var/obj/item/card/id/id_card = user.wear_id
 		if(!istype(id_card)) //If an ID wasn't found in their ID slot, it's probably something holding their ID like a wallet or PDA
 			id_card = locate() in user.wear_id
@@ -239,7 +239,7 @@
 	if(r_hand)
 		user.put_in_r_hand(SSwardrobe.provide_type(r_hand, user))
 
-	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
+	if(!visuals_only) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)
 			EQUIP_OUTFIT_ITEM(l_pocket, ITEM_SLOT_LPOCKET)
 		if(r_pocket)
@@ -267,9 +267,9 @@
 				for(var/i in 1 to number)
 					EQUIP_OUTFIT_ITEM(path, ITEM_SLOT_BELTPACK)
 
-	post_equip(user, visualsOnly)
+	post_equip(user, visuals_only)
 
-	if(!visualsOnly)
+	if(!visuals_only)
 		apply_fingerprints(user)
 		if(internals_slot)
 			if(internals_slot & ITEM_SLOT_HANDS)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -468,7 +468,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 /// result of `get_preview_icon` is expected to be the completed version.
 /datum/antagonist/proc/render_preview_outfit(datum/outfit/outfit, mob/living/carbon/human/dummy)
 	dummy = dummy || new /mob/living/carbon/human/dummy/consistent
-	dummy.equipOutfit(outfit, visualsOnly = TRUE)
+	dummy.equipOutfit(outfit, visuals_only = TRUE)
 	dummy.wear_suit?.update_greyscale()
 	var/icon = getFlatIcon(dummy)
 

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -24,9 +24,9 @@
 			for(var/obj/item/abductor/gizmo/G in B.contents)
 				console.AddGizmo(G)
 
-/datum/outfit/abductor/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/abductor/post_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 
 	if(!isnull(user.mind))
@@ -64,9 +64,9 @@
 		/obj/item/abductor/gizmo = 1
 		)
 
-/datum/outfit/abductor/scientist/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/abductor/scientist/post_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	. = ..()
-	if(!visualsOnly && !isnull(user.mind))
+	if(!visuals_only && !isnull(user.mind))
 		var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(user)
 		beamplant.implant(user)
 

--- a/code/modules/antagonists/clown_ops/clownop.dm
+++ b/code/modules/antagonists/clown_ops/clownop.dm
@@ -76,7 +76,7 @@
 	back = /obj/item/mod/control/pre_equipped/empty/syndicate/honkerative
 	uniform = /obj/item/clothing/under/syndicate
 
-/datum/outfit/clown_operative/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/clown_operative/post_equip(mob/living/carbon/human/H, visuals_only)
 	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
 	booster.active = TRUE
 	H.update_worn_back()
@@ -87,7 +87,7 @@
 	back = /obj/item/mod/control/pre_equipped/empty/syndicate/honkerative
 	uniform = /obj/item/clothing/under/syndicate
 
-/datum/outfit/clown_operative_elite/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/clown_operative_elite/post_equip(mob/living/carbon/human/H, visuals_only)
 	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
 	booster.active = TRUE
 	H.update_worn_back()

--- a/code/modules/antagonists/cult/cult_other.dm
+++ b/code/modules/antagonists/cult/cult_other.dm
@@ -7,7 +7,7 @@
 	shoes = /obj/item/clothing/shoes/cult/alt
 	r_hand = /obj/item/melee/blood_magic/stun
 
-/datum/outfit/cultist/post_equip(mob/living/carbon/human/equipped, visualsOnly)
+/datum/outfit/cultist/post_equip(mob/living/carbon/human/equipped, visuals_only)
 	equipped.eye_color_left = BLOODCULT_EYE
 	equipped.eye_color_right = BLOODCULT_EYE
 	equipped.update_body()

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -4,12 +4,12 @@
 	shoes = /obj/item/clothing/shoes/sneakers/orange
 	r_pocket = /obj/item/knife/shiv
 
-/datum/outfit/prisoner/post_equip(mob/living/carbon/human/prisoner, visualsOnly=FALSE)
+/datum/outfit/prisoner/post_equip(mob/living/carbon/human/prisoner, visuals_only=FALSE)
 	// This outfit is used by the assets SS, which is ran before the atoms SS
 	if(SSatoms.initialized == INITIALIZATION_INSSATOMS)
 		prisoner.w_uniform?.update_greyscale()
 		prisoner.update_worn_undersuit()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	prisoner.fully_replace_character_name(null,"NTP #CC-0[rand(111,999)]") //same as the lavaland prisoner transport, but this time they are from CC, or CentCom
 
@@ -30,10 +30,10 @@
 	ears = /obj/item/radio/headset
 	glasses = /obj/item/clothing/glasses/regular/circle
 
-/datum/outfit/waldo/post_equip(mob/living/carbon/human/equipped_on, visualsOnly=FALSE)
+/datum/outfit/waldo/post_equip(mob/living/carbon/human/equipped_on, visuals_only=FALSE)
 	equipped_on.w_uniform?.update_greyscale()
 	equipped_on.update_worn_undersuit()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	equipped_on.fully_replace_character_name(null, "Waldo")
 	equipped_on.eye_color_left = COLOR_BLACK
@@ -63,8 +63,8 @@
 	uniform = /obj/item/clothing/under/color/white
 	ears = /obj/item/radio/headset
 
-/datum/outfit/synthetic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/synthetic/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	var/obj/item/organ/internal/eyes/robotic/glow/eyes = new()
 	eyes.Insert(H, movement_flags = DELETE_IF_REPLACED)
@@ -82,7 +82,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/invisibility = 3,
 	)
 
-/datum/outfit/invisible_man/post_equip(mob/living/carbon/human/equipee, visualsOnly)
+/datum/outfit/invisible_man/post_equip(mob/living/carbon/human/equipee, visuals_only)
 	. = ..()
 
 	var/obj/item/implant/camouflage/invisibility_implant = new(equipee)

--- a/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
@@ -14,8 +14,8 @@
 	id = /obj/item/card/id/advanced/bountyhunter
 	id_trim = /datum/id_trim/bounty_hunter/police
 
-/datum/outfit/spacepol/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/spacepol/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
@@ -72,8 +72,8 @@
 	if(prob(50))
 		head = pick(alt_helmets)
 
-/datum/outfit/russian_hunter/post_equip(mob/living/carbon/human/equip_to, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/russian_hunter/post_equip(mob/living/carbon/human/equip_to, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	if(istype(equip_to.wear_id, /obj/item/card/id))
@@ -118,8 +118,8 @@
 		/obj/item/ammo_casing/shotgun/incendiary/no_trail = 4,
 	)
 
-/datum/outfit/bountyarmor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/bountyarmor/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
@@ -143,8 +143,8 @@
 		/obj/item/ammo_casing/shotgun/incapacitate = 6
 		)
 
-/datum/outfit/bountyhook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/bountyhook/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
@@ -231,7 +231,7 @@
 	box = /obj/item/storage/box/survival/syndie
 	implants = list(/obj/item/implant/explosive)
 
-/datum/outfit/mi13_hunter/pre_equip(mob/living/carbon/human/agent, visualsOnly = FALSE)
+/datum/outfit/mi13_hunter/pre_equip(mob/living/carbon/human/agent, visuals_only = FALSE)
 	backpack_contents = list()
 	backpack_contents += pick_weight(list(/obj/item/ammo_box/magazine/m9mm = 80,
 	/obj/item/ammo_box/magazine/m9mm/hp = 10,
@@ -253,8 +253,8 @@
 		/obj/item/gun/ballistic/automatic/pistol/clandestine/fisher = 10,
 	))
 
-/datum/outfit/mi13_hunter/post_equip(mob/living/carbon/human/agent, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/mi13_hunter/post_equip(mob/living/carbon/human/agent, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	var/obj/item/card/id/wearing = agent.wear_id
 	wearing.registered_name = agent.real_name

--- a/code/modules/antagonists/nightmare/nightmare.dm
+++ b/code/modules/antagonists/nightmare/nightmare.dm
@@ -20,7 +20,7 @@
 /datum/outfit/nightmare
 	name = "Nightmare (Preview only)"
 
-/datum/outfit/nightmare/post_equip(mob/living/carbon/human/human, visualsOnly)
+/datum/outfit/nightmare/post_equip(mob/living/carbon/human/human, visuals_only)
 	human.set_species(/datum/species/shadow/nightmare)
 
 /datum/objective/nightmare_fluff

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -40,8 +40,8 @@
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
 
-/datum/outfit/syndicate/post_equip(mob/living/carbon/human/nukie, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/syndicate/post_equip(mob/living/carbon/human/nukie, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	// We don't require the nukiebase be loaded to function, but lets go ahead and kick off loading just in case
@@ -107,9 +107,9 @@
 	)
 	var/faction = "The Syndicate"
 
-/datum/outfit/syndicate/reinforcement/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/syndicate/reinforcement/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	to_chat(H, span_notice("You're an agent of [faction], sent to accompany the nuclear squad on their mission. \
 		Support your allies, and remember: Down with Nanotrasen."))
@@ -186,7 +186,7 @@
 	back = /obj/item/mod/control/pre_equipped/empty/syndicate
 	uniform = /obj/item/clothing/under/syndicate
 
-/datum/outfit/nuclear_operative/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/nuclear_operative/post_equip(mob/living/carbon/human/H, visuals_only)
 	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
 	booster.active = TRUE
 	H.update_worn_back()
@@ -199,7 +199,7 @@
 	l_hand = /obj/item/modular_computer/pda/nukeops
 	r_hand = /obj/item/shield/energy
 
-/datum/outfit/nuclear_operative_elite/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/nuclear_operative_elite/post_equip(mob/living/carbon/human/H, visuals_only)
 	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
 	booster.active = TRUE
 	H.update_worn_back()

--- a/code/modules/antagonists/traitor/contractor/contract_teammate.dm
+++ b/code/modules/antagonists/traitor/contractor/contract_teammate.dm
@@ -39,7 +39,7 @@
 		/obj/item/lighter,
 	)
 
-/datum/outfit/contractor_partner/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/contractor_partner/post_equip(mob/living/carbon/human/H, visuals_only)
 	. = ..()
 	var/obj/item/cigarette/syndicate/cig = H.get_item_by_slot(ITEM_SLOT_MASK)
 	cig.light()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -408,7 +408,7 @@
 	r_hand = /obj/item/gun/energy/recharge/ebow
 	shoes = /obj/item/clothing/shoes/magboots/advance
 
-/datum/outfit/traitor/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/traitor/post_equip(mob/living/carbon/human/H, visuals_only)
 	var/obj/item/melee/energy/sword/sword = locate() in H.held_items
 	if(sword.flags_1 & INITIALIZED_1)
 		sword.attack_self()

--- a/code/modules/antagonists/voidwalker/voidwalker.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker.dm
@@ -39,7 +39,7 @@
 /datum/outfit/voidwalker
 	name = "Voidwalker (Preview only)"
 
-/datum/outfit/voidwalker/post_equip(mob/living/carbon/human/human, visualsOnly)
+/datum/outfit/voidwalker/post_equip(mob/living/carbon/human/human, visuals_only)
 	human.set_species(/datum/species/voidwalker)
 
 /datum/objective/voidwalker_objective

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -306,7 +306,7 @@
 	r_hand = /obj/item/claymore
 	l_hand = /obj/item/shield/roman
 
-/datum/outfit/roman/pre_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/roman/pre_equip(mob/living/carbon/human/H, visuals_only)
 	. = ..()
 	head = pick(/obj/item/clothing/head/helmet/roman, /obj/item/clothing/head/helmet/roman/legionnaire)
 

--- a/code/modules/basketball/basketball_teams.dm
+++ b/code/modules/basketball/basketball_teams.dm
@@ -16,8 +16,8 @@
 	//Chance for the wearer to have their height increased. This is repeated three times for maximum height.
 	var/taller_chance = 50
 
-/datum/outfit/basketball/post_equip(mob/living/carbon/human/human_to_equip, visualsOnly=FALSE)
-	if(visualsOnly)
+/datum/outfit/basketball/post_equip(mob/living/carbon/human/human_to_equip, visuals_only=FALSE)
+	if(visuals_only)
 		return
 	var/list/no_drops = list()
 
@@ -98,7 +98,7 @@
 	head = /obj/item/clothing/head/costume/xenos
 	mask = /obj/item/clothing/mask/chameleon
 
-/datum/outfit/basketball/lusty_xenomorphs/post_equip(mob/living/carbon/human/human_to_equip, visualsOnly=FALSE)
+/datum/outfit/basketball/lusty_xenomorphs/post_equip(mob/living/carbon/human/human_to_equip, visuals_only=FALSE)
 	. = ..()
 
 	var/obj/item/card/id/idcard = human_to_equip.wear_id

--- a/code/modules/bitrunning/antagonists/cyber_police.dm
+++ b/code/modules/bitrunning/antagonists/cyber_police.dm
@@ -23,15 +23,15 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	uniform = /obj/item/clothing/under/suit/black_really
 
-/datum/outfit/cyber_police/pre_equip(mob/living/carbon/human/user, visualsOnly)
-	if(!visualsOnly)
+/datum/outfit/cyber_police/pre_equip(mob/living/carbon/human/user, visuals_only)
+	if(!visuals_only)
 		return
 
 	user.set_facial_hairstyle("Shaved", update = FALSE)
 	user.set_haircolor("#4B3D28", update = FALSE)
 	user.set_hairstyle("Business Hair")
 
-/datum/outfit/cyber_police/post_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/cyber_police/post_equip(mob/living/carbon/human/user, visuals_only)
 	var/obj/item/clothing/under/officer_uniform = user.w_uniform
 	if(officer_uniform)
 		officer_uniform.has_sensor = NO_SENSORS

--- a/code/modules/bitrunning/antagonists/cyber_tac.dm
+++ b/code/modules/bitrunning/antagonists/cyber_tac.dm
@@ -24,7 +24,7 @@
 		/obj/item/ammo_box/magazine/m223,
 	)
 
-/datum/outfit/cyber_police/tactical/post_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/cyber_police/tactical/post_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
 
 	var/obj/item/implant/weapons_auth/auth = new(user)

--- a/code/modules/bitrunning/outfits.dm
+++ b/code/modules/bitrunning/outfits.dm
@@ -11,7 +11,7 @@
 	id = /obj/item/card/id/advanced
 
 
-/datum/outfit/echolocator/post_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/echolocator/post_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
 	user.psykerize()
 
@@ -51,7 +51,7 @@
 	)
 
 
-/datum/outfit/beachbum_combat/post_equip(mob/living/carbon/human/bum, visualsOnly)
+/datum/outfit/beachbum_combat/post_equip(mob/living/carbon/human/bum, visuals_only)
 	. = ..()
 
 	var/choice = rand(1, length(ranged_weaps))

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -53,7 +53,7 @@
 	to_wear.suit = null
 	to_wear.suit_store = null
 
-	avatar.equipOutfit(to_wear, visualsOnly = TRUE)
+	avatar.equipOutfit(to_wear, visuals_only = TRUE)
 
 	var/obj/item/clothing/under/jumpsuit = avatar.w_uniform
 	if(istype(jumpsuit))

--- a/code/modules/bitrunning/spawners.dm
+++ b/code/modules/bitrunning/spawners.dm
@@ -70,5 +70,5 @@
 	implants = list(/obj/item/implant/weapons_auth)
 
 
-/datum/outfit/virtual_syndicate/post_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/virtual_syndicate/post_equip(mob/living/carbon/human/user, visuals_only)
 	user.faction |= ROLE_SYNDICATE

--- a/code/modules/capture_the_flag/ctf_classes.dm
+++ b/code/modules/capture_the_flag/ctf_classes.dm
@@ -28,8 +28,8 @@
 	///Which slots to apply TRAIT_NODROP to the items in
 	var/list/nodrop_slots = list(ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_EARS)
 
-/datum/outfit/ctf/post_equip(mob/living/carbon/human/human_to_equip, visualsOnly=FALSE)
-	if(visualsOnly)
+/datum/outfit/ctf/post_equip(mob/living/carbon/human/human_to_equip, visuals_only=FALSE)
+	if(visuals_only)
 		return
 	var/list/no_drops = list()
 

--- a/code/modules/client/preferences/middleware/species.dm
+++ b/code/modules/client/preferences/middleware/species.dm
@@ -18,7 +18,7 @@
 
 		var/mob/living/carbon/human/dummy/consistent/dummy = new
 		dummy.set_species(species_type)
-		dummy.equipOutfit(/datum/outfit/job/assistant/consistent, visualsOnly = TRUE)
+		dummy.equipOutfit(/datum/outfit/job/assistant/consistent, visuals_only = TRUE)
 		dummy.dna.species.prepare_human_for_preview(dummy)
 
 		var/icon/dummy_icon = getFlatIcon(dummy)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -1,8 +1,8 @@
 /datum/outfit/centcom
 	name = "CentCom Base"
 
-/datum/outfit/centcom/post_equip(mob/living/carbon/human/centcom_member, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/post_equip(mob/living/carbon/human/centcom_member, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	var/obj/item/implant/mindshield/mindshield = new /obj/item/implant/mindshield(centcom_member)//hmm lets have centcom officials become revs
 	mindshield.implant(centcom_member, null, silent = TRUE)
@@ -17,8 +17,8 @@
 	shoes = /obj/item/clothing/shoes/combat/swat
 	var/additional_radio
 
-/datum/outfit/centcom/ert/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/ert/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/radio/headset/R = H.ears
@@ -168,8 +168,8 @@
 	r_pocket = /obj/item/modular_computer/pda/heads
 	l_hand = /obj/item/clipboard
 
-/datum/outfit/centcom/centcom_official/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/centcom_official/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/modular_computer/pda/heads/pda = H.r_store
@@ -282,9 +282,9 @@
 	r_pocket = /obj/item/bikehorn/golden
 	additional_radio = /obj/item/encryptionkey/heads/hop
 
-/datum/outfit/centcom/ert/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/centcom/ert/clown/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	ADD_TRAIT(H.mind, TRAIT_NAIVE, INNATE_TRAIT)
 	H.dna.add_mutation(/datum/mutation/human/clumsy)
@@ -308,8 +308,8 @@
 	r_pocket = /obj/item/ammo_box/strilka310
 	l_hand = /obj/item/gun/ballistic/rifle/boltaction
 
-/datum/outfit/centcom/centcom_intern/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/centcom_intern/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
@@ -454,8 +454,8 @@
 		/obj/item/skillchip/disk_verifier,
 	)
 
-/datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/squaddie, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/squaddie, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/radio/radio = squaddie.ears
@@ -472,7 +472,7 @@
 
 	back = /obj/item/mod/control/pre_equipped/apocryphal/officer
 
-/datum/outfit/centcom/death_commando/officer/post_equip(mob/living/carbon/human/squaddie, visualsOnly = FALSE)
+/datum/outfit/centcom/death_commando/officer/post_equip(mob/living/carbon/human/squaddie, visuals_only = FALSE)
 	. = ..()
 	var/obj/item/mod/control/mod = squaddie.back
 	if(!istype(mod))

--- a/code/modules/clothing/outfits/event.dm
+++ b/code/modules/clothing/outfits/event.dm
@@ -14,8 +14,8 @@
 
 	box = /obj/item/storage/box/survival/engineer
 
-/datum/outfit/santa/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/santa/post_equip(mob/living/carbon/human/user, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	user.fully_replace_character_name(user.real_name, "Santa Claus")
 	user.mind.set_assigned_role(SSjob.get_job_type(/datum/job/santa))

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -15,8 +15,8 @@
 	shoes = /obj/item/clothing/shoes/combat/swat
 	r_pocket = /obj/item/lighter
 
-/datum/outfit/centcom/spec_ops/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/spec_ops/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
@@ -81,8 +81,8 @@
 	r_hand = /obj/item/mop
 	l_hand = /obj/item/reagent_containers/cup/bucket
 
-/datum/outfit/tournament/janitor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/tournament/janitor/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/reagent_containers/cup/bucket/bucket = H.get_item_for_held_index(1)
@@ -160,8 +160,8 @@
 	r_pocket = /obj/item/bikehorn
 	l_hand = /obj/item/fireaxe
 
-/datum/outfit/tunnel_clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/tunnel_clown/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
@@ -206,11 +206,11 @@
 	l_pocket = /obj/item/melee/energy/sword/saber
 	l_hand = /obj/item/storage/briefcase/secure
 
-/datum/outfit/assassin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/assassin/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	var/obj/item/clothing/under/U = H.w_uniform
 	U.attach_accessory(new /obj/item/clothing/accessory/waistcoat(H))
 
-	if(visualsOnly)
+	if(visuals_only)
 		return
 
 	//Could use a type
@@ -250,8 +250,8 @@
 	l_pocket = /obj/item/ammo_box/a357
 	r_pocket = /obj/item/lighter
 
-/datum/outfit/centcom/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/commander/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
@@ -303,8 +303,8 @@
 	r_pocket = /obj/item/teleportation_scroll
 	l_hand = /obj/item/staff
 
-/datum/outfit/wizard/post_equip(mob/living/carbon/human/wizard, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/wizard/post_equip(mob/living/carbon/human/wizard, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/spellbook/new_spellbook = locate() in wizard.back
@@ -315,7 +315,7 @@
 	name = "Wizard - Bookless"
 	backpack_contents = list()
 
-/datum/outfit/wizard/bookless/post_equip(mob/living/carbon/human/wizard, visualsOnly)
+/datum/outfit/wizard/bookless/post_equip(mob/living/carbon/human/wizard, visuals_only)
 	return
 
 /datum/outfit/wizard/apprentice
@@ -362,8 +362,8 @@
 	head = /obj/item/clothing/head/costume/pirate/captain
 	shoes = /obj/item/clothing/shoes/combat
 
-/datum/outfit/centcom/soviet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/centcom/soviet/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
@@ -387,8 +387,8 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	l_hand = /obj/item/gun/ballistic/automatic/tommygun
 
-/datum/outfit/mobster/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/mobster/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
@@ -404,7 +404,7 @@
 	mask = /obj/item/clothing/mask/breath
 	back = /obj/item/mod/control/pre_equipped/chrono
 
-/datum/outfit/chrono_agent/post_equip(mob/living/carbon/human/agent, visualsOnly)
+/datum/outfit/chrono_agent/post_equip(mob/living/carbon/human/agent, visuals_only)
 	. = ..()
 	var/obj/item/mod/control/mod = agent.back
 	if(!istype(mod))
@@ -437,7 +437,7 @@
 	box = /obj/item/storage/box/debugtools
 	internals_slot = ITEM_SLOT_SUITSTORE
 
-/datum/outfit/debug/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/debug/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
 	W.update_label()
@@ -469,7 +469,7 @@
 	box = /obj/item/storage/box/debugtools
 	internals_slot = ITEM_SLOT_SUITSTORE
 
-/datum/outfit/admin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/admin/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
 	W.update_label()

--- a/code/modules/clothing/outfits/vv_outfit.dm
+++ b/code/modules/clothing/outfits/vv_outfit.dm
@@ -6,7 +6,7 @@
 	var/list/stored_access
 	var/update_id_name = FALSE //If the name of the human is same as the name on the id they're wearing we'll update provided id when equipping
 
-/datum/outfit/varedit/pre_equip(mob/living/carbon/human/equipping_mob, visualsOnly)
+/datum/outfit/varedit/pre_equip(mob/living/carbon/human/equipping_mob, visuals_only)
 	equipping_mob.delete_equipment() //Applying VV to wrong objects is not reccomended.
 	return ..()
 
@@ -139,7 +139,7 @@
 	GLOB.custom_outfits += outfit
 	to_chat(usr,"Outfit registered, use select equipment to equip it.")
 
-/datum/outfit/varedit/post_equip(mob/living/carbon/human/human, visualsOnly)
+/datum/outfit/varedit/post_equip(mob/living/carbon/human/human, visuals_only)
 	. = ..()
 	//Apply VV
 	for(var/slot in vv_values)

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -12,7 +12,7 @@
 	/// This outfit will grant these mutations if applied
 	var/list/mutations_to_add = list()
 
-/datum/outfit/deathmatch_loadout/pre_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/deathmatch_loadout/pre_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	. = ..()
 	if(isdummy(user))
 		return
@@ -914,13 +914,13 @@
 
 // We don't want them to just punch each other to death
 
-/datum/outfit/deathmatch_loadout/lattice_battles/pre_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/deathmatch_loadout/lattice_battles/pre_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
 	ADD_TRAIT(user, TRAIT_PACIFISM, REF(src))
 
 // Ragnarok: Fight between religions!
 
-/datum/outfit/deathmatch_loadout/cultish/pre_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/deathmatch_loadout/cultish/pre_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
 	ADD_TRAIT(user, TRAIT_ACT_AS_CULTIST, REF(src))
 	user.AddElement(/datum/element/cult_halo, initial_delay = 0 SECONDS)
@@ -990,7 +990,7 @@
 		/datum/action/innate/cult/blood_spell/manipulation,
 	)
 
-/datum/outfit/deathmatch_loadout/cultish/artificer/post_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/deathmatch_loadout/cultish/artificer/post_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
 	var/datum/action/innate/cult/blood_spell/manipulation/magick = locate() in user.get_all_contents()
 	magick.charges = 300
@@ -999,7 +999,7 @@
 	/// Grants the effects of these knowledges to the DMer
 	var/list/knowledge_to_grant
 
-/datum/outfit/deathmatch_loadout/heresy/pre_equip(mob/living/carbon/human/user, visualsOnly)
+/datum/outfit/deathmatch_loadout/heresy/pre_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
 	ADD_TRAIT(user, TRAIT_ACT_AS_HERETIC, REF(src))
 	user.AddElement(/datum/element/leeching_walk)

--- a/code/modules/hallucination/mother.dm
+++ b/code/modules/hallucination/mother.dm
@@ -63,7 +63,7 @@
 	neck = /obj/item/clothing/neck/beads
 	shoes = /obj/item/clothing/shoes/sandal
 
-/datum/outfit/yourmother/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/yourmother/post_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	. = ..()
 	user.set_hairstyle("Braided", update = TRUE) //get_dynamic_human_appearance uses bald dummies
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -349,7 +349,7 @@
 
 	var/pda_slot = ITEM_SLOT_BELT
 
-/datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/pre_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	if(ispath(back, /obj/item/storage/backpack))
 		switch(H.backpack)
 			if(GBACKPACK)
@@ -386,8 +386,8 @@
 	if(client?.is_veteran() && client?.prefs.read_preference(/datum/preference/toggle/playtime_reward_cloak))
 		neck = /obj/item/clothing/neck/cloak/skill_reward/playing
 
-/datum/outfit/job/post_equip(mob/living/carbon/human/equipped, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/job/post_equip(mob/living/carbon/human/equipped, visuals_only = FALSE)
+	if(visuals_only)
 		return
 
 	var/datum/job/equipped_job = SSjob.get_job_type(jobtype)

--- a/code/modules/jobs/job_types/assistant/assistant.dm
+++ b/code/modules/jobs/job_types/assistant/assistant.dm
@@ -94,7 +94,7 @@ Assistant
 /datum/outfit/job/assistant/consistent/give_jumpsuit(mob/living/carbon/human/target)
 	uniform = /obj/item/clothing/under/color/grey
 
-/datum/outfit/job/assistant/consistent/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/job/assistant/consistent/post_equip(mob/living/carbon/human/H, visuals_only)
 	..()
 
 	// This outfit is used by the assets SS, which is ran before the atoms SS

--- a/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
+++ b/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
@@ -47,7 +47,7 @@
 
 	outfit_weight = 2
 
-/datum/outfit/job/assistant/gimmick/cyborg/post_equip(mob/living/carbon/human/equipped, visualsOnly)
+/datum/outfit/job/assistant/gimmick/cyborg/post_equip(mob/living/carbon/human/equipped, visuals_only)
 	. = ..()
 	var/obj/item/organ/internal/tongue/robot/robotongue = new ()
 	robotongue.Insert(equipped, movement_flags = DELETE_IF_REPLACED)
@@ -103,7 +103,7 @@
 
 	outfit_weight = 5
 
-/datum/outfit/job/assistant/gimmick/mopper/post_equip(mob/living/carbon/human/equipped, visualsOnly)
+/datum/outfit/job/assistant/gimmick/mopper/post_equip(mob/living/carbon/human/equipped, visuals_only)
 	. = ..()
 
 	for(var/turf/turf in range(1, equipped))

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -61,7 +61,7 @@
 
 	skillchips = list(/obj/item/skillchip/drunken_brawler)
 
-/datum/outfit/job/bartender/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/job/bartender/post_equip(mob/living/carbon/human/H, visuals_only)
 	. = ..()
 
 	var/obj/item/card/id/W = H.wear_id

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -93,7 +93,7 @@
 
 	var/special_charter
 
-/datum/outfit/job/captain/pre_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/job/captain/pre_equip(mob/living/carbon/human/H, visuals_only)
 	. = ..()
 	special_charter = CHECK_MAP_JOB_CHANGE(JOB_CAPTAIN, "special_charter")
 	if(!special_charter)
@@ -106,9 +106,9 @@
 	else if(!r_hand)
 		r_hand = /obj/item/station_charter/banner
 
-/datum/outfit/job/captain/post_equip(mob/living/carbon/human/equipped, visualsOnly)
+/datum/outfit/job/captain/post_equip(mob/living/carbon/human/equipped, visuals_only)
 	. = ..()
-	if(visualsOnly || !special_charter)
+	if(visuals_only || !special_charter)
 		return
 
 	var/obj/item/station_charter/banner/celestial_charter = locate() in equipped.held_items

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -83,7 +83,7 @@
 	back = /obj/item/mod/control/pre_equipped/cosmohonk
 	internals_slot = ITEM_SLOT_SUITSTORE
 
-/datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visuals_only)
 	. = ..()
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_BANANIUM_SHIPMENTS))
 		backpack_contents[/obj/item/stack/sheet/mineral/bananium/five] = 1
@@ -93,9 +93,9 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_BANANIUM_SHIPMENTS))
 		. += /obj/item/stack/sheet/mineral/bananium/five
 
-/datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -80,7 +80,7 @@
 
 	skillchips = list(/obj/item/skillchip/job/chef)
 
-/datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	..()
 	var/datum/job/cook/other_chefs = SSjob.get_job_type(jobtype)
 	if(other_chefs) // If there's other Chefs, you're a Cook
@@ -88,10 +88,10 @@
 			id_trim = /datum/id_trim/job/cook
 			suit = /obj/item/clothing/suit/apron/chef
 			head = /obj/item/clothing/head/soft/mime
-		if(!visualsOnly)
+		if(!visuals_only)
 			other_chefs.cooks++
 
-/datum/outfit/job/cook/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+/datum/outfit/job/cook/post_equip(mob/living/carbon/human/user, visuals_only = FALSE)
 	. = ..()
 	// Update PDA to match possible new trim.
 	var/obj/item/card/id/worn_id = user.wear_id

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -55,8 +55,8 @@
 
 	accessory = /obj/item/clothing/accessory/pocketprotector/full
 
-/datum/outfit/job/curator/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/job/curator/pre_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return ..()
 
 	/// There can be only one cameraman on this station, and no, not that kind
@@ -67,10 +67,10 @@
 	return ..()
 
 
-/datum/outfit/job/curator/post_equip(mob/living/carbon/human/translator, visualsOnly = FALSE)
+/datum/outfit/job/curator/post_equip(mob/living/carbon/human/translator, visuals_only = FALSE)
 	..()
 
-	if(visualsOnly)
+	if(visuals_only)
 		return
 
 	translator.grant_all_languages(source = LANGUAGE_CURATOR)

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -78,17 +78,17 @@
 
 	skillchips = list(/obj/item/skillchip/job/detectives_taste)
 
-/datum/outfit/job/detective/pre_equip(mob/living/carbon/human/human, visualsOnly = FALSE)
+/datum/outfit/job/detective/pre_equip(mob/living/carbon/human/human, visuals_only = FALSE)
 	. = ..()
 	if (human.age < AGE_MINOR)
 		mask = /obj/item/cigarette/candy
 		head = /obj/item/clothing/head/fedora/det_hat/minor
 
-/datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	..()
 	var/obj/item/cigarette/cig = H.wear_mask
 	if(istype(cig)) //Some species specfic changes can mess this up (plasmamen)
 		cig.light("")
 
-	if(visualsOnly)
+	if(visuals_only)
 		return

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -47,8 +47,8 @@
 
 	chameleon_extras = /obj/item/stamp/law
 
-/datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visuals_only = FALSE)
+	if(visuals_only)
 		return ..()
 
 	var/static/use_purple_suit = FALSE //If there is one lawyer, they get the default blue suit. If another lawyer joins the round, they start with a purple suit.

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -69,10 +69,10 @@
 	box = /obj/item/storage/box/survival/hug/black
 	chameleon_extras = /obj/item/stamp/mime
 
-/datum/outfit/job/mime/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/mime/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	..()
 
-	if(visualsOnly)
+	if(visuals_only)
 		return
 
 	// Start our mime out with a vow of silence and the ability to break (or make) it

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -65,7 +65,7 @@
 	if(prob(1)) // D BOYYYYSSSSS
 		head = /obj/item/clothing/head/beanie/black/dboy
 
-/datum/outfit/job/prisoner/post_equip(mob/living/carbon/human/new_prisoner, visualsOnly)
+/datum/outfit/job/prisoner/post_equip(mob/living/carbon/human/new_prisoner, visuals_only)
 	. = ..()
 
 	var/crime_name = new_prisoner.client?.prefs?.read_preference(/datum/preference/choiced/prisoner_crime)
@@ -74,7 +74,7 @@
 		return
 	var/list/limbs_to_tat = new_prisoner.bodyparts.Copy()
 	for(var/i in 1 to crime.tattoos)
-		if(!length(SSpersistence.prison_tattoos_to_use) || visualsOnly)
+		if(!length(SSpersistence.prison_tattoos_to_use) || visuals_only)
 			return
 		var/obj/item/bodypart/tatted_limb = pick_n_take(limbs_to_tat)
 		var/list/tattoo = pick_n_take(SSpersistence.prison_tattoos_to_use)

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -98,9 +98,9 @@
 	r_pocket = /obj/item/extinguisher/mini
 	belt = /obj/item/storage/belt/mining/healing
 
-/datum/outfit/job/miner/equipped/combat/post_equip(mob/living/carbon/human/miner, visualsOnly = FALSE)
+/datum/outfit/job/miner/equipped/combat/post_equip(mob/living/carbon/human/miner, visuals_only = FALSE)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	var/list/miner_contents = miner.get_all_contents()
 	var/obj/item/clothing/suit/hooded/explorer/explorer_suit = locate() in miner_contents

--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -111,9 +111,9 @@
 
 	l_hand = /obj/item/paper/default_lawset_list
 
-/datum/outfit/job/human_ai/pre_equip(mob/living/carbon/human/equipped, visualsOnly)
+/datum/outfit/job/human_ai/pre_equip(mob/living/carbon/human/equipped, visuals_only)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	if(is_safe_turf(equipped.loc, dense_atoms = TRUE)) //skip this if it's safe. We allow dense atoms because we spawn out of the inactive core.
 		return
@@ -123,9 +123,9 @@
 	suit = /obj/item/clothing/suit/space/nasavoid
 	head = /obj/item/clothing/head/helmet/space/nasavoid
 
-/datum/outfit/job/human_ai/post_equip(mob/living/carbon/human/equipped, visualsOnly)
+/datum/outfit/job/human_ai/post_equip(mob/living/carbon/human/equipped, visuals_only)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	if(!equipped.get_quirk(/datum/quirk/body_purist))
 		var/obj/item/organ/internal/tongue/robot/cybernetic = new()

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -589,9 +589,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	id_trim = /datum/id_trim/away/hilbert
 
-/datum/outfit/doctorhilbert/pre_equip(mob/living/carbon/human/hilbert, visualsOnly)
+/datum/outfit/doctorhilbert/pre_equip(mob/living/carbon/human/hilbert, visuals_only)
 	. = ..()
-	if(!visualsOnly)
+	if(!visuals_only)
 		hilbert.gender = MALE
 		hilbert.update_body()
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -159,7 +159,7 @@
 		return FALSE
 	return !held_items[hand_index]
 
-/mob/proc/put_in_hand(obj/item/I, hand_index, forced = FALSE, ignore_anim = TRUE)
+/mob/proc/put_in_hand(obj/item/I, hand_index, forced = FALSE, ignore_anim = TRUE, visuals_only = FALSE)
 	if(hand_index == null || !held_items.len || (!forced && !can_put_in_hand(I, hand_index)))
 		return FALSE
 
@@ -172,7 +172,7 @@
 	SET_PLANE_EXPLICIT(I, ABOVE_HUD_PLANE, src)
 	if(I.pulledby)
 		I.pulledby.stop_pulling()
-	if(!I.on_equipped(src, ITEM_SLOT_HANDS))
+	if(!I.on_equipped(src, ITEM_SLOT_HANDS, initial = visuals_only))
 		return FALSE
 	update_held_items()
 	I.pixel_x = I.base_pixel_x
@@ -183,12 +183,12 @@
 	return hand_index
 
 //Puts the item into the first available left hand if possible and calls all necessary triggers/updates. returns 1 on success.
-/mob/proc/put_in_l_hand(obj/item/I)
-	return put_in_hand(I, get_empty_held_index_for_side(LEFT_HANDS))
+/mob/proc/put_in_l_hand(obj/item/I, visuals_only = FALSE)
+	return put_in_hand(I, get_empty_held_index_for_side(LEFT_HANDS), visuals_only = visuals_only)
 
 //Puts the item into the first available right hand if possible and calls all necessary triggers/updates. returns 1 on success.
-/mob/proc/put_in_r_hand(obj/item/I)
-	return put_in_hand(I, get_empty_held_index_for_side(RIGHT_HANDS))
+/mob/proc/put_in_r_hand(obj/item/I, visuals_only = FALSE)
+	return put_in_hand(I, get_empty_held_index_for_side(RIGHT_HANDS), visuals_only = visuals_only)
 
 /mob/proc/put_in_hand_check(obj/item/I)
 	return FALSE //nonliving mobs don't have hands
@@ -200,19 +200,19 @@
 	return FALSE
 
 //Puts the item into our active hand if possible. returns TRUE on success.
-/mob/proc/put_in_active_hand(obj/item/I, forced = FALSE, ignore_animation = TRUE)
-	return put_in_hand(I, active_hand_index, forced, ignore_animation)
+/mob/proc/put_in_active_hand(obj/item/I, forced = FALSE, ignore_animation = TRUE, visuals_only = FALSE)
+	return put_in_hand(I, active_hand_index, forced, ignore_animation, visuals_only)
 
 
 //Puts the item into our inactive hand if possible, returns TRUE on success
-/mob/proc/put_in_inactive_hand(obj/item/I, forced = FALSE)
-	return put_in_hand(I, get_inactive_hand_index(), forced)
+/mob/proc/put_in_inactive_hand(obj/item/I, forced = FALSE, visuals_only = FALSE)
+	return put_in_hand(I, get_inactive_hand_index(), forced, visuals_only = visuals_only)
 
 
 //Puts the item our active hand if possible. Failing that it tries other hands. Returns TRUE on success.
 //If both fail it drops it on the floor (or nearby tables if germ sensitive) and returns FALSE.
 //This is probably the main one you need to know :)
-/mob/proc/put_in_hands(obj/item/I, del_on_fail = FALSE, merge_stacks = TRUE, forced = FALSE, ignore_animation = TRUE)
+/mob/proc/put_in_hands(obj/item/I, del_on_fail = FALSE, merge_stacks = TRUE, forced = FALSE, ignore_animation = TRUE, visuals_only = FALSE)
 	if(QDELETED(I))
 		return FALSE
 
@@ -236,14 +236,14 @@
 						to_chat(usr, span_notice("Your [inactive_stack.name] stack now contains [inactive_stack.get_amount()] [inactive_stack.singular_name]\s."))
 						return TRUE
 
-	if(put_in_active_hand(I, forced, ignore_animation))
+	if(put_in_active_hand(I, forced, ignore_animation, visuals_only))
 		return TRUE
 
 	var/hand = get_empty_held_index_for_side(LEFT_HANDS)
 	if(!hand)
 		hand = get_empty_held_index_for_side(RIGHT_HANDS)
 	if(hand)
-		if(put_in_hand(I, hand, forced, ignore_animation))
+		if(put_in_hand(I, hand, forced, ignore_animation, visuals_only))
 			return TRUE
 	if(del_on_fail)
 		qdel(I)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -335,7 +335,7 @@
 /mob/living/carbon/human/toggle_externals(obj/item/tank)
 	return toggle_internals(tank, TRUE)
 
-/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
+/mob/living/carbon/human/proc/equipOutfit(outfit, visuals_only = FALSE)
 	var/datum/outfit/O = null
 
 	if(ispath(outfit))
@@ -347,11 +347,11 @@
 	if(!O)
 		return 0
 
-	return O.equip(src, visualsOnly)
+	return O.equip(src, visuals_only)
 
 
 ///A version of equipOutfit that overrides passed in outfits with their entry on the species' outfit override registry
-/mob/living/carbon/human/proc/equip_species_outfit(outfit, visualsOnly = FALSE)
+/mob/living/carbon/human/proc/equip_species_outfit(outfit, visuals_only = FALSE)
 	var/datum/outfit/outfit_to_equip
 
 	var/override_outfit_path = dna?.species.outfit_override_registry[outfit]
@@ -363,7 +363,7 @@
 	if(isnull(outfit_to_equip))
 		return FALSE
 
-	return outfit_to_equip.equip(src, visualsOnly)
+	return outfit_to_equip.equip(src, visuals_only)
 
 
 //delete all equipment without dropping anything

--- a/code/modules/mob_spawn/corpses/mining_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mining_corpses.dm
@@ -135,9 +135,9 @@
 	mask = /obj/item/clothing/mask/gas/explorer
 	shoes = /obj/item/clothing/shoes/workboots/mining
 
-/datum/outfit/consumed_miner/pre_equip(mob/living/carbon/human/miner, visualsOnly = FALSE)
+/datum/outfit/consumed_miner/pre_equip(mob/living/carbon/human/miner, visuals_only = FALSE)
 	var/regular_uniform = FALSE
-	if(visualsOnly)
+	if(visuals_only)
 		regular_uniform = TRUE //assume human
 	else
 		var/new_species_type = pick_weight(list(
@@ -195,8 +195,8 @@
 	name = "Legion-Consumed Ashwalker"
 	uniform = /obj/item/clothing/under/costume/gladiator/ash_walker
 
-/datum/outfit/consumed_ashwalker/pre_equip(mob/living/carbon/human/ashwalker, visualsOnly = FALSE)
-	if(!visualsOnly)
+/datum/outfit/consumed_ashwalker/pre_equip(mob/living/carbon/human/ashwalker, visuals_only = FALSE)
+	if(!visuals_only)
 		ashwalker.set_species(/datum/species/lizard/ashwalker)
 	if(prob(95))
 		head = /obj/item/clothing/head/helmet/gladiator
@@ -234,8 +234,8 @@
 	///drops a pie cannon on post_equip. i'm so done with this stupid outfit trying to put shit that doesn't fit in the backpack!
 	var/drop_a_pie_cannon = FALSE
 
-/datum/outfit/consumed_clown/pre_equip(mob/living/carbon/human/clown, visualsOnly = FALSE)
-	if(!visualsOnly)
+/datum/outfit/consumed_clown/pre_equip(mob/living/carbon/human/clown, visuals_only = FALSE)
+	if(!visuals_only)
 		clown.fully_replace_character_name(clown.name, pick(GLOB.clown_names))
 	if(prob(70))
 		var/backpack_loot = pick(list(
@@ -260,7 +260,7 @@
 	if(prob(10))
 		r_pocket = /obj/item/implanter/sad_trombone
 
-/datum/outfit/consumed_clown/post_equip(mob/living/carbon/human/clown, visualsOnly)
+/datum/outfit/consumed_clown/post_equip(mob/living/carbon/human/clown, visuals_only)
 	. = ..()
 	if(drop_a_pie_cannon)
 		new /obj/item/pneumatic_cannon/pie(get_turf(clown))
@@ -269,8 +269,8 @@
 	name = "Legion-Consumed Golem"
 	//Oops! All randomized!
 
-/datum/outfit/consumed_golem/pre_equip(mob/living/carbon/human/golem, visualsOnly = FALSE)
-	if(!visualsOnly)
+/datum/outfit/consumed_golem/pre_equip(mob/living/carbon/human/golem, visuals_only = FALSE)
+	if(!visuals_only)
 		golem.set_species(/datum/species/golem)
 	if(prob(30))
 		glasses = pick_weight(list(
@@ -281,7 +281,7 @@
 			/obj/item/clothing/glasses/welding = 2,
 			/obj/item/clothing/glasses/night = 1,
 		))
-	if(prob(10) && !visualsOnly) //visualsonly = not a golem = can't put things in the belt slot without a jumpsuit
+	if(prob(10) && !visuals_only) //visuals_only = not a golem = can't put things in the belt slot without a jumpsuit
 		belt = pick(list(
 			/obj/item/crowbar/power,
 			/obj/item/screwdriver/power,
@@ -299,7 +299,7 @@
 	shoes = /obj/item/clothing/shoes/winterboots
 	mask = /obj/item/clothing/mask/breath
 
-/datum/outfit/consumed_ice_settler/pre_equip(mob/living/carbon/human/ice_settler, visualsOnly = FALSE)
+/datum/outfit/consumed_ice_settler/pre_equip(mob/living/carbon/human/ice_settler, visuals_only = FALSE)
 	if(prob(40))
 		r_pocket = pick_weight(list(
 			/obj/item/coin/silver = 5,
@@ -333,8 +333,8 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/tank/internals/emergency_oxygen
 
-/datum/outfit/consumed_dame/pre_equip(mob/living/carbon/human/dame, visualsOnly = FALSE)
-	if(!visualsOnly)
+/datum/outfit/consumed_dame/pre_equip(mob/living/carbon/human/dame, visuals_only = FALSE)
+	if(!visuals_only)
 		dame.gender = FEMALE
 		dame.physique = FEMALE
 		dame.update_body()
@@ -356,8 +356,8 @@
 
 	accessory = /obj/item/clothing/accessory/medal/plasma/nobel_science
 
-/datum/outfit/consumed_shadowperson/pre_equip(mob/living/carbon/human/shadowperson, visualsOnly = FALSE)
-	if(visualsOnly)
+/datum/outfit/consumed_shadowperson/pre_equip(mob/living/carbon/human/shadowperson, visuals_only = FALSE)
+	if(visuals_only)
 		return
 	shadowperson.set_species(/datum/species/shadow)
 
@@ -381,8 +381,8 @@
 	suit = /obj/item/clothing/suit/hooded/cultrobes/eldritch
 	head = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 
-/datum/outfit/consumed_heremoth/pre_equip(mob/living/carbon/human/moth, visualsOnly = FALSE)
-	if(!visualsOnly)
+/datum/outfit/consumed_heremoth/pre_equip(mob/living/carbon/human/moth, visuals_only = FALSE)
+	if(!visuals_only)
 		moth.set_species(/datum/species/moth)
 	if(prob(70))
 		glasses = /obj/item/clothing/glasses/blindfold

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -99,9 +99,9 @@
 	l_pocket = /obj/item/food/pizzaslice/dank
 	r_pocket = /obj/item/storage/wallet/random
 
-/datum/outfit/beachbum/post_equip(mob/living/carbon/human/bum, visualsOnly = FALSE)
+/datum/outfit/beachbum/post_equip(mob/living/carbon/human/bum, visuals_only = FALSE)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	bum.dna.add_mutation(/datum/mutation/human/stoner)
 
@@ -131,7 +131,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	shoes = /obj/item/clothing/shoes/sneakers/black
 
-/datum/outfit/spacebartender/post_equip(mob/living/carbon/human/bartender, visualsOnly = FALSE)
+/datum/outfit/spacebartender/post_equip(mob/living/carbon/human/bartender, visuals_only = FALSE)
 	. = ..()
 	var/obj/item/card/id/id_card = bartender.wear_id
 	if(bartender.age < AGE_MINOR)
@@ -312,7 +312,7 @@
 
 	implants = list(/obj/item/implant/weapons_auth)
 
-/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
+/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/syndicate, visuals_only = FALSE)
 	syndicate.faction |= ROLE_SYNDICATE
 
 /datum/outfit/lavaland_syndicate/comms

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -301,5 +301,5 @@
 
 /obj/item/reagent_containers/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
-	if((slot & ITEM_SLOT_HANDS) && reagent_container_liquid_sound && reagents.total_volume > 0)
+	if(!initial && (slot & ITEM_SLOT_HANDS) && reagent_container_liquid_sound && reagents.total_volume > 0)
 		playsound(src, reagent_container_liquid_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)

--- a/code/modules/unit_tests/screenshot_humanoids.dm
+++ b/code/modules/unit_tests/screenshot_humanoids.dm
@@ -23,7 +23,7 @@
 	moth.dna.features["moth_markings"] = "None"
 	moth.dna.features["moth_wings"] = "Firewatch"
 	moth.set_species(/datum/species/moth)
-	moth.equipOutfit(/datum/outfit/job/cmo, visualsOnly = TRUE)
+	moth.equipOutfit(/datum/outfit/job/cmo, visuals_only = TRUE)
 	test_screenshot("[/datum/species/moth]", get_flat_icon_for_all_directions(moth))
 	testable_species -= /datum/species/moth
 
@@ -45,5 +45,5 @@
 /datum/unit_test/screenshot_humanoids/proc/make_dummy(species, job_outfit)
 	var/mob/living/carbon/human/dummy/consistent/dummy = allocate(/mob/living/carbon/human/dummy/consistent)
 	dummy.set_species(species)
-	dummy.equipOutfit(job_outfit, visualsOnly = TRUE)
+	dummy.equipOutfit(job_outfit, visuals_only = TRUE)
 	return dummy

--- a/code/modules/unit_tests/screenshot_saturnx.dm
+++ b/code/modules/unit_tests/screenshot_saturnx.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/screenshot_saturnx/Run()
 	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human/dummy/consistent) //we don't use a dummy as they have no organs
-	human.equipOutfit(/datum/outfit/job/assistant/consistent, visualsOnly = TRUE)
+	human.equipOutfit(/datum/outfit/job/assistant/consistent, visuals_only = TRUE)
 
 	var/datum/reagent/drug/saturnx/saturnx_reagent = new()
 


### PR DESCRIPTION

## About The Pull Request

On a downstream, we have an antagonist, that is a less competent wizards. This antagonist's preview outfit has a beer bottle in their hand, which has caused runtimes, as the bottle did not have any reagents instantiated, and it tried check its length for sloshing. After putting in a check for the `initial` argument of `on_equip`, I have noticed that the problem goes deeper: the various procs that handle putting something in your hand do not pass along if the items is put in your hand as a preview or not. This PR adds a new optional var to these procs, ensuring that unwanted behaviour during previews won't trigger.

I also swapped `visualsOnly` to snake case, as it looked inconsistent with the rest of the code style.
 
## Why It's Good For The Game

Making the argument that ensures avoiding side effects during previews work with all kinds of items is good.

## Changelog

:cl:
fix: if an outfit puts a reagent container in the preview dummy's hand, it will not try to slosh
code: outfits putting items in your hand will respect the visual_only argument
/:cl:
