### PR TITLE
Prevents Keykeeper's Burden from being used on centcom/away z levels

### DIFF
--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -55,6 +55,10 @@
 		qdel(src)
 		return
 
+	if(SSmapping.level_trait(z, ZTRAIT_NOPHASE) || SSmapping.level_trait(destination.z, ZTRAIT_NOPHASE))
+		qdel(src)
+		return
+
 	//get it?
 	var/obj/machinery/door/doorstination = (inverted ? !IS_HERETIC_OR_MONSTER(teleportee) : IS_HERETIC_OR_MONSTER(teleportee)) ? destination.our_airlock : find_random_airlock()
 	if(!do_teleport(teleportee, get_turf(doorstination), channel = TELEPORT_CHANNEL_MAGIC))
@@ -73,6 +77,9 @@
 		if(airlock.z != z)
 			continue
 		if(airlock.loc == loc)
+			continue
+		var/area/airlock_area = get_area(airlock)
+		if(airlock_area.area_flags & NOTELEPORT)
 			continue
 		possible_destinations += airlock
 	return pick(possible_destinations)
@@ -178,6 +185,8 @@
 		clear_portals()
 		return ITEM_INTERACT_SUCCESS
 	if(!istype(target, /obj/machinery/door))
+		return NONE
+	if(SSmapping.level_trait(target.z, ZTRAIT_NOPHASE))
 		return NONE
 	var/reference_resolved = link?.resolve()
 	if(reference_resolved == target)


### PR DESCRIPTION

## About The Pull Request

Closes #87591

## Changelog
:cl:
fix: Fixed Keykeeper's Burden being usable on centcom/away z levels
/:cl:
