### PR TITLE
Refactor shield satalites to use proximity_monitor making them more reliable

### DIFF
--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -113,7 +113,7 @@
 	if(user)
 		balloon_alert(user, "looking for [active ? "off" : "on"] button")
 	if(user && !do_after(user, 2 SECONDS, src, IGNORE_HELD_ITEM))
-		return FALSE;
+		return FALSE
 	if(!..(user))
 		return FALSE
 	if(obj_flags & EMAGGED)

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -110,7 +110,7 @@
 				qdel(meteor_to_destroy)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
-	src.balloon_alert(user, "You're looking for the on button on the [src]}")
+	src.balloon_alert(user, "You're looking for the [active ? "off" : "on"] button on the [src]}")
 	if(user && !do_after(user, 2 SECONDS, src, IGNORE_HELD_ITEM))
 		return FALSE;
 	if(!..(user))

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -61,12 +61,13 @@
 	name = "\improper Meteor Shield Satellite"
 	desc = "A meteor point-defense satellite."
 	mode = "M-SHIELD"
-	processing_flags = START_PROCESSING_MANUALLY
-	subsystem_type = /datum/controller/subsystem/processing/fastprocess
 	/// the range a meteor shield sat can destroy meteors
 	var/kill_range = 14
 
 	//emag behavior dark matt-eor stuff
+
+	/// Proximity monitor associated with this atom, needed for it to work.
+	var/datum/proximity_monitor/proximity_monitor
 
 	/// amount of emagged active meteor shields
 	var/static/emagged_active_meteor_shields = 0
@@ -94,17 +95,14 @@
 			return FALSE
 	return TRUE
 
-/obj/machinery/satellite/meteor_shield/process()
-	if(obj_flags & EMAGGED)
-		//kills the processing because emagged meteor shields no longer stop meteors in any way
-		return PROCESS_KILL
-	if(!active)
-		return
-	for(var/obj/effect/meteor/meteor_to_destroy in GLOB.meteor_list)
-		if(meteor_to_destroy.z != z)
-			continue
-		if(get_dist(meteor_to_destroy, src) > kill_range)
-			continue
+/obj/machinery/satellite/meteor_shield/Initialize(mapload)
+	. = ..()
+	proximity_monitor = new(src,0)
+
+/obj/machinery/satellite/meteor_shield/HasProximity(atom/movable/proximity_check_mob)
+	. = ..()
+	if(istype(proximity_check_mob, /obj/effect/meteor))
+		var/obj/effect/meteor/meteor_to_destroy = proximity_check_mob
 		if(space_los(meteor_to_destroy))
 			var/turf/beam_from = get_turf(src)
 			beam_from.Beam(get_turf(meteor_to_destroy), icon_state="sat_beam", time = 5)
@@ -112,16 +110,26 @@
 				qdel(meteor_to_destroy)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
+	src.balloon_alert(user, "You're looking for the on button on the [src]}")
+	if(user && !do_after(user, 2 SECONDS, src, IGNORE_HELD_ITEM))
+		return FALSE;
 	if(!..(user))
 		return FALSE
 	if(obj_flags & EMAGGED)
 		update_emagged_meteor_sat(user)
+
+	if(active)
+		proximity_monitor.set_range(kill_range)
+	else
+		proximity_monitor.set_range(0)
+
 
 	var/datum/station_goal/station_shield/goal = SSstation.get_station_goal(/datum/station_goal/station_shield)
 	goal?.update_coverage()
 
 /obj/machinery/satellite/meteor_shield/Destroy()
 	. = ..()
+	QDEL_NULL(proximity_monitor)
 	if(obj_flags & EMAGGED)
 		//satellites that are destroying are not active, this will count down the number of emagged sats
 		update_emagged_meteor_sat()
@@ -180,6 +188,13 @@
 		meteors.weight *= mod
 	for(var/datum/round_event_control/stray_meteor/stray_meteor in SSevents.control)
 		stray_meteor.weight *= mod
+
+
+/obj/machinery/satellite/meteor_shield/active
+
+/obj/machinery/satellite/meteor_shield/active/Initialize(mapload)
+	. = ..()
+	toggle()
 
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_ONE
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_TWO

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -190,13 +190,6 @@
 	for(var/datum/round_event_control/stray_meteor/stray_meteor in SSevents.control)
 		stray_meteor.weight *= mod
 
-
-/obj/machinery/satellite/meteor_shield/active
-
-/obj/machinery/satellite/meteor_shield/active/Initialize(mapload)
-	. = ..()
-	toggle()
-
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_ONE
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_TWO
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_THREE

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -110,7 +110,8 @@
 				qdel(meteor_to_destroy)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
-	src.balloon_alert(user, "You're looking for the [active ? "off" : "on"] button on the [src]}")
+	if(user)
+		src.balloon_alert(user, "You're looking for the [active ? "off" : "on"] button on the [src]")
 	if(user && !do_after(user, 2 SECONDS, src, IGNORE_HELD_ITEM))
 		return FALSE;
 	if(!..(user))

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -111,7 +111,7 @@
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
 	if(user)
-		src.balloon_alert(user, "You're looking for the [active ? "off" : "on"] button on the [src]")
+		src.balloon_alert(user, "you're looking for the [active ? "off" : "on"] button on the [src]")
 	if(user && !do_after(user, 2 SECONDS, src, IGNORE_HELD_ITEM))
 		return FALSE;
 	if(!..(user))
@@ -189,6 +189,7 @@
 		meteors.weight *= mod
 	for(var/datum/round_event_control/stray_meteor/stray_meteor in SSevents.control)
 		stray_meteor.weight *= mod
+
 
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_ONE
 #undef EMAGGED_METEOR_SHIELD_THRESHOLD_TWO

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -97,17 +97,18 @@
 
 /obj/machinery/satellite/meteor_shield/Initialize(mapload)
 	. = ..()
-	proximity_monitor = new(src,0)
+	proximity_monitor = new(src, /* range = */ 0)
 
 /obj/machinery/satellite/meteor_shield/HasProximity(atom/movable/proximity_check_mob)
 	. = ..()
-	if(istype(proximity_check_mob, /obj/effect/meteor))
-		var/obj/effect/meteor/meteor_to_destroy = proximity_check_mob
-		if(space_los(meteor_to_destroy))
-			var/turf/beam_from = get_turf(src)
-			beam_from.Beam(get_turf(meteor_to_destroy), icon_state="sat_beam", time = 5)
-			if(meteor_to_destroy.shield_defense(src))
-				qdel(meteor_to_destroy)
+	if(!istype(proximity_check_mob, /obj/effect/meteor))
+		return
+	var/obj/effect/meteor/meteor_to_destroy = proximity_check_mob
+	if(space_los(meteor_to_destroy))
+		var/turf/beam_from = get_turf(src)
+		beam_from.Beam(get_turf(meteor_to_destroy), icon_state="sat_beam", time = 5)
+		if(meteor_to_destroy.shield_defense(src))
+			qdel(meteor_to_destroy)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
 	if(user)

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -111,7 +111,7 @@
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
 	if(user)
-		src.balloon_alert(user, "you're looking for the [active ? "off" : "on"] button on the [src]")
+		balloon_alert(user, "looking for [active ? "off" : "on"] button")
 	if(user && !do_after(user, 2 SECONDS, src, IGNORE_HELD_ITEM))
 		return FALSE;
 	if(!..(user))


### PR DESCRIPTION

## About The Pull Request

Refactors the meteor satalites to use proximity_monitor making them MUCH more reliable

## Why It's Good For The Game

Previvously it would process and check if meteor is in range every 0.2 seconds via subsystem. This made it very possible that meteor flew past it before it even got detected, bypassing the shield. For it being station objective that feels rather silly. Especialy when meteors can actuely HIT THE SAT AND DESTROY IT

Also slight delay in toggleing on so you cant spam toggle it

## Changelog
:cl:
refactor: Nanotrasen has introducted new upgrades into the aging station shield statalites, they require a but longer to toggle on however
/:cl:
