### PR TITLE
Fixes a runtime on eye removal

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -285,9 +285,9 @@
 /obj/item/organ/internal/eyes/on_mob_remove(mob/living/carbon/eye_owner)
 	. = ..()
 	if (scarring)
-		owner.cure_nearsighted(TRAIT_RIGHT_EYE_SCAR)
-		owner.cure_nearsighted(TRAIT_LEFT_EYE_SCAR)
-		owner.cure_blind(EYE_SCARRING_TRAIT)
+		eye_owner.cure_nearsighted(TRAIT_RIGHT_EYE_SCAR)
+		eye_owner.cure_nearsighted(TRAIT_LEFT_EYE_SCAR)
+		eye_owner.cure_blind(EYE_SCARRING_TRAIT)
 
 #undef OFFSET_X
 #undef OFFSET_Y


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/87474

## Why It's Good For The Game

Being unable to remove eyes if there is scarring is bad.

## Changelog
:cl:
fix: Fixes a runtime when trying to remove someones scarred eyes. Now you can remove them!
/:cl:
