### PR TITLE
Fix chewable bubblegum not metabolizing due to microdose

### DIFF
--- a/code/datums/elements/chewable.dm
+++ b/code/datums/elements/chewable.dm
@@ -25,7 +25,6 @@
 		// this prevents microdosing which causes the reagent to enter and then delete itself before it can be processed
 		if(metabolization_amount < REAGENTS_METABOLISM)
 			CRASH("Attatching /datum/element/chewable to [target] requires metabolization_amount to be higher than [REAGENTS_METABOLISM]u. The amount used was [metabolization_amount]u!")
-			return ELEMENT_INCOMPATIBLE
 
 		src.metabolization_amount = metabolization_amount
 

--- a/code/datums/elements/chewable.dm
+++ b/code/datums/elements/chewable.dm
@@ -22,6 +22,11 @@
 	var/obj/item/target_item = target
 
 	if (metabolization_amount)
+		// this prevents microdosing which causes the reagent to enter and then delete itself before it can be processed
+		if(metabolization_amount < REAGENTS_METABOLISM)
+			CRASH("Attatching /datum/element/chewable to [target] requires metabolization_amount to be higher than [REAGENTS_METABOLISM]u. The amount used was [metabolization_amount]u!")
+			return ELEMENT_INCOMPATIBLE
+
 		src.metabolization_amount = metabolization_amount
 
 	src.slots_to_check = slots_to_check || target_item.slot_flags

--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -211,7 +211,7 @@
 
 /obj/item/food/bubblegum/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/chewable, metabolization_amount=0.0001)
+	AddElement(/datum/element/chewable)
 
 /obj/item/food/bubblegum/nicotine
 	name = "nicotine gum"

--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -211,7 +211,7 @@
 
 /obj/item/food/bubblegum/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/chewable)
+	AddElement(/datum/element/chewable, metabolization_amount=0.0001)
 
 /obj/item/food/bubblegum/nicotine
 	name = "nicotine gum"

--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -204,9 +204,6 @@
 	slot_flags = ITEM_SLOT_MASK
 	w_class = WEIGHT_CLASS_TINY
 
-	/// The amount to metabolize per second
-	var/metabolization_amount = REAGENTS_METABOLISM / 2
-
 /obj/item/food/bubblegum/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] swallows [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	qdel(src)
@@ -214,7 +211,7 @@
 
 /obj/item/food/bubblegum/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/chewable, metabolization_amount = metabolization_amount)
+	AddElement(/datum/element/chewable)
 
 /obj/item/food/bubblegum/nicotine
 	name = "nicotine gum"

--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -235,7 +235,6 @@
 	color = "#913D3D"
 	food_reagents = list(/datum/reagent/blood = 15)
 	tastes = list("hell" = 1, "people" = 1)
-	metabolization_amount = REAGENTS_METABOLISM
 
 /obj/item/food/bubblegum/bubblegum/process()
 	if(iscarbon(loc))


### PR DESCRIPTION
## About The Pull Request
- Fixes #87873

Bubblegum with the chewable element was not triggering due to a microdose that would get deleted as soon as it was inserted into the mob.

Also added a crash message so if anyone in the future tries to microdose the chewable element it gets caught by our CI/CD checks.

![chrome_MUuaIxcpTI](https://github.com/user-attachments/assets/5d473499-0c42-4677-9a13-598078e512f1)

Special thanks to @SmArtKar for digging around in the code and finding the problem.

## Why It's Good For The Game
Bubblegum now makes you happy.

## Changelog
:cl: timothymtorres, SmArtKar
fix: Fix chewable bubblegum not metabolizing due to microdose
/:cl:
