### PR TITLE
[NO GBP] ACTUALLY allow dot radio prefixes to also work with the tgui-say radio prefix display

### DIFF
--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -23,7 +23,7 @@ type State = {
   size: WINDOW_SIZES;
 };
 
-const CHANNEL_REGEX = /^:\w\s/;
+const CHANNEL_REGEX = /^[:.]\w\s/;
 
 export class TguiSay extends Component<{}, State> {
   private channelIterator: ChannelIterator;


### PR DESCRIPTION

## About The Pull Request

imagine fucking up a port of _your own code_

(i plead "silly")

## Why It's Good For The Game

things working is good

## Changelog
:cl:
 fix: ACTUALLY allow dot radio prefixes to also work with the tgui-say radio prefix display.
/:cl:
