### PR TITLE
Restores Derelict's vault doors hacking immunity

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -82,7 +82,6 @@
 	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N
 	autoclose = TRUE
 	explosion_block = 1
-	has_access_panel = TRUE
 	hud_possible = list(DIAG_AIRLOCK_HUD)
 	smoothing_groups = SMOOTH_GROUP_AIRLOCK
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -82,6 +82,7 @@
 	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N
 	autoclose = TRUE
 	explosion_block = 1
+	has_access_panel = TRUE
 	hud_possible = list(DIAG_AIRLOCK_HUD)
 	smoothing_groups = SMOOTH_GROUP_AIRLOCK
 
@@ -119,7 +120,6 @@
 	var/obj/item/note
 	/// The seal on the airlock
 	var/obj/item/seal
-	var/detonated = FALSE
 	var/abandoned = FALSE
 	/// Controls if the door closes quickly or not. FALSE = the door autocloses in 1.5 seconds, TRUE = 8 seconds - see autoclose_in()
 	var/normalspeed = TRUE
@@ -701,8 +701,9 @@
 
 	switch (held_item?.tool_behaviour)
 		if (TOOL_SCREWDRIVER)
-			context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Close panel" : "Open panel"
-			return CONTEXTUAL_SCREENTIP_SET
+			if(has_access_panel)
+				context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Close panel" : "Open panel"
+				return CONTEXTUAL_SCREENTIP_SET
 		if (TOOL_CROWBAR)
 			if (panel_open)
 				if (security_level == AIRLOCK_SECURITY_PLASTEEL_O_S || security_level == AIRLOCK_SECURITY_PLASTEEL_I_S)
@@ -745,9 +746,6 @@
 			to_chat(user, span_warning("Airlock AI control has been blocked with a firewall. Unable to hack."))
 	if(obj_flags & EMAGGED)
 		to_chat(user, span_warning("Unable to interface: Airlock is unresponsive."))
-		return
-	if(detonated)
-		to_chat(user, span_warning("Unable to interface. Airlock control panel damaged."))
 		return
 
 	ui_interact(user)
@@ -858,7 +856,7 @@
 		set_electrified(MACHINE_ELECTRIFIED_PERMANENT)
 
 /obj/machinery/door/airlock/screwdriver_act(mob/living/user, obj/item/tool)
-	if(panel_open && detonated)
+	if(!has_access_panel)
 		to_chat(user, span_warning("[src] has no maintenance panel!"))
 		return ITEM_INTERACT_SUCCESS
 	toggle_panel_open()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -35,7 +35,7 @@
 	var/obj/structure/fluff/airlock_filler/filler
 	var/welded = FALSE
 	///Whether this door has a panel or not; FALSE also stops the examine blurb about the panel from showing up
-	var/has_access_panel = FALSE
+	var/has_access_panel = TRUE
 	/// For rglass-windowed airlocks and firedoors
 	var/heat_proof = FALSE
 	/// Emergency access override

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -34,6 +34,8 @@
 	/// A filler object used to fill the space of multi-tile airlocks
 	var/obj/structure/fluff/airlock_filler/filler
 	var/welded = FALSE
+	///Whether this door has a panel or not; FALSE also stops the examine blurb about the panel from showing up
+	var/has_access_panel = FALSE
 	/// For rglass-windowed airlocks and firedoors
 	var/heat_proof = FALSE
 	/// Emergency access override
@@ -122,7 +124,8 @@
 			. += span_notice("Due to a security threat, its access requirements have been lifted!")
 		else
 			. += span_notice("In the event of a red alert, its access requirements will automatically lift.")
-	. += span_notice("Its maintenance panel is [panel_open ? "open" : "<b>screwed</b> in place"].")
+	if(has_access_panel)
+		. += span_notice("Its maintenance panel is [panel_open ? "open" : "<b>screwed</b> in place"].")
 
 /obj/machinery/door/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()

--- a/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
@@ -162,11 +162,12 @@
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	id_tag = "derelictvault"
+	has_access_panel = FALSE
 
-///Overrides screwdriver act to prevent all deconstruction and hacking.
+///Overrides screwdriver act to prevent all deconstruction and hacking. Override for extra tuff fluff
 /obj/machinery/door/airlock/vault/derelict/screwdriver_act(mob/living/user, obj/item/tool)
 	to_chat(user, span_danger("The robust make of [src] makes it impossible to access the panel in any way!"))
-	return ITEM_INTERACT_BLOCKING
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/fluff/oldturret
 	name = "broken turret"

--- a/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
@@ -163,11 +163,10 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	id_tag = "derelictvault"
 
-///Overrides screwdriver attack to prevent all deconstruction and hacking.
-/obj/machinery/door/airlock/vault/derelict/attackby(obj/item/C, mob/user, params)
-	if(C.tool_behaviour == TOOL_SCREWDRIVER)
-		return
-	..()
+///Overrides screwdriver act to prevent all deconstruction and hacking.
+/obj/machinery/door/airlock/vault/derelict/screwdriver_act(mob/living/user, obj/item/tool)
+	to_chat(user, span_danger("The robust make of [src] makes it impossible to access the panel in any way!"))
+	return ITEM_INTERACT_BLOCKING
 
 /obj/structure/fluff/oldturret
 	name = "broken turret"


### PR DESCRIPTION
## About The Pull Request

Title; it was handled by `attackby()` and became deprecated at some point, something something attack chain
Also gave it feedback because might as well

## Why It's Good For The Game

Fixes #79926

## Changelog

:cl:
fix: the Derelict vault doors are once again unhackable
qol: the Derelict vault doors provide chat feedback when you try to hack them so you can stop poking them with your tools
/:cl:
