### PR TITLE
Fix coffee maker smoke particles not deleting

### DIFF
--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -392,11 +392,12 @@
 
 ///Updates the smoke state to something else, setting particles if relevant
 /obj/machinery/coffeemaker/proc/toggle_steam()
-	if(brewing)
-		var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_coffeemaker")
-		smoke_particles.particles.position = list(-6, 0, 0)
-	else
+	if(!brewing)
 		remove_shared_particles(/particles/smoke)
+		return
+
+	var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_coffeemaker")
+	smoke_particles.particles.position = list(-6, 0, 0)
 
 /obj/machinery/coffeemaker/proc/operate_for(time, silent = FALSE)
 	brewing = TRUE
@@ -707,6 +708,10 @@
 	update_appearance(UPDATE_OVERLAYS)
 
 /obj/machinery/coffeemaker/impressa/toggle_steam()
+	if(!brewing)
+		remove_shared_particles(/particles/smoke)
+		return
+
 	var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_impressa")
 	smoke_particles.particles.position = list(-2, 1, 0)
 

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -392,8 +392,11 @@
 
 ///Updates the smoke state to something else, setting particles if relevant
 /obj/machinery/coffeemaker/proc/toggle_steam()
-	var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_coffeemaker")
-	smoke_particles.particles.position = list(-6, 0, 0)
+	if(brewing)
+		var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_coffeemaker")
+		smoke_particles.particles.position = list(-6, 0, 0)
+	else
+		remove_shared_particles(/particles/smoke)
 
 /obj/machinery/coffeemaker/proc/operate_for(time, silent = FALSE)
 	brewing = TRUE

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -393,7 +393,7 @@
 ///Updates the smoke state to something else, setting particles if relevant
 /obj/machinery/coffeemaker/proc/toggle_steam()
 	if(!brewing)
-		remove_shared_particles(/particles/smoke)
+		remove_shared_particles("smoke_coffeemaker")
 		return
 
 	var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_coffeemaker")
@@ -709,7 +709,7 @@
 
 /obj/machinery/coffeemaker/impressa/toggle_steam()
 	if(!brewing)
-		remove_shared_particles(/particles/smoke)
+		remove_shared_particles("smoke_impressa")
 		return
 
 	var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/steam/mild, "smoke_impressa")


### PR DESCRIPTION

## About The Pull Request
Caused by:

- #88048

The coffee maker smoke particles stayed on forever after brewing something. This is now fixed.

## Why It's Good For The Game
Coffee brewing is no longer a fire hazard.

## Changelog
:cl:
fix: Fix coffee maker smoke particles not deleting
/:cl:
