### PR TITLE
toy huggers can no longer become shredded

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -316,6 +316,7 @@
 	sterile = TRUE
 	tint = 3 //Makes it feel more authentic when it latches on
 	slowdown = 0
+	integrity_failure = 0
 
 /obj/item/clothing/mask/facehugger/toy/Die()
 	return

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -99,14 +99,3 @@
 	cost = 10
 	surplus = 50
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
-
-/datum/uplink_item/stealthy_weapons/contrabaton
-	name = "Contractor Baton"
-	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets. \
-	These shocks are capable of affecting the inner circuitry of most robots as well, applying a short stun. \
-	Has the added benefit of affecting the vocal cords of your victim, causing them to slur as if inebriated."
-	item = /obj/item/melee/baton/telescopic/contractor_baton
-	cost = 7
-	surplus = 50
-	limited_stock = 1
-	purchasable_from = UPLINK_TRAITORS | UPLINK_SPY

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -109,4 +109,4 @@
 	cost = 7
 	surplus = 50
 	limited_stock = 1
-	purchasable_from = UPLINK_SPY | UPLINK_TRAITOR
+	purchasable_from = UPLINK_TRAITORS | UPLINK_SPY

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -109,4 +109,4 @@
 	cost = 7
 	surplus = 50
 	limited_stock = 1
-	purchasable_from = UPLINK_SPY
+	purchasable_from = UPLINK_SPY | UPLINK_TRAITOR

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -99,3 +99,14 @@
 	cost = 10
 	surplus = 50
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
+
+/datum/uplink_item/stealthy_weapons/contrabaton
+	name = "Contractor Baton"
+	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets. \
+	These shocks are capable of affecting the inner circuitry of most robots as well, applying a short stun. \
+	Has the added benefit of affecting the vocal cords of your victim, causing them to slur as if inebriated."
+	item = /obj/item/melee/baton/telescopic/contractor_baton
+	cost = 7
+	surplus = 50
+	limited_stock = 1
+	purchasable_from = UPLINK_SPY


### PR DESCRIPTION

## About The Pull Request
this PR stops the xeno larva toy from going into a damaged icon state
## Why It's Good For The Game
the toy hugger is a clothing item so it inherrited becoming shredded at low integrity. this gives it a integrity_failure value of 0 so that it no longer becomes shredded
fixes #87386
## Changelog
:cl:
fix: fixes the toy larva hugger getting shredded
/:cl:
