### PR TITLE
Gives the parrot in the bitrunning domain the pirate faction

### DIFF
--- a/_maps/virtual_domains/pirates.dmm
+++ b/_maps/virtual_domains/pirates.dmm
@@ -610,7 +610,8 @@
 "HO" = (
 /obj/structure/table/wood,
 /mob/living/basic/parrot{
-	name = "pepper"
+	name = "pepper";
+	faction = list("pirate")
 	},
 /turf/open/floor/carpet/blue,
 /area/virtual_domain)


### PR DESCRIPTION

## About The Pull Request


While I was testing #87481 i noticed that the pirates next to 
the bird were killing it before the domain even had a chance to load, this stops that from happening

## Why It's Good For The Game

bird murder is bad

## Changelog

:cl:
fix: The parrot from the Corsair Cove will no longer be immediatelly shanked by the pirates upon loading of the domain.
/:cl:

