### PR TITLE
Shuttle docker console camera eyes now refresh if the offset/range is VV'd.

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -59,6 +59,20 @@
 	else
 		QDEL_NULL(my_port)
 
+/obj/machinery/computer/camera_advanced/shuttle_docker/vv_edit_var(vname, vval)
+	. = ..()
+	if(vname in list(NAMEOF(src, view_range), NAMEOF(src, x_offset), NAMEOF(src, y_offset), NAMEOF(src, see_hidden)))
+		refresh_eye()
+
+/// Destroys the eyeobj of this console, safely refreshing it if the console is currently being used.
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/refresh_eye()
+	var/mob/living/user = current_user
+	if(user)
+		remove_eye_control(user)
+	QDEL_NULL(eyeobj)
+	if(user)
+		attack_hand(user)
+
 /// "Initializes" any default port ids we have, done so add_jumpable_port can be a proper setter
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/set_init_ports()
 	var/list/init_ports = jump_to_ports.Copy()


### PR DESCRIPTION
## About The Pull Request

If you VV the `x_offset`, `y_offset`, `view_range`, or `see_hidden` vars of a `/obj/machinery/computer/camera_advanced/shuttle_docker`, it will destroy the current eyeobj - if someone is currently viewing said shuttle console, it'll somewhat seemlessly "refresh" with the new range and offset for them.

## Why It's Good For The Game

Makes it easier for mappers to get the correct offset and range for shuttle docker consoles.

## Changelog

Not really any player-facing changes, this is meant to make it easier to figure out a good offset/view range when designing new shuttles.
