### PR TITLE
Increases shutter damage_deflection 20 -> 21

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/doors/shutters.dmi'
 	layer = SHUTTER_LAYER
 	closingLayer = SHUTTER_LAYER
-	damage_deflection = 24
+	damage_deflection = 21
 	armor_type = /datum/armor/poddoor_shutters
 	max_integrity = 100
 	recipe_type = /datum/crafting_recipe/shutters
@@ -83,7 +83,7 @@
 	icon_state = "closed"
 	opacity = FALSE
 	glass = TRUE
-	damage_deflection = 21
+	damage_deflection = 20
 
 /obj/machinery/door/poddoor/shutters/window/preopen
 	icon_state = "open"

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/doors/shutters.dmi'
 	layer = SHUTTER_LAYER
 	closingLayer = SHUTTER_LAYER
-	damage_deflection = 20
+	damage_deflection = 24
 	armor_type = /datum/armor/poddoor_shutters
 	max_integrity = 100
 	recipe_type = /datum/crafting_recipe/shutters
@@ -83,6 +83,7 @@
 	icon_state = "closed"
 	opacity = FALSE
 	glass = TRUE
+	damage_deflection = 21
 
 /obj/machinery/door/poddoor/shutters/window/preopen
 	icon_state = "open"


### PR DESCRIPTION
## About The Pull Request

Increases the shutter's damage threshold up to 21, from 20, only for the solid shutter

## Why It's Good For The Game

Stops crude weapons like thrown spears from breaking shutters. Shutters cost 5 plasteel, wires and airlock electronics and are supposed to be a decent way to stop low-threat break-ins, or be generally anti-burglary, while not stopping higher-end threats like chainsaws, fireaxes, energy swords and weapons designed to break structures. 

A thrown spear shouldn't be enough to break a whole shutter - it's 5 plasteel after all, and damage_deflection doesn't affect _thrown force or projectiles_, -- NOPE - I meant to say that demolition modifier doesn't affect thrown force -- so they're still rather easy to break. In fact, at 100 HP and 20% armor, they're still far weaker than a basic airlock, that has more armor (30% melee), usually 350 + HP at a minimum. Shutters also can't be repaired, which is definitely an oversight, while airlocks can be repaired fully while closed. 

I've noticed shutters are used for low-level lockdowns like EVA, teleport access and medbay - Imho it's a bit disappointing that a crude, crafted weapon like a spear can so easily get through one, it kind of makes these lockdowns pointless, if almost every room has the necessary ingredients to break shutters (cables, metal rod & a glass shard). 

## Changelog

:cl:
balance: Shutter damage deflection 20 -> 21 for the solid shutter
/:cl:
