### PR TITLE
Fix radio jammer screentips

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -341,7 +341,7 @@ effective or pretty fucking useless.
 	. = ..()
 	register_context()
 
-/atom/movable/screen/alert/give/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+/obj/item/jammer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	context[SCREENTIP_CONTEXT_LMB] = "Release distruptor wave"
 	context[SCREENTIP_CONTEXT_RMB] = "Toggle"
 	return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION

## About The Pull Request
This fixes the radio jammer screentips since it was using the wrong path.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix radio jammer screentips
/:cl:
