### PR TITLE
The immerse element is now lazyloaded

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -1,3 +1,10 @@
+/// A list of movables that shouldn't be affected by the element, either because it'd look bad or barely perceptible
+GLOBAL_LIST_INIT(immerse_ignored_movable, typecacheof(list(
+	/obj/effect,
+	/mob/dead,
+	/obj/projectile,
+)))
+
 /**
  * A visual element that makes movables entering the attached turfs look immersed into that turf.
  *
@@ -9,11 +16,6 @@
 	///An association list of turfs that have this element attached and their affected contents.
 	var/list/attached_turfs_and_movables = list()
 
-	/**
-	 * A list of movables that shouldn't be affected by the element, either because it'd look bad
-	 * or barely perceptible.
-	 */
-	var/static/list/movables_to_ignore
 	///A list of icons generated from a target and a mask, later used as appearances for the overlays.
 	var/static/list/generated_immerse_icons = list()
 	///A list of instances of /atom/movable/immerse_overlay then used as visual overlays for the immersed movables.
@@ -31,16 +33,6 @@
 	. = ..()
 	if(!isturf(target) || !icon || !icon_state || !mask_icon)
 		return ELEMENT_INCOMPATIBLE
-
-	if(isnull(movables_to_ignore))
-		movables_to_ignore = typecacheof(list(
-			/obj/effect,
-			/mob/dead,
-			/obj/projectile,
-		))
-
-		movables_to_ignore += GLOB.WALLITEMS_INTERIOR
-		movables_to_ignore += GLOB.WALLITEMS_EXTERIOR
 
 	src.icon = icon
 	src.icon_state = icon_state
@@ -109,11 +101,11 @@
 	SIGNAL_HANDLER
 	if(QDELETED(movable))
 		return
-	if(HAS_TRAIT(movable, TRAIT_IMMERSED))
+	if(HAS_TRAIT(movable, TRAIT_IMMERSED) || HAS_TRAIT(movable, TRAIT_WALLMOUNTED))
 		return
 	if(movable.layer >= ABOVE_ALL_MOB_LAYER || !ISINRANGE(movable.plane, MUTATE_PLANE(FLOOR_PLANE, source), MUTATE_PLANE(GAME_PLANE, source)))
 		return
-	if(is_type_in_typecache(movable, movables_to_ignore))
+	if(is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
 		return
 
 	var/atom/movable/buckled

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -22,6 +22,7 @@
 	barefootstep = FOOTSTEP_LAVA
 	clawfootstep = FOOTSTEP_LAVA
 	heavyfootstep = FOOTSTEP_LAVA
+	rust_resistance = RUST_RESISTANCE_ABSOLUTE
 	/// How much fire damage we deal to living mobs stepping on us
 	var/lava_damage = 20
 	/// How many firestacks we add to living mobs stepping on us
@@ -42,7 +43,8 @@
 	var/fish_source_type = /datum/fish_source/lavaland
 	/// The color we use for our immersion overlay
 	var/immerse_overlay_color = "#a15e1b"
-	rust_resistance = RUST_RESISTANCE_ABSOLUTE
+	/// Whether the immerse element has been added yet or not
+	var/immerse_added = FALSE
 
 /turf/open/lava/Initialize(mapload)
 	. = ..()
@@ -53,13 +55,37 @@
 	refresh_light()
 	if(!smoothing_flags)
 		update_appearance()
-	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
+	RegisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, PROC_REF(on_atom_inited))
 
 /turf/open/lava/Destroy()
+	UnregisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON)
 	for(var/mob/living/leaving_mob in contents)
 		leaving_mob.RemoveElement(/datum/element/perma_fire_overlay)
 		REMOVE_TRAIT(leaving_mob, TRAIT_NO_EXTINGUISH, TURF_TRAIT)
 	return ..()
+
+///We lazily add the immerse element when something is spawned or crosses this turf and not before.
+/turf/open/lava/proc/on_atom_inited(datum/source, atom/movable/movable)
+	SIGNAL_HANDLER
+	if(burn_stuff(arrived))
+		START_PROCESSING(SSobj, src)
+	if(immerse_added || is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+		return
+	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
+	immerse_added = TRUE
+
+/**
+ * turf/Initialize() calls Entered on its contents too, however
+ * we need to wait for movables that still need to be initialized
+ * before we add the immerse element.
+ */
+/turf/open/lava/Entered(atom/movable/entered)
+	. = ..()
+	if(!immerse_added && !is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
+		immerse_added = TRUE
+	if(burn_stuff(arrived))
+		START_PROCESSING(SSobj, src)
 
 /turf/open/lava/update_overlays()
 	. = ..()
@@ -138,14 +164,6 @@
 
 /turf/open/lava/MakeDry(wet_setting = TURF_WET_WATER)
 	return
-
-/turf/open/lava/airless
-	initial_gas_mix = AIRLESS_ATMOS
-
-/turf/open/lava/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
-	. = ..()
-	if(burn_stuff(arrived))
-		START_PROCESSING(SSobj, src)
 
 /turf/open/lava/Exited(atom/movable/gone, direction)
 	. = ..()
@@ -321,6 +339,9 @@
 
 /turf/open/lava/can_cross_safely(atom/movable/crossing)
 	return HAS_TRAIT(src, TRAIT_LAVA_STOPPED) || HAS_TRAIT(crossing, immunity_trait ) || HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)
+
+/turf/open/lava/airless
+	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/lava/smooth
 	name = "lava"

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -67,7 +67,7 @@
 ///We lazily add the immerse element when something is spawned or crosses this turf and not before.
 /turf/open/lava/proc/on_atom_inited(datum/source, atom/movable/movable)
 	SIGNAL_HANDLER
-	if(burn_stuff(arrived))
+	if(burn_stuff(movable))
 		START_PROCESSING(SSobj, src)
 	if(immerse_added || is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
 		return
@@ -79,9 +79,9 @@
  * we need to wait for movables that still need to be initialized
  * before we add the immerse element.
  */
-/turf/open/lava/Entered(atom/movable/entered)
+/turf/open/lava/Entered(atom/movable/arrived)
 	. = ..()
-	if(!immerse_added && !is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+	if(!immerse_added && !is_type_in_typecache(arrived, GLOB.immerse_ignored_movable))
 		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
 		immerse_added = TRUE
 	if(burn_stuff(arrived))

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -58,9 +58,10 @@
  */
 /turf/open/water/Entered(atom/movable/arrived)
 	. = ..()
-	if(!immerse_added && !is_type_in_typecache(arrived, GLOB.immerse_ignored_movable))
-		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
-		immerse_added = TRUE
+	if(immerse_added || is_type_in_typecache(arrived, GLOB.immerse_ignored_movable))
+		return
+	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
+	immerse_added = TRUE
 
 /turf/open/water/jungle
 

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -27,13 +27,40 @@
 	/// Fishing element for this specific water tile
 	var/datum/fish_source/fishing_datum = /datum/fish_source/river
 
+	/// Whether the immerse element has been added yet or not
+	var/immerse_added = FALSE
+
 /turf/open/water/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
+	RegisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, PROC_REF(on_atom_inited))
 	AddElement(/datum/element/watery_tile)
 	if(!isnull(fishing_datum))
 		AddElement(/datum/element/lazy_fishing_spot, fishing_datum)
 	ADD_TRAIT(src, TRAIT_CATCH_AND_RELEASE, INNATE_TRAIT)
+
+///We lazily add the immerse element when something is spawned or crosses this turf and not before.
+/turf/open/water/proc/on_atom_inited(datum/source, atom/movable/movable)
+	SIGNAL_HANDLER
+	UnregisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON)
+	if(immerse_added || is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+		return
+	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
+	immerse_added = TRUE
+
+/turf/open/water/Destroy()
+	UnregisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON)
+	return ..()
+
+/**
+ * turf/Initialize() calls Entered on its contents too, however
+ * we need to wait for movables that still need to be initialized
+ * before we add the immerse element.
+ */
+/turf/open/water/Entered(atom/movable/entered)
+	. = ..()
+	if(!immerse_added && !is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
+		immerse_added = TRUE
 
 /turf/open/water/jungle
 
@@ -96,18 +123,12 @@
 	animate(filter, offset = 1, time = 3 SECONDS, loop = -1, easing = SINE_EASING|EASE_IN|EASE_OUT)
 	animate(offset = -1, time = 3 SECONDS, easing = SINE_EASING|EASE_IN|EASE_OUT)
 
-	/**
-	 * turf/Initialize() calls Entered on its contents, however
-	 * we need to wait for movables that still need to be initialized.
-	 */
-	RegisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, PROC_REF(enter_initialized_movable))
 
 /turf/open/water/hot_spring/Destroy()
 	QDEL_NULL(particle_effect)
 	remove_filter("hot_spring_waves")
 	for(var/atom/movable/movable as anything in contents)
 		exit_hot_spring(movable)
-	UnregisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON)
 	return ..()
 
 /turf/open/water/hot_spring/Entered(atom/movable/arrived, atom/old_loc)
@@ -118,6 +139,9 @@
 
 /turf/open/water/hot_spring/proc/enter_initialized_movable(datum/source, atom/movable/movable)
 	SIGNAL_HANDLER
+	if(!immerse_added && !is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
+		immerse_added = TRUE
 	enter_hot_spring(movable)
 
 ///Registers the signals from the immerse element and calls dip_in if the movable has the required trait.

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -56,9 +56,9 @@
  * we need to wait for movables that still need to be initialized
  * before we add the immerse element.
  */
-/turf/open/water/Entered(atom/movable/entered)
+/turf/open/water/Entered(atom/movable/arrived)
 	. = ..()
-	if(!immerse_added && !is_type_in_typecache(movable, GLOB.immerse_ignored_movable))
+	if(!immerse_added && !is_type_in_typecache(arrived, GLOB.immerse_ignored_movable))
 		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
 		immerse_added = TRUE
 


### PR DESCRIPTION
## About The Pull Request
SmarKar _kindly_ asked me to reduce time spent loading fishing-related stuff during init, however we cannot further (lazy-load the already (somewhat) lazy fishing spots without resorting to some serious hacky solution worthy of an altogether serious wiggling eyebrow, because of the signals for explosions and examining the turf, however he also asked the same for the immerse element, which can be done, and so it was.

## Why It's Good For The Game
Saving a few hundred milliseconds of when loading turfs on world initialization.

## Changelog
N/A