### PR TITLE
Minor fishing nits and tweaks

### DIFF
--- a/code/__DEFINES/fish.dm
+++ b/code/__DEFINES/fish.dm
@@ -170,7 +170,7 @@
 #define FISH_RARITY_BASIC 1000
 #define FISH_RARITY_RARE 400
 #define FISH_RARITY_VERY_RARE 200
-#define FISH_RARITY_GOOD_LUCK_FINDING_THIS 5
+#define FISH_RARITY_GOOD_LUCK_FINDING_THIS 50
 #define FISH_RARITY_NOPE 0
 
 ///Aquarium fluid variables. The fish' required fluid has to match this, or it'll slowly die.

--- a/code/datums/components/aquarium_content.dm
+++ b/code/datums/components/aquarium_content.dm
@@ -179,13 +179,9 @@
 	remove_visual_from_aquarium()
 	current_aquarium = null
 
-///The visual overlay of the aquarium content. It holds a few vars that we can modity them during signals.
+///The visual overlay of the aquarium content. It can hold a couple vars that we can modify through signal procs.
 /obj/effect/aquarium
 	layer = 0 //set on set_vc_base_position
-	/// Base px offset of the visual object in current aquarium aka current base position
-	var/base_px = 0
-	/// Base px offset of the visual object in current aquarium aka current base position
-	var/base_py = 0
 	/// How the visual will be layered
 	var/layer_mode = AQUARIUM_LAYER_MODE_AUTO
 

--- a/code/modules/fishing/aquarium/aquarium_kit.dm
+++ b/code/modules/fishing/aquarium/aquarium_kit.dm
@@ -58,7 +58,12 @@
 	name = "ominous fish case"
 
 /obj/item/storage/fish_case/syndicate/get_fish_type()
-	return pick(/obj/item/fish/donkfish, /obj/item/fish/emulsijack, /obj/item/fish/jumpercable, /obj/item/fish/chainsawfish)
+	var/datum/fish_source/portal/syndicate = GLOB.preset_fish_sources[/datum/fish_source/portal/syndicate]
+	var/list/picks = syndicate.fish_table.Copy()
+	for(var/fish in picks)
+		if(!ispath(fish, /obj/item/fish))
+			picks -= fish
+	return pick(picks)
 
 /obj/item/storage/fish_case/tiziran
 	name = "imported fish case"
@@ -73,16 +78,19 @@
 
 /obj/item/storage/fish_case/blackmarket/get_fish_type()
 	var/static/list/weighted_list = list(
-		/obj/item/fish/boned = 1,
-		/obj/item/fish/clownfish/lube = 3,
-		/obj/item/fish/emulsijack = 1,
-		/obj/item/fish/jumpercable = 1,
-		/obj/item/fish/sludgefish/purple = 1,
-		/obj/item/fish/pufferfish = 3,
+		/obj/item/fish/clownfish/lube = 2,
+		/obj/item/fish/pufferfish = 2,
+		/obj/item/fish/emulsijack = 2,
+		/obj/item/fish/sludgefish/purple = 2,
 		/obj/item/fish/slimefish = 2,
 		/obj/item/fish/ratfish = 2,
-		/obj/item/fish/chasm_crab/ice = 2,
-		/obj/item/fish/chasm_crab = 2,
+		/obj/item/fish/zipzap = 2,
+		/obj/item/fish/jumpercable = 2,
+		/obj/item/fish/chasm_crab/ice = 1,
+		/obj/item/fish/chasm_crab = 1,
+		/obj/item/fish/boned = 1,
+		/obj/item/fish/pike = 1,
+		/obj/item/fish/swordfish = 1,
 	)
 	return pick_weight(weighted_list)
 

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -927,10 +927,10 @@
 	var/px_min = aq_properties[AQUARIUM_PROPERTIES_PX_MIN] + avg_width - 16
 	var/px_max = aq_properties[AQUARIUM_PROPERTIES_PX_MAX] - avg_width - 16
 	var/py_min = aq_properties[AQUARIUM_PROPERTIES_PY_MIN] + avg_height - 16
-	var/py_max = aq_properties[AQUARIUM_PROPERTIES_PY_MAX] - avg_width - 16
+	var/py_max = aq_properties[AQUARIUM_PROPERTIES_PY_MAX] - avg_height - 16
 
-	visual.pixel_x = visual.base_px = rand(px_min,px_max)
-	visual.pixel_y = visual.base_py = rand(py_min,py_max)
+	visual.pixel_x = visual.base_pixel_x = rand(px_min,px_max)
+	visual.pixel_y = visual.base_pixel_y = rand(py_min,py_max)
 
 /obj/item/fish/proc/get_aquarium_animation()
 	var/obj/structure/aquarium/aquarium = loc
@@ -961,8 +961,8 @@
 	var/py_min = aq_properties[AQUARIUM_PROPERTIES_PY_MIN] + avg_height - 16
 	var/py_max = aq_properties[AQUARIUM_PROPERTIES_PY_MAX] - avg_width - 16
 
-	var/origin_x = visual.base_px
-	var/origin_y = visual.base_py
+	var/origin_x = visual.base_pixel_x
+	var/origin_y = visual.base_pixel_y
 	var/prev_x = origin_x
 	var/prev_y = origin_y
 	animate(visual, pixel_x = origin_x, time = 0, loop = -1) //Just to start the animation
@@ -985,11 +985,11 @@
 		animate(pixel_x = target_x, pixel_y = target_y, time = eyeballed_time, loop = -1)
 
 /obj/item/fish/proc/dead_animation(obj/structure/aquarium/current_aquarium, obj/effect/aquarium/visual)
-	//Set base_py to lowest possible value
+	//Set base_pixel_y to lowest possible value
 	var/avg_height = round(sprite_height / 2)
 	var/list/aq_properties = current_aquarium.get_surface_properties()
 	var/py_min = aq_properties[AQUARIUM_PROPERTIES_PY_MIN] + avg_height - 16
-	visual.base_py = py_min
+	visual.base_pixel_y = py_min
 	animate(visual, pixel_y = py_min, time = 1) //flop to bottom and end current animation.
 
 /// Checks if our current environment lets us live.

--- a/code/modules/fishing/fish/types/station.dm
+++ b/code/modules/fishing/fish/types/station.dm
@@ -140,7 +140,7 @@
 	///How long does it take for us to grow up?
 	var/growth_time = 3.5 MINUTES
 
-/obj/item/fish/fryish/Initialize(mapload)
+/obj/item/fish/fryish/Initialize(mapload, apply_qualities = TRUE)
 	. = ..()
 	if(is_bait)
 		add_traits(list(TRAIT_FISHING_BAIT, TRAIT_GREAT_QUALITY_BAIT), INNATE_TRAIT)

--- a/code/modules/fishing/fish/types/tiziran.dm
+++ b/code/modules/fishing/fish/types/tiziran.dm
@@ -79,8 +79,8 @@
 	. = ..()
 	add_traits(list(TRAIT_FISHING_BAIT, TRAIT_GOOD_QUALITY_BAIT), INNATE_TRAIT)
 
-/obj/item/fish/chasm_crab/get_fish_taste()
+/obj/item/fish/armorfish/get_fish_taste()
 	return list("raw prawn" = 2)
 
-/obj/item/fish/chasm_crab/get_fish_taste_cooked()
+/obj/item/fish/armorfish/get_fish_taste_cooked()
 	return list("cooked prawn" = 2)

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -13,12 +13,10 @@
 		/obj/item/fish/stingray = 8,
 		/obj/item/fish/plaice = 8,
 		/obj/item/fish/monkfish = 5,
-		/obj/item/fish/stingray = 10,
 		/obj/item/fish/lanternfish = 7,
 		/obj/item/fish/zipzap = 7,
 		/obj/item/fish/clownfish/lube = 5,
 		/obj/item/fish/swordfish = 5,
-		/obj/item/fish/swordfish = 3,
 		/obj/structure/mystery_box/fishing = 2,
 	)
 	fish_counts = list(


### PR DESCRIPTION
## About The Pull Request
Several small changes atomized from an upcoming PR. Splitting them into more PRs would have been inefficient.

The value of the fish case rarity `FISH_RARITY_GOOD_LUCK_FINDING_THIS` at 5 is too friccking low, so I raised it up to 50.
The aquarium visual effect used for aquarium content had two variables that were basically dupes of base_pixel_x and base_pixel_y, so I removed them.
The syndicate fish case (found from exploration drones and a few other things I think) should now actually give you all types of fish from thesyndicate fishing portal setting.
Expanded the list of fish you can get from the black market fish case (yes, they're still dead).
A missing Initialize() arg.
Duplicate entries for the beach fishing source
Armorfish should now taste like prawn.

## Why It's Good For The Game
Minor fixes and balance changes too small for their own PR but also not-so-related to my next PR.

## Changelog

:cl:
balance: Some fish should be ever so slightly less rare to get from non-specific fish cases.
fix: Armorfish should now taste like prawn.
/:cl:
