### PR TITLE
Modsuit actions no longer go on cooldown when selected

### DIFF
--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -157,7 +157,6 @@
 			balloon_alert(mod.wearer, "[src] activated, [used_button]-click to use")
 	active = TRUE
 	mod.wearer.update_clothing(mod.slot_flags)
-	start_cooldown()
 	SEND_SIGNAL(src, COMSIG_MODULE_ACTIVATED)
 	on_activation()
 	return TRUE

--- a/code/modules/mod/modules/modules_service.dm
+++ b/code/modules/mod/modules/modules_service.dm
@@ -36,7 +36,7 @@
 	complexity = 1
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 5
 	incompatible_modules = list(/obj/item/mod/module/microwave_beam, /obj/item/mod/module/organizer)
-	cooldown_time = 10 SECONDS
+	cooldown_time = 4 SECONDS
 	required_slots = list(ITEM_SLOT_GLOVES)
 
 /obj/item/mod/module/microwave_beam/on_select_use(atom/target)


### PR DESCRIPTION
## About The Pull Request

Modsuit actions no longer go on cooldown when selected, only when actually used. So you can select an action and use it
## Why It's Good For The Game

I don't even know why this was a thing it just makes modsuits more uncomfortable and unpleasant to use. I see no reason for it to exist so i'm removing it. @Fikou 
## Changelog
:cl:
qol: Modsuit actions no longer go on cooldown when selected
balance: microwave beam module is on a 4s cooldown not 10s
/:cl:
