### PR TITLE
Floorbot 3000 // New RTD item for engie cyborgs

### DIFF
--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -433,7 +433,6 @@
 		return 0
 	var/mob/living/silicon/robot/borgy = user
 	if(!borgy.cell)
-		if(user)
 			balloon_alert(user, "no cell found!")
 		return 0
 	. = borgy.cell.charge >= (amount * energyfactor)

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -427,7 +427,7 @@
 	. = borgy.cell.use(amount * energyfactor)
 	if(!.)
 		balloon_alert(user, "insufficient charge!")
-	return .
+
 /obj/item/construction/rtd/borg/checkResource(amount, mob/user)
 	if(!iscyborg(user))
 		return 0

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -405,8 +405,6 @@
 	if(!(interacting_with in view(1, get_turf(user))))
 		return NONE
 	return try_tiling(interacting_with, user)
-/obj/item/construction/rtd/borg/try_tiling(atom/interacting_with, mob/living/user)
-	. = ..()
 /obj/item/construction/rtd/borg/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	return NONE
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -437,7 +437,7 @@
 			balloon_alert(user, "no cell found!")
 		return 0
 	. = borgy.cell.charge >= (amount * energyfactor)
-	if(!. && user)
+	if(!.)
 		balloon_alert(user, "insufficient charge!")
 	return .
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -406,6 +406,7 @@
 	if(!(interacting_with in view(1, get_turf(user))))
 		return NONE
 	return try_tiling(interacting_with, user)
+	
 /obj/item/construction/rtd/borg/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	return NONE
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -416,6 +416,7 @@
 		return 0
 	max_matter = borgy.cell.maxcharge
 	return borgy.cell.charge
+
 /obj/item/construction/rtd/borg/useResource(amount, mob/user)
 	if(!iscyborg(user))
 		return 0

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -433,7 +433,7 @@
 		return 0
 	var/mob/living/silicon/robot/borgy = user
 	if(!borgy.cell)
-			balloon_alert(user, "no cell found!")
+		balloon_alert(user, "no cell found!")
 		return 0
 	. = borgy.cell.charge >= (amount * energyfactor)
 	if(!.)

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -38,7 +38,7 @@
 	var/datum/tile_info/tile_design
 	/// overlays on a tile
 	var/list/design_overlays = list()
-
+	var/ranged = FALSE
 /// stores the name, type, icon & cost for each tile type
 /datum/tile_info
 	/// name of this tile design for ui
@@ -289,8 +289,12 @@
 	if(!checkResource(selected_design.cost, user))
 		qdel(rcd_effect)
 		return ITEM_INTERACT_BLOCKING
-	var/beam = user.Beam(floor, icon_state = "light_beam", time = delay)
-	playsound(loc, 'sound/effects/light_flicker.ogg', 50, FALSE)
+	var/beam
+	if(ranged)
+		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
+	else
+		beam = user.Beam(floor, icon_state = "light_beam", time = delay)
+		playsound(loc, 'sound/effects/light_flicker.ogg', 50, FALSE)
 	if(!build_delay(user, delay, target = floor))
 		qdel(beam)
 		qdel(rcd_effect)
@@ -391,6 +395,52 @@
 
 /obj/item/construction/rtd/loaded
 	matter = 350
+
+
+/obj/item/construction/rtd/borg
+	var/energyfactor = 0.03 * STANDARD_CELL_CHARGE
+	var/delay = 0
+	ranged = TRUE
+/obj/item/construction/rtd/borg/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!(interacting_with in view(1, get_turf(user))))
+		return NONE
+	return try_tiling(interacting_with, user)
+/obj/item/construction/rtd/borg/try_tiling(atom/interacting_with, mob/living/user)
+	. = ..()
+/obj/item/construction/rtd/borg/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	return 0
+/obj/item/construction/rtd/borg/get_matter(mob/user)
+	if(!iscyborg(user))
+		return 0
+	var/mob/living/silicon/robot/borgy = user
+	if(!borgy.cell)
+		return 0
+	max_matter = borgy.cell.maxcharge
+	return borgy.cell.charge
+/obj/item/construction/rtd/borg/useResource(amount, mob/user)
+	if(!iscyborg(user))
+		return 0
+	var/mob/living/silicon/robot/borgy = user
+	if(!borgy.cell)
+		if(user)
+			balloon_alert(user, "no cell found!")
+		return 0
+	. = borgy.cell.use(amount * energyfactor)
+	if(!. && user)
+		balloon_alert(user, "insufficient charge!")
+	return .
+/obj/item/construction/rtd/borg/checkResource(amount, mob/user)
+	if(!iscyborg(user))
+		return 0
+	var/mob/living/silicon/robot/borgy = user
+	if(!borgy.cell)
+		if(user)
+			balloon_alert(user, "no cell found!")
+		return 0
+	. = borgy.cell.charge >= (amount * energyfactor)
+	if(!. && user)
+		balloon_alert(user, "insufficient charge!")
+	return .
 
 /obj/item/construction/rtd/admin
 	name = "admin RTD"

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -422,7 +422,6 @@
 		return 0
 	var/mob/living/silicon/robot/borgy = user
 	if(!borgy.cell)
-		if(user)
 			balloon_alert(user, "no cell found!")
 		return 0
 	. = borgy.cell.use(amount * energyfactor)

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -422,7 +422,7 @@
 		return 0
 	var/mob/living/silicon/robot/borgy = user
 	if(!borgy.cell)
-			balloon_alert(user, "no cell found!")
+		balloon_alert(user, "no cell found!")
 		return 0
 	. = borgy.cell.use(amount * energyfactor)
 	if(!.)

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -401,6 +401,7 @@
 	var/energyfactor = 0.03 * STANDARD_CELL_CHARGE
 	var/delay = 0
 	ranged = FALSE
+	
 /obj/item/construction/rtd/borg/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!(interacting_with in view(1, get_turf(user))))
 		return NONE

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -425,7 +425,7 @@
 			balloon_alert(user, "no cell found!")
 		return 0
 	. = borgy.cell.use(amount * energyfactor)
-	if(!. && user)
+	if(!.)
 		balloon_alert(user, "insufficient charge!")
 	return .
 /obj/item/construction/rtd/borg/checkResource(amount, mob/user)

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -38,7 +38,7 @@
 	var/datum/tile_info/tile_design
 	/// overlays on a tile
 	var/list/design_overlays = list()
-	var/ranged = FALSE
+	var/ranged = TRUE
 /// stores the name, type, icon & cost for each tile type
 /datum/tile_info
 	/// name of this tile design for ui
@@ -290,7 +290,7 @@
 		qdel(rcd_effect)
 		return ITEM_INTERACT_BLOCKING
 	var/beam
-	if(ranged)
+	if(!ranged)
 		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 	else
 		beam = user.Beam(floor, icon_state = "light_beam", time = delay)
@@ -400,7 +400,7 @@
 /obj/item/construction/rtd/borg
 	var/energyfactor = 0.03 * STANDARD_CELL_CHARGE
 	var/delay = 0
-	ranged = TRUE
+	ranged = FALSE
 /obj/item/construction/rtd/borg/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!(interacting_with in view(1, get_turf(user))))
 		return NONE

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -408,7 +408,8 @@
 /obj/item/construction/rtd/borg/try_tiling(atom/interacting_with, mob/living/user)
 	. = ..()
 /obj/item/construction/rtd/borg/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	return 0
+	return NONE
+
 /obj/item/construction/rtd/borg/get_matter(mob/user)
 	if(!iscyborg(user))
 		return 0

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -438,7 +438,6 @@
 	. = borgy.cell.charge >= (amount * energyfactor)
 	if(!.)
 		balloon_alert(user, "insufficient charge!")
-	return .
 
 /obj/item/construction/rtd/admin
 	name = "admin RTD"

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -397,7 +397,7 @@
 		/obj/item/stack/sheet/glass,
 		/obj/item/borg/apparatus/sheet_manipulator,
 		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/iron/base/cyborg,
+		/obj/item/construction/rtd/borg,
 		/obj/item/stack/cable_coil,
 	)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
@@ -415,7 +415,7 @@
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/crowbar/cyborg,
-		/obj/item/stack/tile/iron/base/cyborg,
+		/obj/item/stack/tile/iron/base/cyborg, // haha jani will have old tiles >:D
 		/obj/item/soap/nanotrasen/cyborg,
 		/obj/item/storage/bag/trash/cyborg,
 		/obj/item/melee/flyswatter,
@@ -919,7 +919,7 @@
 		/obj/item/stack/sheet/glass,
 		/obj/item/borg/apparatus/sheet_manipulator,
 		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/iron/base/cyborg,
+		/obj/item/construction/rtd/borg,
 		/obj/item/dest_tagger/borg,
 		/obj/item/stack/cable_coil,
 		/obj/item/pinpointer/syndicate_cyborg,


### PR DESCRIPTION


## About The Pull Request

- Replaces "cyborg tile stacker" on brand-new "Cyborg Rapid Tiling Device"
![borg_rtd](https://github.com/user-attachments/assets/27d10d10-cbbe-44b7-b127-2a31983ca585)

- Cyborg RTD works now like RCD due to budget-cuts. (Original RTD can place tiles up to 7 tiles range, cyborg one is only 1 tile and no funny beam)

- RTD consumes power pretty much like RCD
![image](https://github.com/user-attachments/assets/49e66627-4f69-46c3-9b56-b1b4271d3507)


## Why It's Good For The Game

The reason why im making RTD because tile placer is broken even code says so. You either need to make every tile with borg subtype to fix this or replace on borg rtd (what i did). Because it suck to place regular tiles when you repairing med white tiles or just want to make fancy room.

## Changelog
:cl:
qol: replaced old engineer borg "tile stacker" on crippled RTD
/:cl:
