### PR TITLE
Empty welders cannot be used as tools for crafting

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -452,29 +452,34 @@
 
 	var/list/surroundings = get_surroundings(user)
 	var/fueled_welder_found = FALSE
-	var/special_welder_found = FALSE
 
+	// set as found as these omnitools don't have fuel, they just work
 	if ((/obj/item/debug/omnitool in surroundings["instances"]) || (/obj/item/abductor/alien_omnitool in surroundings["instances"]))
-		special_welder_found = TRUE
+		fueled_welder_found = TRUE
 
-	if(!special_welder_found)
+	if(!fueled_welder_found)
+		//check if the welders have fuel
 		for (var/obj/item/weldingtool/welder in surroundings["instances"][/obj/item/weldingtool])
 			if (welder.get_fuel() != 0)
 				fueled_welder_found = TRUE
 				break
 
+		// this check is to stop redundant checks since only one welder needs to work for the recipe
 		if (!fueled_welder_found)
+			//check if the lighters have fuel
 			for (var/obj/item/lighter/lighter in surroundings["instances"][/obj/item/lighter])
 				if (lighter.get_fuel() != 0)
 					fueled_welder_found = TRUE
 					break
 
 		if(!fueled_welder_found)
+			//check if the plasmacutter have fuel
 			for (var/obj/item/gun/energy/plasmacutter/plasmacutter in surroundings["instances"][/obj/item/gun/energy/plasmacutter])
 				if (plasmacutter.cell.charge != 0)
 					fueled_welder_found = TRUE
 					break
 
+		//if no fueled welder found, remove the welding as an available tool
 		if(!fueled_welder_found)
 			surroundings["tool_behaviour"] -= TOOL_WELDER
 

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -141,7 +141,7 @@
 					for(var/datum/reagent/reagent as anything in container.reagents.reagent_list)
 						.["other"][reagent.type] += reagent.volume
 				else //a reagent container that is empty can also be used as a tool. e.g. glass bottle can be used as a rolling pin
-					if(item.tool_behaviour)
+					if(item.tool_behaviour && item.tool_use_check(a, amount = (item.tool_behaviour == TOOL_WELDER ? 1 : 0), silent = TRUE))
 						.["tool_behaviour"] += item.tool_behaviour
 		else if (ismachinery(object))
 			LAZYADDASSOCLIST(.["machinery"], object.type, object)
@@ -162,7 +162,7 @@
 				if(subcontained_item.tool_behaviour)
 					present_qualities[subcontained_item.tool_behaviour] = TRUE
 		available_tools[contained_item.type] = TRUE
-		if(contained_item.tool_behaviour)
+		if(contained_item.tool_behaviour && contained_item.tool_use_check(source, amount = (contained_item.tool_behaviour == TOOL_WELDER ? 1 : 0), silent = TRUE))
 			present_qualities[contained_item.tool_behaviour] = TRUE
 
 	for(var/quality in surroundings["tool_behaviour"])
@@ -451,37 +451,6 @@
 	data["display_compact"] = display_compact
 
 	var/list/surroundings = get_surroundings(user)
-	var/fueled_welder_found = FALSE
-
-	// set as found as these omnitools don't have fuel, they just work
-	if ((/obj/item/debug/omnitool in surroundings["instances"]) || (/obj/item/abductor/alien_omnitool in surroundings["instances"]))
-		fueled_welder_found = TRUE
-
-	if(!fueled_welder_found)
-		//check if the welders have fuel
-		for (var/obj/item/weldingtool/welder in surroundings["instances"][/obj/item/weldingtool])
-			if (welder.get_fuel() != 0)
-				fueled_welder_found = TRUE
-				break
-
-		// this check is to stop redundant checks since only one welder needs to work for the recipe
-		if (!fueled_welder_found)
-			//check if the lighters have fuel
-			for (var/obj/item/lighter/lighter in surroundings["instances"][/obj/item/lighter])
-				if (lighter.get_fuel() != 0)
-					fueled_welder_found = TRUE
-					break
-
-		if(!fueled_welder_found)
-			//check if the plasmacutter have fuel
-			for (var/obj/item/gun/energy/plasmacutter/plasmacutter in surroundings["instances"][/obj/item/gun/energy/plasmacutter])
-				if (plasmacutter.cell.charge != 0)
-					fueled_welder_found = TRUE
-					break
-
-		//if no fueled welder found, remove the welding as an available tool
-		if(!fueled_welder_found)
-			surroundings["tool_behaviour"] -= TOOL_WELDER
 
 	var/list/craftability = list()
 	for(var/datum/crafting_recipe/recipe as anything in (mode ? GLOB.cooking_recipes : GLOB.crafting_recipes))

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -451,6 +451,15 @@
 	data["display_compact"] = display_compact
 
 	var/list/surroundings = get_surroundings(user)
+	var/fueled_welder_count = 0
+	for (var/obj/item/weldingtool/welder in surroundings["instances"][/obj/item/weldingtool])
+		fueled_welder_count++
+		if (welder.reagents.get_reagent_amount(/datum/reagent/fuel) == 0)
+			fueled_welder_count--
+
+	if(fueled_welder_count == 0)
+		surroundings["tool_behaviour"] -= "welder"
+
 	var/list/craftability = list()
 	for(var/datum/crafting_recipe/recipe as anything in (mode ? GLOB.cooking_recipes : GLOB.crafting_recipes))
 		if(!is_recipe_available(recipe, user))

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -451,14 +451,32 @@
 	data["display_compact"] = display_compact
 
 	var/list/surroundings = get_surroundings(user)
-	var/fueled_welder_count = 0
-	for (var/obj/item/weldingtool/welder in surroundings["instances"][/obj/item/weldingtool])
-		fueled_welder_count++
-		if (welder.reagents.get_reagent_amount(/datum/reagent/fuel) == 0)
-			fueled_welder_count--
+	var/fueled_welder_found = FALSE
+	var/special_welder_found = FALSE
 
-	if(fueled_welder_count == 0)
-		surroundings["tool_behaviour"] -= "welder"
+	if ((/obj/item/debug/omnitool in surroundings["instances"]) || (/obj/item/abductor/alien_omnitool in surroundings["instances"]))
+		special_welder_found = TRUE
+
+	if(!special_welder_found)
+		for (var/obj/item/weldingtool/welder in surroundings["instances"][/obj/item/weldingtool])
+			if (welder.get_fuel() != 0)
+				fueled_welder_found = TRUE
+				break
+
+		if (!fueled_welder_found)
+			for (var/obj/item/lighter/lighter in surroundings["instances"][/obj/item/lighter])
+				if (lighter.get_fuel() != 0)
+					fueled_welder_found = TRUE
+					break
+
+		if(!fueled_welder_found)
+			for (var/obj/item/gun/energy/plasmacutter/plasmacutter in surroundings["instances"][/obj/item/gun/energy/plasmacutter])
+				if (plasmacutter.cell.charge != 0)
+					fueled_welder_found = TRUE
+					break
+
+		if(!fueled_welder_found)
+			surroundings["tool_behaviour"] -= TOOL_WELDER
 
 	var/list/craftability = list()
 	for(var/datum/crafting_recipe/recipe as anything in (mode ? GLOB.cooking_recipes : GLOB.crafting_recipes))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1187,7 +1187,7 @@
 		SEND_SIGNAL(src, COMSIG_TOOL_START_USE, user)
 
 /// A check called by [/obj/item/proc/tool_start_check] once, and by use_tool on every tick of delay.
-/obj/item/proc/tool_use_check(mob/living/user, amount, heat_required)
+/obj/item/proc/tool_use_check(mob/living/user, amount, heat_required, silent = FALSE)
 	return !amount
 
 /// Generic use proc. Depending on the item, it uses up fuel, charges, sheets, etc. Returns TRUE on success, FALSE on failure.

--- a/code/game/objects/items/lighter.dm
+++ b/code/game/objects/items/lighter.dm
@@ -207,12 +207,14 @@
 		cig.light(span_notice("[user] holds the [name] out for [target_mob], and lights [target_mob.p_their()] [cig.name]."))
 
 ///Checks if the lighter is able to perform a welding task.
-/obj/item/lighter/tool_use_check(mob/living/user, amount, heat_required)
+/obj/item/lighter/tool_use_check(mob/living/user, amount, heat_required, silent = FALSE)
 	if(!lit)
-		to_chat(user, span_warning("[src] has to be on to complete this task!"))
+		if(!silent)
+			to_chat(user, span_warning("[src] has to be on to complete this task!"))
 		return FALSE
 	if(get_fuel() < amount)
-		to_chat(user, span_warning("You need more welding fuel to complete this task!"))
+		if(!silent)
+			to_chat(user, span_warning("You need more welding fuel to complete this task!"))
 		return FALSE
 	if(heat < heat_required)
 		return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -535,18 +535,20 @@
 	update_weight()
 	return TRUE
 
-/obj/item/stack/tool_use_check(mob/living/user, amount, heat_required)
+/obj/item/stack/tool_use_check(mob/living/user, amount, heat_required, silent = FALSE)
 	if(get_amount() < amount)
 		// general balloon alert that says they don't have enough
-		user.balloon_alert(user, "not enough material!")
+		if(!silent)
+			user.balloon_alert(user, "not enough material!")
 		// then a more specific message about how much they need and what they need specifically
-		if(singular_name)
-			if(amount > 1)
-				to_chat(user, span_warning("You need at least [amount] [singular_name]\s to do this!"))
+
+			if(singular_name)
+				if(amount > 1)
+					to_chat(user, span_warning("You need at least [amount] [singular_name]\s to do this!"))
+				else
+					to_chat(user, span_warning("You need at least [amount] [singular_name] to do this!"))
 			else
-				to_chat(user, span_warning("You need at least [amount] [singular_name] to do this!"))
-		else
-			to_chat(user, span_warning("You need at least [amount] to do this!"))
+				to_chat(user, span_warning("You need at least [amount] to do this!"))
 
 		return FALSE
 

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -274,15 +274,18 @@
 	return welding
 
 /// If welding tool ran out of fuel during a construction task, construction fails.
-/obj/item/weldingtool/tool_use_check(mob/living/user, amount, heat_required)
+/obj/item/weldingtool/tool_use_check(mob/living/user, amount, heat_required, silent = FALSE)
 	if(!isOn() || !check_fuel())
-		to_chat(user, span_warning("[src] has to be on to complete this task!"))
+		if(!silent)
+			to_chat(user, span_warning("[src] has to be on to complete this task!"))
 		return FALSE
 	if(get_fuel() < amount)
-		to_chat(user, span_warning("You need more welding fuel to complete this task!"))
+		if(!silent)
+			to_chat(user, span_warning("You need more welding fuel to complete this task!"))
 		return FALSE
 	if(heat < heat_required)
-		to_chat(user, span_warning("[src] is not hot enough to complete this task!"))
+		if(!silent)
+			to_chat(user, span_warning("[src] is not hot enough to complete this task!"))
 		return FALSE
 	return TRUE
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -141,18 +141,21 @@
 
 // Can we weld? Plasma cutter does not use charge continuously.
 // Amount cannot be defaulted to 1: most of the code specifies 0 in the call.
-/obj/item/gun/energy/plasmacutter/tool_use_check(mob/living/user, amount, heat_required)
+/obj/item/gun/energy/plasmacutter/tool_use_check(mob/living/user, amount, heat_required, silent = FALSE)
 	if(QDELETED(cell))
-		balloon_alert(user, "no cell inserted!")
+		if(!silent)
+			balloon_alert(user, "no cell inserted!")
 		return FALSE
 	// Amount cannot be used if drain is made continuous, e.g. amount = 5, charge_weld = 25
 	// Then it'll drain 125 at first and 25 periodically, but fail if charge dips below 125 even though it still can finish action
 	// Alternately it'll need to drain amount*charge_weld every period, which is either obscene or makes it free for other uses
 	if(amount ? cell.charge < PLASMA_CUTTER_CHARGE_WELD * amount : cell.charge < PLASMA_CUTTER_CHARGE_WELD)
-		balloon_alert(user, "not enough charge!")
+		if(!silent)
+			balloon_alert(user, "not enough charge!")
 		return FALSE
 	if(heat < heat_required)
-		to_chat(user, span_warning("[src] is not hot enough to complete this task!"))
+		if(!silent)
+			to_chat(user, span_warning("[src] is not hot enough to complete this task!"))
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

This PR makes it so the crafting respects if a welding tool has fuel or not to be used as a tool. Just makes sense that there should be fuel in the welder that will be used for welding.

 * Closes #87240.
## Why It's Good For The Game

Makes sense that you need fuel to weld for crafting.
## Changelog
:cl:
fix: fixed an oversight that allowed crafting with empty welder
/:cl:
