### PR TITLE
AAS - Research Node Announcement Message fix

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	///If true, researched nodes will be announced to the appropriate channels
 	var/announce_research_node = TRUE
 	/// The text that we send when announcing researched nodes.
-	var/node_message = "The '%NODE' techweb node has been researched"
+	var/node_message = "The %NODE techweb node has been researched"
 
 /obj/machinery/announcement_system/Initialize(mapload)
 	. = ..()
@@ -164,7 +164,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 				newhead = new_message
 				usr.log_message("updated the head announcement to: [new_message]", LOG_GAME)
 		if("node_message")
-			var/new_message = trim(html_encode(param["new_text"]), MAX_MESSAGE_LEN)
+			var/new_message = trim(html_encode(param["newText"]), MAX_MESSAGE_LEN)
 			if(new_message)
 				node_message = new_message
 				usr.log_message("updated the researched node announcement to: [node_message]", LOG_GAME)


### PR DESCRIPTION
((First Pull Request, please bare with me))

There was a reported error from a user across all maps that updating the Research Node message with the AAS system would never update. It turns out to just be a syntax error. the ' around %NODE ' translates them into ASCII code. Leaving out the ', it will properly update the message as intended by the user. I have tested this multiple times and taken screenshots for proof. I also adjusted the other variable of new_text to newText so that it matches the other variables for other announcement messages.

## Why It's Good For The Game

This fixes just a plain old broken bug that seems to have gone unnoticed for the most part.

## Changelog

:cl: Sparex

fix: Fixed Automatic Announcement System bug with the Research Node Announcement message not updating properly. It will now properly save and announce whatever input the user desires!

:cl:
