### PR TITLE
Improves code for remote materials

### DIFF
--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -44,11 +44,9 @@ handles linking back and forth.
 	var/connect_to_silo = FALSE
 	if(force_connect || (mapload && is_station_level(T.z)))
 		connect_to_silo = TRUE
-		if(!(mat_container_flags & MATCONTAINER_NO_INSERT))
-			RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, TYPE_PROC_REF(/datum/component/remote_materials, SiloAttackBy))
 
 	if(mapload) // wait for silo to initialize during mapload
-		addtimer(CALLBACK(src, PROC_REF(_PrepareStorage), connect_to_silo))
+		SSticker.OnRoundstart(CALLBACK(src, PROC_REF(_PrepareStorage), connect_to_silo))
 	else //directly register in round
 		_PrepareStorage(connect_to_silo)
 
@@ -66,17 +64,19 @@ handles linking back and forth.
 		silo = GLOB.ore_silo_default
 		if (silo)
 			silo.ore_connected_machines += src
-			mat_container = silo.GetComponent(/datum/component/material_container)
+			mat_container = silo.materials
+			if(!(mat_container_flags & MATCONTAINER_NO_INSERT))
+				RegisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(on_item_insert))
+
 	if (!mat_container && allow_standalone)
 		_MakeLocal()
 
 /datum/component/remote_materials/Destroy()
-	if (silo)
-		silo.ore_connected_machines -= src
-		silo.holds -= src
-		silo = null
-		UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
+	if(silo)
+		allow_standalone = FALSE
+		disconnect_from(silo)
 	mat_container = null
+
 	return ..()
 
 /datum/component/remote_materials/proc/_MakeLocal()
@@ -93,13 +93,12 @@ handles linking back and forth.
 		allowed_items = /obj/item/stack \
 	)
 
-/datum/component/remote_materials/proc/toggle_holding(force_hold = FALSE)
+/// Adds/Removes this connection from the silo
+/datum/component/remote_materials/proc/toggle_holding()
 	if(isnull(silo))
 		return
 
-	if(force_hold)
-		silo.holds[src] = TRUE
-	else if(!silo.holds[src])
+	if(!silo.holds[src])
 		silo.holds[src] = TRUE
 	else
 		silo.holds -= src
@@ -122,27 +121,16 @@ handles linking back and forth.
  * old_silo- The silo we are trying to disconnect from
  */
 /datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
-	if (!old_silo || silo != old_silo)
+	if (QDELETED(old_silo) || silo != old_silo)
 		return
+
+	UnregisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION)
 	silo.ore_connected_machines -= src
 	silo = null
 	mat_container = null
-	UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
+
 	if (allow_standalone)
 		_MakeLocal()
-
-///Insert mats into silo
-/datum/component/remote_materials/proc/SiloAttackBy(datum/source, obj/item/target, mob/living/user)
-	SIGNAL_HANDLER
-
-	//Allows you to attack the machine with iron sheets for e.g.
-	if(!(mat_container_flags & MATCONTAINER_ANY_INTENT) && user.combat_mode)
-		return
-
-	if(silo)
-		mat_container.user_insert(target, user, parent)
-
-	return COMPONENT_NO_AFTERATTACK
 
 /datum/component/remote_materials/proc/OnMultitool(datum/source, mob/user, obj/item/multitool/M)
 	SIGNAL_HANDLER
@@ -175,9 +163,23 @@ handles linking back and forth.
 		silo.ore_connected_machines += src
 		mat_container = new_container
 		if(!(mat_container_flags & MATCONTAINER_NO_INSERT))
-			RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, TYPE_PROC_REF(/datum/component/remote_materials, SiloAttackBy))
+			RegisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(on_item_insert))
 		to_chat(user, span_notice("You connect [parent] to [silo] from the multitool's buffer."))
 		return ITEM_INTERACT_SUCCESS
+
+///Insert mats into silo
+/datum/component/remote_materials/proc/on_item_insert(datum/source, mob/living/user, obj/item/target)
+	SIGNAL_HANDLER
+
+	//Allows you to attack the machine with iron sheets for e.g.
+	if(!(mat_container_flags & MATCONTAINER_ANY_INTENT) && user.combat_mode)
+		return
+
+	if(silo)
+		mat_container.user_insert(target, user, parent)
+
+	return ITEM_INTERACT_SUCCESS
+
 
 /**
  * Checks if the param silo is in the same level as this components parent i.e. connected machine, rcd, etc


### PR DESCRIPTION
## About The Pull Request
- Moves remote materials attack chain to item interaction level. Another step in moving away from `attackby()`
- Fixes #40070. Though the timer subsystem maybe affected by FPS, round start trigger is always done after everything is set up which is now used by remote materials

## Changelog
:cl:
fix: silo connection on some machines won't time out when changing FPS settings
code: improved attack chain code for silo connection
/:cl:

