### PR TITLE
Fixing a couple issues with pipes rendering and the immerse element.

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -157,6 +157,13 @@
 /// Basically any layer below this (numerically) is "on" a floor for the purposes of washing
 #define FLOOR_CLEAN_LAYER (20 + TOPDOWN_LAYER)
 
+//Placeholders in case the game plane and possibly other things between it and the floor plane are ever made into topdown planes
+
+///Below this level, objects with topdown layers are rendered as if underwater by the immerse element
+#define TOPDOWN_WATER_LEVEL_LAYER 100 + TOPDOWN_LAYER
+///Above this level, objects with topdown layers are unaffected by the immerse element
+#define TOPDOWN_ABOVE_WATER_LAYER 200 + TOPDOWN_LAYER
+
 //WALL_PLANE layers
 #define BELOW_CLOSED_TURF_LAYER 2.053
 #define CLOSED_TURF_LAYER 2.058

--- a/code/__HELPERS/_planes.dm
+++ b/code/__HELPERS/_planes.dm
@@ -92,12 +92,13 @@ GLOBAL_LIST_INIT(topdown_planes, list(
 		"[FLOOR_PLANE]" = TRUE,
 	))
 
+#define IS_TOPDOWN_PLANE(plane) GLOB.topdown_planes["[PLANE_TO_TRUE(plane)]"]
+
 /// Checks if a passed in MA or atom is allowed to have its current plane/layer matchup
 /proc/check_topdown_validity(mutable_appearance/thing_to_check)
 	if(istype(thing_to_check, /atom/movable/screen/plane_master))
 		return
-	var/topdown_plane = GLOB.topdown_planes["[PLANE_TO_TRUE(thing_to_check.plane)]"]
-	if(topdown_plane)
+	if(IS_TOPDOWN_PLANE(thing_to_check.plane))
 		if(thing_to_check.layer - TOPDOWN_LAYER < 0 || thing_to_check.layer >= BACKGROUND_LAYER)
 			stack_trace("[thing_to_check] ([thing_to_check.type]) was expected to have a TOPDOWN_LAYER layer due to its plane, but it DID NOT! layer: ([thing_to_check.layer]) plane: ([thing_to_check.plane])")
 	else if(thing_to_check.layer - TOPDOWN_LAYER >= 0 && thing_to_check.layer < BACKGROUND_LAYER)

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -150,7 +150,6 @@
 	var/height = icon_dimensions["height"] || ICON_SIZE_Y
 
 	///This determines if the overlay should cover the entire surface of the object or not
-	var/turf/mov_turf = movable.loc
 	var/layer_to_check = IS_TOPDOWN_PLANE(movable.plane) ? TOPDOWN_WATER_LEVEL_LAYER : WATER_LEVEL_LAYER
 	var/is_below_water = (movable.layer < layer_to_check) ? "underwater-" : ""
 

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -111,7 +111,10 @@
 		return
 	if(HAS_TRAIT(movable, TRAIT_IMMERSED))
 		return
-	if(movable.layer >= ABOVE_ALL_MOB_LAYER || !ISINRANGE(movable.plane, MUTATE_PLANE(FLOOR_PLANE, source), MUTATE_PLANE(GAME_PLANE, source)))
+	if(!ISINRANGE(movable.plane, MUTATE_PLANE(FLOOR_PLANE, source), MUTATE_PLANE(GAME_PLANE, source)))
+		return
+	//First, floor plane objects use TOPDOWN_LAYER, second this check shouldn't apply to them anyway.
+	if(movable.plane > MUTATE_PLANE(FLOOR_PLANE, source) && movable.layer >= ABOVE_ALL_MOB_LAYER)
 		return
 	if(is_type_in_typecache(movable, movables_to_ignore))
 		return
@@ -145,7 +148,9 @@
 	var/width = icon_dimensions["width"] || ICON_SIZE_X
 	var/height = icon_dimensions["height"] || ICON_SIZE_Y
 
-	var/is_below_water = movable.layer < WATER_LEVEL_LAYER ? "underwater-" : ""
+	///This determines if the overlay should cover the entire surface of the object or not
+	var/turf/mov_turf = movable.loc
+	var/is_below_water = (movable.plane == MUTATE_PLANE(FLOOR_PLANE, mov_turf) || movable.layer < WATER_LEVEL_LAYER) ? "underwater-" : ""
 
 	var/atom/movable/immerse_overlay/vis_overlay = generated_visual_overlays["[is_below_water][width]x[height]"]
 

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -113,8 +113,9 @@
 		return
 	if(!ISINRANGE(movable.plane, MUTATE_PLANE(FLOOR_PLANE, source), MUTATE_PLANE(GAME_PLANE, source)))
 		return
+	var/layer_to_check = IS_TOPDOWN_PLANE(source.plane) ? TOPDOWN_ABOVE_WATER_LAYER : ABOVE_ALL_MOB_LAYER
 	//First, floor plane objects use TOPDOWN_LAYER, second this check shouldn't apply to them anyway.
-	if(movable.plane > MUTATE_PLANE(FLOOR_PLANE, source) && movable.layer >= ABOVE_ALL_MOB_LAYER)
+	if(movable.layer >= layer_to_check)
 		return
 	if(is_type_in_typecache(movable, movables_to_ignore))
 		return
@@ -150,7 +151,8 @@
 
 	///This determines if the overlay should cover the entire surface of the object or not
 	var/turf/mov_turf = movable.loc
-	var/is_below_water = (movable.plane == MUTATE_PLANE(FLOOR_PLANE, mov_turf) || movable.layer < WATER_LEVEL_LAYER) ? "underwater-" : ""
+	var/layer_to_check = IS_TOPDOWN_PLANE(movable.plane) ? TOPDOWN_WATER_LEVEL_LAYER : WATER_LEVEL_LAYER
+	var/is_below_water = (movable.layer < layer_to_check) ? "underwater-" : ""
 
 	var/atom/movable/immerse_overlay/vis_overlay = generated_visual_overlays["[is_below_water][width]x[height]"]
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -661,7 +661,7 @@
 			continue
 
 		var/turf/node_turf = get_turf(node)
-		if(isplatingturf(node_turf) || iscatwalkturf(node_turf))
+		if(node_turf.underfloor_accessibility > UNDERFLOOR_HIDDEN)
 			continue
 
 		var/connected_dir = get_dir(src, node)


### PR DESCRIPTION
## About The Pull Request
Atomizing changes from an upcoming PR. Basically the immerse element didn't work for things on the floor plane ever since the TOPDOWN_LAYER was introduced to the code (eg disposal pipes don't appear underwater), and the type checks for atmos pipe caps are deprecated by the underfloor_accessibility var.

## Why It's Good For The Game
Fixing a couple visual nits.

## Changelog

:cl:
fix: Fixed a couple nits with the water visuals not appearing on objects with a very low layer (rendered just above the floor), as well as atmos pipes looking a bit funky on untiled turfs beside catwalks and platings when beside connected, under-floored pipes.
/:cl:
