### PR TITLE
Rebuild plane masters after client login if switching between 515 and 516

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -151,8 +151,16 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 /datum/hud/proc/client_refresh(datum/source)
 	SIGNAL_HANDLER
-	RegisterSignal(mymob.canon_client, COMSIG_CLIENT_SET_EYE, PROC_REF(on_eye_change))
-	on_eye_change(null, null, mymob.canon_client.eye)
+	var/client/client = mymob.canon_client
+	if(client.rebuild_plane_masters)
+		var/new_relay_loc = (client.byond_version > 515) ? "1,1" : "CENTER"
+		for(var/group_key as anything in master_groups)
+			var/datum/plane_master_group/group = master_groups[group_key]
+			group.relay_loc = new_relay_loc
+			group.rebuild_plane_masters()
+		client.rebuild_plane_masters = FALSE
+	RegisterSignal(client, COMSIG_CLIENT_SET_EYE, PROC_REF(on_eye_change))
+	on_eye_change(null, null, client.eye)
 
 /datum/hud/proc/clear_client(datum/source)
 	SIGNAL_HANDLER

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -88,7 +88,7 @@ SUBSYSTEM_DEF(blackbox)
 
 	for(var/player_key in GLOB.player_details)
 		var/datum/player_details/PD = GLOB.player_details[player_key]
-		record_feedback("tally", "client_byond_version", 1, PD.byond_version)
+		record_feedback("tally", "client_byond_version", 1, PD.full_byond_version())
 
 /datum/controller/subsystem/blackbox/Shutdown()
 	sealed = FALSE

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -269,3 +269,7 @@
 
 	///Which ambient sound this client is currently being provided.
 	var/current_ambient_sound
+
+	/// Does this client's mob need to rebuild its plane masters after login?
+	/// This is currently only used so a client can switch between 515 and 516 without breaking their rendering.
+	var/rebuild_plane_masters = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -329,10 +329,20 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(GLOB.player_details[ckey])
 		reconnecting = TRUE
 		player_details = GLOB.player_details[ckey]
-		player_details.byond_version = full_version
+		var/old_version = player_details.byond_version
+		player_details.byond_version = byond_version
+		player_details.byond_build = byond_build
+
+#if MIN_COMPILER_VERSION > 516
+	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
+#endif
+		if(old_version != byond_version)
+			rebuild_plane_masters = TRUE
+
 	else
 		player_details = new(ckey)
-		player_details.byond_version = full_version
+		player_details.byond_version = byond_version
+		player_details.byond_build = byond_build
 		GLOB.player_details[ckey] = player_details
 
 

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -39,6 +39,8 @@ GLOBAL_LIST_EMPTY_TYPED(player_details, /datum/player_details)
 
 /// Returns the full version string (i.e 515.1642) of the BYOND version and build.
 /datum/player_details/proc/full_byond_version()
+	if(!byond_version)
+		return "Unknown"
 	return "[byond_version].[byond_build || "xxx"]"
 
 /// Adds the new names to the player's played_names list on their /datum/player_details for use of admins.

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -1,6 +1,6 @@
 
 ///assoc list of ckey -> /datum/player_details
-GLOBAL_LIST_EMPTY(player_details)
+GLOBAL_LIST_EMPTY_TYPED(player_details, /datum/player_details)
 
 /// Tracks information about a client between log in and log outs
 /datum/player_details
@@ -18,8 +18,10 @@ GLOBAL_LIST_EMPTY(player_details)
 	/// Lazylist of preference slots this client has joined the round under
 	/// Numbers are stored as strings
 	var/list/joined_as_slots
-	/// Version of byond this client is using
-	var/byond_version = "Unknown"
+	/// Major version of BYOND this client is using.
+	var/byond_version
+	/// Build number of BYOND this client is using.
+	var/byond_build
 	/// Tracks achievements they have earned
 	var/datum/achievement_data/achievements
 	/// World.time this player last died
@@ -34,6 +36,10 @@ GLOBAL_LIST_EMPTY(player_details)
 	for(var/previous_name in played_names)
 		previous_names += html_encode("[previous_name] ([played_names[previous_name]])")
 	return previous_names.Join("; ")
+
+/// Returns the full version string (i.e 515.1642) of the BYOND version and build.
+/datum/player_details/proc/full_byond_version()
+	return "[byond_version].[byond_build || "xxx"]"
 
 /// Adds the new names to the player's played_names list on their /datum/player_details for use of admins.
 /// `ckey` should be their ckey, and `data` should be an associative list with the keys being the names they played under and the values being the unique mob ID tied to that name.


### PR DESCRIPTION
## About The Pull Request

This makes `/datum/player_details` properly track BYOND version and build separately, as opposed to just the full version string.

Whenever a client logs in, and their BYOND version is 516, while their previous version was 515, or vice versa, it'll set a newly added client var, `rebuild_plane_masters`, to TRUE.

During the `COMSIG_MOB_LOGIN` signal handler of a mob's HUD (`/datum/hud/proc/client_refresh`), it will check to see if `rebuild_plane_masters` is TRUE - if so, it will set the appropriate `relay_loc` of (based on client BYOND version) of its plane master groups, and rebuild their plane masters.

## Why It's Good For The Game

Makes testing stuff across 515 and 516 easier, as your screen won't break when switching between the two.

## Changelog

516 is _still_ in private alpha, so no user-facing changes.