### PR TITLE
The Traps won't spawn traps on walls anymore

### DIFF
--- a/code/modules/spells/spell_types/conjure/the_traps.dm
+++ b/code/modules/spells/spell_types/conjure/the_traps.dm
@@ -18,6 +18,7 @@
 	)
 	summon_lifespan = 5 MINUTES
 	summon_amount = 5
+	summon_respects_density = TRUE
 
 	/// The amount of charges the traps spawn with.
 	var/trap_charges = 1


### PR DESCRIPTION

## About The Pull Request

The Traps won't spawn traps on walls anymore

## Why It's Good For The Game

Yesterday I saw a wizard cast the traps twice and both times it only spawned them inside walls. This variable was probably overlooked on this trap, ain't much reason for walltraps.

## Changelog

:cl:
fix: The Traps won't spawn traps on walls anymore
/:cl:

