### PR TITLE
fixes tgui DraggableControl not focusing on first click

### DIFF
--- a/tgui/packages/tgui/components/DraggableControl.jsx
+++ b/tgui/packages/tgui/components/DraggableControl.jsx
@@ -137,12 +137,11 @@ export class DraggableControl extends Component {
       } else if (this.inputRef) {
         const input = this.inputRef.current;
         input.value = internalValue;
-        // IE8: Dies when trying to focus a hidden element
-        // (Error: Object does not support this action)
-        try {
+
+        setTimeout(() => {
           input.focus();
           input.select();
-        } catch {}
+        }, 0);
       }
     };
   }


### PR DESCRIPTION
closes #86536

## About The Pull Request

we were attempting to focus a hidden element, which appears to just fail silently. if we wait until it should be rendered in the dom, it'll be focused correctly

i'm not 100% just throwing a `setTimeout(() => {}, 0)` is appropriate - this is a scary class component that i can't throw a useEffect at. it works, though

i'll pr it over to tgui-core ifff this is all good

## Why It's Good For The Game
clicky buttons clicky click working click

## Changelog
:cl:
fix: certain tgui inputs no longer require 2 clicks to open
/:cl:
