### PR TITLE
fixes synthmeat having 0% purity on reaction

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -40,7 +40,7 @@
 	var/resulting_reagent_purity
 
 /datum/chemical_reaction/food/pre_reaction_other_checks(datum/reagents/holder)
-	resulting_reagent_purity = holder.get_average_purity(/datum/reagent)
+	resulting_reagent_purity = holder.get_average_purity()
 	return TRUE
 
 /datum/chemical_reaction/food/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -40,7 +40,7 @@
 	var/resulting_reagent_purity
 
 /datum/chemical_reaction/food/pre_reaction_other_checks(datum/reagents/holder)
-	resulting_reagent_purity = holder.get_average_purity(/datum/reagent/consumable)
+	resulting_reagent_purity = holder.get_average_purity(/datum/reagent)
 	return TRUE
 
 /datum/chemical_reaction/food/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)


### PR DESCRIPTION
## About The Pull Request

read the title doofus

## Why It's Good For The Game

theoretical meat is bad for the economy

ok so basically the guy who did this whole thing only had it check for reagent/consumable in the entire beaker, which is goofy as hell for a lot of reasons, but it also has the side effect of not including non/consumable reagents like blood, cryoxadone, and carpotoxin. 

there's probably a bug in there where adding pure salt or other reagent to the beaker can make highly pure food items with highly impure ingredients, but if youre bothering to do that you couldve made pure ingredients to begin with, and that wouldve existed before i touched it and i dont wanna bother

## Changelog

:cl:
fix: synthmeat is no longer an nft
/:cl: