### PR TITLE
Fixes SSWardrobe stealing a camera from the camera app when on a dummy, causing a harddel

### DIFF
--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -11,11 +11,17 @@
 	circuit_comp_type = /obj/item/circuit_component/mod_program/camera
 
 	/// Camera built-into the tablet.
-	var/obj/item/camera/internal_camera
+	var/obj/item/camera/app/internal_camera
 	/// Latest picture taken by the app.
 	var/datum/picture/internal_picture
 	/// How many pictures were taken already, used for the camera's TGUI photo display
 	var/picture_number = 1
+
+// Special type of camera for this exact usecase to prevent harddels
+/obj/item/camera/app
+	name = "internal camera"
+	desc = "Specialized internal camera protected from the hellish depths of SSWardrobe. \
+	Yell at coders if you somehow manage to see this"
 
 /datum/computer_file/program/maintenance/camera/on_install()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

See name, if a dummy somehow gets hold of a PDA with the camera app installed (This just so happens to be a default PDA program in the case on Nova, Skyrat, and Bubber), and the delete_equipment proc is called, the camera inside the PDA gets sent to the wardrobe because of `/datum/outfit/job/assistant/gimmick/hall_monitor` having one, and then qdelled with the PDA, leaving a hanging ref

This causes a harddel during tests that has caused me great pains to locate. Turns out a single example holodisk with the clown holds a magical key to trigger all this: a single PDA

## Why It's Good For The Game

Fixes a harddel. There might be other similar ones hiding in the dark like cameras in other objects.

## Changelog

:cl:
fix: Fixes SSWardrobe stealing a camera from the camera app when on a dummy, causing a harddel
/:cl:
