### PR TITLE
[NO GBP] Fixes wings and jetpacks sometimes preventing you from opening doors

### DIFF
--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -164,6 +164,12 @@
 /datum/component/jetpack/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
 	SIGNAL_HANDLER
 
+	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
+		return
+
+	if (!source.client.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
+		return
+
 	if (!should_trigger(source) || !check_on_move.Invoke(FALSE))
 		return
 

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -145,7 +145,7 @@
 	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
 		return
 
-	if (!can_fly(source) || !source.client.intended_direction)
+	if (!can_fly(source) || !source.client.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
 		return
 
 	return COMPONENT_PREVENT_SPACEMOVE_HALT

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -82,7 +82,7 @@
 	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
 		return
 
-	if (!allow_flight() || !source.client.intended_direction)
+	if (!allow_flight() || !source.client.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
 		return
 
 	return COMPONENT_PREVENT_SPACEMOVE_HALT


### PR DESCRIPTION

## About The Pull Request
I hate this timeline. What title says, makes jetpacks and wings allow you to bump into things you're moving into.

## Why It's Good For The Game
This feels awful and requires you to stop pressing movement keys for a moment before resuming movement to get out of the "stuck" state

## Changelog
:cl:
fix: Fixed wings and jetpacks sometimes preventing you from opening doors
/:cl:
