### PR TITLE
Fixes RHD storage interaction

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -207,6 +207,9 @@
  * * [mob][user]- the user building this structure
  */
 /obj/item/construction/rcd/proc/rcd_create(atom/target, mob/user)
+	if(HAS_TRAIT(target, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
+		return NONE
+
 	var/list/rcd_results = target.rcd_vals(user, src) // does this atom allow for rcd actions?
 	if(!rcd_results) // nope
 		return NONE

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -91,6 +91,7 @@
 
 /obj/item/construction/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	SHOULD_CALL_PARENT(TRUE)
+
 	if(istype(interacting_with, /obj/item/rcd_upgrade))
 		install_upgrade(interacting_with, user)
 		return ITEM_INTERACT_SUCCESS
@@ -100,6 +101,7 @@
 
 /obj/item/construction/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	SHOULD_CALL_PARENT(TRUE)
+
 	if(istype(tool, /obj/item/rcd_upgrade))
 		install_upgrade(tool, user)
 		return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -99,7 +99,18 @@
 		return .
 	return try_lighting(interacting_with, user)
 
+/**
+ * Try to place/remove a light or throw a glowstick
+ * Arguments
+ *
+ * * atom/interacting_with - the target atom to light or throw glowsticks at
+ * * mob/user - the player doing this action
+ */
 /obj/item/construction/rld/proc/try_lighting(atom/interacting_with, mob/user)
+	PRIVATE_PROC(TRUE)
+
+	if(HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
+		return NONE
 
 	var/turf/start = get_turf(src)
 	switch(mode)

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -247,6 +247,8 @@
 	. = ..()
 	if(. & ITEM_INTERACT_ANY_BLOCKER)
 		return .
+	if(HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
+		return NONE
 
 	for(var/category_name in plumbing_design_types)
 		var/list/designs = plumbing_design_types[category_name]

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -251,9 +251,13 @@
  * * turf/open/floor/floor - the turf we are trying to put plating on
  * * mob/living/user - the mob trying to do the plating
  */
-/obj/item/construction/rtd/proc/try_tiling(turf/open/floor/floor, mob/living/user)
-	PROTECTED_PROC(TRUE)
+/obj/item/construction/rtd/proc/try_tiling(atom/interacting_with, mob/living/user)
+	PRIVATE_PROC(TRUE)
 
+	if(HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
+		return NONE
+
+	var/turf/open/floor/floor = interacting_with
 	if(!istype(floor))
 		return NONE
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #87568

Not just for RLD but for RCD, RPLD & RTD. They don't touch storage atoms

## Changelog
:cl:
fix: RLD won't try to put lights on storage objects like bags & such
/:cl:
