### PR TITLE
AI-controlled mobs can now cross open space if they won't fall.

### DIFF
--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -165,7 +165,7 @@
 	place_on_top(new_floor_path, flags = flags)
 
 /turf/open/openspace/can_cross_safely(atom/movable/crossing)
-	return HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)
+	return HAS_TRAIT(crossing, TRAIT_MOVE_FLYING) || !crossing.can_z_move(DOWN, src, z_move_flags = ZMOVE_FALL_FLAGS)
 
 /turf/open/openspace/icemoon
 	name = "ice chasm"


### PR DESCRIPTION
## About The Pull Request
Noticed this while playing with the follow pet command on tramstation, which is intentionally designed to be painful to navigate on without using the tram, and as soon I crossed the catwalk, my pet lobstrosities just stood there, looking at me like morons. That's not a good thing, just like how they lose sight of you once you climb some stairs, but that's an issue for another day.

~~Now, this is somewhat more akin to reality for some animals, it's a case by case scenario overall and even within the same species and breed, there are some that fear heights more than others, buuuuut this is a game where NPC/AI mobs are quite honestly dumb af, and it can make pet mechanics quite disheartening. You could add a FEARS_HEIGHT trait to some animals tho.~~

## Why It's Good For The Game
Fixing issues with the game.

## Changelog

:cl:
fix: AI-controlled mobs can now cross open space if they won't fall.
/:cl:
