### PR TITLE
Refactors some more UIs to use DmIcon

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -120,7 +120,8 @@ GLOBAL_LIST_EMPTY(order_console_products)
 			"cat" = item.category_index,
 			"ref" = REF(item),
 			"cost" = round(item.cost_per_order * cargo_cost_multiplier),
-			"product_icon" = icon2base64(getFlatIcon(image(icon = initial(item.item_path.icon), icon_state = initial(item.item_path.icon_state)), no_anim=TRUE))
+			"icon" = item.item_path::icon,
+			"icon_state" = item.item_path::icon_state,
 		))
 	return data
 

--- a/code/game/objects/structures/ore_containers.dm
+++ b/code/game/objects/structures/ore_containers.dm
@@ -23,25 +23,16 @@
 		ui.open()
 
 /obj/structure/ore_container/ui_data(mob/user)
-	var/list/data = list()
-	data["ores"] = list()
+	var/list/ores = list()
 	for(var/obj/item/stack/ore/ore_item in contents)
-		data["ores"] += list(list(
+		ores += list(list(
 			"id" = REF(ore_item),
 			"name" = ore_item.name,
 			"amount" = ore_item.amount,
+			"icon" = ore_item::icon,
+			"icon_state" = ore_item::icon_state,
 		))
-	return data
-
-/obj/structure/ore_container/ui_static_data(mob/user)
-	var/list/data = list()
-	data["ore_images"] = list()
-	for(var/obj/item/stack/ore_item as anything in subtypesof(/obj/item/stack/ore))
-		data["ore_images"] += list(list(
-			"name" = initial(ore_item.name),
-			"icon" = icon2base64(getFlatIcon(image(icon = initial(ore_item.icon), icon_state = initial(ore_item.icon_state)), no_anim=TRUE))
-		))
-	return data
+	return list("ores" = ores)
 
 /obj/structure/ore_container/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -229,21 +229,27 @@
 		for(var/datum/material/material as anything in mat_container.materials)
 			var/amount = mat_container.materials[material]
 			var/sheet_amount = amount / SHEET_MATERIAL_AMOUNT
+			var/obj/sheet_type = material.sheet_type
 			data["materials"] += list(list(
 				"name" = material.name,
 				"id" = REF(material),
 				"amount" = sheet_amount,
 				"category" = "material",
 				"value" = ore_values[material.type],
+				"icon" = sheet_type::icon,
+				"icon_state" = sheet_type::icon_state,
 			))
 
 		for(var/research in stored_research.researched_designs)
 			var/datum/design/alloy = SSresearch.techweb_design_by_id(research)
+			var/obj/alloy_type = alloy.build_path
 			data["materials"] += list(list(
 				"name" = alloy.name,
 				"id" = alloy.id,
 				"category" = "alloy",
 				"amount" = can_smelt_alloy(alloy),
+				"icon" = alloy_type::icon,
+				"icon_state" = alloy_type::icon_state,
 			))
 
 	data["disconnected"] = null
@@ -273,29 +279,6 @@
 				"cash" = "No valid account",
 			)
 	return data
-
-/obj/machinery/mineral/ore_redemption/ui_static_data(mob/user)
-	var/list/data = list()
-
-	var/datum/component/material_container/mat_container = materials.mat_container
-	if (mat_container)
-		for(var/datum/material/material as anything in mat_container.materials)
-			var/obj/material_display = initial(material.sheet_type)
-			data["material_icons"] += list(list(
-				"id" = REF(material),
-				"product_icon" = icon2base64(getFlatIcon(image(icon = initial(material_display.icon), icon_state = initial(material_display.icon_state)), no_anim=TRUE)),
-			))
-
-	for(var/research in stored_research.researched_designs)
-		var/datum/design/alloy = SSresearch.techweb_design_by_id(research)
-		var/obj/alloy_display = initial(alloy.build_path)
-		data["material_icons"] += list(list(
-			"id" = alloy.id,
-			"product_icon" = icon2base64(getFlatIcon(image(icon = initial(alloy_display.icon), icon_state = initial(alloy_display.icon_state)), no_anim=TRUE)),
-		))
-
-	return data
-
 
 /obj/machinery/mineral/ore_redemption/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/OreContainer.tsx
+++ b/tgui/packages/tgui/interfaces/OreContainer.tsx
@@ -2,23 +2,27 @@ import { createSearch, toTitleCase } from 'common/string';
 import { useState } from 'react';
 
 import { useBackend } from '../backend';
-import { Button, Flex, Image, Input, Section, Stack } from '../components';
+import {
+  Button,
+  DmIcon,
+  Flex,
+  Icon,
+  Input,
+  Section,
+  Stack,
+} from '../components';
 import { Window } from '../layouts';
 
 type Ores = {
   id: string;
   name: string;
   amount: number;
-};
-
-type Ore_images = {
-  name: string;
   icon: string;
+  icon_state: string;
 };
 
 type Data = {
   ores: Ores[];
-  ore_images: Ore_images[];
 };
 
 export const OreContainer = (props) => {
@@ -58,7 +62,13 @@ export const OreContainer = (props) => {
                   <Flex.Item key={ore.id}>
                     <Flex direction="column" m={0.5} textAlign="center">
                       <Flex.Item>
-                        <RetrieveIcon ore={ore} />
+                        <DmIcon
+                          height="64px"
+                          width="64px"
+                          icon={ore.icon}
+                          icon_state={ore.icon_state}
+                          fallback={<Icon name="spinner" size={2} spin />}
+                        />
                       </Flex.Item>
                       <Flex.Item>
                         <Orename ore_name={toTitleCase(ore.name)} />
@@ -84,30 +94,6 @@ export const OreContainer = (props) => {
         </Stack>
       </Window.Content>
     </Window>
-  );
-};
-
-const RetrieveIcon = (props) => {
-  const { data } = useBackend<Data>();
-  const { ore_images = [] } = data;
-  const { ore } = props;
-
-  let icon_display = ore_images.find((icon) => icon.name === ore.name);
-
-  if (!icon_display) {
-    return null;
-  }
-
-  return (
-    <Image
-      m={1}
-      src={`data:image/jpeg;base64,${icon_display.icon}`}
-      height="64px"
-      width="64px"
-      style={{
-        verticalAlign: 'middle',
-      }}
-    />
   );
 };
 

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
@@ -6,8 +6,8 @@ import {
   BlockQuote,
   Box,
   Button,
+  DmIcon,
   Icon,
-  Image,
   Input,
   LabeledList,
   Section,
@@ -175,14 +175,8 @@ export const OreRedemptionMachine = (props) => {
 };
 
 const MaterialRow = (props) => {
-  const { data } = useBackend();
   const { compact } = props;
-  const { material_icons } = data;
   const { material, onRelease } = props;
-
-  const display = material_icons.find(
-    (mat_icon) => mat_icon.id === material.id,
-  );
 
   const sheet_amounts = Math.floor(material.amount);
   const print_amount = 5;
@@ -192,14 +186,12 @@ const MaterialRow = (props) => {
     <Table.Row className="candystripe" collapsing>
       {!compact && (
         <Table.Cell collapsing>
-          <Image
-            m={1}
-            src={`data:image/jpeg;base64,${display.product_icon}`}
-            height="18px"
-            width="18px"
-            style={{
-              verticalAlign: 'middle',
-            }}
+          <DmIcon
+            height={'18px'}
+            width={'18px'}
+            icon={material.icon}
+            icon_state={material.icon_state}
+            fallback={<Icon name="spinner" size={2} spin />}
           />
         </Table.Cell>
       )}

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
@@ -175,8 +175,7 @@ export const OreRedemptionMachine = (props) => {
 };
 
 const MaterialRow = (props) => {
-  const { compact } = props;
-  const { material, onRelease } = props;
+  const { compact, material, onRelease } = props;
 
   const sheet_amounts = Math.floor(material.amount);
   const print_amount = 5;

--- a/tgui/packages/tgui/interfaces/ProduceConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.tsx
@@ -8,8 +8,8 @@ import {
   Button,
   Dimmer,
   Divider,
+  DmIcon,
   Icon,
-  Image,
   Input,
   NumberInput,
   Section,
@@ -26,7 +26,8 @@ type OrderDatum = {
   cat: string;
   ref: string;
   cost: number;
-  product_icon: string;
+  icon: string;
+  icon_state: string;
 };
 
 type Item = {
@@ -127,13 +128,13 @@ const ShoppingTab = (props) => {
                   />{' '}
                   {!condensed && (
                     <Stack.Item>
-                      <Image
-                        src={`data:image/jpeg;base64,${item.product_icon}`}
-                        height="34px"
-                        width="34px"
-                        style={{
-                          verticalAlign: 'middle',
-                        }}
+                      <DmIcon
+                        icon={item.icon}
+                        icon_state={item.icon_state}
+                        verticalAlign="middle"
+                        height={'36px'}
+                        width={'36px'}
+                        fallback={<Icon name="spinner" size={2} spin />}
                       />
                     </Stack.Item>
                   )}


### PR DESCRIPTION
## About The Pull Request

Upstream port of https://github.com/Monkestation/Monkestation2.0/pull/4215

This changes some tgui UIs that used icon2base64/getFlatIcon to display items to instead use DmIcon, just passing the icon/icon_state instead.

To be specific: the ORM, the "ore container", and the order console (produce, mining, and bitrunning vendors)

<details>
<summary><h3>UI screenshots / proof of testing</h3></summary>

![2024-11-12 (1731458275) ~ dreamseeker](https://github.com/user-attachments/assets/b1c60677-b117-4c23-8076-8b5072130d55)
![2024-11-12 (1731458281) ~ dreamseeker](https://github.com/user-attachments/assets/b64d3c2f-4754-4e5d-991a-2df69d86eb2a)
![2024-11-12 (1731458286) ~ dreamseeker](https://github.com/user-attachments/assets/287d8db1-8acb-4c4c-a2f0-66227a477d19)
![2024-11-12 (1731458388) ~ dreamseeker](https://github.com/user-attachments/assets/f69f5d51-5cdc-442c-971d-a4abedd4a3d2)
![2024-11-12 (1731458391) ~ dreamseeker](https://github.com/user-attachments/assets/53a95e88-ac41-4f97-a409-10b19d130376)


</details>

## Why It's Good For The Game

gfi bad, especially in ui(_static)_data, dmicon good.

## Changelog
:cl:
refactor: The ORM, "ore container", and order console UIs (produce, mining, bitrunner vendors) now load icons in a more efficient manner.
/:cl:
