### PR TITLE
Prevents bounty pads from sending holographic and abstract items. Tidies the code a bit.

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -117,6 +117,10 @@
 			continue
 		if(possible_shippable.flags_1 & HOLOGRAM_1)
 			continue
+		if(istype(possible_shippable, /obj/item))
+			var/obj/item/possible_shippable_item = possible_shippable
+			if(possible_shippable_item.item_flags & ABSTRACT)
+				continue
 		if(curr_bounty.applies_to(possible_shippable))
 			active_stack ++
 			curr_bounty.ship(possible_shippable)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -84,10 +84,12 @@
 		return FALSE
 	status_report = "Civilian Bounty: "
 	var/obj/machinery/piratepad/civilian/pad = pad_ref?.resolve()
-	for(var/atom/movable/AM in get_turf(pad))
-		if(AM == pad)
+	for(var/atom/movable/possible_shippable in get_turf(pad))
+		if(possible_shippable == pad)
 			continue
-		if(inserted_scan_id.registered_account.civilian_bounty.applies_to(AM))
+		if(possible_shippable.flags_1 & HOLOGRAM_1)
+			continue
+		if(inserted_scan_id.registered_account.civilian_bounty.applies_to(possible_shippable))
 			status_report += "Target Applicable."
 			playsound(loc, 'sound/machines/synth/synth_yes.ogg', 30 , TRUE)
 			return
@@ -110,13 +112,15 @@
 	var/datum/bounty/curr_bounty = inserted_scan_id.registered_account.civilian_bounty
 	var/active_stack = 0
 	var/obj/machinery/piratepad/civilian/pad = pad_ref?.resolve()
-	for(var/atom/movable/AM in get_turf(pad))
-		if(AM == pad)
+	for(var/atom/movable/possible_shippable in get_turf(pad))
+		if(possible_shippable == pad)
 			continue
-		if(curr_bounty.applies_to(AM))
+		if(possible_shippable.flags_1 & HOLOGRAM_1)
+			continue
+		if(curr_bounty.applies_to(possible_shippable))
 			active_stack ++
-			curr_bounty.ship(AM)
-			qdel(AM)
+			curr_bounty.ship(possible_shippable)
+			qdel(possible_shippable)
 	if(active_stack >= 1)
 		status_report += "Bounty Target Found x[active_stack]. "
 	else

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -89,6 +89,10 @@
 			continue
 		if(possible_shippable.flags_1 & HOLOGRAM_1)
 			continue
+		if(isitem(possible_shippable))
+			var/obj/item/possible_shippable_item = possible_shippable
+			if(possible_shippable_item.item_flags & ABSTRACT)
+				continue
 		if(inserted_scan_id.registered_account.civilian_bounty.applies_to(possible_shippable))
 			status_report += "Target Applicable."
 			playsound(loc, 'sound/machines/synth/synth_yes.ogg', 30 , TRUE)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -117,7 +117,7 @@
 			continue
 		if(possible_shippable.flags_1 & HOLOGRAM_1)
 			continue
-		if(istype(possible_shippable, /obj/item))
+		if(isitem(possible_shippable))
 			var/obj/item/possible_shippable_item = possible_shippable
 			if(possible_shippable_item.item_flags & ABSTRACT)
 				continue


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. 

## Why It's Good For The Game

This is a possible exploit for infinite bounty cubes. We're closing this loop early before it becomes a problem.

## Changelog
:cl:
fix: Civilian bounty pads refuse to send holographic items. Nanotrasen have received far too many holographic fish for their liking. Officer Mathews is still weeping in a corner after all the clownfish in his aquarium turned to dust before his very eyes...
code: Cleans up the bounty pad code just a smidge.
/:cl:
