### PR TITLE
[NO GBP] Armor now decreases the chances of getting your eye blown out by a rogue bullet

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -109,9 +109,13 @@
 	SIGNAL_HANDLER
 
 	// Once-a-dozen-rounds level of rare
-	var/blocked = source.check_projectile_armor(def_zone, proj, is_silent = TRUE)
-	if (def_zone != BODY_ZONE_HEAD || !prob(proj.damage * (100 - blocked) * 0.001) || !(proj.damage_type == BRUTE || proj.damage_type == BURN))
+	if (def_zone != BODY_ZONE_HEAD || !prob(proj.damage * 0.1) || !(proj.damage_type == BRUTE || proj.damage_type == BURN))
 		return
+
+	var/blocked = source.check_projectile_armor(def_zone, proj, is_silent = TRUE)
+	if (blocked)
+		if (!proj.armour_penetration || prob(blocked - proj.armour_penetration))
+			return
 
 	var/valid_sides = list()
 	if (!(scarring & RIGHT_EYE_SCAR))

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -105,11 +105,12 @@
 	organ_owner.update_sight()
 	UnregisterSignal(organ_owner, COMSIG_ATOM_BULLET_ACT)
 
-/obj/item/organ/eyes/proc/on_bullet_act(datum/source, obj/projectile/proj, def_zone)
+/obj/item/organ/eyes/proc/on_bullet_act(mob/living/carbon/source, obj/projectile/proj, def_zone)
 	SIGNAL_HANDLER
 
 	// Once-a-dozen-rounds level of rare
-	if (def_zone != BODY_ZONE_HEAD || !prob(proj.damage * 0.1) || !(proj.damage_type == BRUTE || proj.damage_type == BURN))
+	var/blocked = source.check_projectile_armor(def_zone, proj, is_silent = TRUE)
+	if (def_zone != BODY_ZONE_HEAD || !prob(proj.damage * (100 - blocked) * 0.001) || !(proj.damage_type == BRUTE || proj.damage_type == BURN))
 		return
 
 	var/valid_sides = list()

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -113,7 +113,7 @@
 		return
 
 	var/blocked = source.check_projectile_armor(def_zone, proj, is_silent = TRUE)
-	if (blocked)
+	if (blocked && source.is_eyes_covered())
 		if (!proj.armour_penetration || prob(blocked - proj.armour_penetration))
 			return
 


### PR DESCRIPTION

## About The Pull Request
Chance of getting an eye wound from being hit by a projectile now scales inversely with your head armor. Meant to do this originally but forgot, so here we go.

## Why It's Good For The Game
You'd expect that a bulletproof helmet will prevent your eyes from being popped like balloons, especially if you don't take any damage from the hit.

## Changelog
:cl:
balance: Armor now decreases the chances of getting your eye blown out by a rogue bullet
/:cl:
