### PR TITLE
Fixes `Robotize()` and player panel Make AI verb not putting dead player ghosts in the new mob

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -120,7 +120,7 @@
 
 	create_eye()
 
-	if(target_ai.mind)
+	if(target_ai.mind && target_ai.mind.active)
 		target_ai.mind.transfer_to(src)
 		if(mind.special_role)
 			to_chat(src, span_userdanger("You have been installed as an AI! "))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -153,7 +153,7 @@
 	if(mind) //TODO //TODO WHAT
 		if(!transfer_after)
 			mind.active = FALSE
-		mind.transfer_to(new_borg)
+		mind.transfer_to(new_borg, TRUE)
 	else if(transfer_after)
 		new_borg.key = key
 


### PR DESCRIPTION
## About The Pull Request

observer ghosts with no minds skip over mind transfer and get put in the mobs via key transfer, while a dead player ghost has a copy of their character's mind but with `active = FALSE`, which fails the transfer. it's kinda weird how the player panel uses `AIize` for the AI but uses a completely different mob transform for the borg. hmm

## Why It's Good For The Game

fixes #68643

## Changelog

:cl:
fix: fixed Make Cyborg admin verb and player panel Make AI not putting the ghosted player in control if they weren't an observer
/:cl: