### PR TITLE
Changes entertainment radio to be darker

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -374,7 +374,7 @@ em {
 }
 
 .enteradio {
-  color: #5c8a87;
+  color: #79c5a8;
 }
 
 .redteamradio {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -374,7 +374,7 @@ em {
 }
 
 .enteradio {
-  color: #00ff99;
+  color: #5c8a87;
 }
 
 .redteamradio {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -391,7 +391,7 @@ em {
 }
 
 .enteradio {
-  color: #00d680;
+  color: #5c8a87;
 }
 
 .redteamradio {

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -18,7 +18,7 @@ $_channel_map: (
   'Me': #5975da,
   'Med': #57b8f0,
   'OOC': #cca300,
-  'Ent': #00ff99,
+  'Ent': #5c8a87,
   'Radio': #1ecc43,
   'Say': #a4bad6,
   'Sci': #c68cfa,


### PR DESCRIPTION
## About The Pull Request

I made the entertainment radio text a little less eye-searing.

![image](https://github.com/user-attachments/assets/d95c10aa-cfa1-4365-922b-b3a5c03e3bfd)
![image](https://github.com/user-attachments/assets/aed97d39-2938-4fdb-8ccc-930a65deb592)
![image](https://github.com/user-attachments/assets/436632c1-59eb-4fb4-a632-0c3b2448e45a)
## Why It's Good For The Game

I'm sure it looked kind of okay on dark mode, but for us light mode heathens, entertainment chat could be kind of hard to read sometimes. This shade looks better and, while not as bright, I think fits the role better - I went for something similar to the kind of blue/grey of a reporter's suit.
## Changelog
:cl: Vekter
fix: Changed the color of entertainment radio to be darker
/:cl:
