### PR TITLE
Syndicate radio jammer can now block suit sensors, beacons, teleporters, and GPS

### DIFF
--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -119,6 +119,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		return
 	if(is_within_radio_jammer_range(parent))
 		to_chat(user, span_notice("ERROR: Network unavailable, please try again later."))
+		if(ui)
+			ui.close()
 		return
 
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -39,6 +39,9 @@
 		return
 	if (target.weak_reference != target_ref)
 		return
+	if(is_within_radio_jammer_range(target_ref))
+		return
+
 	turn_off()
 	set_teleport_target(null)
 
@@ -231,6 +234,8 @@
 	var/turf/T = get_turf(AM)
 	if(!T)
 		return FALSE
+	if(is_within_radio_jammer_range(AM))
+		return
 	if(is_centcom_level(T.z) || is_away_level(T.z))
 		return FALSE
 	var/area/A = get_area(T)

--- a/code/game/objects/effects/anomalies/anomalies_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bluespace.dm
@@ -35,6 +35,8 @@
 		var/turf/turf = get_turf(beacon)
 		if(!turf)
 			continue
+		if(is_within_radio_jammer_range(beacon))
+			return
 		if(is_centcom_level(turf.z) || is_away_level(turf.z))
 			continue
 		var/area/area = get_area(turf)

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -29,13 +29,18 @@
 	return NONE
 
 /obj/item/beacon/proc/turn_off()
+	enabled = FALSE
 	icon_state = "beacon-off"
 	GLOB.teleportbeacons -= src
 	SEND_SIGNAL(src, COMSIG_BEACON_DISABLED)
 
 /obj/item/beacon/attack_self(mob/user)
+	if(is_within_radio_jammer_range(src))
+		balloon_alert(user, "beacon not responding!")
+		return
+
 	enabled = !enabled
-	if (enabled)
+	if(enabled)
 		icon_state = "beacon"
 		GLOB.teleportbeacons += src
 	else

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -332,7 +332,6 @@ effective or pretty fucking useless.
 	desc = "Device used to disrupt nearby radio, beacon, teleporter, gps, and suit sensor communication. Alternate function creates a powerful distruptor wave which disables all nearby listening devices."
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
 	icon_state = "jammer"
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	var/active = FALSE
 	var/range = 12
 	var/jam_cooldown_duration = 15 SECONDS

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -356,6 +356,7 @@ effective or pretty fucking useless.
 	to_chat(user, span_notice("You release a distruptor wave, disabling all nearby radio devices."))
 	for (var/atom/potential_owner in view(7, user))
 		disable_radios_on(potential_owner)
+		disable_suit_sensors(potential_owner)
 	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
 
 /obj/item/jammer/attack_self_secondary(mob/user, modifiers)
@@ -382,12 +383,21 @@ effective or pretty fucking useless.
 	interacting_with.balloon_alert(user, "radio distrupted!")
 	to_chat(user, span_notice("You release a directed distruptor wave, disabling all radio devices on [interacting_with]."))
 	disable_radios_on(interacting_with)
+	disable_suit_sensors(interacting_with)
 
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/jammer/proc/disable_radios_on(atom/target)
-	for (var/obj/item/radio/radio in target.get_all_contents() + target)
+	for(var/obj/item/radio/radio in target.get_all_contents() + target)
 		radio.set_broadcasting(FALSE)
+
+/obj/item/jammer/proc/disable_suit_sensors(atom/target)
+	for(var/obj/item/clothing/under/uniform in target.get_all_contents() + target)
+		if((uniform.has_sensor == NO_SENSORS) || !uniform.sensor_mode)
+			continue
+
+		uniform.sensor_mode = SENSOR_OFF
+		uniform.update_wearer_status()
 
 /obj/item/jammer/Destroy()
 	GLOB.active_jammers -= src

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -329,7 +329,7 @@ effective or pretty fucking useless.
 
 /obj/item/jammer
 	name = "radio jammer"
-	desc = "Device used to disrupt nearby radio communication. Alternate function creates a powerful distruptor wave which disables all nearby listening devices."
+	desc = "Device used to disrupt nearby radio, beacon, teleporter, gps, and suit sensor communication. Alternate function creates a powerful distruptor wave which disables all nearby listening devices."
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
 	icon_state = "jammer"
 	var/active = FALSE
@@ -357,6 +357,9 @@ effective or pretty fucking useless.
 	for (var/atom/potential_owner in view(7, user))
 		disable_radios_on(potential_owner)
 		disable_suit_sensors(potential_owner)
+		disable_gps_trackers(potential_owner)
+		disable_beacon_trackers(potential_owner)
+
 	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
 
 /obj/item/jammer/attack_self_secondary(mob/user, modifiers)
@@ -384,12 +387,25 @@ effective or pretty fucking useless.
 	to_chat(user, span_notice("You release a directed distruptor wave, disabling all radio devices on [interacting_with]."))
 	disable_radios_on(interacting_with)
 	disable_suit_sensors(interacting_with)
+	disable_gps_trackers(interacting_with)
+	disable_beacon_trackers(interacting_with)
 
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/jammer/proc/disable_radios_on(atom/target)
 	for(var/obj/item/radio/radio in target.get_all_contents() + target)
 		radio.set_broadcasting(FALSE)
+
+/obj/item/jammer/proc/disable_gps_trackers(atom/target)
+	for(var/obj/item/gps/gps in target.get_all_contents() + target)
+		var/datum/component/gps/item/gps_component = gps.GetComponent(/datum/component/gps/item)
+		if(gps_component.tracking)
+			gps.cut_overlay("working")
+			gps_component.tracking = FALSE
+
+/obj/item/jammer/proc/disable_beacon_trackers(atom/target)
+	for(var/obj/item/beacon/beacon in target.get_all_contents() + target)
+		beacon.turn_off()
 
 /obj/item/jammer/proc/disable_suit_sensors(atom/target)
 	for(var/obj/item/clothing/under/uniform in target.get_all_contents() + target)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -332,6 +332,7 @@ effective or pretty fucking useless.
 	desc = "Device used to disrupt nearby radio, beacon, teleporter, gps, and suit sensor communication. Alternate function creates a powerful distruptor wave which disables all nearby listening devices."
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
 	icon_state = "jammer"
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	var/active = FALSE
 	var/range = 12
 	var/jam_cooldown_duration = 15 SECONDS

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -44,7 +44,8 @@
 		// Check every teleport beacon.
 		var/list/tele_beacons = list()
 		for(var/obj/item/beacon/W in GLOB.teleportbeacons)
-
+			if(is_within_radio_jammer_range(W))
+				continue
 			// Get the tracking beacon's turf location.
 			var/turf/tr = get_turf(W)
 
@@ -279,7 +280,7 @@
 /obj/item/hand_tele/proc/can_teleport_notifies(mob/user)
 	var/turf/current_location = get_turf(user)
 	var/area/current_area = current_location.loc
-	if (!current_location || (current_area.area_flags & NOTELEPORT) || is_away_level(current_location.z) || !isturf(user.loc))
+	if (!current_location || (current_area.area_flags & NOTELEPORT) || is_away_level(current_location.z) || !isturf(user.loc) || is_within_radio_jammer_range(src))
 		to_chat(user, span_notice("[src] is malfunctioning."))
 		return FALSE
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -421,6 +421,9 @@
 	if(get_dist(toggler, src) > 1)
 		balloon_alert(toggler, "too far!")
 		return FALSE
+	if(is_within_radio_jammer_range(src))
+		balloon_alert(toggler, "sensor not responding!")
+		return FALSE
 
 	switch(has_sensor)
 		if(LOCKED_SENSORS)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -31,6 +31,9 @@
 	var/list/destinations = list()
 
 	for(var/obj/item/beacon/B in GLOB.teleportbeacons)
+		if(is_within_radio_jammer_range(B))
+			return
+
 		var/turf/T = get_turf(B)
 		if(is_station_level(T.z))
 			destinations += B

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -84,6 +84,7 @@
 	desc = "This device will disrupt any nearby outgoing radio, beacon, teleporter, gps, and suit sensor communication when activated. Does not affect binary chat."
 	item = /obj/item/jammer
 	cost = 5
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/smugglersatchel
 	name = "Smuggler's Satchel"

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -81,7 +81,7 @@
 
 /datum/uplink_item/stealthy_tools/jammer
 	name = "Radio Jammer"
-	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."
+	desc = "This device will disrupt any nearby outgoing radio, beacon, teleporter, gps, and suit sensor communication when activated. Does not affect binary chat."
 	item = /obj/item/jammer
 	cost = 5
 


### PR DESCRIPTION
## About The Pull Request
The radio jammer now affects the following objects:
- Suit sensors
- Beacons
- Handheld Teleporter
- GPS items

It is also removed from nuclear operatives syndie loadout due to balance concerns.

## Why It's Good For The Game
I found out on SS14 that the syndicate radio jammer goes the extra mile and blocks out a bunch of other signals. Thought it was cool and wanted to add it to SS13. I expect this to affect balance slightly, but I don't think it's enough to justify making this item cost more.

Gameplay effects will include:
- Easier concealment of dead bodies
- Harder escaping via a handheld teleporter

## Changelog
:cl:
add: The syndicate radio jammer can block suit sensors, beacons, teleporters, and GPS
balance: Due to Space Geneva Conventions regulations, nuclear operative teams are forbidden to have radio jammers
/:cl:
