### PR TITLE
[NO GBP] Fix overlay lighting messing up alert overlays

### DIFF
--- a/code/__DEFINES/overlays.dm
+++ b/code/__DEFINES/overlays.dm
@@ -23,5 +23,3 @@
 			}\
 		} \
 	}
-
-#define IS_LIGHTING_UNDERLAY(appearance) (PLANE_TO_TRUE(appearance.plane) == O_LIGHTING_VISUAL_PLANE)

--- a/code/__DEFINES/overlays.dm
+++ b/code/__DEFINES/overlays.dm
@@ -23,3 +23,5 @@
 			}\
 		} \
 	}
+
+#define IS_LIGHTING_UNDERLAY(appearance) (PLANE_TO_TRUE(appearance.plane) == O_LIGHTING_VISUAL_PLANE)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1274,10 +1274,11 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 
 	return alert_overlay
 
-/// Strips all lighting underlays from a mutable appearance.
-/proc/strip_light_underlays(mutable_appearance/appearance) as /mutable_appearance
-	RETURN_TYPE(/mutable_appearance)
+/// Strips all underlays on a different plane from an appearance.
+/// Returns the stripped appearance.
+/proc/strip_appearance_underlays(mutable_appearance/appearance)
+	var/base_plane = PLANE_TO_TRUE(appearance.plane)
 	for(var/mutable_appearance/underlay as anything in appearance.underlays)
-		if(IS_LIGHTING_UNDERLAY(underlay))
+		if(PLANE_TO_TRUE(underlay.plane) != base_plane)
 			appearance.underlays -= underlay
 	return appearance

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1273,3 +1273,10 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	alert_overlay.transform = alert_overlay.transform.Scale(scale)
 
 	return alert_overlay
+
+/proc/strip_light_underlays(mutable_appearance/appearance) as /mutable_appearance
+	RETURN_TYPE(/mutable_appearance)
+	for(var/mutable_appearance/underlay as anything in appearance.underlays)
+		if(IS_LIGHTING_UNDERLAY(underlay))
+			appearance.underlays -= underlay
+	return appearance

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1274,6 +1274,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 
 	return alert_overlay
 
+/// Strips all lighting underlays from a mutable appearance.
 /proc/strip_light_underlays(mutable_appearance/appearance) as /mutable_appearance
 	RETURN_TYPE(/mutable_appearance)
 	for(var/mutable_appearance/underlay as anything in appearance.underlays)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -59,7 +59,7 @@
 		master_appearance.pixel_x = new_master.base_pixel_x
 		master_appearance.pixel_y = new_master.base_pixel_y
 		master_appearance.pixel_z = new_master.base_pixel_z
-		thealert.add_overlay(master_appearance)
+		thealert.add_overlay(strip_light_underlays(master_appearance))
 		thealert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 		thealert.master_ref = master_ref
 	else

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -59,7 +59,7 @@
 		master_appearance.pixel_x = new_master.base_pixel_x
 		master_appearance.pixel_y = new_master.base_pixel_y
 		master_appearance.pixel_z = new_master.base_pixel_z
-		thealert.add_overlay(strip_light_underlays(master_appearance))
+		thealert.add_overlay(strip_appearance_underlays(master_appearance))
 		thealert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 		thealert.master_ref = master_ref
 	else


### PR DESCRIPTION

## About The Pull Request

Closes https://github.com/tgstation/tgstation/pull/87357

Adds a `IS_LIGHTING_UNDERLAY` define, and a `strip_light_underlays` helper that uses it (thanks @Kapu1178 for the code)

### Before

![2024-10-21 (1729553782) ~ dreamseeker](https://github.com/user-attachments/assets/da2778f9-40e0-4760-85aa-a17a7d05f01c)

### After

![2024-10-21 (1729553540) ~ dreamseeker](https://github.com/user-attachments/assets/dd240c83-faf9-4e55-b913-58743aa764f0)

## Changelog
:cl: Absolucy, Kapu
fix: Fix overlay lighting (such as lanterns) messing up alert overlays, i.e the rod of asclepius alert.
/:cl:
