### PR TITLE
Update README.md of unit tests folder for VS code support

### DIFF
--- a/code/modules/unit_tests/README.md
+++ b/code/modules/unit_tests/README.md
@@ -39,11 +39,13 @@ Open `code/_compile_options.dm` and uncomment the following line.
 //#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 ```
 
-There are 2 ways to run unit tests
+There are 3 ways to run unit tests
 
 - Run tgstation.dmb in Dream Daemon. Don't bother trying to connect, you won't need to. You'll be able to see the outputs of all the tests. You'll get to see which tests failed and for what reason. If they all pass, you're set!
 
-- Run from VS Code. Launch the game as normal & you will see the output of your unit tests in your fancy chat window. This is preferred as you can use the debugger to step through each line of your unit test & can use the games inbuilt debugging tools to further aid in testing
+- Launch game from VS Code. Launch the game as normal & you will see the output of your unit tests in your fancy chat window. This is preferred as you can use the debugger to step through each line of your unit test & can use the games inbuilt debugging tools to further aid in testing
+
+- Use VS Code Tgstation Test Explorer Extension. This allows you to run tests without launching the game & can also run focused tests(either a single or a selected group)
 
 
 ## How to think about tests

--- a/code/modules/unit_tests/README.md
+++ b/code/modules/unit_tests/README.md
@@ -39,7 +39,12 @@ Open `code/_compile_options.dm` and uncomment the following line.
 //#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 ```
 
-Then, run tgstation.dmb in Dream Daemon. Don't bother trying to connect, you won't need to. You'll be able to see the outputs of all the tests. You'll get to see which tests failed and for what reason. If they all pass, you're set!
+There are 2 ways to run unit tests
+
+- Run tgstation.dmb in Dream Daemon. Don't bother trying to connect, you won't need to. You'll be able to see the outputs of all the tests. You'll get to see which tests failed and for what reason. If they all pass, you're set!
+
+- Run from VS Code. Launch the game as normal & you will see the output of your unit tests in your fancy chat window. This is preferred as you can use the debugger to step through each line of your unit test & can use the games inbuilt debugging tools to further aid in testing
+
 
 ## How to think about tests
 


### PR DESCRIPTION
## About The Pull Request
Turns out using dream daemon isn't the only way to run unit tests.

You can do it from VS code itself & can see the output of each test in the fancy chat window. 
![Screenshot (448)](https://github.com/user-attachments/assets/33aca6b5-3414-4560-9cc4-dd90fe80e2d1)

With the added advantage of using your debugger to step through each line of code this should be the preferred way so I've updated the read me file of the unit tests folder to specify that

You can also check the runtimes log in your game to see the output of each unit test

## Changelog
:cl:
N/A
/:cl:
