### PR TITLE
Fixes mechs with crowbar-like tools holding firelocks open at a distance

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -548,18 +548,20 @@
 	if(welded || operating)
 		return
 
+	var/atom/crowbar_owner = acting_object.loc //catchs mechs and any other non-mob using a crowbar
+
 	if(density)
 		being_held_open = TRUE
-		user.balloon_alert_to_viewers("holding firelock open", "holding firelock open")
+		crowbar_owner.balloon_alert_to_viewers("holding firelock open", "holding firelock open")
 		COOLDOWN_START(src, activation_cooldown, REACTIVATION_DELAY)
 		open()
-		if(QDELETED(user))
+		if(QDELETED(crowbar_owner))
 			being_held_open = FALSE
 			return
-		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(handle_held_open_adjacency))
-		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(handle_held_open_adjacency))
-		RegisterSignal(user, COMSIG_QDELETING, PROC_REF(handle_held_open_adjacency))
-		handle_held_open_adjacency(user)
+		RegisterSignal(crowbar_owner, COMSIG_MOVABLE_MOVED, PROC_REF(handle_held_open_adjacency))
+		RegisterSignal(crowbar_owner, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(handle_held_open_adjacency))
+		RegisterSignal(crowbar_owner, COMSIG_QDELETING, PROC_REF(handle_held_open_adjacency))
+		handle_held_open_adjacency(crowbar_owner)
 	else
 		close()
 


### PR DESCRIPTION

## About The Pull Request
Changes firelock code to register signals on the atom holding the crowbar, not necessarily the mob that initiated the action. Since mobs inside mechs don't technically move, signals listening for the mob's movement wouldn't fire until the mob exits the mech. Registering the signal on the crowbar owner (mech in this case) solves the issue.

This makes no change to mobs holding crowbars, as the mob is considered the crowbar owner in that case, and is thus handled identically as before.
## Why It's Good For The Game

Prevents this:

https://github.com/user-attachments/assets/77150360-c1c2-46a0-8943-3b80fbd5a9e8
## Changelog
:cl:
fix: Firelocks opened by a mech will correctly close when the mech moves out of range.
/:cl:
