### PR TITLE
Fixing a runtime error with the camo fish trait.

### DIFF
--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -806,4 +806,4 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 		return
 	var/init_alpha = initial(source.alpha)
 	if(init_alpha != source.alpha)
-		animate(source.alpha, alpha = init_alpha, time = 1.2 SECONDS, easing = CIRCULAR_EASING|EASE_OUT)
+		animate(source, alpha = init_alpha, time = 1.2 SECONDS, easing = CIRCULAR_EASING|EASE_OUT)


### PR DESCRIPTION
## About The Pull Request
Fixing an animate() call with an incorrect target for the completely cosmetic so far camouflage fish trait.

## Why It's Good For The Game
Fewer runtime errors.

## Changelog
Not worthy of a CL.