### PR TITLE
a few tiny birdshot tweaks and fixes

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -20066,6 +20066,11 @@
 	name = "Pharmacy Shutters Control";
 	req_access = list("pharmacy")
 	},
+/obj/item/reagent_containers/cup/bottle/multiver,
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/cup/bottle/formaldehyde,
+/obj/item/reagent_containers/cup/bottle/acidic_buffer,
+/obj/item/reagent_containers/cup/bottle/basic_buffer,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "hdT" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -25594,6 +25594,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"iPx" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 1;
+	filter_type = list(/datum/gas/nitrogen)
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "iPy" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -90213,7 +90223,7 @@ jNV
 guh
 cBl
 fJe
-aJb
+iPx
 cay
 fMB
 maK

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2837,6 +2837,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bfe" = (
@@ -2858,6 +2859,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bfU" = (
@@ -6737,6 +6739,7 @@
 /area/space/nearstation)
 "cCM" = (
 /obj/structure/cable,
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen)
 "cCP" = (
@@ -10712,15 +10715,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "dZa" = (
-/obj/structure/table/reinforced,
 /obj/machinery/camera/directional/west,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/item/cautery,
 /obj/machinery/camera/autoname/directional/north,
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/status_display/ai/directional/west,
+/obj/item/surgery_tray/full/deployed,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
 "dZk" = (
@@ -13995,13 +13995,13 @@
 /turf/open/floor/iron/small,
 /area/station/security/office)
 "fhp" = (
-/obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/siding{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "fhT" = (
@@ -14979,6 +14979,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fyZ" = (
@@ -15861,6 +15862,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fMg" = (
@@ -17874,10 +17876,6 @@
 	pixel_y = 8
 	},
 /obj/item/clothing/mask/surgical,
-/obj/item/surgical_drapes{
-	pixel_x = -1;
-	pixel_y = 4
-	},
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
@@ -24186,6 +24184,7 @@
 	pixel_y = 18
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/circuitboard/mecha/ripley/main,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "ivC" = (
@@ -26328,6 +26327,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jab" = (
@@ -35514,7 +35514,7 @@
 "mae" = (
 /obj/structure/cable,
 /turf/closed/wall,
-/area/station/service/bar)
+/area/station/maintenance/central/greater)
 "maf" = (
 /turf/closed/wall/rust,
 /area/station/hallway/primary/fore)
@@ -40681,6 +40681,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "nSd" = (
@@ -43687,6 +43688,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oYj" = (
@@ -46101,6 +46103,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/port)
 "pOQ" = (
@@ -51216,10 +51219,10 @@
 	pixel_y = 2
 	},
 /obj/item/holosign_creator/robot_seat/restaurant,
-/obj/structure/table,
 /obj/effect/turf_decal/siding{
 	dir = 9
 	},
+/obj/structure/table,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "rya" = (
@@ -54596,13 +54599,7 @@
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
 "sGt" = (
-/obj/structure/table/reinforced,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/blood_filter,
-/obj/item/circular_saw,
-/obj/item/bonesetter,
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
 "sGE" = (
@@ -61581,6 +61578,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uQT" = (
@@ -62421,15 +62419,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
 "vfI" = (
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/machinery/light_switch/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table,
 /obj/effect/turf_decal/siding/end,
+/obj/machinery/smartfridge/drying,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "vfK" = (
@@ -65157,9 +65152,15 @@
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
 "vTP" = (
-/obj/structure/sink/kitchen/directional/east,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/kitchen/small,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "vTV" = (
 /turf/closed/wall/r_wall,
@@ -67824,7 +67825,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/station/service/bar)
+/area/station/maintenance/central/greater)
 "wKO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/east,
@@ -69547,6 +69548,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xiT" = (
@@ -97998,8 +98000,8 @@ xRV
 jVM
 xjQ
 jVM
-tGq
-tGq
+jVM
+jVM
 xmt
 xmt
 xmt
@@ -100311,7 +100313,7 @@ jVM
 jVM
 jVM
 jVM
-vkh
+jVM
 lnD
 fzw
 bKO
@@ -101339,7 +101341,7 @@ jgb
 hRc
 jVM
 kXC
-vkh
+jVM
 dxV
 jDT
 fOq
@@ -101596,7 +101598,7 @@ vGe
 xno
 jVM
 kXC
-vkh
+jVM
 vkh
 kWF
 wtw
@@ -102110,7 +102112,7 @@ xHD
 xHD
 jVM
 jBu
-vkh
+jVM
 vkh
 vkh
 vkh

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -52596,7 +52596,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rVI" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 8
 	},
 /turf/open/floor/iron,


### PR DESCRIPTION
## About The Pull Request

1st SM filter is now set to N2 by default
A random hallway apc that started unwired is now wired
Chef gets a dehydrator
Surgery theatre now has a surgery tray instead and surplus prosthetic limbs to fill in the empty space
Greater central maintenance owns all of its walls
The chemical closet in pharmacy now has multiver, formaldehyde, epinephrine, basic buffer and the other kind of buffer to compensate for not having a chemstorage room
atmos distro air mixer now mixes correctly

## Why It's Good For The Game

closes #87729
also maintenance is supposed to own all of its walls

## Changelog
:cl:
fix: Added dehydrator to birdshot kitchen. Surgery theatre now has a surgery tray and surplus prosthetics. An unwired hallway APC is now wired. 1st SM filter is now set to Nitrogen. Chemistry closet in pharmacy now contains extra chemicals to compensate for not having a chemical storage. Atmos air for distro mixer now mixes correctly
/:cl:
