### PR TITLE
Tenacious element no longer prints a wear off message when added outside of soft crit and properly removes its effects when detached

### DIFF
--- a/code/datums/elements/tenacious.dm
+++ b/code/datums/elements/tenacious.dm
@@ -19,9 +19,8 @@
 /datum/element/tenacious/Detach(datum/target)
 	UnregisterSignal(target, COMSIG_MOB_STATCHANGE)
 	REMOVE_TRAIT(target, TRAIT_TENACIOUS, ELEMENT_TRAIT(type))
-	if(valid_target.stat == SOFT_CRIT)
+	if(target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious))
 		target.balloon_alert(target, "your tenacity wears off")
-		target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious)
 	return ..()
 
 ///signal called by the stat of the target changing
@@ -31,6 +30,5 @@
 	if(new_stat == SOFT_CRIT)
 		target.balloon_alert(target, "your tenacity kicks in")
 		target.add_movespeed_modifier(/datum/movespeed_modifier/tenacious)
-	else
-		target.balloon_alert(target, "your tenacity wears off")
-		target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious)
+	else if(target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious))
+			target.balloon_alert(target, "your tenacity wears off")

--- a/code/datums/elements/tenacious.dm
+++ b/code/datums/elements/tenacious.dm
@@ -11,8 +11,7 @@
 	if(!ishuman(target))
 		return COMPONENT_INCOMPATIBLE
 	var/mob/living/carbon/human/valid_target = target
-	if(valid_target.stat == SOFT_CRIT)
-		on_stat_change(valid_target, new_stat = valid_target.stat) //immediately try adding movement bonus if they're in soft crit
+	on_stat_change(valid_target, new_stat = valid_target.stat) //immediately try adding movement bonus if they're in soft crit
 	RegisterSignal(target, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 	ADD_TRAIT(target, TRAIT_TENACIOUS, ELEMENT_TRAIT(type))
 

--- a/code/datums/elements/tenacious.dm
+++ b/code/datums/elements/tenacious.dm
@@ -31,4 +31,4 @@
 		target.balloon_alert(target, "your tenacity kicks in")
 		target.add_movespeed_modifier(/datum/movespeed_modifier/tenacious)
 	else if(target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious))
-			target.balloon_alert(target, "your tenacity wears off")
+		target.balloon_alert(target, "your tenacity wears off")

--- a/code/datums/elements/tenacious.dm
+++ b/code/datums/elements/tenacious.dm
@@ -18,8 +18,9 @@
 /datum/element/tenacious/Detach(datum/target)
 	UnregisterSignal(target, COMSIG_MOB_STATCHANGE)
 	REMOVE_TRAIT(target, TRAIT_TENACIOUS, ELEMENT_TRAIT(type))
-	if(target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious))
-		target.balloon_alert(target, "your tenacity wears off")
+	var/mob/living/carbon/human/valid_target = target
+	if(valid_target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious))
+		valid_target.balloon_alert(valid_target, "your tenacity wears off")
 	return ..()
 
 ///signal called by the stat of the target changing

--- a/code/datums/elements/tenacious.dm
+++ b/code/datums/elements/tenacious.dm
@@ -11,13 +11,17 @@
 	if(!ishuman(target))
 		return COMPONENT_INCOMPATIBLE
 	var/mob/living/carbon/human/valid_target = target
-	on_stat_change(valid_target, new_stat = valid_target.stat) //immediately try adding movement bonus if they're in soft crit
+	if(valid_target.stat == SOFT_CRIT)
+		on_stat_change(valid_target, new_stat = valid_target.stat) //immediately try adding movement bonus if they're in soft crit
 	RegisterSignal(target, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 	ADD_TRAIT(target, TRAIT_TENACIOUS, ELEMENT_TRAIT(type))
 
 /datum/element/tenacious/Detach(datum/target)
 	UnregisterSignal(target, COMSIG_MOB_STATCHANGE)
 	REMOVE_TRAIT(target, TRAIT_TENACIOUS, ELEMENT_TRAIT(type))
+	if(valid_target.stat == SOFT_CRIT)
+		target.balloon_alert(target, "your tenacity wears off")
+		target.remove_movespeed_modifier(/datum/movespeed_modifier/tenacious)
 	return ..()
 
 ///signal called by the stat of the target changing


### PR DESCRIPTION

## About The Pull Request

Wear off message is only printed if the user actually had the effect active before, and speed modifier is removed alongside the element.

## Changelog
:cl:
fix: Fixed tenacity effect printing its messages when it shouldn't be, and not removing its' effects when it should've.
/:cl:
