### PR TITLE
Micro-optimize the `DREAMLUAU_CALL` macro

### DIFF
--- a/code/__HELPERS/_dreamluau.dm
+++ b/code/__HELPERS/_dreamluau.dm
@@ -6,7 +6,7 @@
 
 #define DREAMLUAU (world.system_type == MS_WINDOWS ? "dreamluau.dll" : (__dreamluau ||= __detect_auxtools("dreamluau")))
 
-#define DREAMLUAU_CALL(func) (!DREAMLUAU_EXISTS) ? null : call_ext(DREAMLUAU, "byond:[#func]")
+#define DREAMLUAU_CALL(func) (!DREAMLUAU_EXISTS) ? null : call_ext(DREAMLUAU, "byond:" + #func)
 
 /**
  * All of the following functions will return a string if the underlying rust code returns an error or a wrapped panic.


### PR DESCRIPTION

## About The Pull Request

iirc, BYOND will automatically turn `"byond:" + "whatever"` into `"byond:whatever"` during compile, but `"byond:["whatever"]"` will still be formatted during runtime instead. no reason *not* to do this, it doesn't hurt.

## Why It's Good For The Game

Micro-optimization with no downsides.

## Changelog

No user-facing changes at all.
