### PR TITLE
(TM ONLY) Doubles the speed of all projectiles (that matter)

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -75,7 +75,7 @@
 	/// During each fire of SSprojectiles, the number of deciseconds since the last fire of SSprojectiles
 	/// is divided by this var, and the result truncated to the next lowest integer is
 	/// the number of times the projectile's `pixel_move` proc will be called.
-	var/speed = 0.8
+	var/speed = 0.4
 
 	/// This var is multiplied by SSprojectiles.global_pixel_speed to get how many pixels
 	/// the projectile moves during each iteration of the movement loop

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -53,7 +53,7 @@
 	icon_state = "hellfire"
 	wound_bonus = 0
 	damage = 30
-	speed = 0.6 // higher power = faster, that's how light works right
+	speed = 0.2 // higher power = faster, that's how light works right
 	light_color = "#FF969D"
 
 /obj/projectile/beam/laser/heavylaser

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -35,7 +35,7 @@
 	suppressed = SUPPRESSED_VERY
 	damage_type = BURN
 	armor_flag = BOMB
-	speed = 1.2
+	speed = 0.6
 	wound_bonus = 30
 	bare_wound_bonus = 30
 	wound_falloff_tile = -4

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -79,7 +79,7 @@
 	icon_state = "smartgun"
 	damage = 10
 	embed_type = /datum/embed_data/bullet_c160smart
-	speed = 2
+	speed = 1
 	homing_turn_speed = 5
 	homing_inaccuracy_min = 4
 	homing_inaccuracy_max = 10

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -67,7 +67,7 @@
 	name = "rebar"
 	icon_state = "rebar"
 	damage = 30
-	speed = 0.4
+	speed = 0.2
 	dismemberment = 1 //because a 1 in 100 chance to just blow someones arm off is enough to be cool but also not enough to be reliable
 	armour_penetration = 10
 	wound_bonus = -20
@@ -93,7 +93,7 @@
 	name = "rebar"
 	icon_state = "rebar"
 	damage = 45
-	speed = 0.4
+	speed = 0.2
 	dismemberment = 2 //It's a budget sniper rifle.
 	armour_penetration = 20 //A bit better versus armor. Gets past anti laser armor or a vest, but doesnt wound proc on sec armor.
 	wound_bonus = 10
@@ -116,7 +116,7 @@
 	name = "zaukerite shard"
 	icon_state = "rebar_zaukerite"
 	damage = 60
-	speed = 0.6
+	speed = 0.3
 	dismemberment = 10
 	damage_type = TOX
 	eyeblur = 5
@@ -141,7 +141,7 @@
 	name = "metallic hydrogen bolt"
 	icon_state = "rebar_hydrogen"
 	damage = 35
-	speed = 0.6
+	speed = 0.3
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
 	phasing_ignore_direct_target = TRUE
@@ -176,7 +176,7 @@
 	name = "healium bolt"
 	icon_state = "rebar_healium"
 	damage = 0
-	speed = 0.4
+	speed = 0.2
 	dismemberment = 0
 	damage_type = BRUTE
 	armour_penetration = 100
@@ -203,7 +203,7 @@
 	name = "supermatter bolt"
 	icon_state = "rebar_supermatter"
 	damage = 0
-	speed = 0.4
+	speed = 0.2
 	dismemberment = 0
 	damage_type = TOX
 	embed_type = null

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -94,7 +94,7 @@
 	stamina = 11
 	sharpness = NONE
 	embed_type = null
-	speed = 1.2
+	speed = 0.6
 	stamina_falloff_tile = -0.25
 	ricochets_max = 4
 	ricochet_chance = 120
@@ -124,7 +124,6 @@
 	wound_bonus = -25
 	bare_wound_bonus = 50
 	wound_falloff_tile = -10
-	speed = 0.8
 	ricochet_decay_chance = 0.6
 	ricochet_decay_damage = 0.3
 	demolition_mod = 10

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -2,7 +2,7 @@
 
 /obj/projectile/bullet/p50
 	name =".50 BMG bullet"
-	speed = 0.4
+	speed = 0.2
 	range = 400 // Enough to travel from one corner of the Z to the opposite corner and then some.
 	damage = 70
 	paralyze = 100
@@ -87,7 +87,7 @@
 	name = ".50 BMG aggression dissuasion round"
 	icon_state = "gaussstrong"
 	damage = 25
-	speed = 0.3
+	speed = 0.1
 	range = 16
 
 /obj/projectile/bullet/p50/marksman


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. There might be some missed (colossus projectiles I deliberately ignored), but who cares.

## Why It's Good For The Game

I'm really curious to see what the effects of increasing the projectile speed broadly will have. People often complain about the fact that you can, in many circumstances, outrun bullets due to baseline move speed being so high..

 Many others argue that this is an important balancing point, as not being able to avoid projectiles will make ranged weapons simply too good and removes an aspect of skill expression to engagements in being able to avoid shots.

Let's see what happens.

## Changelog
:cl:
balance: All projectiles have had their flight speed increased by nearly double their original speed.
/:cl:
