### PR TITLE
Add screentips to hat stabilizer component

### DIFF
--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -152,7 +152,6 @@
 		var/mob/wearer = apparel.loc
 		wearer.update_clothing(wearer.get_slot_by_item(apparel))
 
-// maybe we don't need the item context proc but instead the hand one? since we don't need to check held_item
 /datum/component/hat_stabilizer/proc/on_requesting_context_from_item(atom/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER
 

--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -156,7 +156,7 @@
 /datum/component/hat_stabilizer/proc/on_requesting_context_from_item(atom/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER
 
-	if(attached_hat)
+	if(attached_hat && !held_item)
 		context[SCREENTIP_CONTEXT_RMB] = "Remove hat"
 		return CONTEXTUAL_SCREENTIP_SET
 


### PR DESCRIPTION

## About The Pull Request
Initially this was added in:

- #87285

And then removed in:

- #87305

Not sure if @SmArtKar was aware that screentips can be added to components.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix missing screentips plasmaman helmets and MOD suit hat stabilizer helmets.
/:cl:
