### PR TITLE
Fixed advanced camera consoles runtiming on eye init

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -206,17 +206,18 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	SIGNAL_HANDLER
 	update_parallax_pref() // If your eye changes z level, so should your parallax prefs
 	var/turf/eye_turf = get_turf(eye)
-	SEND_SIGNAL(src, COMSIG_HUD_Z_CHANGED, eye_turf.z)
-	var/new_offset = GET_TURF_PLANE_OFFSET(eye_turf)
-	if(current_plane_offset == new_offset)
-		return
-	var/old_offset = current_plane_offset
-	current_plane_offset = new_offset
+	if(eye_turf)
+		SEND_SIGNAL(src, COMSIG_HUD_Z_CHANGED, eye_turf.z)
+		var/new_offset = GET_TURF_PLANE_OFFSET(eye_turf)
+		if(current_plane_offset == new_offset)
+			return
+		var/old_offset = current_plane_offset
+		current_plane_offset = new_offset
 
-	SEND_SIGNAL(src, COMSIG_HUD_OFFSET_CHANGED, old_offset, new_offset)
-	for(var/group_key as anything in master_groups)
-		var/datum/plane_master_group/group = master_groups[group_key]
-		group.build_planes_offset(src, new_offset)
+		SEND_SIGNAL(src, COMSIG_HUD_OFFSET_CHANGED, old_offset, new_offset)
+		for(var/group_key as anything in master_groups)
+			var/datum/plane_master_group/group = master_groups[group_key]
+			group.build_planes_offset(src, new_offset)
 
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -206,18 +206,19 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	SIGNAL_HANDLER
 	update_parallax_pref() // If your eye changes z level, so should your parallax prefs
 	var/turf/eye_turf = get_turf(eye)
-	if(eye_turf)
-		SEND_SIGNAL(src, COMSIG_HUD_Z_CHANGED, eye_turf.z)
-		var/new_offset = GET_TURF_PLANE_OFFSET(eye_turf)
-		if(current_plane_offset == new_offset)
-			return
-		var/old_offset = current_plane_offset
-		current_plane_offset = new_offset
+	if(!eye_turf)
+		return
+	SEND_SIGNAL(src, COMSIG_HUD_Z_CHANGED, eye_turf.z)
+	var/new_offset = GET_TURF_PLANE_OFFSET(eye_turf)
+	if(current_plane_offset == new_offset)
+		return
+	var/old_offset = current_plane_offset
+	current_plane_offset = new_offset
 
-		SEND_SIGNAL(src, COMSIG_HUD_OFFSET_CHANGED, old_offset, new_offset)
-		for(var/group_key as anything in master_groups)
-			var/datum/plane_master_group/group = master_groups[group_key]
-			group.build_planes_offset(src, new_offset)
+	SEND_SIGNAL(src, COMSIG_HUD_OFFSET_CHANGED, old_offset, new_offset)
+	for(var/group_key as anything in master_groups)
+		var/datum/plane_master_group/group = master_groups[group_key]
+		group.build_planes_offset(src, new_offset)
 
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)


### PR DESCRIPTION
## About The Pull Request

Currently when the camera eye of an advanced camera console is initialized, it tries to send COMSIG_HUD_Z_CHANGED while the eye is still in nullspace. Added an if to make sure the eye has a valid location.