### PR TITLE
Makes wound treatment with medical stack items less jank

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -303,8 +303,8 @@ GLOBAL_LIST_INIT(biotypes_to_scar_file, list(
 // ~random wound balance defines
 /// how quickly sanitization removes infestation and decays per second
 #define WOUND_BURN_SANITIZATION_RATE 0.075
-/// how much blood you can lose per tick per slash max.
-#define WOUND_SLASH_MAX_BLOODFLOW 4.5
+/// how much blood you can lose per tick per wound max.
+#define WOUND_MAX_BLOODFLOW 4.5
 /// further slash attacks on a bodypart with a slash wound have their blood_flow further increased by damage * this (10 damage slash adds .25 flow)
 #define WOUND_SLASH_DAMAGE_FLOW_COEFF 0.025
 /// if we suffer a bone wound to the head that creates brain traumas, the timer for the trauma cycle is +/- by this percent (0-100)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -223,25 +223,13 @@
 	new burn common procs
 */
 
-/// if someone is using ointment or mesh on our burns
-/datum/wound/burn/flesh/proc/ointmentmesh(obj/item/stack/medical/I, mob/user)
-	user.visible_message(span_notice("[user] begins applying [I] to [victim]'s [limb.plaintext_zone]..."), span_notice("You begin applying [I] to [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone]..."))
-	if (I.amount <= 0)
+/// Checks if the wound is in a state that ointment or flesh will help
+/datum/wound/burn/flesh/proc/can_be_ointmented_or_meshed()
+	if(infestation > 0 || sanitization < infestation)
 		return TRUE
-	if(!do_after(user, (user == victim ? I.self_delay : I.other_delay), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if(flesh_damage > 0 || flesh_healing <= flesh_damage)
 		return TRUE
-
-	limb.heal_damage(I.heal_brute, I.heal_burn)
-	user.visible_message(span_green("[user] applies [I] to [victim]."), span_green("You apply [I] to [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone]."))
-	I.use(1)
-	sanitization += I.sanitization
-	flesh_healing += I.flesh_regeneration
-
-	if((infestation <= 0 || sanitization >= infestation) && (flesh_damage <= 0 || flesh_healing > flesh_damage))
-		to_chat(user, span_notice("You've done all you can with [I], now you must wait for the flesh on [victim]'s [limb.plaintext_zone] to recover."))
-		return TRUE
-	else
-		return try_treating(I, user)
+	return FALSE
 
 /// Paramedic UV penlights
 /datum/wound/burn/flesh/proc/uv(obj/item/flashlight/pen/paramedic/I, mob/user)
@@ -258,15 +246,7 @@
 	return TRUE
 
 /datum/wound/burn/flesh/treat(obj/item/I, mob/user)
-	if(istype(I, /obj/item/stack/medical/ointment))
-		return ointmentmesh(I, user)
-	else if(istype(I, /obj/item/stack/medical/mesh))
-		var/obj/item/stack/medical/mesh/mesh_check = I
-		if(!mesh_check.is_open)
-			to_chat(user, span_warning("You need to open [mesh_check] first."))
-			return
-		return ointmentmesh(mesh_check, user)
-	else if(istype(I, /obj/item/flashlight/pen/paramedic))
+	if(istype(I, /obj/item/flashlight/pen/paramedic))
 		return uv(I, user)
 
 // people complained about burns not healing on stasis beds, so in addition to checking if it's cured, they also get the special ability to very slowly heal on stasis beds if they have the healing effects stored

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -159,7 +159,7 @@
 			if(4 to INFINITY)
 				bandage_condition = "clean"
 
-		condition += " underneath a dressing of [bandage_condition] [limb.current_gauze.name]"
+		condition += " underneath a dressing of [bandage_condition] [limb.current_gauze.name]."
 	else
 		switch(infestation)
 			if(WOUND_INFECTION_MODERATE to WOUND_INFECTION_SEVERE)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -36,9 +36,6 @@
 	/// Once the blood flow drops below minimum_flow, we demote it to this type of wound. If there's none, we're all better
 	var/demotes_to
 
-	/// The maximum flow we've had so far
-	var/highest_flow
-
 	/// A bad system I'm using to track the worst scar we earned (since we can demote, we want the biggest our wound has been, not what it was when it was cured (probably moderate))
 	var/datum/scar/highest_scar
 
@@ -133,44 +130,23 @@
 		return BLOOD_FLOW_INCREASING
 
 /datum/wound/slash/flesh/handle_process(seconds_per_tick, times_fired)
-
 	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS))
 		return
 
 	// in case the victim has the NOBLOOD trait, the wound will simply not clot on its own
 	if(limb.can_bleed())
-		set_blood_flow(min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW))
+		if(clot_rate > 0)
+			adjust_blood_flow(-clot_rate * seconds_per_tick)
+			if(QDELETED(src))
+				return
 
 		if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
 			adjust_blood_flow(0.25) // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 
-	//gauze always reduces blood flow, even for non bleeders
 	if(limb.current_gauze)
-		if(clot_rate > 0)
-			adjust_blood_flow(-clot_rate * seconds_per_tick)
-		adjust_blood_flow(-limb.current_gauze.absorption_rate * seconds_per_tick)
-		limb.seep_gauze(limb.current_gauze.absorption_rate * seconds_per_tick)
-	//otherwise, only clot if it's a bleeder
-	else if(limb.can_bleed())
-		adjust_blood_flow(-clot_rate * seconds_per_tick)
-
-	if(blood_flow > highest_flow)
-		highest_flow = blood_flow
-
-	if(blood_flow < minimum_flow)
-		if(demotes_to)
-			replace_wound(new demotes_to)
-		else
-			to_chat(victim, span_green("The cut on your [limb.plaintext_zone] has [!limb.can_bleed() ? "healed up" : "stopped bleeding"]!"))
-			qdel(src)
-
-/datum/wound/slash/flesh/on_stasis(seconds_per_tick, times_fired)
-	if(blood_flow >= minimum_flow)
-		return
-	if(demotes_to)
-		replace_wound(new demotes_to)
-		return
-	qdel(src)
+		var/gauze_power = limb.current_gauze.absorption_rate
+		limb.seep_gauze(gauze_power * seconds_per_tick)
+		adjust_blood_flow(-gauze_power * seconds_per_tick)
 
 /* BEWARE, THE BELOW NONSENSE IS MADNESS. bones.dm looks more like what I have in mind and is sufficiently clean, don't pay attention to this messiness */
 
@@ -185,8 +161,6 @@
 		return las_cauterize(I, user)
 	else if(I.tool_behaviour == TOOL_CAUTERY || I.get_temperature())
 		return tool_cauterize(I, user)
-	else if(istype(I, /obj/item/stack/medical/suture))
-		return suture(I, user)
 
 /datum/wound/slash/flesh/try_handling(mob/living/user)
 	if(user.pulling != victim || !HAS_TRAIT(user, TRAIT_WOUND_LICKER) || !victim.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))
@@ -212,8 +186,7 @@
 /// if a felinid is licking this cut to reduce bleeding
 /datum/wound/slash/flesh/proc/lick_wounds(mob/living/carbon/human/user)
 	// transmission is one way patient -> felinid since google said cat saliva is antiseptic or whatever, and also because felinids are already risking getting beaten for this even without people suspecting they're spreading a deathvirus
-	for(var/i in victim.diseases)
-		var/datum/disease/iter_disease = i
+	for(var/datum/disease/iter_disease as anything in victim.diseases)
 		if(iter_disease.spread_flags & (DISEASE_SPREAD_SPECIAL | DISEASE_SPREAD_NON_CONTAGIOUS))
 			continue
 		user.ForceContractDisease(iter_disease)
@@ -225,18 +198,28 @@
 
 	user.visible_message(span_notice("[user] licks the wounds on [victim]'s [limb.plaintext_zone]."), span_notice("You lick some of the wounds on [victim]'s [limb.plaintext_zone]"), ignored_mobs=victim)
 	to_chat(victim, span_green("[user] licks the wounds on your [limb.plaintext_zone]!"))
+	var/mob/victim_stored = victim
 	adjust_blood_flow(-0.5)
 
 	if(blood_flow > minimum_flow)
 		try_handling(user)
 	else if(demotes_to)
-		to_chat(user, span_green("You successfully lower the severity of [victim]'s cuts."))
+		to_chat(user, span_green("You successfully lower the severity of [user == victim_stored ? "your" : "[victim_stored]'s"] cuts."))
+
+/datum/wound/slash/flesh/adjust_blood_flow(adjust_by, minimum)
+	. = ..()
+	if(blood_flow > WOUND_MAX_BLOODFLOW)
+		blood_flow = WOUND_MAX_BLOODFLOW
+	if(blood_flow < minimum_flow && !QDELETED(src))
+		if(demotes_to)
+			replace_wound(new demotes_to)
+		else
+			to_chat(victim, span_green("The cut on your [limb.plaintext_zone] has [!limb.can_bleed() ? "healed up" : "stopped bleeding"]!"))
+			qdel(src)
 
 /datum/wound/slash/flesh/on_xadone(power)
 	. = ..()
-
-	if (limb) // parent can cause us to be removed, so its reasonable to check if we're still applied
-		adjust_blood_flow(-0.03 * power) // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
+	adjust_blood_flow(-0.03 * power) // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
 
 /datum/wound/slash/flesh/on_synthflesh(reac_volume)
 	. = ..()
@@ -271,49 +254,28 @@
 	else
 		user.visible_message(span_danger("[user] begins cauterizing [victim]'s [limb.plaintext_zone] with [I]..."), span_warning("You begin cauterizing [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone] with [I]..."))
 
+	playsound(user, 'sound/items/handling/surgery/cautery1.ogg', 75, TRUE)
+
 	if(!do_after(user, treatment_delay, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
+
+	playsound(user, 'sound/items/handling/surgery/cautery2.ogg', 75, TRUE)
+
 	var/bleeding_wording = (!limb.can_bleed() ? "cuts" : "bleeding")
 	user.visible_message(span_green("[user] cauterizes some of the [bleeding_wording] on [victim]."), span_green("You cauterize some of the [bleeding_wording] on [victim]."))
 	limb.receive_damage(burn = 2 + severity, wound_bonus = CANT_WOUND)
 	if(prob(30))
 		victim.emote("scream")
 	var/blood_cauterized = (0.6 / (self_penalty_mult * improv_penalty_mult))
+	var/mob/victim_stored = victim
 	adjust_blood_flow(-blood_cauterized)
 
 	if(blood_flow > minimum_flow)
 		return try_treating(I, user)
 	else if(demotes_to)
-		to_chat(user, span_green("You successfully lower the severity of [user == victim ? "your" : "[victim]'s"] cuts."))
+		to_chat(user, span_green("You successfully lower the severity of [user == victim_stored ? "your" : "[victim_stored]'s"] cuts."))
 		return TRUE
 	return FALSE
-
-/// If someone is using a suture to close this cut
-/datum/wound/slash/flesh/proc/suture(obj/item/stack/medical/suture/I, mob/user)
-	var/self_penalty_mult = (user == victim ? 1.4 : 1)
-	var/treatment_delay = base_treat_time * self_penalty_mult
-
-	if(HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
-		treatment_delay *= 0.5
-		user.visible_message(span_notice("[user] begins expertly stitching [victim]'s [limb.plaintext_zone] with [I]..."), span_notice("You begin stitching [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone] with [I], keeping the holo-image information in mind..."))
-	else
-		user.visible_message(span_notice("[user] begins stitching [victim]'s [limb.plaintext_zone] with [I]..."), span_notice("You begin stitching [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone] with [I]..."))
-
-	if(!do_after(user, treatment_delay, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
-		return TRUE
-	var/bleeding_wording = (!limb.can_bleed() ? "cuts" : "bleeding")
-	user.visible_message(span_green("[user] stitches up some of the [bleeding_wording] on [victim]."), span_green("You stitch up some of the [bleeding_wording] on [user == victim ? "yourself" : "[victim]"]."))
-	var/blood_sutured = I.stop_bleeding / self_penalty_mult
-	adjust_blood_flow(-blood_sutured)
-	limb.heal_damage(I.heal_brute, I.heal_burn)
-	I.use(1)
-
-	if(blood_flow > minimum_flow)
-		return try_treating(I, user)
-	else if(demotes_to)
-		to_chat(user, span_green("You successfully lower the severity of [user == victim ? "your" : "[victim]'s"] cuts."))
-		return TRUE
-	return TRUE
 
 /datum/wound/slash/get_limb_examine_description()
 	return span_warning("The flesh on this limb appears badly lacerated.")

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -153,8 +153,10 @@
 		patient.balloon_alert(user, "fully treated")
 		return
 
-	user.balloon_alert(user, "treating [other_affected_limbs[1]]...")
-	try_heal(patient, user, other_affected_limbs[1], silent = TRUE)
+	var/preferred_target = check_zone(user.zone_selected)
+	var/next_picked = (preferred_target in other_affected_limbs) ? preferred_target : other_affected_limbs[1]
+	user.balloon_alert(user, "treating [next_picked]...")
+	try_heal(patient, user, next_picked, silent = TRUE)
 
 /// Checks if the passed patient can be healed by the passed user
 /obj/item/stack/medical/proc/can_heal(mob/living/patient, mob/living/user, healed_zone, silent = FALSE)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -133,8 +133,9 @@
 		var/atom/alert_loc = QDELETED(src) ? user : src
 		alert_loc.balloon_alert(user, repeating ? "all used up!" : "treated [parse_zone(healed_zone)]")
 		return
-	if(try_heal_checks(patient, user, healed_zone, silent = TRUE))
-		try_heal(patient, user, healed_zone, silent = TRUE)
+	var/preferred_target = check_zone(user.zone_selected)
+	if(try_heal_checks(patient, user, preferred_target, silent = TRUE))
+		try_heal(patient, user, preferred_target, silent = TRUE)
 		return
 	if(!iscarbon(patient))
 		patient.balloon_alert(user, "fully treated")
@@ -153,7 +154,6 @@
 		patient.balloon_alert(user, "fully treated")
 		return
 
-	var/preferred_target = check_zone(user.zone_selected)
 	var/next_picked = (preferred_target in other_affected_limbs) ? preferred_target : other_affected_limbs[1]
 	user.balloon_alert(user, "treating [next_picked]...")
 	try_heal(patient, user, next_picked, silent = TRUE)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -271,7 +271,7 @@
 
 /obj/item/stack/medical/gauze/try_heal_checks(mob/living/patient, mob/user)
 	var/obj/item/bodypart/limb = patient.get_bodypart(check_zone(user.zone_selected))
-	if(!limb)
+	if(isnull(limb))
 		patient.balloon_alert(user, "no [parse_zone(user.zone_selected)]!")
 		return FALSE
 	if(!LAZYLEN(limb.wounds))
@@ -288,6 +288,7 @@
 
 // gauze is only relevant for wounds, which are handled in the wounds themselves
 /obj/item/stack/medical/gauze/try_heal(mob/living/patient, mob/user, silent)
+	var/obj/item/bodypart/limb = patient.get_bodypart(check_zone(user.zone_selected))
 	var/treatment_delay = (user == patient ? self_delay : other_delay)
 	var/any_scanned = FALSE
 	for(var/datum/wound/woundies as anything in limb.wounds)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -391,10 +391,7 @@
 /mob/living/carbon/human/try_inject(mob/user, target_zone, injection_flags)
 	. = ..()
 	if(!. && (injection_flags & INJECT_TRY_SHOW_ERROR_MESSAGE) && user)
-		if(!target_zone)
-			target_zone = get_bodypart(check_zone(user.zone_selected))
-		var/obj/item/bodypart/the_part = isbodypart(target_zone) ? target_zone : get_bodypart(check_zone(target_zone)) //keep these synced
-		to_chat(user, span_alert("There is no exposed flesh or thin material on [p_their()] [the_part.name]."))
+		balloon_alert(user, "no exposed skin on [target_zone || check_zone(user.zone_selected)]!")
 
 /mob/living/carbon/human/get_butt_sprite()
 	var/obj/item/bodypart/chest/chest = get_bodypart(BODY_ZONE_CHEST)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1264,14 +1264,11 @@
  * * gauze- Just the gauze stack we're taking a sheet from to apply here
  */
 /obj/item/bodypart/proc/apply_gauze(obj/item/stack/medical/gauze/new_gauze)
-	if(!istype(new_gauze) || !new_gauze.absorption_capacity)
+	if(!istype(new_gauze) || !new_gauze.absorption_capacity || !new_gauze.use(1))
 		return
-	var/newly_gauzed = FALSE
-	if(!current_gauze)
-		newly_gauzed = TRUE
+	var/newly_gauzed = !current_gauze
 	QDEL_NULL(current_gauze)
 	current_gauze = new new_gauze.type(src, 1)
-	new_gauze.use(1)
 	current_gauze.gauzed_bodypart = src
 	if(newly_gauzed)
 		SEND_SIGNAL(src, COMSIG_BODYPART_GAUZED, current_gauze, new_gauze)

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -144,7 +144,7 @@
 	)
 	log_combat(user, target, "dressed burns in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 	pierce_wound.adjust_blood_flow(-0.5)
-	if(pierce_wound.blood_flow > 0)
+	if(!QDELETED(pierce_wound) && pierce_wound.blood_flow > 0)
 		surgery.status = REALIGN_INNARDS
 		to_chat(user, span_notice("<i>There still seems to be misaligned blood vessels to finish...</i>"))
 	else


### PR DESCRIPTION
## About The Pull Request

- Erratas the "assessing injury" do after on medical stack items
- Makes wound treatment just a natural part of medical stack items, meaning you don't do an entirely separate interaction to suture a bleeding wound, and then an entirely separate interaction to treat bruises
- Bleeding wounds will go away immediately upon losing all blood flow, rather than waiting next life tick
- Cauterizing wounds now plays the cautery sfx

## Why It's Good For The Game

- I found the assessing do after really annoying, like damn I already assessed it with my eyes
- It's suuuuper unintuitive that treating bruises is different to treating cuts, there are some instances in which you stop treating the wounds because it downgraded and you just don't notice, it's annoying. This just makes it nice and uniform
- More reactive = easier to work with
- Always found it to be weird

TLDR: Have you ever been suturing someone but you randomly get forced to stop because the wound got better, or have you ever been suturing someone and they started bleeding so you have to stop suturing then start again to actually count as fixing the bleed rather than treating bruises? Yeah that changes that, it's all one do after

## Changelog

:cl: Melbert
qol: Cauterizing bleeding wounds now plays the cautery sfx.
qol: Bleeding wounds will now go away the moment they're fully healed, rather than a second or two later.
qol: Suture / Mesh treatment is now uniform! meaning healing bruises with a suture is now the same thing as healing cuts with a suture. This has very little difference in practice, but it should generally result in a lot smoother experience. 
qol: Suture / Mesh usage has been reworked slightly, and now offers two modes of use: 
qol: LEFT CLICKING will heal in AUTO MODE, which will AUTOMATICALLY switch between damaged bodyparts, prioritizing your targeted limb. You cannot change target mid-heal; changing target simply changes your priority for your NEXT heal.
qol: RIGHT CLICKING will heal in MANUAL MODE, which functions like it does currently - allowing you to change your target before you finish your heal and giving you a 1 second "assessment" step to change your target when you're done healing a limb. Manual mode is 10% faster than Auto mode.
/:cl:
