### PR TITLE
Fix rare runtime if there are no available organs to take

### DIFF
--- a/code/modules/lost_crew/damages/post_mortem.dm
+++ b/code/modules/lost_crew/damages/post_mortem.dm
@@ -13,14 +13,15 @@
 	var/organs_to_take = round(min_organs + (max_organs - min_organs) * severity)
 	var/list/organs_we_can_take = body.organs - body.get_organ_slot(ORGAN_SLOT_BRAIN)
 
-	if(organs_we_can_take)
-		for(var/i in 1 to organs_to_take)
-			var/obj/organ = pick(organs_we_can_take)
-			if(prob(organ_save_chance) && saved_movables) //if lucky, we can save the organ and have it be delivered with the body
-				organ.moveToNullspace()
-				saved_movables += organ
-			else
-				qdel(organ)
+	if (!length(organs_we_can_take))
+		return
+	for(var/i in 1 to organs_to_take)
+		var/obj/organ = pick(organs_we_can_take)
+		if(prob(organ_save_chance) && saved_movables) //if lucky, we can save the organ and have it be delivered with the body
+			organ.moveToNullspace()
+			saved_movables += organ
+		else
+			qdel(organ)
 
 /// Damn space vultures man! At least they dont go for the chest or head, or they do but we don't get to see those bodies :O
 /datum/corpse_damage/post_mortem/limb_loss

--- a/code/modules/lost_crew/damages/post_mortem.dm
+++ b/code/modules/lost_crew/damages/post_mortem.dm
@@ -13,13 +13,14 @@
 	var/organs_to_take = round(min_organs + (max_organs - min_organs) * severity)
 	var/list/organs_we_can_take = body.organs - body.get_organ_slot(ORGAN_SLOT_BRAIN)
 
-	for(var/i in 1 to organs_to_take)
-		var/obj/organ = pick(organs_we_can_take)
-		if(prob(organ_save_chance) && saved_movables) //if lucky, we can save the organ and have it be delivered with the body
-			organ.moveToNullspace()
-			saved_movables += organ
-		else
-			qdel(organ)
+	if(organs_we_can_take)
+		for(var/i in 1 to organs_to_take)
+			var/obj/organ = pick(organs_we_can_take)
+			if(prob(organ_save_chance) && saved_movables) //if lucky, we can save the organ and have it be delivered with the body
+				organ.moveToNullspace()
+				saved_movables += organ
+			else
+				qdel(organ)
 
 /// Damn space vultures man! At least they dont go for the chest or head, or they do but we don't get to see those bodies :O
 /datum/corpse_damage/post_mortem/limb_loss


### PR DESCRIPTION

## About The Pull Request

This PR fixes a rare runtime error, regarding lost crew members, that occurs when there are no organs in the `organs_we_can_take` list, which causes an exception due to an attempt to `pick()` from an empty list. 
## Why It's Good For The Game

The less exceptions exists, the better.
## Changelog
:cl:
fix: fixed a rare runtime with lost crew having no organs
/:cl:
