### PR TITLE
Fix broken link to issue manager guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Things you **CAN'T** do:
 * [Close PRs](https://imgur.com/w2RqpX8.png): Only maintainers are allowed to close PRs. Do not hit that button.
 * Close issues purely for breaking a template if the same information is contained without it.
 
-For more information reference the [Issue Manager Guide](.github/guides/ISSUE_MANAGER.md).
+For more information reference the [Issue Manager Guide](./guides/ISSUE_MANAGER.md).
 
 </details>
 


### PR DESCRIPTION

## About The Pull Request
There was a malformed markdown link in the contributor guide.

## Why It's Good For The Game
Nothing player facing.

## Changelog
:cl:
fix: Fix broken link to issue manager guide in Github contributor guide
/:cl:
