### PR TITLE
Ports pixelshifting from monkestation

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -54,6 +54,11 @@
 #define COMSIG_KB_LIVING_DISABLE_COMBAT_DOWN "keybinding_living_disable_combat_down"
 #define COMSIG_KB_LIVING_TOGGLEMOVEINTENT_DOWN "keybinding_mob_togglemoveintent_down"
 #define COMSIG_KB_LIVING_TOGGLEMOVEINTENTALT_DOWN "keybinding_mob_togglemoveintentalt_down"
+#define COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN "keybinding_living_item_pixelshift_down"
+#define COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_UP "keybinding_living_item_pixelshift_up"
+#define COMSIG_KB_LIVING_PIXELSHIFT	"keybinding_living_pixelshift"
+#define COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN "keybinding_living_pixelshift_down"
+#define COMSIG_KB_LIVING_PIXEL_SHIFT_UP "keybinding_living_pixelshift_up"
 
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"

--- a/code/__DEFINES/living.dm
+++ b/code/__DEFINES/living.dm
@@ -13,3 +13,13 @@
 
 /// Getter for a mob/living's lying angle, otherwise protected
 #define GET_LYING_ANGLE(mob) (UNLINT(mob.lying_angle))
+
+//  || pixelshifting ||
+///from base of living/set_pull_offset(): (mob/living/pull_target, grab_state)
+#define COMSIG_LIVING_SET_PULL_OFFSET "living_set_pull_offset"
+///from base of living/reset_pull_offsets(): (mob/living/pull_target, override)
+#define COMSIG_LIVING_RESET_PULL_OFFSETS "living_reset_pull_offsets"
+///from base of living/CanAllowThrough(): (atom/movable/mover, border_dir)
+#define COMSIG_LIVING_CAN_ALLOW_THROUGH "living_can_allow_through"
+/// Allow to movable atoms to pass through this living mob
+#define COMPONENT_LIVING_PASSABLE (1<<0)

--- a/code/datums/components/pixelshifting.dm
+++ b/code/datums/components/pixelshifting.dm
@@ -1,0 +1,143 @@
+#define SHIFTING_PARENT 1
+#define SHIFTING_ITEMS 2
+
+/datum/component/pixel_shift
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	//what type of shifting parent is doing, or if they aren't shifting at all
+	var/shifting = FALSE
+	//the maximum amount we/an item can move
+	var/maximum_pixel_shift = 16
+	//If we are shifted
+	var/is_shifted = FALSE
+	//Allows atoms entering Parent's turf to pass through freely from given directions
+	var/passthroughable = NONE
+	//Amount of shifting necessary to make the parent passthroughable
+	var/passthrough_threshold = 8
+
+/datum/component/pixel_shift/Initialize(...)
+	. = ..()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/pixel_shift/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN, PROC_REF(item_pixel_shift_down))
+	RegisterSignal(parent, COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_UP, PROC_REF(item_pixel_shift_up))
+	RegisterSignal(parent, COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN, PROC_REF(pixel_shift_down))
+	RegisterSignal(parent, COMSIG_KB_LIVING_PIXEL_SHIFT_UP, PROC_REF(pixel_shift_up))
+	RegisterSignals(parent, list(COMSIG_LIVING_RESET_PULL_OFFSETS, COMSIG_LIVING_SET_PULL_OFFSET, COMSIG_MOVABLE_MOVED), PROC_REF(unpixel_shift))
+	RegisterSignal(parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(pre_move_check))
+	RegisterSignal(parent, COMSIG_LIVING_CAN_ALLOW_THROUGH, PROC_REF(check_passable))
+
+/datum/component/pixel_shift/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN,
+		COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_UP,
+		COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN,
+		COMSIG_KB_LIVING_PIXEL_SHIFT_UP,
+		COMSIG_MOB_CLIENT_PRE_LIVING_MOVE,
+		COMSIG_LIVING_RESET_PULL_OFFSETS,
+		COMSIG_LIVING_SET_PULL_OFFSET,
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_LIVING_CAN_ALLOW_THROUGH,
+	))
+
+//locks our movement when holding our keybinds
+/datum/component/pixel_shift/proc/pre_move_check(mob/source, new_loc, direct)
+	SIGNAL_HANDLER
+	if(shifting)
+		pixel_shift(source, direct)
+		return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
+
+//Procs for shifting items
+
+/datum/component/pixel_shift/proc/item_pixel_shift_down()
+	SIGNAL_HANDLER
+	shifting = SHIFTING_ITEMS
+	return COMSIG_KB_ACTIVATED
+
+/datum/component/pixel_shift/proc/item_pixel_shift_up()
+	SIGNAL_HANDLER
+	shifting = FALSE
+
+//Procs for shifting mobs
+
+/datum/component/pixel_shift/proc/pixel_shift_down()
+	SIGNAL_HANDLER
+	shifting = SHIFTING_PARENT
+	return COMSIG_KB_ACTIVATED
+
+/datum/component/pixel_shift/proc/pixel_shift_up()
+	SIGNAL_HANDLER
+	shifting = FALSE
+
+/// Checks if the parent is considered passthroughable from a direction. Projectiles will ignore the check and hit.
+/datum/component/pixel_shift/proc/check_passable(mob/source, atom/movable/mover, border_dir)
+	SIGNAL_HANDLER
+	if(!isprojectile(mover) && !mover.throwing && (passthroughable & border_dir))
+		return COMPONENT_LIVING_PASSABLE
+
+/// Sets parent pixel offsets to default and deletes the component.
+/datum/component/pixel_shift/proc/unpixel_shift()
+	SIGNAL_HANDLER
+	passthroughable = NONE
+	if(is_shifted)
+		var/mob/living/owner = parent
+		owner.pixel_x = owner.body_position_pixel_x_offset + owner.base_pixel_x
+		owner.pixel_y = owner.body_position_pixel_y_offset + owner.base_pixel_y
+	qdel(src)
+
+/// In-turf pixel movement which can allow things to pass through if the threshold is met.
+/datum/component/pixel_shift/proc/pixel_shift(mob/source, direct)
+	passthroughable = NONE
+	var/mob/living/owner = parent
+	switch(shifting)
+		if(SHIFTING_ITEMS)
+			var/atom/pulled_atom = source.pulling
+			if(!isitem(pulled_atom))
+				return
+			var/obj/item/pulled_item = pulled_atom
+			switch(direct)
+				if(NORTH)
+					if(pulled_item.pixel_y <= maximum_pixel_shift + pulled_item.base_pixel_y)
+						pulled_item.pixel_y++
+				if(EAST)
+					if(pulled_item.pixel_x <= maximum_pixel_shift + pulled_item.base_pixel_x)
+						pulled_item.pixel_x++
+				if(SOUTH)
+					if(pulled_item.pixel_y >= -maximum_pixel_shift + pulled_item.base_pixel_y)
+						pulled_item.pixel_y--
+				if(WEST)
+					if(pulled_item.pixel_x >= -maximum_pixel_shift + pulled_item.base_pixel_x)
+						pulled_item.pixel_x--
+		if(SHIFTING_PARENT)
+			switch(direct)
+				if(NORTH)
+					if(owner.pixel_y <= maximum_pixel_shift + owner.base_pixel_y)
+						owner.pixel_y++
+						is_shifted = TRUE
+				if(EAST)
+					if(owner.pixel_x <= maximum_pixel_shift + owner.base_pixel_x)
+						owner.pixel_x++
+						is_shifted = TRUE
+				if(SOUTH)
+					if(owner.pixel_y >= -maximum_pixel_shift + owner.base_pixel_y)
+						owner.pixel_y--
+						is_shifted = TRUE
+				if(WEST)
+					if(owner.pixel_x >= -maximum_pixel_shift + owner.base_pixel_x)
+						owner.pixel_x--
+						is_shifted = TRUE
+
+	// Yes, I know this sets it to true for everything if more than one is matched.
+	// Movement doesn't check diagonals, and instead just checks EAST or WEST, depending on where you are for those.
+	if(owner.pixel_y > passthrough_threshold)
+		passthroughable |= EAST | SOUTH | WEST
+	else if(owner.pixel_y < -passthrough_threshold)
+		passthroughable |= NORTH | EAST | WEST
+	if(owner.pixel_x > passthrough_threshold)
+		passthroughable |= NORTH | SOUTH | WEST
+	else if(owner.pixel_x < -passthrough_threshold)
+		passthroughable |= NORTH | EAST | SOUTH
+
+#undef SHIFTING_PARENT
+#undef SHIFTING_ITEMS

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -152,3 +152,42 @@
 	var/mob/living/M = user.mob
 	M.toggle_move_intent()
 	return TRUE
+
+
+/datum/keybinding/living/item_pixel_shift
+	hotkey_keys = list("V")
+	name = "item_pixel_shift"
+	full_name = "Item Pixel Shift"
+	description = "Shift a pulled item's offset"
+	category = CATEGORY_MISC
+	keybind_signal = COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN
+
+/datum/keybinding/living/item_pixel_shift/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mob.AddComponent(/datum/component/pixel_shift)
+	SEND_SIGNAL(user.mob, COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN)
+
+/datum/keybinding/living/item_pixel_shift/up(client/user)
+	. = ..()
+	SEND_SIGNAL(user.mob, COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_UP)
+
+/datum/keybinding/living/pixel_shift
+	hotkey_keys = list("C")
+	name = "pixel_shift"
+	full_name = "Pixel Shift"
+	description = "Shift your character's offset."
+	category = CATEGORY_MOVEMENT
+	keybind_signal = COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN
+
+/datum/keybinding/living/pixel_shift/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mob.AddComponent(/datum/component/pixel_shift)
+	SEND_SIGNAL(user.mob, COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN)
+
+/datum/keybinding/living/pixel_shift/up(client/user)
+	. = ..()
+	SEND_SIGNAL(user.mob, COMSIG_KB_LIVING_PIXEL_SHIFT_UP)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -66,6 +66,8 @@
 		return TRUE
 	if(ismob(mover) && (mover in buckled_mobs))
 		return TRUE
+	if(SEND_SIGNAL(src, COMSIG_LIVING_CAN_ALLOW_THROUGH, mover, border_dir) & COMPONENT_LIVING_PASSABLE)
+		return TRUE
 	return !mover.density || body_position == LYING_DOWN
 
 /mob/living/update_config_movespeed()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1187,6 +1187,7 @@
 #include "code\datums\components\phylactery.dm"
 #include "code\datums\components\pinata.dm"
 #include "code\datums\components\pinnable_accessory.dm"
+#include "code\datums\components\pixelshifting.dm"
 #include "code\datums\components\plundering_attacks.dm"
 #include "code\datums\components\pricetag.dm"
 #include "code\datums\components\profound_fisher.dm"


### PR DESCRIPTION
## About The Pull Request
port of https://github.com/Monkestation/Monkestation2.0/pull/2850 with some minor changes, namely V as the pixel shift keybind and shift+V as the item pixel shift keybind as the defaults.

https://github.com/user-attachments/assets/827d3322-539c-479a-be82-55169d2fb118

Note: I don't think it warrants wall leaning removal as that one has other benefits like fov vision increase and cigarette fluff, plus wall leaning is faster than pixel shifting.
## Why It's Good For The Game
I think it adds a neat RP mechanic, you can lean on machines, then accidentally fall over and break it, lean into people's faces to scream at them, lean over a railing. For a sandbox roleplaying game I think it's a must.
## Changelog
:cl: Odairu and grungussuss
add: Living mobs can now pixel shift their character, the default keybind for this is V!
add: Living mobs can now pixel shift items they are dragging, the default keybind for this is Shift+V!
/:cl:
