### PR TITLE
Refactor gene combination recipes to not use strings

### DIFF
--- a/code/_globalvars/genetics.dm
+++ b/code/_globalvars/genetics.dm
@@ -5,5 +5,3 @@ GLOBAL_LIST_EMPTY(bad_mutations) //bad initialized mutations
 GLOBAL_LIST_EMPTY(good_mutations) //good initialized mutations
 GLOBAL_LIST_EMPTY(not_good_mutations) //neutral initialized mutations
 GLOBAL_LIST_EMPTY(alias_mutations) //alias = type
-
-GLOBAL_LIST_EMPTY(mutation_recipes)

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -173,8 +173,6 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/proc/setupGenetics()
 	var/list/mutations = subtypesof(/datum/mutation/human)
 	shuffle_inplace(mutations)
-	for(var/datum/generecipe/GR as anything in subtypesof(/datum/generecipe))
-		GLOB.mutation_recipes |= GR
 	for(var/i in 1 to LAZYLEN(mutations))
 		var/path = mutations[i] //byond gets pissy when we do it in one line
 		var/datum/mutation/human/B = new path ()

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -173,9 +173,8 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/proc/setupGenetics()
 	var/list/mutations = subtypesof(/datum/mutation/human)
 	shuffle_inplace(mutations)
-	for(var/A in subtypesof(/datum/generecipe))
-		var/datum/generecipe/GR = A
-		GLOB.mutation_recipes[initial(GR.required)] = initial(GR.result)
+	for(var/datum/generecipe/GR as anything in subtypesof(/datum/generecipe))
+		GLOB.mutation_recipes |= GR
 	for(var/i in 1 to LAZYLEN(mutations))
 		var/path = mutations[i] //byond gets pissy when we do it in one line
 		var/datum/mutation/human/B = new path ()

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -8,7 +8,7 @@
 		return FALSE
 	if(mutation1 == mutation2) //this could otherwise be bad
 		return FALSE
-	for(var/datum/generecipe/GR as anything in GLOB.mutation_recipes)
+	for(var/datum/generecipe/GR as anything in subtypesof(/datum/generecipe))
 		if((initial(GR.input_one) == mutation1 && initial(GR.input_two) == mutation2) || (initial(GR.input_one) == mutation2 && initial(GR.input_two) == mutation1))
 			return initial(GR.result)
 

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -1,5 +1,6 @@
 /datum/generecipe
-	var/required = "" //it hurts so bad but initial is not compatible with lists
+	var/input_one = null
+	var/input_two = null
 	var/result = null
 
 /proc/get_mixed_mutation(mutation1, mutation2)
@@ -7,52 +8,63 @@
 		return FALSE
 	if(mutation1 == mutation2) //this could otherwise be bad
 		return FALSE
-	for(var/A in GLOB.mutation_recipes)
-		if(findtext(A, "[mutation1]") && findtext(A, "[mutation2]"))
-			return GLOB.mutation_recipes[A]
+	for(var/datum/generecipe/GR as anything in GLOB.mutation_recipes)
+		if((initial(GR.input_one) == mutation1 && initial(GR.input_two) == mutation2) || (initial(GR.input_one) == mutation2 && initial(GR.input_two) == mutation1))
+			return initial(GR.result)
 
 /* RECIPES */
 
 /datum/generecipe/hulk
-	required = "/datum/mutation/human/strong; /datum/mutation/human/radioactive"
+	input_one = /datum/mutation/human/strong
+	input_two = /datum/mutation/human/radioactive
 	result = /datum/mutation/human/hulk
 
 /datum/generecipe/mindread
-	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
+	input_one = /datum/mutation/human/antenna
+	input_two = /datum/mutation/human/paranoia
 	result = /datum/mutation/human/mindreader
 
 /datum/generecipe/shock
-	required = "/datum/mutation/human/insulated; /datum/mutation/human/radioactive"
+	input_one = /datum/mutation/human/insulated
+	input_two = /datum/mutation/human/radioactive
 	result = /datum/mutation/human/shock
 
 /datum/generecipe/cindikinesis
-	required = "/datum/mutation/human/geladikinesis; /datum/mutation/human/firebreath"
+	input_one = /datum/mutation/human/geladikinesis
+	input_two = /datum/mutation/human/firebreath
 	result = /datum/mutation/human/cindikinesis
 
 /datum/generecipe/pyrokinesis
-	required = "/datum/mutation/human/cryokinesis; /datum/mutation/human/firebreath"
+	input_one = /datum/mutation/human/cryokinesis
+	input_two = /datum/mutation/human/firebreath
 	result = /datum/mutation/human/pyrokinesis
 
 /datum/generecipe/thermal_adaptation
-	required = "/datum/mutation/human/adaptation/cold; /datum/mutation/human/adaptation/heat"
+	input_one = /datum/mutation/human/adaptation/cold
+	input_two = /datum/mutation/human/adaptation/heat
 	result = /datum/mutation/human/adaptation/thermal
 
 /datum/generecipe/antiglow
-	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
+	input_one = /datum/mutation/human/glow
+	input_two = /datum/mutation/human/void
 	result = /datum/mutation/human/glow/anti
 
 /datum/generecipe/tonguechem
-	required = "/datum/mutation/human/tongue_spike; /datum/mutation/human/stimmed"
+	input_one = /datum/mutation/human/tongue_spike
+	input_two = /datum/mutation/human/stimmed
 	result = /datum/mutation/human/tongue_spike/chem
 
 /datum/generecipe/martyrdom
-	required = "/datum/mutation/human/strong; /datum/mutation/human/stimmed"
+	input_one = /datum/mutation/human/strong
+	input_two = /datum/mutation/human/stimmed
 	result = /datum/mutation/human/martyrdom
 
 /datum/generecipe/heckacious
-	required = "/datum/mutation/human/wacky; /datum/mutation/human/stoner"
+	input_one = /datum/mutation/human/wacky
+	input_two = /datum/mutation/human/stoner
 	result = /datum/mutation/human/heckacious
 
 /datum/generecipe/ork
-	required = "/datum/mutation/human/hulk; /datum/mutation/human/clumsy"
+	input_one = /datum/mutation/human/hulk
+	input_two = /datum/mutation/human/clumsy
 	result = /datum/mutation/human/hulk/ork


### PR DESCRIPTION

## About The Pull Request
Rewrite `/datum/generecipe` to have two variables, `input_one` and `input_two` that hold the type path of the ingredients for the recipe, instead of it being a semicolon-separated string.

## Why It's Good For The Game

Better code, will catch invalid type paths in recipes at compile-time.

## Changelog

No player-facing changes
