### PR TITLE
Hitting an SM with extraction tongs won't dust them anymore

### DIFF
--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -85,7 +85,7 @@
 		return
 
 	if(istype(item, /obj/item/hemostat/supermatter))
-		to_chat(user, span_warning("You poke \The [src] with\the [item]'s hyper-noblium tips. Nothing happens."))
+		to_chat(user, span_warning("You poke [src] with [item]'s hyper-noblium tips. Nothing happens."))
 		return
 
 	if(istype(item, /obj/item/destabilizing_crystal))

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -86,6 +86,7 @@
 
 	if(istype(item, /obj/item/hemostat/supermatter))
 		to_chat(user, span_warning("You poke \The [src] with\the [item]'s hyper-noblium tips. Nothing happens."))
+		return
 
 	if(istype(item, /obj/item/destabilizing_crystal))
 		var/obj/item/destabilizing_crystal/destabilizing_crystal = item

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -84,6 +84,9 @@
 			to_chat(user, span_warning("You fail to extract a sliver from \The [src]! \the [scalpel] isn't sharp enough anymore."))
 		return
 
+	if(istype(item, /obj/item/hemostat/supermatter))
+		to_chat(user, span_warning("You poke \The [src] with\the [item]'s hyper-noblium tips. Nothing happens."))
+
 	if(istype(item, /obj/item/destabilizing_crystal))
 		var/obj/item/destabilizing_crystal/destabilizing_crystal = item
 


### PR DESCRIPTION

## About The Pull Request

Hitting an SM with extraction tongs won't dust them anymore (the tips are made out of hypernob too)

## Why It's Good For The Game

consistency

(real reason is me hitting the sm crystal with tongs while sleep deprived and ruining my planned gimmick, but come on. theyre hypernob tongs. )

## Changelog

:cl:
fix: Hitting an SM with extraction tongs won't dust them anymore
/:cl:

