### PR TITLE
small slime ai tweaks

### DIFF
--- a/code/modules/mob/living/basic/slime/ai/behaviours.dm
+++ b/code/modules/mob/living/basic/slime/ai/behaviours.dm
@@ -25,6 +25,7 @@
 	return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_SUCCEEDED
 
 /datum/ai_behavior/find_hunt_target/find_slime_food
+	action_cooldown = 7.5 SECONDS
 
 // Check if the slime can drain the target
 /datum/ai_behavior/find_hunt_target/find_slime_food/valid_dinner(mob/living/basic/slime/hunter, mob/living/dinner, radius, datum/ai_controller/controller, seconds_per_tick)

--- a/code/modules/mob/living/basic/slime/ai/controller.dm
+++ b/code/modules/mob/living/basic/slime/ai/controller.dm
@@ -4,7 +4,6 @@
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/not_friends,
 		BB_SLIME_RABID = FALSE,
 		BB_SLIME_HUNGER_DISABLED = FALSE,
-		BB_CURRENT_HUNTING_TARGET = null, // people whose energy we want to drain
 	)
 
 	ai_movement = /datum/ai_movement/basic_avoidance
@@ -13,13 +12,12 @@
 		/datum/ai_planning_subtree/change_slime_face,
 		/datum/ai_planning_subtree/use_mob_ability/evolve,
 		/datum/ai_planning_subtree/use_mob_ability/reproduce,
-		/datum/ai_planning_subtree/target_retaliate,
 		/datum/ai_planning_subtree/pet_planning,
+		/datum/ai_planning_subtree/target_retaliate,
 		/datum/ai_planning_subtree/find_and_hunt_target/find_slime_food,
 		/datum/ai_planning_subtree/basic_melee_attack_subtree/slime,
 		/datum/ai_planning_subtree/random_speech/slime,
 	)
-	can_idle = FALSE
 
 /datum/ai_controller/basic_controller/slime/CancelActions()
 	..()


### PR DESCRIPTION

## About The Pull Request
after profiling live servers for a little bit, i noticed `/datum/ai_behavior/find_hunt_target/find_slime_food` was the most expensive behavior because of how often it ran. and when u had an astronomical number of slimes all shoved into small pens, theyd be constantly running lots of checks on each other. this gives the find behavior a small cooldown to make it run less often, which shouldnt be noticeable by players. also, makes slimes able to idle. now that idled ai controllers can perform actions, this shouldnt be a problem. 

## Why It's Good For The Game
slimes reproduce alot. since we dont have a cap on slime population, this can heavily impact ai performance later into the round. 

## Changelog
:cl:
/:cl:
