### PR TITLE
Ensure the master and failsafe controllers never have a `usr`

### DIFF
--- a/code/controllers/failsafe.dm
+++ b/code/controllers/failsafe.dm
@@ -24,6 +24,9 @@ GLOBAL_REAL(Failsafe, /datum/controller/failsafe)
 	var/running = TRUE
 
 /datum/controller/failsafe/New()
+	// Ensure usr is null, to prevent any potential weirdness resulting from the failsafe having a usr if it's manually restarted.
+	usr = null
+
 	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
 	if(Failsafe != src)
 		if(istype(Failsafe))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -84,6 +84,9 @@ GLOBAL_REAL(Master, /datum/controller/master)
 	var/rolling_usage_length = 5 SECONDS
 
 /datum/controller/master/New()
+	// Ensure usr is null, to prevent any potential weirdness resulting from the MC having a usr if it's manually restarted.
+	usr = null
+
 	if(!config)
 		config = new
 	// Highlander-style: there can only be one! Kill off the old and replace it with the new.


### PR DESCRIPTION

## About The Pull Request

Let's just uh- yeah, controllers should not have a `usr`, at least right now, and it can cause problems if it does - and running Recreate_MC via the admin verb will result in the restarted controller having a `usr`, which can cause weird problems. So, we set `usr` to null in first thing both `/datum/controller/master/New()` and `/datum/controller/failsafe/New()`

[MSO's cursed idea of using `usr` to track subsystems](https://discord.com/channels/484170914754330625/484170915253321734/1298172060685828137) will come later, maybe.

## Changelog
:cl:
fix: Fixed a potential rare source of strange behavior resulting from an admin manually restarting the MC.
/:cl:
