### PR TITLE
Fixing throw impact sounds playing if the item has been caught.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -860,6 +860,8 @@
 		playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE, vary = sound_vary)
 		return
 	var/volume = get_volume_by_throwforce_and_or_w_class()
+	if(.) //it's been caught.
+		return
 	if (throwforce > 0 || HAS_TRAIT(src, TRAIT_CUSTOM_TAP_SOUND))
 		if (mob_throw_hit_sound)
 			playsound(hit_atom, mob_throw_hit_sound, volume, TRUE, -1)


### PR DESCRIPTION
## About The Pull Request
This will fix #87404

## Why It's Good For The Game
This will fix #87404.

## Changelog

:cl:
fix: Throw impact sounds won't play if the item has been caught.
