### PR TITLE
Blob zombies inherit the faction of the blob spore when created

### DIFF
--- a/code/modules/mob/living/basic/blob_minions/blob_spore.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_spore.dm
@@ -56,6 +56,7 @@
 /mob/living/basic/blob_minion/spore/proc/zombify(mob/living/carbon/human/target)
 	visible_message(span_warning("The corpse of [target.name] suddenly rises!"))
 	var/mob/living/basic/blob_minion/zombie/blombie = change_mob_type(zombie_type, loc, new_name = initial(zombie_type.name))
+	blombie.faction |= faction //inherit the spore's faction in case it was spawned with a different one (eg gold core)
 	blombie.set_name()
 	if (istype(blombie)) // In case of badmin
 		blombie.consume_corpse(target)


### PR DESCRIPTION
## About The Pull Request

...which means that any blob spore with a different faction (i.e. gold core spawned with a blood reaction have `FACTION_NEUTRAL`) will assign the blob zombie its faction.

## Why It's Good For The Game

Fixes #66728

## Changelog

:cl:
fix: blob zombies inherit the blob spore's faction now, which means gold extract-spawned passive blob spores won't make aggressive blob zombies
/:cl: