### PR TITLE
Chef groceries more clearly say who they are for.

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -8,6 +8,8 @@
 		CATEGORY_SAUCES_REAGENTS,
 	)
 	blackbox_key = "chef"
+	// Discount for items in the chefs category like mining/bitrunning consoles
+	cargo_cost_multiplier =  0.65
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -146,8 +146,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.
 	if(SSshuttle.chef_groceries.len)
 		var/obj/structure/closet/crate/freezer/grocery_crate = new(pick_n_take(empty_turfs))
-		grocery_crate.name = "Kitchen produce freezer"
-		grocery_crate.desc = "Produce order for the Kitchen, deliver to the chef ASAP"
+		grocery_crate.name = "kitchen produce freezer"
+		grocery_crate.desc = "Produce order for the Kitchen, deliver to the chef ASAP."
 		investigate_log("Chef's [SSshuttle.chef_groceries.len] sized produce order arrived. Cost was deducted from orderer, not cargo.", INVESTIGATE_CARGO)
 		for(var/datum/orderable_item/item as anything in SSshuttle.chef_groceries)//every order
 			for(var/amt in 1 to SSshuttle.chef_groceries[item])//every order amount

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -146,7 +146,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.
 	if(SSshuttle.chef_groceries.len)
 		var/obj/structure/closet/crate/freezer/grocery_crate = new(pick_n_take(empty_turfs))
-		grocery_crate.name = "kitchen produce freezer"
+		grocery_crate.name = "Kitchen produce freezer"
+		grocery_crate.desc = "Produce order for the Kitchen, deliver to the chef ASAP"
 		investigate_log("Chef's [SSshuttle.chef_groceries.len] sized produce order arrived. Cost was deducted from orderer, not cargo.", INVESTIGATE_CARGO)
 		for(var/datum/orderable_item/item as anything in SSshuttle.chef_groceries)//every order
 			for(var/amt in 1 to SSshuttle.chef_groceries[item])//every order amount


### PR DESCRIPTION
Chef produces is 35% cheaper to order from the chef console
## Why It's Good For The Game
If chef is forced to order from the cargo because botany isn't growing what they need they deserve a discount, also this is inline with mining and bitrunning discounts.

## Changelog
:cl:oranges
balance: Chef produce orders are cheaper
/:cl:
