### PR TITLE
prevents sending messages to newscaster channels without permission

### DIFF
--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -699,15 +699,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  * Finally, it submits the message to the network, is logged globally, and clears all message-specific variables from the machine.
  */
 /obj/machinery/newscaster/proc/create_story(channel_name)
-	for(var/datum/feed_channel/potential_channel as anything in GLOB.news_network.network_channels)
-		if(channel_name == potential_channel.channel_ID)
-			current_channel = potential_channel
-			break
 	var/temp_message = tgui_input_text(usr, "Write your Feed story", "Network Channel Handler", feed_channel_message, max_length = MAX_BROADCAST_LEN, multiline = TRUE)
 	if(length(temp_message) <= 1)
 		return TRUE
 	if(temp_message)
 		feed_channel_message = temp_message
+
+	for(var/datum/feed_channel/potential_channel as anything in GLOB.news_network.network_channels)
+		if(channel_name == potential_channel.channel_ID)
+			current_channel = potential_channel
+			break
+
 	GLOB.news_network.submit_article("<font face=\"[PEN_FONT]\">[parsemarkdown(feed_channel_message, usr)]</font>", newscaster_username, current_channel.channel_name, send_photo_data(), adminMessage = FALSE, allow_comments = TRUE)
 	SSblackbox.record_feedback("amount", "newscaster_stories", 1)
 	feed_channel_message = ""


### PR DESCRIPTION
closes #82279
## About The Pull Request

`tgui_input_text()` sleeps so would allow people to switch the `current_channel` elsewhere in the ui, and then send the message to that channel, despite not having permissions to send to that channel
## Why It's Good For The Game
though funny people probably shouldn't be able to post whatever they want in station announcements

## Changelog
:cl:
fix: you can no longer send newscaster messages to channels you don't have permissions for
/:cl:
