### PR TITLE
Fixes for borg attack chain interactions

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -39,12 +39,6 @@
 	if(LAZYACCESS(modifiers, CTRL_CLICK))
 		CtrlClickOn(A)
 		return
-	if(LAZYACCESS(modifiers, RIGHT_CLICK) && !module_active)
-		var/secondary_result = A.attack_robot_secondary(src, modifiers)
-		if(secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
-			return
-		else if (secondary_result != SECONDARY_ATTACK_CALL_NORMAL)
-			CRASH("attack_robot_secondary did not return a SECONDARY_ATTACK_* define.")
 
 	if(next_move >= world.time)
 		return
@@ -53,7 +47,15 @@
 
 	var/obj/item/W = get_active_held_item()
 
-	if(!W && get_dist(src,A) <= interaction_range)
+	//wireless interaction with an atom
+	if(!W && get_dist(src, A) <= interaction_range)
+		if(LAZYACCESS(modifiers, RIGHT_CLICK) && !module_active)
+			var/secondary_result = A.attack_robot_secondary(src, modifiers)
+			if(secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
+				return
+			if (secondary_result != SECONDARY_ATTACK_CALL_NORMAL)
+				CRASH("attack_robot_secondary did not return a SECONDARY_ATTACK_* define.")
+
 		A.attack_robot(src, modifiers)
 		return
 
@@ -197,12 +199,13 @@
 
 	return A.attack_robot(src, modifiers)
 
-/mob/living/silicon/robot/RangedAttack(atom/A, modifiers)
-	A.attack_robot(src, modifiers)
-
-/mob/living/silicon/robot/ranged_secondary_attack(atom/A, modifiers)
-	A.attack_robot_secondary(src,)
-
+/**
+ * What happens when the cyborg holds left-click on an item.
+ *
+ * Arguments:
+ * * user The mob holding the right click
+ * * modifiers The list of the custom click modifiers
+ */
 /atom/proc/attack_robot(mob/user, modifiers)
 	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT, user, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -54,7 +54,7 @@
 	var/obj/item/W = get_active_held_item()
 
 	if(!W && get_dist(src,A) <= interaction_range)
-		A.attack_robot(src)
+		A.attack_robot(src, modifiers)
 		return
 
 	if(W)
@@ -191,17 +191,23 @@
 /mob/living/silicon/robot/UnarmedAttack(atom/A, proximity_flag, list/modifiers)
 	if(!can_unarmed_attack())
 		return
-	A.attack_robot(src)
 
-/mob/living/silicon/robot/RangedAttack(atom/A)
-	A.attack_robot(src)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		return A.attack_robot_secondary(src, modifiers)
 
-/atom/proc/attack_robot(mob/user)
-	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+	return A.attack_robot(src, modifiers)
+
+/mob/living/silicon/robot/RangedAttack(atom/A, modifiers)
+	A.attack_robot(src, modifiers)
+
+/mob/living/silicon/robot/ranged_secondary_attack(atom/A, modifiers)
+	A.attack_robot_secondary(src,)
+
+/atom/proc/attack_robot(mob/user, modifiers)
+	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT, user, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return
 
 	attack_ai(user)
-	return
 
 /**
  * What happens when the cyborg without active module holds right-click on an item. Returns a SECONDARY_ATTACK_* value.
@@ -211,7 +217,7 @@
  * * modifiers The list of the custom click modifiers
  */
 /atom/proc/attack_robot_secondary(mob/user, list/modifiers)
-	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT_SECONDARY, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
-		return
+	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT_SECONDARY, user, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	return attack_ai_secondary(user, modifiers)

--- a/code/modules/mining/boulder_processing/brm.dm
+++ b/code/modules/mining/boulder_processing/brm.dm
@@ -240,6 +240,8 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || panel_open)
 		return
+	if(!user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(!anchored)
 		balloon_alert(user, "unanchored!")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION
## About The Pull Request
- Fixes #87612 by returning the correct define when `COMSIG_ATOM_ATTACK_ROBOT_SECONDARY` blocks the attack
- Borg `UnarmedAttack()` now checks for modifiers (i.e. are we left or right clicking) this allows `redirect_attack_hand_from_turf` (which calls `UnarmedAttack()`) component to call either `attack_robot()` or `attack_robot_secondary()` correctly so you can now turn the fire alarm on & off by attacking its mounted wall as a borg
- Borg's `attack_robot_secondary()` now checks for `interaction_range` just like `attack_robot()` so you can't do shinanigens like resetting a fire alarm/turning on or off the conveyer switch from an infinite distance like through camera's & such
- Removed Borgs `RangedAttack()` proc which called `attack_robot()` because it violates `interaction_range` for the proc

## Changelog
:cl:
fix: No runtime when clicking on a fire alarm's mounted wall as a borg
fix: You can turn the fire alarm on & off (And not just on) as a borg via left & right click on its mounted wall
fix: certain secondary interactions of items & borgs now respect the borgs interaction range
/:cl:
