### PR TITLE
Add human organ crate to emergency medical holodeck simulation

### DIFF
--- a/_maps/templates/holodeck_medicalsim.dmm
+++ b/_maps/templates/holodeck_medicalsim.dmm
@@ -109,10 +109,12 @@
 /area/template_noop)
 "gr" = (
 /obj/structure/table/glass,
-/obj/item/retractor,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/item/stack/medical/gauze,
+/obj/item/retractor,
+/obj/item/cautery,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -467,12 +469,10 @@
 	},
 /area/template_noop)
 "Qu" = (
-/obj/structure/table/glass,
-/obj/item/stack/medical/gauze,
-/obj/item/cautery,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/closet/crate/freezer/organ,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -295,6 +295,22 @@
 	new /obj/item/bodypart/leg/right/robot/surplus(src)
 	new /obj/item/bodypart/leg/right/robot/surplus(src)
 
+/obj/structure/closet/crate/freezer/organ
+	name = "organ freezer"
+	desc = "A freezer containing a set of organic organs."
+
+/obj/structure/closet/crate/freezer/organ/PopulateContents()
+	. = ..()
+	new /obj/item/organ/brain(src)
+	new /obj/item/organ/heart(src)
+	new /obj/item/organ/lungs(src)
+	new /obj/item/organ/eyes(src)
+	new /obj/item/organ/ears(src)
+	new /obj/item/organ/tongue(src)
+	new /obj/item/organ/liver(src)
+	new /obj/item/organ/stomach(src)
+	new /obj/item/organ/appendix(src)
+
 /obj/structure/closet/crate/freezer/food
 	name = "food icebox"
 	icon_state = "food"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -301,7 +301,6 @@
 
 /obj/structure/closet/crate/freezer/organ/PopulateContents()
 	. = ..()
-	new /obj/item/organ/brain(src)
 	new /obj/item/organ/heart(src)
 	new /obj/item/organ/lungs(src)
 	new /obj/item/organ/eyes(src)

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -209,19 +209,3 @@
 	crate_name = "body freezer"
 	crate_type = /obj/structure/closet/crate/secure/freezer
 
-/datum/supply_pack/medical/organs
-	name = "Organ Crate"
-	desc = "A freezer containing a set of organic organs. May or may not have been obtained illegally."
-	cost = CARGO_CRATE_VALUE * 2.5
-	contains = list(/obj/item/organ/brain,
-					/obj/item/organ/heart,
-					/obj/item/organ/lungs,
-					/obj/item/organ/eyes,
-					/obj/item/organ/ears,
-					/obj/item/organ/tongue,
-					/obj/item/organ/liver,
-					/obj/item/organ/stomach,
-					/obj/item/organ/appendix,
-				)
-	crate_name = "organ freezer"
-	crate_type = /obj/structure/closet/crate/freezer

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -208,3 +208,20 @@
 	contains = list(/obj/structure/closet/body_bag/lost_crew/with_body)
 	crate_name = "body freezer"
 	crate_type = /obj/structure/closet/crate/secure/freezer
+
+/datum/supply_pack/medical/organs
+	name = "Organ Crate"
+	desc = "A freezer containing a set of organic organs. May or may not have been obtained illegally."
+	cost = CARGO_CRATE_VALUE * 2.5
+	contains = list(/obj/item/organ/brain,
+					/obj/item/organ/heart,
+					/obj/item/organ/lungs,
+					/obj/item/organ/eyes,
+					/obj/item/organ/ears,
+					/obj/item/organ/tongue,
+					/obj/item/organ/liver,
+					/obj/item/organ/stomach,
+					/obj/item/organ/appendix,
+				)
+	crate_name = "organ freezer"
+	crate_type = /obj/structure/closet/crate/freezer

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -344,7 +344,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	if(istype(holo_atom, /obj/item/organ))
 		var/obj/item/organ/holo_organ = holo_atom
 		if(holo_organ.owner) // a mob has the holo organ inside them... oh dear
-			to_chat(holo_organ.owner, span_notice("\The [holo_organ] inside of you fades away!"))
+			to_chat(holo_organ.owner, span_warning("\The [holo_organ] inside of you fades away!"))
 	if(!silent)
 		visible_message(span_notice("[holo_atom] fades away!"))
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -344,7 +344,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	if(istype(holo_atom, /obj/item/organ))
 		var/obj/item/organ/holo_organ = holo_atom
 		if(holo_organ.owner) // a mob has the holo organ inside them... oh dear
-			to_chat(holo_organ.owner, span_notice("The [holo_organ] inside you fades away!"))
+			to_chat(holo_organ.owner, span_notice("\The [holo_organ] inside of you fades away!"))
 	if(!silent)
 		visible_message(span_notice("[holo_atom] fades away!"))
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -341,6 +341,10 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 		var/obj/item/clothing/under/holo_clothing = holo_atom
 		holo_clothing.dump_attachments()
 
+	if(istype(holo_atom, /obj/item/organ))
+		var/obj/item/organ/holo_organ = holo_atom
+		if(holo_organ.owner) // a mob has the holo organ inside them... oh dear
+			to_chat(holo_organ.owner, span_notice("The [holo_organ] inside you fades away!"))
 	if(!silent)
 		visible_message(span_notice("[holo_atom] fades away!"))
 


### PR DESCRIPTION
## About The Pull Request
This adds a crate to medical holodeck sim with a full set of human organs inside a freezer containing:
- heart
- lungs
- eyes
- ears
- tongue
- liver
- stomach
- appendix

##### (And yes, a holodeck organ can fade away while it's still inside someone causing them to suffer organ loss)

## Why It's Good For The Game

Immersion.

## Changelog
:cl:
add: Add medical human organ crate emergency medical holodeck simulation
/:cl:
