### PR TITLE
Fix advanced leg name

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -574,7 +574,7 @@
 	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED
 
 /obj/item/bodypart/leg/right/robot/advanced
-	name = "heavy robotic right leg"
+	name = "advanced robotic right leg"
 	desc = "An advanced cybernetic leg, capable of greater feats of strength and durability."
 	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
 	icon = 'icons/mob/augmentation/advanced_augments.dmi'


### PR DESCRIPTION

## About The Pull Request
Fixes printed advanced robotic right leg name, instead of it being "heavy"

## Why It's Good For The Game
Bugfix good

## Changelog
:cl:
fix: Printed advanced robotic right leg now has correct name, instead of being "heavy"
/:cl:
