### PR TITLE
Fixes selling space cash bills not giving the advertised amount

### DIFF
--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -469,12 +469,12 @@
 
 /datum/export/pirate/cash
 	cost = 1
-	unit_name = "bills"
+	unit_name = "bill"
 	export_types = list(/obj/item/stack/spacecash)
 
-/datum/export/pirate/cash/get_amount(obj/exported_item)
+/datum/export/pirate/cash/get_cost(obj/exported_item)
 	var/obj/item/stack/spacecash/cash = exported_item
-	return ..() * cash.amount * cash.value
+	return cash.value * cash.amount
 
 /datum/export/pirate/holochip
 	cost = 1


### PR DESCRIPTION
## About The Pull Request

Basically instead of passing the export value through get_cost() it was being passed through get_amount()
The oversight means that if you sold a single spacecash bill of 1000cr, get_amount returned that you were selling a thousand amount of the item, once elasticity gets factored in that amount gets reduced to basically nothing.
Ended up just moving the formula from get_amount to get_cost, which is basically how holocredit exports already worked so hurray for consistency

Also fixed the small typo of an s being added at the end of bill despite unit_name asking for the name of a singular unit.

## Why It's Good For The Game

Fixes #87476 which is the result of an oversight.

## Changelog
:cl:
fix: You will now receive the advertised amount of credits for selling spacecash bills through cargo
/:cl:
