### PR TITLE
Revert "Master-overlayed screen alerts (i.e aura healing) now use appearance cloning instead of directly overlaying the master"

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -51,15 +51,13 @@
 	thealert.owner = src
 
 	if(new_master)
-		var/mutable_appearance/master_appearance = new(new_master)
-		master_appearance.appearance_flags = KEEP_TOGETHER
-		master_appearance.layer = FLOAT_LAYER
-		master_appearance.plane = FLOAT_PLANE
-		master_appearance.dir = SOUTH
-		master_appearance.pixel_x = new_master.base_pixel_x
-		master_appearance.pixel_y = new_master.base_pixel_y
-		master_appearance.pixel_z = new_master.base_pixel_z
-		thealert.add_overlay(master_appearance)
+		var/old_layer = new_master.layer
+		var/old_plane = new_master.plane
+		new_master.layer = FLOAT_LAYER
+		new_master.plane = FLOAT_PLANE
+		thealert.add_overlay(new_master)
+		new_master.layer = old_layer
+		new_master.plane = old_plane
 		thealert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 		thealert.master_ref = master_ref
 	else


### PR DESCRIPTION
Reverts tgstation/tgstation#87281

This copies stuff like lighting overlays which are really big so it breaks your screen

![image](https://github.com/user-attachments/assets/fa3765e8-45fc-4d7b-96b2-b10c6a9eba0d)
