### PR TITLE
Runechat no longer awkwardly fades in if in bulk

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -223,7 +223,10 @@
 			var/remaining_time = time_before_fade * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** combined_height)
 			// Ensure we don't accidentially spike alpha up or something silly like that
 			m.message.alpha = m.get_current_alpha(time_spent)
-			if (remaining_time > 0)
+			if(remaining_time > 0)
+				if(time_spent < CHAT_MESSAGE_SPAWN_TIME)
+					// We haven't even had the time to fade in yet!
+					animate(m.message, alpha = 255, CHAT_MESSAGE_SPAWN_TIME - time_spent)
 				// Stay faded in for a while, then
 				animate(m.message, alpha = 255, remaining_time)
 				// Fade out
@@ -259,7 +262,7 @@
 
 	animate_start = rough_time
 	animate_lifespan = lifespan
-
+	owned_by.seen_messages
 	// View the message
 	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
 	owned_by.images |= message

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -262,7 +262,7 @@
 
 	animate_start = rough_time
 	animate_lifespan = lifespan
-	
+
 	// View the message
 	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
 	owned_by.images |= message

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -228,7 +228,7 @@
 					// We haven't even had the time to fade in yet!
 					animate(m.message, alpha = 255, CHAT_MESSAGE_SPAWN_TIME - time_spent)
 				// Stay faded in for a while, then
-				animate(m.message, alpha = 255, remaining_time)
+				animate(m.message, alpha = 255, remaining_time, flags=ANIMATION_CONTINUE)
 				// Fade out
 				animate(alpha = 0, time = CHAT_MESSAGE_EOL_FADE)
 				m.animate_lifespan = remaining_time + CHAT_MESSAGE_EOL_FADE

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -262,7 +262,7 @@
 
 	animate_start = rough_time
 	animate_lifespan = lifespan
-	owned_by.seen_messages
+	
 	// View the message
 	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
 	owned_by.images |= message


### PR DESCRIPTION
## About The Pull Request

So you know how if you tried to use a ? or ! in a message with signer the second message would very slowly fade in? I fixed that

## Why It's Good For The Game

why IS IT good for the game?

## Changelog

:cl:
fix: runetext fades in correctly in bulk. signers rejoice
/:cl:
