### PR TITLE
Add's support for population limits on keep_me_secure component (Loneop event balance change)

### DIFF
--- a/code/datums/components/keep_me_secure.dm
+++ b/code/datums/components/keep_me_secure.dm
@@ -14,13 +14,16 @@
 	var/turf/last_secured_location
 	/// The last world time the parent moved.
 	var/last_move
+	/// Living population must be above this amount for security checks to apply.
+	var/min_pop_limit
 
-/datum/component/keep_me_secure/Initialize(secured_callback, unsecured_callback)
+/datum/component/keep_me_secure/Initialize(secured_callback, unsecured_callback, min_pop_limit)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	src.secured_callback = secured_callback
 	src.unsecured_callback = unsecured_callback
+	src.min_pop_limit = min_pop_limit
 
 /datum/component/keep_me_secure/Destroy(force)
 	secured_callback = null
@@ -41,6 +44,9 @@
 
 /// Returns whether the game is supposed to consider the parent "secure".
 /datum/component/keep_me_secure/proc/is_secured()
+	if(living_player_count < src.min_pop_limit)
+		return TRUE
+
 	var/obj/item/item_parent = parent
 	if (last_secured_location == get_turf(item_parent))
 		return FALSE

--- a/code/datums/components/keep_me_secure.dm
+++ b/code/datums/components/keep_me_secure.dm
@@ -44,7 +44,7 @@
 
 /// Returns whether the game is supposed to consider the parent "secure".
 /datum/component/keep_me_secure/proc/is_secured()
-	if(living_player_count < src.min_pop_limit)
+	if(living_player_count() < src.min_pop_limit)
 		return TRUE
 
 	var/obj/item/item_parent = parent

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -633,7 +633,7 @@
 			"I WILL DIE TO JUST ONE ATTTTTTAAAAACKKKKKK!!",
 			"I WILLLLLL NOT DROP GOOOD IITITTEEEEEMMMS!!",
 		)
-	AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)) , CALLBACK(src, PROC_REF(unsecured_process)))
+	AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)) , CALLBACK(src, PROC_REF(unsecured_process)), 0)
 
 /obj/item/toy/plush/whiny_plushie/proc/secured_process(last_move)
 	icon_state = initial(icon_state)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -30,9 +30,10 @@
 	AddComponent(/datum/component/stationloving, !fake)
 
 	if(!fake)
-		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)))
+		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
+		// ??? wtf
 		AddComponent(/datum/component/keep_me_secure)
 
 /obj/item/disk/nuclear/proc/secured_process(last_move)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -33,7 +33,7 @@
 		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
-		// ??? wtf
+		// Ensure fake disks still have examine text, but dont actually do anything
 		AddComponent(/datum/component/keep_me_secure)
 
 /obj/item/disk/nuclear/proc/secured_process(last_move)


### PR DESCRIPTION
This is used to set the nuke disk's safety factor from applying on very low pop player counts, as it's unlikely the disk can be secured.

I don't believe this precludes the event from being randomly chosen, but it makes sure it wont be a certainty on very low pop when the disk hasn't been secured from lack of players

Just to clarify this applies only at 9 population or lower.

## Why It's Good For The Game
On very very low pop, the disk is often unsecured, and.. more importantly, a lone op is likely to have a very high chance of easily succeeding as there is not enough crew to upkeep a watch on the relevant areas.

This event is fun on higher populations, and needing to protect the disk makes sense, but on very lowpop, I think it doens't quite work as designed, as instead it just means a lot of low pop rounds will end due to a loneop spawning if there's any ghosts about at all.
## Changelog
:cl: oranges
balance: Nuclear disk no longer needs to be secured at sub 10 population
/:cl:
