### PR TITLE
[TM ONLY] The roundstart report will only ever show either Pulsar Star or White Dwarf

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -1,9 +1,3 @@
-#define FAKE_GREENSHIFT_FORM_CHANCE 15
-#define FAKE_REPORT_CHANCE 8
-#define PULSAR_REPORT_CHANCE 8
-#define REPORT_NEG_DIVERGENCE -15
-#define REPORT_POS_DIVERGENCE 15
-
 // Are HIGH_IMPACT_RULESETs allowed to stack?
 GLOBAL_VAR_INIT(dynamic_no_stacking, TRUE)
 // If enabled does not accept or execute any rulesets.
@@ -373,53 +367,15 @@ SUBSYSTEM_DEF(dynamic)
 
 	return .
 
-/// Generate the advisory level depending on the shown threat level.
+/// Threat level always shows either Pulsar Star or White Dwarf, Centcom doesn't know what threat it is, I guess it's a mystery
 /datum/controller/subsystem/dynamic/proc/generate_advisory_level()
-	var/advisory_string = ""
-	if(prob(PULSAR_REPORT_CHANCE))
-		for(var/datum/station_trait/our_trait as anything in shuffle(SSstation.station_traits))
-			advisory_string += our_trait.get_pulsar_message()
-			if(length(advisory_string))
-				return advisory_string
-
-		advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
-		advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
-		return advisory_string
-	//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
-	if(round(shown_threat) == 0 && round(threat_level) == 0)
+	advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
+	advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
+	return advisory_string
+	if(round(threat_level) == 0)
 		advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
 		advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
 		return advisory_string
-
-	switch(round(shown_threat))
-		if(0 to 19)
-			var/show_core_territory = (GLOB.current_living_antags.len > 0)
-			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))
-				show_core_territory = !show_core_territory
-
-			if (show_core_territory)
-				advisory_string += "Advisory Level: <b>Blue Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Blue Star. At this threat advisory, the risk of attacks on Nanotrasen assets within the sector is minor but cannot be ruled out entirely. Remain vigilant."
-			else
-				advisory_string += "Advisory Level: <b>Green Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department of Intelligence advises maintaining vigilance against potential threats, regardless of a lack of known threats."
-		if(20 to 39)
-			advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
-		if(40 to 65)
-			advisory_string += "Advisory Level: <b>Orange Star</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Orange Star. Upon reviewing your sector's intelligence, the Department has determined that the risk of enemy activity is moderate to severe. At this advisory, we recommend maintaining a higher degree of security and reviewing red alert protocols with command and the crew."
-		if(66 to 79)
-			advisory_string += "Advisory Level: <b>Red Star</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Red Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
-		if(80 to 99)
-			advisory_string += "Advisory Level: <b>Black Orbit</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Black Orbit. Your sector's local communications network is currently undergoing a blackout, and we are therefore unable to accurately judge enemy movements within the region. However, information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of an impending attack. Remain on high alert and vigilant against any other potential threats."
-		if(100)
-			advisory_string += "Advisory Level: <b>Midnight Sun</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Midnight Sun. Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
-
-	return advisory_string
 
 /datum/controller/subsystem/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -1,3 +1,9 @@
+#define FAKE_GREENSHIFT_FORM_CHANCE 15
+#define FAKE_REPORT_CHANCE 8
+#define PULSAR_REPORT_CHANCE 8
+#define REPORT_NEG_DIVERGENCE -15
+#define REPORT_POS_DIVERGENCE 15
+
 // Are HIGH_IMPACT_RULESETs allowed to stack?
 GLOBAL_VAR_INIT(dynamic_no_stacking, TRUE)
 // If enabled does not accept or execute any rulesets.
@@ -367,15 +373,53 @@ SUBSYSTEM_DEF(dynamic)
 
 	return .
 
-/// Threat level always shows either Pulsar Star or White Dwarf, Centcom doesn't know what threat it is, I guess it's a mystery
+/// Generate the advisory level depending on the shown threat level.
 /datum/controller/subsystem/dynamic/proc/generate_advisory_level()
-	advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
-	advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
-	return advisory_string
-	if(round(threat_level) == 0)
+	var/advisory_string = ""
+	if(prob(PULSAR_REPORT_CHANCE))
+		for(var/datum/station_trait/our_trait as anything in shuffle(SSstation.station_traits))
+			advisory_string += our_trait.get_pulsar_message()
+			if(length(advisory_string))
+				return advisory_string
+
+		advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
+		advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
+		return advisory_string
+	//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
+	if(round(shown_threat) == 0 && round(threat_level) == 0)
 		advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
 		advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
 		return advisory_string
+
+	switch(round(shown_threat))
+		if(0 to 19)
+			var/show_core_territory = (GLOB.current_living_antags.len > 0)
+			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))
+				show_core_territory = !show_core_territory
+
+			if (show_core_territory)
+				advisory_string += "Advisory Level: <b>Blue Star</b></center><BR>"
+				advisory_string += "Your sector's advisory level is Blue Star. At this threat advisory, the risk of attacks on Nanotrasen assets within the sector is minor but cannot be ruled out entirely. Remain vigilant."
+			else
+				advisory_string += "Advisory Level: <b>Green Star</b></center><BR>"
+				advisory_string += "Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department of Intelligence advises maintaining vigilance against potential threats, regardless of a lack of known threats."
+		if(20 to 39)
+			advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
+			advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
+		if(40 to 65)
+			advisory_string += "Advisory Level: <b>Orange Star</b></center><BR>"
+			advisory_string += "Your sector's advisory level is Orange Star. Upon reviewing your sector's intelligence, the Department has determined that the risk of enemy activity is moderate to severe. At this advisory, we recommend maintaining a higher degree of security and reviewing red alert protocols with command and the crew."
+		if(66 to 79)
+			advisory_string += "Advisory Level: <b>Red Star</b></center><BR>"
+			advisory_string += "Your sector's advisory level is Red Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
+		if(80 to 99)
+			advisory_string += "Advisory Level: <b>Black Orbit</b></center><BR>"
+			advisory_string += "Your sector's advisory level is Black Orbit. Your sector's local communications network is currently undergoing a blackout, and we are therefore unable to accurately judge enemy movements within the region. However, information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of an impending attack. Remain on high alert and vigilant against any other potential threats."
+		if(100)
+			advisory_string += "Advisory Level: <b>Midnight Sun</b></center><BR>"
+			advisory_string += "Your sector's advisory level is Midnight Sun. Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
+
+	return advisory_string
 
 /datum/controller/subsystem/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -381,45 +381,16 @@ SUBSYSTEM_DEF(dynamic)
 			advisory_string += our_trait.get_pulsar_message()
 			if(length(advisory_string))
 				return advisory_string
-
-		advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
-		advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
 		return advisory_string
 	//a white dwarf shift leads to a green security alert on report and special announcement, this prevents a meta check if the alert report is fake or not.
 	if(round(shown_threat) == 0 && round(threat_level) == 0)
 		advisory_string += "Advisory Level: <b>White Dwarf</b></center><BR>"
 		advisory_string += "Your sector's advisory level is White Dwarf. Our surveillance has ruled out any and all potential threats known in our database, eliminating most risks to our assets in the Spinward Sector. We advise a lower level of security, alongside distributing resources on potential profit."
 		return advisory_string
-
-	switch(round(shown_threat))
-		if(0 to 19)
-			var/show_core_territory = (GLOB.current_living_antags.len > 0)
-			if (prob(FAKE_GREENSHIFT_FORM_CHANCE))
-				show_core_territory = !show_core_territory
-
-			if (show_core_territory)
-				advisory_string += "Advisory Level: <b>Blue Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Blue Star. At this threat advisory, the risk of attacks on Nanotrasen assets within the sector is minor but cannot be ruled out entirely. Remain vigilant."
-			else
-				advisory_string += "Advisory Level: <b>Green Star</b></center><BR>"
-				advisory_string += "Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department of Intelligence advises maintaining vigilance against potential threats, regardless of a lack of known threats."
-		if(20 to 39)
-			advisory_string += "Advisory Level: <b>Yellow Star</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
-		if(40 to 65)
-			advisory_string += "Advisory Level: <b>Orange Star</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Orange Star. Upon reviewing your sector's intelligence, the Department has determined that the risk of enemy activity is moderate to severe. At this advisory, we recommend maintaining a higher degree of security and reviewing red alert protocols with command and the crew."
-		if(66 to 79)
-			advisory_string += "Advisory Level: <b>Red Star</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Red Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
-		if(80 to 99)
-			advisory_string += "Advisory Level: <b>Black Orbit</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Black Orbit. Your sector's local communications network is currently undergoing a blackout, and we are therefore unable to accurately judge enemy movements within the region. However, information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of an impending attack. Remain on high alert and vigilant against any other potential threats."
-		if(100)
-			advisory_string += "Advisory Level: <b>Midnight Sun</b></center><BR>"
-			advisory_string += "Your sector's advisory level is Midnight Sun. Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
-
-	return advisory_string
+	else
+		advisory_string += "Advisory Level: <b>Pulsar Star</b></center><BR>"
+		advisory_string += "Your sector's advisory level is Pulsar Star. A large, unknown electromagnetic field has stormed through nearby surveillance equipment, causing major data loss. Partial data was recovered and showed no credible threats to Nanotrasen assets within the Spinward Sector; however, the Department of Intelligence advises maintaining high alert against potential threats due to the lack of complete data."
+		return advisory_string
 
 /datum/controller/subsystem/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())


### PR DESCRIPTION
E: I am no longer monitoring the comments on this PR as they have turned into a clown show, if you have feedback or data regarding a round this was TMed in please hit me up on Discord.

## About The Pull Request
I've been getting a lot of feedback from people that players are using the roundstart report as their sole indicator as to whether or not to play the round, to the point of some people killing themselves without using the "suicide" verb, reading the report, then either going DNR or re-entering their body to get healed.

That's fucking cringe.

This sets the report so it can only ever show a Pulsar Star or a White Dwarf. I want to keep the ability for the report to outright say if it's going to be an extended round, but it should be a mystery otherwise.

I want to run this as a test for a week or so and see how this changes the meta. If it results in more people playing more rounds for longer, I think it'll have been a success.
## Why It's Good For The Game
Players are entirely too reliant on the roundstart report to determine whether or not something will happen, and I feel it's both killing a lot of paranoia while also giving people an indicator as to whether or not they're going to get valids to fight that round, which I feel is bad for the health of the game in general. This keeps the other aspects about the report (traits and station goal) without just killing the whole thing.

I recall a few folks mentioning them wanting to work on a replacement for the report that more indicates potential issues than a straight up determination of round threat, which I like, but I want to see what this does.
## Changelog
:cl:
balance: Centcom's threat assessment AI has gone rampant, resulting in significantly less reliable threat reports.
/:cl:
