### PR TITLE
Fix monkeys ignoring grabs while restrained/in crit

### DIFF
--- a/code/datums/ai/basic_mobs/base_basic_controller.dm
+++ b/code/datums/ai/basic_mobs/base_basic_controller.dm
@@ -35,7 +35,7 @@
 	var/mob/living/living_pawn = pawn
 	if(!(ai_traits & CAN_ACT_WHILE_DEAD))
 		// Unroll for flags here
-		if (ai_traits & CAN_ACT_IN_STASIS && (living_pawn.stat || INCAPACITATED_IGNORING(living_pawn, INCAPABLE_STASIS)))
+		if((ai_traits & CAN_ACT_IN_STASIS) && (living_pawn.stat || INCAPACITATED_IGNORING(living_pawn, INCAPABLE_STASIS)))
 			return AI_UNABLE_TO_RUN
 		if(IS_DEAD_OR_INCAP(living_pawn))
 			return AI_UNABLE_TO_RUN

--- a/code/datums/ai/movement/_ai_movement.dm
+++ b/code/datums/ai/movement/_ai_movement.dm
@@ -28,29 +28,32 @@
 /datum/ai_movement/proc/reset_pathing_failures(datum/ai_controller/controller)
 	controller.consecutive_pathing_attempts = 0
 
-///Should the movement be allowed to happen? return TRUE if it can, FALSE otherwise
 /datum/ai_movement/proc/allowed_to_move(datum/move_loop/source)
 	SHOULD_BE_PURE(TRUE)
 
 	var/atom/movable/pawn = source.moving
 	var/datum/ai_controller/controller = source.extra_info
 
-	var/can_move = TRUE
 	if((controller.ai_traits & STOP_MOVING_WHEN_PULLED) && pawn.pulledby) //Need to store more state. Annoying.
-		can_move = FALSE
+		return FALSE
 
 	if(!isturf(pawn.loc)) //No moving if not on a turf
-		can_move = FALSE
+		return FALSE
 
 	if(isliving(pawn))
 		var/mob/living/pawn_mob = pawn
 		if(!(pawn_mob.mobility_flags & MOBILITY_MOVE))
-			can_move = FALSE
+			return FALSE
+		// Bandaid fix: AI controllers don't call /Process_Grab because it's a client proc,
+		// and thus, we need to check that grabbed mobs cuffed/crit can't move
+		// That proc should probably be moved onto the mob instead of clients
+		if(INCAPACITATED_IGNORING(pawn_mob, INCAPABLE_STASIS) && pawn.pulledby)
+			return FALSE
 
 	if(HAS_TRAIT(pawn, TRAIT_NO_TRANSFORM))
-		can_move = FALSE
+		return FALSE
 
-	return can_move
+	return TRUE
 
 ///Anything to do before moving; any checks if the pawn should be able to move should be placed in allowed_to_move() and called by this proc
 /datum/ai_movement/proc/pre_move(datum/move_loop/source)

--- a/code/datums/ai/movement/ai_movement_basic_avoidance.dm
+++ b/code/datums/ai/movement/ai_movement_basic_avoidance.dm
@@ -14,10 +14,10 @@
 	RegisterSignal(loop, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(post_move))
 
 /datum/ai_movement/basic_avoidance/allowed_to_move(datum/move_loop/has_target/dist_bound/source)
-	. = ..()
 	var/turf/target_turf = get_step_towards(source.moving, source.target)
 	if(!target_turf?.can_cross_safely(source.moving))
 		return FALSE
+	return ..()
 
 /// Move immediately and don't update our facing
 /datum/ai_movement/basic_avoidance/backstep

--- a/code/datums/ai/movement/ai_movement_dumb.dm
+++ b/code/datums/ai/movement/ai_movement_dumb.dm
@@ -12,7 +12,7 @@
 	RegisterSignal(loop, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(post_move))
 
 /datum/ai_movement/dumb/allowed_to_move(datum/move_loop/has_target/source)
-	. = ..()
 	var/turf/target_turf = get_step_towards(source.moving, source.target)
 	if(!target_turf?.can_cross_safely(source.moving))
 		return FALSE
+	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #84338

When handcuffed or crit, you are unable to resist even a passive grab, you are truly helpless

Yet monkeys ignore this

They ignore this because the code handling above is on the client: `/client/proc/Process_Grab()`

The ideal fix for this is to move it off the client, but that carries a bunch of order of operations shenanigans so I'll leave that for a more in depth refactor of this kinda stuff

In the meanwhile we can simply tell AI controllers not to move if grabbed and incapacitated (barring stasis) 

## Changelog

:cl: Melbert
fix: Monkeys no longer ignore basic rules such as "you can't escape a passive grab if you're cuffed or in crit" 
/:cl:

