### PR TITLE
Implements final type filtering for spawn commands

### DIFF
--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -128,11 +128,32 @@
 	if(endcheck.len > 1)
 		filter = endcheck[1]
 		end_len = length_char(filter)
+	var/endtype = (filter[length(filter)] == "*")
+	if (endtype)
+		filter = splittext(filter, "*")[1]
 
 	for(var/key in L)
 		var/value = L[key]
-		if(findtext("[key]", filter, -end_len) || findtext("[value]", filter, -end_len))
-			matches[key] = value
+		if (findtext("[key]", filter, -end_len))
+			if (endtype)
+				var/list/split_filter = splittext("[key]", filter)
+				if (!findtext(split_filter[length(split_filter)], "/"))
+					matches[key] = value
+					continue
+			else
+				matches[key] = value
+				continue
+
+		if (findtext("[value]", filter, -end_len))
+			if (endtype)
+				var/list/split_filter = splittext("[value]", filter)
+				if (!findtext(split_filter[length(split_filter)], "/"))
+					matches[key] = value
+					continue
+			else
+				matches[key] = value
+				continue
+
 	return matches
 
 /proc/return_typenames(type)

--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -147,12 +147,9 @@
 		if (findtext("[value]", filter, -end_len))
 			if (endtype)
 				var/list/split_filter = splittext("[value]", filter)
-				if (!findtext(split_filter[length(split_filter)], "/"))
-					matches[key] = value
+				if (findtext(split_filter[length(split_filter)], "/"))
 					continue
-			else
-				matches[key] = value
-				continue
+			matches[key] = value
 
 	return matches
 


### PR DESCRIPTION

## About The Pull Request

Putting ``*`` at the end of a spawn type string will tell the command to not offer subtypes of that string. For example, running ``laser/cap`` offers you two types: ``GUN_LASER/captain`` and ``GUN_LASER/captain/scattershot``. Adding a start to the end like ``laser/cap*`` would only offer ``GUN_LASER/captain`` without the scattershot subtype, and instantly spawn it without an input window because its the only fitting type.

## Why It's Good For The Game
Easier to spawn certain types without having subtypes offered to you

## Changelog
:cl:
admin: Implemented final type filtering for spawn commands - putting * at the end of a spawn string will signify that there should be no subtypes offered!
/:cl:
