### PR TITLE
Fixes MODsuit deactivation not disabling modules

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -190,7 +190,6 @@
 	for(var/obj/item/part as anything in get_parts()) //seals/unseals all deployed parts
 		if(part.loc == src)
 			continue
-		to_chat(world, "[part]")
 		if(!delayed_seal_part(part)) //shit something broke, revert it all
 			activating = FALSE
 			for(var/obj/item/sealed_part as anything in sealed_parts)
@@ -229,7 +228,6 @@
 		if(!silent)
 			to_chat(wearer, span_notice("[part] [!part_datum.sealed ? part_datum.sealed_message : part_datum.unsealed_message]."))
 			playsound(src, 'sound/vehicles/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		to_chat(world, "calling sealing [part] [!part_datum.sealed]")
 		seal_part(part, is_sealed = !part_datum.sealed)
 		return TRUE
 
@@ -295,7 +293,7 @@
 			module.part_activated = TRUE
 	else
 		for(var/obj/item/mod/module/module as anything in modules)
-			if(!module.part_activated || module.has_required_parts(mod_parts, need_active = TRUE))
+			if(!module.part_activated)
 				continue
 			module.on_part_deactivation()
 			module.part_activated = FALSE

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -190,6 +190,7 @@
 	for(var/obj/item/part as anything in get_parts()) //seals/unseals all deployed parts
 		if(part.loc == src)
 			continue
+		to_chat(world, "[part]")
 		if(!delayed_seal_part(part)) //shit something broke, revert it all
 			activating = FALSE
 			for(var/obj/item/sealed_part as anything in sealed_parts)
@@ -228,6 +229,7 @@
 		if(!silent)
 			to_chat(wearer, span_notice("[part] [!part_datum.sealed ? part_datum.sealed_message : part_datum.unsealed_message]."))
 			playsound(src, 'sound/vehicles/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		to_chat(world, "calling sealing [part] [!part_datum.sealed]")
 		seal_part(part, is_sealed = !part_datum.sealed)
 		return TRUE
 
@@ -262,9 +264,9 @@
 	wearer.update_obscured_slots(part.visor_flags_inv)
 	if((part.clothing_flags & (MASKINTERNALS|HEADINTERNALS)) && wearer.invalid_internals())
 		wearer.cutoff_internals()
-	if(!active)
-		return
 	if(is_sealed)
+		if (!active)
+			return
 		for(var/obj/item/mod/module/module as anything in modules)
 			if(module.part_activated || !module.has_required_parts(mod_parts, need_active = TRUE))
 				continue
@@ -297,6 +299,9 @@
 				continue
 			module.on_part_deactivation()
 			module.part_activated = FALSE
+			if(!module.active || (module.allow_flags & MODULE_ALLOW_INACTIVE))
+				continue
+			module.deactivate(display_message = FALSE)
 	update_speed()
 	update_charge_alert()
 	update_appearance(UPDATE_ICON_STATE)


### PR DESCRIPTION

## About The Pull Request

Closes #87618
Technically either part of this fix (moving the active check in seal_part and removing the parts check in control_activation) is enough to fix this particular issue but I'm doing both for sanity reasons (and possibly edge cases with modules that modify their required parts? not sure if we have those)

also yeah it didn't call deactivate()

## Changelog
:cl:
fix: Fixed MODsuit deactivation not disabling modules
/:cl:
