### PR TITLE
Reduces required crayons for crayon bounty

### DIFF
--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -173,8 +173,8 @@
 /datum/bounty/item/assistant/crayons
 	name = "Crayons"
 	description = "Dr. Jones's kid ate all of our crayons again. Please send us yours."
-	reward = CARGO_CRATE_VALUE * 4
-	required_count = 24
+	reward = CARGO_CRATE_VALUE * 3
+	required_count = 8
 	wanted_types = list(/obj/item/toy/crayon = TRUE)
 
 /datum/bounty/item/assistant/pens

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -173,7 +173,7 @@
 /datum/bounty/item/assistant/crayons
 	name = "Crayons"
 	description = "Dr. Jones's kid ate all of our crayons again. Please send us yours."
-	reward = CARGO_CRATE_VALUE * 3
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 8
 	wanted_types = list(/obj/item/toy/crayon = TRUE)
 


### PR DESCRIPTION

## About The Pull Request

This reduces the bounty size of the crayon civilian pack.

Instead of 24 crayons, it only needs 8. Same payout, less quantity.
## Why It's Good For The Game

Crayons are not easily produced or scavenged. Even if a map contains 2 full crayon packs in the Library, it still isn't enough to fulfill a single bounty for crayons. 

This new deal will get you a full payout with a full pack plus one _mystery crayon._ Go rob the clown or detective or something if you need the last one. Get that money!
## Changelog
:cl:
qol: Crayon bounties are less demanding, and require less crayons for payout.
/:cl:
