### PR TITLE
[NO GBP] You can perform fish scanning experiments again (plus other stuff)

### DIFF
--- a/code/__DEFINES/fish.dm
+++ b/code/__DEFINES/fish.dm
@@ -157,7 +157,7 @@
 ///This fish can be scanned to complete fish scanning experiments
 #define FISH_FLAG_EXPERIMENT_SCANNABLE (1<<3)
 ///It lets us know that fish/update_size_and_weight() is currently running.
-#define FISH_FLAG_UPDATING_SIZE_AND_WEIGHT (1<<3)
+#define FISH_FLAG_UPDATING_SIZE_AND_WEIGHT (1<<4)
 
 
 #define MIN_AQUARIUM_TEMP T0C

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -220,7 +220,7 @@
 		balloon_alert(user, "it's stuck to your hand!")
 		return ITEM_INTERACT_BLOCKING
 	balloon_alert(user, "releasing fish...")
-	if(!do_after(src, 3 SECONDS, interacting_with))
+	if(!do_after(user, 3 SECONDS, interacting_with))
 		return ITEM_INTERACT_BLOCKING
 	balloon_alert(user, "fish released")
 	var/goodbye_text = "Bye bye [name]."

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -801,11 +801,11 @@
 
 /obj/item/fishing_rod/material/Initialize(mapload)
 	. = ..()
-	name = "fishing_rod"
+	name = "fishing rod"
 
 /obj/item/fishing_rod/material/finalize_remove_material_effects(list/materials)
 	. = ..()
-	name = "fishing_rod" //so it doesn't reset to "material fishing rod"
+	name = "fishing rod" //so it doesn't reset to "material fishing rod"
 
 #undef ROD_SLOT_BAIT
 #undef ROD_SLOT_LINE


### PR DESCRIPTION
## About The Pull Request
I've accidentally assigned the FISH_FLAG_UPDATING_SIZE_AND_WEIGHT flag the same value of FISH_FLAG_EXPERIMENT_SCANNABLE, that's why I couldn't perform it while playing the game.

Also, this PR fixes the broken interaction of catch'n'release, as well as a typo in the name of material fishing rods.

## Why It's Good For The Game
I broke a couple things.

## Changelog


:cl:
fix: You can perform fish scanning experiments again.
fix: You can actually release fish on water turfs after catching them.
spellcheck: Fixed a typo in the name of material fishing rods.
/:cl:

