### PR TITLE
Makes mayhem-in-a-bottle text more obvious

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -433,7 +433,7 @@
 		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 25)
 
 	owner.log_message("entered a blood frenzy", LOG_ATTACK)
-	to_chat(owner, span_warning("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, KILL THEM ALL!"))
+	to_chat(owner, span_narsiesmall("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, NO TEAM MATES OR ALLEGIANCES! KILL THEM ALL!"))
 
 	var/datum/client_colour/colour = owner.add_client_colour(/datum/client_colour/bloodlust)
 	QDEL_IN(colour, 1.1 SECONDS)


### PR DESCRIPTION
## About The Pull Request
Apparently, mayhem-in-a-bottle currently just uses warning span which makes it tiny. It also isn't very clear about what happens if you're a team antag and someone pops one on you (you kill _everyone_, including teammates) so I tried to clarify that.

![image](https://github.com/user-attachments/assets/b47c3cbc-1e6b-4230-8572-d169fe861983)

## Why It's Good For The Game
Less confusion around what you're supposed to be doing (ripping and tearing) and to whom (literally anyone in eyeshot).
## Changelog
:cl:
fix: Clarifies mayhem-in-a-bottle's effects and makes the text much, much more obvious.
/:cl:
