### PR TITLE
Fix fireplace particles runtimes

### DIFF
--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -170,11 +170,11 @@
 
 	switch(dir)
 		if(SOUTH)
-			smoke_particles.particles.position = list(0, 36, 0)
+			smoke_particles.particles.position = list(0, 29, 0)
 		if(EAST)
-			smoke_particles.particles.position = list(-12, 16, 0)
+			smoke_particles.particles.position = list(-20, 9, 0)
 		if(WEST)
-			smoke_particles.particles.position = list(12, 16, 0)
+			smoke_particles.particles.position = list(20, 9, 0)
 		if(NORTH) // there is no icon state for SOUTH
 			remove_shared_particles(/particles/smoke/burning)
 

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -30,6 +30,7 @@
 /obj/structure/fireplace/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(burning_loop)
+	remove_shared_particles(/particles/smoke/burning)
 	. = ..()
 
 /obj/structure/fireplace/setDir(newdir)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -166,17 +166,17 @@
 	fuel_added = 0
 	update_appearance()
 	adjust_light()
-	add_shared_particles(/particles/smoke/burning)
+	var/obj/effect/abstract/shared_particle_holder/smoke_particles = add_shared_particles(/particles/smoke/burning)
 
 	switch(dir)
 		if(SOUTH)
-			particles.position = list(0, 29, 0)
+			smoke_particles.position = list(0, 29, 0)
 		if(EAST)
-			particles.position = list(-20, 9, 0)
+			smoke_particles.position = list(-20, 9, 0)
 		if(WEST)
-			particles.position = list(20, 9, 0)
+			smoke_particles.position = list(20, 9, 0)
 		if(NORTH) // there is no icon state for SOUTH
-			QDEL_NULL(particles)
+			remove_shared_particles(/particles/smoke/burning)
 
 /obj/structure/fireplace/proc/put_out()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -170,11 +170,11 @@
 
 	switch(dir)
 		if(SOUTH)
-			smoke_particles.position = list(0, 29, 0)
+			smoke_particles.particles.position = list(0, 29, 0)
 		if(EAST)
-			smoke_particles.position = list(-20, 9, 0)
+			smoke_particles.particles.position = list(-20, 9, 0)
 		if(WEST)
-			smoke_particles.position = list(20, 9, 0)
+			smoke_particles.particles.position = list(20, 9, 0)
 		if(NORTH) // there is no icon state for SOUTH
 			remove_shared_particles(/particles/smoke/burning)
 

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -170,11 +170,11 @@
 
 	switch(dir)
 		if(SOUTH)
-			smoke_particles.particles.position = list(0, 29, 0)
+			smoke_particles.particles.position = list(0, 36, 0)
 		if(EAST)
-			smoke_particles.particles.position = list(-20, 9, 0)
+			smoke_particles.particles.position = list(-12, 16, 0)
 		if(WEST)
-			smoke_particles.particles.position = list(20, 9, 0)
+			smoke_particles.particles.position = list(12, 16, 0)
 		if(NORTH) // there is no icon state for SOUTH
 			remove_shared_particles(/particles/smoke/burning)
 


### PR DESCRIPTION

## About The Pull Request
Caused by:

- https://github.com/tgstation/tgstation/pull/88048

Trying to use the fireplace would result in runtimes and the smoke particles not triggering.

Even though the runtime is fixed, the new particle changes in #88048 broke the pixel offsets. While I was testing, anytime I tried switching a pixel offset it would update all fireplaces. I tried to limit it to add the shared particle id to `"fireplace_[dir]"` so that it would only apply to the objects in that direction but I couldn't get it to work. I would guess this also affects a lot of other objects that have particle pixel offsets.

Runtime is fixed. Particle offsets are still broken.

## Why It's Good For The Game
Fireplaces no more runtime.

## Changelog
:cl:
fix: Fix fireplace particles runtimes.
/:cl:
