### PR TITLE
[No GBP] Deluxe Vegan Donk Pockets now stay vegan when cooked

### DIFF
--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -342,7 +342,7 @@
 	tastes = list("rice patty" = 2, "dough" = 2, "peppery kick" = 1)
 	foodtypes = GRAIN | VEGETABLES
 	crafting_complexity = FOOD_COMPLEXITY_4
-	warm_type = /obj/item/food/donkpocket/warm/deluxe/nocarb
+	warm_type = /obj/item/food/donkpocket/warm/deluxe/vegan
 
 /obj/item/food/donkpocket/deluxe/vegan/make_bakeable()
 	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, deluxe_added_reagents)

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -310,7 +310,6 @@
 	tastes = list("raw meat" = 2, "more meat" = 2, "no carbs" = 1)
 	foodtypes = MEAT | RAW
 	crafting_complexity = FOOD_COMPLEXITY_4
-
 	warm_type = /obj/item/food/donkpocket/warm/deluxe/nocarb
 
 /obj/item/food/donkpocket/deluxe/meat/make_bakeable()
@@ -343,6 +342,7 @@
 	tastes = list("rice patty" = 2, "dough" = 2, "peppery kick" = 1)
 	foodtypes = GRAIN | VEGETABLES
 	crafting_complexity = FOOD_COMPLEXITY_4
+	warm_type = /obj/item/food/donkpocket/warm/deluxe/nocarb
 
 /obj/item/food/donkpocket/deluxe/vegan/make_bakeable()
 	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, deluxe_added_reagents)


### PR DESCRIPTION

## About The Pull Request
There was a missing line so cooking the vegan option defaulted to giving you the meat-filled version instead.
## Why It's Good For The Game
bugfix
## Changelog
:cl:
fix: Donk-Rolls no longer turn into Deluxe Donk Pockets when microwaved.
/:cl:
