### PR TITLE
Prevent slimes from feeding while immobilized

### DIFF
--- a/code/modules/mob/living/basic/slime/feeding.dm
+++ b/code/modules/mob/living/basic/slime/feeding.dm
@@ -23,6 +23,11 @@
 	if(check_adjacent && (!Adjacent(meal) || !isturf(loc)))
 		return FALSE
 
+	if(!(mobility_flags & MOBILITY_MOVE))
+		if(!silent)
+			balloon_alert(src, "can't move!")
+		return FALSE
+
 	if(meal.stat == DEAD)
 		if(!silent)
 			balloon_alert(src, "no life energy!")


### PR DESCRIPTION
## About The Pull Request

So there's a few ways to tackle this

- Freezing should stop people from taking actions in general?
- Being immobilized should stop you from buckling in general?

But I went for the least offensive option, of simply blocking feeding if you can't move

Fixes #88185 (partially)

## Changelog

:cl: Melbert
fix: Frozen slimes can't latch on to you (but they can still attack you technically)
/:cl:


