### PR TITLE
Changes w_class tooltips to explain where an item can be stored

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1213,7 +1213,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		if(WEIGHT_CLASS_NORMAL)
 			return "This item can fit into backpacks."
 		if(WEIGHT_CLASS_BULKY to WEIGHT_CLASS_GIGANTIC)
-			return "This item is too large to fit into any storage."
+			return "This item is too large to fit into any standard storage."
 	return ""
 
 /// Removes all non-alphanumerics from the text, keep in mind this can lead to id conflicts

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1206,6 +1206,16 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		else
 			. = ""
 
+/proc/weight_class_to_tooltip(w_class)
+	switch(w_class)
+		if(WEIGHT_CLASS_TINY to WEIGHT_CLASS_SMALL)
+			return "This item can fit into pockets, boxes and backpacks."
+		if(WEIGHT_CLASS_NORMAL)
+			return "This item can fit into backpacks."
+		if(WEIGHT_CLASS_BULKY to WEIGHT_CLASS_GIGANTIC)
+			return "This item is too large to fit into any storage."
+	return ""
+
 /// Removes all non-alphanumerics from the text, keep in mind this can lead to id conflicts
 /proc/sanitize_css_class_name(name)
 	var/static/regex/regex = new(@"[^a-zA-Z0-9]","g")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -443,7 +443,7 @@
 	var/list/parent_tags = ..()
 	parent_tags.Insert(1, weight_class_to_text(w_class)) // To make size display first, otherwise it looks goofy
 	. = parent_tags
-	.[weight_class_to_text(w_class)] = "[gender == PLURAL ? "They are" : "It is"] a [weight_class_to_text(w_class)] item."
+	.[weight_class_to_text(w_class)] = weight_class_to_tooltip(w_class)
 
 	if(item_flags & CRUEL_IMPLEMENT)
 		.[span_red("morbid")] = "It seems quite practical for particularly <font color='red'>morbid</font> procedures and experiments."


### PR DESCRIPTION

## About The Pull Request

Tiny to small items can fit into pockets, boxes and backpacks, normal items only fit in backpacks and anything above does not fit anywhere. Thanks to Fikou for pointing this out.
![image](https://github.com/user-attachments/assets/746afbdd-043a-4bdd-a268-0e6cfbaba60b)

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/495bc909-7b47-4057-958f-d5d92a1592f6)
This tooltip is kinda useless if you think about it a bit

## Changelog
:cl:
qol: Improved descriptions on size tooltips to explain where the item can be stored
/:cl:
