### PR TITLE
Fix hands/clothes still getting covered in blood with light step

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -108,7 +108,7 @@
 	set_bloody_shoes(pool.blood_state, new_our_bloodiness)
 	pool.bloodiness = total_bloodiness - new_our_bloodiness // Give the pool the remaining blood incase we were limited
 
-	if(HAS_TRAIT(parent_atom, TRAIT_LIGHT_STEP)) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
+	if(HAS_TRAIT(parent_atom, TRAIT_LIGHT_STEP) || (wielder && HAS_TRAIT(wielder, TRAIT_LIGHT_STEP))) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
 		return TRUE
 
 	parent_atom.add_blood_DNA(GET_ATOM_BLOOD_DNA(pool))


### PR DESCRIPTION

## About The Pull Request

the Light Step quirk says this:
> Also, your hands and clothes will not get messed in case of stepping in blood.

However, the bloodysoles component improperly checked this - it only checked the parent object for `TRAIT_LIGHT_STEP`, not the wielder. I've fixed this by making it also check the wielder for the trait, if there is any.

https://github.com/user-attachments/assets/b41086af-cf29-41e5-b0dc-2463b2c95013

## Why It's Good For The Game

It's nice for things to work as intended.

## Changelog
:cl:
fix: Light Step now properly prevents your hands and clothes from getting covered in blood when stepping in it.
/:cl:
