### PR TITLE
Human authority defaults edit

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -108,7 +108,7 @@
 /datum/config_entry/flag/protect_assistant_from_antagonist //If assistants can be traitor/cult/other
 
 /datum/config_entry/string/human_authority //Controls how to enforce human authority
-	default = "HUMAN_WHITELIST"
+	default = "DISABLED"
 
 /////////////////////////////////////////////////Outdated human authority settings
 /datum/config_entry/flag/enforce_human_authority

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -127,7 +127,8 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## "HUMAN_WHITELIST": all heads-of-staff jobs will be able to be played by non-humans, unless that job incorporates the "human only" flag (Which can be configured via a variable or the job config txt).
 ## "NON_HUMAN_WHITELIST": non-humans will not be able to play as heads of staff, unless that job incorporates the "allow non-humans" flag (Which can be configured via a variable or the job config txt).
 ## "ENFORCED": non-humans cannot be heads of staff, only humans can. the "allow non-humans" setting will be ignored.
-HUMAN_AUTHORITY HUMAN_WHITELIST
+## Uncomment to enable a human authority mode of your choice.
+#HUMAN_AUTHORITY HUMAN_WHITELIST
 
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS


### PR DESCRIPTION
## About The Pull Request

Extremely simple PR that edits the defaults for the new config options added in #86886 - this restores the default behaviour that was in place before #86886; human authority is disabled but easily restored to TG norms by uncommenting the associated line in the config.

This doesn't impact any of the TG servers directly since they're all on TGS and have static config files, but this does avoid downstreams being blindsided by their configs mysteriously breaking and test instances having behaviour change.  I spent an embarrassing amount of time trying to figure out what *I* broke the past day, only to realize it was an upstream issue breaking configs all along, and I strongly suspect I won't be the only one.

## Why It's Good For The Game

No impact on the TG playerbase directly, this is just for the sanity of developers and downstreams that use static configs.  More time spent being productive, less time spent wondering if your PR buggered up spawnin and humanized everyone.

## Changelog

:cl:
config: altered coded defaults for human authority, no impact on TG
/:cl:
