### PR TITLE
RD modsuit advanced reagent scanner fix

### DIFF
--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -30,13 +30,13 @@
 	var/explosion_detection_dist = 21
 
 /obj/item/mod/module/reagent_scanner/advanced/on_activation()
+	. = ..()
 	ADD_TRAIT(mod.wearer, TRAIT_RESEARCH_SCANNER, MOD_TRAIT)
-	ADD_TRAIT(mod.wearer, TRAIT_REAGENT_SCANNER, MOD_TRAIT)
 	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, PROC_REF(sense_explosion))
 
 /obj/item/mod/module/reagent_scanner/advanced/on_deactivation(display_message = TRUE, deleting = FALSE)
+	. = ..()
 	REMOVE_TRAIT(mod.wearer, TRAIT_RESEARCH_SCANNER, MOD_TRAIT)
-	REMOVE_TRAIT(mod.wearer, TRAIT_REAGENT_SCANNER, MOD_TRAIT)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION)
 
 /obj/item/mod/module/reagent_scanner/advanced/proc/sense_explosion(datum/source, turf/epicenter,

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -21,16 +21,22 @@
 
 /obj/item/mod/module/reagent_scanner/advanced
 	name = "MOD advanced reagent scanner module"
+	desc = "An advanced module with all the features of research-oriented Nanotrasen HUDs, this is capable of scanning \
+		the contents of containers and projecting the information in an easy-to-read format on the wearer's display. \
+		It also contains a research scanner and an explosion sensor that gives details on nearby explosions. \
+		No improvements have been made to allow it to detect flavors so that's still up to you."
 	complexity = 0
 	removable = FALSE
 	var/explosion_detection_dist = 21
 
 /obj/item/mod/module/reagent_scanner/advanced/on_activation()
 	ADD_TRAIT(mod.wearer, TRAIT_RESEARCH_SCANNER, MOD_TRAIT)
+	ADD_TRAIT(mod.wearer, TRAIT_REAGENT_SCANNER, MOD_TRAIT)
 	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, PROC_REF(sense_explosion))
 
 /obj/item/mod/module/reagent_scanner/advanced/on_deactivation(display_message = TRUE, deleting = FALSE)
 	REMOVE_TRAIT(mod.wearer, TRAIT_RESEARCH_SCANNER, MOD_TRAIT)
+	REMOVE_TRAIT(mod.wearer, TRAIT_REAGENT_SCANNER, MOD_TRAIT)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION)
 
 /obj/item/mod/module/reagent_scanner/advanced/proc/sense_explosion(datum/source, turf/epicenter,


### PR DESCRIPTION
## About The Pull Request
Makes the Research Director's modsuit advanced reagent scanner actually detect reagents, also changes descriptions to mention its explosion sensor and research scanner.
## Why It's Good For The Game
Currently the research director's modsuit has an unremovable advanced reagent scanner module that does not scan reagents and can't be replaced with a working reagent scanner, this fixes that.

It is also good to mention its explosion sensor ability and research scanner as it lets research directors know what the module does.
## Changelog
:cl:
fix: Made the Research Director's Modsuit's Advanced Reagent Scanner scan reagents.
spellcheck: Changes description of the Advanced Reagent Scanner to mention its explosion sensor and research scanner.
/:cl:
