### PR TITLE
Actions remove filters from mutable appearances they copy

### DIFF
--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -74,6 +74,7 @@
 	muse_appearance.layer = FLOAT_LAYER
 	muse_appearance.pixel_x = 0
 	muse_appearance.pixel_y = 0
+	muse_appearance.clear_filters()
 
 	current_button.add_overlay(muse_appearance)
 	item_appearance = muse_appearance


### PR DESCRIPTION

## About The Pull Request
This way if the user has hover highlights turned on, action buttons won't inherit those from every single item they wear

## Changelog
:cl:
fix: Action buttons no longer keep hover outlines of items they're attached to.
/:cl:
