### PR TITLE
Toolbox Mastery: Finally gives toolboxes a real use

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -277,6 +277,38 @@ GLOBAL_LIST_INIT(mining_suit_allowed, list(
 	/obj/item/spear,
 ))
 
+/// List of all "tools" that can fit into belts or work from toolboxes
+
+GLOBAL_LIST_INIT(tool_items, list(
+	/obj/item/airlock_painter,
+	/obj/item/analyzer,
+	/obj/item/assembly/signaler,
+	/obj/item/construction/rcd,
+	/obj/item/construction/rld,
+	/obj/item/construction/rtd,
+	/obj/item/crowbar,
+	/obj/item/extinguisher/mini,
+	/obj/item/flashlight,
+	/obj/item/forcefield_projector,
+	/obj/item/geiger_counter,
+	/obj/item/holosign_creator/atmos,
+	/obj/item/holosign_creator/engineering,
+	/obj/item/inducer,
+	/obj/item/lightreplacer,
+	/obj/item/multitool,
+	/obj/item/pipe_dispenser,
+	/obj/item/pipe_painter,
+	/obj/item/plunger,
+	/obj/item/radio,
+	/obj/item/screwdriver,
+	/obj/item/stack/cable_coil,
+	/obj/item/t_scanner,
+	/obj/item/weldingtool,
+	/obj/item/wirecutters,
+	/obj/item/wrench,
+	/obj/item/spess_knife,
+))
+
 /// String for items placed into the left pocket.
 #define LOCATION_LPOCKET "in your left pocket"
 /// String for items placed into the right pocket

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -46,35 +46,9 @@
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 21
-	atom_storage.set_holdable(list(
-		/obj/item/airlock_painter,
-		/obj/item/analyzer,
-		/obj/item/assembly/signaler,
+	atom_storage.set_holdable(GLOB.tool_items + list(
 		/obj/item/clothing/gloves,
-		/obj/item/construction/rcd,
-		/obj/item/construction/rld,
-		/obj/item/construction/rtd,
-		/obj/item/crowbar,
-		/obj/item/extinguisher/mini,
-		/obj/item/flashlight,
-		/obj/item/forcefield_projector,
-		/obj/item/geiger_counter,
-		/obj/item/holosign_creator/atmos,
-		/obj/item/holosign_creator/engineering,
-		/obj/item/inducer,
-		/obj/item/lightreplacer,
-		/obj/item/multitool,
-		/obj/item/pipe_dispenser,
-		/obj/item/pipe_painter,
-		/obj/item/plunger,
 		/obj/item/radio,
-		/obj/item/screwdriver,
-		/obj/item/stack/cable_coil,
-		/obj/item/t_scanner,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/spess_knife,
 		/obj/item/melee/sickly_blade/lock,
 		/obj/item/reagent_containers/cup/soda_cans,
 	))

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -64,6 +64,7 @@
 	if (!user.put_in_inactive_hand(picked_item))
 		return ITEM_INTERACT_BLOCKING
 
+	atom_storage.animate_parent()
 	if (istype(picked_item, /obj/item/weldingtool))
 		var/obj/item/weldingtool/welder = picked_item
 		if (!welder.welding)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -56,10 +56,9 @@
 
 	var/list/item_radial = list()
 	for (var/obj/item/tool in atom_storage.real_location)
-		for (var/item_type in GLOB.tool_items)
-			if (istype(tool, item_type))
-				item_radial[tool] = tool.appearance
-				break
+		if(is_type_in_list(tool, GLOB.tool_items))
+			item_radial[tool] = tool.appearance
+			break
 
 	if (!length(item_radial))
 		return NONE

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -234,7 +234,7 @@
 // /Switches the welder on
 /obj/item/weldingtool/proc/switched_on(mob/user)
 	if(!status)
-		to_chat(user, span_warning("[src] can't be turned on while unsecured!"))
+		balloon_alert(user, "unsecured!")
 		return
 	set_welding(!welding)
 	if(welding)


### PR DESCRIPTION

## About The Pull Request

Using a toolbox on an object will now bring up a radial menu containing all "tools" inside of it, and picking one will put it in your offhand and use it on the object you clicked. After use, the item will be stowed back in the toolbox. Welding tools will be turned on (and off when stowed), and spess knives will give you an option to pick which tool you want to use. Only certain items qualify as tools (most items that would fit into a toolbelt do), so you cannot use this to sneakily attack someone with an esword.

https://github.com/user-attachments/assets/0cd5c859-490f-4643-b451-92ce15a34fba

Using a toolbox in such a fashion passes click modifiers through, allowing you to use left/right, ctrl and alt click modes of items just fine.

God bless our attack chain.

## Why It's Good For The Game

Toolboxes are inferior to toolbelts and boxes in almost every single way, being only capable of storing 7 items and not fitting anywhere. This gives them an actual use and maybe they'll see use in actual construction projects.

## Changelog
:cl:
add: Toolboxes can be used on any object to pull out and use a tool from it as long as your offhand is free.
/:cl:
