### PR TITLE
AIs can no longer read confidential communication console messages, including the roundstart status report.

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -91,7 +91,7 @@
 		else
 			GLOB.news_network.submit_article(text, "[command_name()] Update", "Station Announcements", null)
 
-/proc/print_command_report(text = "", title = null, announce=TRUE)
+/proc/print_command_report(text = "", title = null, announce=TRUE, classified=FALSE)
 	if(!title)
 		title = "Classified [command_name()] Update"
 
@@ -106,6 +106,7 @@
 	var/datum/comm_message/message = new
 	message.title = title
 	message.content = text
+	message.classified = classified
 
 	GLOB.communications_controller.send_message(message)
 

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -362,7 +362,7 @@ SUBSYSTEM_DEF(dynamic)
 		. += "<hr><b>Additional Notes: </b><BR><BR>" + footnote_pile
 
 #ifndef MAP_TEST
-	print_command_report(., "[command_name()] Status Summary", announce=FALSE)
+	print_command_report(., "[command_name()] Status Summary", announce=FALSE, classified = TRUE)
 	if(greenshift)
 		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", SSstation.announcer.get_rand_report_sound(), color_override = "green")
 	else

--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -50,8 +50,6 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 			if(unique)
 				C.add_message(sending)
 			else //We copy the message for each console, answers and deletions won't be shared
-				var a = "hello"
-
 				var/datum/comm_message/M = new /datum/comm_message(sending.title,sending.content,sending.classified,sending.possible_answers.Copy())
 				C.add_message(M)
 			if(print)

--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -44,13 +44,15 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 	user.log_talk(input, LOG_SAY, tag="priority announcement")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")
 
-/datum/communciations_controller/proc/send_message(datum/comm_message/sending,print = TRUE,unique = FALSE)
+/datum/communciations_controller/proc/send_message(datum/comm_message/sending, print = TRUE, unique = FALSE)
 	for(var/obj/machinery/computer/communications/C in GLOB.shuttle_caller_list)
 		if(!(C.machine_stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
 			if(unique)
 				C.add_message(sending)
 			else //We copy the message for each console, answers and deletions won't be shared
-				var/datum/comm_message/M = new(sending.title,sending.content,sending.possible_answers.Copy())
+				var a = "hello"
+
+				var/datum/comm_message/M = new /datum/comm_message(sending.title,sending.content,sending.classified,sending.possible_answers.Copy())
 				C.add_message(M)
 			if(print)
 				var/obj/item/paper/printed_paper = new /obj/item/paper(C.loc)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -581,6 +581,8 @@
 				if (messages)
 					for (var/_message in messages)
 						var/datum/comm_message/message = _message
+						if (message.classified && HAS_SILICON_ACCESS(user))
+							continue
 						data["messages"] += list(list(
 							"answered" = message.answered,
 							"content" = message.content,
@@ -917,9 +919,10 @@
 	var/content
 	var/list/possible_answers = list()
 	var/answered = FALSE
+	var/classified
 	var/datum/callback/answer_callback
 
-/datum/comm_message/New(new_title,new_content,new_possible_answers)
+/datum/comm_message/New(new_title,new_content,new_classified,new_possible_answers)
 	..()
 	if(new_title)
 		title = new_title
@@ -927,6 +930,7 @@
 		content = new_content
 	if(new_possible_answers)
 		possible_answers = new_possible_answers
+	classified = new_classified
 
 /datum/comm_message/Destroy()
 	answer_callback = null

--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -146,7 +146,7 @@ ADMIN_VERB(create_command_report, R_ADMIN, "Create Command Report", "Create a co
 		priority_announce(command_report_content, subheader == ""? null : subheader, report_sound, has_important_message = TRUE, color_override = chosen_color)
 
 	if(!announce_contents || print_report)
-		print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][command_name] Update", !announce_contents)
+		print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][command_name] Update", !announce_contents, !announce_contents)
 
 	change_command_name(original_command_name)
 

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -42,7 +42,7 @@
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
 	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, world.time)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_pirates), threat, chosen_gang), RESPONSE_MAX_TIME)
-	GLOB.communications_controller.send_message(threat, unique = TRUE)
+	GLOB.communications_controller.send_message(threat, unique = TRUE, confidential = TRUE)
 
 /proc/pirates_answered(datum/comm_message/threat, datum/pirate_gang/chosen_gang, payoff, initial_send_time)
 	if(world.time > initial_send_time + RESPONSE_MAX_TIME)

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -43,7 +43,7 @@
 /datum/round_event/shuttle_insurance/start()
 	insurance_message = new("Shuttle Insurance", "Hey, pal, this is the [ship_name]. Can't help but notice you're rocking a wild and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've done a quick evaluation on your rates in this sector and we're offering [insurance_evaluation] to cover for your shuttle in case of any disaster.", list("Purchase Insurance.","Reject Offer."))
 	insurance_message.answer_callback = CALLBACK(src, PROC_REF(answered))
-	GLOB.communications_controller.send_message(insurance_message, unique = TRUE)
+	GLOB.communications_controller.send_message(insurance_message, unique = TRUE, confidential = TRUE)
 
 /datum/round_event/shuttle_insurance/proc/answered()
 	if(EMERGENCY_AT_LEAST_DOCKED)


### PR DESCRIPTION

## About The Pull Request
AIs will no longer be able to read confidential communication console messages including the pirate one, the shuttle insurance one, or the roundstart status summary.

When admins send communication consoles they can already select it to be announced or not, that will decide if an AI can read it. 

## Why It's Good For The Game
It's annoying as a captain when you want to hide the fact its a green star but the AI blurts it out before you get a chance to stop them. If the Captain wants the advisory status to be revealed, it is now entirely their prerogative.

## Changelog
:cl:
balance: Nanotrasen has changed the password to communication consoles so that AIs no longer have access to classified command reports.
/:cl:
