### PR TITLE
Fixes sec and command comms not working

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -352,7 +352,7 @@
 	if(isliving(talking_movable))
 		var/mob/living/talking_living = talking_movable
 		if(radio_noise && talking_living.can_hear() && talking_living.client?.prefs.read_preference(/datum/preference/toggle/radio_noise) && signal.frequency != FREQ_COMMON)
-			var/sound/radio_noise = 'sound/items/radio/radio_talk.ogg'
+			var/sound/radio_noise = sound('sound/items/radio/radio_talk.ogg')
 			radio_noise.frequency = get_rand_frequency_low_range()
 			SEND_SOUND(talking_living, radio_noise)
 


### PR DESCRIPTION
The sound runtimed and prevented radio's from working because it treated a string as a sound datum

:cl:
fix: Fixes sec and command coms not working correctly
/:cl:

Admins can hotfix this on live by mass editing radio_noise to 0