### PR TITLE
Fixes `set_sanity()` math maybe hopefully oh fuck

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -462,8 +462,8 @@
 /datum/mood/proc/set_sanity(amount, minimum = SANITY_INSANE, maximum = SANITY_GREAT, override = FALSE)
 	// If we're out of the acceptable minimum-maximum range move back towards it in steps of 0.7
 	// If the new amount would move towards the acceptable range faster then use it instead
-	if(amount < minimum)
-		amount += clamp(minimum - amount, 0, 0.7)
+	if(amount < minimum && sanity < minimum)
+		amount = sanity + 0.7
 	if((!override && HAS_TRAIT(mob_parent, TRAIT_UNSTABLE)) || amount > maximum)
 		amount = min(sanity, amount)
 	if(amount == sanity) //Prevents stuff from flicking around.


### PR DESCRIPTION
## About The Pull Request

okay so judging by the code comment when sanity dips lower than the minimum aka 0 we're supposed to move up from our current sanity by 0.7 instead. however in code it's instead using the passed `amount` value, which from the looks of it is mostly passed by already modifying sanity with other math operations, like the madness mask 
https://github.com/tgstation/tgstation/blob/762a52ed83c3d910b14258060d4693d120fe628a/code/modules/antagonists/heretic/items/madness_mask.dm#L59
https://github.com/tgstation/tgstation/blob/762a52ed83c3d910b14258060d4693d120fe628a/code/datums/mood.dm#L530-L532
so instead we're passing an even lower value than the current sanity and are moving up from there instead of current sanity. wack
i think it started as far back as https://github.com/tgstation/tgstation/commit/091f221fe615cfa5e741b98f14b6e5c8eeadbe47 but i might be wrong and my math might be wrong and do we need the `clamp()` part of the equation even oh god oh fuck

## Why It's Good For The Game

Fixes #69082

## Changelog

:cl:
fix: sanity dropping below zero should now properly slowly recover back to zero instead of dropping even further
/:cl: