### PR TITLE
Fixed fishing rod duping with poly belts and shapeshift spells.

### DIFF
--- a/code/datums/components/profound_fisher.dm
+++ b/code/datums/components/profound_fisher.dm
@@ -3,15 +3,15 @@
 	///the fishing rod this mob will use
 	var/obj/item/fishing_rod/mob_fisher/our_rod
 	///Wether we should delete the fishing rod along with the component or replace it if it's somehow removed from the parent
-	var/delete_rod = TRUE
+	var/delete_rod_when_deleted = TRUE
 
-/datum/component/profound_fisher/Initialize(our_rod, delete_rod = TRUE)
+/datum/component/profound_fisher/Initialize(our_rod, delete_rod_when_deleted = TRUE)
 	var/isgloves = istype(parent, /obj/item/clothing/gloves)
 	if(!isliving(parent) && !isgloves)
 		return COMPONENT_INCOMPATIBLE
 	src.our_rod = our_rod || new(parent)
 	src.our_rod.internal = TRUE
-	src.delete_rod = delete_rod
+	src.delete_rod_when_deleted = delete_rod_when_deleted
 	ADD_TRAIT(src.our_rod, TRAIT_NOT_BARFABLE, REF(src))
 	RegisterSignal(src.our_rod, COMSIG_MOVABLE_MOVED, PROC_REF(on_rod_moved))
 
@@ -40,12 +40,12 @@
 	examine_list += span_info("When [EXAMINE_HINT("held")] or [EXAMINE_HINT("equipped")], [EXAMINE_HINT("right-click")] with a empty hand to open the integrated fishing rod interface.")
 	examine_list += span_tinynoticeital("To fish, you need to turn combat mode off.")
 
-///Handles replacing the fishing rod if somehow removed from the parent movable if delete_rod is TRUE, otherwise delete the component.
+///Handles replacing the fishing rod if somehow removed from the parent movable if delete_rod_when_deleted is TRUE, otherwise delete the component.
 /datum/component/profound_fisher/proc/on_rod_moved(datum/source)
 	SIGNAL_HANDLER
 	if(QDELETED(src) || our_rod.loc == parent)
 		return
-	if(delete_rod)
+	if(delete_rod_when_deleted)
 		UnregisterSignal(our_rod, COMSIG_MOVABLE_MOVED)
 		if(!QDELETED(our_rod))
 			qdel(our_rod)
@@ -55,10 +55,10 @@
 
 /datum/component/profound_fisher/Destroy()
 	UnregisterSignal(our_rod, COMSIG_MOVABLE_MOVED)
-	if(!delete_rod)
+	if(!delete_rod_when_deleted)
 		our_rod.internal = FALSE
 		REMOVE_TRAIT(our_rod, TRAIT_NOT_BARFABLE, REF(src))
-	else if(QDELETED(our_rod))
+	else if(!QDELETED(our_rod))
 		QDEL_NULL(our_rod)
 	our_rod = null
 	return ..()

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -115,7 +115,7 @@
 	if(hook)
 		equipped_stuff += "[icon2html(hook, user)] <b>[hook.name]</b>"
 	if(bait)
-		equipped_stuff += "[icon2html(bait, user)] <b>[bait]</b> as bait"
+		equipped_stuff += "[icon2html(bait, user)] <b>[bait]</b>"
 	if(length(equipped_stuff))
 		. += span_notice("It has \a [english_list(equipped_stuff)] equipped.")
 	if(!bait)

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -115,7 +115,7 @@
 	if(hook)
 		equipped_stuff += "[icon2html(hook, user)] <b>[hook.name]</b>"
 	if(bait)
-		equipped_stuff += "[icon2html(bait, user)] <b>[bait]</b> as bait."
+		equipped_stuff += "[icon2html(bait, user)] <b>[bait]</b> as bait"
 	if(length(equipped_stuff))
 		. += span_notice("It has \a [english_list(equipped_stuff)] equipped.")
 	if(!bait)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -985,7 +985,7 @@
 		return
 	gloves.AddComponent(/datum/component/adjust_fishing_difficulty, 5)
 	if(equipped)
-		gloves.AddComponent(/datum/component/profound_fisher, equipped)
+		gloves.AddComponent(/datum/component/profound_fisher, equipped, delete_rod = FALSE)
 
 /obj/item/mod/module/fishing_glove/on_part_deactivation(deleting = FALSE)
 	var/obj/item/gloves = mod.get_part_from_slot(ITEM_SLOT_GLOVES)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -985,7 +985,7 @@
 		return
 	gloves.AddComponent(/datum/component/adjust_fishing_difficulty, 5)
 	if(equipped)
-		gloves.AddComponent(/datum/component/profound_fisher, equipped, delete_rod = FALSE)
+		gloves.AddComponent(/datum/component/profound_fisher, equipped, delete_rod_when_deleted = FALSE)
 
 /obj/item/mod/module/fishing_glove/on_part_deactivation(deleting = FALSE)
 	var/obj/item/gloves = mod.get_part_from_slot(ITEM_SLOT_GLOVES)

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -194,7 +194,7 @@
 	if(owner?.contents)
 		// Prevent round removal and consuming stuff when losing shapeshift
 		for(var/atom/movable/thing as anything in owner.contents)
-			if(thing == caster_mob)
+			if(thing == caster_mob || HAS_TRAIT(thing, TRAIT_NOT_BARFABLE))
 				continue
 			thing.forceMove(get_turf(owner))
 


### PR DESCRIPTION
## About The Pull Request
It turns out the "shapeshifted from spell" status ejects everything inside the shapeshifted mob when removed. That's been causing a little issue with the fishing rod from the profound_fisher component, which a few mobs have. This PR fixes just that.

## Why It's Good For The Game
![immagine](https://github.com/user-attachments/assets/b664ffa6-567f-4332-b7dc-a5d2badb43d3)
![immagine](https://github.com/user-attachments/assets/4c453f91-2852-40c0-8f54-c5d66f28fdb1)


## Changelog

:cl:
fix: Fixed fishing rod duping with poly belts and shapeshift spells.
spellcheck: Fixed a small typo when examining fishing rods.
/:cl:
