### PR TITLE
fixes stationary medbots still searching for patrol beacons

### DIFF
--- a/code/modules/mob/living/basic/bots/medbot/medbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot_ai.dm
@@ -218,6 +218,13 @@
 	///travel towards beacon behavior
 	travel_behavior = /datum/ai_behavior/travel_towards/beacon/medbot
 
+/datum/ai_planning_subtree/find_patrol_beacon/medbot/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
+	var/mob/living/basic/bot/medbot/bot_pawn = controller.pawn
+	if(bot_pawn.medical_mode_flags & MEDBOT_STATIONARY_MODE)
+		return
+	return ..()
+
+
 /datum/ai_behavior/travel_towards/beacon/medbot
 	new_movement_type = /datum/ai_movement/jps/bot/medbot/travel_to_beacon
 


### PR DESCRIPTION

## About The Pull Request
eventhough medbots wouldnt move towards them, itd still keep searching for beacons. this fixes that

## Why It's Good For The Game
fixes stationary medbots still searching for patrol beacons

## Changelog
:cl:
fix: stationary medbots no longer search for patrol beacons
/:cl:
