### PR TITLE
Holosign creators interact with storage correctly

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -35,6 +35,11 @@
 		return
 	. += span_notice("It is currently maintaining <b>[signs.len]/[max_signs]</b> projections.")
 
+/obj/item/holosign_creator/check_allowed_items(atom/target, not_inside, target_self)
+	if(HAS_TRAIT(target, TRAIT_COMBAT_MODE_SKIP_INTERACTION))
+		return FALSE
+	return ..()
+
 /obj/item/holosign_creator/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!check_allowed_items(interacting_with, not_inside = TRUE))
 		return NONE


### PR DESCRIPTION
## About The Pull Request
- Fixes #87539
 
Racks, bags & basically anything that stores stuff will interact with all holosign creator's correctly

## Changelog
:cl:
fix: holosign creators interact with storage items correctly
/:cl:

