### PR TITLE
Xenobio console puts sucked up slimes into stasis

### DIFF
--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -305,5 +305,8 @@
 /// Trait added by style component
 #define STYLE_TRAIT "style"
 
+/// Trait added by a xenobio console
+#define XENOBIO_CONSOLE_TRAIT "xenobio_console_trait"
+
 /// Trait from an engraving
 #define ENGRAVED_TRAIT "engraved"

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -169,6 +169,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		stored_slime.forceMove(target_turf)
 		stored_slime.visible_message(span_notice("[stored_slime] warps in!"))
 		stored_slimes -= stored_slime
+		REMOVE_TRAIT(stored_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
 
 ///Places every slime not controlled by a player into the internal storage, respecting its limits
 ///Returns TRUE to signal it hitting the limit, in case its being called from a loop and we want it to stop
@@ -184,6 +185,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 	target_slime.visible_message(span_notice("[target_slime] vanishes in a flash of light!"))
 	target_slime.forceMove(src)
 	stored_slimes += target_slime
+	ADD_TRAIT(target_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
 
 	return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Closes #87715
Also fixes potential issues that slimes could cause by atmos processing while inside

## Changelog
:cl:
fix: Xenobio console puts sucked up slimes into stasis so they no longer split up inside
/:cl:
