### PR TITLE
Bitrunning: falling into chasms returns back to body

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -95,7 +95,7 @@
 	 */
 	RegisterSignals(parent, list(COMSIG_BITRUNNER_ALERT_SEVER, COMSIG_BITRUNNER_CACHE_SEVER, COMSIG_BITRUNNER_LADDER_SEVER), PROC_REF(on_safe_disconnect))
 	RegisterSignal(parent, COMSIG_LIVING_PILL_CONSUMED, PROC_REF(disconnect_if_red_pill))
-	RegisterSignal(parent, COMSIG_LIVING_DEATH, PROC_REF(on_sever_connection))
+	RegisterSignals(parent, list(COMSIG_LIVING_DEATH, COMSIG_QDELETING), PROC_REF(on_sever_connection))
 	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_linked_damage))
 
 


### PR DESCRIPTION

## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/87419

When the avatar is qdel'd, the player returns to original body

## Why It's Good For The Game
Less bugs good

## Changelog
:cl:
fix: Bitrunning: falling into chasms and other ways of destroying your virtual body instead of killing it, WILL now return you to your body
/:cl:
