### PR TITLE
ghosts don't get ambience cut off when changing areas

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -108,7 +108,7 @@ SUBSYSTEM_DEF(ambience)
 /mob/proc/refresh_looping_ambience()
 	SIGNAL_HANDLER
 
-	if(!client) // If a tree falls in the woods.
+	if(!client || isobserver(client.mob)) // If a tree falls in the woods. sadboysuss: Don't refresh for ghosts, it sounds bad
 		return
 
 	var/area/my_area = get_area(src)


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/85568
## Changelog
:cl: grungussuss
sound: ambience no longer gets cut off for ghosts
/:cl:
