### PR TITLE
Fix oil slime making vegetable oil instead of corn oil

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -384,7 +384,7 @@
 
 
 /datum/chemical_reaction/slime/slimeoil
-	results = list(/datum/reagent/consumable/nutriment/fat/oil = 10)
+	results = list(/datum/reagent/consumable/nutriment/fat/oil/corn = 10)
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/oil
 


### PR DESCRIPTION
## About The Pull Request
Fixes bug caused by https://github.com/tgstation/tgstation/commit/b1c5e5e0f6a1edf58b49b238af7d3094da76c69b#diff-aedb81aab354c31e90007bd0ad4e8babf347ac7d6003c3b01da14021ff5a10f4R387

The wiki and code prior both say oil slimes should make corn oil, but they currently make vegetable oil. Since corn oil is needed for nitroglycerin and oil slimes are explosive-centric, it makes sense they should be making corn oil.
## Why It's Good For The Game
Fixes: #81036
## Changelog
:cl:
fix: Fixes oil slimes making vegetable oil instead of corn oil
/:cl:
