### PR TITLE
Use native BYOND `isnan` and `isinf` for math defines

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -1,4 +1,3 @@
-#define IS_INF(a) (isnum(a) && isinf(a))
 #define IS_FINITE__UNSAFE(a) (!isinf(a) && !isnan(a))
 #define IS_FINITE(a) (isnum(a) && IS_FINITE__UNSAFE(a))
 

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -1,14 +1,6 @@
-// Remove these once we have Byond implementation.
-// ------------------------------------
-#define IS_NAN(a) (a != a)
-
-#define IS_INF__UNSAFE(a) (a == a && a-a != a-a)
-#define IS_INF(a) (isnum(a) && IS_INF__UNSAFE(a))
-
-#define IS_FINITE__UNSAFE(a) (a-a == a-a)
+#define IS_INF(a) (isnum(a) && isinf(a))
+#define IS_FINITE__UNSAFE(a) (!isinf(a) && !isnan(a))
 #define IS_FINITE(a) (isnum(a) && IS_FINITE__UNSAFE(a))
-// ------------------------------------
-// Aight dont remove the rest
 
 // Credits to Nickr5 for the useful procs I've taken from his library resource.
 // This file is quadruple wrapped for your pleasure


### PR DESCRIPTION
## About The Pull Request

`// Remove these once we have Byond implementation.`

Well guess what we have now?

Altho sadly we still lack a native `isfinite`, so we still use a define for that.

## Why It's Good For The Game

Native BYOND impls have better performance usually, due to them compiling down to instructions, avoiding proc overhead.

## Changelog

No user-facing changes.
