### PR TITLE
Fix missing returns in limb dislocation treatment code

### DIFF
--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -347,7 +347,7 @@
 		user.visible_message(span_danger("[user] begins [scanned ? "expertly" : ""] resetting [victim]'s [limb.plaintext_zone] with [I]."), span_notice("You begin resetting [victim]'s [limb.plaintext_zone] with [I][scanned ? ", keeping the holo-image's indications in mind" : ""]..."))
 
 	if(!do_after(user, treatment_delay, target = victim, extra_checks=CALLBACK(src, PROC_REF(still_exists))))
-		return
+		return TRUE
 
 	if(victim == user)
 		limb.receive_damage(brute=15, wound_bonus=CANT_WOUND)
@@ -359,6 +359,7 @@
 
 	victim.emote("scream")
 	qdel(src)
+	return TRUE
 
 /*
 	Severe (Hairline Fracture)


### PR DESCRIPTION
## About The Pull Request

Add `return TRUE` to two spots of `/datum/wound/blunt/bone/moderate/treat` because the lack of them was causing you to hit the patient with the bonesetter after you successfully set the bone.

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: Using a bonesetter to correct a dislocated limb should no longer cause you to hit the patient with it too.
/:cl:
