### PR TITLE
clickable alerts glow + the slimed status effect now actually tells you how to get it off without water in the description

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -121,7 +121,7 @@
 /atom/movable/screen/alert/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(clickable_glow)
-		add_filter("clickglow", 2, list("type" = "outline", "color" = COLOR_GOLD, "size" = 1))
+		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -107,6 +107,8 @@
 	name = "Alert"
 	desc = "Something seems to have gone wrong with this alert, so report this bug please"
 	mouse_opacity = MOUSE_OPACITY_ICON
+	/// do we glow to represent we do stuff when clicked
+	var/clickable_glow = FALSE
 	var/timeout = 0 //If set to a number, this alert will clear itself after that many deciseconds
 	var/severity = 0
 	var/alerttooltipstyle = ""
@@ -116,6 +118,10 @@
 	/// Boolean. If TRUE, the Click() proc will attempt to Click() on the master first if there is a master.
 	var/click_master = TRUE
 
+/atom/movable/screen/alert/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(clickable_glow)
+		add_filter("clickglow", 2, list("type" = "outline", "color" = COLOR_GOLD, "size" = 1))
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()
@@ -237,6 +243,7 @@
 	name = "Mind Control"
 	desc = "Your mind has been hijacked! Click to view the mind control command."
 	icon_state = ALERT_MIND_CONTROL
+	clickable_glow = TRUE
 	var/command
 
 /atom/movable/screen/alert/mind_control/Click()
@@ -250,6 +257,7 @@
 	desc = "Something got lodged into your flesh and is causing major bleeding. It might fall out with time, but surgery is the safest way. \
 		If you're feeling frisky, examine yourself and click the underlined item to pull the object out."
 	icon_state = ALERT_EMBEDDED_OBJECT
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/embeddedobject/Click()
 	. = ..()
@@ -287,6 +295,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "On Fire"
 	desc = "You're on fire. Stop, drop and roll to put the fire out or move to a vacuum area."
 	icon_state = "fire"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/fire/Click()
 	. = ..()
@@ -305,6 +314,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
+	clickable_glow = TRUE
 	/// The offer we're linked to, yes this is suspiciously like a status effect alert
 	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
@@ -476,6 +486,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Succumb"
 	desc = "Shuffle off this mortal coil."
 	icon_state = ALERT_SUCCUMB
+	clickable_glow = TRUE
 	var/static/list/death_titles = list(
 		"Goodnight, Sweet Prince",
 		"Game Over, Man",
@@ -811,6 +822,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		additional processing time to unlock more malfunction abilities."
 	icon_state = ALERT_HACKING_APC
 	timeout = 60 SECONDS
+	clickable_glow = TRUE
 	var/atom/target = null
 
 /atom/movable/screen/alert/hackingapc/Click()
@@ -838,6 +850,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Someone is trying to revive you. Re-enter your corpse if you want to be revived!"
 	icon_state = "template"
 	timeout = 300
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/revival/Click()
 	. = ..()
@@ -851,6 +864,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "This can be clicked on to perform an action."
 	icon_state = "template"
 	timeout = 30 SECONDS
+	clickable_glow = TRUE
 	/// Weakref to the target atom to use the action on
 	var/datum/weakref/target_ref
 	/// If we want to interact on click rather than jump/orbit
@@ -1028,6 +1042,10 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Buckled"
 	desc = "You've been buckled to something. Click the alert to unbuckle unless you're handcuffed."
 	icon_state = ALERT_BUCKLED
+	clickable_glow = TRUE
+
+/atom/movable/screen/alert/restrained
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "Handcuffed"
@@ -1075,6 +1093,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Knotted Shoes"
 	desc = "Someone tied your shoelaces together! Click the alert or your shoes to undo the knot."
 	icon_state = ALERT_SHOES_KNOT
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/shoes/Click()
 	. = ..()
@@ -1093,6 +1112,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Unpossess"
 	desc = "You are possessing an object. Click this alert to unpossess it."
 	icon_state = "buckled"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/unpossess_object/Click()
 	. = ..()

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -874,6 +874,7 @@
 	name = "Ants!"
 	desc = span_warning("JESUS FUCKING CHRIST! CLICK TO GET THOSE THINGS OFF!")
 	icon_state = "antalert"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/ants/Click()
 	. = ..()

--- a/code/datums/status_effects/debuffs/hooked.dm
+++ b/code/datums/status_effects/debuffs/hooked.dm
@@ -29,6 +29,7 @@
 	name = "Snagged By Hook"
 	desc = "You're being caught like a fish by some asshat! Click to safely remove the hook or move away far enough to snap it off."
 	icon_state = "hooked"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/hooked/Click()
 	. = ..()

--- a/code/datums/status_effects/debuffs/slime/slimed.dm
+++ b/code/datums/status_effects/debuffs/slime/slimed.dm
@@ -7,6 +7,7 @@
 	name = "Covered in Slime"
 	desc = "You are covered in slime and it's eating away at you! Click to start cleaning it off, or find a faster way to wash it away!"
 	icon_state = "slimed"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/slimed/Click()
 	. = ..()

--- a/code/datums/status_effects/debuffs/slime/slimed.dm
+++ b/code/datums/status_effects/debuffs/slime/slimed.dm
@@ -62,7 +62,7 @@
 /datum/status_effect/slimed/on_apply()
 	if(owner.get_organic_health() <= MIN_HEALTH)
 		return FALSE
-	to_chat(owner, span_userdanger("You have been covered in a thick layer of slime! Find a way to wash it off!"))
+	to_chat(owner, span_userdanger("You have been covered in a thick layer of slime! Find a way to wash it off with water, or try to clean it off by clicking the status effect alert!"))
 	return ..()
 
 /datum/status_effect/slimed/proc/remove_stacks(stacks_to_remove = 1)

--- a/code/datums/status_effects/debuffs/slime/slimed.dm
+++ b/code/datums/status_effects/debuffs/slime/slimed.dm
@@ -63,7 +63,7 @@
 /datum/status_effect/slimed/on_apply()
 	if(owner.get_organic_health() <= MIN_HEALTH)
 		return FALSE
-	to_chat(owner, span_userdanger("You have been covered in a thick layer of slime! Find a way to wash it off with water, or try to clean it off by clicking the status effect alert!"))
+	to_chat(owner, span_userdanger("You have been covered in a thick layer of slime! Find a way to wash it off!"))
 	return ..()
 
 /datum/status_effect/slimed/proc/remove_stacks(stacks_to_remove = 1)

--- a/code/datums/status_effects/debuffs/strandling.dm
+++ b/code/datums/status_effects/debuffs/strandling.dm
@@ -88,6 +88,7 @@
 	desc = "Strands of Durathread are wrapped around your neck, preventing you from breathing! Click this icon to remove the strand."
 	icon_state = "his_grace"
 	alerttooltipstyle = "hisgrace"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/strandling/Click(location, control, params)
 	. = ..()

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -176,6 +176,7 @@
 	name = "Holding Up"
 	desc = "You're currently pointing a gun at someone. Click to cancel."
 	icon_state = "aimed"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/holdup/Click(location, control, params)
 	. = ..()
@@ -358,6 +359,7 @@
 	name = "Surrender"
 	desc = "Looks like you're in trouble now, bud. Click here to surrender. (Warning: You will be incapacitated.)"
 	icon_state = "surrender"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/surrender/Click(location, control, params)
 	. = ..()

--- a/code/modules/bitrunning/alerts.dm
+++ b/code/modules/bitrunning/alerts.dm
@@ -7,6 +7,7 @@
 	name = "Domain Completed"
 	desc = "The domain is completed. Activate to exit."
 	timeout = 20 SECONDS
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/bitrunning/qserver_domain_complete/Click(location, control, params)
 	. = ..()

--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -511,6 +511,7 @@
 	desc = "Someone is calling you! Left-click this to accept the call. Right-click to deny it."
 	icon_state = "called"
 	timeout = 10 SECONDS
+	clickable_glow = TRUE
 	var/end_message = "call timed out!"
 	/// A weak reference to the MODlink that is calling.
 	var/datum/weakref/caller_ref

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -243,6 +243,7 @@
 	desc = "Your form is not your own... you're shapeshifted into another creature! \
 		A wizard could turn you back - or maybe you're stuck like this for good?"
 	icon_state = "shapeshifted"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/shapeshifted/Click(location, control, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

 clickable alerts glow (regex: /atom/movable/screen/alert/.*/Click)

## Why It's Good For The Game

people are much more likely to look at the chat or anywhere else than the status effect (really, its usually never worth reading 99% of them so they end up ignored)

## Changelog
:cl:
qol: alerts that do stuff when clicked glow gold
/:cl:
