### PR TITLE
[NO GBP] Fixes pixel position of fish overlays for aquariums

### DIFF
--- a/code/datums/components/aquarium_content.dm
+++ b/code/datums/components/aquarium_content.dm
@@ -91,8 +91,8 @@
 
 /datum/component/aquarium_content/proc/set_vc_base_position()
 	var/atom/movable/movable = parent
+	SEND_SIGNAL(movable.loc, COMSIG_AQUARIUM_SET_VISUAL, vc_obj) //set the necessary layer as well as the pixel bounds first
 	SEND_SIGNAL(movable, COMSIG_AQUARIUM_CONTENT_RANDOMIZE_POSITION, movable.loc, vc_obj)
-	SEND_SIGNAL(movable.loc, COMSIG_AQUARIUM_SET_VISUAL, vc_obj)
 
 /datum/component/aquarium_content/proc/on_removed(atom/movable/aquarium, atom/movable/gone, direction)
 	SIGNAL_HANDLER

--- a/code/modules/fishing/aquarium/aquarium.dm
+++ b/code/modules/fishing/aquarium/aquarium.dm
@@ -157,7 +157,7 @@
 		min_px = 6,\
 		max_px = 26,\
 		min_py = 6,\
-		min_py = 24,\
+		max_py = 24,\
 		default_beauty = 100,\
 		reagents_size = src.reagent_size,\
 		min_fluid_temp = src.min_fluid_temp,\


### PR DESCRIPTION
## About The Pull Request
I got the order of signals wrong. We need the variables from the aquarium before we proceed with the random position signal.

## Why It's Good For The Game
McGill has breached containment. I repeat. McGill has breached. Dispatching anti-fish personnel. This is not a drill. This will close #88137.

## Changelog

:cl:
fix: Fixed pixel position of fish overlays for aquariums.
/:cl:
