### PR TITLE
Add time dilation to hub status.

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -397,6 +397,8 @@ GLOBAL_VAR(tracy_log)
 			new_status += "<br>Time: <b>[time2text(STATION_TIME_PASSED(), "hh:mm", 0)]</b>"
 			if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
 				new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
+			if(SStime_track?.time_dilation_avg > 0)
+				new_status += " | Time Dilation: <b>[round(SStime_track?.time_dilation_avg)]%</b>"
 		else if(SSticker.current_state == GAME_STATE_FINISHED)
 			new_status += "<br><b>RESTARTING</b>"
 	if(SSmapping.current_map)


### PR DESCRIPTION
If tg is gonna get new hardware might as well use it to flex on the hub.

This takes the middle number from the 3 avgs shown in the status tab and displays it on the hub next to the current round time.

The hub status field is only updated whenever somebody joins or leaves the server so the real-time number would be less useful.

