### PR TITLE
Makes office chairs named "office chair"

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -30219,7 +30219,6 @@
 /area/station/command/corporate_dock)
 "kmD" = (
 /obj/structure/chair/office/light{
-	name = "blue office chair";
 	color = "#6495ED";
 	dir = 4
 	},
@@ -64493,7 +64492,6 @@
 /area/station/security/checkpoint/customs/auxiliary)
 "vKn" = (
 /obj/structure/chair/office/light{
-	name = "blue office chair";
 	color = "#6495ED";
 	dir = 8
 	},

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -30219,7 +30219,7 @@
 /area/station/command/corporate_dock)
 "kmD" = (
 /obj/structure/chair/office/light{
-	name = "blue";
+	name = "blue office chair";
 	color = "#6495ED";
 	dir = 4
 	},
@@ -64493,7 +64493,7 @@
 /area/station/security/checkpoint/customs/auxiliary)
 "vKn" = (
 /obj/structure/chair/office/light{
-	name = "blue";
+	name = "blue office chair";
 	color = "#6495ED";
 	dir = 8
 	},

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -227,6 +227,7 @@
 	fishing_modifier = -12
 
 /obj/structure/chair/office
+	name = "office chair"
 	anchored = FALSE
 	buildstackamount = 5
 	item_chair = null
@@ -247,6 +248,7 @@
 	fishing_modifier = -10
 
 /obj/structure/chair/office/light
+	name = "light office chair"
 	icon_state = "officechair_white"
 
 //Stool

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -248,7 +248,7 @@
 	fishing_modifier = -10
 
 /obj/structure/chair/office/light
-	name = "light office chair"
+	name = "office chair"
 	icon_state = "officechair_white"
 
 //Stool


### PR DESCRIPTION
## About The Pull Request

Adds a name to the office chair obj and its light variants describing them as "office chair". Additionally removes the custom name "blue" from the blue variant of light office chair in birdshot.

## Why It's Good For The Game

Chairs are not lights and therefore need names that include "chair"
Fixes #87501 

## Changelog
:cl:
fix: certain office chairs are now properly labelled
/:cl:
