### PR TITLE
Lowers the price of the energy sword.

### DIFF
--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -37,7 +37,7 @@
 			pocketed when inactive. Activating it produces a loud, distinctive noise."
 	progression_minimum = 20 MINUTES
 	item = /obj/item/melee/energy/sword/saber
-	cost = 8
+	cost = 6
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
 /datum/uplink_item/dangerous/powerfist


### PR DESCRIPTION
## About The Pull Request

E-sword uplink price has been lowered from 8 to 6 TC.

## Why It's Good For The Game

It's no secret that the E-sword has fallen out of flavor over the last year or so.

Its purchase rate is so low it doesn't even show on the MRP chart.

https://superset.moth.fans/superset/dashboard/4/?native_filters_key=gJDhU4Ug60OlqSjRelTSMUWlVWVPGZRQr16s6OFMNXTqcUaVO8-O0yCX1cjJJK9y

Part of the reason I feel is that on its own the weapon doesn't really offer much.

It's a decent melee weapon  but not as good as the powerfist, which is less expensive, hits twice as hard, stuns, and is unblockable.

It offers decent protection, but again a shield is so easy to steal these days you might just save your tc for something better

And when you really think about it, his bigger sister, the desword, is only 5 TC more expensive and offers way more damage and block chance.

(Also you can get one for free if you space explore for a few minutes, but that's besides the point).

Now I'm not saying the energy sword is a bad weapon, it being  1handed opens you up for a few nasty combos.

But for what it represents, i.e a shield with some decent damage strapped on top , it could probably receive a small discount.

I don't really have any strong attachments to the weapon or anything, so If you can provide a good reason why this is a bad idea by all means.

## Changelog

:cl:
balance: The Uplink cost of the energy sword has been lowered from 8 to 6 TC.
/:cl:

