### PR TITLE
Partial fix for inconsistent atmos pipe connection colors

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -69,12 +69,13 @@
 		. += get_attached_image(get_dir(src, machine_check), 4, COLOR_BLUE)
 		//. += get_attached_image(get_dir(src, machine_check), 2, COLOR_RED) // Only the distro node is added currently to the pipenet, it doesn't merge the pipenet with the waste node
 		return
-	. += get_attached_image(get_dir(src, machine_check), machine_check.piping_layer, machine_check.pipe_color)
+	//. += get_attached_image(get_dir(src, machine_check), machine_check.piping_layer, machine_check.pipe_color)
+	. += get_attached_image(get_dir(src, machine_check), machine_check.piping_layer, src.color)
 
 /obj/machinery/atmospherics/pipe/layer_manifold/proc/get_attached_image(p_dir, p_layer, p_color)
 	var/working_layer = FLOAT_LAYER - HAS_TRAIT(src, TRAIT_UNDERFLOOR) ? 1 : 0.01
 	var/mutable_appearance/muta = mutable_appearance('icons/obj/pipes_n_cables/layer_manifold_underlays.dmi', "intact_[p_dir]_[p_layer]", layer = working_layer, appearance_flags = RESET_COLOR)
-	muta.color = p_color
+	muta.color = src.color
 	return muta
 
 /obj/machinery/atmospherics/pipe/layer_manifold/set_init_directions()


### PR DESCRIPTION

## About The Pull Request

#### Summary
Partial fix for issue #87526 
Improves consistency of colors between omni and color pipe underlay connections, specifically those with layer adapters.
Only a partial fix as it does not affect color inconsistency issues that don't involve layer adapters. (like pump/valve connections for example)
#### Technical Changes
Changes layermanifold.dm to only use src.color when generating underlays instead of inheriting color of the connected nodes.
As far as I can tell this seems to fix more problems than it creates.

## Why It's Good For The Game
This change allows for:
- Layer adapters no longer generate gray underlays that don't match the pipe components they are connected to
- Seamless coloring in certain pipe setups, like staggered filter arrangements
- Consistent, seamless coloring in certain roundstart atmos connections
- Layer adapters otherwise still behave mostly normally
- See screenshots for visual reference

## Old behavior
![atmospipes6](https://github.com/user-attachments/assets/6002099b-ce3e-4536-8072-a3f739abc9a9)
![atmospipes9](https://github.com/user-attachments/assets/58764b6e-cb73-4363-908a-afe02f3192e1)
![atmospipes4](https://github.com/user-attachments/assets/6779e9a0-bdf8-4da2-b8f7-81df7da20fb4)

## New behavior
![atmospipes7](https://github.com/user-attachments/assets/1376f653-e708-4778-a858-4aa3c7db6afb)
![atmospipes8](https://github.com/user-attachments/assets/05205b10-5dc6-4733-bdaa-823a23996879)
![atmospipes5](https://github.com/user-attachments/assets/7d138e9e-665f-4454-b93f-a3f64001edb6)

## Warning
May need more testing
Does not fix any of the other color inconsistency problems between other kinds of pipe components. It only fixes connections with layer adapters
Not sure if connections between HE junctions and color layer adapters (last screenshot in each set) look better or worse

## Changelog
:cl:
fix: Improves consistency of colors between omni and color pipe underlay connections, specifically those with layer adapters.
/:cl:
