### PR TITLE
Fix auto-reel fishing line item catching logic

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -118,10 +118,10 @@
 	else
 		destination = user
 		throw_callback = CALLBACK(src, PROC_REF(clear_hitby_signal), movable_target)
-		RegisterSignal(movable_target, COMSIG_ATOM_PREHITBY, PROC_REF(catch_it_chucklenut))
+		RegisterSignal(movable_target, COMSIG_MOVABLE_PRE_IMPACT, PROC_REF(catch_it_chucklenut))
 
 	if(!movable_target.safe_throw_at(destination, source.cast_range, 2, callback = throw_callback, gentle = please_be_gentle))
-		UnregisterSignal(movable_target, COMSIG_ATOM_PREHITBY)
+		UnregisterSignal(movable_target, COMSIG_MOVABLE_PRE_IMPACT)
 	else
 		playsound(src, 'sound/items/weapons/batonextend.ogg', 50, TRUE)
 
@@ -129,12 +129,13 @@
 	SIGNAL_HANDLER
 	var/mob/living/user = throwingdatum.initial_target.resolve()
 	if(QDELETED(user) || hit_atom != user)
-		return
-	if(user.try_catch_item(source, skip_throw_mode_check = TRUE, try_offhand = TRUE))
-		return COMSIG_HIT_PREVENTED
+		return NONE
+	if(!user.try_catch_item(source, skip_throw_mode_check = TRUE, try_offhand = TRUE))
+		return NONE
+	return COMPONENT_MOVABLE_IMPACT_NEVERMIND
 
 /obj/item/fishing_line/auto_reel/proc/clear_hitby_signal(obj/item/item)
-	UnregisterSignal(item, COMSIG_ATOM_PREHITBY)
+	UnregisterSignal(item, COMSIG_MOVABLE_PRE_IMPACT)
 
 // Hooks
 


### PR DESCRIPTION

## About The Pull Request

So while working on a frog tongue concept, I realized the auto-reel fishing line was... always hitting you with the items you reeled in.
Looking into the code, that seemed weird, because it seemed like it had an entire segment of code dedicated to avoiding just that: catching those items with your offhand.
But apparently this code never actually ran, because it registers `COMSIG_ATOM_PREHITBY` on the reeled in item, which only gets sent to the atom that gets hit.

So in this pr we just shift it to using `COMSIG_MOVABLE_PRE_IMPACT` instead, which is the equivalent signal sent to the thrown movable.
This fixes our issues.
## Why It's Good For The Game

Fixes the auto-reel fishing line always smacking you in the face with whatever you reel in, rather than going through its "catch this" checks.
## Changelog
:cl:
fix: Fixed auto-reel fishing line item catching logic.
/:cl:
