### PR TITLE
[NEEDS SPRITE] Adds an achievement for bladeless heretic ascensions

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -60,6 +60,7 @@
 #define MEDAL_CIGARETTES "Cigarettes"
 #define MEDAL_SHARKDRAGON "Sharkdragon"
 #define MEDAL_THEORETICAL_LIMITS "All Within Theoretical Limits"
+#define MEDAL_BLADELESS_ASCENSION "While You Studied The Blade..."
 
 //Skill medal hub IDs
 #define MEDAL_LEGENDARY_MINER "Legendary Miner"

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -244,3 +244,9 @@
 	desc = "Nutritionists often recommend a balanced and varied diet. However that clearly isn't the case for some creatures."
 	database_id = MEDAL_SHARKDRAGON
 	icon_state = "dragon_plus_fish"
+
+/datum/award/achievement/misc/bladeless_ascension
+	name = "While You Studied The Blade..."
+	desc = "Ascend as a heretic without ever crafting or using a blade."
+	database_id = MEDAL_BLADELESS_ASCENSION
+	icon_state = "theoreticallimits"

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -82,6 +82,8 @@
 	)
 	/// Simpler version of above used to limit amount of loot that can be hoarded
 	var/rewards_given = 0
+	/// If this heretic has ever crafted or used a blade, for the bladeless ascension achievement.
+	var/used_blade = FALSE
 
 /datum/antagonist/heretic/Destroy()
 	LAZYNULL(sac_targets)
@@ -303,6 +305,7 @@
 	RegisterSignals(our_mob, list(COMSIG_MOB_BEFORE_SPELL_CAST, COMSIG_MOB_SPELL_ACTIVATED), PROC_REF(on_spell_cast))
 	RegisterSignal(our_mob, COMSIG_USER_ITEM_INTERACTION, PROC_REF(on_item_use))
 	RegisterSignal(our_mob, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(after_fully_healed))
+	RegisterSignals(our_mob, list(COMSIG_HERETIC_BLADE_ATTACK, COMSIG_HERETIC_RANGED_BLADE_ATTACK))
 
 /datum/antagonist/heretic/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/our_mob = mob_override || owner.current
@@ -319,6 +322,8 @@
 		COMSIG_USER_ITEM_INTERACTION,
 		COMSIG_LIVING_POST_FULLY_HEAL,
 		COMSIG_LIVING_CULT_SACRIFICED,
+		COMSIG_HERETIC_BLADE_ATTACK,
+		COMSIG_HERETIC_RANGED_BLADE_ATTACK,
 	))
 
 /datum/antagonist/heretic/on_body_transfer(mob/living/old_body, mob/living/new_body)
@@ -376,6 +381,14 @@
 
 	try_draw_rune(source, target, additional_checks = CALLBACK(src, PROC_REF(check_mansus_grasp_offhand), source))
 	return ITEM_INTERACT_SUCCESS
+
+/*
+ * Signal proc for [COMSIG_HERETIC_BLADE_ATTACK] and [COMSIG_HERETIC_RANGED_BLADE_ATTACK].
+ * Used to set the `used_blade` var.
+ */
+/datum/antagonist/heretic/proc/on_blade_attack()
+	SIGNAL_HANDLER
+	used_blade = TRUE
 
 /**
  * Attempt to draw a rune on [target_turf].

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -305,7 +305,7 @@
 	RegisterSignals(our_mob, list(COMSIG_MOB_BEFORE_SPELL_CAST, COMSIG_MOB_SPELL_ACTIVATED), PROC_REF(on_spell_cast))
 	RegisterSignal(our_mob, COMSIG_USER_ITEM_INTERACTION, PROC_REF(on_item_use))
 	RegisterSignal(our_mob, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(after_fully_healed))
-	RegisterSignals(our_mob, list(COMSIG_HERETIC_BLADE_ATTACK, COMSIG_HERETIC_RANGED_BLADE_ATTACK))
+	RegisterSignals(our_mob, list(COMSIG_HERETIC_BLADE_ATTACK, COMSIG_HERETIC_RANGED_BLADE_ATTACK), PROC_REF(on_blade_attack))
 
 /datum/antagonist/heretic/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/our_mob = mob_override || owner.current

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -288,6 +288,12 @@
 	our_heretic.heretic_path = route
 	SSblackbox.record_feedback("tally", "heretic_path_taken", 1, route)
 
+/datum/heretic_knowledge/limited_amount/starting/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	. = ..()
+	if(.)
+		var/datum/antagonist/heretic/our_heretic = GET_HERETIC(user)
+		our_heretic.used_blade = TRUE
+
 /**
  * A knowledge subtype for heretic knowledge
  * that applies a mark on use.
@@ -747,6 +753,8 @@
 /datum/heretic_knowledge/ultimate/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/heretic_datum = GET_HERETIC(user)
 	heretic_datum.ascended = TRUE
+	if(!heretic_datum.used_blade)
+		user.client?.give_award(/datum/award/achievement/misc/bladeless_ascension, user)
 
 	// Show the cool red gradiant in our UI
 	heretic_datum.update_static_data(user)

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -55,6 +55,8 @@
 /// Attempts to teleport the passed mob to somewhere safe on the station, if they can use the blade.
 /obj/item/melee/sickly_blade/proc/seek_safety(mob/user)
 	var/turf/safe_turf = find_safe_turf(zlevels = z, extended_safety_checks = TRUE)
+	var/datum/antagonist/heretic/our_heretic = GET_HERETIC(user)
+	our_heretic?.used_blade = TRUE
 	if(check_usability(user))
 		if(do_teleport(user, safe_turf, channel = TELEPORT_CHANNEL_MAGIC))
 			to_chat(user, span_warning("As you shatter [src], you feel a gust of energy flow through your body. [after_use_message]"))


### PR DESCRIPTION

## About The Pull Request

This adds a new achievement, "While You Studied The Blade...", for ascending as a heretic without crafting or using a blade.

This is tracked somewhat thoroughly, with a "used_blade" flag on the heretic antag datum, which will be set if you ever complete a blade crafting ritual - and, to prevent potential cheesing by having another heretic craft and give you blades - the flag will also be set if you ever attack with a heretic blade, or smash one to teleport.

***I NEED A SPRITE FOR THIS, MARKED AS DRAFT UNTIL THERE IS A SPRITE***

## Why It's Good For The Game

it's a fun challenge.

## Changelog
:cl:
add: Added a new achievement for ascending as a heretic without crafting or using a blade at any point.
/:cl:
