### PR TITLE
suit storage units can now hold backpacks in their mod storage

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -2,7 +2,7 @@
 // SUIT STORAGE UNIT /////////////////
 /obj/machinery/suit_storage_unit
 	name = "suit storage unit"
-	desc = "An industrial unit made to hold and decontaminate irradiated equipment. It comes with a built-in UV cauterization mechanism. A small warning label advises that organic matter should not be placed into the unit."
+	desc = "An industrial unit made to hold, charge, and decontaminate equipment. It comes with a built-in UV cauterization mechanism. A small warning label advises that organic matter should not be placed into the unit."
 	icon = 'icons/obj/machines/suit_storage.dmi'
 	icon_state = "classic"
 	base_icon_state = "classic"
@@ -751,9 +751,9 @@
 			if(!user.transferItemToLoc(weapon, src))
 				return
 			mask = weapon
-		else if(istype(weapon, /obj/item/mod/control))
+		else if(istype(weapon, /obj/item/storage/backpack) || istype(weapon, /obj/item/mod/control))
 			if(mod)
-				to_chat(user, span_warning("The unit already contains a MOD!"))
+				to_chat(user, span_warning("The unit already contains a backpack or MOD!"))
 				return
 			if(!user.transferItemToLoc(weapon, src))
 				return

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -401,7 +401,7 @@
 			if (occupant && safeties)
 				say("Alert: safeties triggered, occupant detected!")
 				return
-			else if (!helmet && !mask && !suit && !storage && !occupant)
+			else if (!helmet && !mask && !suit && !mod && !storage && !occupant)
 				to_chat(user, "There's nothing inside [src] to disinfect!")
 				return
 			else


### PR DESCRIPTION

## About The Pull Request
what the title says
also changes their description to mention how they charge items inside them, which is a cool thing that is completely unmentioned anywhere

## Why It's Good For The Game
previously if you wanted to put your suit, backpack and hat in a safe place after putting on a modsuit you had to shove the backpack in the auxiliary slot, so if you had a suit storage item that wouldnt fit in the unit anymore, now with backpacks fitting the mod slot you can shove them away there and retrieve when youre done using the modsuit

## Changelog
:cl:
qol: suit storage units can hold backpacks in the modsuit slot
/:cl:
