### PR TITLE
Fixes instant summons not ripping out embedded items

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -52,6 +52,7 @@
 	limb._embed_object(weapon) // on the inside... on the inside...
 	weapon.forceMove(victim)
 	RegisterSignals(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING), PROC_REF(weaponDeleted))
+	RegisterSignal(weapon, COMSIG_MAGIC_RECALL, PROC_REF(magic_pull))
 	victim.visible_message(span_danger("[weapon] [harmful ? "embeds" : "sticks"] itself [harmful ? "in" : "to"] [victim]'s [limb.plaintext_zone]!"), span_userdanger("[weapon] [harmful ? "embeds" : "sticks"] itself [harmful ? "in" : "to"] your [limb.plaintext_zone]!"))
 
 	var/damage = weapon.throwforce
@@ -84,7 +85,6 @@
 	RegisterSignal(parent, COMSIG_CARBON_EMBED_RIP, PROC_REF(ripOut))
 	RegisterSignal(parent, COMSIG_CARBON_EMBED_REMOVAL, PROC_REF(safeRemove))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(checkTweeze))
-	RegisterSignal(parent, COMSIG_MAGIC_RECALL, PROC_REF(magic_pull))
 	RegisterSignal(parent, COMSIG_ATOM_EX_ACT, PROC_REF(on_ex_act))
 
 /datum/component/embedded/UnregisterFromParent()

--- a/code/modules/spells/spell_types/self/summonitem.dm
+++ b/code/modules/spells/spell_types/self/summonitem.dm
@@ -138,8 +138,6 @@
 					item_to_retrieve = null
 					break
 
-				holding_mark.dropItemToGround(item_to_retrieve)
-
 			else if(isobj(item_to_retrieve.loc))
 				var/obj/retrieved_item = item_to_retrieve.loc
 				// Can't bring anchored things
@@ -159,6 +157,12 @@
 	if(!item_to_retrieve)
 		return
 
+	SEND_SIGNAL(item_to_retrieve, COMSIG_MAGIC_RECALL, caster, item_to_retrieve)
+
+	if (ismob(item_to_retrieve.loc))
+		var/mob/holder = item_to_retrieve.loc
+		holder.dropItemToGround(item_to_retrieve)
+
 	item_to_retrieve.loc?.visible_message(span_warning("[item_to_retrieve] suddenly disappears!"))
 
 	if(isitem(item_to_retrieve) && caster.put_in_hands(item_to_retrieve))
@@ -167,7 +171,6 @@
 		item_to_retrieve.forceMove(caster.drop_location())
 		item_to_retrieve.loc.visible_message(span_warning("[item_to_retrieve] suddenly appears!"))
 
-	SEND_SIGNAL(item_to_retrieve, COMSIG_MAGIC_RECALL, caster, item_to_retrieve)
 	playsound(get_turf(item_to_retrieve), 'sound/effects/magic/summonitems_generic.ogg', 50, TRUE)
 
 /datum/action/cooldown/spell/summonitem/abductor


### PR DESCRIPTION

## About The Pull Request
Closes #88115
How did this even work in the first place bro its wrong on 3 different levels

## Changelog
:cl:
fix: Fixed instant summons not ripping out embedded items
/:cl:
