### PR TITLE
Separate forced injection between latejoin and midround

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -67,7 +67,9 @@ SUBSYSTEM_DEF(dynamic)
 	var/list/executed_rules = list()
 	/// If TRUE, the next player to latejoin will guarantee roll for a random latejoin antag
 	/// (this does not guarantee they get said antag roll, depending on preferences and circumstances)
-	var/forced_injection = FALSE
+	var/late_forced_injection = FALSE
+	/// If TRUE, a midround ruleset will be rolled
+	var/mid_forced_injection = FALSE
 	/// Forced ruleset to be executed for the next latejoin.
 	var/datum/dynamic_ruleset/latejoin/forced_latejoin_rule = null
 	/// How many percent of the rounds are more peaceful.
@@ -258,10 +260,10 @@ SUBSYSTEM_DEF(dynamic)
 			spend_midround_budget(-threatadd, threat_log, "[worldtime2text()]: decreased by [key_name(usr)]")
 	else if (href_list["injectlate"])
 		latejoin_injection_cooldown = 0
-		forced_injection = TRUE
+		late_forced_injection = TRUE
 		message_admins("[key_name(usr)] forced a latejoin injection.")
 	else if (href_list["injectmid"])
-		forced_injection = TRUE
+		mid_forced_injection = TRUE
 		message_admins("[key_name(usr)] forced a midround injection.")
 		try_midround_roll()
 	else if (href_list["threatlog"])
@@ -873,14 +875,14 @@ SUBSYSTEM_DEF(dynamic)
 		forced_latejoin_rule = null
 		return
 
-	if(!forced_injection)
+	if(!late_forced_injection)
 		if(latejoin_injection_cooldown >= world.time)
 			return
 		if(!prob(latejoin_roll_chance))
 			return
 
-	var/was_forced = forced_injection
-	forced_injection = FALSE
+	var/was_forced = late_forced_injection
+	late_forced_injection = FALSE
 	var/list/possible_latejoin_rules = list()
 	for (var/datum/dynamic_ruleset/latejoin/rule in latejoin_rules)
 		if(!rule.weight)

--- a/code/controllers/subsystem/dynamic/dynamic_midround_rolling.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_midround_rolling.dm
@@ -17,7 +17,7 @@
 	return last_midround_injection_attempt + distance
 
 /datum/controller/subsystem/dynamic/proc/try_midround_roll()
-	if (!forced_injection && next_midround_injection() > world.time)
+	if (!mid_forced_injection && next_midround_injection() > world.time)
 		return
 
 	if (GLOB.dynamic_forced_extended)
@@ -30,7 +30,7 @@
 
 	last_midround_injection_attempt = world.time
 	next_midround_injection = null
-	forced_injection = FALSE
+	mid_forced_injection = FALSE
 
 	log_dynamic_and_announce("A midround ruleset is rolling, and will be [spawn_heavy ? "HEAVY" : "LIGHT"].")
 


### PR DESCRIPTION

## About The Pull Request

Fixes an issue mentioned in https://github.com/tgstation/tgstation/issues/72526, where pressing "Now!" in the game panel for injecting a latejoin, caused midround one to occur as well. This was because the same boolean was used for forcing both, which caused both to happen.

* Closes https://github.com/tgstation/tgstation/issues/72526
## Why It's Good For The Game

Improves admin tools by fixing a bug.
## Changelog
:cl:
admin: doing a latejoin injection no longer causes a midround one as well
/:cl:
