### PR TITLE
Thermal insulation tags will now format correctly

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -379,7 +379,7 @@
 				cold_desc = "very low"
 			if (0 to 71)
 				cold_desc = "extremely low"
-		.["thermally insulated"] = "Protects the wearer from [jointext(list(heat_desc, cold_desc), " and ")] temperatures."
+		.["thermally insulated"] = "Protects the wearer from [jointext(list(heat_desc, cold_desc) - null, " and ")] temperatures."
 
 /obj/item/clothing/examine_descriptor(mob/user)
 	return "clothing"


### PR DESCRIPTION
## About The Pull Request

closes #87439
jointext() will still join together lists, even if some entries are "null"
the PR removes null from the list so that jointext won't run if clothing is either only hot-insulated or only cold-insulated

## Picture of fucked up dog
![fucked-up-looking-dog-spookston](https://github.com/user-attachments/assets/3919fe7c-b439-41a1-bd32-4d9829836699)

## Testing Evidence

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/0e29f278-c107-4caf-b36d-16f0cd385aad)

</details>

:cl:
fix: thermal insulation tags are correctly formatted if they're only cold or hot insulated
/:cl:
