### PR TITLE
Reagent grinders display number of material sheets they hold instead of defaulting to 1

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -90,10 +90,14 @@
 	for(var/obj/item/target in src)
 		if((target in component_parts) || target == beaker)
 			continue
-		to_process["[target.name]"] += 1
+		var/amount = 1
+		if (isstack(target))
+			var/obj/item/stack/target_stack = target
+			amount = target_stack.amount
+		to_process["[target.name]"] += amount
 		total_weight += target.w_class
 	if(to_process.len)
-		. += span_notice("Currently holding.")
+		. += span_notice("Currently holding:")
 		for(var/target_name as anything in to_process)
 			. += span_notice("[to_process[target_name]] [target_name]")
 		. += span_notice("Filled to <b>[round((total_weight / maximum_weight) * 100)]%</b> capacity.")


### PR DESCRIPTION

## About The Pull Request

Currently grinders just increase the amount of items by 1 when displaying them, which works fine for everything except stacks. This PR makes grinders take into account the amount of sheets in a stack so they properly display how many materials you put into them.

## Why It's Good For The Game
You'd expect 50 sheets of silver you put in a grinder to display as 50 sheets instead of 1.

## Changelog
:cl:
qol: Reagent grinders display number of material sheets they hold instead of defaulting to 1
/:cl:
