### PR TITLE
MODsuits will not play the glove pickup sound when undeployed

### DIFF
--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -44,6 +44,7 @@
 	cold_protection = HANDS|ARMS
 	item_flags = IMMUTABLE_SLOW
 	equip_sound = null
+	pickup_sound = null
 	drop_sound = null
 
 /obj/item/clothing/shoes/mod


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
it doesn't fit and doesn't make sense
## Changelog
:cl: grungussuss
sound: the glove pickup sound will no longer play for modsuits undeploying
/:cl:
