### PR TITLE
Hotfix: Tgui panel light mode [No gbp]

### DIFF
--- a/tgui/packages/tgui-panel/styles/themes/light.scss
+++ b/tgui/packages/tgui-panel/styles/themes/light.scss
@@ -21,7 +21,6 @@
 @use '~tgui/styles/base.scss' with (
   $color-fg: hsl(0, 0%, 0%),
   $color-bg: hsl(0, 0%, 93.3%),
-  $color-bg-section: hsl(0, 0%, 100%),
   $color-bg-grad-spread: 0%
 );
 
@@ -41,7 +40,11 @@
       'tab-color-hovered': rgba(0, 0, 0, 0.075)
     )
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css(
+    'pkg:tgui-styles/components/Section',
+    $with: ('background-color': hsl(0, 0%, 100%))
+  );
+
   @include meta.load-css(
     'pkg:tgui-styles/components/Button',
     $with: (


### PR DESCRIPTION

## About The Pull Request
Makes light mode light again. There is some weirdness going on with imports that I must troubleshoot longer. This will work in the meantime 
## Why It's Good For The Game
it brite
![image](https://github.com/user-attachments/assets/9f1fa64f-1d9f-4aa8-8cff-9a8b16e191b0)
## Changelog
:cl:
fix: TGUI panel light mode should no longer be gross gray
/:cl:
