### PR TITLE
Fix NT Software Hub displaying >100% completion or NaN/Infinite% completion.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -108,12 +108,9 @@
 		return
 	if(HAS_TRAIT(computer, TRAIT_MODPC_HALVED_DOWNLOAD_SPEED))
 		download_netspeed *= 0.5
-
-	download_completion += download_netspeed
-	if(download_completion > downloaded_file.size)
-		// We don't complete it here so we stay on 100% for a cycle
-		// We do cap out our completion to avoid UI issues
-		download_completion = downloaded_file.size
+	// We don't complete it here so we stay on 100% for a cycle
+	// We do cap out our completion to avoid UI issues
+	download_completion = min(download_completion  + download_netspeed, downloaded_file.size)
 
 /datum/computer_file/program/ntnetdownload/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -65,7 +65,7 @@
 
 	downloaded_file = PRG.clone()
 
-	// If the filesize is 0 (or somehow lower), we instantly download.
+	// If the filesize is 0 (or somehow lower), we instantly download to avoid invalid number issues with stepwise completion.
 	if(downloaded_file.size <= 0)
 		complete_file_download()
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -65,7 +65,7 @@
 
 	downloaded_file = PRG.clone()
 
-	// If the filesize is 0 (or somehow lower), we instantly download to avoid invalid number issues with stepwise completion.
+	// If the filesize is 0 (or somehow lower), we instantly download to avoid invalid number issues with stepwise download.
 	if(downloaded_file.size <= 0)
 		complete_file_download()
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -110,7 +110,7 @@
 		download_netspeed *= 0.5
 
 	download_completion += download_netspeed
-	if(download_completion >= downloaded_file.size)
+	if(download_completion > downloaded_file.size)
 		// We don't complete it here so we stay on 100% for a cycle
 		// We do cap out our completion to avoid UI issues
 		download_completion = downloaded_file.size

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -89,8 +89,9 @@
 		return
 	if(download_completion >= downloaded_file.size)
 		complete_file_download()
+		return
 	// Download speed according to connectivity state. NTNet server is assumed to be on unlimited speed so we're limited by our local connectivity
-	var/download_netspeed
+	var/download_netspeed = 0
 	// Speed defines are found in misc.dm
 	switch(ntnet_status)
 		if(NTNET_LOW_SIGNAL)
@@ -99,10 +100,16 @@
 			download_netspeed = NTNETSPEED_HIGHSIGNAL
 		if(NTNET_ETHERNET_SIGNAL)
 			download_netspeed = NTNETSPEED_ETHERNET
-	if(download_netspeed)
-		if(HAS_TRAIT(computer, TRAIT_MODPC_HALVED_DOWNLOAD_SPEED))
-			download_netspeed *= 0.5
-		download_completion += download_netspeed
+	if(download_netspeed <= 0)
+		return
+	if(HAS_TRAIT(computer, TRAIT_MODPC_HALVED_DOWNLOAD_SPEED))
+		download_netspeed *= 0.5
+
+	download_completion += download_netspeed
+	if(download_completion >= downloaded_file.size)
+		// We don't complete it here so we stay on 100% for a cycle
+		// We do cap out our completion to avoid UI issues
+		download_completion = downloaded_file.size
 
 /datum/computer_file/program/ntnetdownload/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -65,6 +65,10 @@
 
 	downloaded_file = PRG.clone()
 
+	// If the filesize is 0 (or somehow lower), we instantly download.
+	if(downloaded_file.size <= 0)
+		complete_file_download()
+
 /datum/computer_file/program/ntnetdownload/proc/abort_file_download()
 	if(!downloaded_file)
 		return


### PR DESCRIPTION

## About The Pull Request

During all that fiddling with NTNRC I noticed that sometimes the download percentage would shoot above 100%.
Looking into it, it seems that that's just because it isn't actually capped at the downloaded file size.

So we cap it to the file size after adding our next download chunk, but parallel to before don't complete it immediately so that we stay on 100% for another cycle before finishing. For style reasons.

Then I noticed files with a size of 0 would sometimes display NaN% or Infinite%, presumably because both of the progress percentage calculations in the ui would be dividing by zero.
So to avoid this, we just skip the downloading cycle entirely for 0 size programs, and go to download completion immediately on clicking.

This fixes our issues.
## Why It's Good For The Game

Fixes some jank.
## Changelog
:cl:
fix: NT Software Hub no longer displays >100% completion on downloads sometimes.
fix: NT Software Hub no longer displays NaN% or Infinite% completion on files with a size of 0 sometimes.
/:cl:
