### PR TITLE
Removes the contractor baton from the standard traitor uplink.

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -99,14 +99,3 @@
 	cost = 10
 	surplus = 50
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
-
-/datum/uplink_item/stealthy_weapons/contrabaton
-	name = "Contractor Baton"
-	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets. \
-	These shocks are capable of affecting the inner circuitry of most robots as well, applying a short stun. \
-	Has the added benefit of affecting the vocal cords of your victim, causing them to slur as if inebriated."
-	item = /obj/item/melee/baton/telescopic/contractor_baton
-	cost = 7
-	surplus = 50
-	limited_stock = 1
-	purchasable_from = UPLINK_TRAITORS | UPLINK_SPY

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -99,3 +99,14 @@
 	cost = 10
 	surplus = 50
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
+
+/datum/uplink_item/stealthy_weapons/contrabaton
+	name = "Contractor Baton"
+	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets. \
+	These shocks are capable of affecting the inner circuitry of most robots as well, applying a short stun. \
+	Has the added benefit of affecting the vocal cords of your victim, causing them to slur as if inebriated."
+	item = /obj/item/melee/baton/telescopic/contractor_baton
+	cost = 7
+	surplus = 50
+	limited_stock = 1
+	purchasable_from = UPLINK_SPY


### PR DESCRIPTION

## About The Pull Request
this PR removes the contractor baton being buyable from the uplink. the contractor KIT is unaffected
## Why It's Good For The Game

i think the contractor baton treads on other traitor items territory for a low cost while lacking the flavor of other traitor available stuns. it treads on the territory of explicit anti borg items(EMP kit, eye contacts, EMP flashlight), stuns (radioactive analyzer, ebow, scarp, chem pen). and it generally lacks flavor, its much more boring than the items it treads on and is very very cost effective. for 7TC you can have what is essentially a telebaton and flash at your disposal. 

## Changelog
:cl:
del: Removed contractor baton from the traitor uplink
/:cl:
