### PR TITLE
Replaces scarves station trait with scryers

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -291,38 +291,22 @@
 	greyscale_config = /datum/greyscale_config/festive_hat
 	greyscale_config_worn = /datum/greyscale_config/festive_hat/worn
 
-/datum/station_trait/scarves
-	name = "Scarves"
+/datum/station_trait/scryers
+	name = "Scryers"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 5
-	cost = STATION_TRAIT_COST_MINIMAL
+	weight = 2
+	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
-	var/list/scarves
+	force = TRUE
 
-/datum/station_trait/scarves/New()
+/datum/station_trait/scryers/New()
 	. = ..()
-	report_message = pick(
-		"Nanotrasen is experimenting with seeing if neck warmth improves employee morale.",
-		"After Space Fashion Week, scarves are the hot new accessory.",
-		"Everyone was simultaneously a little bit cold when they packed to go to the station.",
-		"The station is definitely not under attack by neck grappling aliens masquerading as wool. Definitely not.",
-		"You all get free scarves. Don't ask why.",
-		"A shipment of scarves was delivered to the station.",
-	)
-	scarves = typesof(/obj/item/clothing/neck/scarf) + list(
-		/obj/item/clothing/neck/large_scarf/red,
-		/obj/item/clothing/neck/large_scarf/green,
-		/obj/item/clothing/neck/large_scarf/blue,
-	)
-
+	report_message = "Nanotrasen has chosen your station for an experiment - everyone has free scryers! Use these to talk to other people easily and privately."
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
 
-
-/datum/station_trait/scarves/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
+/datum/station_trait/scryers/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER
-	var/scarf_type = pick(scarves)
-
-	spawned.equip_to_slot_or_del(new scarf_type(spawned), ITEM_SLOT_NECK, initial = FALSE)
+	spawned.equip_to_slot_or_del(new /obj/item/clothing/neck/link_scryer/loaded(spawned), ITEM_SLOT_NECK, initial = FALSE)
 
 /datum/station_trait/wallets
 	name = "Wallets!"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -297,11 +297,11 @@
 	weight = 2
 	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
+	report_message = "Nanotrasen has chosen your station for an experiment - everyone has free scryers! Use these to talk to other people easily and privately."
 	force = TRUE
 
 /datum/station_trait/scryers/New()
 	. = ..()
-	report_message = "Nanotrasen has chosen your station for an experiment - everyone has free scryers! Use these to talk to other people easily and privately."
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
 
 /datum/station_trait/scryers/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -306,6 +306,16 @@
 
 /datum/station_trait/scryers/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER
+	if(!ishuman(spawned))
+		return
+	var/mob/living/carbon/human/humanspawned = spawned
+	// Put their silly little scarf or necktie somewhere else
+	if(humanspawned.wear_neck)
+		humanspawned.temporarilyRemoveItemFromInventory(wear_neck)
+		wear_neck.forceMove(get_turf(humanspawned))
+		humanspawned.equip_in_one_of_slots(wear_neck, ITEM_SLOT_BACKPACK, ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET)
+
+
 	spawned.equip_to_slot_or_del(new /obj/item/clothing/neck/link_scryer/loaded(spawned), ITEM_SLOT_NECK, initial = FALSE)
 
 /datum/station_trait/wallets

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -311,9 +311,9 @@
 	var/mob/living/carbon/human/humanspawned = spawned
 	// Put their silly little scarf or necktie somewhere else
 	if(humanspawned.wear_neck)
-		humanspawned.temporarilyRemoveItemFromInventory(wear_neck)
-		wear_neck.forceMove(get_turf(humanspawned))
-		humanspawned.equip_in_one_of_slots(wear_neck, ITEM_SLOT_BACKPACK, ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET)
+		humanspawned.temporarilyRemoveItemFromInventory(humanspawned.wear_neck)
+		humanspawned.wear_neck.forceMove(get_turf(humanspawned))
+		humanspawned.equip_in_one_of_slots(humanspawned.wear_neck, ITEM_SLOT_BACKPACK, ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET)
 
 
 	spawned.equip_to_slot_or_del(new /obj/item/clothing/neck/link_scryer/loaded(spawned), ITEM_SLOT_NECK, initial = FALSE)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -297,7 +297,6 @@
 	weight = 2
 	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
-	force = TRUE
 
 /datum/station_trait/scryers/New()
 	. = ..()
@@ -310,13 +309,17 @@
 		return
 	var/mob/living/carbon/human/humanspawned = spawned
 	// Put their silly little scarf or necktie somewhere else
-	if(humanspawned.wear_neck)
-		humanspawned.temporarilyRemoveItemFromInventory(humanspawned.wear_neck)
-		humanspawned.wear_neck.forceMove(get_turf(humanspawned))
-		humanspawned.equip_in_one_of_slots(humanspawned.wear_neck, ITEM_SLOT_BACKPACK, ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET)
+	var/obj/item/silly_little_scarf = humanspawned.wear_neck
+	if(silly_little_scarf)
+		humanspawned.temporarilyRemoveItemFromInventory(silly_little_scarf)
+		silly_little_scarf.forceMove(get_turf(humanspawned))
+		humanspawned.equip_in_one_of_slots(silly_little_scarf, ITEM_SLOT_BACKPACK, ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET, qdel_on_fail = FALSE, indirect_action = TRUE)
 
+	var/obj/item/clothing/neck/link_scryer/loaded/new_scryer = new(spawned)
+	new_scryer.label = spawned.name
+	new_scryer.update_name()
 
-	spawned.equip_to_slot_or_del(new /obj/item/clothing/neck/link_scryer/loaded(spawned), ITEM_SLOT_NECK, initial = FALSE)
+	spawned.equip_to_slot_or_del(new_scryer, ITEM_SLOT_NECK, initial = FALSE)
 
 /datum/station_trait/wallets
 	name = "Wallets!"


### PR DESCRIPTION

## About The Pull Request

Removed the scarves station trait and replaced it with modlink scryers.

If you're confused, they're those things on the robotics mod crate whose sprite annoyingly and opaquely covers up the actual cores. 

The scryers allow you to start a semi-private conversation with any other modlink _ignoring the status of comms_. This doesn't make them as useful for shouting out threats but lets you discuss things with essential personnel, or report crime, even after comms is blown up.

![260621454-062983ee-6058-4e78-a3aa-bccda1a3e224](https://github.com/user-attachments/assets/9a6aa38b-e10a-4e23-8691-12538fd3348c)
![image](https://github.com/user-attachments/assets/5464d1a4-5b5b-47c6-9074-080ae3b3592d)


https://github.com/tgstation/tgstation/pull/77639

This PR doesn't actually give the modlinks names, so they'll all show up as modlink (394) and be unusable. Something should be done there I'm just not quite sure how to handle it and the inevitable deluge of dropped modlinks that would recieve tons of unheeded calls. ~~Maybe we can make them undroppable for the first 30 minutes.~~
## Why It's Good For The Game

Scryers are a cool and underused aspect of the game. Their ability to function off comms is balanced out by their _in_ability to speak to more than one person at once. Having this as a trait helps showcase them and will likely allow for some enjoyable moments. I'm imagining spam calls, death threats, _actual_ death threats, prank calls, etc.

![image](https://github.com/user-attachments/assets/c505dab5-cd08-4485-b6cb-2d7390630e2a)
## Changelog
:cl:
add: Centcom's janitorial department has gotten tired of scooping up discarded scarves from the floor and has instead assigned MODlink scryers to some stations' crew in an attempt to spice up the disposal team's jobs.
/:cl:
