### PR TITLE
Labeller now tells you how many labels are left.

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -119,7 +119,7 @@
 /obj/item/hand_labeler/examine()
 	. = ..()
 	switch(labels_left)
-		if(2 to INFINITE)
+		if(2 to INFINITY)
 			. += span_notice("It looks like it could label [labels_left] more things.")
 		if(1)
 			. += span_notice("It looks like it could label [labels_left] more thing.")

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -116,6 +116,15 @@
 	labels_left = initial(labels_left) //Yes, it's capped at its initial value
 	return ITEM_INTERACT_SUCCESS
 
+/obj/item/hand_labeler/examine()
+	. = ..()
+	if(labels_left > 1)
+		. += span_notice("It looks like it could label [labels_left] more things.")
+	if(labels_left == 1)
+		. += span_notice("It looks like it could label [labels_left] more thing.")
+	if(labels_left == 0)
+		. += span_notice("It's out of labels.")
+
 /obj/item/hand_labeler/borg
 	name = "cyborg-hand labeler"
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -118,12 +118,13 @@
 
 /obj/item/hand_labeler/examine()
 	. = ..()
-	if(labels_left > 1)
-		. += span_notice("It looks like it could label [labels_left] more things.")
-	if(labels_left == 1)
-		. += span_notice("It looks like it could label [labels_left] more thing.")
-	if(labels_left == 0)
-		. += span_notice("It's out of labels.")
+	switch(labels_left)
+		if(2 to INFINITE)
+			. += span_notice("It looks like it could label [labels_left] more things.")
+		if(1)
+			. += span_notice("It looks like it could label [labels_left] more thing.")
+		if(0)
+			. += span_notice("It's out of labels.")
 
 /obj/item/hand_labeler/borg
 	name = "cyborg-hand labeler"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -118,13 +118,10 @@
 
 /obj/item/hand_labeler/examine()
 	. = ..()
-	switch(labels_left)
-		if(2 to INFINITY)
-			. += span_notice("It looks like it could label [labels_left] more things.")
-		if(1)
-			. += span_notice("It looks like it could label [labels_left] more thing.")
-		if(0)
-			. += span_notice("It's out of labels.")
+	if(labels_left > 0)
+		. += span_notice("It looks like it could label [labels_left] more thing\s.")
+	else
+		. += span_notice("It's out of labels.")
 
 /obj/item/hand_labeler/borg
 	name = "cyborg-hand labeler"


### PR DESCRIPTION
## About The Pull Request

New `examine` proc for hand labellers so you can tell how many labels are left on examine.

## Why It's Good For The Game

It's vital to know how many more times I can ~~spam labels~~ organize my paperwork.

## Changelog
:cl: Goat
qol: You can now examine labelers to tell how many more labels it has.
/:cl:
