### PR TITLE
Puts EMP protection and resistance flags into their correct spots for the broadcasting camera

### DIFF
--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -13,7 +13,7 @@
 	force = 8
 	throwforce = 12
 	w_class = WEIGHT_CLASS_NORMAL
-	obj_flags = INDESTRUCTIBLE | EMP_PROTECT_ALL // No fun police
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	slot_flags = NONE
 	light_system = OVERLAY_LIGHT
 	light_color = COLOR_SOFT_RED
@@ -32,6 +32,11 @@
 	var/obj/machinery/camera/internal_camera
 	/// The "virtual" radio inside of the the physical camera, a la microphone
 	var/obj/item/radio/entertainment/microphone/internal_radio
+
+/obj/item/broadcast_cameraInitialize(mapload)
+	. = ..()
+
+	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
 
 /obj/item/broadcast_camera/Destroy(force)
 	QDEL_NULL(internal_radio)

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -33,7 +33,7 @@
 	/// The "virtual" radio inside of the the physical camera, a la microphone
 	var/obj/item/radio/entertainment/microphone/internal_radio
 
-/obj/item/broadcast_cameraInitialize(mapload)
+/obj/item/broadcast_camera/Initialize(mapload)
 	. = ..()
 
 	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)


### PR DESCRIPTION

## About The Pull Request

Currently, the broadcasting camera has incorrectly placed flags for resistance and EMP protection, which were improperly placed into ``obj_flags``, causing bugs. This resolves that. Also includes some additional flags in the ``resistance_flag``var that are often shared by other objects with the INDESTRUCTIBLE flag for sanity reasons. (alternatively, resistance flags are mildly nonsensical sometimes)

closes https://github.com/tgstation/tgstation/issues/88037

## Why It's Good For The Game

Why IS this thing so babyproofed anyway? Whatever, this thing is acting WEIRD so let's resolve that.

## Changelog
:cl:
fix: Correctly applies resistance and EMP proofing to the broadcasting camera so that it doesn't cause weird things to happen.
/:cl:
