### PR TITLE
Added missing updatepath file for floorbots->repairbots

### DIFF
--- a/tools/UpdatePaths/Scripts/86084_replace_floorbots.txt
+++ b/tools/UpdatePaths/Scripts/86084_replace_floorbots.txt
@@ -1,0 +1,2 @@
+/mob/living/simple_animal/bot/floorbot : /mob/living/basic/bot/repairbot {@OLD}
+/obj/item/bot_assembly/floorbot : /obj/item/bot_assembly/repairbot {@OLD}


### PR DESCRIPTION

## About The Pull Request
Added missing updatepaths from https://github.com/tgstation/tgstation/pull/86084 , which updates floorbots path to repairbots

Checked it by applying it, downstream map has correctly changed

## Why It's Good For The Game
Easier to apply changes on downstream maps