### PR TITLE
The pulse rifle should spawn from the arcade machine now.

### DIFF
--- a/code/game/machinery/computer/arcade/_arcade.dm
+++ b/code/game/machinery/computer/arcade/_arcade.dm
@@ -85,7 +85,7 @@
 	for(var/i in 1 to prizes)
 		user.add_mood_event("arcade", /datum/mood_event/arcade)
 		if(prob(0.0001)) //1 in a million
-			new /obj/item/gun/energy/pulse/prize(src)
+			new /obj/item/gun/energy/pulse/prize(get_turf(src))
 			visible_message(span_notice("[src] dispenses.. woah, a gun! Way past cool."), span_notice("You hear a chime and a shot."))
 			user.client.give_award(/datum/award/achievement/misc/pulse, user)
 			continue


### PR DESCRIPTION

## About The Pull Request

Tested on a private server with edited odds that the pulse rifle doesn't spawn when won and only the message pops. 
After code edit it spawned accordingly but the low odds remain.

## Why It's Good For The Game

Beating one in a million odds and not getting a pulse rifle is disappointing, it should spawn now. 
## Changelog

:cl:
fix: fixed the pulse rifle not spawning when won
code: added get_turf to the pulserifle  when the odds are beat.
:cl:
