### PR TITLE
[IDED] Syndicate shuttle .50 BMG turrets' bullets now self-disintegrate before hitting a nukie

### DIFF
--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -96,7 +96,7 @@
 		return .
 
 	var/mob/living/our_target = target
-	if(IS_NUKE_OP(our_target))
+	if(ACCESS_SYNDICATE in our_target.get_access())
 		do_sparks(2, FALSE, src)
 		visible_message("[src] beeps, and self-detonates right before it hits [our_target]!")
 		return PROJECTILE_DELETE_WITHOUT_HITTING

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -90,6 +90,17 @@
 	speed = 0.3
 	range = 16
 
+/obj/projectile/bullet/p50/penetrator/shuttle/prehit_pierce(atom/target)
+	. = ..()
+	if(!isliving(target))
+		return .
+
+	var/mob/living/our_target = target
+	if(IS_NUKE_OP(our_target))
+		do_sparks(2, FALSE, src)
+		visible_message("[src] beeps, and self-detonates right before it hits [our_target]!")
+		return PROJECTILE_DELETE_WITHOUT_HITTING
+
 /obj/projectile/bullet/p50/marksman
 	name = ".50 BMG marksman round"
 	damage = 50


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/701284a4-3519-4b0b-b3cb-021c61d26847)
## Why It's Good For The Game

The amount of times these have caused my death as a nukie op is crazy. I see it all the time, either a nukie takes damage or a cyborg does. Last Terry round TWO CYBORGS (one was me) lost all their modules and were left to flounder around helplessly because this dumb fuck turret noticed some jackass through a wall and annihilated our health.

These things are a huge hassle and 95% of the time some funnyman comes in with smart foam to hard counter them anyways. At least let them not be a net negative to nuclear operatives.
## Changelog
:cl:
balance: Syndicate shuttle .50 BMG turrets' bullets now self-disintegrate before hitting a nukie
/:cl:
