### PR TITLE
Moves destructive analyser attack chain to base item interact level

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -38,20 +38,21 @@
 	else
 		. += span_notice("An item can be loaded inside via [EXAMINE_HINT("Left-Click")].")
 
-/obj/machinery/rnd/destructive_analyzer/attackby(obj/item/weapon, mob/living/user, params)
+/obj/machinery/rnd/destructive_analyzer/base_item_interaction(mob/living/user, obj/item/weapon, list/modifiers)
 	if(user.combat_mode)
 		return ..()
 	if(!is_insertion_ready(user))
 		return ..()
 	if(!user.transferItemToLoc(weapon, src))
 		to_chat(user, span_warning("\The [weapon] is stuck to your hand, you cannot put it in the [name]!"))
-		return TRUE
+		return ..()
+
 	busy = TRUE
 	loaded_item = weapon
 	to_chat(user, span_notice("You place the [weapon.name] inside the [name]."))
 	flick("[base_icon_state]_la", src)
 	addtimer(CALLBACK(src, PROC_REF(finish_loading)), 1 SECONDS)
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/rnd/destructive_analyzer/click_alt(mob/user)
 	unload_item()

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -45,7 +45,7 @@
 		return ..()
 	if(!user.transferItemToLoc(weapon, src))
 		to_chat(user, span_warning("\The [weapon] is stuck to your hand, you cannot put it in the [name]!"))
-		return ..()
+		return ITEM_INTERACT_BLOCKING
 
 	busy = TRUE
 	loaded_item = weapon


### PR DESCRIPTION
## About The Pull Request
- Fixes #87658
- Fixes #84583

Use combat mode to get the desired item interaction (like planting c4 on the machine) cause all items are accepted now

## Changelog
:cl:
fix: destructive analyser accepts all items without interacting with them (no planting c4 on the machine or radio jammer jamming the machine). Use combat mode to get these default behaviour's instead
/:cl:

