### PR TITLE
[no gbp] renmoves bartender skillchip from chipped quuirk

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -110,7 +110,6 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 	"GENUINE ID Appraisal Now!" = /obj/item/skillchip/appraiser,
 	"Le S48R4G3" = /obj/item/skillchip/sabrage,
 	"Integrated Intuitive Thinking and Judging" = /obj/item/skillchip/intj,
-	"F0RC3 4DD1CT10N" = /obj/item/skillchip/drunken_brawler,
 	"\"Space Station 13: The Musical\"" = /obj/item/skillchip/musical,
 	"Mast-Angl-Er skillchip" = /obj/item/skillchip/master_angler,
 ))


### PR DESCRIPTION

## About The Pull Request

job skillchip, combat skilchip, bad skilchip

## Why It's Good For The Game

combat is bad job is bad no quirk no good no no no, no quirk get combat no quirk get job contant, ver ybad not good

## Changelog

:cl:
fix: [no gbp] renmoves bartender skillchip from chipped quirk
/:cl:

