### PR TITLE
Fixes storage & evidence bag pre attack

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -688,12 +688,13 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_preattack(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
-	if(!istype(thing) || !allow_quick_gather || thing.atom_storage)
+	if(!istype(thing) || thing == parent.loc || !allow_quick_gather || thing.atom_storage)
 		return
 
 	if(collection_mode == COLLECT_ONE)
-		if(user.temporarilyRemoveItemFromInventory(thing, newloc = parent))
-			attempt_insert(thing, user)
+		if(thing.loc == user)
+			user.dropItemToGround(thing, silent = TRUE) //this is nessassary to update any inventory slot it is attached to
+		attempt_insert(thing, user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!isturf(thing.loc))

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -692,7 +692,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return
 
 	if(collection_mode == COLLECT_ONE)
-		attempt_insert(thing, user)
+		if(user.temporarilyRemoveItemFromInventory(thing, newloc = parent))
+			attempt_insert(thing, user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!isturf(thing.loc))

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -15,20 +15,10 @@
 		max_slots = 1,
 		max_specific_storage = WEIGHT_CLASS_NORMAL,
 	)
+	atom_storage.allow_quick_gather = TRUE
+	atom_storage.collection_mode = COLLECT_ONE
 	RegisterSignal(atom_storage, COMSIG_STORAGE_STORED_ITEM, PROC_REF(on_insert))
 	RegisterSignal(atom_storage, COMSIG_STORAGE_REMOVED_ITEM, PROC_REF(on_remove))
-
-/obj/item/evidencebag/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
-	if(interacting_with == loc || !isitem(interacting_with) || HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
-		return NONE
-	if(atom_storage.attempt_insert(interacting_with, user))
-		return ITEM_INTERACT_SUCCESS
-	return NONE
-
-/obj/item/evidencebag/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(atom_storage.attempt_insert(tool, user))
-		return ITEM_INTERACT_SUCCESS
-	return NONE
 
 /obj/item/evidencebag/update_desc(updates)
 	. = ..()
@@ -60,12 +50,15 @@
 
 /obj/item/evidencebag/proc/on_insert(datum/storage/storage, obj/item/to_insert, mob/user, force)
 	SIGNAL_HANDLER
+
 	update_weight_class(to_insert.w_class)
 
 /obj/item/evidencebag/proc/on_remove(datum/storage/storage, obj/item/to_remove, atom/remove_to_loc, silent)
 	SIGNAL_HANDLER
+
 	if(!atom_storage.get_total_weight())
 		return
+
 	update_weight_class(WEIGHT_CLASS_TINY)
 
 /obj/item/evidencebag/attack_self(mob/user)


### PR DESCRIPTION
## About The Pull Request
- Fixes #87788

Usually when you force move an item anywhere `obj/item/doMove()` is responsible for removing the item from the players hand & updating the visuals. When you move that item from say your pocket to your hand we call `attempt_pickup()` which also updates visuals.

The one case where these 2 procs don't help is when that item is equipped from anywhere else but the hand(pockets for e.g) into a storage medium that is held in hand. For this edge case we have to drop the item to ground to update the visuals of whatever inventory slot it was attached to

Now evidence bag uses the storage pre attack mode rather than implementing its own item interaction thus fixing the visual glitch not just for it but for all items that have `allow_quick_gather = TRUE`

## Changelog
:cl:
fix: Fixed visual glitches when inserting items from an slot other than the hands into evidence bags & other storages that have quick gather mode enabled
/:cl:

