### PR TITLE
Fixes a non-player facing runtime in portable atmos machinery code

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -220,7 +220,7 @@
 		return FALSE
 	if(!user)
 		return FALSE
-	if(!user.transferItemToLoc(new_tank, src))
+	if(new_tank && !user.transferItemToLoc(new_tank, src))
 		return FALSE
 
 	if(holding && new_tank)//for when we are actually switching tanks


### PR DESCRIPTION

## About The Pull Request

transferItemToLoc doesn't check if item exists, and tries to call animation code on a non-existent item if you're only removing the canister. No clue how I haven't caught it during #86734, or how anyone hasn't caught it in the past 5 months to be honest. This doesn't actually do anything from player's perspective since it doesn't abort the main proc.

## Changelog
:cl:
fix: Fixed a non-player facing runtime in portable atmos machinery code.
/:cl:
