### PR TITLE
Prevents atmos tanks from fetching icons every atmos tick

### DIFF
--- a/code/datums/components/sizzle.dm
+++ b/code/datums/components/sizzle.dm
@@ -1,13 +1,3 @@
-GLOBAL_VAR_INIT(crash_rscs, FALSE)
-
-/icon/RscFile()
-	. = ..()
-	if (GLOB.crash_rscs)
-		stack_trace("test")
-
-/mob/proc/crash_rsc()
-	GLOB.crash_rscs = TRUE
-
 /datum/component/sizzle
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 

--- a/code/datums/components/sizzle.dm
+++ b/code/datums/components/sizzle.dm
@@ -1,3 +1,13 @@
+GLOBAL_VAR_INIT(crash_rscs, FALSE)
+
+/icon/RscFile()
+	. = ..()
+	if (GLOB.crash_rscs)
+		stack_trace("test")
+
+/mob/proc/crash_rsc()
+	GLOB.crash_rscs = TRUE
+
 /datum/component/sizzle
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -268,10 +268,14 @@
 
 	window = image(icon, icon_state = "window-bg", layer = FLOAT_LAYER)
 
+	var/static/alpha_filter
+	if(!alpha_filter) // Gotta do this separate since the icon may not be correct at world init
+		alpha_filter = filter(type="alpha", icon = icon('icons/obj/pipes_n_cables/stationary_canisters.dmi', "window-bg"))
+
 	var/list/new_underlays = list()
 	for(var/obj/effect/overlay/gas/gas as anything in air_contents.return_visuals(get_turf(src)))
 		var/image/new_underlay = image(gas.icon, icon_state = gas.icon_state, layer = FLOAT_LAYER)
-		new_underlay.filters = alpha_mask_filter(icon = icon(icon, icon_state = "window-bg"))
+		new_underlay.filters = alpha_filter
 		new_underlays += new_underlay
 
 	var/image/foreground = image(icon, icon_state = "window-fg", layer = FLOAT_LAYER)


### PR DESCRIPTION
## About The Pull Request

According to Kapu, RscFile() is a hash operation and thus is relatively slow. Having dozens of them ran every tick by atmos tanks is not ideal. There's more uncached icons in filters to tackle but the only one relatively impactful is status display init mask - however our filter code is mildly fucked to say the least, as icon() is ran ***regardless of whenever a filter is cached or not*** because we pass them as lists, not actual filter objects - and filter() seems to call one internally regardless of what its passed, so every update_filters fetches an icon for anything with an alpha/displacement filter. This doesn't actually do much on its own, but is nice to have so that future contributors don't make the same mistake by copypasting code.

## Changelog
:cl: SmArtKar, Kapu
fix: Atmospheric tanks no longer fetch icons every tick
/:cl:
