### PR TITLE
Remove non-functioning <B> and <br> for changeling victim's memories

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -106,12 +106,12 @@
 	var/list/recent_speech = target.copy_recent_speech()
 
 	if(recent_speech.len)
-		changeling.antag_memory += "<B>Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]!</B><br>"
+		changeling.antag_memory += "Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]: "
 		to_chat(owner, span_boldnotice("Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]!"))
 		for(var/spoken_memory in recent_speech)
-			changeling.antag_memory += "\"[spoken_memory]\"<br>"
+			changeling.antag_memory += " \"[spoken_memory]\""
 			to_chat(owner, span_notice("\"[spoken_memory]\""))
-		changeling.antag_memory += "<B>We have no more knowledge of [target]'s speech patterns.</B><br>"
+		changeling.antag_memory += ". We have no more knowledge of [target]'s speech patterns. "
 		to_chat(owner, span_boldnotice("We have no more knowledge of [target]'s speech patterns."))
 
 


### PR DESCRIPTION

## About The Pull Request

This PR removes the `<B>` and `<br>` from changeling memories since they did not function at all and ruined immersion. 

* Closes https://github.com/tgstation/tgstation/issues/84586

Before: 
![345110418-fa95f4ba-d26a-47f5-bc5e-4d23454bb066](https://github.com/user-attachments/assets/11fd72d5-472b-468b-af2b-4fafe7c83ae8)

After:
![image](https://github.com/user-attachments/assets/a07691e6-fb2a-40e0-8f2b-17826bbe8b14)
## Why It's Good For The Game

Remove immersion breaking text.
## Changelog
:cl:
fix: changeling memories of victims no longer include `<B>` and `<br>`
/:cl:
