### PR TITLE
Fixes nuclear bomb/self-destruct overlays for deconstruction/lights, adds more examine text

### DIFF
--- a/code/__DEFINES/nuclear_bomb.dm
+++ b/code/__DEFINES/nuclear_bomb.dm
@@ -1,23 +1,39 @@
 // Nuclear bomb de/construction status
+///Pristine condition, no tampering has occurred yet
 #define NUKESTATE_INTACT 5
+///Front panel has been unscrewed
 #define NUKESTATE_UNSCREWED 4
+///Front panel has been removed with a crowbar, exposing the reinforced cover
 #define NUKESTATE_PANEL_REMOVED 3
+///Reinforced cover has been welded, preparing it for removal
 #define NUKESTATE_WELDED 2
+///Reinforced cover has been removed with a crowbar, revealing the core
 #define NUKESTATE_CORE_EXPOSED 1
+///Nuke core removed with the special kit
 #define NUKESTATE_CORE_REMOVED 0
 
 // Nuclear bomb UI modes
+///Device is locked and is awaiting the disk for further operations (additionally shows time left if armed)
 #define NUKEUI_AWAIT_DISK 0
+///Device is awaiting activation codes input
 #define NUKEUI_AWAIT_CODE 1
+///Device is awaiting timer input
 #define NUKEUI_AWAIT_TIMER 2
+///Device is awaiting confirmation of arming process and shows the time set
 #define NUKEUI_AWAIT_ARM 3
+///Device is counting down to setting off the charge
 #define NUKEUI_TIMING 4
+///Device is setting off the charge, aka `proc/actually_explode()`
 #define NUKEUI_EXPLODED 5
 
 // Nuclear bomb states
+///Device has not received activation codes and no timer have been set, all lights are off
 #define NUKE_OFF_LOCKED 0
+///Device has received activation codes and the timer is set; awaiting arming and the safety warning lights are on
 #define NUKE_OFF_UNLOCKED 1
+///Device is counting down to setting off the charge, red lights are on
 #define NUKE_ON_TIMING 2
+///Device is setting off the charge, aka `proc/actually_explode()`, red lights are blinking fast
 #define NUKE_ON_EXPLODING 3
 
 // Nuclear bomb detonation statuses

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -74,10 +74,31 @@ GLOBAL_VAR(station_nuke_source)
 
 /obj/machinery/nuclearbomb/examine(mob/user)
 	. = ..()
-	if(exploding)
-		. += span_bolddanger("It is in the process of exploding. Perhaps reviewing your affairs is in order.")
-	if(timing)
-		. += span_danger("There are [get_time_left()] seconds until detonation.")
+	switch(deconstruction_state)
+		if(NUKESTATE_UNSCREWED)
+			. += span_notice("The front panel has been unscrewed and can be <b>pried open</b>.")
+		if(NUKESTATE_PANEL_REMOVED)
+			. += span_notice("The inner plate is exposed and can be cut with a <b>welding tool</b>.")
+		if(NUKESTATE_WELDED)
+			. += span_notice("The inner plate has been cut through and can be <b>pried off</b>.")
+		if(NUKESTATE_CORE_EXPOSED)
+			. += span_danger("The inner chamber is exposed, revealing [core] to the outside!")
+			. += span_notice("The damaged inner plate covering the inner chamber can be replaced with some <b>iron</b>.")
+		if(NUKESTATE_CORE_REMOVED)
+			. += span_notice("The inner chamber is exposed, but is empty.")
+		if(NUKESTATE_INTACT)
+			. += span_notice("The front panel is secured.")
+
+	switch(get_nuke_state())
+		if(NUKE_OFF_LOCKED)
+			. += span_notice("The device is awaiting activation codes.")
+		if(NUKE_OFF_UNLOCKED)
+			. += span_notice("The device is set and is ready for arming the detonation countdown.")
+		if(NUKE_ON_TIMING)
+			. += span_danger("There are [get_time_left()] seconds until detonation.")
+		if(NUKE_ON_EXPLODING)
+			. += span_bolddanger("It is in the process of exploding. Perhaps reviewing your affairs is in order.")
+
 
 /// Checks if the disk inserted is a real nuke disk or not.
 /obj/machinery/nuclearbomb/proc/disk_check(obj/item/disk/nuclear/inserted_disk)
@@ -225,12 +246,11 @@ GLOBAL_VAR(station_nuke_source)
 		if(NUKESTATE_CORE_REMOVED)
 			interior = "core-removed"
 		if(NUKESTATE_INTACT)
-			return
+			interior = null
 
 	switch(get_nuke_state())
 		if(NUKE_OFF_LOCKED)
-			lights = ""
-			return
+			lights = null
 		if(NUKE_OFF_UNLOCKED)
 			lights = "lights-safety"
 		if(NUKE_ON_TIMING)
@@ -425,11 +445,12 @@ GLOBAL_VAR(station_nuke_source)
 	// We're safe now, so stop any ongoing timers
 	if(safety)
 		if(timing)
+			timing = FALSE
 			disarm_nuke()
 
-		timing = FALSE
 		detonation_timer = null
 		countdown.stop()
+	update_appearance(UPDATE_OVERLAYS) //only the lights overlay are affected by safety
 
 /// Arms the nuke, or disarms it if it's already active.
 /obj/machinery/nuclearbomb/proc/toggle_nuke_armed()


### PR DESCRIPTION
## About The Pull Request

hey turns out the overlays for this were not working for a good while, probably ever since #67144 because that merged the procs for deconstruct/lights overlay handling into one but didn't adjust the code or something. this PR fixes that plus adds an overlay update during toggling safety of the nuke so both overlays work as expected. also fixes disarming of the nuke still showing the red armed lights.
also adds more to the decsription of the devices because why the hell not (worst case if overlays break again people can examine the damn thing to make sure)
![i am going to sleep now](https://github.com/user-attachments/assets/3aa4b4c2-bf6a-4be2-b100-171221041465)

## Why It's Good For The Game

Fixes #68322
more feedback equal good

## Changelog

:cl:
fix: fixed nuclear devices not showing the overlays for deconstruction states and lights for arming state properly
qol: more examine feedback for nuclear devices (deconstruction/arming state)
/:cl: