### PR TITLE
Fixes stingbangs using wrong sprites

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -53,7 +53,7 @@
 
 /obj/item/grenade/stingbang
 	name = "stingbang"
-	icon_state = "timeg"
+	icon_state = "timeg_locked"
 	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -121,7 +121,7 @@
 /obj/item/grenade/primer
 	name = "rotfrag grenade"
 	desc = "A grenade that generates more shrapnel the more you rotate it in your hand after pulling the pin. This one releases shrapnel shards."
-	icon_state = "timeg"
+	icon_state = "timeg_locked"
 	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'


### PR DESCRIPTION

## About The Pull Request

Stingbangs (and much rarer rotfrags) used their disassembled sprite until primed this entire time. Yeah.

## Why It's Good For The Game

Handle appearing out of nowhere looks very jarring

## Changelog
:cl:
fix: Fixed stingbangs using wrong sprites
/:cl:
