### PR TITLE
Goliath Tendril Hammer is now resistant to acid and fire

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -102,6 +102,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/goliath_hammer_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/goliath_hammer_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	w_class = WEIGHT_CLASS_HUGE
 	force = 20
 	throwforce = 0


### PR DESCRIPTION

## About The Pull Request

The goliath hammer is now resistant to fire and acid.

Being an extension of your body, this should probably not burn off until the entire limb does.
## Why It's Good For The Game

Closes #87566.
## Changelog
:cl:
fix: Goliath Tendril Hammer arm (from the gene brain) is now resistant to being burned off by acid/fire.
/:cl:
