### PR TITLE
Add CI mapping linter to check for directional fire alarms

### DIFF
--- a/tools/maplint/lints/firealarm_directionals.yml
+++ b/tools/maplint/lints/firealarm_directionals.yml
@@ -1,0 +1,5 @@
+help: "Use the directional variants when possible."
+/obj/machinery/firealarm:
+  banned_variables:
+    pixel_x:
+    pixel_y:


### PR DESCRIPTION

## About The Pull Request
This adds a mapping linter that checks if fire alarms are using pixel y or x offsets. If they are then it fails the mapping CI.

## Why It's Good For The Game
Better mapping consistency.

## Changelog
:cl:
map: PLACEHOLDER FOR MAP CHANGES
code: Add CI mapping linter to check for directional fire alarms
/:cl:
