### PR TITLE
Updates the list of station commission plaques

### DIFF
--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -115,6 +115,14 @@
 
 //Current stations
 
+// Birdshot: added Apr 29, 2023 (#74371)
+/obj/structure/plaque/static_plaque/golden/commission/birdshot
+	desc = "Spinward Sector Station SS-13\n'Birdshot' Class Outpost\nCommissioned 29/04/2563\n'Shooting for the Stars'"
+
+// Deltastation: added Dec 17, 2016 (#22066)
+/obj/structure/plaque/static_plaque/golden/commission/delta
+	desc = "Spinward Sector Station SS-13\n'Delta' Class Outpost\nCommissioned 17/12/2556\n'Efficiency Through Redundancy'"
+
 // Icebox Station: added May 13, 2020 (#51090)
 /obj/structure/plaque/static_plaque/golden/commission/icebox
 	desc = "Spinward Sector Station SS-13\n'Box' Class Outpost (Revision 2.2: 'Icebox')\nCommissioned 13/05/2560\n'Cold Reliable'"
@@ -123,25 +131,17 @@
 /obj/structure/plaque/static_plaque/golden/commission/meta
 	desc = "Spinward Sector Station SS-13\n'Meta' Class Outpost\nCommissioned 11/03/2553\n'Theseus' Station'"
 
-// Deltastation: added Dec 17, 2016 (#22066)
-/obj/structure/plaque/static_plaque/golden/commission/delta
-	desc = "Spinward Sector Station SS-13\n'Delta' Class Outpost\nCommissioned 17/12/2556\n'Efficiency Through Redundancy'"
+// Nebulastation: added Nov 6, 2024 (#84826)
+/obj/structure/plaque/static_plaque/golden/commission/nebula
+	desc = "Spinward Sector Station SS-13\n'Nebula' Class Outpost\nCommissioned 06/11/2564\n'The New Future'"
 
 // Tramstation: added Mar 11, 2021 (#56509)
 /obj/structure/plaque/static_plaque/golden/commission/tram
 	desc = "Spinward Sector Station SS-13\n'Tram' Class Outpost\nCommissioned 11/03/2561\n'Making Moves'"
 
-// Wawastation: added add date here
+// Wawastation: added Jun 4, 2024 (#82298)
 /obj/structure/plaque/static_plaque/golden/commission/wawa
-	desc = "Spinward Sector Station SS-13\n'Wawa' Class Outpost\nCommissioned 11/03/add here\n'Forever Vertical'"
-
-// North Star: added Apr 13, 2023 (#74371)
-/obj/structure/plaque/static_plaque/golden/commission/northstar
-	desc = "Spinward Sector Ship SS-13\n'North Star' Class Vessel\nCommissioned 13/04/2563\n'New Opportunities'"
-
-// Birdshot: added Apr 29, 2023 (#74371)
-/obj/structure/plaque/static_plaque/golden/commission/birdshot
-	desc = "Spinward Sector Station SS-13\n'Birdshot' Class Outpost\nCommissioned 29/04/2563\n'Shooting for the Stars'"
+	desc = "Spinward Sector Station SS-13\n'Wawa' Class Outpost\nCommissioned 04/06/2564\n'Forever Vertical'"
 
 //Removed stations
 
@@ -188,6 +188,10 @@
 // Ministation: added Jan 29, 2014 (7a76e9456b782e6626bf81e27a912d8232c76b18), removed Dec 27, 2016 (#22453)- 2 years, 10 months, 28 days
 /obj/structure/plaque/static_plaque/golden/commission/mini
 	desc = "Spinward Sector Station SS-08\n'Mini' Class Outpost\nCommissioned 29/01/2554\nDecommissioned 27/12/2556\n'The Littlest Station'"
+
+// North Star: added Apr 13, 2023 (#74371), removed Nov 25, 2024 (#87937)- 1 year, 7 months, 12 days
+/obj/structure/plaque/static_plaque/golden/commission/northstar
+	desc = "Spinward Sector Ship SS-13\n'North Star' Class Vessel\nCommissioned 13/04/2563\nDecommissioned 25/11/2564\n'New Opportunities'"
 
 // Omegastation: added Dec 27, 2016 (#22453), removed Sep 20, 2018 (#40352)- 1 year, 8 months, 24 days
 /obj/structure/plaque/static_plaque/golden/commission/omega


### PR DESCRIPTION

## About The Pull Request
Commission plaques were outdated, so they needed updating. This adds Wawa's merge date, which was not present, moves Northstar's to the removed station list, and adds one for Nebulastation. I also alphabetized the current map list to be in line with the removed list. No map edits were made.
## Why It's Good For The Game
Just keeping things up to date
## Changelog
:cl:
spellcheck: Station commission plaques (the gold ones that have the date they were added) have been updated, adding Nebula's, fixing Wawa's, and decommissioning Northstar's.
/:cl:
