### PR TITLE
damage done by thrown objects to /obj is multiplied by the demolition modifier

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,7 +1,11 @@
 
-/obj/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+/obj/hitby(atom/movable/hit_by, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	..()
-	take_damage(AM.throwforce, BRUTE, MELEE, 1, get_dir(src, AM))
+	var/damage_taken = hit_by.throwforce
+	if(isitem(hit_by))
+		var/obj/item/as_item = hit_by
+		damage_taken *= as_item.demolition_mod
+	take_damage(damage_taken, BRUTE, MELEE, 1, get_dir(src, hit_by))
 
 /obj/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)


### PR DESCRIPTION

## About The Pull Request

damage done by thrown objects to /obj is multiplied by the demolition modifier

## Why It's Good For The Game

i think its supposed to respect the demolition mod i mean uhh that seems like an oversight??

## Changelog
:cl:
fix: damage done by thrown objects to objects respects their demolition modifier
/:cl:
