### PR TITLE
fixes borgs linking to ais in mechs cards and modsuits

### DIFF
--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -11,7 +11,7 @@ GLOBAL_VAR(station_level_z_scratch)
 // Called a lot, somewhat slow, so has its own cache
 #define is_station_level(z_level) \
 	( \
-		(z_level) && \
+		(z_level) && ( \
 		( \
 			/* The right hand side of this guarantees that we'll have the space to fill later on, while also not failing the condition */ \
 			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = (z_level)) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \
@@ -19,6 +19,7 @@ GLOBAL_VAR(station_level_z_scratch)
 		) \
 			? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(GLOB.station_level_z_scratch, ZTRAIT_STATION)) \
 			: GLOB.station_levels_cache[GLOB.station_level_z_scratch] \
+		) \
 	)
 
 #define is_mining_level(z) SSmapping.level_trait(z, ZTRAIT_MINING)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -489,7 +489,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 		. += borg
 
 //Returns a list of AI's
-/proc/active_ais(check_mind=FALSE, z = null, skip_syndicate, only_syndicate)
+/proc/active_ais(check_mind = FALSE, z = null, skip_syndicate = FALSE, only_syndicate = FALSE)
 	. = list()
 	for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
 		if(ai.stat == DEAD)
@@ -501,10 +501,9 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 			continue
 		if(only_syndicate && !syndie_ai)
 			continue
-		if(check_mind)
-			if(!ai.mind)
-				continue
-		if(z && !(z == ai.z) && (!is_station_level(z) || !is_station_level(ai.z))) //if a Z level was specified, AND the AI is not on the same level, AND either is off the station...
+		if(check_mind && !ai.mind)
+			continue
+		if(!isnull(z) && z != ai.z && (!is_station_level(z) || !is_station_level(ai.z))) //if a Z level was specified, AND the AI is not on the same level, AND either is off the station...
 			continue
 		. += ai
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -162,7 +162,7 @@ Des: Removes all infected images from the alien.
 	if(!unique_name)
 		return
 
-	if(old_number != 0)
+	if(old_identifier != 0)
 		identifier = old_identifier
 		name = initial(name) // prevent chicanery like two different numerical identifiers tied to the same mob
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -139,7 +139,7 @@ Des: Removes all infected images from the alien.
 	)
 
 	new_xeno.setDir(dir)
-	new_xeno.change_name(name, real_name, numba)
+	new_xeno.change_name(name, real_name, identifier)
 
 	if(mind)
 		mind.name = new_xeno.real_name
@@ -153,7 +153,7 @@ Des: Removes all infected images from the alien.
 	qdel(src)
 
 /// Changes the name of the xeno we are evolving into in order to keep the same numerical identifier the old xeno had.
-/mob/living/carbon/alien/proc/change_name(old_name, old_real_name, old_number)
+/mob/living/carbon/alien/proc/change_name(old_name, old_real_name, old_identifier)
 	if(!alien_name_regex.Find(old_name)) // check to make sure there's no admins doing funny stuff with naming these aliens
 		name = old_name
 		real_name = old_real_name
@@ -163,7 +163,7 @@ Des: Removes all infected images from the alien.
 		return
 
 	if(old_number != 0)
-		numba = old_number
+		identifier = old_identifier
 		name = initial(name) // prevent chicanery like two different numerical identifiers tied to the same mob
 
 	set_name()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1961,9 +1961,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	user.put_in_hands(holder)
 
 /mob/living/proc/set_name()
-	if(numba == 0)
-		numba = rand(1, 1000)
-	name = "[name] ([numba])"
+	if(identifier == 0)
+		identifier = rand(1, 999)
+	name = "[name] ([identifier])"
 	real_name = name
 
 /mob/living/proc/mob_try_pickup(mob/living/user, instant=FALSE)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -148,7 +148,7 @@
 	///if a mob's name should be appended with an id when created e.g. Mob (666)
 	var/unique_name = FALSE
 	///the id a mob gets when it's created
-	var/numba = 0
+	var/identifier = 0
 
 	///these will be yielded from butchering with a probability chance equal to the butcher item's effectiveness
 	var/list/butcher_results = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -182,10 +182,9 @@
 
 	model.transform_to(model_list[input_model])
 
-/mob/living/silicon/robot/set_name() //we have our own name to make, after we make our mmi
+/mob/living/silicon/robot/set_name() //we have our name-making proc to call after we make our mmi, just set identifier here
 	if(identifier == 0)
 		identifier = rand(1, 999)
-	return
 
 /// Used to setup the a basic and (somewhat) unique name for the robot.
 /mob/living/silicon/robot/proc/setup_default_name()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -28,8 +28,6 @@
 	inv2 = new /atom/movable/screen/robot/module2()
 	inv3 = new /atom/movable/screen/robot/module3()
 
-	ident = rand(1, 999)
-
 	previous_health = health
 
 	if(ispath(cell))
@@ -184,6 +182,10 @@
 
 	model.transform_to(model_list[input_model])
 
+/mob/living/silicon/robot/set_name() //we have our own name to make, after we make our mmi
+	if(identifier == 0)
+		identifier = rand(1, 999)
+	return
 
 /// Used to setup the a basic and (somewhat) unique name for the robot.
 /mob/living/silicon/robot/proc/setup_default_name()
@@ -219,7 +221,7 @@
 
 
 /mob/living/silicon/robot/proc/get_standard_name()
-	return "[(designation ? "[designation] " : "")][mmi.braintype]-[ident]"
+	return "[(designation ? "[designation] " : "")][mmi.braintype]-[identifier]"
 
 /mob/living/silicon/robot/proc/ionpulse()
 	if(!ionpulse_on)
@@ -842,7 +844,7 @@
 
 	shell = TRUE
 	braintype = "AI Shell"
-	name = "Empty AI Shell-[ident]"
+	name = "Empty AI Shell-[identifier]"
 	real_name = name
 	GLOB.available_ai_shells |= src
 	if(!QDELETED(builtInCamera))
@@ -861,7 +863,7 @@
 		qdel(boris)
 	shell = FALSE
 	GLOB.available_ai_shells -= src
-	name = "Unformatted Cyborg-[ident]"
+	name = "Unformatted Cyborg-[identifier]"
 	real_name = name
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name
@@ -874,7 +876,7 @@
  * * AI - AI unit that initiated the deployment into the AI shell
  */
 /mob/living/silicon/robot/proc/deploy_init(mob/living/silicon/ai/AI)
-	real_name = "[AI.real_name] [designation] Shell-[ident]"
+	real_name = "[AI.real_name] [designation] Shell-[identifier]"
 	name = real_name
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name //update the camera name too

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -15,6 +15,7 @@
 	designation = "Default" //used for displaying the prefix & getting the current model of cyborg
 	has_limbs = TRUE
 	hud_type = /datum/hud/robot
+	unique_name = TRUE
 
 	///Represents the cyborg's model (engineering, medical, etc.)
 	var/obj/item/robot_model/model = null
@@ -110,8 +111,6 @@
 	var/ai_lockdown = FALSE
 	///Timer that allows the borg to self-unlock after a set amount of time
 	var/lockdown_timer = null
-	///Random serial number generated for each cyborg upon its initialization
-	var/ident = 0
 	var/locked = TRUE
 	req_one_access = list(ACCESS_ROBOTICS)
 


### PR DESCRIPTION

## About The Pull Request
our code checking if something is on station level was not protected for z level being 0 (like it is on stuff thats inside other objects)
so now it is, and therefore borgs no longer link to ais on z level 0 (inside stuff), and some other stuff will probably be affected by this as well
also: the "numba" variable on living and "ident" variable on borgs has been merged into an "identifier" variable. i called it numba back when i first added it because i thought it was funny

## Why It's Good For The Game
bug

## Changelog
:cl:
fix: fixes borgs linking to ais in mechs cards and modsuits
/:cl:
