### PR TITLE
a better method of getting ambience cooldown

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -59,16 +59,16 @@ SUBSYSTEM_DEF(ambience)
 	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume*volume_modifier, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)
 
-	return rand(min_ambience_cooldown, max_ambience_cooldown)
+	/// gets the length of the sound about to play in SECONDS and then multiplies it to deciseconds
+	var/sound_length = new_sound.len * 10
+	/// choose a random cooldown amount to give time between playing ambiences
+	var/ambience_cooldown = rand(min_ambience_cooldown, max_ambience_cooldown)
+	return rand(sound_length, ambience_cooldown)
 
 /datum/controller/subsystem/ambience/proc/remove_ambience_client(client/to_remove)
 	ambience_listening_clients -= to_remove
 	client_old_areas -= to_remove
 	currentrun -= to_remove
-
-/area/station/maintenance
-	min_ambience_cooldown = 20 SECONDS
-	max_ambience_cooldown = 35 SECONDS
 
 	///A list of rare sound effects to fuck with players. No, it does not contain actual minecraft sounds anymore.
 	var/static/list/minecraft_cave_noises = list(

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(ambience)
 	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume*volume_modifier, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)
 
-	/// gets the length of the sound about to play in SECONDS
+	/// gets the length of the sound about to play in deciseconds
 	var/sound_length = new_sound.len
 	/// choose a random cooldown amount to give time between playing ambiences
 	var/ambience_cooldown = rand(min_ambience_cooldown, max_ambience_cooldown)

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -59,8 +59,8 @@ SUBSYSTEM_DEF(ambience)
 	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume*volume_modifier, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)
 
-	/// gets the length of the sound about to play in SECONDS and then multiplies it to deciseconds
-	var/sound_length = new_sound.len * 10
+	/// gets the length of the sound about to play in SECONDS
+	var/sound_length = new_sound.len
 	/// choose a random cooldown amount to give time between playing ambiences
 	var/ambience_cooldown = rand(min_ambience_cooldown, max_ambience_cooldown)
 	return rand(sound_length, ambience_cooldown)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -95,9 +95,9 @@
 	///The volume of the ambient buzz
 	var/ambient_buzz_vol = 35
 	///Used to decide what the minimum time between ambience is
-	var/min_ambience_cooldown = 30 SECONDS
+	var/min_ambience_cooldown = 7 SECONDS
 	///Used to decide what the maximum time between ambience is
-	var/max_ambience_cooldown = 60 SECONDS
+	var/max_ambience_cooldown = 15 SECONDS
 
 	flags_1 = CAN_BE_DIRTY_1
 

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -278,8 +278,6 @@
 	ambience_index = AMBIENCE_MINING
 	flags_1 = CAN_BE_DIRTY_1
 	sound_environment = SOUND_AREA_ASTEROID
-	min_ambience_cooldown = 70 SECONDS
-	max_ambience_cooldown = 220 SECONDS
 
 /area/centcom/asteroid/nearstation
 	static_lighting = TRUE

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -146,8 +146,8 @@
 	requires_power = TRUE
 	ambience_index = AMBIENCE_MINING
 	area_flags = VALID_TERRITORY | UNIQUE_AREA
-	min_ambience_cooldown = 70 SECONDS
-	max_ambience_cooldown = 220 SECONDS
+	min_ambience_cooldown = 15 SECONDS
+	max_ambience_cooldown = 40 SECONDS
 
 /area/lavaland/underground
 	name = "Lavaland Caves"
@@ -159,8 +159,8 @@
 	power_light = FALSE
 	ambience_index = AMBIENCE_MINING
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | FLORA_ALLOWED
-	min_ambience_cooldown = 70 SECONDS
-	max_ambience_cooldown = 220 SECONDS
+	min_ambience_cooldown = 15 SECONDS
+	max_ambience_cooldown = 40 SECONDS
 
 /area/lavaland/surface/outdoors
 	name = "Lavaland Wastes"
@@ -206,8 +206,8 @@
 	power_light = FALSE
 	requires_power = TRUE
 	area_flags = UNIQUE_AREA | FLORA_ALLOWED
-	min_ambience_cooldown = 70 SECONDS
-	max_ambience_cooldown = 220 SECONDS
+	min_ambience_cooldown = 15 SECONDS
+	max_ambience_cooldown = 40 SECONDS
 
 /area/icemoon/surface/outdoors // parent that defines if something is on the exterior of the station.
 	name = "Icemoon Wastes"
@@ -269,8 +269,8 @@
 	power_equip = FALSE
 	power_light = FALSE
 	area_flags = UNIQUE_AREA | FLORA_ALLOWED
-	min_ambience_cooldown = 70 SECONDS
-	max_ambience_cooldown = 220 SECONDS
+	min_ambience_cooldown = 15 SECONDS
+	max_ambience_cooldown = 40 SECONDS
 
 /area/icemoon/underground/unexplored // mobs and megafauna and ruins spawn here
 	name = "Icemoon Caves"

--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -17,8 +17,6 @@
 	flags_1 = CAN_BE_DIRTY_1
 	sound_environment = SOUND_AREA_SPACE
 	ambient_buzz = null //Space is deafeningly quiet
-	min_ambience_cooldown = 195 SECONDS //length of ambispace.ogg
-	max_ambience_cooldown = 200 SECONDS
 
 /area/space/nearstation
 	icon_state = "space_near"

--- a/code/game/area/areas/station/engineering.dm
+++ b/code/game/area/areas/station/engineering.dm
@@ -31,8 +31,6 @@
 	sound_environment = SOUND_AREA_SPACE
 	ambience_index = AMBIENCE_SPACE
 	ambient_buzz = null //Space is deafeningly quiet
-	min_ambience_cooldown = 195 SECONDS //length of ambispace.ogg
-	max_ambience_cooldown = 200 SECONDS
 
 /area/station/engineering/atmos/project
 	name = "\improper Atmospherics Project Room"

--- a/code/game/area/areas/station/medical.dm
+++ b/code/game/area/areas/station/medical.dm
@@ -4,8 +4,8 @@
 	ambience_index = AMBIENCE_MEDICAL
 	airlock_wires = /datum/wires/airlock/medbay
 	sound_environment = SOUND_AREA_STANDARD_STATION
-	min_ambience_cooldown = 90 SECONDS
-	max_ambience_cooldown = 180 SECONDS
+	min_ambience_cooldown = 15 SECONDS
+	max_ambience_cooldown = 45 SECONDS
 
 /area/station/medical/abandoned
 	name = "\improper Abandoned Medbay"


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/87054
instead of some snowflake value that starts from when the ambience began, we take the length of the sound and add a small randomized cooldown to it, so the "cooldown" starts after the sound ended.
## Why It's Good For The Game
- future proofs ambience sounds and makes the cooldown more sane.
- standardizes ambience cooldowns
## Changelog
:cl: grungussuss
sound: ambience cooldowns will now start from after the ambience has ended
/:cl:
