### PR TITLE
[NO GBP] Fixes deathsquad commandos not getting their berets

### DIFF
--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -77,9 +77,16 @@
 
 	if(!user.transferItemToLoc(hat, parent, force = FALSE, silent = TRUE))
 		return
+
+	attach_hat(hat, user)
+
+/datum/component/hat_stabilizer/proc/attach_hat(obj/item/clothing/hat, mob/user)
+	var/atom/movable/movable_parent = parent
 	attached_hat = hat
 	RegisterSignal(hat, COMSIG_MOVABLE_MOVED, PROC_REF(remove_hat))
-	movable_parent.balloon_alert(user, "hat attached, right-click to remove")
+
+	if (!isnull(user))
+		movable_parent.balloon_alert(user, "hat attached, right-click to remove")
 
 	if (!istype(parent, /obj/item/clothing))
 		movable_parent.update_appearance()
@@ -92,6 +99,7 @@
 	apparel.flags_cover |= attached_hat.flags_cover
 	apparel.visor_flags_cover |= attached_hat.visor_flags_cover
 	apparel.update_appearance()
+
 	if (ismob(apparel.loc))
 		var/mob/wearer = apparel.loc
 		wearer.update_clothing(wearer.get_slot_by_item(apparel))

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -477,10 +477,11 @@
 	var/obj/item/mod/control/mod = squaddie.back
 	if(!istype(mod))
 		return
-	var/obj/item/mod/module/hat_stabilizer/hat_holder = locate() in mod.modules
-	var/obj/item/clothing/head/helmet/space/beret/beret = new(hat_holder)
-	hat_holder.attached_hat = beret
-	squaddie.update_clothing(mod.slot_flags)
+	var/obj/item/clothing/helmet = mod.get_part_from_slot(ITEM_SLOT_HEAD)
+	var/obj/item/clothing/head/helmet/space/beret/beret = new(helmet)
+	var/datum/component/hat_stabilizer/component = helmet.GetComponent(/datum/component/hat_stabilizer)
+	component.attach_hat(beret)
+	squaddie.update_clothing(helmet.slot_flags)
 
 /datum/outfit/centcom/ert/marine
 	name = "Marine Commander"

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -694,8 +694,6 @@
 	required_slots = list(ITEM_SLOT_HEAD)
 	/*Intentionally left inheriting 0 complexity and removable = TRUE;
 	even though it comes inbuilt into the Magnate/Corporate MODS and spawns in maints, I like the idea of stealing them*/
-	/// Currently "stored" hat. No armor or function will be inherited, only the icon and cover flags.
-	var/obj/item/clothing/head/attached_hat
 	/// Original cover flags for the MOD helmet, before a hat is placed
 	var/former_flags
 	var/former_visor_flags


### PR DESCRIPTION

## About The Pull Request
Outfit was directly assigning the attached hat and i forgor to remove the var which is how it compiled in the first place

## Changelog
:cl:
fix: Fixed deathsquad commandos not getting their berets
/:cl:
