### PR TITLE
Buffs Morphine by nerfing its sedative power

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -674,11 +674,11 @@
 
 		if(24 to 36) // 5u to 7.5u
 			if(SPT_PROB(33 * (2 - creation_purity), seconds_per_tick))
-				affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 6 SECONDS)
+				affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 6 SECONDS)
 
 		if(36 to 48) // 7.5u to 10u
 			if(SPT_PROB(66 * (2 - creation_purity), seconds_per_tick))
-				affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 12 SECONDS)
+				affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 12 SECONDS)
 
 		if(48 to INFINITY) //10u onward
 			affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 20 SECONDS)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -661,13 +661,28 @@
 	. = ..()
 	if(current_cycle > 5)
 		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
+	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * max(1 - creation_purity, 0.5), seconds_per_tick))
+		affected_mob.adjust_disgust(1.5 * REM * seconds_per_tick)
+
 	switch(current_cycle)
-		if(12)
-			to_chat(affected_mob, span_warning("You start to feel tired...") )
-		if(13 to 25)
-			affected_mob.adjust_drowsiness(2 SECONDS * REM * seconds_per_tick)
-		if(25 to INFINITY)
-			affected_mob.Sleeping(40 * REM * seconds_per_tick)
+		if(16) //~3u
+			to_chat(affected_mob, span_warning("You start to feel tired..."))
+			affected_mob.adjust_eye_blur(2 SECONDS * REM * seconds_per_tick) // just a hint teehee
+			if(SPT_PROB(50, seconds_per_tick))
+				affected_mob.emote("yawn")
+
+		if(24 to 36) // 5u to 7.5u
+			if(SPT_PROB(33, seconds_per_tick))
+				affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 6 SECONDS)
+
+		if(36 to 48) // 7.5u to 10u
+			if(SPT_PROB(66, seconds_per_tick))
+				affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 12 SECONDS)
+
+		if(48 to INFINITY) //10u onward
+			affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 20 SECONDS)
+			if(SPT_PROB((48 - current_cycle) * 20), seconds_per_tick)
+				affected_mob.Sleeping(4 SECONDS * REM * seconds_per_tick)
 
 /datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -646,7 +646,7 @@
 	overdose_threshold = 30
 	ph = 8.96
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opioids = 10)
+	addiction_types = list(/datum/addiction/opioids = 20)
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
 /datum/reagent/medicine/morphine/on_mob_metabolize(mob/living/affected_mob)
@@ -661,27 +661,29 @@
 	. = ..()
 	if(current_cycle > 5)
 		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
-	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * max(1 - creation_purity, 0.5), seconds_per_tick))
+	var/normalized = normalise_creation_purity()
+	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * (2 - creation_purity), seconds_per_tick))
 		affected_mob.adjust_disgust(1.5 * REM * seconds_per_tick)
 
 	switch(current_cycle)
 		if(16) //~3u
 			to_chat(affected_mob, span_warning("You start to feel tired..."))
-			affected_mob.adjust_eye_blur(2 SECONDS * REM * seconds_per_tick) // just a hint teehee
-			if(SPT_PROB(50, seconds_per_tick))
+			affected_mob.adjust_eye_blur(2 SECONDS * REM * seconds_per_tick)
+			if(SPT_PROB(66, seconds_per_tick))
 				affected_mob.emote("yawn")
 
 		if(24 to 36) // 5u to 7.5u
-			if(SPT_PROB(33, seconds_per_tick))
+			if(SPT_PROB(33 * (2 - creation_purity), seconds_per_tick))
 				affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 6 SECONDS)
 
 		if(36 to 48) // 7.5u to 10u
-			if(SPT_PROB(66, seconds_per_tick))
+			if(SPT_PROB(66 * (2 - creation_purity), seconds_per_tick))
 				affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 12 SECONDS)
 
 		if(48 to INFINITY) //10u onward
 			affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 20 SECONDS)
-			if(SPT_PROB((48 - current_cycle) * 20), seconds_per_tick)
+			// doesn't scale from purity - at this point it tries to guarantee sleep
+			if(SPT_PROB(30 * (48 - current_cycle), seconds_per_tick))
 				affected_mob.Sleeping(4 SECONDS * REM * seconds_per_tick)
 
 /datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -646,7 +646,7 @@
 	overdose_threshold = 30
 	ph = 8.96
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opioids = 30) // 30 units of morphine may cause addition
+	addiction_types = list(/datum/addiction/opioids = 20) // 30 units of morphine may cause addition
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
 /datum/reagent/medicine/morphine/on_mob_metabolize(mob/living/affected_mob)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -646,7 +646,7 @@
 	overdose_threshold = 30
 	ph = 8.96
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opioids = 20)
+	addiction_types = list(/datum/addiction/opioids = 30) // 30 units of morphine may cause addition
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
 /datum/reagent/medicine/morphine/on_mob_metabolize(mob/living/affected_mob)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -661,7 +661,6 @@
 	. = ..()
 	if(current_cycle > 5)
 		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
-	var/normalized = normalise_creation_purity()
 	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * (2 - creation_purity), seconds_per_tick))
 		affected_mob.adjust_disgust(1.5 * REM * seconds_per_tick)
 
@@ -673,15 +672,14 @@
 				affected_mob.emote("yawn")
 
 		if(24 to 36) // 5u to 7.5u
-			if(SPT_PROB(33 * (2 - creation_purity), seconds_per_tick))
-				affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 6 SECONDS)
-
-		if(36 to 48) // 7.5u to 10u
 			if(SPT_PROB(66 * (2 - creation_purity), seconds_per_tick))
 				affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 12 SECONDS)
 
+		if(36 to 48) // 7.5u to 10u
+			affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 12 SECONDS)
+
 		if(48 to INFINITY) //10u onward
-			affected_mob.adjust_drowsiness_up_to(1 * REM * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(3 SECONDS * REM * seconds_per_tick, 20 SECONDS)
 			// doesn't scale from purity - at this point it tries to guarantee sleep
 			if(SPT_PROB(30 * (48 - current_cycle), seconds_per_tick))
 				affected_mob.Sleeping(4 SECONDS * REM * seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request

- Morphine now takes roughly double the amount of units before it forces sleep. 
	- Note, it can still cause sleep before this threshold, thanks to drowsiness RNG.
- Morphine now causes a mild amount of disgust. Never reaches enough to vomitlock.
- Doubles the addiction caused by Morphine

## Why It's Good For The Game

I have never seen Morphine used for its "intended use" 

Its description, `Causes drowsiness and eventually unconsciousness in high doses`, is a lie because the "high dose" it mentions is the smallest dose the codebase normally provides pills (5u). Any lower and it lasts too short to matter.

This means it's far more effective as a sedative than its intended use, which is lame, because there are even more effective sedatives. So why would you ever use it? 

By bumping up the sleep threshold to ~10 units, this pr intends to make Morphine a lot more usable - 5u pills will rarely cause sleep, and 10u pills will be a bit risky, but still "safe". Beyond 10 units it still guarantees sleep, so it can still be used in a syringe gun or in surgery.  

To offset its safety, it's now far more addictive, having the potential to cause Opiate addiction in just over 30 units. 

I also gave it a tiny bit of disgust, not enough to really matter, mostly for flavor.

TL;DR I want to be able to shoot a morphine autoinjector into my leg to escape from certain death, not to guarantee my death

## Changelog

:cl: Melbert
balance: Morphine's sedative power has been halved. It now takes ~10 units to guarantee sleep, up from ~5. 
balance: Morphine now causes mild disgust. 
balance: Morphine is now twice as addictive, causing addiction if you down over ~30 units without pause.
/:cl:
