### PR TITLE
Fix NTNRC muting not working at all.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -59,7 +59,7 @@
 		if("PRG_speak")
 			if(!channel || isnull(active_channel))
 				return
-			if(src in channel.muted_clients) // Mute safety check
+			if(src in channel.muted_clients) // Make sure we aren't muted
 				return
 			var/message = reject_bad_chattext(params["message"], MESSAGE_SIZE)
 			if(!message)

--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -59,6 +59,8 @@
 		if("PRG_speak")
 			if(!channel || isnull(active_channel))
 				return
+			if(src in channel.muted_clients) // Mute safety check
+				return
 			var/message = reject_bad_chattext(params["message"], MESSAGE_SIZE)
 			if(!message)
 				return

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -179,6 +179,7 @@ export const NtosNetChat = (props) => {
                     'Message ' + title
                   }
                   fluid
+                  disabled={this_client && this_client.muted}
                   selfClear
                   mt={1}
                   onEnter={(e, value) =>


### PR DESCRIPTION

## About The Pull Request

When fiddling around with NTNRC, I noticed that muted clients... can still talk.
While the input bar is reddened and displays a mute message, it isn't actually disabled- even more so, there's no sanity checks for being muted on the `ui_act(...)`.

In this pr we just make it so the input gets disabled, and add a sanity check to avoid people bypassing it.
## Why It's Good For The Game

...good if the app's muting feature like, actually works.
## Changelog
:cl:
fix: NTNRC muting actually works again.
/:cl:
