### PR TITLE
Fixes the randomizer fishing portal not working as intended.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_fish.dm
+++ b/code/__DEFINES/dcs/signals/signals_fish.dm
@@ -45,6 +45,8 @@
 #define COMSIG_FISHING_CHALLENGE_ROLL_REWARD "fishing_roll_reward"
 /// Adjusting the difficulty of a rishing challenge, often based on the reward path
 #define COMSIG_FISHING_CHALLENGE_GET_DIFFICULTY "fishing_get_difficulty"
+/// From /datum/fishing_challenge/start_minigame_phase, called after the fish movement datum is spawned: (datum/fish_movement/mover)
+#define COMSIG_FISHING_CHALLENGE_MOVER_INITIALIZED "fishing_mover_initialized"
 /// Fishing challenge completed
 /// Sent to the fisherman when the reward is dispensed: (reward)
 #define COMSIG_FISH_SOURCE_REWARD_DISPENSED "fish_source_reward_dispensed"

--- a/code/modules/fishing/aquarium/aquarium.dm
+++ b/code/modules/fishing/aquarium/aquarium.dm
@@ -318,7 +318,7 @@
 			var/obj/item/fish/fish = item
 			.["fishData"] += list(list(
 				"fish_ref" = REF(fish),
-				"fish_name" = fish.name,
+				"fish_name" = uppertext(fish.name),
 				"fish_happiness" = fish.get_happiness_value(),
 				"fish_icon" = fish::icon,
 				"fish_icon_state" = fish::icon_state,

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -506,6 +506,8 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	else
 		mover = new /datum/fish_movement(src)
 
+	SEND_SIGNAL(src, COMSIG_FISHING_CHALLENGE_MOVER_INITIALIZED, mover)
+
 	if(auto_reel)
 		completion *= 1.3
 	else

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -271,7 +271,7 @@
 
 ///In the spirit of randomness, we skew a few values here and there
 /datum/fish_source/portal/random/pre_challenge_started(obj/item/fishing_rod/rod, mob/user, datum/fishing_challenge/challenge)
-	challenge.bait_bounce_mult = clamp(challenge.bait_bounce_mult + (rand(-3, 3) * 0.1), 0.1, 1)
+	challenge.bait_bounce_mult = max(challenge.bait_bounce_mult + rand(-3, 3) * 0.1, 0.1)
 	challenge.completion_loss = max(challenge.completion_loss + rand(-2, 2), 0)
 	challenge.completion_gain = max(challenge.completion_gain + rand(-1, 1), 2)
 	challenge.mover.short_jump_velocity_limit += rand(-100, 100)
@@ -280,6 +280,12 @@
 	for(var/effect in active_effects)
 		if(prob(30))
 			challenge.special_effects |= effect
+	RegisterSignal(challenge, COMSIG_FISHING_CHALLENGE_MOVER_INITIALIZED, PROC_REF(randomize_mover_velocity))
+
+/datum/fish_source/portal/random/proc/randomize_mover_velocity(datum/source, datum/fish_movement/mover)
+	SIGNAL_HANDLER
+	mover.short_jump_velocity_limit += rand(-100, 100)
+	mover.long_jump_velocity_limit += rand(-100, 100)
 
 ///Cherry on top, fish caught from the randomizer portal also have (almost completely) random traits
 /datum/fish_source/portal/random/spawn_reward(reward_path, atom/movable/spawn_location, turf/fishing_spot)
@@ -295,7 +301,7 @@
 
 	var/obj/item/fish/caught_fish = new reward_path(spawn_location, FALSE)
 	var/list/new_traits = list()
-	for(var/iteration in rand(1, 4))
+	for(var/iteration in 1 to rand(1, 4))
 		new_traits |= pick_weight(weighted_traits)
 	caught_fish.inherit_traits(new_traits)
 	caught_fish.randomize_size_and_weight(deviation = 0.3)

--- a/tgui/packages/tgui/interfaces/Aquarium.tsx
+++ b/tgui/packages/tgui/interfaces/Aquarium.tsx
@@ -116,7 +116,7 @@ const FishInfo = (props) => {
                 ml={1}
                 style={{ fontSize: '13px', fontWeight: 'bold' }}
               >
-                {fish.fish_name.toUpperCase()}
+                {fish.fish_name}
               </Stack.Item>
               <Stack.Item mt={fish.fish_health > 0 ? -4 : 1}>
                 {(fish.fish_health > 0 && (


### PR DESCRIPTION
## About The Pull Request
It was runtiming at some point since I refactored fish movement into its own datum. Also, it never gave random traits to the caught fish because of a missing instruction in the for loop statement.

Also, this PR should fix names of fish with spacing characters between them from being cut by the toUpperCase() JavaScript function for some ungodly reason, since that isn't even supposed to happen in standard JS, maybe it has something to do with our frontend code, like idk and I'm not going to spend a lot of time figuring out what's wrong with our backend for something so tangential. Also this is the reason why I'm not putting a NO GBP update label since the aquarium UI is not mine.

## Why It's Good For The Game
Fixing an issue that's been reported on Discord by our dear carlarctg.

## Changelog

:cl: carlarctg, Ghommie
fix: Fixes the randomizer fishing portal not working as intended. Fish from it should now receive random traits.
fix: Fish names are no longer partially shown in the aquarium UI if they contain a space character.
/:cl:
