### PR TITLE
Tendril chests and mystery boxes can now be fished multiple times with a 30 minutes cooldown.

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -272,10 +272,10 @@ GLOBAL_LIST_INIT(mystery_fishing, list(
 /obj/structure/mystery_box/wands/generate_valid_types()
 	valid_types = GLOB.mystery_magic
 
-///One of a kind, rarely found by fishing in the ocean.
+///A fishing and pirate-themed mystery box, rarely found by fishing in the ocean, then another cannot be caught for the next 30 minutes.
 /obj/structure/mystery_box/fishing
 	name = "treasure chest"
-	desc = "A pirate-y chest that seems equally magial and mysterious, capable of granting the user different pieces of gear."
+	desc = "A piratey coffer equally magical and mysterious, capable of granting different pieces of gear to whoever opens it."
 	icon_state = "treasure"
 	uses_left = 18
 	max_integrity = 100

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -27,6 +27,7 @@
 	fish_count_regen = list(
 		/obj/item/fish/clownfish/lube = 3 MINUTES,
 		/obj/item/fish/swordfish = 5 MINUTES,
+		/obj/structure/mystery_box/fishing = 32 MINUTES,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
@@ -347,7 +348,9 @@
 	fish_counts = list(
 		/obj/structure/closet/crate/necropolis/tendril = 1
 	)
-
+	fish_count_regen = list(
+		/obj/structure/closet/crate/necropolis/tendril = 27 MINUTES,
+	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
@@ -373,6 +376,10 @@
 	fish_counts = list(
 		/obj/item/stack/sheet/mineral/adamantine = 3,
 		/obj/item/stack/sheet/mineral/runite = 2,
+	)
+	fish_count_regen = list(
+		/obj/item/stack/sheet/mineral/adamantine = 8 MINUTES,
+		/obj/item/stack/sheet/mineral/runite = 10 MINUTES,
 	)
 	overlay_state = "portal_plasma"
 
@@ -600,6 +607,9 @@
 	fish_counts = list(
 		/mob/living/basic/carp/mega = 2,
 	)
+	fish_count_regen = list(
+		/mob/living/basic/carp/mega = 9 MINUTES,
+	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 18
 
 /datum/fish_source/deepfryer
@@ -621,5 +631,6 @@
 	fish_count_regen = list(
 		/obj/item/fish/fryish = 2 MINUTES,
 		/obj/item/fish/fryish/fritterish = 6 MINUTES,
+		/obj/item/fish/fryish/nessie = 22 MINUTES,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 13


### PR DESCRIPTION
## About The Pull Request
Someone told me chests and some other rare fishing loot should regenerate over time. I kind of agreed, just because the somewhat infrequent hour(s) long rounds can get a little dull if the content is expended.

This PR doesn't just affect the chests, it also gives cooldowns to a few limited materials from icemoon (8-10 minutes) as well as the megacarp from the space dragon rift (dunno why really) and the big fish nugget nessie (22 minutes).

## Why It's Good For The Game
It should be possible to get multiple chests during particularly long rounds as well as some other loot that you can't farm with explosives.

Maybe I'll bump up the regen time from 30 mins to whatever for the mystery box, idk.

## Changelog

:cl:
balance: Tendril chests and mystery boxes can now be fished multiple times with a 30 minutes cooldown.
balance: other previously fishing loot available in limited amount, such as adamantine and runite from plasma rivers, regenerate over time.
/:cl:
