### PR TITLE
Improves code for recycling circuits in component printer

### DIFF
--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -274,7 +274,7 @@
  * * user - the mob inserting this item
  * * context - the atom performing the operation, this is the last argument sent in COMSIG_MATCONTAINER_ITEM_CONSUMED and is used mostly for silo logging
  */
-/datum/component/material_container/proc/user_insert(obj/item/held_item, mob/living/user, atom/context = parent, forced_type = FALSE)
+/datum/component/material_container/proc/user_insert(obj/item/held_item, mob/living/user, atom/context = parent)
 	set waitfor = FALSE
 	. = 0
 
@@ -312,7 +312,7 @@
 		if(SEND_SIGNAL(src, COMSIG_MATCONTAINER_PRE_USER_INSERT, target_item, user) & MATCONTAINER_BLOCK_INSERT)
 			continue
 		//item is either indestructible, not allowed for redemption or not in the allowed types
-		if((target_item.resistance_flags & INDESTRUCTIBLE) || (target_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(target_item, allowed_item_typecache) && !forced_type))
+		if((target_item.resistance_flags & INDESTRUCTIBLE) || (target_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(target_item, allowed_item_typecache)))
 			if(!(mat_container_flags & MATCONTAINER_SILENT))
 				var/list/status_data = chat_msgs["[MATERIAL_INSERT_ITEM_FAILURE]"] || list()
 				var/list/item_data = status_data[target_item.name] || list()

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -23,8 +23,6 @@ handles linking back and forth.
 	var/mat_container_flags = NONE
 	///List of signals to hook onto the local container
 	var/list/mat_container_signals
-	///Typecache for items that the silo will accept through this remote no matter what
-	var/list/whitelist_typecache
 
 /datum/component/remote_materials/Initialize(
 	mapload,
@@ -32,7 +30,6 @@ handles linking back and forth.
 	force_connect = FALSE,
 	mat_container_flags = NONE,
 	list/mat_container_signals = null,
-	list/whitelist_typecache = null
 )
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -40,7 +37,6 @@ handles linking back and forth.
 	src.allow_standalone = allow_standalone
 	src.mat_container_flags = mat_container_flags
 	src.mat_container_signals = mat_container_signals
-	src.whitelist_typecache = whitelist_typecache
 
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(OnMultitool))
 
@@ -97,9 +93,6 @@ handles linking back and forth.
 		allowed_items = /obj/item/stack \
 	)
 
-	if (whitelist_typecache)
-		mat_container.allowed_item_typecache |= whitelist_typecache
-
 /datum/component/remote_materials/proc/toggle_holding(force_hold = FALSE)
 	if(isnull(silo))
 		return
@@ -147,7 +140,7 @@ handles linking back and forth.
 		return
 
 	if(silo)
-		mat_container.user_insert(target, user, parent, (whitelist_typecache && is_type_in_typecache(target, whitelist_typecache)))
+		mat_container.user_insert(target, user, parent)
 
 	return COMPONENT_NO_AFTERATTACK
 

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/component_printer/Initialize(mapload)
 	. = ..()
-	materials = AddComponent(/datum/component/remote_materials, mapload, whitelist_typecache = typecacheof(/obj/item/circuit_component))
+	materials = AddComponent(/datum/component/remote_materials, mapload)
 
 /obj/machinery/component_printer/post_machine_initialize()
 	. = ..()
@@ -66,6 +66,19 @@
 		return
 	current_unlocked_designs -= added_design.build_path
 
+/obj/machinery/component_printer/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	//to allow quick recycling of circuits
+	if(istype(tool, /obj/item/circuit_component))
+		var/amount_inserted = materials.insert_item(tool)
+
+		if(amount_inserted)
+			to_chat(user, span_notice("[tool] worth [amount_inserted / SHEET_MATERIAL_AMOUNT] sheets of material was consumed by [src]"))
+		else
+			to_chat(user, span_warning("[tool] was rejected by [src]"))
+
+		return amount_inserted > 0 ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_FAILURE
+
+	return ..()
 
 /obj/machinery/component_printer/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -501,11 +501,13 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 				return
 			component.disconnect()
 			remove_component(component)
+
+			var/mob/user = ui.user
 			if(component.loc == src)
-				usr.put_in_hands(component)
+				user.put_in_hands(component)
 			var/obj/machinery/component_printer/printer = linked_component_printer?.resolve()
 			if (!isnull(printer))
-				printer.attackby(component, usr)
+				printer.base_item_interaction(user, component)
 			. = TRUE
 		if("set_component_coordinates")
 			var/component_id = text2num(params["component_id"])


### PR DESCRIPTION
## About The Pull Request
Writes a better way for recycling circuits inserted into component printers which was implemented back in #85648

Instead of creating a typecache of items which bypasses all sanity checks for material container we can implement this interaction directly in the `base_item_interaction()` proc of the component printer.

Not only is the code reduced for material container but also `insert_item()` is much more light weight compared to `user_insert()` so it's faster as well

## Changelog
:cl:
code: improves code for recycling circuits in component printer
/:cl:
