### PR TITLE
Makes Knock path grasp way easier to use against mechs than before

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -76,10 +76,12 @@
 	if(ismecha(target))
 		var/obj/vehicle/sealed/mecha/mecha = target
 		mecha.dna_lock = null
+		mecha.mecha_flags &= ~ID_LOCK_ON
 		for(var/mob/living/occupant as anything in mecha.occupants)
 			if(isAI(occupant))
 				continue
 			mecha.mob_exit(occupant, randomstep = TRUE)
+			occupant.Paralyze(50)
 	else if(istype(target,/obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/door = target
 		door.unbolt()

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -81,7 +81,7 @@
 			if(isAI(occupant))
 				continue
 			mecha.mob_exit(occupant, randomstep = TRUE)
-			occupant.Paralyze(50)
+			occupant.Paralyze(5 SECONDS)
 	else if(istype(target,/obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/door = target
 		door.unbolt()


### PR DESCRIPTION
## About The Pull Request

This PR aims to simply make it so the mech-kickout-entry ability is reliable and easy to use for the heretic, allowing them to not only kick out the previous occupant but as well give them a stun juuust long enough for the heretic to board AND most importantly turn off the other lock.

## Why It's Good For The Game

If the ability is clearly attempting to let you board a mech, why would it only turn off one of the locks instead of both? Mechs are hard to counter and this ability seemed to try and be that counter, but it forgot to let the heretic enter without stealing captain's spare or otherwise, which is... Quite strenuous in my opinion as the point of this path is to have access in your abilities already.

This was before I added the paralyze, but I think it highlights my point
https://github.com/user-attachments/assets/b144b688-919b-4712-a16e-a52580787867


:cl:
balance: Knock path's grasp now stuns the previous mech occupant when ejecting them and unlocks BOTH the ID and DNA lock, allowing the heretic to freely board the vehicle.
/:cl:

