### PR TITLE
Fixes "is blacking out" message

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -265,6 +265,10 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
+
+	if(QDELETED(src))
+		return
+
 	RegisterSignal(owner, COMSIG_ATOM_SPLASHED, PROC_REF(on_splashed))
 	notify_ghosts(
 		"[owner] is blacking out!",


### PR DESCRIPTION
As a ghost, you can get a stray "is blacking out!" appearing in your chatbox whenever no one takes a blacked out drunkard roll

If no ghosts sign up, it deletes itself and then posts the message anyway while not having an owner, making that message appear

:cl:
fix: No more "is blacking out!"
/:cl: