### PR TITLE
Increase gas mask filter effectiveness.

### DIFF
--- a/code/modules/clothing/masks/gas_filter.dm
+++ b/code/modules/clothing/masks/gas_filter.dm
@@ -1,15 +1,15 @@
 ///Filtering ratio for high amounts of gas
-#define HIGH_FILTERING_RATIO 0.001
+#define HIGH_FILTERING_RATIO 0.01
 ///Filtering ratio for min amount of gas
-#define LOW_FILTERING_RATIO 0.0005
+#define LOW_FILTERING_RATIO 0.0025
 ///Min amount of high filtering gases for high filtering ratio
 #define HIGH_FILTERING_MOLES 0.001
 ///Min amount of mid filtering gases for high filtering ratio
 #define MID_FILTERING_MOLES 0.0025
 ///Min amount of low filtering gases for high filtering ratio
-#define LOW_FILTERING_MOLES 0.0005
+#define LOW_FILTERING_MOLES 0.005
 ///Min amount of wear that the filter gets when used
-#define FILTERS_CONSTANT_WEAR 0.05
+#define FILTERS_CONSTANT_WEAR 0.025
 
 /obj/item/gas_filter
 	name = "atmospheric gas filter"
@@ -71,23 +71,23 @@
 		if(gas_id in high_filtering_gases)
 			if(breath.gases[gas_id][MOLES] > HIGH_FILTERING_MOLES)
 				breath.gases[gas_id][MOLES] = max(breath.gases[gas_id][MOLES] - filter_strength_high * filter_efficiency * HIGH_FILTERING_RATIO, 0)
-				danger_points += 0.5
+				danger_points += 1
 				continue
 			breath.gases[gas_id][MOLES] = max(breath.gases[gas_id][MOLES] - filter_strength_high * filter_efficiency * LOW_FILTERING_RATIO, 0)
-			danger_points += 0.05
+			danger_points += 0.2
 			continue
 		if(gas_id in mid_filtering_gases)
 			if(breath.gases[gas_id][MOLES] > MID_FILTERING_MOLES)
 				breath.gases[gas_id][MOLES] = max(breath.gases[gas_id][MOLES] - filter_strength_mid * filter_efficiency * HIGH_FILTERING_RATIO, 0)
-				danger_points += 0.75
+				danger_points += 1.25
 				continue
 			breath.gases[gas_id][MOLES] = max(breath.gases[gas_id][MOLES] - filter_strength_mid * filter_efficiency * LOW_FILTERING_RATIO, 0)
-			danger_points += 0.15
+			danger_points += 0.25
 			continue
 		if(gas_id in low_filtering_gases)
 			if(breath.gases[gas_id][MOLES] > LOW_FILTERING_MOLES)
 				breath.gases[gas_id][MOLES] = max(breath.gases[gas_id][MOLES] - filter_strength_low * filter_efficiency * HIGH_FILTERING_RATIO, 0)
-				danger_points += 1
+				danger_points += 1.5
 				continue
 			breath.gases[gas_id][MOLES] = max(breath.gases[gas_id][MOLES] - filter_strength_low * filter_efficiency * LOW_FILTERING_RATIO, 0)
 			danger_points += 0.5


### PR DESCRIPTION
## About The Pull Request
This PR increases the effectiveness of gas mask filters against small amounts of gas. It increases the filtering efficiency of filters, makes them remove more gas from inhaled air, and makes their degradation more dependent on if they are in use or not. When a mask filter isnt being used it will degrade much slower and when it is being used it will degrade much faster. Testing: all this changes are some magic numbers used in a single short math equation. If this breaks something, I might as well quit TG anyways. 
## Why It's Good For The Game
Currently, gas mask filters are nigh redundant, and have no noticable effect on any gasses except for those with incredibly low minimum effect concentrations. For example, against n2o or plasma, a filter will make a room temp air mixture with an extra 2 mol of n2o/plasma added, which would normally inhale as a partial pressure of ~3.83, to a partial pressure of ~3.78. Note that the effect PP thresholds of n2o are 0.05 for giggling, 1 for n2o alert, and 4 for sedation. Increasing the effectiveness of filters will not prevent you from being affected by full-on floods, but they will reduce the impact of small concentrations of dangerous gasses. If a chemist boils off plasma accidentally, the pharmacy can end up poisoning people inside it for 10 minutes or longer, without even triggering air alarms. Making it possible to prepare for and work against minor leaks, spills, and the after-effects of cleaned up gas floods will reduce the frequency of "firelock hell" scenarios.
## Changelog
:cl:
balance: Gas mask filters are now more effective, and their degradation is more heavily influenced by what gasses they are filtering.
/:cl:
