### PR TITLE
Updating player last seen info and connection log no longer blocks

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -384,12 +384,30 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	return new /datum/db_query(connection, sql_query, arguments)
 
+/**
+ * Creates and executes a query without waiting for or tracking the results.
+ * Query is executed asynchronously (without blocking) and deleted afterwards - any results or errors are discarded.
+ *
+ * Arguments:
+ * * sql_query - The SQL query string to execute
+ * * arguments - List of arguments to pass to the query for parameter binding
+ * * allow_during_shutdown - If TRUE, allows query to be created during subsystem shutdown. Generally, only cleanup queries should set this.
+ */
+/datum/controller/subsystem/dbcore/proc/FireAndForget(sql_query, arguments, allow_during_shutdown = FALSE)
+	var/datum/db_query/query = NewQuery(sql_query, arguments, allow_during_shutdown)
+	if(!query)
+		return
+	ASYNC
+		query.Execute()
+		qdel(query)
+
 /** QuerySelect
 	Run a list of query datums in parallel, blocking until they all complete.
 	* queries - List of queries or single query datum to run.
 	* warn - Controls rather warn_execute() or Execute() is called.
 	* qdel - If you don't care about the result or checking for errors, you can have the queries be deleted afterwards.
-		This can be combined with invoke_async as a way of running queries async without having to care about waiting for them to finish so they can be deleted.
+		This can be combined with invoke_async as a way of running queries async without having to care about waiting for them to finish so they can be deleted,
+		however you should probably just use FireAndForget instead if it's just a single query.
 */
 /datum/controller/subsystem/dbcore/proc/QuerySelect(list/queries, warn = FALSE, qdel = FALSE)
 	if (!islist(queries))
@@ -414,8 +432,6 @@ SUBSYSTEM_DEF(dbcore)
 		query.sync()
 		if (qdel)
 			qdel(query)
-
-
 
 /*
 Takes a list of rows (each row being an associated list of column => value) and inserts them via a single mass query.

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -214,7 +214,7 @@
 
 		if (ban["fromdb"])
 			if(SSdbcore.Connect())
-				INVOKE_ASYNC(SSdbcore, /datum/controller/subsystem/dbcore/proc.QuerySelect, list(
+				INVOKE_ASYNC(SSdbcore, TYPE_PROC_REF(/datum/controller/subsystem/dbcore, QuerySelect), list(
 					SSdbcore.NewQuery(
 						"INSERT INTO [format_table_name("stickyban_matched_ckey")] (matched_ckey, stickyban) VALUES (:ckey, :bannedckey) ON DUPLICATE KEY UPDATE last_matched = now()",
 						list("ckey" = ckey, "bannedckey" = bannedckey)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -726,37 +726,16 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 					qdel(query_datediff)
 	qdel(query_get_client_age)
 	if(!new_player)
-		INVOKE_ASYNC(SSdbcore, TYPE_PROC_REF(/datum/controller/subsystem/dbcore, QuerySelect),
-			SSdbcore.NewQuery(
-				"UPDATE [format_table_name("player")] SET lastseen = Now(), lastseen_round_id = :round_id, ip = INET_ATON(:ip), computerid = :computerid, lastadminrank = :admin_rank, accountjoindate = :account_join_date WHERE ckey = :ckey",
-				list(
-					"round_id" = GLOB.round_id,
-					"ip" = address,
-					"computerid" = computer_id,
-					"admin_rank" = admin_rank,
-					"account_join_date" = account_join_date || null,
-					"ckey" = ckey,
-				)
-			),
-			FALSE, TRUE
+		SSdbcore.FireAndForget(
+			"UPDATE [format_table_name("player")] SET lastseen = Now(), lastseen_round_id = :round_id, ip = INET_ATON(:ip), computerid = :computerid, lastadminrank = :admin_rank, accountjoindate = :account_join_date WHERE ckey = :ckey",
+			list("round_id" = GLOB.round_id, "ip" = address, "computerid" = computer_id, "admin_rank" = admin_rank, "account_join_date" = account_join_date || null, "ckey" = ckey)
 		)
 	if(!account_join_date)
 		account_join_date = "Error"
-	INVOKE_ASYNC(SSdbcore, TYPE_PROC_REF(/datum/controller/subsystem/dbcore, QuerySelect),
-		SSdbcore.NewQuery({"
-			INSERT INTO `[format_table_name("connection_log")]` (`id`,`datetime`,`server_ip`,`server_port`,`round_id`,`ckey`,`ip`,`computerid`)
-			VALUES(null,Now(),INET_ATON(:internet_address),:port,:round_id,:ckey,INET_ATON(:ip),:computerid)"},
-			list(
-				"internet_address" = world.internet_address || "0",
-				"port" = world.port,
-				"round_id" = GLOB.round_id,
-				"ckey" = ckey,
-				"ip" = address,
-				"computerid" = computer_id,
-			)
-		),
-		FALSE, TRUE
-	)
+	SSdbcore.FireAndForget({"
+		INSERT INTO `[format_table_name("connection_log")]` (`id`,`datetime`,`server_ip`,`server_port`,`round_id`,`ckey`,`ip`,`computerid`)
+		VALUES(null,Now(),INET_ATON(:internet_address),:port,:round_id,:ckey,INET_ATON(:ip),:computerid)
+	"}, list("internet_address" = world.internet_address || "0", "port" = world.port, "round_id" = GLOB.round_id, "ckey" = ckey, "ip" = address, "computerid" = computer_id))
 
 	SSserver_maint.UpdateHubStatus()
 


### PR DESCRIPTION
## About The Pull Request

Was investigating some stuff downstream related to undeleted SQL queries, and these two queries were related.

thought it'd be best to make them not block `/client/proc/set_client_age_from_db`, as the results are never checked anyways, not even for errors.

I've added a new proc to SSdbcore, `FireAndForget` - takes the same parameters as NewQuery, but instead of returning the query, it just asynchronously executes and then deletes it.

## Why It's Good For The Game

less undeleted sql queries, less blocking. yay?

## Changelog

does this count as user-facing? unsure how i'd changelog this tbh