### PR TITLE
Makes goliath cloak not override digitigrade legs

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -109,6 +109,7 @@
 	icon_state = "goliath_cloak"
 	desc = "A staunch, practical cape made out of numerous monster materials, it is coveted amongst exiles & hermits."
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION

## About The Pull Request
Adds the digitigrade leg exception flag to the goliath cloak.
## Why It's Good For The Game
As an ashlizard (as far as using it as armor is concerned) item I feel like it shouldn't override digi legs. Also now that you can adjust it to wear it around your neck and it looks fine when you do that with digi legs anyways so. 
## Changelog
:cl:
fix: Goliath cloaks are no longer so hard on the calves that they force digitigrade legs to disable.
/:cl:
