### PR TITLE
party popper doesn't make sloshing sounds

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -402,6 +402,7 @@
 	spray_range = 2
 	spray_sound = 'sound/effects/snap.ogg'
 	possible_transfer_amounts = list(5)
+	reagent_container_liquid_sound = null
 
 /obj/item/reagent_containers/spray/chemsprayer/party/spray(atom/A, mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/87330
## Changelog
:cl: grungussuss
sound: party popper no longer makes reagent sloshing sounds
/:cl:
