### PR TITLE
Fixes NTNRC username sorting, additionally makes subcategories sort alphabetically.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -211,7 +211,7 @@
 	return ..()
 
 /// Converts active/idle/closed to a numerical status for sorting clients by.
-/datum/computer_file/program/chatclient/proc/get_status()
+/datum/computer_file/program/chatclient/proc/get_numerical_status()
 	if(src == computer.active_program)
 		return STATUS_ONLINE
 	if(src in computer.idle_threads)
@@ -254,7 +254,7 @@
 				"away" = (channel_client in channel_client.computer.idle_threads),
 				"muted" = (channel_client in channel.muted_clients),
 				"operator" = (channel.channel_operator == channel_client),
-				"status" = channel_client.get_status(),
+				"status" = channel_client.get_numerical_status(),
 				"ref" = REF(channel_client),
 			)))
 		//no fishing for ui data allowed

--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -4,6 +4,10 @@
 
 #define PING_COOLDOWN_TIME (3 SECONDS)
 
+#define STATUS_ONLINE 3
+#define STATUS_AWAY 2
+#define STATUS_OFFLINE 1
+
 /datum/computer_file/program/chatclient
 	filename = "ntnrc_client"
 	filedesc = "Chat Client"
@@ -206,6 +210,13 @@
 	active_channel = null
 	return ..()
 
+/datum/computer_file/program/chatclient/proc/get_status()
+	if(src == computer.active_program)
+		return STATUS_ONLINE
+	if(src in computer.idle_threads)
+		return STATUS_AWAY
+	return STATUS_OFFLINE
+
 /datum/computer_file/program/chatclient/ui_static_data(mob/user)
 	var/list/data = list()
 	data["selfref"] = REF(src) //used to verify who is you, as usernames can be copied.
@@ -242,6 +253,7 @@
 				"away" = (channel_client in channel_client.computer.idle_threads),
 				"muted" = (channel_client in channel.muted_clients),
 				"operator" = (channel.channel_operator == channel_client),
+				"status" = channel_client.get_status(),
 				"ref" = REF(channel_client),
 			)))
 		//no fishing for ui data allowed
@@ -267,3 +279,7 @@
 #undef MESSAGE_SIZE
 
 #undef PING_COOLDOWN_TIME
+
+#undef STATUS_ONLINE
+#undef STATUS_AWAY
+#undef STATUS_OFFLINE

--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -210,6 +210,7 @@
 	active_channel = null
 	return ..()
 
+/// Converts active/idle/closed to a numerical status for sorting clients by.
 /datum/computer_file/program/chatclient/proc/get_status()
 	if(src == computer.active_program)
 		return STATUS_ONLINE

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -64,7 +64,9 @@ export const NtosNetChat = (props) => {
   const authorized = authed || adminmode;
   // this list has cliented ordered from their status. online > away > offline
   const displayed_clients = clients.sort((clientA, clientB) => {
-    return (clientB.operator - clientA.operator) || (clientB.status - clientA.status) || (clientB.name < clientA.name);
+    return (clientB.operator - clientA.operator) ||
+	(clientB.status - clientA.status) ||
+	(clientB.name < clientA.name);
   });
   const client_color = (client) => {
     if (client.operator) {

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -64,9 +64,11 @@ export const NtosNetChat = (props) => {
   const authorized = authed || adminmode;
   // This list has clients ordered by operator>status>alphabetical
   const displayed_clients = clients.sort((clientA, clientB) => {
-    return (clientB.operator - clientA.operator) ||
-      (clientB.status - clientA.status) ||
-      (clientB.name < clientA.name);
+    return (
+      clientB.operator - clientA.operator ||
+      clientB.status - clientA.status ||
+      clientB.name < clientA.name
+    );
   });
   const client_color = (client) => {
     if (client.operator) {

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -65,8 +65,8 @@ export const NtosNetChat = (props) => {
   // This list has clients ordered by operator>status>alphabetical
   const displayed_clients = clients.sort((clientA, clientB) => {
     return (clientB.operator - clientA.operator) ||
-	(clientB.status - clientA.status) ||
-	(clientB.name < clientA.name);
+    (clientB.status - clientA.status) ||
+    (clientB.name < clientA.name);
   });
   const client_color = (client) => {
     if (client.operator) {

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -64,7 +64,7 @@ export const NtosNetChat = (props) => {
   const authorized = authed || adminmode;
   // this list has cliented ordered from their status. online > away > offline
   const displayed_clients = clients.sort((clientA, clientB) => {
-    return (clientB.operator - clientA.operator) || (clientB.status - clientA.status) || (clientB.name < clientA.name)
+    return (clientB.operator - clientA.operator) || (clientB.status - clientA.status) || (clientB.name < clientA.name);
   });
   const client_color = (client) => {
     if (client.operator) {

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -62,7 +62,7 @@ export const NtosNetChat = (props) => {
   } = data;
   const in_channel = active_channel !== null;
   const authorized = authed || adminmode;
-  // this list has cliented ordered from their status. online > away > offline
+  // This list has clients ordered by operator>status>alphabetical
   const displayed_clients = clients.sort((clientA, clientB) => {
     return (clientB.operator - clientA.operator) ||
 	(clientB.status - clientA.status) ||

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -64,13 +64,7 @@ export const NtosNetChat = (props) => {
   const authorized = authed || adminmode;
   // this list has cliented ordered from their status. online > away > offline
   const displayed_clients = clients.sort((clientA, clientB) => {
-    if (clientA.operator) {
-      return -1;
-    }
-    if (clientB.operator) {
-      return 1;
-    }
-    return clientB.status - clientA.status;
+    return (clientB.operator - clientA.operator) || (clientB.status - clientA.status) || (clientB.name < clientA.name)
   });
   const client_color = (client) => {
     if (client.operator) {

--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -65,8 +65,8 @@ export const NtosNetChat = (props) => {
   // This list has clients ordered by operator>status>alphabetical
   const displayed_clients = clients.sort((clientA, clientB) => {
     return (clientB.operator - clientA.operator) ||
-    (clientB.status - clientA.status) ||
-    (clientB.name < clientA.name);
+      (clientB.status - clientA.status) ||
+      (clientB.name < clientA.name);
   });
   const client_color = (client) => {
     if (client.operator) {


### PR DESCRIPTION

## About The Pull Request

While looking into getting the NTNRC username list sorted, I found out that it was _already_ supposed to be sorted by status, but just got broken in a pr that removes the program status variable forwarded for this reason.

In this pr we simply add a `get_numerical_status()` proc that converts the new logic into a number we can sort by, then make the tgui sort account for this.
Additionally, we make it sort alphabetically in its subcategories, for sanity's sake.
It now sorts by operator perms first, then online>away(background)>offline, then alphabetically.

While I dislike operators being at the top regardless of their status, it seems like that is how it was intended to work, and doing so sanely would requite rethinking how names are coloured entirely. On the other end, I think it's potentially good to have operators be at the top and thus easily pingable at all times.
## Why It's Good For The Game

Fixes broken status sorting.
Alphabetical sorting makes finding a specific user to mute or ping them less of a pain.
## Changelog
:cl:
fix: NTNRC channel user list is sorted by status again. It goes operator>online>away>offline.
qol: NTNRC channel user list is now alphabetically sorted under its status subcategories.
/:cl:
