### PR TITLE
Fixes space kidnap being instant

### DIFF
--- a/code/datums/components/space_kidnap.dm
+++ b/code/datums/components/space_kidnap.dm
@@ -39,7 +39,7 @@
 	var/obj/particles = new /obj/effect/abstract/particle_holder (victim, /particles/void_kidnap)
 	kidnapping = TRUE
 
-	if(do_after(parent, kidnap_time, victim, extra_checks = CALLBACK(victim, PROC_REF(check_incapacitated))))
+	if(do_after(parent, kidnap_time, victim, extra_checks = CALLBACK(src, PROC_REF(check_incapacitated), victim))))
 		take_them(victim)
 
 	qdel(particles)
@@ -69,6 +69,5 @@
 	SEND_SIGNAL(parent, COMSIG_VOIDWALKER_SUCCESFUL_KIDNAP, kidnappee)
 
 /datum/component/space_kidnap/proc/check_incapacitated(mob/living/carbon/human/kidnappee)
-	SIGNAL_HANDLER
 
 	return kidnappee.incapacitated

--- a/code/datums/components/space_kidnap.dm
+++ b/code/datums/components/space_kidnap.dm
@@ -39,7 +39,7 @@
 	var/obj/particles = new /obj/effect/abstract/particle_holder (victim, /particles/void_kidnap)
 	kidnapping = TRUE
 
-	if(do_after(parent, kidnap_time, victim, extra_checks = victim.incapacitated))
+	if(do_after(parent, kidnap_time, victim, extra_checks = CALLBACK(victim, PROC_REF(check_incapacitated))))
 		take_them(victim)
 
 	qdel(particles)
@@ -67,3 +67,8 @@
 
 /datum/component/space_kidnap/proc/succesfully_kidnapped(mob/living/carbon/human/kidnappee)
 	SEND_SIGNAL(parent, COMSIG_VOIDWALKER_SUCCESFUL_KIDNAP, kidnappee)
+
+/datum/component/space_kidnap/proc/check_incapacitated(mob/living/carbon/human/kidnappee)
+	SIGNAL_HANDLER
+
+	return kidnappee.incapacitated

--- a/code/datums/components/space_kidnap.dm
+++ b/code/datums/components/space_kidnap.dm
@@ -39,7 +39,7 @@
 	var/obj/particles = new /obj/effect/abstract/particle_holder (victim, /particles/void_kidnap)
 	kidnapping = TRUE
 
-	if(do_after(parent, kidnap_time, victim, extra_checks = CALLBACK(src, PROC_REF(check_incapacitated), victim))))
+	if(do_after(parent, kidnap_time, victim, extra_checks = CALLBACK(src, PROC_REF(check_incapacitated), victim)))
 		take_them(victim)
 
 	qdel(particles)
@@ -69,5 +69,4 @@
 	SEND_SIGNAL(parent, COMSIG_VOIDWALKER_SUCCESFUL_KIDNAP, kidnappee)
 
 /datum/component/space_kidnap/proc/check_incapacitated(mob/living/carbon/human/kidnappee)
-
 	return kidnappee.incapacitated


### PR DESCRIPTION
Yeah apparently the voidwalker kidnap was completely instant

https://github.com/tgstation/tgstation/pull/86031 replaced the callback that checked for being incapacitated with the number 1

:cl:
fix: Fixes voidwalker having an instant kidnap
/:cl: