### PR TITLE
Revert "replaces reputation locks with instead being prohibitively expensive based on rep"

### DIFF
--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -69,6 +69,10 @@
 	SEND_SIGNAL(src, COMSIG_UPLINK_HANDLER_ON_UPDATE)
 	return
 
+/// Checks if traitor has enough reputation to purchase an item
+/datum/uplink_handler/proc/not_enough_reputation(datum/uplink_item/to_purchase)
+	return has_progression && progression_points < to_purchase.progression_minimum
+
 /// Checks for uplink flags as well as items restricted to roles and species
 /datum/uplink_handler/proc/check_if_restricted(datum/uplink_item/to_purchase)
 	if(!to_purchase.can_be_bought(src))
@@ -100,7 +104,7 @@
 
 	var/current_stock = item_stock[to_purchase.stock_key]
 	var/stock = current_stock != null ? current_stock : INFINITY
-	if(telecrystals < to_purchase.real_cost(src) || stock <= 0)
+	if(telecrystals < to_purchase.cost || stock <= 0 || not_enough_reputation(to_purchase))
 		return FALSE
 
 	return TRUE
@@ -112,7 +116,7 @@
 	if(to_purchase.limited_stock != -1 && !(to_purchase.stock_key in item_stock))
 		item_stock[to_purchase.stock_key] = to_purchase.limited_stock
 
-	telecrystals -= to_purchase.real_cost(src)
+	telecrystals -= to_purchase.cost
 	to_purchase.purchase(user, src, source)
 
 	if(to_purchase.stock_key in item_stock)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -200,14 +200,6 @@
 /datum/uplink_item/proc/can_be_bought(datum/uplink_handler/source)
 	return TRUE
 
-///Real cost if this item, accounting for progression_points if uplink_handler has_progression is TRUE
-/datum/uplink_item/proc/real_cost(datum/uplink_handler/source)
-	if (progression_minimum <= 0 || !source?.has_progression)
-		return cost
-	var percentage = CLAMP01(source.progression_points / progression_minimum)
-	var mult = (1 - percentage) * 3 + percentage * 1
-	return ceil(cost * mult)
-
 /datum/uplink_category/discounts
 	name = "Discounted Gear"
 	weight = -1

--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -89,26 +89,28 @@
 			continue
 		if(!uplink_item.surplus)
 			continue
+		if(handler.not_enough_reputation(uplink_item))
+			continue
 		possible_items += uplink_item
 	return possible_items
 
 /// picks items from the list given to proc and generates a valid uplink item that is less or equal to the amount of TC it can spend
-/datum/uplink_item/bundles_tc/surplus/proc/pick_possible_item(list/possible_items, tc_budget, datum/uplink_handler/handler)
+/datum/uplink_item/bundles_tc/surplus/proc/pick_possible_item(list/possible_items, tc_budget)
 	var/datum/uplink_item/uplink_item = pick(possible_items)
 	if(prob(100 - uplink_item.surplus))
 		return null
-	if(tc_budget < uplink_item.real_cost(handler))
+	if(tc_budget < uplink_item.cost)
 		return null
 	return uplink_item
 
 /// fills the crate that will be given to the traitor, edit this to change the crate and how the item is filled
-/datum/uplink_item/bundles_tc/surplus/proc/fill_crate(obj/structure/closet/crate/surplus_crate, list/possible_items, datum/uplink_handler/handler)
+/datum/uplink_item/bundles_tc/surplus/proc/fill_crate(obj/structure/closet/crate/surplus_crate, list/possible_items)
 	var/tc_budget = crate_tc_value
 	while(tc_budget)
-		var/datum/uplink_item/uplink_item = pick_possible_item(possible_items, tc_budget, handler)
+		var/datum/uplink_item/uplink_item = pick_possible_item(possible_items, tc_budget)
 		if(!uplink_item)
 			continue
-		tc_budget -= uplink_item.real_cost(handler)
+		tc_budget -= uplink_item.cost
 		new uplink_item.item(surplus_crate)
 
 /// overwrites item spawning proc for surplus items to spawn an appropriate crate via a podspawn
@@ -140,7 +142,7 @@
 	crate_type = /obj/structure/closet/crate/secure/syndicrate
 
 /// edited version of fill crate for super surplus to ensure it can only be unlocked with the syndicrate key
-/datum/uplink_item/bundles_tc/surplus/united/fill_crate(obj/structure/closet/crate/secure/syndicrate/surplus_crate, list/possible_items, datum/uplink_handler/handler)
+/datum/uplink_item/bundles_tc/surplus/united/fill_crate(obj/structure/closet/crate/secure/syndicrate/surplus_crate, list/possible_items)
 	if(!istype(surplus_crate))
 		return
 	var/tc_budget = crate_tc_value
@@ -148,7 +150,7 @@
 		var/datum/uplink_item/uplink_item = pick_possible_item(possible_items, tc_budget)
 		if(!uplink_item)
 			continue
-		tc_budget -= uplink_item.real_cost(handler)
+		tc_budget -= uplink_item.cost
 		surplus_crate.unlock_contents += uplink_item.item
 
 /datum/uplink_item/bundles_tc/surplus_key

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -1,4 +1,3 @@
-import { clamp } from 'common/math';
 import { BooleanLike } from 'common/react';
 import { Component, Fragment } from 'react';
 
@@ -97,19 +96,6 @@ type ItemExtraData = Item & {
     icon_state: string;
   };
 };
-
-function real_cost(item: UplinkItem, uplink: UplinkData) {
-  if (item.progression_minimum <= 0 || !uplink.has_progression) {
-    return item.cost;
-  }
-  let percentage = clamp(
-    uplink.progression_points / item.progression_minimum,
-    0,
-    1,
-  );
-  let mult = (1 - percentage) * 3 + percentage * 1;
-  return Math.ceil(item.cost * mult);
-}
 
 // Cache response so it's only sent once
 let fetchServerData: Promise<ServerData> | undefined;
@@ -227,6 +213,8 @@ export class Uplink extends Component<{}, UplinkState> {
     }
     for (let i = 0; i < itemsToAdd.length; i++) {
       const item = itemsToAdd[i];
+      const hasEnoughProgression =
+        progression_points >= item.progression_minimum;
 
       let stock: number | null = current_stock[item.stock_key];
       if (item.ref) {
@@ -235,8 +223,7 @@ export class Uplink extends Component<{}, UplinkState> {
       if (!stock && stock !== 0) {
         stock = null;
       }
-      const canBuy =
-        telecrystals >= real_cost(item, data) && (stock === null || stock > 0);
+      const canBuy = telecrystals >= item.cost && (stock === null || stock > 0);
       items.push({
         id: item.id,
         name: item.name,
@@ -258,7 +245,7 @@ export class Uplink extends Component<{}, UplinkState> {
         ),
         cost: (
           <Box>
-            {item.cost_override_string || `${real_cost(item, data)} TC`}
+            {item.cost_override_string || `${item.cost} TC`}
             {has_progression ? (
               <>
                 ,&nbsp;
@@ -271,7 +258,10 @@ export class Uplink extends Component<{}, UplinkState> {
             )}
           </Box>
         ),
-        disabled: !canBuy || (item.lock_other_purchases && purchased_items > 0),
+        disabled:
+          !canBuy ||
+          (has_progression && !hasEnoughProgression) ||
+          (item.lock_other_purchases && purchased_items > 0),
         extraData: {
           ref: item.ref,
           icon: item.icon,
@@ -308,9 +298,7 @@ export class Uplink extends Component<{}, UplinkState> {
                               {has_objectives
                                 ? ' the severity of secondary objectives you get and '
                                 : ' '}
-                              the price of certain items, which will return to
-                              their normal price once you have enough
-                              reputation.&nbsp;
+                              what items you can purchase.&nbsp;
                               <Box mt={0.5}>
                                 {/* A minute in deciseconds */}
                                 Threat passively increases by{' '}


### PR DESCRIPTION
Reverts tgstation/tgstation#87382

huge noob trap with unclear UI

bypasses the utility of side objectives granting reputation

the time lock is no longer a time lock

@Watermelon914 

:cl:
balance: Time-gated traitor uplink gear is returned to being hard reputation locked with a static price.
/:cl: