### PR TITLE
Buff spacer by reducing it's cost

### DIFF
--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -9,7 +9,7 @@
 	gain_text = span_notice("You feel at home in space.")
 	lose_text = span_danger("You feel homesick.")
 	icon = FA_ICON_USER_ASTRONAUT
-	value = 7
+	value = 5
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 	medical_record_text = "Patient is well-adapted to non-terrestrial environments."
 	mail_goodies = list(


### PR DESCRIPTION

## About The Pull Request

Reduced cost of "Spacer" quirk by 2 points
## Why It's Good For The Game

Spacer is a quirk with many downsides built in, but it's cost is on par with strong perks that have no negatives.

 20% less damage from space and faster movement is debatably worth built in depression while on Icebox or playing Shaft Miner, but it's cost makes using it really restrictive for the flavor and gameplay benefits it offers
## Changelog
:cl:
tweak: Reduce Spacers cost from 7 to 5
/:cl:
