### PR TITLE
Fixes cigarettes not fitting in gas masks

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -94,9 +94,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	var/valid_wearer = ismob(loc)
 	var/mob/wearer = loc
 	if(istype(tool, /obj/item/cigarette))
-		if(MASKCOVERSMOUTH)
-			balloon_alert(user, "mask's mouth is covered!")
-			return ..()
 
 		if(max_filters <= 0 || cig)
 			balloon_alert(user, "can't hold that!")

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -94,6 +94,10 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	var/valid_wearer = ismob(loc)
 	var/mob/wearer = loc
 	if(istype(tool, /obj/item/cigarette))
+		if(MASKCOVERSMOUTH)
+			balloon_alert(user, "mask's mouth is covered!")
+			return ..()
+
 		if(max_filters <= 0 || cig)
 			balloon_alert(user, "can't hold that!")
 			return ..()

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -94,10 +94,6 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	var/valid_wearer = ismob(loc)
 	var/mob/wearer = loc
 	if(istype(tool, /obj/item/cigarette))
-		if(flags_cover)
-			balloon_alert(user, "mask's mouth is covered!")
-			return ..()
-
 		if(max_filters <= 0 || cig)
 			balloon_alert(user, "can't hold that!")
 			return ..()

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -94,7 +94,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	var/valid_wearer = ismob(loc)
 	var/mob/wearer = loc
 	if(istype(tool, /obj/item/cigarette))
-		if(flags_cover & MASKCOVERSMOUTH)
+		if(flags_cover)
 			balloon_alert(user, "mask's mouth is covered!")
 			return ..()
 


### PR DESCRIPTION
## About The Pull Request
You couldn't put cigarettes in gas masks due to a check for if the masks mouth is covered
## Why It's Good For The Game
You can now filter the air through your cigarettes as was intended.
## Changelog
:cl:
fix: removes the gas mask check for if the gas mask mouth is covered. Now it only checks for filters and other cigs
/:cl:
