### PR TITLE
Silver extract food now transfers its slime trait to any processed slices

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -700,6 +700,9 @@
 /atom/proc/OnCreatedFromProcessing(mob/living/user, obj/item/work_tool, list/chosen_option, atom/original_atom)
 	SHOULD_CALL_PARENT(TRUE)
 
+	if(HAS_TRAIT(original_atom, TRAIT_FOOD_SILVER))
+		ADD_TRAIT(src, TRAIT_FOOD_SILVER, INNATE_TRAIT) // stinky food always stinky
+
 	SEND_SIGNAL(src, COMSIG_ATOM_CREATEDBY_PROCESSING, original_atom, chosen_option)
 	if(user.mind)
 		ADD_TRAIT(src, TRAIT_FOOD_CHEF_MADE, REF(user.mind))


### PR DESCRIPTION
…ices
## About The Pull Request

Closes #87123

When slicing food, it now checks if it has the yucky silver trait, and if so it adds the trait to the slices
## Why It's Good For The Game

Bug

thjere really should be a consistency tag btw. for stuff that isnt a fix but comes close, like adding moodlets to simple activities
## Changelog
:cl:
fix: Silver extract food now transfers its slime trait to any processed slices
/:cl:
