### PR TITLE
Blob/Blob minion say logging

### DIFF
--- a/code/datums/components/blob_minion.dm
+++ b/code/datums/components/blob_minion.dm
@@ -139,6 +139,7 @@
 /// We only speak telepathically to blobs
 /datum/component/blob_minion/proc/on_try_speech(mob/living/minion, message, ignore_spam, forced)
 	SIGNAL_HANDLER
+	minion.log_talk(message, LOG_SAY, tag = "blob hivemind telepathy")
 	var/spanned_message = minion.say_quote(message)
 	var/rendered = span_blob("<b>\[Blob Telepathy\] [minion.real_name]</b> [spanned_message]")
 	relay_to_list_and_observers(rendered, GLOB.blob_telepathy_mobs, minion)


### PR DESCRIPTION

## About The Pull Request

The `/datum/component/blob_minion` component now properly logs spoken messages before relaying them.

![image](https://github.com/user-attachments/assets/f89b3e61-379c-4851-a571-fc31bf8a1ddc)

Radical.
## Why It's Good For The Game

Closes #86904.
## Changelog
:cl: Rhials
fix: Blob Overmind/Minion/Blobbernaut speech is now logged. Beware.
/:cl:
