### PR TITLE
Tramstation Barber Disposals Fix

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -28229,13 +28229,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/security)
-"jer" = (
-/obj/item/clothing/under/color/jumpskirt/white,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
 "jev" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -105391,7 +105384,7 @@ xpb
 xpb
 kVP
 xpb
-jer
+sKN
 xJG
 vsn
 bHn

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -43869,8 +43869,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 2
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)


### PR DESCRIPTION

## About The Pull Request

Noticed on downstream. 

Swaps a junction - 

![image](https://github.com/user-attachments/assets/5a2db74a-ac64-461e-8456-8bcec51a1620)

To a y-junction -

![image](https://github.com/user-attachments/assets/a4266a93-2b6d-46aa-b843-1c249cf95695)

## Why It's Good For The Game

Stuff that gets thrown away in tool storage now properly gets routed to disposals and not to the barber shop.

Also removes a stray white jumpskirt that's just kinda... sitting there. See first screenshot

## Changelog
:cl:
map: tramstation tool storage trash no longer routes to the barber shop
/:cl:
