### PR TITLE
Fixes all hoverboards having holyboard space slowdown effect

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -213,7 +213,7 @@
 	instability = 3
 	icon_state = "hoverboard_holy"
 
-/obj/vehicle/ridden/scooter/skateboard/hoverboard/make_ridable()
+/obj/vehicle/ridden/scooter/skateboard/hoverboard/holyboarded/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/hover/holy)
 
 /obj/vehicle/ridden/scooter/skateboard/hoverboard/holyboarded/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

Proc was overriden on the wrong subtype, making all hoverboards have holyboard behavior (being slowed down in space or when hovering in the air)

## Changelog
:cl:
fix: Fixed all hoverboards having holyboard space slowdown effect
/:cl:
