### PR TITLE
Runechat messages no longer hang in SS queue with invalid callbacks if the client logs out before they've finished building themselves

### DIFF
--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -7,8 +7,9 @@ TIMER_SUBSYSTEM_DEF(runechat)
 /datum/controller/subsystem/timer/runechat/fire(resumed)
 	. = ..() //poggers
 	while(message_queue.len)
-		var/datum/callback/queued_message = message_queue[message_queue.len]
-		queued_message.Invoke()
-		message_queue.len--
+		var/datum/chatmessage/queued_message = message_queue[message_queue.len]
+		var/datum/callback/message_callback = message_queue[queued_message]
+		message_callback.Invoke()
+		message_queue -= queued_message
 		if(MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -7,9 +7,8 @@ TIMER_SUBSYSTEM_DEF(runechat)
 /datum/controller/subsystem/timer/runechat/fire(resumed)
 	. = ..() //poggers
 	while(message_queue.len)
-		var/datum/chatmessage/queued_message = message_queue[message_queue.len]
-		var/datum/callback/message_callback = message_queue[queued_message]
-		message_callback.Invoke()
-		message_queue -= queued_message
+		var/datum/callback/queued_message = message_queue[message_queue.len]
+		queued_message.Invoke()
+		message_queue.len--
 		if(MC_TICK_CHECK)
 			return

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -50,6 +50,8 @@
 	var/animate_start = 0
 	/// Our animation lifespan, how long this message will last
 	var/animate_lifespan = 0
+	/// Callback to finish_image_generation passed to SSrunechat
+	var/datum/callback/finish_callback
 
 /**
  * Constructs a chat message overlay
@@ -81,7 +83,10 @@
 			LAZYREMOVEASSOC(owned_by.seen_messages, message_loc, src)
 		owned_by.images.Remove(message)
 
-	SSrunechat.message_queue -= src
+	if (finish_callback)
+		SSrunechat.message_queue -= finish_callback
+		finish_callback = null
+
 	owned_by = null
 	message_loc = null
 	message = null
@@ -189,13 +194,14 @@
 	if(!VERB_SHOULD_YIELD)
 		return finish_image_generation(mheight, target, owner, complete_text, lifespan)
 
-	var/datum/callback/our_callback = CALLBACK(src, PROC_REF(finish_image_generation), mheight, target, owner, complete_text, lifespan)
-	SSrunechat.message_queue[src] = our_callback
+	finish_callback = CALLBACK(src, PROC_REF(finish_image_generation), mheight, target, owner, complete_text, lifespan)
+	SSrunechat.message_queue += finish_callback
 	return
 
 ///finishes the image generation after the MeasureText() call in generate_image().
 ///necessary because after that call the proc can resume at the end of the tick and cause overtime.
 /datum/chatmessage/proc/finish_image_generation(mheight, atom/target, mob/owner, complete_text, lifespan)
+	finish_callback = null
 	var/rough_time = REALTIMEOFDAY
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 	var/starting_height = target.maptext_height

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -81,6 +81,7 @@
 			LAZYREMOVEASSOC(owned_by.seen_messages, message_loc, src)
 		owned_by.images.Remove(message)
 
+	SSrunechat.message_queue -= src
 	owned_by = null
 	message_loc = null
 	message = null
@@ -189,7 +190,7 @@
 		return finish_image_generation(mheight, target, owner, complete_text, lifespan)
 
 	var/datum/callback/our_callback = CALLBACK(src, PROC_REF(finish_image_generation), mheight, target, owner, complete_text, lifespan)
-	SSrunechat.message_queue += our_callback
+	SSrunechat.message_queue[src] = our_callback
 	return
 
 ///finishes the image generation after the MeasureText() call in generate_image().


### PR DESCRIPTION

## About The Pull Request

Super niche, unnoticeable in-game, found when runtime diving. Don't leave callbacks to qdeleted datums and clients in queue please.

## Changelog
:cl:
fix: Fixed a runtime caused by logging out while your runechat message was appearing.
/:cl:
