### PR TITLE
Fix lustrous brain trauma not removing during polymorph

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -449,6 +449,14 @@
 	can_smoothen_out = FALSE
 	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP)
 
+// This fixes an edge case from species/regenerate_organs that would transfer the brain trauma before organ/on_mob_remove can remove it
+// Prevents wizards from using the magic mirror to gain bluespace_prophet trauma and then switching to another race
+/obj/item/organ/brain/lustrous/before_organ_replacement(obj/item/organ/replacement)
+	if(owner)
+		owner.cure_trauma_type(/datum/brain_trauma/special/bluespace_prophet, TRAUMA_RESILIENCE_ABSOLUTE)
+		owner.RemoveElement(/datum/element/tenacious)
+	. = ..()
+
 /obj/item/organ/brain/lustrous/on_mob_remove(mob/living/carbon/organ_owner, special)
 	. = ..()
 	organ_owner.cure_trauma_type(/datum/brain_trauma/special/bluespace_prophet, TRAUMA_RESILIENCE_ABSOLUTE)


### PR DESCRIPTION
## About The Pull Request
- Fixes #87897

There was an exploit where you can polymorph into the lustrous race and gain the beneficial brain trauma and then polymorph into another race and still keep the trauma. The code was transferring the brain traumas to the new body before it was deleted from the brain.

It's now fixed. Special thanks to Melber for coming up with a better solution than the ones I brainstormed.

## Why It's Good For The Game
Exploits are bad m'kay.

## Changelog
:cl: timothymtorres, MrMelbert
fix: Fix lustrous brain trauma not removing during polymorph
/:cl:
