### PR TITLE
drones can no longer speak pirate

### DIFF
--- a/code/modules/clothing/head/pirate.dm
+++ b/code/modules/clothing/head/pirate.dm
@@ -11,7 +11,7 @@
 
 /obj/item/clothing/head/costume/pirate/equipped(mob/user, slot)
 	. = ..()
-	if(!(slot_flags & slot))
+	if(!(slot_flags & slot) || isdrone(user))
 		return
 	user.grant_language(/datum/language/piratespeak, source = LANGUAGE_HAT)
 	to_chat(user, span_boldnotice("You suddenly know how to speak like a pirate!"))


### PR DESCRIPTION
## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/87405
## Changelog
:cl: grungussuss
fix: drones can no longer speak pirate if they have a pirate hat on
/:cl:
