### PR TITLE
Fix airlock shell for circuit camera component

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -297,7 +297,7 @@
 	if(electronics.shell)
 		door.AddComponent( \
 			/datum/component/shell, \
-			unremovable_circuit_components = list(new /obj/item/circuit_component/airlock, new /obj/item/circuit_component/airlock_access_event), \
+			unremovable_circuit_components = list(new /obj/item/circuit_component/airlock, new /obj/item/circuit_component/airlock_access_event, new /obj/item/circuit_component/remotecam/airlock), \
 			capacity = SHELL_CAPACITY_LARGE, \
 			shell_flags = SHELL_FLAG_ALLOW_FAILURE_ACTION|SHELL_FLAG_REQUIRE_ANCHOR \
 		)


### PR DESCRIPTION
## About The Pull Request
This PR resolves an issue relating to circuit cameras and airlock shells.

Fixes #84650

## Why It's Good For The Game
This is a bug fix, and makes airlock shells actually usable.

## Changelog
:cl:
fix: Airlock shells are properly assigned circuit cameras modules
/:cl:
