### PR TITLE
Renames characters in dark matter singulo description

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -474,7 +474,7 @@
 	desc = "<i>\"Surviving the encounter with the \
 		horrible thing, I realized immediately what I \
 		had to do: sell marketable toys of it. \
-		\"</i><br>- Chief Engineer Miles O'Brien"
+		\"</i><br>- Chief Engineer Tenshin Nakamura"
 	icon = 'icons/obj/machines/engine/singularity.dmi'
 	icon_state = "dark_matter_s1"
 

--- a/code/modules/power/singularity/dark_matter_singularity.dm
+++ b/code/modules/power/singularity/dark_matter_singularity.dm
@@ -8,7 +8,7 @@
 		a cosmic paradox that defies all logic. I can't \
 		take my eyes off it, even though I know it could \
 		devour us all in an instant.\
-		\"</i><br>- Chief Engineer Miles O'Brien"
+		\"</i><br>- Chief Engineer Tenshin Nakamura"
 	ghost_notification_message = "IT'S HERE"
 	icon_state = "dark_matter_s1"
 	singularity_icon_variant = "dark_matter"
@@ -39,7 +39,7 @@
 		we have collected from this sector. The singularity does not seem \
 		to care for other inanimate objects or machines, but will consume \
 		them all the same. We have tried to communicate with it using various \
-		methods, but received no response.\"</i><br>- Research Director Jadzia Dax")
+		methods, but received no response.\"</i><br>- Research Director Huey Knorr")
 
 /obj/singularity/dark_matter/ex_act(severity, target)
 	if(!COOLDOWN_FINISHED(src, initial_explosion_immunity))


### PR DESCRIPTION

## About The Pull Request
The dark matter singularity and its toy have long quotes in the examine text. This doesn't change the quotes themselves, but changes the name of the characters in the attributions. "Miles O'Brien" is now "Tenshin Nakamura", that surname implies a connection to the ingame faction Nakamura Engineering. "Jadzia Dax" if now "Huey Knorr" because it sounds a bit like 'who knows'.
## Why It's Good For The Game
These were changed in #75133 to remove references to player names. I don't disagree with the reasons for changing them, but the replacements were half-assed. Just names of characters from Star Trek. Muh immersion.
## Changelog
:cl:
spellcheck: Changed names in the description of dark matter singularities and their toy version.
/:cl:
