### PR TITLE
floor lights have the same light range during nightshift

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -725,7 +725,7 @@
 	plane = FLOOR_PLANE
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
-	nightshift_brightness = 3
+	nightshift_brightness = 4
 	fire_brightness = 4.5
 
 /obj/machinery/light/floor/get_light_offset()


### PR DESCRIPTION

## About The Pull Request

floor lights have the same light range during nightshifts

## Why It's Good For The Game

theyre horrendously bad at lighting up stuff in nightshift and birdshots bar looks horrendous as a result

## Changelog
:cl:
fix: floor lights have the same light range during nightshift, so you can actually see the bar during a night shift on birdshot
/:cl:
