### PR TITLE
Fix light emitters being deleted in pod bay when deleting everything

### DIFF
--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -788,12 +788,16 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 		selector.moveToNullspace() //Otherwise, we move the selector to nullspace until it is needed again
 
 /datum/centcom_podlauncher/proc/clearBay() //Clear all objs and mobs from the selected bay
-	for (var/obj/O in bay.get_all_contents())
-		qdel(O)
-	for (var/mob/M in bay.get_all_contents())
-		qdel(M)
+	for (var/obj/object in bay.get_all_contents())
+		if (object.type == /obj/effect/light_emitter/podbay)
+			continue
+		qdel(object)
+	for (var/mob/mob in bay.get_all_contents())
+		qdel(mob)
 	for (var/bayturf in bay)
 		var/turf/turf_to_clear = bayturf
+		if (turf_to_clear.type == /obj/effect/light_emitter/podbay)
+			continue
 		turf_to_clear.ChangeTurf(/turf/open/floor/iron)
 
 /datum/centcom_podlauncher/Destroy() //The Destroy() proc. This is called by ui_close proc, or whenever the user leaves the game

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -789,14 +789,14 @@ ADMIN_VERB(centcom_podlauncher, R_ADMIN, "Config/Launch Supplypod", "Configure a
 
 /datum/centcom_podlauncher/proc/clearBay() //Clear all objs and mobs from the selected bay
 	for (var/obj/object in bay.get_all_contents())
-		if (object.type == /obj/effect/light_emitter/podbay)
+		if (istype(object.type, /obj/effect/light_emitter/podbay))
 			continue
 		qdel(object)
 	for (var/mob/mob in bay.get_all_contents())
 		qdel(mob)
 	for (var/bayturf in bay)
 		var/turf/turf_to_clear = bayturf
-		if (turf_to_clear.type == /obj/effect/light_emitter/podbay)
+		if (istype(turf_to_clear, /obj/effect/light_emitter/podbay))
 			continue
 		turf_to_clear.ChangeTurf(/turf/open/floor/iron)
 


### PR DESCRIPTION

## About The Pull Request

When you delete everything with the "delete that shit" button in the pod bay, it also deleted the light emitters, which makes it difficult to see what is happening in the bay. This PR makes it so the light emitters are not deleted. Also removes some one letter variables in that part of the code.


* Closes https://github.com/tgstation/tgstation/issues/83219
## Why It's Good For The Game

Helps admins do their work more easily.
## Changelog
:cl:
code: removed two one letter variables
admin: clearing the pod bay will not remove the light emitters.
/:cl:
