### PR TITLE
Make roundstart book publishing on bird possible.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -21826,9 +21826,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
 "hIm" = (
-/obj/machinery/libraryscanner,
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/bookbinder,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "hIE" = (
@@ -44195,6 +44195,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"phk" = (
+/obj/structure/table/wood,
+/obj/machinery/libraryscanner,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "phm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -94921,7 +94926,7 @@ sXD
 qSa
 feR
 aZh
-jdx
+phk
 pOQ
 wKr
 wKr


### PR DESCRIPTION

## About The Pull Request
Adds a book binder to the birdshot library in the spot the book scanner used to be and moves the scanner right next to the library computer on the desk. 

## Why It's Good For The Game
Curator shouldn't have to wait for research to be able to put books into the archive. 
## Changelog
:cl: Goat
map: The library's scanner on Birdshot is now close enough to connect to the computer and was also given a book binder.
/:cl:
