### PR TITLE
Reverts change that altered pyrokinesis recipe to require firebreath instead of fiery sweat

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -31,12 +31,12 @@
 
 /datum/generecipe/cindikinesis
 	input_one = /datum/mutation/human/geladikinesis
-	input_two = /datum/mutation/human/firebreath
+	input_two = /datum/mutation/human/fire // fiery sweat NOT fiery breath
 	result = /datum/mutation/human/cindikinesis
 
 /datum/generecipe/pyrokinesis
 	input_one = /datum/mutation/human/cryokinesis
-	input_two = /datum/mutation/human/firebreath
+	input_two = /datum/mutation/human/fire // fiery sweat NOT fiery breath
 	result = /datum/mutation/human/pyrokinesis
 
 /datum/generecipe/thermal_adaptation


### PR DESCRIPTION

## About The Pull Request

Reverts change that altered pyrokinesis recipe to require firebreath instead of fiery sweat

## Why It's Good For The Game

I don't know who did this and why. Fiery breath is a PITA to obtain and I never wanted it to need it.

## Changelog

:cl:
fix: Reverts change that altered pyrokinesis recipe to require firebreath instead of fiery sweat
/:cl:

