### PR TITLE
Fixes mafia's vest and reveal abilities

### DIFF
--- a/code/modules/mafia/abilities/investigative/reveal.dm
+++ b/code/modules/mafia/abilities/investigative/reveal.dm
@@ -4,11 +4,11 @@
  * During the night, revealing someone will announce their role when day comes.
  * This is one time use, we'll delete ourselves once done.
  */
-/datum/mafia_ability/reaveal_role
+/datum/mafia_ability/reveal_role
 	name = "Reveal"
 	ability_action = "psychologically evaluate"
 
-/datum/mafia_ability/reaveal_role/perform_action_target(datum/mafia_controller/game, datum/mafia_role/day_target)
+/datum/mafia_ability/reveal_role/perform_action_target(datum/mafia_controller/game, datum/mafia_role/day_target)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -17,7 +17,7 @@
 	target_role.reveal_role(game, verbose = TRUE)
 	return TRUE
 
-/datum/mafia_ability/vest/clean_action_refs(datum/mafia_controller/game)
+/datum/mafia_ability/reveal_role/clean_action_refs(datum/mafia_controller/game)
 	if(using_ability)
 		host_role.role_unique_actions -= src
 		qdel(src)

--- a/code/modules/mafia/roles/town/town_investigative.dm
+++ b/code/modules/mafia/roles/town/town_investigative.dm
@@ -20,7 +20,7 @@
 	hud_icon = "hudpsychologist"
 	revealed_icon = "psychologist"
 
-	role_unique_actions = list(/datum/mafia_ability/reaveal_role)
+	role_unique_actions = list(/datum/mafia_ability/reveal_role)
 
 /datum/mafia_role/chaplain
 	name = "Chaplain"


### PR DESCRIPTION

## About The Pull Request
Psych's ability to reveal now has a single charge
Vest's ability should now have two charges instead of deleting after use

## Why It's Good For The Game
Bugfix good

## Changelog
:cl:
fix: Mafia: Psych's reveal ability now correctly has a single use
fix: Mafia: Fugitive's vest ability now correctly should have two uses
/:cl:
