### PR TITLE
Fixes a potential harddel in Ripley code

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -301,6 +301,10 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
 	workmech.cargo_hold = src
 
+/obj/item/mecha_parts/mecha_equipment/ejector/detach()
+	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
+	workmech.cargo_hold = null
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/Destroy()
 	for(var/atom/stored in contents)


### PR DESCRIPTION

## About The Pull Request

Ejector didn't clean its ref in parent ripley before deleting itself which could cause harddels if it didn't delete fast enough (as seen during round 243009)

## Changelog
:cl:
fix: Fixed a potential harddel in Ripley code
/:cl:
