### PR TITLE
Fix bad index exception when typecache is null

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -303,9 +303,11 @@
 /proc/typecache_filter_list(list/atoms, list/typecache)
 	RETURN_TYPE(/list)
 	. = list()
-	for(var/atom/atom_checked as anything in atoms)
-		if (typecache[atom_checked.type])
-			. += atom_checked
+
+	if(typecache)
+		for(var/atom/atom_checked as anything in atoms)
+			if (typecache[atom_checked.type])
+				. += atom_checked
 
 ///return a new list with atoms that are not in the typecache list
 /proc/typecache_filter_list_reverse(list/atoms, list/typecache)


### PR DESCRIPTION

## About The Pull Request

Fixes a bad index exception that occurres often in Metastation at least, because of `grass patch` when found in the `/datum/ai_behavior/find_and_set/proc/search_tactic`. Just checks if typecache is not null before proceeding with the logic.
## Why It's Good For The Game

Fixes an exception.
## Changelog
:cl:
fix: fixed bad index exception with grass patch
/:cl:
