### PR TITLE
Fix two broken gene combination recipes

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -26,11 +26,11 @@
 	result = /datum/mutation/human/shock
 
 /datum/generecipe/cindikinesis
-	required = "/datum/mutation/human/geladikinesis; /datum/mutation/human/fire_breath"
+	required = "/datum/mutation/human/geladikinesis; /datum/mutation/human/firebreath"
 	result = /datum/mutation/human/cindikinesis
 
 /datum/generecipe/pyrokinesis
-	required = "/datum/mutation/human/cryokinesis; /datum/mutation/human/fire_breath"
+	required = "/datum/mutation/human/cryokinesis; /datum/mutation/human/firebreath"
 	result = /datum/mutation/human/pyrokinesis
 
 /datum/generecipe/thermal_adaptation


### PR DESCRIPTION

## About The Pull Request
Changes the required genes for `/datum/generecipe/cindikinesis` and `/datum/generecipe/pyrokinesis` to have the correct path to the fire breath gene.

## Why It's Good For The Game
Bug fix is good.

## Changelog
:cl:
fix: The gene recipes for cindikinesis and pyrokinesis should now work properly.
/:cl:
