### PR TITLE
Teleporting while leaning now makes you fall on your face

### DIFF
--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -98,7 +98,7 @@
 	// Make sure we unregister signal handlers and reset animation
 	stop_leaning()
 	// -1000 aura
-	src.visible_message("[src] falls flat on their face from losing their balance", "You fall suddenly as the object you were leaning on vanishes from contact with you")
+	visible_message(span_notice("[src] falls flat on [p_their()] face from losing [p_their()] balance!"), span_warning("You fall suddenly as the object you were leaning on vanishes from contact with you!"))
 	src.SetKnockdown((3 SECONDS))
 
 /mob/living/proc/stop_leaning()

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -86,10 +86,19 @@
 		COMSIG_MOB_CLIENT_PRE_MOVE,
 		COMSIG_LIVING_DISARM_HIT,
 		COMSIG_LIVING_GET_PULLED,
-		COMSIG_MOVABLE_TELEPORTING,
 	), PROC_REF(stop_leaning))
+
+	RegisterSignal(src, COMSIG_MOVABLE_TELEPORTED, PROC_REF(teleport_away_while_leaning))
 	RegisterSignal(src, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(lean_dir_changed))
 	update_fov()
+
+/// You fall on your face if you get teleported while leaning
+/mob/living/proc/teleport_away_while_leaning()
+	// Make sure we unregister signal handlers and reset animation
+	stop_leaning()
+	// -1000 aura
+	src.visible_message("[src] falls flat on their face from losing their balance")
+	src.SetKnockdown((3 SECONDS))
 
 /mob/living/proc/stop_leaning()
 	SIGNAL_HANDLER
@@ -97,8 +106,8 @@
 		COMSIG_MOB_CLIENT_PRE_MOVE,
 		COMSIG_LIVING_DISARM_HIT,
 		COMSIG_LIVING_GET_PULLED,
-		COMSIG_MOVABLE_TELEPORTING,
 		COMSIG_ATOM_POST_DIR_CHANGE,
+		COMSIG_MOVABLE_TELEPORTED,
 	))
 	animate(src, 0.2 SECONDS, pixel_x = base_pixel_x + body_position_pixel_x_offset, pixel_y = base_pixel_y + body_position_pixel_y_offset)
 	remove_traits(list(TRAIT_UNDENSE, TRAIT_EXPANDED_FOV), LEANING_TRAIT)

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -99,7 +99,7 @@
 	stop_leaning()
 	// -1000 aura
 	visible_message(span_notice("[src] falls flat on [p_their()] face from losing [p_their()] balance!"), span_warning("You fall suddenly as the object you were leaning on vanishes from contact with you!"))
-	src.SetKnockdown((3 SECONDS))
+	Knockdown(3 SECONDS)
 
 /mob/living/proc/stop_leaning()
 	SIGNAL_HANDLER

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -94,6 +94,7 @@
 
 /// You fall on your face if you get teleported while leaning
 /mob/living/proc/teleport_away_while_leaning()
+	SIGNAL_HANDLER
 	// Make sure we unregister signal handlers and reset animation
 	stop_leaning()
 	// -1000 aura

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -97,7 +97,7 @@
 	// Make sure we unregister signal handlers and reset animation
 	stop_leaning()
 	// -1000 aura
-	src.visible_message("[src] falls flat on their face from losing their balance")
+	src.visible_message("[src] falls flat on their face from losing their balance", "You fall suddenly as the object you were leaning on vanishes from contact with you")
 	src.SetKnockdown((3 SECONDS))
 
 /mob/living/proc/stop_leaning()


### PR DESCRIPTION
Way to lose aura

Credit to mothbloks for the idea

## Why It's Good For The Game
You can give -1000 aura for leaners you catch lacking with a bluespace crystal by throwing it at them

## Changelog

:cl: oranges
add: Teleporting a leaning person will now make them fall over
/:cl:
