### PR TITLE
Fixes benches attempting to add a nonexisting armrest overlay

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -74,6 +74,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	icon_state = "bench_middle"
 	greyscale_config = /datum/greyscale_config/bench_middle
 	greyscale_colors = "#af7d28"
+	has_armrest = FALSE
 
 /obj/structure/chair/sofa/bench/left
 	icon_state = "bench_left"
@@ -101,6 +102,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	max_integrity = 60
 	buildstacktype = /obj/item/stack/sheet/mineral/bamboo
 	buildstackamount = 3
+	has_armrest = FALSE
 
 /obj/structure/chair/sofa/bamboo/left
 	icon_state = "bamboo_sofaend_left"


### PR DESCRIPTION
## About The Pull Request

Benches produced an error overlay when you buckled to them, due to them inheriting `has_armrest = TRUE` from sofas. This PR fixes that.

## Why It's Good For The Game

Closes #87364

~~There is also #87338 but that is a duplicate.~~  Closed.

## Changelog

:cl:
fix: Benches no longer produce an Error overlay when buckled
/:cl:

