### PR TITLE
[NO GBP] Fixed fish still being hungry when fed if in aquarium with the 'growth and reproduction' option disabled

### DIFF
--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -831,9 +831,11 @@
 	if(isaquarium(loc))
 		var/obj/structure/aquarium/aquarium = loc
 		if(!aquarium.reproduction_and_growth)
+			last_feeding = world.time
 			return
 	var/hunger = get_hunger()
 	if(hunger < 0.05) //don't bother growing for very small amounts.
+		last_feeding = world.time
 		return
 	last_feeding = world.time
 	var/new_size = size


### PR DESCRIPTION
## About The Pull Request
See title.

## Why It's Good For The Game
That's a bug.

## Changelog

:cl:
fix: Fixed fish still being hungry when fed if in aquarium with the 'growth and reproduction' option disabled.
/:cl:
