### PR TITLE
syndicate (and all) climbing hooks are small-sized

### DIFF
--- a/code/game/objects/items/climbingrope.dm
+++ b/code/game/objects/items/climbingrope.dm
@@ -14,6 +14,7 @@
 	attack_verb_continuous = list("whacks", "flails", "bludgeons")
 	attack_verb_simple = list("whack", "flail", "bludgeon")
 	resistance_flags = FLAMMABLE
+	w_class = WEIGHT_CLASS_SMALL
 	///how many times can we climb with this rope
 	var/uses = 5
 	///climb time
@@ -97,7 +98,6 @@
 	desc = "An emergency climbing hook to scale up holes. The rope is EXTREMELY cheap and may not withstand extended use."
 	uses = 2
 	climb_time = 4 SECONDS
-	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/climbing_hook/syndicate
 	name = "suspicious climbing hook"


### PR DESCRIPTION

## About The Pull Request

syndicate (and normal) climbing hooks are small sized.

## Why It's Good For The Game

nobody has ever used a syndicate climbing hook because they take up a massive normal slot. why is the upgrade that costs TC worse than the normal emergency hook? probably an oversight.

similarly, anyone who buys a climbing rope from the goodie pack will soon notice it's normal sized and toss it on the ground.

i don't think there's much of a good reason for these to be normal sized. i'd call this a consistency fix more than anything. its not like extended oxygen tanks are normal sized, sometimes things that take more effort to get are just better.

## Changelog

:cl:
qol: syndicate (and all) climbing hooks are small-sized
/:cl:

