### PR TITLE
[NO GBP] Fixed special DNA infusions from squids and pufferfish

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infusion.dm
+++ b/code/game/machinery/dna_infuser/dna_infusion.dm
@@ -40,8 +40,8 @@
 /// Requires the target mob to have an existing organic organ to "mutate".
 // TODO: In the future, this should have more logic:
 // - Replace non-mutant organs before mutant ones.
-/mob/living/carbon/human/proc/infuse_organ(datum/infuser_entry/entry)
-	var/obj/item/organ/new_organ = pick_infusion_organ(entry)
+/mob/living/carbon/human/proc/infuse_organ(datum/infuser_entry/entry, atom/movable/infused_from)
+	var/obj/item/organ/new_organ = pick_infusion_organ(entry, infused_from)
 	if(!new_organ)
 		return FALSE
 	// Valid organ successfully picked.

--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -802,6 +802,8 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/camouflage/proc/reset_alpha(obj/item/fish/source)
 	SIGNAL_HANDLER
+	if(QDELETED(source))
+		return
 	var/init_alpha = initial(source.alpha)
 	if(init_alpha != source.alpha)
 		animate(source.alpha, alpha = init_alpha, time = 1.2 SECONDS, easing = CIRCULAR_EASING|EASE_OUT)


### PR DESCRIPTION
## About The Pull Request
#87323 actually broke special infusions from fish traits. This PR fixes that. And also a runtime error.

## Why It's Good For The Game
Fixing what I've broken.

## Changelog

:cl:
fix: Fixed special DNA infusions from squids and pufferfish.
/:cl:
