### PR TITLE
bouncy castles are on obj layer

### DIFF
--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -134,6 +134,7 @@
 	icon_state = "bouncy_castle"
 	anchored = TRUE
 	density = TRUE
+	layer = OBJ_LAYER
 
 /obj/structure/bouncy_castle/Initialize(mapload, mob/gored)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
they layer under gibs and it looks bad. i dont know why all structures are on lower obj layer thats kind of strange.

## Changelog
:cl:
fix: bouncy castles no longer render under the gibs they spawn
/:cl:
