### PR TITLE
Fixes roundstart active turfs on lavaland pod crashsite ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_crashsite.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_crashsite.dmm
@@ -62,7 +62,7 @@
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/unpowered)
 "l" = (
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/lavaland_atmos,
 /area/lavaland/surface)
 "m" = (
 /obj/machinery/door/airlock/survival_pod/glass,
@@ -118,7 +118,7 @@
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/turf/open/misc/ashplanet/wateryrock,
+/turf/open/misc/ashplanet/wateryrock/lavaland_atmos,
 /area/lavaland/surface)
 "y" = (
 /obj/structure/chair/comfy/shuttle{
@@ -129,7 +129,7 @@
 /area/ruin/unpowered)
 "z" = (
 /obj/item/book/manual/fish_catalog,
-/turf/open/misc/ashplanet/wateryrock,
+/turf/open/misc/ashplanet/wateryrock/lavaland_atmos,
 /area/lavaland/surface)
 "B" = (
 /mob/living/basic/mining/goliath,
@@ -140,7 +140,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface)
 "E" = (
-/turf/open/misc/ashplanet/wateryrock,
+/turf/open/misc/ashplanet/wateryrock/lavaland_atmos,
 /area/lavaland/surface)
 "F" = (
 /obj/effect/mob_spawn/corpse/human/cargo_tech,
@@ -175,7 +175,7 @@
 /area/ruin/powered)
 "L" = (
 /obj/item/storage/toolbox/fishing,
-/turf/open/misc/ashplanet/wateryrock,
+/turf/open/misc/ashplanet/wateryrock/lavaland_atmos,
 /area/lavaland/surface)
 "M" = (
 /obj/structure/rack,
@@ -213,7 +213,7 @@
 /area/ruin/powered)
 "U" = (
 /obj/item/bait_can/worm/premium,
-/turf/open/misc/ashplanet/wateryrock,
+/turf/open/misc/ashplanet/wateryrock/lavaland_atmos,
 /area/lavaland/surface)
 "V" = (
 /obj/structure/table/survival_pod,

--- a/code/game/turfs/open/ashplanet.dm
+++ b/code/game/turfs/open/ashplanet.dm
@@ -69,3 +69,6 @@
 /turf/open/misc/ashplanet/wateryrock/Initialize(mapload)
 	icon_state = "[icon_state][rand(1, 9)]"
 	. = ..()
+
+/turf/open/misc/ashplanet/wateryrock/lavaland_atmos
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -167,3 +167,6 @@
 		living.add_mood_event("hot_spring", /datum/mood_event/hot_spring_left)
 	else
 		living.add_mood_event("hot_spring", /datum/mood_event/hot_spring_hater_left)
+
+/turf/open/water/hot_spring/lavaland_atmos
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS


### PR DESCRIPTION

## About The Pull Request
The hotspring and the surrounding watery tiles didn't have lavaland atmos so it caused active turfs roundstart.

<details>
  <summary>Full changes</summary>
  
Adds /turf/open/water/hot_spring/lavaland_atmos
Adds /turf/open/misc/ashplanet/wateryrock/lavaland_atmos
Replaces matching turfs on lavaland_surface_crashsite.dmm with the above turfs to remove roundstart active turfs
 
</details>


## Why It's Good For The Game
Squashes a few round start active turfs

## Changelog
Not really player facing
