### PR TITLE
xeno princesses no longer lose their unique identifier

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -56,14 +56,16 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	..()
 
 //For alien evolution/promotion/queen finder procs. Checks for an active alien of that type
-/proc/get_alien_type(alienpath)
-	for(var/mob/living/carbon/alien/adult/A in GLOB.alive_mob_list)
-		if(!istype(A, alienpath))
+/proc/get_alien_type(alien_path, mob/ignored)
+	for(var/mob/living/carbon/alien/alien in GLOB.carbon_list)
+		if(alien == ignored)
 			continue
-		if(!A.key || A.stat == DEAD) //Only living aliens with a ckey are valid.
+		if(!istype(alien, alien_path))
 			continue
-		return A
-	return FALSE
+		if(!alien.key || alien.stat == DEAD) //Only living aliens with a ckey are valid.
+			continue
+		return alien
+	return null
 
 /mob/living/carbon/alien/adult/check_breath(datum/gas_mixture/breath)
 	if(breath?.total_moles() > 0 && !HAS_TRAIT(src, TRAIT_SNEAK))

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -61,7 +61,8 @@
 	return ..()
 
 /mob/living/carbon/alien/adult/royal/queen/set_name()
-	name = "alien princess"
+	if(get_alien_type(/mob/living/carbon/alien/adult/royal/queen, src))
+		name = "alien princess"
 	return ..()
 
 //Queen verbs

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -44,18 +44,6 @@
 	alien_speed = 2
 
 /mob/living/carbon/alien/adult/royal/queen/Initialize(mapload)
-	//there should only be one queen
-	for(var/mob/living/carbon/alien/adult/royal/queen/Q in GLOB.carbon_list)
-		if(Q == src)
-			continue
-		if(Q.stat == DEAD)
-			continue
-		if(Q.client)
-			name = "alien princess ([rand(1, 999)])" //if this is too cutesy feel free to change it/remove it.
-			break
-
-	real_name = src.name
-
 	var/static/list/innate_actions = list(
 		/datum/action/cooldown/alien/promote,
 		/datum/action/cooldown/spell/aoe/repulse/xeno,
@@ -70,6 +58,10 @@
 	organs += new /obj/item/organ/alien/acid
 	organs += new /obj/item/organ/alien/neurotoxin
 	organs += new /obj/item/organ/alien/eggsac
+	return ..()
+
+/mob/living/carbon/alien/adult/royal/queen/set_name()
+	name = "alien princess"
 	return ..()
 
 //Queen verbs

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -61,7 +61,7 @@
 	return ..()
 
 /mob/living/carbon/alien/adult/royal/queen/set_name()
-	if(get_alien_type(/mob/living/carbon/alien/adult/royal/queen, src))
+	if(get_alien_type(/mob/living/carbon/alien/adult/royal/queen, ignored = src))
 		name = "alien princess"
 	return ..()
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -22,7 +22,7 @@
 	gib_type = /obj/effect/decal/cleanable/xenoblood/xgibs
 	unique_name = TRUE
 
-	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
+	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|princess|queen)( \\(\\d+\\))?")
 	var/static/list/xeno_allowed_items = typecacheof(list(
 		/obj/item/clothing/mask/facehugger,
 		/obj/item/toy/basketball, // playing ball against a xeno is rigged since they cannot be disarmed, their game is out of this world


### PR DESCRIPTION

## About The Pull Request
xeno princesses set their name not caring about identifier, just random number
so lets make them not do that

## Why It's Good For The Game
awesome

## Changelog
:cl:
fix: xeno princesses no longer lose their unique identifier
/:cl:
