### PR TITLE
Triples natural firestack decay rate

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -39,7 +39,7 @@
 	var/move_intent = MOVE_INTENT_RUN
 
 	/// Rate at which fire stacks should decay from this mob
-	var/fire_stack_decay_rate = -0.05
+	var/fire_stack_decay_rate = -0.15
 
 	/// when the mob goes from "normal" to crit
 	var/crit_threshold = HEALTH_THRESHOLD_CRIT


### PR DESCRIPTION
## About The Pull Request

Triples natural firestack decay rate, from 0.05 (!) to 0.15

## Why It's Good For The Game

Fire stacks take SO long to decay it's genuinely insane. Like, oh my god. It's so long. They just DON'T. CLEAR. If you're in crit and ignited you're FUCKED. It's suuuuuuuuper annoying becaue it means you always need to treat fire like an emergency, even though it's incredibly common to get a minor amount of ignition from things like cigars, sparks, welding fuel...

Look at this:
![image](https://github.com/user-attachments/assets/77106fbe-4167-4e8c-a4e6-15edc9ed5fed)
It took me seven minutes for flame to decay. Seven whole-ass minutes. With a elite modsuit!!

Fire will still overheat you, will still burn your clothes off. This just makes it so that welding fuel fire isn't literally fucking napalm.

## Changelog

:cl:
balance: Triples natural firestack decay rate
/:cl:

