### PR TITLE
Fixes ink spit not respecting its cooldown.

### DIFF
--- a/code/game/machinery/dna_infuser/infuser_actions.dm
+++ b/code/game/machinery/dna_infuser/infuser_actions.dm
@@ -41,6 +41,8 @@
 	if(!LAZYACCESS(params2list(params), RIGHT_CLICK))
 		return
 	. = ..()
+	if(!.)
+		return
 
 	var/modifiers = params2list(params)
 	caller.visible_message(


### PR DESCRIPTION
## About The Pull Request
It isn't meant to be spammable while wearing a gas mask or incapacitated.

## Why It's Good For The Game
Closes #88027.

## Changelog

:cl:
fix: Fixes ink spit not respecting its 21 seconds cooldown.
/:cl:
