### PR TITLE
Makes wild anomaly spawns more bearable

### DIFF
--- a/code/__DEFINES/anomaly.dm
+++ b/code/__DEFINES/anomaly.dm
@@ -4,7 +4,7 @@
  */
 
 ///Time in ticks before the anomaly goes poof/explodes depending on type.
-#define ANOMALY_COUNTDOWN_TIMER (99 SECONDS)
+#define ANOMALY_COUNTDOWN_TIMER (120 SECONDS)
 
 /**
  * Nuisance/funny anomalies

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -11,10 +11,15 @@
 	var/obj/item/assembly/signaler/anomaly/anomaly_core = /obj/item/assembly/signaler/anomaly
 	var/area/impact_area
 
+	/// How long till we seppuku? Blocked by immortal
 	var/lifespan = ANOMALY_COUNTDOWN_TIMER
+	/// Call warn_end_of_life when this much time is left
+	var/warn_at = 10 SECONDS
 	var/death_time
 
+	/// Color of the countdown effect
 	var/countdown_colour
+	/// Reference to the countdown effect
 	var/obj/effect/countdown/anomaly/countdown
 
 	/// Do we drop a core when we're neutralized?
@@ -53,6 +58,7 @@
 	if(immortal)
 		return
 	countdown.start()
+	addtimer(CALLBACK(src, PROC_REF(warn_end_of_life)), lifespan - warn_at)
 
 /obj/effect/anomaly/vv_edit_var(vname, vval)
 	. = ..()
@@ -129,7 +135,6 @@
 	to_chat(user, span_notice("Analyzing... [src]'s unstable field is not fluctuating along a stable frequency."))
 	return ITEM_INTERACT_BLOCKING
 
-
 ///Stabilize an anomaly, letting it stay around forever or untill destabilizes by a player. An anomaly without a core can't be signalled, but can be destabilized
 /obj/effect/anomaly/proc/stabilize(anchor = FALSE, has_core = TRUE)
 	immortal = TRUE
@@ -139,3 +144,7 @@
 		QDEL_NULL(anomaly_core)
 	if (anchor)
 		move_chance = 0
+
+/obj/effect/anomaly/proc/warn_end_of_life()
+	animate(src, time = warn_at, transform = matrix().Scale(3, 3), flags = ANIMATION_PARALLEL)
+	return

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -13,8 +13,6 @@
 
 	/// How long till we seppuku? Blocked by immortal
 	var/lifespan = ANOMALY_COUNTDOWN_TIMER
-	/// Call warn_end_of_life when this much time is left
-	var/warn_at = 10 SECONDS
 	var/death_time
 
 	/// Color of the countdown effect
@@ -58,7 +56,6 @@
 	if(immortal)
 		return
 	countdown.start()
-	addtimer(CALLBACK(src, PROC_REF(warn_end_of_life)), lifespan - warn_at)
 
 /obj/effect/anomaly/vv_edit_var(vname, vval)
 	. = ..()
@@ -144,7 +141,3 @@
 		QDEL_NULL(anomaly_core)
 	if (anchor)
 		move_chance = 0
-
-/obj/effect/anomaly/proc/warn_end_of_life()
-	animate(src, time = warn_at, transform = matrix().Scale(3, 3), flags = ANIMATION_PARALLEL)
-	return

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -3,7 +3,6 @@
 	name = "bioscrambler anomaly"
 	icon_state = "bioscrambler"
 	anomaly_core = /obj/item/assembly/signaler/anomaly/bioscrambler
-	immortal = TRUE
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 	layer = ABOVE_MOB_LAYER
 	/// Who are we moving towards?

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -79,6 +79,10 @@
 /obj/effect/anomaly/bioscrambler/docile/update_target()
 	return
 
+/obj/effect/anomaly/bioscrambler/detonate()
+	COOLDOWN_RESET(src, pulse_cooldown)
+	anomalyEffect()
+
 /// Visual effect spawned when the bioscrambler scrambles your bio
 /obj/effect/temp_visual/circle_wave
 	icon = 'icons/effects/64x64.dmi'

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -5,6 +5,8 @@
 	anomaly_core = /obj/item/assembly/signaler/anomaly/bioscrambler
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 	layer = ABOVE_MOB_LAYER
+	lifespan = ANOMALY_COUNTDOWN_TIMER * 2
+
 	/// Who are we moving towards?
 	var/datum/weakref/pursuit_target
 	/// Cooldown for every anomaly pulse

--- a/code/game/objects/effects/anomalies/anomalies_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bluespace.dm
@@ -115,4 +115,6 @@
 	living.apply_status_effect(/datum/status_effect/teleport_madness)
 
 /obj/effect/temp_visual/circle_wave/bluespace
-	color = COLOR_BLUE
+	color = COLOR_BLUE_LIGHT
+	duration = 1 SECONDS
+	amount_to_scale = 5

--- a/code/game/objects/effects/anomalies/anomalies_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bluespace.dm
@@ -24,6 +24,9 @@
 		do_teleport(AM, locate(AM.x, AM.y, AM.z), 8, channel = TELEPORT_CHANNEL_BLUESPACE)
 
 /obj/effect/anomaly/bluespace/detonate()
+	new /obj/effect/temp_visual/circle_wave/bluespace(get_turf(src))
+	playsound(src, 'sound/effects/magic/cosmic_energy.ogg', vol = 50)
+
 	var/turf/T = pick(get_area_turfs(impact_area))
 	if(!T)
 		return
@@ -110,3 +113,6 @@
 
 	var/mob/living/living = bumpee
 	living.apply_status_effect(/datum/status_effect/teleport_madness)
+
+/obj/effect/temp_visual/circle_wave/bluespace
+	color = COLOR_BLUE

--- a/code/game/objects/effects/anomalies/anomalies_dimensional.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional.dm
@@ -3,7 +3,7 @@
 	name = "dimensional anomaly"
 	icon_state = "dimensional"
 	anomaly_core = /obj/item/assembly/signaler/anomaly/dimensional
-	immortal = TRUE
+	lifespan = ANOMALY_COUNTDOWN_TIMER * 20 // will generally be killed off by reaching max teleports first
 	move_chance = 0
 	/// Range of effect, if left alone anomaly will convert a 2(range)+1 squared area.
 	var/range = 3
@@ -13,6 +13,12 @@
 	var/datum/dimension_theme/theme
 	/// Effect displaying on the anomaly to represent the theme.
 	var/mutable_appearance/theme_icon
+	/// How many times we can still teleport. Delete self if it hits 0 and we try to teleport. If immortal, will simply stay where it is
+	var/teleports_left
+	/// Minimum teleports it will do before going away permanently
+	var/minimum_teleports = 1
+	/// Maximum teleports it will do before going away permanently
+	var/maximum_teleports = 4
 
 /obj/effect/anomaly/dimensional/Initialize(mapload, new_lifespan, drops_core)
 	. = ..()
@@ -20,6 +26,8 @@
 
 	animate(src, transform = matrix()*0.85, time = 3, loop = -1)
 	animate(transform = matrix(), time = 3, loop = -1)
+
+	teleports_left = rand(minimum_teleports, maximum_teleports)
 
 /obj/effect/anomaly/dimensional/Destroy()
 	theme = null
@@ -37,6 +45,10 @@
 	if (!theme)
 		prepare_area()
 	if (!target_turfs.len)
+		if(teleports_left <= 0 && !immortal)
+			detonate()
+			return
+		teleports_left--
 		relocate()
 		return
 
@@ -79,6 +91,9 @@
 	priority_announce("Dimensional instability relocated. Expected location: [new_area.name].", "Anomaly Alert")
 	src.forceMove(new_turf)
 	prepare_area()
+
+/obj/effect/anomaly/dimensional/detonate()
+	qdel(src)
 
 /obj/effect/temp_visual/transmute_tile_flash
 	icon = 'icons/effects/effects.dmi'

--- a/code/game/objects/effects/anomalies/anomalies_gravity.dm
+++ b/code/game/objects/effects/anomalies/anomalies_gravity.dm
@@ -82,6 +82,10 @@
 		A.throw_at(target, 5, 1)
 		boing = 0
 
+/obj/effect/anomaly/grav/detonate()
+	new /obj/effect/temp_visual/circle_wave/gravity(get_turf(src))
+	playsound(src, 'sound/effects/magic/cosmic_energy.ogg', vol = 50)
+
 /obj/effect/anomaly/grav/high
 	var/datum/proximity_monitor/advanced/gravity/grav_field
 
@@ -93,6 +97,7 @@
 	grav_field = new(src, 7, TRUE, rand(0, 3))
 
 /obj/effect/anomaly/grav/high/detonate()
+	..()
 	for(var/obj/machinery/gravity_generator/main/the_generator as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/gravity_generator/main))
 		if(is_station_level(the_generator.z))
 			the_generator.blackout()
@@ -111,3 +116,6 @@
 	. = ..()
 
 	transform *= 3
+
+/obj/effect/temp_visual/circle_wave/gravity
+	color = COLOR_NAVY

--- a/code/game/objects/effects/anomalies/anomalies_vortex.dm
+++ b/code/game/objects/effects/anomalies/anomalies_vortex.dm
@@ -62,3 +62,13 @@
 				SSexplosions.medturf += T
 			if(EXPLODE_LIGHT)
 				SSexplosions.lowturf += T
+
+/obj/effect/anomaly/bhole/detonate()
+	new /obj/effect/temp_visual/circle_wave/vortex(get_turf(src))
+	playsound(src, 'sound/effects/hallucinations/far_noise.ogg', vol = 50)
+
+/obj/effect/temp_visual/circle_wave/vortex
+	color = COLOR_BLACK
+	duration = 3 SECONDS
+	amount_to_scale = 4
+

--- a/code/modules/events/anomaly/anomaly_bioscrambler.dm
+++ b/code/modules/events/anomaly/anomaly_bioscrambler.dm
@@ -17,4 +17,4 @@
 /datum/round_event/anomaly/anomaly_bioscrambler/announce(fake)
 	if(isnull(impact_area))
 		impact_area = placer.findValidArea()
-	priority_announce("Biologic limb swapping agent detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name]. Wear biosuits or other protective gear to counter the effects. Calculated half-life of %9£$T$%F3 years.", "Anomaly Alert")
+	priority_announce("Biologic limb swapping agent detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name]. Wear biosuits or other protective gear to counter the effects.", "Anomaly Alert")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Material anomaly will now self-delete after 1-4 relocations
- Bioscrambler now has a countdown like all other anomalies
- Increased anomaly lifetime from 99 seconds to 120
- Adds some more detonation effects where there were none (see: I abuse the circle effect jacq added (again))

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Material anomalies can wreak insane havok throughout the station if it's not caught quickly. It's a cat and mouse game, which can get kinda frustrating (flashbacks to trying to get the anomaly but it constantly teleporting just before I get to it). I don't wanna kill the cat & mouse game, but putting a limit on it so the entire station doesn't suffer endlessly to pizza/snow/jungle toilets is a nice middle road.

Bioscramblers are actually beyond frustrating. If someone doesn't immediately go for them, they'll start locking on and noclipping through the entire station and mutating every single person for the rest of the shift. This would probably be less bad if the bioscrambler couldn't give every single organ (par some blacklisted), causing a lot of irreversible damage, spontaneous combustions, glitches and creeping rare organs and limbs into a round "for the lulz". (This doesn't fix the absolute organ slop that they cause, but reworking bioscramblers not to be shit is for later.) 

I've also given anomalies 20 extra seconds of runtime. Anomalies take 99 seconds, take 30 to announce (for most), giving scientists 69 seconds to get anomaly catching gear and navigate to the area and defuse it. It's always felt like just barely too little time, often not getting the anomaly even when I am beelining. It was usually enough from when we just had meta, but we got bigger and bigger maps. It also gives them more time to wreak havoc for chaos lovers.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bioscramblers are no longer immortal
balance: Anomalies give 20 extra seconds to defuse! Or 20 extra seconds for them to reach havoc...
balance: Material anomalies only teleport 1-4 times before detonating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
