### PR TITLE
Added 'loose hat' functionality to the hat stabilizing component, used in modsuist

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -141,6 +141,8 @@
 #define COMSIG_LIVING_SLAM_TABLE "living_slam_table"
 ///from /obj/item/hand_item/slapper/attack(): (source=mob/living/slapper, mob/living/slapped)
 #define COMSIG_LIVING_SLAP_MOB "living_slap_mob"
+///from /obj/item/hand_item/slapper/attack(): (source=mob/living/slapper, mob/living/slapped)
+#define COMSIG_LIVING_SLAPPED "living_slapped"
 /// from /mob/living/*/UnarmedAttack(), before sending [COMSIG_LIVING_UNARMED_ATTACK]: (mob/living/source, atom/target, proximity, modifiers)
 /// The only reason this exists is so hulk can fire before Fists of the North Star.
 /// Note that this is called before [/mob/living/proc/can_unarmed_attack] is called, so be wary of that.
@@ -288,6 +290,8 @@
 
 ///From mob/living/carbon/proc/throw_mode_on and throw_mode_off
 #define COMSIG_LIVING_THROW_MODE_TOGGLE "living_throw_mode_toggle"
+/// From mob/living/proc/on_fall
+#define COMSIG_LIVING_THUD "living_thud"
 ///From /datum/component/happiness()
 #define COMSIG_MOB_HAPPINESS_CHANGE "happiness_change"
 /// From /obj/item/melee/baton/baton_effect(): (datum/source, mob/living/user, /obj/item/melee/baton)

--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -1,7 +1,10 @@
 /// Allows players to place hats on the atom this is attached to
 /datum/component/hat_stabilizer
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	/// Currently "stored" hat. No armor or function will be inherited, only the icon and cover flags.
 	var/obj/item/clothing/head/attached_hat
+	/// If TRUE, the hat will fall to the ground when the owner does so. It can also be shot off.
+	var/loose_hat = FALSE
 	/// Original cover flags for the helmet, before a hat is placed
 	var/former_flags
 	var/former_visor_flags
@@ -9,8 +12,10 @@
 	var/use_worn_icon = TRUE
 	/// Pixel_y offset for the hat
 	var/pixel_y_offset
+	/// The hat overlay to add & delete
+	var/mutable_appearance/icon_overlay
 
-/datum/component/hat_stabilizer/Initialize(add_overlay = FALSE, use_worn_icon = TRUE, pixel_y_offset = 0)
+/datum/component/hat_stabilizer/Initialize(use_worn_icon = TRUE, pixel_y_offset = 0, loose_hat = FALSE)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -19,14 +24,39 @@
 
 	src.use_worn_icon = use_worn_icon
 	src.pixel_y_offset = pixel_y_offset
+	src.loose_hat = loose_hat
+	// Examine signals
 	RegisterSignal(source, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
-	RegisterSignal(source, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
-	RegisterSignal(source, COMSIG_QDELETING, PROC_REF(on_qdel))
-	RegisterSignal(source, COMSIG_ATOM_ATTACK_HAND_SECONDARY, PROC_REF(on_secondary_attack_hand))
-	RegisterSignals(source, list(COMSIG_MODULE_GENERATE_WORN_OVERLAY, COMSIG_ITEM_GET_WORN_OVERLAYS), PROC_REF(get_worn_overlays))
 	RegisterSignal(source, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
-	if (add_overlay)
-		RegisterSignal(source, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
+
+	// Equip signals, used to drop loose hats
+	RegisterSignal(source, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
+	RegisterSignal(source, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
+
+	// Wear & Remove
+	RegisterSignal(source, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
+	RegisterSignal(source, COMSIG_ATOM_ATTACK_HAND_SECONDARY, PROC_REF(on_secondary_attack_hand))
+
+	// Overlays
+	RegisterSignals(source, list(COMSIG_MODULE_GENERATE_WORN_OVERLAY, COMSIG_ITEM_GET_WORN_OVERLAYS), PROC_REF(get_worn_overlays))
+
+	RegisterSignal(source, COMSIG_QDELETING, PROC_REF(on_qdel))
+
+// Inherit the new values passed to the component
+/datum/component/hat_stabilizer/InheritComponent(datum/component/hat_stabilizer/new_comp, original, use_worn_icon, pixel_y_offset, loose_hat)
+
+	if(!original)
+		return
+
+	//add_overlay
+	if(!isnull(use_worn_icon))
+		src.use_worn_icon = use_worn_icon
+	if(!isnull(use_worn_icon))
+		src.use_worn_icon = use_worn_icon
+	if(!isnull(pixel_y_offset))
+		src.pixel_y_offset = pixel_y_offset
+	if(!isnull(loose_hat))
+		src.loose_hat = loose_hat
 
 /datum/component/hat_stabilizer/UnregisterFromParent()
 	if (attached_hat)
@@ -34,12 +64,40 @@
 	UnregisterSignal(parent, list(COMSIG_ATOM_EXAMINE, COMSIG_ATOM_ATTACKBY,
 	COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_MODULE_GENERATE_WORN_OVERLAY,
 	COMSIG_ITEM_GET_WORN_OVERLAYS, COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_QDELETING,
-	COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))
+	COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
+
+/datum/component/hat_stabilizer/proc/on_equip(datum/source, mob/equipper, slot)
+	SIGNAL_HANDLER
+
+	if(!loose_hat)
+		return
+
+	var/obj/item/our_item = parent
+	if(!(slot & our_item.slot_flags))
+		return
+	RegisterSignals(equipper, list(COMSIG_MOB_SLIPPED, COMSIG_LIVING_SLAPPED, COMSIG_MOVABLE_POST_THROW), PROC_REF(throw_hat))
+	RegisterSignal(equipper, COMSIG_LIVING_THUD, PROC_REF(drop_hat))
+
+/datum/component/hat_stabilizer/proc/on_drop(datum/source, mob/dropper)
+	SIGNAL_HANDLER
+	UnregisterSignal(dropper, list(COMSIG_MOB_SLIPPED, COMSIG_LIVING_SLAPPED, COMSIG_MOVABLE_POST_THROW, COMSIG_LIVING_THUD))
+
+/datum/component/hat_stabilizer/proc/throw_hat(mob/hatless)
+	SIGNAL_HANDLER
+	var/obj/item/hat = remove_hat()
+	if(!hat)
+		return
+	hat.visible_message(span_danger("[hat] goes flying off [hatless]'s head!"))
+	hat.throw_at(get_edge_target_turf(get_turf(hat), pick(GLOB.alldirs)), 2, 1, spin = TRUE)
+
+/datum/component/hat_stabilizer/proc/drop_hat(mob/hatless)
+	SIGNAL_HANDLER
+	remove_hat()
 
 /datum/component/hat_stabilizer/proc/on_examine(datum/source, mob/user, list/base_examine)
 	SIGNAL_HANDLER
 	if(attached_hat)
-		base_examine += span_notice("There's \a [attached_hat] placed on [parent].")
+		base_examine += span_notice("There's \a [attached_hat] [loose_hat ? "loosely" : ""] placed on [parent].")
 	else
 		base_examine += span_notice("There's nothing placed on [parent]. Yet.")
 
@@ -49,16 +107,21 @@
 		return
 	if(attached_hat)
 		var/mutable_appearance/worn_overlay = attached_hat.build_worn_icon(default_layer = ABOVE_BODY_FRONT_HEAD_LAYER-0.1, default_icon_file = 'icons/mob/clothing/head/default.dmi')
+		// loose hats are slightly angled
+		if(loose_hat)
+			var/matrix/tilt_trix = matrix(worn_overlay.transform)
+			var/angle = rand(2, 6)
+			tilt_trix.Turn(prob(50) ? angle : (angle * -1))
+			worn_overlay.transform = tilt_trix
 		worn_overlay.pixel_y = pixel_y_offset + attached_hat.worn_y_offset
 		overlays += worn_overlay
 
 /datum/component/hat_stabilizer/proc/on_update_overlays(atom/movable/source, list/overlays)
 	SIGNAL_HANDLER
-	if (isnull(attached_hat))
-		return
-	var/mutable_appearance/worn_overlay = use_worn_icon ? attached_hat.build_worn_icon(default_layer = ABOVE_OBJ_LAYER, default_icon_file = 'icons/mob/clothing/head/default.dmi') : mutable_appearance(attached_hat, layer = ABOVE_OBJ_LAYER)
-	worn_overlay.pixel_y = pixel_y_offset
-	overlays += worn_overlay
+
+	icon_overlay = use_worn_icon ? attached_hat.build_worn_icon(default_layer = ABOVE_OBJ_LAYER, default_icon_file = 'icons/mob/clothing/head/default.dmi') : mutable_appearance(attached_hat, layer = ABOVE_OBJ_LAYER)
+	icon_overlay.pixel_y = pixel_y_offset
+	overlays += icon_overlay
 
 /datum/component/hat_stabilizer/proc/on_qdel(atom/movable/source)
 	SIGNAL_HANDLER
@@ -90,7 +153,7 @@
 /datum/component/hat_stabilizer/proc/attach_hat(obj/item/clothing/hat, mob/user)
 	var/atom/movable/movable_parent = parent
 	attached_hat = hat
-	RegisterSignal(hat, COMSIG_MOVABLE_MOVED, PROC_REF(remove_hat))
+	RegisterSignal(hat, COMSIG_MOVABLE_MOVED, PROC_REF(on_hat_movement))
 
 	if (!isnull(user))
 		movable_parent.balloon_alert(user, "hat attached")
@@ -111,6 +174,10 @@
 		var/mob/wearer = apparel.loc
 		wearer.update_clothing(wearer.get_slot_by_item(apparel))
 
+/datum/component/hat_stabilizer/proc/on_hat_movement(obj/hat, mob/user)
+	SIGNAL_HANDLER
+	remove_hat(user)
+
 /datum/component/hat_stabilizer/proc/on_secondary_attack_hand(datum/source, mob/user)
 	SIGNAL_HANDLER
 	. = COMPONENT_CANCEL_ATTACK_CHAIN
@@ -122,9 +189,9 @@
 	else
 		movable_parent.balloon_alert_to_viewers("the hat falls to the floor!")
 
-/datum/component/hat_stabilizer/proc/remove_hat(mob/user)
-	SIGNAL_HANDLER
+/datum/component/hat_stabilizer/proc/on_retraction()
 
+/datum/component/hat_stabilizer/proc/remove_hat(mob/user)
 	if(QDELETED(attached_hat))
 		return
 
@@ -144,15 +211,19 @@
 		movable_parent.update_appearance()
 		return
 
+	var/former_hat = attached_hat
 	var/obj/item/clothing/apparel = parent
 	apparel.detach_clothing_traits(attached_hat)
 	apparel.flags_cover = former_flags
 	apparel.visor_flags_cover = former_visor_flags
 	apparel.update_appearance()
+	apparel.update_icon()
 	attached_hat = null
 	if (ismob(apparel.loc))
 		var/mob/wearer = apparel.loc
 		wearer.update_clothing(wearer.get_slot_by_item(apparel))
+
+	return former_hat
 
 /datum/component/hat_stabilizer/proc/on_requesting_context_from_item(atom/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -37,7 +37,6 @@
 
 	// Overlays
 	RegisterSignals(source, list(COMSIG_MODULE_GENERATE_WORN_OVERLAY, COMSIG_ITEM_GET_WORN_OVERLAYS), PROC_REF(get_worn_overlays))
-	RegisterSignal(source, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
 
 	RegisterSignal(source, COMSIG_QDELETING, PROC_REF(on_qdel))
 

--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -110,7 +110,7 @@
 		// loose hats are slightly angled
 		if(loose_hat)
 			var/matrix/tilt_trix = matrix(worn_overlay.transform)
-			var/angle = rand(2, 6)
+			var/angle = 5
 			tilt_trix.Turn(angle * pick(1, -1))
 			worn_overlay.transform = tilt_trix
 		worn_overlay.pixel_y = pixel_y_offset + attached_hat.worn_y_offset

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1320,6 +1320,7 @@
 		step(src, hitting_atom.dir)
 	return ..()
 
+// Calls throw_at after checking that the move strength is greater than the thrown atom's move resist. Identical args.
 /atom/movable/proc/safe_throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, gentle = FALSE)
 	if((force < (move_resist * MOVE_FORCE_THROW_RATIO)) || (move_resist == INFINITY))
 		return

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -218,6 +218,7 @@
 
 /obj/item/hand_item/slapper/attack(mob/living/slapped, mob/living/carbon/human/user)
 	SEND_SIGNAL(user, COMSIG_LIVING_SLAP_MOB, slapped)
+	SEND_SIGNAL(slapped, COMSIG_LIVING_SLAPPED, user)
 
 	if(iscarbon(slapped))
 		var/mob/living/carbon/potential_tailed = slapped

--- a/code/modules/cargo/markets/market_items/misc.dm
+++ b/code/modules/cargo/markets/market_items/misc.dm
@@ -51,6 +51,33 @@
 	stock_max = 2
 	availability_prob = 30
 
+/datum/market_item/misc/atrocinator
+	name = "MOD Anti-Gravity Module"
+	desc = "We found this module in a maintenance tunnel, behind several warning cones and hazard signs, unlabeled. It's probably safe."
+	item = /obj/item/mod/module/atrocinator
+	price_min = CARGO_CRATE_VALUE * 4
+	price_max = CARGO_CRATE_VALUE * 7
+	stock_max = 1
+	availability_prob = 22
+
+/datum/market_item/misc/tanner
+	name = "MOD Tanning Module"
+	desc = "Ever wanted to be at the beach AND at work? Now you can with this snazzy tanning module!"
+	item = /obj/item/mod/module/tanner
+	price_min = CARGO_CRATE_VALUE * 2
+	price_max = CARGO_CRATE_VALUE * 3
+	stock_max = 2
+	availability_prob = 30
+
+/datum/market_item/misc/hat_stabilizer
+	name = "MOD Hat Stabilizer Module"
+	desc = "Don't sacrifice style for substance with this module! Hats not included."
+	item = /obj/item/mod/module/tanner
+	price_min = CARGO_CRATE_VALUE * 2
+	price_max = CARGO_CRATE_VALUE * 3
+	stock_max = 2
+	availability_prob = 35
+
 /datum/market_item/misc/shove_blocker
 	name = "MOD Bulwark Module"
 	desc = "You have no idea how much effort it took us to extract this module from that damn safeguard MODsuit last shift."

--- a/code/modules/clothing/head/perceptomatrix.dm
+++ b/code/modules/clothing/head/perceptomatrix.dm
@@ -66,6 +66,8 @@
 
 	update_appearance(UPDATE_ICON_STATE)
 	update_anomaly_state()
+	AddComponent(/datum/component/adjust_fishing_difficulty, -7) // PSYCHIC FISHING
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /obj/item/clothing/head/helmet/perceptomatrix/equipped(mob/living/user, slot)
 	. = ..()

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -36,6 +36,10 @@
 	. = ..()
 	if(fishing_modifier)
 		AddComponent(/datum/component/adjust_fishing_difficulty, fishing_modifier)
+	add_stabilizer()
+
+/obj/item/clothing/head/helmet/space/proc/add_stabilizer(loose_hat = TRUE)
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = loose_hat)
 
 /datum/armor/helmet_space
 	bio = 100

--- a/code/modules/clothing/spacesuits/pirate.dm
+++ b/code/modules/clothing/spacesuits/pirate.dm
@@ -39,6 +39,9 @@
 	desc = "A modified EVA helmet with a five-thousand credit Lizzy Vuitton hat affixed to the top, proving that working in deep space is no excuse for being poor."
 	icon_state = "spacetophat"
 
+/obj/item/clothing/head/helmet/space/pirate/tophat/add_stabilizer(loose_hat = FALSE)
+	return
+
 /obj/item/clothing/suit/space/pirate/silverscale
 	name = "designer pirate suit"
 	desc = "A specially-made Cybersun branded space suit; the fine plastisilk exterior is woven from the cocoons of black-market Lümlan mothroaches \

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -109,9 +109,11 @@
 /obj/item/clothing/head/helmet/space/plasmaman/Initialize(mapload)
 	. = ..()
 	visor_toggling()
-	AddComponent(/datum/component/hat_stabilizer)
 	update_appearance()
 	register_context()
+
+/obj/item/clothing/head/helmet/space/plasmaman/add_stabilizer(loose_hat = FALSE)
+	..()
 
 /obj/item/clothing/head/helmet/space/plasmaman/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	context[SCREENTIP_CONTEXT_ALT_LMB] = "Toggle Welding Screen"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -17,6 +17,7 @@
 	if(flags_inv & HIDEFACE)
 		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 6)
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /datum/armor/head_bio_hood
 	bio = 100

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -109,6 +109,7 @@
 	if(flags_inv & HIDEFACE)
 		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 8)
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /datum/armor/utility_bomb_hood
 	melee = 20
@@ -189,6 +190,7 @@
 	if(flags_inv & HIDEFACE)
 		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 7)
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /datum/armor/utility_radiation
 	bio = 60

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -244,10 +244,6 @@
 
 		paper_note.show_through_camera(usr)
 
-/mob/living/carbon/on_fall()
-	. = ..()
-	loc?.handle_fall(src)//it's loc so it doesn't call the mob's handle_fall which does nothing
-
 /mob/living/carbon/resist_buckle()
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED))
 		buckled.user_unbuckle_mob(src, src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1896,6 +1896,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /// Called when mob changes from a standing position into a prone while lacking the ability to stand up at the moment.
 /mob/living/proc/on_fall()
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(src, COMSIG_LIVING_THUD)
+	loc?.handle_fall(src)//it's loc so it doesn't call the mob's handle_fall which does nothing
 	return
 
 /mob/living/forceMove(atom/destination)

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -11,6 +11,11 @@
 	cold_protection = HEAD
 	item_flags = IMMUTABLE_SLOW
 
+// Even without a hat stabilizer, hats can be worn - however, they'll fall off very easily
+/obj/item/clothing/head/mod/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
+
 /obj/item/clothing/suit/mod
 	name = "MOD chestplate"
 	desc = "A chestplate for a MODsuit."

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -699,7 +699,8 @@
 	var/obj/item/clothing/helmet = mod.get_part_from_slot(ITEM_SLOT_HEAD)
 	if(!istype(helmet))
 		return
-	helmet.AddComponent(/datum/component/hat_stabilizer)
+	// Override pre-existing component
+	helmet.AddComponent(/datum/component/hat_stabilizer, loose_hat = FALSE)
 
 /obj/item/mod/module/hat_stabilizer/on_part_deactivation(deleting = FALSE)
 	if(deleting)
@@ -707,7 +708,8 @@
 	var/obj/item/clothing/helmet = mod.get_part_from_slot(ITEM_SLOT_HEAD)
 	if(!istype(helmet))
 		return
-	qdel(helmet.GetComponent(/datum/component/hat_stabilizer))
+	// Override again!
+	helmet.AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /obj/item/mod/module/hat_stabilizer/syndicate
 	name = "MOD elite hat stabilizer module"


### PR DESCRIPTION
## About The Pull Request

You can now wear a hat on any modsuit, even w/o the stabilizing module.

However:
- It will always sit slightly askew, at an angle.
- Involuntarily falling to the ground for any reason will cause the hat to fall to the ground.
- Being thrown, slapped, or slipped will send it flying off.

Added the Atrocinator, Hat Stabilizer, and Tanning modules to the black market.

Added the loose hat component to bio/bomb/rad hoods and space helmets.

## Why It's Good For The Game

> You can now wear a hat on any modsuit, even w/o the stabilizing module.

I think the notion of, say, the Head of Security putting his cap on his modsuit and then being slipped by the clown, who then steals the cap, is really funny.

https://github.com/user-attachments/assets/3ad8a74d-0cb8-4118-8beb-d2ce9c76b358

The module is fairly rare and sometimes I just want to wear a silly hat alongside the modsuit without badgering the captain for his hat module. The downsides are rather plentiful so it's not like the hat module is made irrelevant - if anything it makes it more notable.

This will add a bunch of enjoyable silliness to rounds, so I think it's worth it.

> Added the Atrocinator, Hat Stabilizer, and Tanning modules to the black market.

> Added the loose hat component to bio/bomb/rad hoods and space helmets.

It sucks losing your iconic drip when you need to venture out to space for whichever reason - this lets you keep it without taking up space in your bag, while having the throw downside.

They just feel perfect for the vibes of the black market. More miscellaneous completely useless fancy stuff that has exorbitant prices please!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now wear a hat on any modsuit, even w/o the stabilizing module. But it may easily fall off...
add: Added the Atrocinator, Hat Stabilizer, and Tanning modules to the black market.
add: Added the loose hat component to bio/bomb/rad hoods and space helmets.
/:cl:

~~I'm having a bit of an issue. Somewhere I fugged up and now the worn overlay on the mod helmet sprite doesn't work properly...~~ Turns out that code was never used and nonfunctional to begin with so I removed it entirely yay