### PR TITLE
Lower singularity beacon cost and time 

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -242,9 +242,9 @@
 			active gravitational singularities or tesla balls towards it. This will not work when the engine is still \
 			in containment. Because of its size, it cannot be carried. Ordering this \
 			sends you a small beacon that will teleport the larger beacon to your location upon activation."
-	progression_minimum = 30 MINUTES
+	progression_minimum = 20 MINUTES
 	item = /obj/item/sbeacondrop
-	cost = 10
+	cost = 4
 	surplus = 0 // not while there isnt one on any station
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 


### PR DESCRIPTION

## About The Pull Request
This lowers the cost of the singularity beacon to 4 crystals. Right now this item never gets used due to the high cost and niche requirements. According to the statistics it is not even on the list:

https://superset.moth.fans/superset/dashboard/4/?native_filters_key=Gd84-_rrITStPTkyo7BlqnE5aYcHmofhLU2GjWEiWdqY-ZaK2WVxrq1eG6qS0bNa

Before we had the SM, the singularity engine was often sabotaged with this beacon since all you needed to do was disable an emitter or cut a wire and the singularity would break loose. It was a relatively easy process. 

The criteria to achieve a singularity now is very difficult. You either have to overload the SM and fight off anyone who tries to fix it OR purchase one from cargo and make a pipe setup to feed it a ton of gas. All the crew has to do to prevent it, is leak the gas by opening an airlock, breach the floor, or a window. If there is an AI or cyborgs, your job is now ten times harder.

Then you have another problem. The beacon requires powered wires and if the SMESs gets destroyed by the singularity it's useless. This is guaranteed to happen if using the SM from engineering since it's so close to the SMESs. So now you have to either rely on solars or a generator to power the device.

The hassle of spending 10 crystals on this item is not worth it. Too many things can go wrong and it would be a waste of points.

## Why It's Good For The Game
This item never gets picked due to it's high cost and difficulty. By lowering the cost, it would make it a more reasonable choice. 

## Changelog
:cl:
balance: Lower the telecrystal price of the singularity beacon from 10 to 4 and reduce the timer to 20 minutes before it can be purchased.
/:cl:
