### PR TITLE
fixes raptors breaking their troughs, removes troublesome raptors and you can now rename ur raptors

### DIFF
--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -60,16 +60,10 @@ GLOBAL_LIST_EMPTY(customized_pets)
 #define BB_RAPTOR_PLAYFUL "raptor_playful"
 ///this mob will flee combat when it feels threatened
 #define BB_RAPTOR_COWARD "raptor_coward"
-///this mob will go out seeking trouble against its kind
-#define BB_RAPTOR_TROUBLE_MAKER "raptor_trouble_maker"
-///cooldown till we go out cause trouble again
-#define BB_RAPTOR_TROUBLE_COOLDOWN "raptor_trouble_maker_cooldown"
 ///our raptor baby target we will take care of
 #define BB_RAPTOR_BABY "raptor_baby"
 ///the raptor we will heal up
 #define BB_INJURED_RAPTOR "injured_raptor"
-///the raptor we will bully
-#define BB_RAPTOR_VICTIM "raptor_victim"
 ///the cooldown for next time we eat
 #define BB_RAPTOR_EAT_COOLDOWN "raptor_eat_cooldown"
 ///our trough target

--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -12,7 +12,6 @@ GLOBAL_LIST_INIT(raptor_inherit_traits, list(
 	BB_RAPTOR_MOTHERLY = "Motherly",
 	BB_RAPTOR_PLAYFUL = "Playful",
 	BB_RAPTOR_COWARD = "Coward",
-	BB_RAPTOR_TROUBLE_MAKER = "Trouble Maker",
 ))
 
 GLOBAL_LIST_EMPTY(raptor_population)
@@ -70,6 +69,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 		change_offsets = FALSE
 		icon = 'icons/mob/simple/lavaland/raptor_icebox.dmi'
 
+	AddElement(/datum/element/wears_collar)
 	add_traits(list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE, TRAIT_SNOWSTORM_IMMUNE), INNATE_TRAIT)
 
 	if(!mapload)
@@ -159,7 +159,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 		balloon_alert(src, "no food!")
 	else
 		melee_attack(ore_food)
-	return TRUE
+	return FALSE
 
 /mob/living/basic/raptor/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)
 	if(!combat_mode && istype(target, /mob/living/basic/raptor/baby_raptor))

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_behavior.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_behavior.dm
@@ -7,21 +7,6 @@
 /datum/ai_behavior/find_hunt_target/injured_raptor/valid_dinner(mob/living/source, mob/living/target, radius)
 	return (source != target && target.health < target.maxHealth)
 
-/datum/ai_behavior/find_hunt_target/raptor_victim
-	action_cooldown = 30 SECONDS
-
-/datum/ai_behavior/find_hunt_target/raptor_victim/valid_dinner(mob/living/source, mob/living/target, radius)
-	if(target.ai_controller?.blackboard[BB_RAPTOR_TROUBLE_MAKER])
-		return FALSE
-	return target.stat != DEAD && can_see(source, target, radius)
-
-/datum/ai_behavior/hunt_target/interact_with_target/reset_target/bully_raptors
-
-/datum/ai_behavior/hunt_target/interact_with_target/bully_raptors/finish_action(datum/ai_controller/controller, succeeded, hunting_target_key, hunting_cooldown_key)
-	if(succeeded)
-		controller.set_blackboard_key(BB_RAPTOR_TROUBLE_COOLDOWN, world.time + 2 MINUTES)
-	return ..()
-
 /datum/ai_behavior/find_hunt_target/raptor_baby/valid_dinner(mob/living/source, mob/living/target, radius)
 	return can_see(source, target, radius) && target.stat != DEAD
 

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
@@ -27,7 +27,6 @@
 		/datum/ai_planning_subtree/find_and_hunt_target/raptor_trough,
 		/datum/ai_planning_subtree/find_and_hunt_target/care_for_young,
 		/datum/ai_planning_subtree/make_babies,
-		/datum/ai_planning_subtree/find_and_hunt_target/raptor_start_trouble,
 		/datum/ai_planning_subtree/express_happiness,
 		/datum/ai_planning_subtree/find_and_hunt_target/play_with_owner/raptor,
 	)

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_subtrees.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_subtrees.dm
@@ -11,21 +11,6 @@
 		return
 	return ..()
 
-/datum/ai_planning_subtree/find_and_hunt_target/raptor_start_trouble
-	target_key = BB_RAPTOR_VICTIM
-	hunting_behavior = /datum/ai_behavior/hunt_target/interact_with_target/reset_target/bully_raptors
-	finding_behavior = /datum/ai_behavior/find_hunt_target/raptor_victim
-	hunt_targets = list(/mob/living/basic/raptor)
-	hunt_chance = 30
-	hunt_range = 9
-
-/datum/ai_planning_subtree/find_and_hunt_target/raptor_start_trouble/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
-	if(controller.blackboard[BB_BASIC_MOB_HEALER] || !controller.blackboard[BB_RAPTOR_TROUBLE_MAKER])
-		return
-	if(world.time < controller.blackboard[BB_RAPTOR_TROUBLE_COOLDOWN])
-		return
-	return ..()
-
 /datum/ai_planning_subtree/find_nearest_thing_which_attacked_me_to_flee/raptor
 	target_key = BB_BASIC_MOB_FLEE_TARGET
 


### PR DESCRIPTION

## About The Pull Request
after my PR removing most self-registering attack signals, raptors would sometimes break their troughs after interacting with it, this fixes that. Also, removes the troublesome trait from raptors. raptors with this trait would go out and harm other raptors everyonce in a while, but ive discovered that this can be annoying to deal with when you have many of them, so ive removed it and im going to replace it with something less annoying in the future. Also you can now give your raptors pet collars, effectively allowing u to rename them

## Why It's Good For The Game
fixes raptors breaking their trough and provides some QOL to raptor ranching

## Changelog
:cl:
fix: raptors no longer break their trough upon interacting with it
balance: removed the troublesome trait from raptors, they now wont go out to attack their colleagues. 
add: you can now give pet collars to ur raptors to rename them
/:cl:
