### PR TITLE
Nerfs fish infusion slipperiness and make them slightly more susceptible to fire and heat.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -378,6 +378,8 @@
 #define SLIPPERY_TURF (1<<5)
 /// For mobs who are slippery, this requires the mob holding it to be lying down.
 #define SLIPPERY_WHEN_LYING_DOWN (1<<6)
+///Like sliding, but it's short, it doesn't knockdown, it doesn't stun, it just staggers a bit.
+#define WEAK_SLIDE (1<<7)
 
 #define MAX_CHICKENS 50
 

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -325,7 +325,7 @@
 
 /datum/status_effect/fire_handler/wet_stacks/proc/become_slippery()
 	SIGNAL_HANDLER
-	slipperiness = owner.AddComponent(/datum/component/slippery, 5 SECONDS, lube_flags = SLIPPERY_WHEN_LYING_DOWN)
+	slipperiness = owner.AddComponent(/datum/component/slippery, 5 SECONDS, lube_flags = SLIPPERY_WHEN_LYING_DOWN|NO_SLIP_WHEN_WALKING|WEAK_SLIDE)
 	ADD_TRAIT(owner, TRAIT_NO_SLIP_WATER, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/fire_handler/wet_stacks/proc/no_longer_slippery()

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -8,8 +8,8 @@
 	id = "organ_set_bonus_fish"
 	tick_interval = 1 SECONDS
 	organs_needed = 3
-	bonus_activate_text = span_notice("Fish DNA is deeply infused with you! While wet, you crawl faster, are slippery, and cannot slip, and it takes longer to dry out. \
-		You're also more resistant to high pressure, better at fishing, but less resilient when dry, especially against burns.")
+	bonus_activate_text = span_notice("Fish DNA is deeply infused with you! While wet, you crawl faster, are slippery, cannot slip, and it takes longer to dry out. \
+		You're also resistant to high pressure, better at fishing, but less resilient when dry, especially against burns.")
 	bonus_deactivate_text = span_notice("You no longer feel as fishy. The moisture around your body begins to dissipate faster...")
 	bonus_traits = list(
 		TRAIT_RESISTHIGHPRESSURE,
@@ -34,6 +34,9 @@
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human = owner
+		//Fish is slightly weaker to being cooked. oh oh.
+		human.physiology.burn_mod *= 1.15
+		human.physiology.heat_mod *= 1.15
 		human.physiology.damage_resistance += 8 //base 8% damage resistance, much wow.
 	if(!HAS_TRAIT(owner, TRAIT_IS_WET))
 		apply_debuff()
@@ -61,6 +64,8 @@
 	owner.clear_mood_event("fish_organs_bonus")
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human = owner
+		human.physiology.burn_mod /= 1.15
+		human.physiology.heat_mod /= 1.15
 		human.physiology.damage_resistance -= 8
 	if(HAS_TRAIT(owner, TRAIT_IS_WET) && istype(owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL), /obj/item/organ/tail/fish))
 		remove_speed_buff()

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -354,13 +354,15 @@
 	if(lube & SLIDE_ICE)
 		// Ice slides only go 1 tile, this is so you will slip across ice until you reach a non-slip tile
 		slide_distance = 1
-	else if(HAS_TRAIT(slipper, TRAIT_CURSED))
+	else if(HAS_TRAIT(slipper, TRAIT_CURSED) && !(lube & WEAK_SLIDE))
 		// When cursed, all slips send you flying
 		lube |= SLIDE
 		slide_distance = rand(5, 9)
 	else if(HAS_TRAIT(slipper, TRAIT_NO_SLIP_SLIDE))
 		// Stops sliding
 		slide_distance = 0
+	else if(lube & WEAK_SLIDE)
+		slide_distance = rand(1, 2)
 
 	var/obj/buckled_obj
 	if(slipper.buckled)
@@ -390,10 +392,12 @@
 		// They need to be kept upright to maintain the combo effect (So don't knockdown)
 		slipper.Immobilize(1 SECONDS)
 		slipper.incapacitate(1 SECONDS)
+	else if(lube & WEAK_SLIDE)
+		slipper.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
+		slipper.stop_pulling()
 	else
 		slipper.Knockdown(knockdown_amount)
 		slipper.Paralyze(paralyze_amount)
-		slipper.stop_pulling()
 
 	if(buckled_obj)
 		buckled_obj.unbuckle_mob(slipper)
@@ -403,7 +407,7 @@
 
 	if(slide_distance)
 		var/turf/target = get_ranged_target_turf(slipper, olddir, slide_distance)
-		if(lube & SLIDE)
+		if(lube & (SLIDE|WEAK_SLIDE))
 			slipper.AddComponent(/datum/component/force_move, target, TRUE)
 		else if(lube & SLIDE_ICE)
 			slipper.AddComponent(/datum/component/force_move, target, FALSE)//spinning would be bad for ice, fucks up the next dir

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -36,6 +36,13 @@
 	icon_state = "lava"
 	temperature = 100 // Raise the body temp by 100 points
 
+/obj/projectile/temp/hot/on_hit(atom/target, blocked = FALSE, pierce_hit)
+	. = ..()
+
+	if(isliving(target))
+		var/mob/living/living_target = target
+		living_target.adjust_wet_stacks(-10)
+
 /obj/projectile/temp/cryo
 	name = "cryo beam"
 	range = 9


### PR DESCRIPTION
## About The Pull Request
The fish infusion is good, perhaps a bit too good, and that's mostly fine, because if a feature is bad it will often go ignored, accomplishing little to nothing as a result, though I reckon the slipperiness to be a tad annoying and obstructive, especially outside combat situations, so I've made it so fish infusion slips don't stun nor knockdown, but slide the user one or two tiles ahead while staggering them instead. They can also be avoided by walking, though that's of little relevance during chases.

Plus there's a general lack of drawbacks aside the need of water, which is available in abundance, but I don't want to over-nerf it so I just limited myself to give fish infusion a slight weakness to heat/fire, which, taking into consideration the damage resistance the infusion gives when the owner is properly wet, is very mild.

On a sidenote, I've made hot temperature projectiles from the temperature gun dry mobs hit by it. The change is so small I couldn't bother making its own PR, plus it fits in.

## Why It's Good For The Game
Fish infusion is good and that's fine to me but the slipperiness should be nerfed a little.

## Changelog

:cl:
balance: Nerfed slipperiness from fish infusion. It no longer knockdowns but it staggers and slides the user one or two tiles away.
balance: Added a slight natural weakness to fire/heat to the fish infusion, which, taking the minor general damage resistance resistance when wet, is pretty mild.
balance: hot temperature projectiles from the temperature gun (and watchers I think) also dry living creatures hit by them.
/:cl:
