### PR TITLE
Minor broadcast camera code cleanup

### DIFF
--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -41,11 +41,10 @@
 /obj/item/broadcast_camera/Destroy(force)
 	QDEL_NULL(internal_radio)
 	QDEL_NULL(internal_camera)
-
 	return ..()
 
 /obj/item/broadcast_camera/update_icon_state()
-	icon_state = "[base_icon_state]0"
+	icon_state = "[base_icon_state][active]"
 	return ..()
 
 /obj/item/broadcast_camera/attack_self(mob/user, modifiers)
@@ -80,7 +79,7 @@
 	if(!iscarbon(loc))
 		return
 	active = TRUE
-	icon_state = "[base_icon_state][active]"
+	update_icon_state()
 	/// The carbon who wielded the camera, allegedly
 	var/mob/living/carbon/wielding_carbon = loc
 
@@ -103,7 +102,7 @@
 /// When deactivating the camera
 /obj/item/broadcast_camera/proc/on_deactivating()
 	active = FALSE
-	icon_state = "[base_icon_state][active]"
+	update_icon_state()
 	QDEL_NULL(internal_camera)
 	QDEL_NULL(internal_radio)
 


### PR DESCRIPTION

## About The Pull Request

Moved all the icon_state setting logic of the broadcast camera to `update_icon_state`, rather than setting it manually on (de)activation, and resetting it to inactive in `update_icon_state`

## Why It's Good For The Game

Makes things more consistent.

## Changelog
:cl:
fix: Made the broadcast camera's sprite more consistent, it hopefully shouldn't reset to the inactive sprite while recording in some weird scenarios now.
/:cl:
