### PR TITLE
Aliens cannot be husked

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -41,7 +41,7 @@
 
 	create_internal_organs()
 
-	add_traits(list(TRAIT_NEVER_WOUNDED, TRAIT_VENTCRAWLER_ALWAYS), INNATE_TRAIT)
+	add_traits(list(TRAIT_NEVER_WOUNDED, TRAIT_VENTCRAWLER_ALWAYS, TRAIT_UNHUSKABLE), INNATE_TRAIT)
 
 	. = ..()
 	if(alien_speed)


### PR DESCRIPTION

## About The Pull Request

Xenomorphs now innately have the UNHUSKABLE trait.

## Why It's Good For The Game

Xenomorphs behave rather uniquely compared to humans, especially in their health department. Various stupid oddities in it result in the fact that xenomorphs almost always husk nigh-instantly after death - they have 300+ burn or whatnot, when a normal human has 200 burn at the point of death. This is annoying for some niche interactions, such as reviver implant, which works on xenos, never being able to do its job because it can't revive husks.

That's the walance bit. The other bit is that, uh, how do you husk an exoskeleton. I dunno seems odd.

TL;DR: It arises from buggy behavior, breaks niche interactions, and makes no 'realistic' sense anyways.

## Changelog

:cl:
code: Aliens cannot be husked
/:cl:

