### PR TITLE
Fixes Mech Spin Sounds

### DIFF
--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -139,16 +139,14 @@
 	// if we're not strafing or if we are forced to rotate or if we are holding down the key
 	if(dir != direction && (!strafe || forcerotate || keyheld))
 		setDir(direction)
+		if(!QUIET_TURNS)
+			playsound(src, turnsound, 40, TRUE)
 		if(keyheld || !pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
 			return TRUE
 
 	set_glide_size(DELAY_TO_GLIDE_SIZE(movedelay))
 	//Otherwise just walk normally
 	. = try_step_multiz(direction)
-
-	//dir and olddir are the current direction of the sprite and the old direction of the sprite respectively
-	if (dir != olddir && !(mecha_flags & QUIET_TURNS))
-		playsound(src, turnsound, 40, TRUE)
 
 	if(phasing)
 		use_energy(phasing_energy_drain)

--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -139,7 +139,7 @@
 	// if we're not strafing or if we are forced to rotate or if we are holding down the key
 	if(dir != direction && (!strafe || forcerotate || keyheld))
 		setDir(direction)
-		if(!QUIET_TURNS)
+		if(!(mecha_flags & QUIET_TURNS))
 			playsound(src, turnsound, 40, TRUE)
 		if(keyheld || !pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
 			return TRUE


### PR DESCRIPTION

## About The Pull Request
Mechs were playing spin sound effects (_on top_ of normal step sounds) every time they'd take a step while strafing. Additionally, they would not play the spin sound effect when actually turning. This fixes both.
## Why It's Good For The Game
Bugfix. Also, cleaner sounding mechs.
## Changelog
:cl:
Fix: Fixed the triggering of mech turn sound effects
/:cl:
