### PR TITLE
Omen component no longer tries to crush you from inside of a vent

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -106,7 +106,7 @@
 
 	var/has_watchers = FALSE
 	for(var/mob/viewer in viewers(our_guy, world.view))
-		if(viewer.client)
+		if(viewer.client && !viewer.client.is_afk())
 			has_watchers = TRUE
 			break
 	if(!has_watchers)
@@ -115,7 +115,9 @@
 	if(!prob(8 * effective_luck))
 		return
 
-	var/our_guy_pos = get_turf(living_guy)
+	var/turf/open/our_guy_pos = living_guy.loc
+	if(!isopenturf(our_guy_pos))
+		return
 	for(var/obj/machinery/door/airlock/darth_airlock in our_guy_pos)
 		if(darth_airlock.locked || !darth_airlock.hasPower())
 			continue


### PR DESCRIPTION

## About The Pull Request

This makes it so the omen component (cursed) will no longer try to crush you with vendors/doors/etc next to you... if you're not on a turf in the first place, i.e ventcrawling.

Also, made it so afk clients aren't considered watchers.

## Why It's Good For The Game

Unintended behavior/bugfixing is good.

## Changelog
:cl:
fix: You can no longer crush random unsuspecting people with vendors by ventcrawling while cursed.
qol: AFK players don't count as "watchers" for cursed stuff.
/:cl:
