### PR TITLE
Everything uses trim(), trim returns "" if empty, removes the SDQL2 trimtext

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -270,7 +270,7 @@
 	if(!filter_name_ic(trimmed)) // Contains IC chat prohibited words
 		return
 
-	return trimtext(trimmed)
+	return trim(trimmed)
 
 
 /// Helper proc to check if a name is valid for the IC filter
@@ -357,7 +357,7 @@
 /proc/trim(text, max_length)
 	if(max_length)
 		text = copytext_char(text, 1, max_length)
-	return trimtext(text)
+	return trimtext(text) || ""
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(t)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -357,7 +357,7 @@
 /proc/trim(text, max_length)
 	if(max_length)
 		text = copytext_char(text, 1, max_length)
-	return trimtext(text) || ""
+	return trimtext(text) || "" //users expect atleast an empty string
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(t)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -117,9 +117,6 @@
 /proc/_text2num(T)
 	return text2num(T)
 
-/proc/_trimtext(Text)
-	return trimtext(Text)
-
 /proc/_ohearers(Dist, Center = usr)
 	return ohearers(Dist, Center)
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -839,7 +839,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			if(member_string[length(member_string)] == "}")
 				variables_start = findtext(member_string, "{")
 
-			var/path_text = trimtext(copytext(member_string, 1, variables_start))
+			var/path_text = trim(copytext(member_string, 1, variables_start))
 			var/atom_def = text2path(path_text) //path definition, e.g /obj/foo/bar
 
 			if(!ispath(atom_def, /atom)) // Skip the item if the path does not exist.  Fix your crap, mappers!
@@ -1011,7 +1011,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 
 		// check if this is a simple variable (as in list(var1, var2)) or an associative one (as in list(var1="foo",var2=7))
 		var/equal_position = findtext(text,"=",old_position, position)
-		var/trim_left = trimtext(copytext(text,old_position,(equal_position ? equal_position : position)))
+		var/trim_left = trim(copytext(text,old_position,(equal_position ? equal_position : position)))
 		var/left_constant = parse_constant(trim_left)
 		if(position)
 			old_position = position + length(text[position])
@@ -1021,7 +1021,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		if(equal_position && !isnum(left_constant))
 			// Associative var, so do the association.
 			// Note that numbers cannot be keys - the RHS is dropped if so.
-			var/trim_right = trimtext(copytext(text, equal_position + length(text[equal_position]), position))
+			var/trim_right = trim(copytext(text, equal_position + length(text[equal_position]), position))
 			var/right_constant = parse_constant(trim_right)
 			.[left_constant] = right_constant
 		else  // simple var


### PR DESCRIPTION
## About The Pull Request
Title. I may have been wrong about how depended on this behaviour was
Also, uh, fixes #87986
## Why It's Good For The Game

trim_reduced no longer needs to exist because trimtext() does it faster, and there's no reason to have a special proc if trim just calls that proc anyways. I sincerely doubt the proc overhead is so severe that we need another proc that will ever only be called directly 3 times in the code.

Since trimtext() does something we don't expect, it's better to just have SDQL2 queries use trim() so we're all on the same page.

## Changelog

NO!!!
