### PR TITLE
`/datum/surgery/organ_manipulation/Destroy()` calls parent

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -36,7 +36,7 @@
 
 /datum/surgery/organ_manipulation/Destroy()
 	if(QDELETED(target) || !HAS_TRAIT(target, TRAIT_FISHING_SPOT))
-		return
+		return ..()
 	// The surgery is not finished yet and we're currently on manipulate organs step
 	if(status <= length(steps) && ispath(steps[status], /datum/surgery_step/manipulate_organs))
 		remove_fishing_spot()


### PR DESCRIPTION
## About The Pull Request

`/datum/surgery/organ_manipulation/Destroy()` now returns `..()` instead of nothing, kinda important

Fixes #88172 , probably

## Changelog

:cl: Melbert
fix: Maybe fixes some organ manipulation bugs
/:cl:

