### PR TITLE
Metastation - cargo to sec chute fix

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58054,9 +58054,6 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "uyP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,


### PR DESCRIPTION

## About The Pull Request

Noticed downstream. Meta's cargo delivery has two disposals on the same tile.

![image](https://github.com/user-attachments/assets/d0e8651a-f703-4a1a-8427-df3f0950f005)

Axes the horizontal pipe.

## Why It's Good For The Game

Map fix good.


## Changelog
:cl:
map: metastation's security mail chute no longer has an extra erroneous pipe.
/:cl:
