### PR TITLE
Disable hauntium teleporting during unit tests

### DIFF
--- a/code/datums/ai/idle_behaviors/idle_haunted.dm
+++ b/code/datums/ai/idle_behaviors/idle_haunted.dm
@@ -10,4 +10,6 @@
 		return
 	if(SPT_PROB(teleport_chance, seconds_per_tick))
 		playsound(item_pawn.loc, 'sound/items/haunted/ghostitemattack.ogg', 100, TRUE)
+		#ifndef UNIT_TESTS // hauntium teleports can cause mapping nearstation tests to fail if it teleports outside an area
 		do_teleport(item_pawn, get_turf(item_pawn), 4, channel = TELEPORT_CHANNEL_MAGIC)
+		#endif


### PR DESCRIPTION
## About The Pull Request

Disable the idle teleporting behavior in `/datum/idle_behavior/idle_ghost_item` during unit testing.

## Why It's Good For The Game

I've seen two instances now of the mapping nearstation tests failing because something made of hauntium spawned near the edge of the station and then teleported outside into space. This will fix that flaky behavior.

## Changelog

No player-facing changes.
