### PR TITLE
Nuclear Operative Uplink Maintenance; improved descriptions and making sure the Core Equipment is priced correctly

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -52,7 +52,8 @@
 		Note: This bundle is not at a discount. You can purchase all of these items separately. You do not NEED these items, but most operatives fail WITHOUT at \
 		least SOME of these items. More experienced operatives can do without."
 	item = /obj/item/storage/box/syndie_kit/core_gear
-	cost = 22 //freedom 5, doormag 3, c-4 1, stimpack 5, shield modsuit module 8
+	//The cost for the core kit is always equivalent to the combined costs of the included items
+	cost = (/datum/uplink_item/device_tools/doorjack::cost + /datum/uplink_item/implants/freedom::cost + /datum/uplink_item/explosives/c4::cost + /datum/uplink_item/device_tools/stimpack::cost +	/datum/uplink_item/suits/energy_shield::cost)
 	limited_stock = 1
 	cant_discount = TRUE
 	purchasable_from = UPLINK_SERIOUS_OPS
@@ -178,7 +179,7 @@
 
 /datum/uplink_item/weapon_kits/medium_cost/sword_and_board
 	name = "Energy Shield and Sword Case (Very Hard)"
-	desc = "A case containing an energy sword and energy shield. Paired together, it provides considerable defensive power without lethal potency. \
+	desc = "A case containing an energy sword and energy shield. Paired together, it provides considerable defensive power without compromising lethal potency. \
 		Perfect for the enterprising nuclear knight. Comes with a medieval helmet for your MODsuit!"
 	item = /obj/item/storage/toolbox/guncase/sword_and_board
 
@@ -195,13 +196,13 @@
 /datum/uplink_item/weapon_kits/medium_cost/revolvercase
 	name = "Syndicate Revolver Case (Moderate)"
 	desc = "Waffle Corp's modernized Syndicate revolver. Fires 7 brutal rounds of .357 Magnum. \
-		A classic operative weapon, brought to the modern era. Comes with 3 additional speedloaders of .357."
+		A classic operative weapon, improved for the modern era. Comes with 3 additional speedloaders of .357."
 	item = /obj/item/storage/toolbox/guncase/revolver
 
 /datum/uplink_item/ammo_nuclear/basic/revolver
 	name = ".357 Speed Loader (Revolver)"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \
-		For when you really need a lot of things dead. Operatives get a discount from most of our agents!"
+		For when you really need a lot of things dead. Unlike field agents, operates get a premium price for their speedloaders!"
 	item = /obj/item/ammo_box/a357
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
 
@@ -228,7 +229,7 @@
 /datum/uplink_item/weapon_kits/medium_cost/rawketlawnchair
 	name = "Dardo-RE Rocket Propelled Grenade Launcher (Hard)"
 	desc = "A reusable rocket propelled grenade launcher preloaded with a low-yield 84mm HE round. \
-		Guaranteed to send your target out with a bang or your money back! Comes with a bouquet of additional rockets!"
+		Guaranteed to take your target out with a bang, or your money back! Comes with a bouquet of additional rockets!"
 	item = /obj/item/storage/toolbox/guncase/rocketlauncher
 
 /datum/uplink_item/ammo_nuclear/basic/rocket
@@ -291,8 +292,8 @@
 
 /datum/uplink_item/weapon_kits/high_cost/carbine
 	name = "M-90gl Carbine Case (Hard)"
-	desc = "A fully-loaded, specialized three-round burst carbine that fires .223 ammunition from a 30 round magazine \
-		with a 40mm underbarrel grenade launcher. Use secondary-fire to fire the grenade launcher. Comes with two spare magazines \
+	desc = "A fully-loaded, specialized three-round burst carbine that fires .223 ammunition from a 30 round magazine.\
+		Comes with a 40mm underbarrel grenade launcher. Use secondary-fire to fire the grenade launcher. Also comes with two spare magazines \
 		and a box of 40mm rubber slugs."
 	item = /obj/item/storage/toolbox/guncase/m90gl
 
@@ -320,7 +321,7 @@
 
 /datum/uplink_item/weapon_kits/high_cost/sniper
 	name = "Anti-Materiel Sniper Rifle Briefcase (Hard)"
-	desc = "An outdated, but still extremely powerful anti-material sniper rifle. Fires .50 BMG cartridges from a 6 round magazine. \
+	desc = "An outdated, but still extremely powerful anti-materiel sniper rifle. Fires .50 BMG cartridges from a 6 round magazine. \
 		Can be fitted with a suppressor. If anyone asks how that even works, tell them it's Nanotrasen's fault. Comes with \
 		3 spare magazines; 2 regular magazines and 1 disruptor magazine. Also comes with a suit and tie."
 	item = /obj/item/storage/briefcase/sniper
@@ -374,9 +375,11 @@
 
 /datum/uplink_item/weapon_kits/surplus_smg
 	name = "Surplus Smart-SMG (Flukie)"
-	desc = "An outdated smart-SMG with limited stopping power, however it's bullets will gradually track towards whatever \
-		the gun was shot at. This does require you to actually aim at the person you are shooting at before firing, but \
-		surely a highly trained operative such as yourself can manage that."
+	desc = "A failed experimental 'smart gun'. The use of .160 rocket propelled projectiles resulted in reduced stopping power \
+		but increased overally accuracy so long as the shooter vaguely aimed towards their target. The relative increase in \
+		operator effort from absurd recoil contradicted advertized advantages, resulting in poor market performance. However, \
+		there sure are a lots still lying around in poorly secured warehouses. So we took them. And now you can have them. \
+		If you REALLY want it. All I'm saying is: good luck."
 	item = /obj/item/gun/ballistic/automatic/smartgun
 	cost = 2
 	purchasable_from = UPLINK_SERIOUS_OPS

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -202,7 +202,7 @@
 /datum/uplink_item/ammo_nuclear/basic/revolver
 	name = ".357 Speed Loader (Revolver)"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \
-		For when you really need a lot of things dead. Unlike field agents, operates get a premium price for their speedloaders!"
+		For when you really need a lot of things dead. Unlike field agents, operatives get a premium price for their speedloaders!"
 	item = /obj/item/ammo_box/a357
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
 


### PR DESCRIPTION

## About The Pull Request

The Core equipment for nuclear operatives will always use the combined value of the included items, drawing the cost value straight from their uplink entries.

Some descriptions have had spelling and grammar passes, as well as improved wording to make a bit more sense.

## Why It's Good For The Game

This is useful for future proofing the cost of the Core Equipment, which is always meant to be at the equivalent cost of contained items.

There was some writing that needed a pass over in the descriptions. Most of this is my fault, probably.

## Changelog
:cl:
code: The cost for Core Equipment for nuclear operatives will always be equal to the cost of the contained items if purchased directly from the uplink.
fix: Improves the descriptions for some uplink entries.
/:cl:
