### PR TITLE
Makes #87029 Opt-Out

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -364,7 +364,7 @@ Used by the AI doomsday and the self-destruct nuke.
 	loaded_lazy_templates = SSmapping.loaded_lazy_templates
 
 #define INIT_ANNOUNCE(X) to_chat(world, span_boldannounce("[X]")); log_world(X)
-/datum/controller/subsystem/mapping/proc/LoadGroup(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE)
+/datum/controller/subsystem/mapping/proc/LoadGroup(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE, height_autosetup = TRUE)
 	. = list()
 	var/start_time = REALTIMEOFDAY
 
@@ -394,7 +394,7 @@ Used by the AI doomsday and the self-destruct nuke.
 		while (total_z > traits.len)  // fall back to defaults on extra levels
 			traits += list(default_traits.Copy())
 
-	if(total_z > 1) // it's a multi z map
+	if(total_z > 1 && height_autosetup) // it's a multi z map, and we haven't opted out of trait autosetup
 		for(var/z in 1 to total_z)
 			if(z == 1) // bottom z-level
 				traits[z]["Up"] = TRUE
@@ -433,7 +433,7 @@ Used by the AI doomsday and the self-destruct nuke.
 	// load the station
 	station_start = world.maxz + 1
 	INIT_ANNOUNCE("Loading [current_map.map_name]...")
-	LoadGroup(FailedZs, "Station", current_map.map_path, current_map.map_file, current_map.traits, ZTRAITS_STATION)
+	LoadGroup(FailedZs, "Station", current_map.map_path, current_map.map_file, current_map.traits, ZTRAITS_STATION, height_autosetup = current_map.height_autosetup)
 
 	if(SSdbcore.Connect())
 		var/datum/db_query/query_round_map_name = SSdbcore.NewQuery({"

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -40,6 +40,8 @@
 	var/job_changes = list()
 	/// List of additional areas that count as a part of the library
 	var/library_areas = list()
+	/// Boolean - if TRUE, the "Up" and "Down" traits are automatically distributed to the map's z-levels. If FALSE; they're set via JSON.
+	var/height_autosetup = TRUE
 
 	/// List of unit tests that are skipped when running this map
 	var/list/skipped_tests
@@ -207,6 +209,9 @@
 				stack_trace("Invalid path in mapping config for additional library areas: \[[path_as_text]\]")
 				continue
 			library_areas += path
+
+	if ("height_autosetup" in json)
+		height_autosetup = json["height_autosetup"]
 
 #ifdef UNIT_TESTS
 	// Check for unit tests to skip, no reason to check these if we're not running tests


### PR DESCRIPTION

## About The Pull Request
Adds a new boolean that lets you opt out of automatically linking zlevels in `LoadGroup()` (as implemented in https://github.com/tgstation/tgstation/pull/87029); and forwards that support to map jsons. Does ***not*** change any /tg/ map jsons in the process; as they all still work as intended.

A modified Icebox JSON loading correctly:
![image](https://github.com/user-attachments/assets/5f7a731d-3d4a-461f-9d86-04e1bf162885)

### How do I disable automatic z-level linking?
Add the following to your json; under planetary:
```	"height_autosetup": 0, ```

For each z-level's trait; you can then add either `"Up": true` or  `"Down": true` to link them manually, as you would've prior to #87029 .
## Why It's Good For The Game
tl;dr, map experimentation. It was prior possible to have station segments separated by z-level that weren't vertically linked; which was put to practice most prominently on Nova Sector, of all places, - but #87029 made it automatically assume that they should be linked in that manner.

This middleground keeps the new assumption while preserving the old manual process for any mapping projects that need it.
## Changelog
:cl:
code: Mappers can now opt out of automatically linking their up/down station traits.
/:cl:
