### PR TITLE
Removes the unused GLOB.alcohol_containers

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -80,6 +80,3 @@ GLOBAL_LIST_EMPTY(roundstart_station_borgcharger_areas)
 
 /// List of area names of roundstart station mech rechargers, for the low charge/no charge mech screen alert tooltips.
 GLOBAL_LIST_EMPTY(roundstart_station_mechcharger_areas)
-
-/// Associative list of alcoholic container typepath to instances, currently used by the alcoholic quirk
-GLOBAL_LIST_INIT(alcohol_containers, init_alcohol_containers())

--- a/code/datums/quirks/negative_quirks/addict.dm
+++ b/code/datums/quirks/negative_quirks/addict.dm
@@ -211,7 +211,7 @@
 	RegisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK, PROC_REF(check_brandy))
 	var/obj/item/reagent_containers/brandy_container = drug_container_type
 	if(isnull(brandy_container))
-		stack_trace("Alcoholic quirk added while the GLOB.alcohol_containers is (somehow) not initialized!")
+		stack_trace("Alcoholic quirk added while the GLOB.possible_alcoholic_addictions is (somehow) not initialized!")
 		brandy_container = new drug_container_type
 		qdel(brandy_container)
 

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -4,18 +4,6 @@
 //Functionally identical to regular drinks. The only difference is that the default bottle size is 100. - Darem
 //Bottles now knockdown and break when smashed on people's heads. - Giacom
 
-/// Initializes GLOB.alcohol_containers, only containers that actually have reagents are added to the list.
-/proc/init_alcohol_containers()
-	var/list/containers = subtypesof(/obj/item/reagent_containers/cup/glass/bottle)
-	for(var/typepath in containers)
-		containers -= typepath
-		var/obj/item/reagent_containers/cup/glass/bottle/instance = new typepath
-		if(!length(instance.list_reagents))
-			qdel(instance)
-			continue
-		containers[typepath] = instance
-	return containers
-
 /obj/item/reagent_containers/cup/glass/bottle
 	name = "glass bottle"
 	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."


### PR DESCRIPTION

## About The Pull Request

This PR removes the unused GLOB.alcohol_containers. It used to be used by the alcoholic quirk, before it was changed to use a much more sensible dictionary. The PR also updates the warning given when the selected alcoholic container is null, to make it refer to the new dictionary.

## Why It's Good For The Game

Its initialization code was unused, and also, spawned every single alcoholic container in nullspace. This was done so originally because `initial()` could not retrieve lists. With the new dictionary, this is not needed anymore.

## Changelog

Nothing player facing
