### PR TITLE
[tools] Fixes tgui build warning

### DIFF
--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,8 +1,16 @@
 @echo off
 set NODE_SKIP_PLATFORM_CHECK=1
-call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
+
+:: Call pwsh if available
+set "powershellCmd=powershell"
+where pwsh >nul 2>nul
+if %errorlevel%==0 (
+    set "powershellCmd=pwsh"
+)
+
+call %powershellCmd% -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
-	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path
+	call %powershellCmd% -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path
 `) do (
 	set "PATH=%%s;%PATH%"
 )


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This might very well only happen to me, there were no issues, but running `bin\tgui-build` rather than <kbd>CTRL</kbd><kbd>SHIFT</kbd><kbd>B</kbd> would error. The default windows powershell (5.1 for me) is the culprit. This routes it to an [upgraded powershell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.4), if you have it installed. 

![image](https://github.com/user-attachments/assets/b1ccc00b-d109-4e11-9459-942a765a7d45)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I hate red letters in my terminal >:(
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

Dev only