### PR TITLE
Adds Allergic reactions to a few things (Bee stings, Beer)

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -565,7 +565,7 @@ Behavior that's still missing from this component that original food items had t
 	last_check_time = world.time
 
 	var/food_quality = get_perceived_food_quality(gourmand)
-	if(food_quality <= FOOD_QUALITY_DANGEROUS && gourmand.check_allergic_reaction(foodtypes))
+	if(food_quality <= FOOD_QUALITY_DANGEROUS && gourmand.check_allergic_reaction(foodtypes, chance = 100, histamine_add = 10))
 		return
 
 	if(food_quality <= TOXIC_FOOD_QUALITY_THRESHOLD)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -565,10 +565,7 @@ Behavior that's still missing from this component that original food items had t
 	last_check_time = world.time
 
 	var/food_quality = get_perceived_food_quality(gourmand)
-	if(food_quality <= FOOD_QUALITY_DANGEROUS && (foodtypes & gourmand.get_allergic_foodtypes())) // Only cause anaphylaxis if we're ACTUALLY allergic, otherwise it just tastes horrible
-		if(gourmand.ForceContractDisease(new /datum/disease/anaphylaxis(), make_copy = FALSE, del_on_fail = TRUE))
-			to_chat(gourmand, span_warning("You feel your throat start to itch."))
-			gourmand.add_mood_event("allergic_food", /datum/mood_event/allergic_food)
+	if(food_quality <= FOOD_QUALITY_DANGEROUS && gourmand.check_allergic_reaction(foodtypes))
 		return
 
 	if(food_quality <= TOXIC_FOOD_QUALITY_THRESHOLD)

--- a/code/datums/elements/basic_allergenic_attack.dm
+++ b/code/datums/elements/basic_allergenic_attack.dm
@@ -6,14 +6,17 @@
 	var/allergen = NONE
 	/// Chance of the reaction happening
 	var/allergen_chance = 100
+	/// How much histamine to add to the target on reaction
+	var/histamine_add = 0
 
-/datum/element/basic_allergenic_attack/Attach(datum/target, allergen = NONE, allergen_chance = 100)
+/datum/element/basic_allergenic_attack/Attach(datum/target, allergen = NONE, allergen_chance = 100, histamine_add = 0)
 	. = ..()
 	if(!isbasicmob(target))
 		return ELEMENT_INCOMPATIBLE
 
 	src.allergen = allergen
 	src.allergen_chance = allergen_chance
+	src.histamine_add = histamine_add
 	RegisterSignal(target, COMSIG_HOSTILE_POST_ATTACKINGTARGET, PROC_REF(trigger_allergy))
 
 /datum/element/basic_allergenic_attack/Detach(datum/source, ...)
@@ -28,4 +31,4 @@
 	if(!target.can_inject(source))
 		return
 
-	target.check_allergic_reaction(allergen, allergen_chance)
+	target.check_allergic_reaction(allergen, allergen_chance, histamine_add)

--- a/code/datums/elements/basic_allergenic_attack.dm
+++ b/code/datums/elements/basic_allergenic_attack.dm
@@ -1,0 +1,29 @@
+/// Attach to basic mobs, when they attack, they may trigger a food-based allergic reaction in the target.
+/datum/element/basic_allergenic_attack
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// What allergen is being used. Corresponds to a FOODTYPE
+	var/allergen = NONE
+	/// Chance of the reaction happening
+	var/allergen_chance = 100
+
+/datum/element/basic_allergenic_attack/Attach(datum/target, allergen = NONE, allergen_chance = 100)
+	. = ..()
+	if(!isbasicmob(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.allergen = allergen
+	src.allergen_chance = allergen_chance
+	RegisterSignal(target, COMSIG_HOSTILE_POST_ATTACKINGTARGET, PROC_REF(trigger_allergy))
+
+/datum/element/basic_allergenic_attack/Detach(datum/source, ...)
+	. = ..()
+	UnregisterSignal(source, COMSIG_HOSTILE_POST_ATTACKINGTARGET)
+
+/datum/element/basic_allergenic_attack/proc/trigger_allergy(datum/source, mob/living/target, result)
+	SIGNAL_HANDLER
+
+	if(result <= 0 || !istype(target))
+		return
+
+	target.check_allergic_reaction(allergen, allergen_chance)

--- a/code/datums/elements/basic_allergenic_attack.dm
+++ b/code/datums/elements/basic_allergenic_attack.dm
@@ -20,10 +20,12 @@
 	. = ..()
 	UnregisterSignal(source, COMSIG_HOSTILE_POST_ATTACKINGTARGET)
 
-/datum/element/basic_allergenic_attack/proc/trigger_allergy(datum/source, mob/living/target, result)
+/datum/element/basic_allergenic_attack/proc/trigger_allergy(mob/living/source, mob/living/target, result)
 	SIGNAL_HANDLER
 
 	if(result <= 0 || !istype(target))
+		return
+	if(!target.can_inject(source))
 		return
 
 	target.check_allergic_reaction(allergen, allergen_chance)

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -70,7 +70,7 @@
 	AddComponent(/datum/component/swarming)
 	AddComponent(/datum/component/obeys_commands, pet_commands)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_QUEEN_BEE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
-	AddElement(/datum/element/basic_allergenic_attack, BUGS)
+	AddElement(/datum/element/basic_allergenic_attack, allergen = BUGS, allergen_chance = 33, histamine_add = 5)
 
 /mob/living/basic/bee/mob_pickup(mob/living/picker)
 	if(flags_1 & HOLOGRAM_1)

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -70,6 +70,7 @@
 	AddComponent(/datum/component/swarming)
 	AddComponent(/datum/component/obeys_commands, pet_commands)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_QUEEN_BEE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+	AddElement(/datum/element/basic_allergenic_attack, BUGS)
 
 /mob/living/basic/bee/mob_pickup(mob/living/picker)
 	if(flags_1 & HOLOGRAM_1)

--- a/code/modules/mob/living/basic/space_fauna/ant.dm
+++ b/code/modules/mob/living/basic/space_fauna/ant.dm
@@ -52,7 +52,7 @@
 	AddElement(/datum/element/pet_bonus, "clack")
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
-	AddElement(/datum/element/basic_allergenic_attack, BUGS)
+	AddElement(/datum/element/basic_allergenic_attack, allergen = BUGS, allergen_chance = 20, histamine_add = 5)
 
 /datum/ai_controller/basic_controller/ant
 	blackboard = list(

--- a/code/modules/mob/living/basic/space_fauna/ant.dm
+++ b/code/modules/mob/living/basic/space_fauna/ant.dm
@@ -52,6 +52,7 @@
 	AddElement(/datum/element/pet_bonus, "clack")
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
+	AddElement(/datum/element/basic_allergenic_attack, BUGS)
 
 /datum/ai_controller/basic_controller/ant
 	blackboard = list(

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -69,7 +69,7 @@
 	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!")
 	AddElement(/datum/element/cliff_walking)
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = 1.5)
-	AddElement(/datum/element/basic_allergenic_attack, BUGS)
+	AddElement(/datum/element/basic_allergenic_attack, allergen = BUGS, allergen_chance = 20, histamine_add = 5)
 
 	if(poison_per_bite)
 		AddElement(/datum/element/venomous, poison_type, poison_per_bite, injection_flags = bite_injection_flags)

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -69,6 +69,7 @@
 	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!")
 	AddElement(/datum/element/cliff_walking)
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = 1.5)
+	AddElement(/datum/element/basic_allergenic_attack, BUGS)
 
 	if(poison_per_bite)
 		AddElement(/datum/element/venomous, poison_type, poison_per_bite, injection_flags = bite_injection_flags)

--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -107,10 +107,11 @@
  *
  * * to_foodtype: The food type to check for an allergic reaction to.
  * * chance: The chance of an allergic reaction occurring. Default is 100 (guaranteed).
+ * * histamine_add: The amount of histamine to add to the mob if they are already experiencing an allergic reaction.
  *
  * Returns TRUE if the mob had an allergic reaction, FALSE otherwise.
  */
-/mob/living/proc/check_allergic_reaction(to_foodtype = NONE, chance = 100)
+/mob/living/proc/check_allergic_reaction(to_foodtype = NONE, chance = 100, histamine_add = 0)
 	if(!(get_allergic_foodtypes() & to_foodtype))
 		return FALSE
 	if(!prob(chance))
@@ -118,8 +119,9 @@
 	if(ForceContractDisease(new /datum/disease/anaphylaxis(), make_copy = FALSE, del_on_fail = TRUE))
 		to_chat(src, span_warning("You feel your throat start to itch."))
 		add_mood_event("allergic_food", /datum/mood_event/allergic_food)
-		return TRUE
-	return FALSE
+	else if(histamine_add)
+		reagents.add_reagent(/datum/reagent/toxin/histamine, histamine_add)
+	return TRUE
 
 /**
  * Gets the food reaction a mob would normally have from the given food item,

--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -102,6 +102,26 @@
 	return allergy?.target_foodtypes || NONE
 
 /**
+ * Checks if the mob has an allergic reaction to the given food type.
+ * If so, the mob will contract anaphylaxis.
+ *
+ * * to_foodtype: The food type to check for an allergic reaction to.
+ * * chance: The chance of an allergic reaction occurring. Default is 100 (guaranteed).
+ *
+ * Returns TRUE if the mob had an allergic reaction, FALSE otherwise.
+ */
+/mob/living/proc/check_allergic_reaction(to_foodtype = NONE, chance = 100)
+	if(!(get_allergic_foodtypes() & to_foodtype))
+		return FALSE
+	if(!prob(chance))
+		return FALSE
+	if(ForceContractDisease(new /datum/disease/anaphylaxis(), make_copy = FALSE, del_on_fail = TRUE))
+		to_chat(src, span_warning("You feel your throat start to itch."))
+		add_mood_event("allergic_food", /datum/mood_event/allergic_food)
+		return TRUE
+	return FALSE
+
+/**
  * Gets the food reaction a mob would normally have from the given food item,
  * assuming that no check_liked callback was used in the edible component.
  *

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -98,7 +98,7 @@
 /datum/reagent/consumable/ethanol/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with ethanol isn't quite as good as fuel.
 	. = ..()
 	if(methods & INGEST)
-		exposed_mob.check_allergic_reaction(ALCOHOL, reac_volume * 5)
+		exposed_mob.check_allergic_reaction(ALCOHOL, chance = reac_volume * 5, histamine_add = min(10, reac_volume))
 
 	if(methods & (TOUCH|VAPOR|PATCH))
 		exposed_mob.adjust_fire_stacks(reac_volume / 15)

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -97,19 +97,14 @@
 
 /datum/reagent/consumable/ethanol/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with ethanol isn't quite as good as fuel.
 	. = ..()
-	if(!(methods & (TOUCH|VAPOR|PATCH)))
-		return
+	if(methods & INGEST)
+		exposed_mob.check_allergic_reaction(ALCOHOL, reac_volume * 5)
 
-	exposed_mob.adjust_fire_stacks(reac_volume / 15)
-
-	if(!iscarbon(exposed_mob))
-		return
-
-	var/mob/living/carbon/exposed_carbon = exposed_mob
-	var/power_multiplier = boozepwr / 65 // Weak alcohol has less sterilizing power
-
-	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(0.1 * power_multiplier, surgery.speed_modifier)
+	if(methods & (TOUCH|VAPOR|PATCH))
+		exposed_mob.adjust_fire_stacks(reac_volume / 15)
+		var/power_multiplier = boozepwr / 65 // Weak alcohol has less sterilizing power
+		for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
+			surgery.speed_modifier = max(0.1 * power_multiplier, surgery.speed_modifier)
 
 /datum/reagent/consumable/ethanol/beer
 	name = "Beer"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -305,7 +305,7 @@
 /datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
 	if(methods & INGEST)
-		exposed_mob.check_allergic_reaction(SUGAR, reac_volume * 10)
+		exposed_mob.check_allergic_reaction(SUGAR, chance = reac_volume * 10, histamine_add = min(10, reac_volume * 2))
 
 /datum/reagent/consumable/virus_food
 	name = "Virus Food"
@@ -1012,6 +1012,11 @@
 	taste_description = "caramel"
 	reagent_state = SOLID
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/consumable/caramel/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
+	. = ..()
+	if(methods & INGEST)
+		exposed_mob.check_allergic_reaction(SUGAR, chance = reac_volume * 10, histamine_add = min(10, reac_volume * 2))
 
 /datum/reagent/consumable/char
 	name = "Char"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -302,6 +302,11 @@
 	. = ..()
 	affected_mob.adjust_drowsiness_up_to((5 SECONDS * REM * seconds_per_tick), 60 SECONDS)
 
+/datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with ethanol isn't quite as good as fuel.
+	. = ..()
+	if(methods & INGEST)
+		exposed_mob.check_allergic_reaction(SUGAR, reac_volume * 10)
+
 /datum/reagent/consumable/virus_food
 	name = "Virus Food"
 	description = "A mixture of water and milk. Virus cells can use this mixture to reproduce."

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -302,7 +302,7 @@
 	. = ..()
 	affected_mob.adjust_drowsiness_up_to((5 SECONDS * REM * seconds_per_tick), 60 SECONDS)
 
-/datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with ethanol isn't quite as good as fuel.
+/datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
 	if(methods & INGEST)
 		exposed_mob.check_allergic_reaction(SUGAR, reac_volume * 10)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2934,7 +2934,7 @@
 	if(!iscarbon(exposed_mob))
 		return
 	if(methods & INGEST)
-		exposed_mob.check_allergic_reaction(BUGS, reac_volume * 10)
+		exposed_mob.check_allergic_reaction(BUGS, chance = reac_volume * 10, histamine_add = min(10, reac_volume))
 	if(methods & (PATCH|TOUCH|VAPOR))
 		amount_left = round(reac_volume,0.1)
 		exposed_mob.apply_status_effect(status_effect, amount_left)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2931,8 +2931,10 @@
 
 /datum/reagent/ants/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
-	if(!iscarbon(exposed_mob) || (methods & (INGEST|INJECT)))
+	if(!iscarbon(exposed_mob))
 		return
+	if(methods & INGEST)
+		exposed_mob.check_allergic_reaction(BUGS, reac_volume * 10)
 	if(methods & (PATCH|TOUCH|VAPOR))
 		amount_left = round(reac_volume,0.1)
 		exposed_mob.apply_status_effect(status_effect, amount_left)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1424,6 +1424,7 @@
 #include "code\datums\elements\attack_zone_randomiser.dm"
 #include "code\datums\elements\backblast.dm"
 #include "code\datums\elements\bane.dm"
+#include "code\datums\elements\basic_allergenic_attack.dm"
 #include "code\datums\elements\basic_eating.dm"
 #include "code\datums\elements\basic_health_examine.dm"
 #include "code\datums\elements\beauty.dm"


### PR DESCRIPTION
## About The Pull Request

The following effects will trigger allergic reactions for the "Food Allergy" quirk
- For Alcohol allergies:
   - Drinking any ethanol (beer, wine, etc) 
- For Bug allergies:
   - Drinking ants
   - Getting stung by a bee
   - Getting bit by a (giant) ant
   - Getting bit by a (giant) spider 
- For Sugar allergies:
   - Drinking Sugar

Other notes
- Any mob undergoing surgery will benefit from ethanol speeding it up, rather than just carbons

## Why It's Good For The Game

I saw a random discord comment that said "Bee stings should trigger bug allergies" and I thought it was funny, so I added it, then I thought I could add similar triggers to a few other things. 

Important to note for the reagent based effects, they only trigger on ingestion. And on top of that, it's a % chance to trigger, scaling with the amount you drink at once. So you can sneak a sip of alcohol if you want to roll the dice (I figure if I made syringes kill you, I'd have to up the point reward, which I don't want to bother with)

## Changelog

:cl: Melbert
add: Drinking any ethanol (beer, wine, etc) will trigger alcohol allergies 
add: Drinking ants will trigger Bug allergies
add: Getting stung by a bee, or bitten by a (giant) ant or (giant) spider, will trigger bug allergies
add: Drinking plain sugar or caramel will trigger sugar allergies
qol: Ethanol can speed up the surgeries of any mob type applied to, rather than solely humans.
/:cl:
