### PR TITLE
Add unit test for gene combination recipes

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -152,6 +152,7 @@
 #include "food_edibility_check.dm"
 #include "full_heal.dm"
 #include "gas_transfer.dm"
+#include "genetics.dm"
 #include "get_turf_pixel.dm"
 #include "geyser.dm"
 #include "gloves_and_shoes_armor.dm"

--- a/code/modules/unit_tests/genetics.dm
+++ b/code/modules/unit_tests/genetics.dm
@@ -1,0 +1,16 @@
+///Checks the gene combination recipes for validity.
+///Tests:
+///Check that recipe contains exactly two genes as ingredients
+///Checks that both ingredients are valid types
+/datum/unit_test/genetics_recipes
+
+/datum/unit_test/genetics_recipes/Run()
+	for(var/datum/generecipe/recipe as anything in subtypesof(/datum/generecipe))
+		var/list/ingredients = splittext(initial(recipe.required), "; ")
+		if(length(ingredients) != 2)
+			TEST_FAIL("[recipe] does not have exactly two ingredients!")
+			continue
+		if(!text2path(ingredients[1]))
+			TEST_FAIL("[recipe]: [ingredients[1]] is not a valid gene type!")
+		if(!text2path(ingredients[2]))
+			TEST_FAIL("[recipe]: [ingredients[2]] is not a valid gene type!")


### PR DESCRIPTION
## About The Pull Request
Adds a new unit test that checks that every gene combination recipe consists of exactly two gene type paths and that those type paths actually exist. 

NOTE: The checks on this are going to fail until #87581 is merged

## Why It's Good For The Game
Will prevent silent errors in gene recipes because strings mean invalid type paths aren't caught at compile-time.

## Changelog

No user facing changes