### PR TITLE
A smattering of minor fixes to birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1666,7 +1666,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/glass,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "aGy" = (
 /obj/structure/flora/bush/large/style_random{
@@ -2830,6 +2830,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bfe" = (
@@ -2851,6 +2852,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bfU" = (
@@ -3234,10 +3236,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/white,
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
 "bmT" = (
@@ -4952,6 +4950,10 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/tram,
 /area/station/security/tram)
+"bVr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/small,
+/area/station/maintenance/department/engine)
 "bVD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6739,7 +6741,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "cCV" = (
-/obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7175,10 +7176,6 @@
 "cKk" = (
 /turf/closed/mineral/random/stationside,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"cKm" = (
-/obj/machinery/camera/directional/west,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
 "cKt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8470,6 +8467,7 @@
 /obj/structure/rack/skeletal,
 /obj/machinery/camera/autoname/directional/west,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/library/private)
 "dgy" = (
@@ -14975,6 +14973,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fyZ" = (
@@ -15857,6 +15856,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fMg" = (
@@ -16208,7 +16208,7 @@
 /area/station/maintenance/department/engine/atmos)
 "fRI" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/misc/asteroid,
@@ -17731,6 +17731,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"gul" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/small,
+/area/station/maintenance/department/engine)
 "gun" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/red{
@@ -19272,14 +19276,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
-"gRH" = (
-/obj/machinery/button/door/directional/north{
-	id = "Cabin4";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1
-	},
-/turf/closed/wall,
-/area/station/service/abandoned_gambling_den)
 "gRL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -21435,6 +21431,7 @@
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/engineering/atmos/pumproom)
 "hBq" = (
@@ -25865,7 +25862,7 @@
 /area/station/hallway/primary/port)
 "iUp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
@@ -26320,6 +26317,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jab" = (
@@ -28052,6 +28050,11 @@
 	dir = 8
 	},
 /area/station/commons/storage/tools)
+"jEY" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/small,
+/area/station/security/processing)
 "jEZ" = (
 /obj/structure/hedge,
 /obj/effect/decal/cleanable/dirt,
@@ -28165,7 +28168,9 @@
 	},
 /area/station/cargo/storage)
 "jGK" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29719,7 +29724,7 @@
 /area/station/cargo/lobby)
 "kgu" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
 "kgw" = (
@@ -30692,6 +30697,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "engine_airlock_2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "kux" = (
@@ -30770,7 +30776,7 @@
 "kvO" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera/directional/east{
-	c_tag = "Prison Isolation Cell";
+	c_tag = "Prison Reflection Chamber";
 	network = list("ss13","prison","isolation")
 	},
 /obj/structure/chair,
@@ -31357,9 +31363,7 @@
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 6
-	},
+/obj/effect/turf_decal/siding/wideplating/corner,
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
 "kHL" = (
@@ -35496,6 +35500,11 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
+"mab" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mac" = (
 /obj/structure/hedge,
 /obj/item/radio/intercom/directional/south,
@@ -39340,10 +39349,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/recreation/entertainment)
-"num" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/closed/wall,
-/area/station/maintenance/port/lesser)
 "nun" = (
 /obj/structure/flora/bush/flowers_br/style_random{
 	pixel_x = -3;
@@ -40672,6 +40677,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "nSd" = (
@@ -41296,7 +41302,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical/central)
 "ofx" = (
-/obj/effect/turf_decal/sand/plating,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "ofU" = (
@@ -43678,6 +43683,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oYj" = (
@@ -46063,6 +46069,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/port)
 "pOQ" = (
@@ -50207,7 +50214,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/glass,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "rfP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51116,6 +51123,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central/fore)
+"rxG" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/small,
+/area/station/security/processing)
 "rxJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53069,6 +53081,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sfB" = (
@@ -54413,8 +54426,8 @@
 /obj/machinery/modular_computer/preset/research{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/purple,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "sDj" = (
@@ -55373,10 +55386,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random/directional/west,
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/item/book/codex_gigas,
 /obj/machinery/light/small/dim/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/library/private)
 "sTR" = (
@@ -56548,7 +56561,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "tnh" = (
-/obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating{
@@ -59000,7 +59012,9 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/obj/structure/chair/wood,
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /turf/open/floor/iron/small,
 /area/station/service/barber)
 "ucJ" = (
@@ -61512,6 +61526,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uQT" = (
@@ -62789,12 +62804,13 @@
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
 "vlB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Filter"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
 "vlV" = (
@@ -67969,7 +67985,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
-/turf/open/floor/glass,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "wNU" = (
 /obj/structure/lattice/catwalk,
@@ -69479,6 +69495,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xiT" = (
@@ -69758,7 +69775,7 @@
 "xnC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/glass,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "xnE" = (
 /turf/closed/wall/r_wall,
@@ -84336,7 +84353,7 @@ eHN
 uhq
 tXl
 vAD
-num
+fEC
 aJq
 aJq
 aJq
@@ -87542,7 +87559,7 @@ wCc
 dDB
 wZs
 dDB
-bSo
+dDB
 aJq
 aJq
 aJq
@@ -87592,7 +87609,7 @@ blb
 dDB
 dDB
 dDB
-tYT
+gcs
 aJq
 dDB
 slY
@@ -88363,7 +88380,7 @@ blb
 dDB
 dDB
 tYT
-blb
+gcs
 dDB
 dDB
 dDB
@@ -90895,7 +90912,7 @@ pMM
 tIR
 hCT
 kAz
-cKm
+tIR
 szg
 tpW
 pUM
@@ -91775,11 +91792,11 @@ wpO
 huE
 wpO
 wpO
-iYY
+rxG
 xKv
 blb
 xKv
-iYY
+jEY
 wpO
 wpO
 huE
@@ -93719,7 +93736,7 @@ dDB
 dDB
 dDB
 vxt
-nST
+bVr
 evM
 aOa
 rtX
@@ -93976,9 +93993,9 @@ dDB
 dDB
 dDB
 vxt
+bVr
 nST
-nST
-nST
+gul
 vxt
 yfa
 yfa
@@ -94490,9 +94507,9 @@ dDB
 dDB
 dDB
 vxt
-gcs
-gcs
-gcs
+vxt
+vxt
+vxt
 vxt
 vxt
 vxt
@@ -94747,10 +94764,10 @@ dDB
 dDB
 dDB
 dDB
-bSo
-bSo
-bSo
-bSo
+dDB
+dDB
+aJq
+aJq
 aJq
 vxt
 hVq
@@ -100662,15 +100679,15 @@ aJq
 aJq
 aJq
 aJq
-gcs
-blb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
+aJq
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+aJq
 aJq
 aJq
 yjV
@@ -100919,15 +100936,15 @@ aJq
 aJq
 aJq
 aJq
-tYT
-tYT
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-aJq
+gcs
+blb
+mab
+blb
+blb
+blb
+blb
+blb
+gcs
 aJq
 aJq
 aJq
@@ -108779,7 +108796,7 @@ fnz
 ufn
 yhH
 tuT
-dDB
+blb
 dDB
 dDB
 dDB
@@ -109036,10 +109053,10 @@ meN
 rDj
 tuT
 tuT
-dDB
-dDB
-dDB
-dDB
+blb
+blb
+blb
+xxo
 dDB
 dDB
 dDB
@@ -109280,11 +109297,11 @@ vtC
 vtC
 kxL
 vtC
-blb
 dDB
 dDB
 dDB
-blb
+dDB
+dDB
 vtC
 kxL
 vtC
@@ -109292,8 +109309,8 @@ vtC
 vtC
 vtC
 tuT
-dDB
-dDB
+blb
+blb
 dDB
 dDB
 dDB
@@ -109531,25 +109548,25 @@ idp
 tuT
 tuT
 tuT
-dDB
-dDB
+blb
+blb
 blb
 vtC
 cWZ
 vtC
 blb
-dDB
-dDB
-dDB
+blb
+blb
+blb
 blb
 vtC
 cWZ
 vtC
+dDB
+dDB
+dDB
+dDB
 blb
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -109787,26 +109804,26 @@ aNX
 idp
 vtC
 blb
-blb
-blb
-blb
-blb
-dDB
-dDB
-dDB
-blb
-blb
-blb
-blb
-blb
-dDB
-dDB
-dDB
-blb
 dDB
 dDB
 dDB
 dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+blb
 dDB
 dDB
 dDB
@@ -110047,23 +110064,23 @@ blb
 dDB
 dDB
 dDB
-blb
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
 blb
-dDB
-dDB
-dDB
 blb
-blb
-blb
-blb
-blb
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -110304,23 +110321,23 @@ blb
 dDB
 dDB
 dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 blb
-dDB
-dDB
-dDB
-blb
-dDB
-dDB
-dDB
-blb
-dDB
-dDB
-dDB
-blb
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -110561,23 +110578,23 @@ blb
 dDB
 dDB
 dDB
-blb
-blb
-blb
-blb
-blb
 dDB
 dDB
 dDB
-blb
 dDB
 dDB
 dDB
-blb
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 esv
 dDB
 dDB
-dDB
+blb
 dDB
 dDB
 dDB
@@ -110818,23 +110835,23 @@ blb
 dDB
 dDB
 dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 blb
-dDB
-dDB
-dDB
-blb
-dDB
-dDB
-dDB
-blb
-dDB
-dDB
-dDB
-blb
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -111075,23 +111092,23 @@ blb
 dDB
 dDB
 dDB
-blb
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
 blb
-dDB
-dDB
-dDB
 blb
-blb
-blb
-blb
-blb
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -111329,26 +111346,26 @@ nBF
 idp
 vtC
 blb
-blb
-blb
-blb
-blb
-dDB
-dDB
-dDB
-blb
-blb
-blb
-blb
-blb
-dDB
-dDB
-dDB
-blb
 dDB
 dDB
 dDB
 dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
+blb
 dDB
 dDB
 dDB
@@ -111587,25 +111604,25 @@ idp
 tuT
 tuT
 tuT
-dDB
-dDB
+blb
+blb
 blb
 vtC
 ijI
 vtC
 blb
-dDB
-dDB
-dDB
+blb
+blb
+blb
 blb
 vtC
 ijI
 vtC
+dDB
+dDB
+dDB
+dDB
 blb
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -111850,11 +111867,11 @@ vtC
 vtC
 kxL
 vtC
-blb
 dDB
 dDB
 dDB
-blb
+dDB
+dDB
 vtC
 kxL
 vtC
@@ -111862,8 +111879,8 @@ vtC
 vtC
 vtC
 tuT
-dDB
-dDB
+blb
+blb
 dDB
 dDB
 dDB
@@ -112120,10 +112137,10 @@ vJN
 fhZ
 tuT
 tuT
-dDB
-dDB
-dDB
-dDB
+blb
+blb
+blb
+xxo
 dDB
 dDB
 dDB
@@ -112377,7 +112394,7 @@ vbR
 ufn
 yhH
 tuT
-dDB
+blb
 dDB
 dDB
 dDB
@@ -114849,7 +114866,7 @@ aJq
 aJq
 aJq
 wOp
-gRH
+wOp
 wOp
 wOp
 nWk

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -35500,11 +35500,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"mab" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mac" = (
 /obj/structure/hedge,
 /obj/item/radio/intercom/directional/south,
@@ -100938,7 +100933,7 @@ aJq
 aJq
 gcs
 blb
-mab
+blb
 blb
 blb
 blb


### PR DESCRIPTION

## About The Pull Request
Birdshot had a few minor issues so I went to fix those. I used the mapping verbs and found a good few more.

<details>
  <summary>Full changes</summary>
  
Removed incorrectly placed sandy plating decal from room below security escape pod
Fixed a few decals above the atmospherics storage room
Added missing air alarm to atmospherics (yea)
Added missing air alarm to library private room
Edited an air tank canister refiller above grav gen so that the connector is facing the correct way and gave a pressure pump to make it more useable.
Moved one of the lattice moorings at the asteroid above the ai sat one over so the lattice would connect nicely
Added lights to the gulag shuttle airlocks because it was very dark
Changed the c_tag of the reflection chamber camera because it shared one with the isolation camera
Fixed nearstation area tiles outside engine maintenance
Connected atmospheric pumping room APC to the power grid
Connected Port Primary Hallway APC to the power grid
Fixed engine maintenance vent and scrubbers not being connected to anything
Made a passive vent properly connect to perma's scrubbernet
Rotated gas connectors in telecomms so they connect properly
Connected scrubber in the engine room to the scrubbernet
Removed a double camera from the SM chamber
Remade the lattices at arrivals because the arrivals shuttle would ruin it the first time it landed
Removed a cabin door bolt button from the wall in the maintenance bar
Replaced the glass tiles in RD office with grey tiles because glass tiles show pipes and it looked pretty bad.
Added walls for lattice to connect to on the asteroid above cargo
Removed a sandy plating decal and a nearspace that were incorrectly placed outside the engine room airlock
Rotated two chairs in the barber shop
Removed an incorrectly placed hazard stripe box and double stacked disposal pipe from the wall in tool storage

  
</details>

## Why It's Good For The Game
some of the fixes are somewhat important like atmospherics having an air alarm or the hallway to escape having power, the rest are just minor map polish.

## Changelog
Most of the changes probably aren't important enough to put in the main changelog.

:cl:

fix: Birdshot Atmospherics now has an Air alarm 
fix: Birdshot Atmospherics pumping room APC is now connected to the main grid
fix: Birdshot Port Primary Hallway APC is now connected to the main grid

/:cl:
