### PR TITLE
you need spaceproof arm and leg covering to be spaceproof

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -430,9 +430,9 @@
 				parts_covered += "head"
 			if(body_parts_covered & CHEST)
 				parts_covered += "torso"
-			if(body_parts_covered & ARMS)
+			if(body_parts_covered & ARMS|HANDS)
 				parts_covered += "arms"
-			if(body_parts_covered & LEGS)
+			if(body_parts_covered & LEGS|FEET)
 				parts_covered += "legs"
 			if(length(parts_covered))
 				readout += "[output_string] will protect the wearer's [english_list(parts_covered)] from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -430,7 +430,11 @@
 				parts_covered += "head"
 			if(body_parts_covered & CHEST)
 				parts_covered += "torso"
-			if(length(parts_covered)) // Just in case someone makes spaceproof gloves or something
+			if(body_parts_covered & ARMS)
+				parts_covered += "arms"
+			if(body_parts_covered & LEGS)
+				parts_covered += "legs"
+			if(length(parts_covered))
 				readout += "[output_string] will protect the wearer's [english_list(parts_covered)] from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."
 
 		var/heat_prot

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -168,7 +168,7 @@
 	resistance_flags = FIRE_PROOF
 	siemens_coefficient = 0.3
 	clothing_traits = list(TRAIT_QUICKER_CARRY, TRAIT_CHUNKYFINGERS)
-	clothing_flags = THICKMATERIAL
+	clothing_flags = THICKMATERIAL|STOPSPRESSUREDAMAGE
 
 /obj/item/clothing/gloves/atmos/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -12,7 +12,7 @@
 	strip_delay = 70
 	equip_delay_other = 70
 	resistance_flags = FIRE_PROOF
-
+	clothing_flags = STOPSPRESSUREDAMAGE
 	slowdown = SHOES_SLOWDOWN
 	/// Whether the magpulse system is active
 	var/magpulse = FALSE

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -54,19 +54,19 @@
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	var/chest_covered = FALSE
 	var/head_covered = FALSE
-	var/arms_covered = FALSE
-	var/legs_covered = FALSE
+	var/hands_covered = FALSE
+	var/feet_covered = FALSE
 	for(var/obj/item/clothing/equipped in get_equipped_items())
 		if((equipped.body_parts_covered & CHEST) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			chest_covered = TRUE
 		if((equipped.body_parts_covered & HEAD) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			head_covered = TRUE
-		if((equipped.body_parts_covered & ARMS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
-			arms_covered = TRUE
-		if((equipped.body_parts_covered & LEGS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
-			legs_covered = TRUE
+		if((equipped.body_parts_covered & HANDS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+			hands_covered = TRUE
+		if((equipped.body_parts_covered & FEET) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+			feet_covered = TRUE
 
-	if(chest_covered && head_covered && arms_covered && legs_covered)
+	if(chest_covered && head_covered && hands_covered && feet_covered)
 		return ONE_ATMOSPHERE
 	if(ismovable(loc))
 		/// If we're in a space with 0.5 content pressure protection, it averages the values, for example.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -52,18 +52,18 @@
 
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
-	var/chest_covered = FALSE
-	var/head_covered = FALSE
-	var/hands_covered = FALSE
-	var/feet_covered = FALSE
+	var/chest_covered = !get_bodypart(BODY_ZONE_CHEST)
+	var/head_covered = !get_bodypart(BODY_ZONE_HEAD)
+	var/hands_covered = !get_bodypart(BODY_ZONE_L_ARM) && !get_bodypart(BODY_ZONE_R_ARM)
+	var/feet_covered = !get_bodypart(BODY_ZONE_L_LEG) && !get_bodypart(BODY_ZONE_R_LEG)
 	for(var/obj/item/clothing/equipped in get_equipped_items())
-		if((equipped.body_parts_covered & CHEST) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+		if(!chest_covered && (equipped.body_parts_covered & CHEST) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			chest_covered = TRUE
-		if((equipped.body_parts_covered & HEAD) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+		if(!head_covered && (equipped.body_parts_covered & HEAD) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			head_covered = TRUE
-		if((equipped.body_parts_covered & HANDS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+		if(!hands_covered && (equipped.body_parts_covered & HANDS|ARMS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			hands_covered = TRUE
-		if((equipped.body_parts_covered & FEET) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+		if(!feet_covered && (equipped.body_parts_covered & FEET|LEGS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			feet_covered = TRUE
 
 	if(chest_covered && head_covered && hands_covered && feet_covered)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -54,13 +54,19 @@
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	var/chest_covered = FALSE
 	var/head_covered = FALSE
+	var/arms_covered = FALSE
+	var/legs_covered = FALSE
 	for(var/obj/item/clothing/equipped in get_equipped_items())
 		if((equipped.body_parts_covered & CHEST) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			chest_covered = TRUE
 		if((equipped.body_parts_covered & HEAD) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			head_covered = TRUE
+		if((equipped.body_parts_covered & ARMS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+			arms_covered = TRUE
+		if((equipped.body_parts_covered & LEGS) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
+			legs_covered = TRUE
 
-	if(chest_covered && head_covered)
+	if(chest_covered && head_covered && arms_covered && legs_covered)
 		return ONE_ATMOSPHERE
 	if(ismovable(loc))
 		/// If we're in a space with 0.5 content pressure protection, it averages the values, for example.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
you no longer only need a spaceproof helmet and chest extended to be spaceproof, but also arms (or hands) and legs (or feet)
this checks for them being covered, not the slot itself. like if youre in an eva suit you dont need any gloves or anything because it covers your hands
if you dont have both of your arms you dont need arm/hand covering
if you dont have both of your legs you dont need leg/feet covering

**what this means in practice:**
you cannot only extend modsuit head and chest out to be spaceproof
if you xenobio potion a sec vest you also need to potion your gloves and shoes. if you potion something that covers arms like a winter coat then only shoes, if you potion something like a firesuit then youre overall good
technically also now if you were to lose your head youd be spaceproof in just a spaceproof suit (hars buff??)

**possible iffiness:**
while you only now need one arm to wear gloves, the same is not the case for legs and shoes. if youre in a modsuit and have your leg dismembered your leg will not be covered and you will take damage (though you can dismember your other leg and then you wont :P )

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
a bit silly in practice to have modsuits protect you from space in just a helmet and chestplate

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: you need something spaceproof to cover your legs (or feet) and arms (or hands) to be spaceproof, not only head and chest
balance: magboots and atmos gloves now have pressure protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
