### PR TITLE
You can succumb quietly by right-clicking the UI

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -512,7 +512,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 		//Succumbing without a message
-		var/choice = tgui_alert(living_owner, "Are you sure you want to succumb?", title, list(FASTSUCCUMB_NO, FASTSUCCUMB_WAIT, FASTSUCCUMB_YES))
+		var/choice = tgui_alert(living_owner, "Are you sure you want to succumb?", title, list(FASTSUCCUMB_YES, FASTSUCCUMB_WAIT, FASTSUCCUMB_NO))
 		switch(choice)
 			if(FASTSUCCUMB_NO, null)
 				return

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -474,7 +474,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /// Gives the player the option to succumb while in critical condition
 /atom/movable/screen/alert/succumb
 	name = "Succumb"
-	desc = "Shuffle off this mortal coil.<br/>Right-Click to succumb silently."
+	desc = "Shuffle off this mortal coil."
 	icon_state = ALERT_SUCCUMB
 	var/static/list/death_titles = list(
 		"Goodnight, Sweet Prince",
@@ -486,6 +486,15 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		"The Curtains Close",
 		"All Good Things Must End"
 	)
+
+/atom/movable/screen/alert/succumb/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	register_context()
+
+/atom/movable/screen/alert/succumb/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_LMB] = "Succumb With Last Words"
+	context[SCREENTIP_CONTEXT_RMB] = "Succumb Silently"
+	return CONTEXTUAL_SCREENTIP_SET
 
 #define FASTSUCCUMB_YES "Yes"
 #define FASTSUCCUMB_WAIT "Wait, I have last words!"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -532,10 +532,10 @@
 	if (!CAN_SUCCUMB(src))
 		if(HAS_TRAIT(src, TRAIT_SUCCUMB_OVERRIDE))
 			if(whispered)
-				to_chat(src, text="You are unable to succumb to death! Unless you just press the UI button.", type=MESSAGE_TYPE_INFO)
+				to_chat(src, span_notice("Your immortal body is keeping you alive. If you want to accept death, you must do so [span_bold("quietly")]."), type=MESSAGE_TYPE_INFO)
 				return
 		else
-			to_chat(src, text="You are unable to succumb to death! This life continues.", type=MESSAGE_TYPE_INFO)
+			to_chat(src, span_warning("You are unable to succumb to death! This life continues."), type=MESSAGE_TYPE_INFO)
 			return
 	log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] with [round(health, 0.1)] points of health!", LOG_ATTACK)
 	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)


### PR DESCRIPTION
## About The Pull Request

fixes #87662 
Right-clicking the succumb alert will let you succumb without a message
also fixes a few bugs

## Fucked Up Looking Dog
![fucked-up-looking-dog-spookston](https://github.com/user-attachments/assets/9715ecfe-977f-41e1-b45b-050a111c6b54)

## Changelog

:cl:
qol: you can now right-click the succumb action button to succumb silently
qol: the succumb inputs have a few more titles to choose from now
fix: the succumb text input now shows the actual correct number of characters you can say
fix: attempting to cancel a succumb will no longer kill you
spellcheck: the text for failing to succumb is now spanned
/:cl: