### PR TITLE
Fixes a runtime in cranial fissure remove code

### DIFF
--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -52,7 +52,7 @@
 
 /datum/wound/cranial_fissure/remove_wound(ignore_limb, replaced)
 	REMOVE_TRAIT(limb, TRAIT_IMMUNE_TO_CRANIAL_FISSURE, type)
-	if (!QDELETED(victim))
+	if (!isnull(victim))
 		REMOVE_TRAIT(victim, TRAIT_HAS_CRANIAL_FISSURE, type)
 		victim.remove_filter(CRANIAL_FISSURE_FILTER_DISPLACEMENT)
 		UnregisterSignal(victim, COMSIG_MOB_SLIPPED)

--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -52,12 +52,10 @@
 
 /datum/wound/cranial_fissure/remove_wound(ignore_limb, replaced)
 	REMOVE_TRAIT(limb, TRAIT_IMMUNE_TO_CRANIAL_FISSURE, type)
-	REMOVE_TRAIT(victim, TRAIT_HAS_CRANIAL_FISSURE, type)
-
-	victim.remove_filter(CRANIAL_FISSURE_FILTER_DISPLACEMENT)
-
-	UnregisterSignal(victim, COMSIG_MOB_SLIPPED)
-
+	if (!QDELETED(victim))
+		REMOVE_TRAIT(victim, TRAIT_HAS_CRANIAL_FISSURE, type)
+		victim.remove_filter(CRANIAL_FISSURE_FILTER_DISPLACEMENT)
+		UnregisterSignal(victim, COMSIG_MOB_SLIPPED)
 	return ..()
 
 /datum/wound/cranial_fissure/proc/on_owner_slipped(mob/source)


### PR DESCRIPTION

## About The Pull Request

This can be called after victim gets qdeleted from bodypart cleanup, runtimes here prevent wound from cleaning itself up which in return prevents the bodypart from deleting properly.

## Changelog
:cl:
fix: Fixed a runtime in cranial fissure remove code
/:cl:
