### PR TITLE
Removes some duplicate crossbow defines

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -56,10 +56,6 @@
 #define CALIBER_HARPOON "harpoon"
 /// The caliber used by the rebar crossbow.
 #define CALIBER_REBAR "sharpened rod"
-/// The caliber used by the rebar crossbow when forced to hold 2 rods.
-#define CALIBER_REBAR_FORCED "sharpened rod"
-/// The caliber used by the syndicate rebar crossbow.
-#define CALIBER_REBAR_SYNDIE "sharpened rod"
 /// The caliber used by the meat hook.
 #define CALIBER_HOOK "hook"
 /// The caliber used by the changeling tentacle mutation.

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -54,11 +54,9 @@
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/force
 	name = "two round magazine"
 	max_ammo = 2
-	caliber = CALIBER_REBAR_FORCED
 	ammo_type = /obj/item/ammo_casing/rebar
 
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
 	max_ammo = 3
-	caliber = CALIBER_REBAR_SYNDIE
 	ammo_type = /obj/item/ammo_casing/rebar/syndie
 

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -54,9 +54,11 @@
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/force
 	name = "two round magazine"
 	max_ammo = 2
+	caliber = CALIBER_REBAR
 	ammo_type = /obj/item/ammo_casing/rebar
 
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
 	max_ammo = 3
+	caliber = CALIBER_REBAR
 	ammo_type = /obj/item/ammo_casing/rebar/syndie
 


### PR DESCRIPTION

## About The Pull Request

Removes some duplicate defines for crossbow ammunition.
Fixes #88046 

## Why It's Good For The Game

Unnecessary confusion between defines that do the same thing is bad

## Changelog
Not player facing
