### PR TITLE
Fixes scanner gates saying both bypass and detection lines when malfunctioning

### DIFF
--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -202,6 +202,7 @@
 	var/beep = FALSE
 	var/color = null
 	var/detected_thing = null
+	var/bypassed = FALSE
 	playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
 	switch(scangate_mode)
 		if(SCANGATE_NONE)
@@ -251,7 +252,7 @@
 						if((!HAS_TRAIT(scanned_human, TRAIT_MINDSHIELD)) && (isnull(idcard) || !(ACCESS_WEAPONS in idcard.access))) // mindshield or ID card with weapons access, like bartender
 							beep = TRUE
 							break
-						say("[detected_thing] detection bypassed.")
+						bypassed = TRUE
 						break
 			else
 				for(var/obj/item/content in thing.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
@@ -291,6 +292,8 @@
 			assembly?.activate()
 	else
 		SEND_SIGNAL(src, COMSIG_SCANGATE_PASS_NO_TRIGGER, thing)
+		if(bypassed)
+			say("[detected_thing] detection bypassed.")
 		if(!ignore_signals)
 			color = wires.get_color_of_wire(WIRE_DENY)
 			var/obj/item/assembly/assembly = wires.get_attached(color)


### PR DESCRIPTION

## About The Pull Request
Closes #87542
## Changelog
:cl:
fix: Fixed scanner gates saying both bypass and detection lines when malfunctioning
/:cl:
