### PR TITLE
Fix double-encode in AI shuttle call reasons

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -356,6 +356,13 @@ SUBSYSTEM_DEF(shuttle)
 
 	return TRUE
 
+/**
+ * Calls the emergency shuttle.
+ *
+ * Arguments:
+ * * user - The mob that called the shuttle.
+ * * call_reason - The reason the shuttle was called, which should be non-html-encoded text.
+ */
 /datum/controller/subsystem/shuttle/proc/requestEvac(mob/user, call_reason)
 	if (!check_backup_emergency_shuttle())
 		return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -350,6 +350,7 @@
 		"What is the nature of your emergency? ([CALL_SHUTTLE_REASON_LENGTH] characters required.)",
 		"Confirm Shuttle Call",
 		max_length = MAX_MESSAGE_LEN,
+		encode = FALSE,
 	)
 
 	if(incapacitated)


### PR DESCRIPTION

## About The Pull Request

This fixes double html encoding with AI shuttle calls, due to `tgui_input_text` being called without setting `encode = FALSE` - `SSshuttle.requestEvac` expects unencoded text.

I added documentation to `SSshuttle.requestEvac`, including clarifying that it expects non-html-encoded text.

## Why It's Good For The Game

&​#​39;​ is annoying

## Changelog
:cl:
fix: Fixed double-encoded messages with AI shuttle call reasons.
/:cl:
