### PR TITLE
Bleaches the cargo cap in loadout

### DIFF
--- a/code/modules/loadout/categories/heads.dm
+++ b/code/modules/loadout/categories/heads.dm
@@ -66,7 +66,7 @@
 
 /datum/loadout_item/head/white_cap
 	name = "Cap (White)"
-	item_path = /obj/item/clothing/head/soft
+	item_path = /obj/item/clothing/head/soft/mime
 
 /datum/loadout_item/head/yellow_cap
 	name = "Cap (Yellow)"
@@ -147,7 +147,7 @@
 /datum/loadout_item/head/geranium
 	name = "Geranium"
 	item_path = /obj/item/food/grown/poppy/geranium
-	
+
 /datum/loadout_item/head/harebell
 	name = "Harebell"
 	item_path = /obj/item/food/grown/harebell


### PR DESCRIPTION

## About The Pull Request
So the white cap in loadout isn't very white. In fact it's a cargo cap. 
![image](https://github.com/user-attachments/assets/d80e9270-08ec-42a2-9931-39dc3e55aa08)
![image](https://github.com/user-attachments/assets/732118d3-97df-4e18-b042-5ab55f12e29b)
Now it's a white cap.
Speaking of loadout someone should add thin prescription glasses to it. Not me though I'm starving for gbp...
## Why It's Good For The Game
The loadout shouldn't lie.
## Changelog
:cl:
fix: Turns Cap (White) into a white cap in loadout
/:cl:
