### PR TITLE
Akimbo firing automatic guns no longer forces the offhand gun to fire even if dry on ammo

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -309,8 +309,11 @@
 	var/bonus_spread = 0
 	if(istype(akimbo_gun) && weapon_weight < WEAPON_MEDIUM && allow_akimbo)
 		if(akimbo_gun.weapon_weight < WEAPON_MEDIUM && akimbo_gun.can_trigger_gun(shooter))
-			bonus_spread = dual_wield_spread
-			addtimer(CALLBACK(akimbo_gun, TYPE_PROC_REF(/obj/item/gun, process_fire), target, shooter, TRUE, params, null, bonus_spread), 0.1 SECONDS)
+			if(!akimbo_gun.can_shoot())
+				addtimer(CALLBACK(akimbo_gun, TYPE_PROC_REF(/obj/item/gun, shoot_with_empty_chamber), shooter), 0.1 SECONDS)
+			else
+				bonus_spread = dual_wield_spread
+				addtimer(CALLBACK(akimbo_gun, TYPE_PROC_REF(/obj/item/gun, process_fire), target, shooter, TRUE, params, null, bonus_spread), 0.1 SECONDS)
 	process_fire(target, shooter, TRUE, params, null, bonus_spread)
 
 #undef AUTOFIRE_MOUSEUP


### PR DESCRIPTION
## About The Pull Request

...preventing runtimes and playing dry click sounds correctly i think? was that part of the issue caused by the runtime? iunno 

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/68161

## Changelog

:cl:
fix: fixed akimbo firing automatic guns runtiming on the offhand gun when it's empty, possibly causing dry fire clicks to not play
/:cl: