### PR TITLE
Chem dispenser droplets colored

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -225,9 +225,11 @@
 		var/datum/reagent/temp = GLOB.chemical_reagents_list[re]
 		if(temp)
 			var/chemname = temp.name
+			var/chemcolor = temp.color
 			if(is_hallucinating && prob(5))
 				chemname = "[pick_list_replacements("hallucination.json", "chemicals")]"
-			chemicals += list(list("title" = chemname, "id" = temp.name, "pH" = temp.ph, "color" = temp.color, "pHCol" = convert_ph_to_readable_color(temp.ph)))
+				chemcolor = random_colour()
+			chemicals += list(list("title" = chemname, "id" = temp.name, "pH" = temp.ph, "color" = chemcolor, "pHCol" = convert_ph_to_readable_color(temp.ph)))
 	.["chemicals"] = chemicals
 	.["recipes"] = saved_recipes
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -227,7 +227,7 @@
 			var/chemname = temp.name
 			if(is_hallucinating && prob(5))
 				chemname = "[pick_list_replacements("hallucination.json", "chemicals")]"
-			chemicals += list(list("title" = chemname, "id" = temp.name, "pH" = temp.ph, "pHCol" = convert_ph_to_readable_color(temp.ph)))
+			chemicals += list(list("title" = chemname, "id" = temp.name, "pH" = temp.ph, "color" = temp.color, "pHCol" = convert_ph_to_readable_color(temp.ph)))
 	.["chemicals"] = chemicals
 	.["recipes"] = saved_recipes
 

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -44,7 +44,7 @@ export const ChemDispenser = (props) => {
   const { act, data } = useBackend<Data>();
   const recording = !!data.recordingRecipe;
   const { recipeReagents = [], recipes = [], beaker } = data;
-  const [hasCol, setHasCol] = useState(false);
+  const [showPhCol, setShowPhCol] = useState(false);
 
   const beakerTransferAmounts = beaker ? beaker.transferAmounts : [];
   const recordedContents =
@@ -85,8 +85,8 @@ export const ChemDispenser = (props) => {
                 icon="cog"
                 tooltip="Color code the reagents by pH"
                 tooltipPosition="bottom-start"
-                selected={hasCol}
-                onClick={() => setHasCol(!hasCol)}
+                selected={showPhCol}
+                onClick={() => setShowPhCol(!showPhCol)}
               />
             </>
           }
@@ -187,18 +187,16 @@ export const ChemDispenser = (props) => {
               <Button
                 key={chemical.id}
                 icon="tint"
-                textColor={chemical.color}
+                textColor={showPhCol ? chemical.pHCol : chemical.color}
                 width="129.5px"
                 lineHeight={1.75}
                 tooltip={'pH: ' + chemical.pH}
                 backgroundColor={
                   recipeReagents.includes(chemical.id)
-                    ? hasCol
+                    ? showPhCol
                       ? 'black'
                       : 'green'
-                    : hasCol
-                      ? chemical.pHCol
-                      : 'default'
+                    : 'default'
                 }
                 onClick={() =>
                   act('dispense', {

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -18,6 +18,7 @@ type DispensableReagent = {
   title: string;
   id: string;
   pH: number;
+  color: string;
   pHCol: string;
 };
 
@@ -186,6 +187,7 @@ export const ChemDispenser = (props) => {
               <Button
                 key={chemical.id}
                 icon="tint"
+                textColor={chemical.color}
                 width="129.5px"
                 lineHeight={1.75}
                 tooltip={'pH: ' + chemical.pH}
@@ -204,7 +206,7 @@ export const ChemDispenser = (props) => {
                   })
                 }
               >
-                {chemical.title}
+                <span style={{ color: 'white' }}>{chemical.title}</span>
               </Button>
             ))}
           </Box>


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/35492711-3ba9-4c5e-b013-ef8d39ac633f)

Made the droplets show the reagent color (or PH color if ph display is enabled)

## Why It's Good For The Game

Better UX when you know your colors.

## Changelog

:cl:
qol: chem dispenser droplets in UI colored as their reagent
/:cl:

