### PR TITLE
[NO GBP] Post-Material rods fixes and tweaks

### DIFF
--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -80,7 +80,7 @@
 	composition = list(/datum/material/titanium=1, /datum/material/plasma=1)
 	mat_rust_resistance = RUST_RESISTANCE_TITANIUM
 	fish_weight_modifier = 1.1
-	fishing_difficulty_modifier = -10
+	fishing_difficulty_modifier = -7
 	fishing_cast_range = 1
 	fishing_experience_multiplier = 0.95
 
@@ -204,7 +204,7 @@
 	composition = list(/datum/material/iron=2, /datum/material/plasma=2)
 	added_slowdown = 0.1
 	fish_weight_modifier = 2.4
-	fishing_difficulty_modifier = -25
+	fishing_difficulty_modifier = -20
 	fishing_cast_range = 2
 	fishing_experience_multiplier = 0.5
 	fishing_completion_speed = 2

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -105,10 +105,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_difficulty_modifier = -5
 	fishing_experience_multiplier = 0.85
 	fishing_completion_speed = 1.1
-	fishing_bait_speed_mult = 1.1
 	fishing_deceleration_mult = 1.1
 	fishing_bounciness_mult = 0.9
-	fishing_gravity_mult = 1.15
+	fishing_gravity_mult = 1.1
 
 /datum/material/silver/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
@@ -138,14 +137,14 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	points_per_unit = 18 / SHEET_MATERIAL_AMOUNT
 	texture_layer_icon_state = "shine"
 	fish_weight_modifier = 1.5
-	fishing_difficulty_modifier = -10
+	fishing_difficulty_modifier = -8
 	fishing_cast_range = 1
 	fishing_experience_multiplier = 0.75
 	fishing_completion_speed = 1.2
-	fishing_bait_speed_mult = 1.3
+	fishing_bait_speed_mult = 1.1
 	fishing_deceleration_mult = 1.2
 	fishing_bounciness_mult = 0.8
-	fishing_gravity_mult = 1.25
+	fishing_gravity_mult = 1.2
 
 /datum/material/gold/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
@@ -177,14 +176,14 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	mineral_rarity = MATERIAL_RARITY_RARE
 	points_per_unit = 50 / SHEET_MATERIAL_AMOUNT
 	fish_weight_modifier = 1.4
-	fishing_difficulty_modifier = -13
+	fishing_difficulty_modifier = -12
 	fishing_cast_range = -1
 	fishing_experience_multiplier = 0.7
 	fishing_completion_speed = 1.25
-	fishing_bait_speed_mult = 1.3
+	fishing_bait_speed_mult = 1.1
 	fishing_deceleration_mult = 1.25
 	fishing_bounciness_mult = 0.8
-	fishing_gravity_mult = 1.2
+	fishing_gravity_mult = 1.1
 
 /datum/material/diamond/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
@@ -216,7 +215,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_bait_speed_mult = 0.8
 	fishing_deceleration_mult = 1.4
 	fishing_bounciness_mult = 0.6
-	fishing_gravity_mult = 1.6
+	fishing_gravity_mult = 1.4
 
 /datum/material/uranium/on_applied(atom/source, mat_amount, multiplier)
 	. = ..()
@@ -313,7 +312,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_cast_range = 5 //space-bending scifi magic
 	fishing_experience_multiplier = 0.85
 	fishing_completion_speed = 1.1
-	fishing_bait_speed_mult = 1.2
+	fishing_bait_speed_mult = 1.1
 	fishing_deceleration_mult = 0.9
 	fishing_bounciness_mult = 1.1
 
@@ -439,7 +438,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_difficulty_modifier = -5
 	fishing_cast_range = 1
 	fishing_completion_speed = 1.15
-	fishing_bait_speed_mult = 1.15
+	fishing_bait_speed_mult = 1.1
 	fishing_deceleration_mult = 1.3
 	fishing_bounciness_mult = 0.75
 	fishing_gravity_mult = 1.1
@@ -466,13 +465,13 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	mineral_rarity = MATERIAL_RARITY_UNDISCOVERED
 	points_per_unit = 100 / SHEET_MATERIAL_AMOUNT
 	fish_weight_modifier = 1.5
-	fishing_difficulty_modifier = -18
+	fishing_difficulty_modifier = -13
 	fishing_cast_range = 1
 	fishing_experience_multiplier = 3.2 //grind all the way to level 100 in no time.
 	fishing_completion_speed = 1.3
 	fishing_bait_speed_mult = 0.9
 	fishing_deceleration_mult = 1.2
-	fishing_gravity_mult = 1.25
+	fishing_gravity_mult = 1.2
 
 /datum/material/runite/on_applied(atom/source, mat_amount, multiplier)
 	. = ..()
@@ -512,7 +511,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_difficulty_modifier = -5
 	fishing_cast_range = 2
 	fishing_experience_multiplier = 1.2
-	fishing_bait_speed_mult = 1.3
+	fishing_bait_speed_mult = 1.2
 	fishing_deceleration_mult = 0.8
 	fishing_bounciness_mult = 1.3
 	fishing_gravity_mult = 0.85
@@ -594,14 +593,14 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	mineral_rarity = MATERIAL_RARITY_UNDISCOVERED //Doesn't naturally spawn on lavaland.
 	points_per_unit = 100 / SHEET_MATERIAL_AMOUNT
 	fish_weight_modifier = 1.6
-	fishing_difficulty_modifier = -23
+	fishing_difficulty_modifier = -17
 	fishing_cast_range = 1
 	fishing_experience_multiplier = 0.6
 	fishing_completion_speed = 1.3
-	fishing_bait_speed_mult = 1.3
+	fishing_bait_speed_mult = 1.2
 	fishing_deceleration_mult = 1.3
 	fishing_bounciness_mult = 0.7
-	fishing_gravity_mult = 1.4
+	fishing_gravity_mult = 1.3
 
 /datum/material/adamantine/on_applied(atom/source, mat_amount, multiplier)
 	. = ..()
@@ -636,14 +635,14 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	mineral_rarity = MATERIAL_RARITY_UNDISCOVERED //Doesn't naturally spawn on lavaland.
 	points_per_unit = 100 / SHEET_MATERIAL_AMOUNT
 	fish_weight_modifier = 1.4
-	fishing_difficulty_modifier = -25
+	fishing_difficulty_modifier = -20
 	fishing_cast_range = 2
 	fishing_experience_multiplier = 0.5
 	fishing_completion_speed = 1.35
-	fishing_bait_speed_mult = 1.35
+	fishing_bait_speed_mult = 1.2
 	fishing_deceleration_mult = 1.35
 	fishing_bounciness_mult = 0.65
-	fishing_gravity_mult = 1.4
+	fishing_gravity_mult = 1.3
 
 /datum/material/mythril/on_applied(atom/source, mat_amount, multiplier)
 	. = ..()
@@ -678,11 +677,11 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 400 / SHEET_MATERIAL_AMOUNT
 	beauty_modifier = 0.2
 	fish_weight_modifier = 0.9
-	fishing_difficulty_modifier = -10
+	fishing_difficulty_modifier = -8
 	fishing_cast_range = 1
 	fishing_experience_multiplier = 0.9
 	fishing_completion_speed = 1.4
-	fishing_bait_speed_mult = 1.5
+	fishing_bait_speed_mult = 1.3
 	fishing_deceleration_mult = 0.5
 	fishing_bounciness_mult = 0.3
 	fishing_gravity_mult = 0.8
@@ -719,11 +718,11 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	strength_modifier = 1.2
 	armor_modifiers = list(MELEE = 1.35, BULLET = 1.3, LASER = 1.3, ENERGY = 1.25, BOMB = 0.7, BIO = 1, FIRE = 1.3, ACID = 1)
 	fish_weight_modifier = 0.6 //It may be metallic, but it's just "denser" hydrogen at the end of the day, no?
-	fishing_difficulty_modifier = -15
+	fishing_difficulty_modifier = -13
 	fishing_cast_range = 4
 	fishing_experience_multiplier = 0.8
 	fishing_completion_speed = 1.4
-	fishing_bait_speed_mult = 1.6
+	fishing_bait_speed_mult = 1.3
 	fishing_deceleration_mult = 0.8
 	fishing_bounciness_mult = 1.7
 	fishing_gravity_mult = 0.7
@@ -838,9 +837,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = -0.15
 	texture_layer_icon_state = "runed"
 	fish_weight_modifier = 1.5
-	fishing_difficulty_modifier = -12
-	fishing_experience_multiplier = 0.9
-	fishing_completion_speed = 1.2
+	fishing_difficulty_modifier = -6.66
+	fishing_experience_multiplier = 0.666
+	fishing_completion_speed = 1.666
 	fishing_bait_speed_mult = 1.666
 	fishing_deceleration_mult = 1.666
 	fishing_bounciness_mult = 0.666
@@ -1041,7 +1040,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_cast_range = -1
 	fishing_experience_multiplier = 1.3
 	fishing_completion_speed = 1.15
-	fishing_bait_speed_mult = 1.2
+	fishing_bait_speed_mult = 1.1
 	fishing_deceleration_mult = 0.8
 	fishing_bounciness_mult = 0.7
 	fishing_gravity_mult = 0.7
@@ -1061,13 +1060,13 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	armor_modifiers = list(MELEE = 0.9, BULLET = 0.9, LASER = 1.75, ENERGY = 1.75, BOMB = 0.5, BIO = 1, FIRE = 0.1, ACID = 1)
 	beauty_modifier = 0.001
 	fish_weight_modifier = 1.2
-	fishing_difficulty_modifier = -16
+	fishing_difficulty_modifier = -14
 	fishing_experience_multiplier = 0.9
 	fishing_completion_speed = 1.3
-	fishing_bait_speed_mult = 1.3
+	fishing_bait_speed_mult = 1.2
 	fishing_deceleration_mult = 1.3
 	fishing_bounciness_mult = 1.1
-	fishing_gravity_mult = 1.35
+	fishing_gravity_mult = 1.3
 
 /datum/material/zaukerite/on_applied(atom/source, mat_amount, multiplier)
 	. = ..()

--- a/code/datums/materials/hauntium.dm
+++ b/code/datums/materials/hauntium.dm
@@ -18,7 +18,7 @@
 	strength_modifier = 1.2
 	armor_modifiers = list(MELEE = 1.1, BULLET = 1.1, LASER = 1.15, ENERGY = 1.15, BOMB = 1, BIO = 1, FIRE = 1, ACID = 0.7)
 	fish_weight_modifier = 1.4
-	fishing_difficulty_modifier = -30 //Only the undead and the coroner can game this.
+	fishing_difficulty_modifier = -25 //Only the undead and the coroner can game this.
 	fishing_cast_range = 2
 	fishing_experience_multiplier = 1.5
 	fishing_completion_speed = 1.1

--- a/code/modules/cargo/exports/fish.dm
+++ b/code/modules/cargo/exports/fish.dm
@@ -6,4 +6,4 @@
 /datum/export/fish/get_cost(obj/item/fish/fish, apply_elastic)
 	var/elastic_cost = ..()
 	var/elastic_percent = elastic_cost / init_cost
-	return fish.get_export_price(elastic_cost, elastic_percent)
+	return round(fish.get_export_price(elastic_cost, elastic_percent))

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1352,7 +1352,7 @@
 	var/size_weight_exponentation = (size * weight * FISH_PRICE_MULTIPLIER)^FISH_PRICE_CURVE_EXPONENT
 	var/raw_price = price + size_weight_exponentation
 	if(raw_price >= FISH_PRICE_SOFT_CAP_THRESHOLD + 1)
-		var/soft_cap = (calculated_price - FISH_PRICE_SOFT_CAP_THRESHOLD)^FISH_PRICE_SOFT_CAP_EXPONENT
+		var/soft_cap = (raw_price - FISH_PRICE_SOFT_CAP_THRESHOLD)^FISH_PRICE_SOFT_CAP_EXPONENT
 		raw_price = FISH_PRICE_SOFT_CAP_THRESHOLD + soft_cap
 	if(HAS_TRAIT(src, TRAIT_FISH_FROM_CASE)) //Avoid printing money by simply ordering fish and sending it back.
 		raw_price *= 0.05

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1339,7 +1339,7 @@
 	var/size_weight_exponentation = (size * weight * 0.01)^0.85
 	var/calculated_price = price + size_weight_exponentation * percent
 	if(calculated_price > 6000) //it's become possible to grow fish that, without this cap, would sell for over 22k each.
-		var/soft_cap = (calculated_price - 6000)^0.85
+		var/soft_cap = (calculated_price - 6000)^0.86
 		calculated_price = 6000 + soft_cap
 	if(HAS_TRAIT(src, TRAIT_FISH_FROM_CASE)) //Avoid printing money by simply ordering fish and sending it back.
 		calculated_price *= 0.05

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1334,16 +1334,34 @@
 		fish_zap_flags |= (ZAP_GENERATES_POWER | ZAP_MOB_STUN)
 	tesla_zap(source = get_turf(src), zap_range = fish_zap_range, power = fish_zap_power, cutoff = 1 MEGA JOULES, zap_flags = fish_zap_flags)
 
+///The multiplier of the factor of size and weight of the fish, used to determinate the raw price before exponentation
+#define FISH_PRICE_MULTIPLIER 0.01
+///This makes each additional unit of fish weight and size yields diminishing marginal returns.
+#define FISH_PRICE_CURVE_EXPONENT 0.85
+/**
+ * past this threshold, the price of fish will plateu even faster.
+ * This stops particularly huge fish from being an overly efficient way to make money
+ * that bypasses price elasticity by selling fewer units.
+ */
+#define FISH_PRICE_SOFT_CAP_THRESHOLD 6000
+///The second exponent used for soft-capping the fish price.
+#define FISH_PRICE_SOFT_CAP_EXPONENT 0.86
+
 ///Returns the price of this fish, for the fish export.
-/obj/item/fish/proc/get_export_price(price, percent)
-	var/size_weight_exponentation = (size * weight * 0.01)^0.85
-	var/calculated_price = price + size_weight_exponentation * percent
-	if(calculated_price > 6000) //it's become possible to grow fish that, without this cap, would sell for over 22k each.
-		var/soft_cap = (calculated_price - 6000)^0.86
-		calculated_price = 6000 + soft_cap
+/obj/item/fish/proc/get_export_price(price, elasticity_percent)
+	var/size_weight_exponentation = (size * weight * FISH_PRICE_MULTIPLIER)^FISH_PRICE_CURVE_EXPONENT
+	var/raw_price = price + size_weight_exponentation
+	if(raw_price >= FISH_PRICE_SOFT_CAP_THRESHOLD + 1)
+		var/soft_cap = (calculated_price - FISH_PRICE_SOFT_CAP_THRESHOLD)^FISH_PRICE_SOFT_CAP_EXPONENT
+		raw_price = FISH_PRICE_SOFT_CAP_THRESHOLD + soft_cap
 	if(HAS_TRAIT(src, TRAIT_FISH_FROM_CASE)) //Avoid printing money by simply ordering fish and sending it back.
-		calculated_price *= 0.05
-	return round(calculated_price)
+		raw_price *= 0.05
+	return raw_price * elasticity_percent
+
+#undef FISH_PRICE_MULTIPLIER
+#undef FISH_PRICE_CURVE_EXPONENT
+#undef FISH_PRICE_SOFT_CAP_THRESHOLD
+#undef FISH_PRICE_SOFT_CAP_EXPONENT
 
 /obj/item/fish/proc/get_happiness_value()
 	var/happiness_value = 0

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1338,6 +1338,9 @@
 /obj/item/fish/proc/get_export_price(price, percent)
 	var/size_weight_exponentation = (size * weight * 0.01)^0.85
 	var/calculated_price = price + size_weight_exponentation * percent
+	if(calculated_price > 6000) //it's become possible to grow fish that, without this cap, would sell for over 22k each.
+		var/soft_cap = (calculated_price - 6000)^0.86
+		calculated_price = 6000 + soft_cap
 	if(HAS_TRAIT(src, TRAIT_FISH_FROM_CASE)) //Avoid printing money by simply ordering fish and sending it back.
 		calculated_price *= 0.05
 	return round(calculated_price)

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1339,7 +1339,7 @@
 	var/size_weight_exponentation = (size * weight * 0.01)^0.85
 	var/calculated_price = price + size_weight_exponentation * percent
 	if(calculated_price > 6000) //it's become possible to grow fish that, without this cap, would sell for over 22k each.
-		var/soft_cap = (calculated_price - 6000)^0.86
+		var/soft_cap = (calculated_price - 6000)^0.85
 		calculated_price = 6000 + soft_cap
 	if(HAS_TRAIT(src, TRAIT_FISH_FROM_CASE)) //Avoid printing money by simply ordering fish and sending it back.
 		calculated_price *= 0.05

--- a/code/modules/fishing/fish/types/freshwater.dm
+++ b/code/modules/fishing/fish/types/freshwater.dm
@@ -202,7 +202,7 @@
 	SIGNAL_HANDLER
 	playsound(result, result.attack_sound, 50, TRUE) // reeeeeeeeeeeeeee...
 
-/obj/item/fish/tadpole/get_export_price(price, percent)
+/obj/item/fish/tadpole/get_export_price(price, elasticity_percent)
 	return 2 //two credits. Tadpoles aren't really that valueable.
 
 /obj/item/fish/perch

--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -33,6 +33,9 @@
 /obj/item/fish/mastodon/make_edible(weight_val)
 	return //it's all bones and gibs.
 
+/obj/item/fish/mastodon/get_export_price(price, percent)
+	return ..() * 1.2 //This should push its soft-capped (it's pretty big) price a bit above the rest
+
 ///From the cursed spring
 /obj/item/fish/soul
 	name = "soulfish"

--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -33,7 +33,7 @@
 /obj/item/fish/mastodon/make_edible(weight_val)
 	return //it's all bones and gibs.
 
-/obj/item/fish/mastodon/get_export_price(price, percent)
+/obj/item/fish/mastodon/get_export_price(price, elasticity_percent)
 	return ..() * 1.2 //This should push its soft-capped (it's pretty big) price a bit above the rest
 
 ///From the cursed spring

--- a/code/modules/fishing/fish/types/station.dm
+++ b/code/modules/fishing/fish/types/station.dm
@@ -146,7 +146,7 @@
 		add_traits(list(TRAIT_FISHING_BAIT, TRAIT_GREAT_QUALITY_BAIT), INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_FISH_SURVIVE_COOKING, INNATE_TRAIT)
 
-/obj/item/fish/fryish/update_size_and_weight(new_size = average_size, new_weight = average_weight, update_materials = FALSE)
+/obj/item/fish/fryish/update_size_and_weight(new_size = average_size, new_weight = average_weight, update_materials = TRUE)
 	. = ..()
 	if(!next_type)
 		return

--- a/code/modules/fishing/fish/types/syndicate.dm
+++ b/code/modules/fishing/fish/types/syndicate.dm
@@ -52,8 +52,9 @@
 	electrogenesis_power = 0.9 MEGA JOULES
 	beauty = FISH_BEAUTY_UGLY
 
-/obj/item/fish/jumpercable/get_export_price(price, percent)
-	return ..() * 0.4 //without this, they'd sell for over 6000 each, and require no maintance or partner to farm.
+/obj/item/fish/jumpercable/get_export_price(price, elasticity_percent)
+	//without this, they'd sell for over 6000 each, minimum. That's a lot for a fish that requires no maintance nor partner to farm.
+	return ..() * 0.4
 
 /obj/item/fish/chainsawfish
 	name = "chainsawfish"

--- a/code/modules/fishing/fish/types/syndicate.dm
+++ b/code/modules/fishing/fish/types/syndicate.dm
@@ -52,6 +52,9 @@
 	electrogenesis_power = 0.9 MEGA JOULES
 	beauty = FISH_BEAUTY_UGLY
 
+/obj/item/fish/jumpercable/get_export_price(price, percent)
+	return ..() * 0.4 //without this, they'd sell for over 6000 each, and require no maintance or partner to farm.
+
 /obj/item/fish/chainsawfish
 	name = "chainsawfish"
 	desc = "A very, very angry bioweapon, whose sole purpose is to rip and tear."

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -472,7 +472,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	//early return if the difficulty is the same or we crush the minigame all the way to 0 difficulty
 	if(!get_difficulty() || difficulty == old_difficulty)
 		return
-	bait_height = initial(bait_height)
+	bait_height = initial(bait_height) * used_rod.bait_height_mult
 	experience_multiplier -= difficulty * FISHING_SKILL_DIFFIULTY_EXP_MULT
 	mover.reset_difficulty_values()
 	adjust_to_difficulty()

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -69,6 +69,13 @@
 	var/bounciness_mult = 1
 	/// The multiplier of negative velocity that pulls the bait/bobber down when not holding the click
 	var/gravity_mult = 1
+	/**
+	 * The multiplier of the bait height. Influenced by the strength_modifier of a material,
+	 * unlike the other variables, lest we add too many vars to materials.
+	 * Also materials with a strength_modifier lower than 1 don't do anything, since
+	 * they're already likely to be quite bad
+	 */
+	var/bait_height_mult = 1
 
 /obj/item/fishing_rod/Initialize(mapload)
 	. = ..()
@@ -187,6 +194,9 @@
 	deceleration_mult *= GET_MATERIAL_MODIFIER(custom_material.fishing_deceleration_mult, multiplier)
 	bounciness_mult *= GET_MATERIAL_MODIFIER(custom_material.fishing_bounciness_mult, multiplier)
 	gravity_mult *= GET_MATERIAL_MODIFIER(custom_material.fishing_gravity_mult, multiplier)
+	var/height_mod = GET_MATERIAL_MODIFIER(custom_material.strength_modifier, multiplier)
+	if(height_mod > 1)
+		bait_height_mult *= bait_height_mod**0.75
 
 
 /obj/item/fishing_rod/remove_single_mat_effect(datum/material/custom_material, amount, multiplier)
@@ -199,6 +209,9 @@
 	deceleration_mult /= GET_MATERIAL_MODIFIER(custom_material.fishing_deceleration_mult, multiplier)
 	bounciness_mult /= GET_MATERIAL_MODIFIER(custom_material.fishing_bounciness_mult, multiplier)
 	gravity_mult /= GET_MATERIAL_MODIFIER(custom_material.fishing_gravity_mult, multiplier)
+	var/height_mod = GET_MATERIAL_MODIFIER(custom_material.strength_modifier, multiplier)
+	if(height_mod > 1)
+		bait_height_mult *= 1/(bait_height_mod**0.75)
 
 /**
  * Is there a reason why this fishing rod couldn't fish in target_fish_source?
@@ -254,6 +267,7 @@
 		else if(HAS_TRAIT(bait, TRAIT_BASIC_QUALITY_BAIT))
 			material_chance += 4
 	material_chance += user.mind?.get_skill_level(/datum/skill/fishing) * 1.5
+	return material_chance
 
 ///Fishing rodss should only bane fish DNA-infused spessman
 /obj/item/fishing_rod/proc/attempt_bane(datum/source, mob/living/fish)
@@ -747,10 +761,11 @@
 	hook = /obj/item/fishing_hook/weighted
 	completion_speed_mult = 1.55
 	bait_speed_mult = 1.2
-	deceleration_mult = 1.55
+	deceleration_mult = 1.2
 	bounciness_mult = 0.3
 	gravity_mult = 1.2
 	material_fish_chance = 33 //if somehow you metalgen it.
+	bait_height_mult = 1.4
 
 /obj/item/fishing_rod/tech
 	name = "advanced fishing rod"

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -196,7 +196,7 @@
 	gravity_mult *= GET_MATERIAL_MODIFIER(custom_material.fishing_gravity_mult, multiplier)
 	var/height_mod = GET_MATERIAL_MODIFIER(custom_material.strength_modifier, multiplier)
 	if(height_mod > 1)
-		bait_height_mult *= bait_height_mod**0.75
+		bait_height_mult *= height_mod**0.75
 
 
 /obj/item/fishing_rod/remove_single_mat_effect(datum/material/custom_material, amount, multiplier)
@@ -211,7 +211,7 @@
 	gravity_mult /= GET_MATERIAL_MODIFIER(custom_material.fishing_gravity_mult, multiplier)
 	var/height_mod = GET_MATERIAL_MODIFIER(custom_material.strength_modifier, multiplier)
 	if(height_mod > 1)
-		bait_height_mult *= 1/(bait_height_mod**0.75)
+		bait_height_mult *= 1/(height_mod**0.75)
 
 /**
  * Is there a reason why this fishing rod couldn't fish in target_fish_source?


### PR DESCRIPTION
## About The Pull Request
This PR follows the material fishing rod PR, which had a small issue in which I had forgotten to add a return value to a proc and thus fish caught from material fishing rods would never be made of that specific material.

I've tweaked some values for materials and fishing rods, I felt some of the "better" rods were a bit too fast, and some downright let you skip the fishing minigame with zero to one level. Also, I felt that, despite making fishing easier kinda, the area of the bait slider still felt a tad too small, so I've introduced a height multiplier for the slider so that it could cover more space, depending on the strength multiplier of the material (for once, not a new niche variable). This doesn't apply to fishing rods with strength multiplier less than 1 because they don't need to be made worse.

About fish and cargo, I've added a soft cap (a 0.86 exponent) to fish selling price. It shouldn't affect the wide majority of fish you catch, however it does affect those that sell for over 6k per unit, which are few and rare. However, I've been pinged about some ludicrous money-making done by selling fish alone on a downstream server, likely from growing the big fish to be up twice their initial size and weight (capped to 2.5 the average value for the species), however, new features may push things a little further, so it's better to be safe than sorry.
Screenshot below: They said it took them about a hour, however take it with a pinch of salt since it's by no mean easy and fast money by Terry's standards:
![immagine](https://github.com/user-attachments/assets/4e3d787c-13b4-48ad-abf4-ab4cbfbdbd36)


I've also halved the selling price of jumpercable fish, which, despite requiring an emag or some sort luck, could easily be farmed in due time with little to no maintenance, being self-reproducing and hunger-less, and each of them would sell for 6k. conversely, I've increased the price of the unmarine mastodon a little because of the soft-cap, since it's very rare.

## Why It's Good For The Game
Fixing one code "skill issue", and balancing and tuning other gameplay aspects pertaining fishing.

## Changelog

:cl:
fix: You can actually catch custom material fish with custom material fishing rods.
balance: Tweaked some values of custom material fishing rods.
balance: Soft-capped the selling price per unit for fish at 6k (the value of the fish plateaus even faster past that threshold).
/:cl:
