### PR TITLE
hunting behaviors no longer share a cooldown

### DIFF
--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -49,8 +49,10 @@
 #define BB_BANE_BATMAN "BB_bane_batman"
 //yep that's it
 
-///Hunting BB keys
+//Hunting BB keys
+///key that holds our current hunting target
 #define BB_CURRENT_HUNTING_TARGET "BB_current_hunting_target"
+///key that holds our less priority hunting target
 #define BB_LOW_PRIORITY_HUNTING_TARGET "BB_low_priority_hunting_target"
 #define BB_HUNTING_COOLDOWN(type) "BB_HUNTING_COOLDOWN_[type]"
 ///Basic Mob Keys

--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -54,6 +54,7 @@
 #define BB_CURRENT_HUNTING_TARGET "BB_current_hunting_target"
 ///key that holds our less priority hunting target
 #define BB_LOW_PRIORITY_HUNTING_TARGET "BB_low_priority_hunting_target"
+///key that holds the cooldown for our hunting subtree
 #define BB_HUNTING_COOLDOWN(type) "BB_HUNTING_COOLDOWN_[type]"
 ///Basic Mob Keys
 

--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -52,8 +52,7 @@
 ///Hunting BB keys
 #define BB_CURRENT_HUNTING_TARGET "BB_current_hunting_target"
 #define BB_LOW_PRIORITY_HUNTING_TARGET "BB_low_priority_hunting_target"
-#define BB_HUNTING_COOLDOWN "BB_HUNTING_COOLDOWN"
-
+#define BB_HUNTING_COOLDOWN(type) "BB_HUNTING_COOLDOWN_[type]"
 ///Basic Mob Keys
 
 ///Targeting subtrees

--- a/code/datums/ai/hunting_behavior/hunting_behaviors.dm
+++ b/code/datums/ai/hunting_behavior/hunting_behaviors.dm
@@ -26,16 +26,11 @@
 /datum/ai_planning_subtree/find_and_hunt_target/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	if(!SPT_PROB(hunt_chance, seconds_per_tick))
 		return
-	if(controller.blackboard[BB_HUNTING_COOLDOWN] >= world.time)
-		return
-	var/mob/living/living_pawn = controller.pawn
-	// We can't hunt if we're indisposed
-	if(HAS_TRAIT(controller.pawn, TRAIT_HANDS_BLOCKED) || living_pawn.stat != CONSCIOUS)
+
+	if(controller.blackboard[BB_HUNTING_COOLDOWN(type)] >= world.time)
 		return
 
-	var/atom/hunted = controller.blackboard[target_key]
-	// We're not hunting anything, look around for something
-	if(isnull(hunted))
+	if(!controller.blackboard_key_exists(target_key))
 		controller.queue_behavior(finding_behavior, target_key, hunt_targets, hunt_range)
 		return
 
@@ -44,7 +39,7 @@
 	// we may accidentally be executing another tree's hunt - not ideal,
 	// try to set a unique target key if you have multiple
 
-	controller.queue_behavior(hunting_behavior, target_key, BB_HUNTING_COOLDOWN)
+	controller.queue_behavior(hunting_behavior, target_key, BB_HUNTING_COOLDOWN(type))
 	if(finish_planning)
 		return SUBTREE_RETURN_FINISH_PLANNING //If we're hunting we're too busy for anything else
 
@@ -115,7 +110,7 @@
 
 /datum/ai_behavior/hunt_target/finish_action(datum/ai_controller/controller, succeeded, hunting_target_key, hunting_cooldown_key)
 	. = ..()
-	if(succeeded)
+	if(succeeded && hunting_cooldown_key)
 		controller.set_blackboard_key(hunting_cooldown_key, world.time + hunt_cooldown)
 	else if(hunting_target_key)
 		controller.clear_blackboard_key(hunting_target_key)

--- a/code/modules/mob/living/basic/slime/ai/pet_command.dm
+++ b/code/modules/mob/living/basic/slime/ai/pet_command.dm
@@ -10,7 +10,7 @@
 
 	var/mob/living/basic/slime/slime_pawn = controller.pawn
 	if(isslime(slime_pawn) && slime_pawn.can_feed_on(controller.blackboard[BB_CURRENT_PET_TARGET], check_friendship = TRUE))
-		controller.queue_behavior(hunting_behavior, BB_CURRENT_PET_TARGET, BB_HUNTING_COOLDOWN)
+		controller.queue_behavior(hunting_behavior, BB_CURRENT_PET_TARGET)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request
all hunting subtrees were sharing a singular cooldown. this makes it so each subtree has its own cooldown

## Why It's Good For The Game
fixes hunting subtree cooldowns affecting other subtrees. 

## Changelog
:cl:
/:cl:
