### PR TITLE
Fixes basic mob performance impact created by the factorio PR

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -270,7 +270,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
  * * type_list - are we checking for types of atoms to ignore and not physical atoms
  */
 /turf/proc/is_blocked_turf(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms, type_list = FALSE)
-	if((!isnull(source_atom) && !CanPass(source_atom, get_dir(src, source_atom))) || density)
+	if(density)
 		return TRUE
 
 	for(var/atom/movable/movable_content as anything in contents)

--- a/code/modules/manufactorio/_manufacturing.dm
+++ b/code/modules/manufactorio/_manufacturing.dm
@@ -106,7 +106,7 @@
 		if(!manufactury.anchored)
 			return MANUFACTURING_FAIL
 		return manufactury.receive_resource(sending, src, isturf(what_or_dir) ? get_dir(src, what_or_dir) : what_or_dir)
-	if(next_turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = sending))
+	if(next_turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = sending) && !ischasm(next_turf))
 		return MANUFACTURING_FAIL
 	if(length(next_turf.contents) >= MANUFACTURING_TURF_LAG_LIMIT)
 		return MANUFACTURING_FAIL_FULL


### PR DESCRIPTION

## About The Pull Request

#86063 was a mistake, some of the code there is really bad this being the peak change. This was done to exclusively snowflake chasms but in reality *did not do anything whatsoever* because chasms override CanAllowThrough to always return TRUE anyways. Yesh.

is_blocked_turf is relatively hot in basic mob AI so this was really bad.

## Changelog
:cl:
fix: Fixed basic mob performance impact created by the factorio PR
/:cl:
