### PR TITLE
Wraps detailed examine descriptions in an examine block

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -458,7 +458,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 
 	if(rod)
 		info = span_tooltip("boldened are the fish you're more likely to catch with your current setup. The opposite is true for smaller names", info)
-	examine_text += examine_block(span_info("[info]: [english_list(known_fishes)]."))
+	examine_text += span_info("[info]: [english_list(known_fishes)].")
 
 /datum/fish_source/proc/spawn_reward_from_explosion(atom/location, severity)
 	if(!explosive_malus)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -532,7 +532,7 @@
 			var/list/result = examinify.examine_more(src)
 			if(!length(result))
 				result += span_notice("<i>You examine [examinify] closer, but find nothing of interest...</i>")
-			result_combined = jointext(result, "<br>")
+			result_combined = examine_block(jointext(result, "<br>"))
 
 		else
 			client.recent_examines[ref_to_atom] = world.time // set to when we last normal examine'd them

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -166,7 +166,7 @@
 
 /obj/item/mod/control/examine_more(mob/user)
 	. = ..()
-	. += examine_block("<i>[extended_desc]</i>")
+	. += "<i>[extended_desc]</i>"
 
 /obj/item/mod/control/process(seconds_per_tick)
 	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -166,7 +166,7 @@
 
 /obj/item/mod/control/examine_more(mob/user)
 	. = ..()
-	. += "<i>[extended_desc]</i>"
+	. += examine_block("<i>[extended_desc]</i>")
 
 /obj/item/mod/control/process(seconds_per_tick)
 	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)


### PR DESCRIPTION
## About The Pull Request
Now extended descriptions look like this
![image](https://github.com/user-attachments/assets/edec4c49-0772-4787-b044-7c429146347d)

## Why It's Good For The Game

This does not look good

![image](https://github.com/user-attachments/assets/d8db7c34-487b-42cb-ab84-597585d5aaa8)

## Changelog
:cl:
qol: Detailed examine descriptions are prettier now.
/:cl:
