### PR TITLE
Allows Atmospherics MODsuits store extinguishers on their suit storage slot

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -316,10 +316,10 @@
 	slowdown_active = 1
 	allowed_suit_storage = list(
 		/obj/item/analyzer,
+		/obj/item/extinguisher,
 		/obj/item/fireaxe/metal_h2_axe,
 		/obj/item/pipe_dispenser,
 		/obj/item/t_scanner,
-		/obj/item/extinguisher
 	)
 	variants = list(
 		"atmospheric" = list(

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -319,6 +319,7 @@
 		/obj/item/fireaxe/metal_h2_axe,
 		/obj/item/pipe_dispenser,
 		/obj/item/t_scanner,
+		/obj/item/extinguisher
 	)
 	variants = list(
 		"atmospheric" = list(


### PR DESCRIPTION

## About The Pull Request

Adds the ability for Atmospherics MODsuits to store extinguishers on the suit storage slot
## Why It's Good For The Game

Atmos technicians are, arguably, firefighters. And if their overalls and firesuits can store extinguishers in the suit storage slot, why not their MODsuits, which are just beefed up firesuits?
Tested locally and functions as expected. Also this is just something I forgot to add to my last PR on tgstation where I added this ability to their overalls. Whoops!
## Changelog
:cl:
qol: Atmos MODsuits can now hold extinguishers on their suit slot
/:cl:
