### PR TITLE
Lavaland equipment no longer accepts near-vacuum conditions as lavaland atmosphere

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -4,6 +4,9 @@
 /// Returns either the error landmark or the location of the room. Needless to say, if this is used, it means things have gone awry.
 #define GET_ERROR_ROOM ((locate(/obj/effect/landmark/error) in GLOB.landmarks_list) || locate(4,4,1))
 
+///The minimum pressure for lavaland equiment checks to be considered valid.
+#define MINIMUM_LAVALAND_ATMOS_PRESSURE 3
+
 ///Returns the name of the area the atom is in
 /proc/get_area_name(atom/checked_atom, format_text = FALSE)
 	var/area/checked_area = isarea(checked_atom) ? checked_atom : get_area(checked_atom)
@@ -263,7 +266,7 @@
 	if(!istype(environment))
 		return
 	var/pressure = environment.return_pressure()
-	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
+	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE && pressure >= MINIMUM_LAVALAND_ATMOS_PRESSURE)
 		. = TRUE
 
 ///Find an obstruction free turf that's within the range of the center. Can also condition on if it is of a certain area type.
@@ -350,3 +353,5 @@
 	else
 		message = copytext(message, 2)
 	to_chat(target, span_purple(examine_block("<span class='oocplain'><b>[source]: </b>[message]</span>")))
+
+#undef MINIMUM_LAVALAND_ATMOS_PRESSURE

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -518,7 +518,7 @@
 
 /obj/item/mod/module/sphere_transform/used()
 	if(!lavaland_equipment_pressure_check(get_turf(src)))
-		balloon_alert(mod.wearer, "too much pressure!")
+		balloon_alert(mod.wearer, "atomosphere lacks adequate pressure!")
 		playsound(src, 'sound/items/weapons/gun/general/dry_fire.ogg', 25, TRUE)
 		return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

I figured since you guys like my PRs so much I'd celebrate my 300th by making one you're probably going to hate.

This nerfs all lavaland equipment (mechs, KPA, resonator, minebots) to not be considered in "lavaland atmos" below a near-vacuum pressure threshold.

This modifies `lavaland_equipment_pressure_check()`, a helper used to determine if a given functionality is supposed to work in "lavaland" mode or not. This is used to determine if a KPA fires a standard or weakened shot, resonator attack damage, medipen speed, and whether or not certain things like minebot abilities work or the calculated Ripley speed.

This does nothing more than make sure that the pressure check returns false when near a vacuum. If there's something that works differently "on Lavaland" than when it's "on-station", it will simply work "on-station" in a vacuum instead of "on Lavaland". 
## Why It's Good For The Game

These becoming a frequently used weapon station-side was a complete mistake. Lavaland equipment is balanced around lavaland's balance level. Station/antag equipment is balanced around station/antag balance level. If you've seen megafauna ride the mining shuttle up to the station before, you'll know what happens when differing sides of the balance menagerie find each other.

Lavaland equipment being brought topside (or mass-produced on-site) presents another comparable situation of disparate power, typically at the expense of any antagonist occupying space for any reason. It could be a human traitor, a dragon, a blob. Anything trying to leverage the atmospheric simulation has now opened itself up to a dominant strategy that they are going to mathematically lose.

This equipment is too powerful to be a go-to for onstation combat, even under crisis conditions where an area may be vented. I'd be willing to wager this stuff working in space was an oversight in-and-of itself.

The issue isn't damage numbers or armors on the weapons or antagonists or anything, it's that this equipment (namely KPAs, Crushers, pens) works too well when introduced to the station. Lavaland balance does not need to affect station balance nor the other way around, they just need to be separated if they want to exist harmoniously in the same sandbox.

With regards to space mining -- this is a relic of the past that never happens outside of the sparse instances of Charlie respawns committed to a new station. Space explorers will need to be more resourceful, maybe, but asteroid mining rarely even warrants having a weapon to protect yourself.
## Changelog
:cl: Rhials
balance: Lavaland equipment is no longer effective in near-vacuum conditions.
/:cl:
