### PR TITLE
Fixing a small, crucial, fish reproduction issue.

### DIFF
--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1154,7 +1154,7 @@
 		var/list/available_fishes = list()
 		var/types_to_mate_with = aquarium.tracked_fish_by_type
 		if(!HAS_TRAIT(src, TRAIT_FISH_CROSSBREEDER))
-			var/list/types_to_check = list(src)
+			var/list/types_to_check = list(type)
 			if(compatible_types)
 				types_to_check |= compatible_types
 			types_to_mate_with = types_to_mate_with & types_to_check


### PR DESCRIPTION
## About The Pull Request
This PR should fix fishes not being able to reproduce with others of the same type, simply because the list of **types** to check was instantiated with the first key being src instead of src.type.

I should really make a second fish reproduction unit test that doesn't involve crossbreeding, self-reproducing and sterile fishes, all of which are edges cases that are actually working unlike the main thing.

## Why It's Good For The Game
Yeah, sorry if this took so long to get to this. I hadn't really notice it until now. I have indeed played with the aquarium a few times but with other goals in mind, and when I had seen that fish could indeed reproduce with different yet compatible fish (e.g. clownfish and lubefish, goldfish and three-eyed goldfish) I thought the feature was working as intended. I was simply wrong.

## Changelog

:cl:
fix: Fixed fish not being able to reproduce with other fish of the same type without the crossbreeding trait.
/:cl:

