### PR TITLE
[NO GBP] adds big pointer to chipped quirk

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -120,5 +120,6 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 	"Integrated Intuitive Thinking and Judging" = /obj/item/skillchip/intj,
 	"F0RC3 4DD1CT10N" = /obj/item/skillchip/drunken_brawler,
 	"\"Space Station 13: The Musical\"" = /obj/item/skillchip/musical,
-	"Mast-Angl-Er skillchip" = /obj/item/skillchip/master_angler,
+	"Mast-Angl-Er" = /obj/item/skillchip/master_angler,
+	"Kommand" = /obj/item/skillchip/big_pointer,
 ))


### PR DESCRIPTION

## About The Pull Request

adds the big pointer chip that lets you recolor your large pointer to the chipped quirk

## Why It's Good For The Game

i forgot to add this, whoops

if you are worried about spam. the 2 cost chip that literally makes every message you say be spoken like a musical has really shocked me in how little it has been used so far. so that is not a concern

## Changelog

:cl:
add: adds big pointer to chipped quirk
/:cl:

