### PR TITLE
Alien operating tables now have a 20% surgery speed bonus

### DIFF
--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -11,7 +11,7 @@
 		/obj/structure/bed = 0.7,
 	))
 	. = 0.5
-	for(var/obj/thingy as anything in get_turf(located_mob))
+	for(var/obj/thingy in get_turf(located_mob))
 		. = max(., modifiers[thingy.type])
 
 

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -12,9 +12,7 @@
 	))
 	. = 0.5
 	for(var/obj/thingy as anything in get_turf(located_mob))
-		var/modifier = modifiers[thingy.type]
-		if(!isnull(modifier))
-			. = max(., modifier)
+		. = max(., modifiers[thingy.type])
 
 
 /proc/get_location_accessible(mob/located_mob, location)

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -1,15 +1,20 @@
+/*
+ * Gets the surgery speed modifier for a given mob, based off what sort of table/bed/whatever is on their turf.
+ */
 /proc/get_location_modifier(mob/located_mob)
-	var/turf/mob_turf = get_turf(located_mob)
-	if(locate(/obj/structure/table/optable, mob_turf))
-		return 1
-	else if(locate(/obj/machinery/stasis, mob_turf))
-		return 0.9
-	else if(locate(/obj/structure/table, mob_turf))
-		return 0.8
-	else if(locate(/obj/structure/bed, mob_turf))
-		return 0.7
-	else
-		return 0.5
+	// Technically this IS a typecache, just not the usual kind :3
+	var/static/list/modifiers = zebra_typecacheof(list(
+		/obj/structure/table = 0.8,
+		/obj/structure/table/optable = 1,
+		/obj/structure/table/optable/abductor = 1.2,
+		/obj/machinery/stasis = 0.9,
+		/obj/structure/bed = 0.7,
+	))
+	. = 0.5
+	for(var/obj/thingy as anything in get_turf(located_mob))
+		var/modifier = modifiers[thingy.type]
+		if(!isnull(modifier))
+			. = max(., modifier)
 
 
 /proc/get_location_accessible(mob/located_mob, location)


### PR DESCRIPTION
## About The Pull Request

Alien operating tables (made by making a table frame with alien alloy, then adding silver) now have a 20% surgery speed bonus, as compared to normal operating tables.

I also refactored the `get_location_modifier` proc, it now uses a "typecache" rather than a else-if locate tower.

## Why It's Good For The Game

Medbaymaxxing with alien tech is nice - and this somewhat cursed code is still better than the else-if locate tower, honestly.

## Changelog
:cl:
balance: Alien operating tables now have a 20% surgery speed bonus.
refactor: Refactored how table/bed surgery speed modifiers are calculated, so it's hopefully more efficient now.
/:cl:
