### PR TITLE
spray-on insulated gloves are chunky once more

### DIFF
--- a/code/modules/clothing/gloves/insulated.dm
+++ b/code/modules/clothing/gloves/insulated.dm
@@ -63,6 +63,7 @@
 	icon_state = "sprayon"
 	inhand_icon_state = null
 	item_flags = DROPDEL
+	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 	armor_type = /datum/armor/none
 	resistance_flags = ACID_PROOF
 	var/charges_remaining = 10


### PR DESCRIPTION

## About The Pull Request

spray-on insulated gloves are chunky once more. does not affect regular ones

## Why It's Good For The Game

AFAIK the intention always was for these to be kind of clunky and awkward with the puzzle of 'how do i take this shit off?', and the loss of chunkiness kinda ruins that.

## Changelog

:cl:
fix: spray-on insulated gloves are chunky once more. does not affect regular ones
/:cl:

