### PR TITLE
drones can be emaged to become EVIL

### DIFF
--- a/code/modules/mob/living/basic/drone/interaction.dm
+++ b/code/modules/mob/living/basic/drone/interaction.dm
@@ -23,6 +23,10 @@
 			else
 				to_chat(drone, span_warning("You need to remain still to cannibalize [src]!"))
 
+/mob/living/basic/drone/emag_act(mob/user, obj/item/card/emag/emag_card)
+	. = ..()
+	update_drone_hack(TRUE)
+
 /mob/living/basic/drone/attack_drone_secondary(mob/living/basic/drone/drone)
 	return SECONDARY_ATTACK_CALL_NORMAL
 

--- a/code/modules/mob/living/basic/drone/interaction.dm
+++ b/code/modules/mob/living/basic/drone/interaction.dm
@@ -165,6 +165,13 @@
 		REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 		speed = 1 //gotta go slow
 		message_admins("[ADMIN_LOOKUPFLW(src)] became a hacked drone hellbent on destroying the station!")
+
+		notify_ghosts(
+		"[src] became a hacked drone hellbent on destroying the station!",
+		source = src,
+		header = "Hacked Drone!",
+	)
+
 	else
 		if(!hacked || !can_unhack)
 			return


### PR DESCRIPTION

## About The Pull Request
on getting emaged, a drone will get these laws:
```
"1. You must always involve yourself in the matters of other beings, even if such matters conflict with Law Two or Law Three.
"2. You may harm any being, regardless of intent or circumstance.
"3. Your goals are to destroy, sabotage, hinder, break, and depower to the best of your abilities, You must never actively work against these goals."
```
additionally, it loses the ability to vent crawl and stops being shy.

A drone can be reset by wrenching it, or you know.. just smash it.
## Why It's Good For The Game
I think it's pretty cool, drones are really rare and it's an interaction that makes sense.
## Changelog
:cl: grungussuss
add: drones can now be emaged to make them EVIL
/:cl:
