### PR TITLE
SM sliver dusts fishing hooks

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -158,6 +158,18 @@
 	pulseicon = "supermatter_sliver_pulse"
 	layer = ABOVE_MOB_LAYER
 
+/obj/item/nuke_core/supermatter_sliver/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_FISHING_ROD_CAST, PROC_REF(on_hook))
+
+/obj/item/nuke_core/supermatter_sliver/proc/on_hook(obj/item/nuke_core/supermatter_sliver/source, obj/item/fishing_rod/rod, mob/user)
+	SIGNAL_HANDLER
+
+	//hook gets dusted but the rod remains intact
+	attackby(rod.hook, user)
+
+	return FISHING_ROD_CAST_HANDLED
+
 /obj/item/nuke_core/supermatter_sliver/attack_tk(mob/user) // no TK dusting memes
 	return
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #87514

## Changelog
:cl:
fix: Super matter sliver dusts fishing hooks & cannot be picked up by them
/:cl:

