### PR TITLE
Fixes ghosts being able to make analyzing sounds

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -183,8 +183,8 @@
 
 	var/icon = target
 	var/message = list()
-	playsound(user, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
 	if(!silent && isliving(user))
+		playsound(user, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
 		user.visible_message(span_notice("[user] uses the analyzer on [icon2html(icon, viewers(user))] [target]."), span_notice("You use the analyzer on [icon2html(icon, user)] [target]."))
 	message += span_boldnotice("Results of analysis of [icon2html(icon, user)] [target].")
 


### PR DESCRIPTION

## About The Pull Request
Prevents ghost from emitting analyzing sounds when using the gas scan verb
## Why It's Good For The Game
Fixes a little bug

## Changelog
:cl: Hardly
fix: Ghosts can no longer emit spooky analyzing sounds when scanning
/:cl:
