### PR TITLE
Fixes meteors freezing in place if they continiously miss the station on a looping z level

### DIFF
--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -42,7 +42,7 @@
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
 	chase_target(target)
-	QDEL_IN(lifetime)
+	QDEL_IN(src, lifetime)
 
 /obj/effect/meteor/Destroy()
 	GLOB.meteor_list -= src

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -42,7 +42,6 @@
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
 	chase_target(target)
-	QDEL_IN(src, lifetime)
 
 /obj/effect/meteor/Destroy()
 	GLOB.meteor_list -= src
@@ -77,8 +76,12 @@
 	if(!isatom(chasing))
 		return
 	var/datum/move_loop/new_loop = GLOB.move_manager.move_towards(src, chasing, delay, home, lifetime)
-	if(!new_loop)
-		return
+	if(new_loop)
+		RegisterSignal(new_loop, COMSIG_MOVELOOP_STOP, PROC_REF(on_loop_stopped))
+
+/obj/effect/meteor/proc/on_loop_stopped(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)
 
 ///Deals with what happens when we stop moving, IE we die
 /obj/effect/meteor/proc/moved_off_z()

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -42,6 +42,7 @@
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
 	chase_target(target)
+	QDEL_IN(lifetime)
 
 /obj/effect/meteor/Destroy()
 	GLOB.meteor_list -= src


### PR DESCRIPTION

## About The Pull Request

Closes #88004
How has this not been caught before? They have a moveloop timeout (sane) but don't delete themselves once it expires (insane)

## Changelog
:cl:
fix: Fixed meteors freezing in place if they continiously miss the station on a looping z level
/:cl:
