### PR TITLE
Fixes a runtime in detomatix logging

### DIFF
--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -80,5 +80,5 @@
 
 	GLOB.bombers += bomb_message
 	var/area/bomb_area = get_area(bomb)
-	if(message_admins && !(bomb_area && (bomb_area.area_flags & QUIET_LOGS))) // Don't spam the logs with deathmatch bombs
+	if(message_admins && !(bomb_area?.area_flags & QUIET_LOGS)) // Don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -80,5 +80,5 @@
 
 	GLOB.bombers += bomb_message
 	var/area/bomb_area = get_area(bomb)
-	if(message_admins && !(bomb_area.area_flags & QUIET_LOGS)) // Don't spam the logs with deathmatch bombs
+	if(message_admins && !(bomb_area && (bomb_area.area_flags & QUIET_LOGS))) // Don't spam the logs with deathmatch bombs
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")


### PR DESCRIPTION

## About The Pull Request

Detomatix doesn't pass the ``bomb`` arg to ``log_bomber`` for a rather obvious reason, and admin messaging code takes that into account. Not the check that allows that code to run though, that part just runtimes. 
Admins should probably be actually informed about players using detomatixes, yeah.

## Changelog
:cl:
fix: Fixed a runtime in detomatix logging
/:cl:
