### PR TITLE
Fix holymelon armor not inheriting magic resistance

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -699,7 +699,7 @@
 
 	AddComponent(
 		/datum/component/anti_magic, \
-		antimagic_flags = MAGIC_RESISTANCE_HOLY, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
 		inventory_flags = ITEM_SLOT_OCLOTHING, \
 		charges = 1, \
 		drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -685,7 +685,6 @@
 	dog_fashion = /datum/dog_fashion/head/holymelon
 	armor_type = /datum/armor/helmet_watermelon
 	max_integrity = 15
-	var/decayed = FALSE
 
 /obj/item/clothing/head/helmet/durability/holymelon/fire_resist
 	resistance_flags = FIRE_PROOF
@@ -693,9 +692,6 @@
 
 /obj/item/clothing/head/helmet/durability/holymelon/Initialize(mapload)
 	. = ..()
-	if(decayed)
-		decay()
-		return
 
 	AddComponent(
 		/datum/component/anti_magic, \

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -817,7 +817,7 @@
 
 	AddComponent(
 		/datum/component/anti_magic, \
-		antimagic_flags = MAGIC_RESISTANCE_HOLY, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
 		inventory_flags = ITEM_SLOT_OCLOTHING, \
 		charges = 1, \
 		drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -803,7 +803,6 @@
 	equip_delay_other = 40
 	clothing_traits = list(TRAIT_BRAWLING_KNOCKDOWN_BLOCKED)
 	max_integrity = 15
-	var/decayed = FALSE
 
 /obj/item/clothing/suit/armor/durability/holymelon/fire_resist
 	resistance_flags = FIRE_PROOF
@@ -811,9 +810,6 @@
 
 /obj/item/clothing/suit/armor/durability/holymelon/Initialize(mapload)
 	. = ..()
-	if(decayed)
-		decay()
-		return
 
 	AddComponent(
 		/datum/component/anti_magic, \


### PR DESCRIPTION

## About The Pull Request
- Fixes #87621

Holymelon armor had a missing antimagic flag that did not stop magic attacks. The holymelon plant gene has `MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY` but the armor only had `MAGIC_RESISTANCE_HOLY` so this is just making it consistent.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix holymelon armor not inheriting magic resistance
/:cl:
