### PR TITLE
fixes some dynamic rulesets purging their candidate pools

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -261,7 +261,7 @@
 			candidates -= player
 		else if(is_centcom_level(player.z))
 			candidates -= player // We don't autotator people in CentCom
-		else if(player.mind && (player.mind.special_role || player.mind.can_roll_midround()))
+		else if(player.mind && (player.mind.special_role || !player.mind.can_roll_midround()))
 			candidates -= player // We don't autotator people with roles already
 
 /datum/dynamic_ruleset/midround/from_living/autotraitor/execute()
@@ -310,7 +310,7 @@
 			continue
 		if(isnull(player.mind))
 			continue
-		if(player.mind.special_role || player.mind.can_roll_midround())
+		if(player.mind.special_role || !player.mind.can_roll_midround())
 			continue
 		candidates += player
 
@@ -479,7 +479,7 @@
 			candidates -= player
 			continue
 
-		if(player.mind && (player.mind.special_role || player.mind.can_roll_midround()))
+		if(player.mind && (player.mind.special_role || !player.mind.can_roll_midround()))
 			candidates -= player
 
 /datum/dynamic_ruleset/midround/from_living/blob_infection/execute()


### PR DESCRIPTION

## About The Pull Request
autotator, malf and blob's candidates would all get wiped out by this, as `can_roll_midround()` returns TRUE if they can roll midround

## Why It's Good For The Game
seems like we want candidates in these roles, given the game is trying to get some

## Changelog
:cl:
fix: dynamic rulesets can get candidates for their roles
/:cl:
fixes #87535