### PR TITLE
Labor shuttle no longer takes off with more than one prisoner inside 

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_shuttle.dm
+++ b/code/__DEFINES/dcs/signals/signals_shuttle.dm
@@ -1,0 +1,7 @@
+// Shuttle signals. this file is empty because shuttle code is ancient, feel free to
+// add more signals where its appropriate to have them
+
+/// Called when the shuttle tries to move. Do not return anything to continue with default behaviour (always allow) : ()
+#define COMSIG_SHUTTLE_SHOULD_MOVE "shuttle_should_move"
+	/// Return this when the shuttle move should be blocked.
+	#define BLOCK_SHUTTLE_MOVE (1<<0)

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -12,15 +12,29 @@
 	var/obj/machinery/mineral/stacking_machine/laborstacker/stacking_machine
 	/// Needed to send messages to sec radio
 	var/obj/item/radio/security_radio
+	/// Whether the claim console initiated the launch.
+	var/initiated_launch = FALSE
+	/// Cooldown for console says.
+	COOLDOWN_DECLARE(say_cooldown)
 
 /obj/machinery/mineral/labor_claim_console/Initialize(mapload)
 	. = ..()
 	security_radio = new /obj/item/radio(src)
 	security_radio.set_listening(FALSE)
 	locate_stacking_machine()
+	if(!SSshuttle.initialized)
+		RegisterSignal(SSshuttle, COMSIG_SUBSYSTEM_POST_INITIALIZE, PROC_REF(register_shuttle_signal))
+	else
+		register_shuttle_signal()
 	//If we can't find a stacking machine end it all ok?
 	if(!stacking_machine)
 		return INITIALIZE_HINT_QDEL
+
+/obj/machinery/mineral/labor_claim_console/proc/register_shuttle_signal()
+	SIGNAL_HANDLER
+	var/obj/docking_port/mobile/laborshuttle = SSshuttle.getShuttle("laborcamp")
+	RegisterSignal(laborshuttle, COMSIG_SHUTTLE_SHOULD_MOVE, PROC_REF(on_laborshuttle_can_move))
+	UnregisterSignal(SSshuttle, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 
 /obj/machinery/mineral/labor_claim_console/Destroy()
 	QDEL_NULL(security_radio)
@@ -86,23 +100,34 @@
 				var/obj/item/card/id/advanced/prisoner/worn_prisoner_id = worn_id
 				worn_prisoner_id.points += stacking_machine.points
 				stacking_machine.points = 0
-				to_chat(user_mob, span_notice("Points transferred."))
+				say("Points transferred.")
 				return TRUE
 			else
-				to_chat(user_mob, span_alert("No valid id for point transfer detected."))
+				if(COOLDOWN_FINISHED(src, say_cooldown))
+					say("No valid id for point transfer detected.")
+					COOLDOWN_START(src, say_cooldown, 2 SECONDS)
 
 		if("move_shuttle")
-			if(!alone_in_area(get_area(src), user_mob))
-				to_chat(user_mob, span_alert("Prisoners are only allowed to be released while alone."))
+			var/list/labor_shuttle_mobs = find_labor_shuttle_mobs()
+			if(length(labor_shuttle_mobs) > 1 || labor_shuttle_mobs[1] != user_mob)
+				if(COOLDOWN_FINISHED(src, say_cooldown))
+					say("Prisoners may only be released one at a time.")
+					COOLDOWN_START(src, say_cooldown, 2 SECONDS)
 				return
 
 			switch(SSshuttle.moveShuttle("laborcamp", "laborcamp_home", TRUE))
 				if(1)
-					to_chat(user_mob, span_alert("Shuttle not found."))
+					if(COOLDOWN_FINISHED(src, say_cooldown))
+						say("Shuttle not found.")
+						COOLDOWN_START(src, say_cooldown, 2 SECONDS)
 				if(2)
-					to_chat(user_mob, span_alert("Shuttle already at station."))
+					if(COOLDOWN_FINISHED(src, say_cooldown))
+						say("Shuttle already at station.")
+						COOLDOWN_START(src, say_cooldown, 2 SECONDS)
 				if(3)
-					to_chat(user_mob, span_alert("No permission to dock could be granted."))
+					if(COOLDOWN_FINISHED(src, say_cooldown))
+						say("No permission to dock could be granted.")
+						COOLDOWN_START(src, say_cooldown, 2 SECONDS)
 				else
 					if(!(obj_flags & EMAGGED))
 						security_radio.set_frequency(FREQ_SECURITY)
@@ -111,8 +136,28 @@
 
 						security_radio.talk_into(src, "[user_mob.name] returned to the station. Minerals and Prisoner ID card ready for retrieval.", FREQ_SECURITY)
 					user_mob.log_message("has completed their labor points goal and is now sending the gulag shuttle back to the station.", LOG_GAME)
-					to_chat(user_mob, span_notice("Shuttle received message and will be sent shortly."))
+					say("Labor sentence finished, shuttle returning.")
+					initiated_launch = TRUE
 					return TRUE
+
+/obj/machinery/mineral/labor_claim_console/proc/find_labor_shuttle_mobs()
+	var/list/prisoners = mobs_in_area_type(list(get_area(src)))
+
+	// security personnel and nonhumans do not count towards this
+	for(var/mob/living/mob as anything in prisoners)
+		var/obj/item/card/id/card = mob.get_idcard(FALSE)
+		if(!ishuman(mob) || (ACCESS_BRIG in card?.GetAccess()))
+			prisoners -= mob
+
+	return prisoners
+
+/obj/machinery/mineral/labor_claim_console/proc/on_laborshuttle_can_move(obj/docking_port/mobile/source)
+	SIGNAL_HANDLER
+
+	if(initiated_launch && length(find_labor_shuttle_mobs()) > 1)
+		initiated_launch = FALSE
+		say("Takeoff aborted. Prisoners may only be released one at a time.")
+		return BLOCK_SHUTTLE_MOVE
 
 /obj/machinery/mineral/labor_claim_console/proc/locate_stacking_machine()
 	stacking_machine = locate(/obj/machinery/mineral/stacking_machine) in dview(2, get_turf(src))

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -644,6 +644,9 @@
 
 //this is a hook for custom behaviour. Maybe at some point we could add checks to see if engines are intact
 /obj/docking_port/mobile/proc/canMove()
+	SHOULD_CALL_PARENT(TRUE)
+	if(SEND_SIGNAL(src, COMSIG_SHUTTLE_SHOULD_MOVE) & BLOCK_SHUTTLE_MOVE)
+		return FALSE
 	return TRUE
 
 //this is to check if this shuttle can physically dock at dock stationary_dock

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -55,9 +55,11 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	SSshuttle.supply = src
 
 /obj/docking_port/mobile/supply/canMove()
+	. = ..()
+	if(!.)
+		return FALSE
 	if(is_station_level(z))
 		return check_blacklist(shuttle_areas)
-	return ..()
 
 /obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances)
 	for(var/area/shuttle_area as anything in areaInstances)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -352,6 +352,7 @@
 #include "code\__DEFINES\dcs\signals\signals_restaurant.dm"
 #include "code\__DEFINES\dcs\signals\signals_scangate.dm"
 #include "code\__DEFINES\dcs\signals\signals_screentips.dm"
+#include "code\__DEFINES\dcs\signals\signals_shuttle.dm"
 #include "code\__DEFINES\dcs\signals\signals_spatial_grid.dm"
 #include "code\__DEFINES\dcs\signals\signals_species.dm"
 #include "code\__DEFINES\dcs\signals\signals_spell.dm"


### PR DESCRIPTION
## About The Pull Request

Created a new signal for blocking shuttle takeoffs. Hooked that signal into the labor shuttle from the points claimer console. 
The console should now block the shuttle from taking off if there is more than one non-security human on the shuttle.

I needed to hook post shuttle subsystem initialization for this because atoms initialize before shuttles are set up.

Lastly I converted a bunch of `to_chat`s to `say`s for better player feedback.

## Why It's Good For The Game

Labor camp escapes are cool, but they should require an amount of effort that is more than just 1. wait for other prisoner to arrive and 2. wait for them to complete their sentence before hopping on the shuttle. There is no point in gulagging people if they can just hitch an easy ride home, regardless if they won't be able to get their stuff back.

Also perma gulag prisoners are a thing now, yippe?

## Changelog

:cl:
fix: The labor shuttle can no longer be cheesed by piggybacking a prisoner who has completed their sentence.
/:cl:
