### PR TITLE
Gives Runtimestation a bounty pad and event spawnpoints

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -216,6 +216,10 @@
 /obj/machinery/announcement_system,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"bs" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "bu" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
@@ -1640,10 +1644,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"xN" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/construction)
 "xY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -2292,6 +2292,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"Pe" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/station/construction)
 "Pk" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/unlocked,
@@ -6542,7 +6546,7 @@ dn
 dn
 dn
 dn
-xN
+Pe
 dn
 dn
 dn
@@ -7015,7 +7019,7 @@ Rb
 fg
 aa
 aa
-aa
+bs
 aa
 aa
 aa

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -2396,7 +2396,7 @@
 /area/station/cargo/bitrunning/den)
 "Rq" = (
 /obj/machinery/piratepad/civilian{
-	cooldown_reduction = 99
+	cooldown_reduction = 99999
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -443,10 +443,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"dd" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "de" = (
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"df" = (
+/obj/machinery/computer/piratepad_control/civilian{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "dh" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
@@ -2361,6 +2371,9 @@
 /area/station/cargo/bitrunning/den)
 "Rb" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "light_control"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "Re" = (
@@ -2373,6 +2386,12 @@
 /obj/machinery/byteforge,
 /turf/open/floor/circuit/green,
 /area/station/cargo/bitrunning/den)
+"Rq" = (
+/obj/machinery/piratepad/civilian{
+	cooldown_reduction = 99
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "Ru" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -2483,6 +2502,13 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"TY" = (
+/obj/machinery/button/door/directional/south{
+	id = "light_control";
+	name = "Light Control"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "Ue" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/bitrunning/den)
@@ -6704,7 +6730,7 @@ dn
 dn
 dL
 cN
-Tt
+dd
 bL
 fg
 aa
@@ -7256,7 +7282,7 @@ dl
 dp
 dE
 cS
-Tt
+TY
 bL
 aa
 aa
@@ -8531,8 +8557,8 @@ XA
 vB
 es
 by
-eu
-eu
+df
+Rq
 qx
 eP
 fY

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1640,6 +1640,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"xN" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/station/construction)
 "xY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -6538,7 +6542,7 @@ dn
 dn
 dn
 dn
-dn
+xN
 dn
 dn
 dn


### PR DESCRIPTION

## About The Pull Request

This updates Runtime with a few minor changes that may help in a variety of debugging situations related to cargo and event tests.

1: Bounty/Pad setup in cargo. Part of the basic cargo facilities and useful for bounty testing.

2: Generic `event_spawn` marker (blob and other events) in undertile antechamber of station. Maintenance (nightmare, fugitive) `generic_maintenance_landmark` marker in the maintenance area between circuits/evac, with shutters to control the light into the tunnel (as some spawns are light-sensitive). `carpspawn` space spawn point (carp events, dragon) outside of maintenance window.

![image](https://github.com/user-attachments/assets/4a8f07a0-db52-4c4c-9eb2-8f19ae9fdfa1)
## Why It's Good For The Game

This stuff is all standard for any station run on the codebase. Having them on the debug station reduces the amount of wasted time having to spawn these in while testing. This applies to all additions made in this PR.

I'm confident that any interference that random events (enabled by the additions in this PR) might have during testing won't be an issue.
## Changelog
:cl:
qol: Makes some minor updates to Runtimestation, including event spawn points and a cargo bounty pad.
/:cl:
