### PR TITLE
[NO GBP] Fix a small logic whoopsie with byond-tracy init

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -73,7 +73,8 @@ GLOBAL_PROTECT(tracy_init_reason)
 /world/proc/Genesis(tracy_initialized = FALSE)
 	RETURN_TYPE(/datum/controller/master)
 
-	GLOB.tracy_initialized = FALSE
+	if(!tracy_initialized)
+		GLOB.tracy_initialized = FALSE
 #ifndef OPENDREAM
 	if(!tracy_initialized)
 #ifdef USE_BYOND_TRACY


### PR DESCRIPTION

## About The Pull Request

i made a small whoopsie here - `GLOB.tracy_initialized` would get set back to `FALSE` during `Genesis(tracy_initialized = TRUE)`, after tracy had been initialized.

## Why It's Good For The Game

this broke the mc panel and other stuff relying on `GLOB.tracy_initialized`

## Changelog

No user-facing changes