### PR TITLE
Fix weather effects not applying to areas like space

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -51,6 +51,8 @@
 	var/protect_indoors = FALSE
 	/// Areas to be affected by the weather, calculated when the weather begins
 	var/list/impacted_areas = list()
+	/// Areas affected by weather have their blend modes changed
+	var/list/impacted_areas_blend_modes = list()
 	/// Areas that are protected and excluded from the affected areas.
 	var/list/protected_areas = list()
 	/// The list of z-levels that this weather is actively affecting
@@ -233,8 +235,17 @@
 	for(var/area/impacted as anything in impacted_areas)
 		if(length(overlay_cache))
 			impacted.overlays -= overlay_cache
+			if(impacted_areas_blend_modes[impacted])
+				// revert the blend mode to the old state
+				impacted.blend_mode = impacted_areas_blend_modes[impacted]
+				impacted_areas_blend_modes[impacted] = null
 		if(length(new_overlay_cache))
 			impacted.overlays += new_overlay_cache
+			// only change the blend mode if it's not default or overlay
+			if(impacted.blend_mode > BLEND_OVERLAY)
+				// save the old blend mode state
+				impacted_areas_blend_modes[impacted] = impacted.blend_mode
+				impacted.blend_mode = BLEND_OVERLAY
 
 	overlay_cache = new_overlay_cache
 

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -102,16 +102,19 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_WEATHER_TELEGRAPH(type), src)
 	stage = STARTUP_STAGE
 	var/list/affectareas = list()
-	for(var/V in get_areas(area_type))
-		affectareas += V
-	for(var/V in protected_areas)
-		affectareas -= get_areas(V)
-	for(var/V in affectareas)
-		var/area/A = V
-		if(protect_indoors && !A.outdoors)
+	for(var/area/selected_area as anything in get_areas(area_type))
+		affectareas += selected_area
+	for(var/area/protected_area as anything in protected_areas)
+		affectareas -= get_areas(protected_area)
+	for(var/area/affected_area as anything in affectareas)
+		if(protect_indoors && !affected_area.outdoors)
 			continue
-		if(A.z in impacted_z_levels)
-			impacted_areas |= A
+
+		for(var/z as anything in impacted_z_levels)
+			if(length(affected_area.turfs_by_zlevel) >= z && length(affected_area.turfs_by_zlevel[z]))
+				impacted_areas |= affected_area
+				continue
+
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
 	SSweather.processing |= src
 	update_areas()

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -110,7 +110,7 @@
 		if(protect_indoors && !affected_area.outdoors)
 			continue
 
-		for(var/z as anything in impacted_z_levels)
+		for(var/z in impacted_z_levels)
 			if(length(affected_area.turfs_by_zlevel) >= z && length(affected_area.turfs_by_zlevel[z]))
 				impacted_areas |= affected_area
 				continue


### PR DESCRIPTION

## About The Pull Request
Weather effects were ignoring certain areas like space. This was due to checking the area's `z` position. Some areas like `area/space` are in many different z-levels and the `z` position defaults to Centcomm `z=1`. 

The solution is to loop through `area.turfs_by_zlevel` and check if it has any turfs in that z-level.

CC @LemonInTheDark the mutable overlay for weather effects is not applying to space.

https://github.com/tgstation/tgstation/blob/7e27663517731fe8f3d955477b1a97ace5a6ff83/code/datums/weather/weather.dm#L253-L271

I'm assuming this is due to plane master shengians. I could just add the effects like the radiation nebula:

https://github.com/tgstation/tgstation/blob/7e27663517731fe8f3d955477b1a97ace5a6ff83/code/datums/station_traits/negative_traits.dm#L486-L493

But this doesn't appear reversible. I'm open to suggestions.

## Why It's Good For The Game
Rad storms now affect space outside the station. Other weather effects should also be consistent and not be ignored by certain misc. areas types.

## Changelog
:cl:
fix: Fix weather effects ignoring certain areas like space. 
/:cl:
