### PR TITLE
fix clicking other ghosts' screen alerts

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -858,6 +858,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/notify_action/Click()
 	. = ..()
+	if(!.)
+		return
 
 	var/atom/target = target_ref?.resolve()
 	if(isnull(target) || !isobserver(owner) || target == owner)


### PR DESCRIPTION

closes #87572

## About The Pull Request

usr does not necessarily mean owner for screen alerts, thanks Observe

## Why It's Good For The Game

shouldn't be teleporting other ghosts around

## Changelog

:cl:
fix: ghosts observing ghosts can no longer click on their screen alerts
/:cl:

