### PR TITLE
Moved COMSIG_REAGENTS_REM_REAGENT below update_total() on /trans_to()

### DIFF
--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -257,14 +257,14 @@
 		if(!include_subtypes)
 			break
 
-	//inform others about our reagents being removed
-	for(var/datum/reagent/removed_reagent as anything in removed_reagents)
-		SEND_SIGNAL(src, COMSIG_REAGENTS_REM_REAGENT, removed_reagent, removed_reagents[removed_reagent])
-
 	//update the holder & handle reactions
 	update_total()
 	if(!safety)
 		handle_reactions()
+
+	//inform others about our reagents being removed
+	for(var/datum/reagent/removed_reagent as anything in removed_reagents)
+		SEND_SIGNAL(src, COMSIG_REAGENTS_REM_REAGENT, removed_reagent, removed_reagents[removed_reagent])
 
 	return round(total_removed_amount, CHEMICAL_VOLUME_ROUNDING)
 


### PR DESCRIPTION

## About The Pull Request

at some point, someone changed things up, so that the for loop that holds the signal of reagents being removed happens before the actual total volume variable is changed in update_total(). this puts it below where it probably (?) was beforehand

## Why It's Good For The Game

this has a bunch of cascading effects probably. what matters for me is that this means total_volume is not updated by the time the chain reaches update_icon_state(), which had the effect of causing it so that BVAK autoinjectors did not have the 'half-empty' state being activated.

i'm very sick so i havent tested this beyond 'it works with the thing im trying to fix', but it's prooobably okay . i mean, presumably we want to know the reduced total volume on the signal being sent anyhow right?

## Changelog

:cl:
code: Moved the reagent deletion signal below updating the total volume of containers. If any bugs seem related please report them!
fix: BVAK injectors have their middleground icon state once more
/:cl:

