### PR TITLE
Fixes moon heretic ascension not working as intended

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -227,9 +227,11 @@
 			continue
 		lunatic_candidates += crewmate
 
-	var/max_lunatics = ceil(length(GLOB.manifest.locked) * 0.2) // use the manifest for the maximum
+	// Roughly 1/5th of the station will rise up as lunatics to the heretic.
+	// We use the (locked) manifest for the maximum,
+	// but if there's more eligible humans than crew, more power to them I guess.
+	var/max_lunatics = ceil(max(length(GLOB.manifest.locked), length(lunatic_candidates)) * 0.2)
 
-	// Roughly 1/5th of the station will rise up as lunatics to the heretic
 	for(var/mob/living/carbon/human/crewmate as anything in lunatic_candidates)
 		// Heretics, lunatics and monsters shouldn't become lunatics because they either have a master or have a mansus grasp
 		if(IS_HERETIC_OR_MONSTER(crewmate))

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -228,8 +228,8 @@
 		lunatic_candidates += crewmate
 
 	// Roughly 1/5th of the station will rise up as lunatics to the heretic.
-	// We use the (locked) manifest for the maximum,
-	// but if there's more eligible humans than crew, more power to them I guess.
+	// We use either the (locked) manifest for the maximum, or the amount of candidates, whichever is larger.
+	// If there's more eligible humans than crew, more power to them I guess.
 	var/max_lunatics = ceil(max(length(GLOB.manifest.locked), length(lunatic_candidates)) * 0.2)
 
 	for(var/mob/living/carbon/human/crewmate as anything in lunatic_candidates)

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -227,7 +227,7 @@
 			continue
 		lunatic_candidates += crewmate
 
-	var/max_lunatics = ceil(length(lunatic_candidates) * 0.2)
+	var/max_lunatics = ceil(length(GLOB.manifest.locked) * 0.2) // use the manifest for the maximum
 
 	// Roughly 1/5th of the station will rise up as lunatics to the heretic
 	for(var/mob/living/carbon/human/crewmate as anything in lunatic_candidates)

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -216,10 +216,11 @@
 	user.mind.add_antag_datum(/datum/antagonist/lunatic/master)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
+	// How many lunatics we have
+	var/amount_of_lunatics = 0
+
 	// Roughly 1/5th of the station will rise up as lunatics to the heretic
 	for (var/mob/living/carbon/human/crewmate as anything in GLOB.human_list)
-		// How many lunatics we have
-		var/amount_of_lunatics = 0
 		// Where the crewmate is, used to check their z-level
 		var/turf/crewmate_turf = get_turf(crewmate)
 		var/crewmate_z = crewmate_turf?.z

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -216,20 +216,21 @@
 	user.mind.add_antag_datum(/datum/antagonist/lunatic/master)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
-	// How many lunatics we have
 	var/amount_of_lunatics = 0
-
-	// Roughly 1/5th of the station will rise up as lunatics to the heretic
-	for (var/mob/living/carbon/human/crewmate as anything in GLOB.human_list)
-		// Where the crewmate is, used to check their z-level
+	var/list/lunatic_candidates = list()
+	for(var/mob/living/carbon/human/crewmate as anything in shuffle(GLOB.human_list))
+		if(QDELETED(crewmate) || isnull(crewmate.client) || isnull(crewmate.mind) || crewmate.stat != CONSCIOUS)
+			continue
 		var/turf/crewmate_turf = get_turf(crewmate)
 		var/crewmate_z = crewmate_turf?.z
-		if(isnull(crewmate.mind))
-			continue
-		if(crewmate.stat != CONSCIOUS)
-			continue
 		if(!is_station_level(crewmate_z))
 			continue
+		lunatic_candidates += crewmate
+
+	var/max_lunatics = ceil(length(lunatic_candidates) * 0.2)
+
+	// Roughly 1/5th of the station will rise up as lunatics to the heretic
+	for(var/mob/living/carbon/human/crewmate as anything in lunatic_candidates)
 		// Heretics, lunatics and monsters shouldn't become lunatics because they either have a master or have a mansus grasp
 		if(IS_HERETIC_OR_MONSTER(crewmate))
 			to_chat(crewmate, span_boldwarning("[user]'s rise is influencing those who are weak willed. Their minds shall rend." ))
@@ -238,12 +239,12 @@
 		if(HAS_MIND_TRAIT(crewmate, TRAIT_UNCONVERTABLE) || crewmate.can_block_magic(MAGIC_RESISTANCE))
 			to_chat(crewmate, span_boldwarning("You feel shielded from something." ))
 			continue
-		if(amount_of_lunatics > length(GLOB.human_list) * 0.2)
-			to_chat(crewmate, span_boldwarning("You feel uneasy, as if for a brief moment something was gazing at you." ))
+		if(amount_of_lunatics > max_lunatics)
+			to_chat(crewmate, span_boldwarning("You feel uneasy, as if for a brief moment something was gazing at you."))
 			continue
 		var/datum/antagonist/lunatic/lunatic = crewmate.mind.add_antag_datum(/datum/antagonist/lunatic)
 		lunatic.set_master(user.mind, user)
-		var/obj/item/clothing/neck/heretic_focus/moon_amulet/amulet = new(crewmate_turf)
+		var/obj/item/clothing/neck/heretic_focus/moon_amulet/amulet = new(crewmate.drop_location())
 		var/static/list/slots = list(
 			"neck" = ITEM_SLOT_NECK,
 			"hands" = ITEM_SLOT_HANDS,
@@ -253,7 +254,7 @@
 		)
 		crewmate.equip_in_one_of_slots(amulet, slots, qdel_on_fail = FALSE)
 		crewmate.emote("laugh")
-		amount_of_lunatics += 1
+		amount_of_lunatics++
 
 /datum/heretic_knowledge/ultimate/moon_final/proc/on_life(mob/living/source, seconds_per_tick, times_fired)
 	var/obj/effect/moon_effect = /obj/effect/temp_visual/moon_ringleader


### PR DESCRIPTION

## About The Pull Request

this was turning the _entire eligible crew_ into lunatics, bc `amount_of_lunatics` was specified INSIDE the loop...

went ahead and improved the code while I was there

## Why It's Good For The Game

bugs bad... (how did nobody notice this for so long???)

## Changelog
:cl:
fix: Moon heretic ascension now properly turns 20% of the crew into lunatics, rather than ALL ELIGIBLE CREW.
/:cl:
