### PR TITLE
Fixes human_beg behavior not working

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/kitten_ai.dm
+++ b/code/modules/mob/living/basic/pets/cat/kitten_ai.dm
@@ -61,8 +61,7 @@
 	for(var/mob/living/carbon/human/human_target in oview(search_range, controller.pawn))
 		if(human_target.stat != CONSCIOUS || isnull(human_target.mind))
 			continue
-		if(!length(typecache_filter_list(human_target.held_items, locate_items)))
-			continue
-		return human_target
-
+		for (var/obj/item/held_item in human_target.held_items)
+			if (is_type_in_typecache(held_item, locate_items))
+				return human_target
 	return null


### PR DESCRIPTION

## About The Pull Request
``held_items`` can contain nulls and typecaches don't check if the passed var is valid, so it just runtimed and never worked if at least one hand was empty

## Changelog
:cl:
fix: Fixed cats not begging people for food
/:cl:
