### PR TITLE
Stealthier Doorjack

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -14,15 +14,16 @@
 	stoplag(0.2 SECONDS)
 	open(FORCING_DOOR_CHECKS)
 
-	locked = TRUE
+	if (!(obj_flags & EMAGGED))
+		locked = TRUE
 	update_appearance()
 
 /// Forces the airlock to close and bolt
 /obj/machinery/door/airlock/proc/secure_close(force_crush = FALSE)
 	locked = FALSE
 	close(forced = TRUE, force_crush = force_crush)
-
-	locked = TRUE
+	if (!(obj_flags & EMAGGED))
+		locked = TRUE
 	stoplag(0.2 SECONDS)
 	update_appearance()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -253,9 +253,11 @@
 	update_appearance()
 
 /obj/machinery/door/airlock/proc/set_bolt(should_bolt)
+	if (obj_flags & EMAGGED)
+		should_bolt = FALSE
 	if(locked == should_bolt)
 		return
-	if (should_bolt && !(obj_flags & EMAGGED))
+	if (should_bolt)
 		locked = TRUE
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_SET_BOLT, should_bolt)
 	. = locked

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -231,7 +231,7 @@
 
 /obj/machinery/door/Bumped(atom/movable/AM)
 	. = ..()
-	if(operating || (obj_flags & EMAGGED) || (!can_open_with_hands && density))
+	if(operating || (!can_open_with_hands && density))
 		return
 	if(ismob(AM))
 		var/mob/B = AM
@@ -281,7 +281,7 @@
 		return
 
 	add_fingerprint(user)
-	if(!density || (obj_flags & EMAGGED))
+	if(!density)
 		return
 
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
@@ -308,7 +308,7 @@
 
 /obj/machinery/door/proc/try_to_activate_door(mob/user, access_bypass = FALSE)
 	add_fingerprint(user)
-	if(operating || (obj_flags & EMAGGED) || !can_open_with_hands)
+	if(operating || !can_open_with_hands)
 		return
 	if(access_bypass || (requiresID() && allowed(user)))
 		if(density)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -263,13 +263,11 @@
 /obj/machinery/door/window/try_to_force_door_open(force_type = DEFAULT_DOOR_CHECKS)
 	switch(force_type)
 		if(DEFAULT_DOOR_CHECKS)
-			if(!hasPower() || (obj_flags & EMAGGED))
+			if(!hasPower())
 				return FALSE
 			return TRUE
 
 		if(FORCING_DOOR_CHECKS)
-			if(obj_flags & EMAGGED)
-				return FALSE
 			return TRUE
 
 		if(BYPASS_DOOR_CHECKS) // Get it open!
@@ -305,13 +303,11 @@
 /obj/machinery/door/window/try_to_force_door_shut(force_type = DEFAULT_DOOR_CHECKS)
 	switch(force_type)
 		if(DEFAULT_DOOR_CHECKS)
-			if(!hasPower() || (obj_flags & EMAGGED))
+			if(!hasPower())
 				return FALSE
 			return TRUE
 
 		if(FORCING_DOOR_CHECKS)
-			if(obj_flags & EMAGGED)
-				return FALSE
 			return TRUE
 
 		if(BYPASS_DOOR_CHECKS) // Get it shut!
@@ -376,6 +372,8 @@
 /// Timer proc, called ~0.6 seconds after [emag_act]. Finishes the emag sequence by breaking the windoor.
 /obj/machinery/door/window/proc/finish_emag_act()
 	operating = FALSE
+	req_access = list()
+	req_one_access = list()
 	open(BYPASS_DOOR_CHECKS)
 
 /obj/machinery/door/window/examine(mob/user)

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -166,18 +166,23 @@
 	name = "airlock authentication override card"
 	icon_state = "doorjack"
 	worn_icon_state = "doorjack"
-	var/type_whitelist //List of types
+	/// List of all acceptable typepaths that this device can affect
+	var/type_whitelist
+	/// Currently available count of charges, starts fully charged
 	var/charges = 3
+	/// We can't gain more charges if we already have this many
 	var/max_charges = 3
+	/// Timers for when our charges will come back
 	var/list/charge_timers = list()
-	var/charge_time = 1800 //three minutes
+	/// How long it takes for each charge to come home from the war
+	var/charge_time = 3 MINUTES
 
 /obj/item/card/emag/doorjack/Initialize(mapload)
 	. = ..()
-	type_whitelist = list(typesof(/obj/machinery/door/airlock), typesof(/obj/machinery/door/window/), typesof(/obj/machinery/door/firedoor)) //list of all acceptable typepaths that this device can affect
+	type_whitelist = list(typesof(/obj/machinery/door/airlock), typesof(/obj/machinery/door/window/), typesof(/obj/machinery/door/firedoor))
 
 /obj/item/card/emag/doorjack/proc/use_charge(mob/user)
-	charges --
+	charges--
 	to_chat(user, span_notice("You use [src]. It now has [charges] charge[charges == 1 ? "" : "s"] remaining."))
 	charge_timers.Add(addtimer(CALLBACK(src, PROC_REF(recharge)), charge_time, TIMER_STOPPABLE))
 


### PR DESCRIPTION
## About The Pull Request

Rather than permanently busting airlocks open, the doorjack now instead:
- Unbolts the door.
- Unshocks the door.
- Removes all door access requirements.
- Opens the door.
- "Locks" bolts such that the door can no longer be bolted until the circuitry is replaced.

For the rare set of doors which cycle automatically and form an actual airlock, this also essentially removes any safety feature preventing them from opening before the cycle is finished, making them somewhat more dangerous.

As a tradeoff these two other extremely small changes have also been made:
- It takes 0.1 seconds longer for the doorjack to actually open a door (this allows the animation for the door opening to actually play).
- You can't doorjack doors with plasteel cover reinforcements (you still need to use tools to open the vault).

This change currently **does** also affect Ninjas which I am not totally satisfied with... on the one hand this is a much more ninja-y thing to do but on the other I thought the old behaviour was funny. Maintaining both is a bit of a pain in the ass though. May or may not change this based on what PR comments think.

## Why It's Good For The Game

The doorjack is fairly commonly considered to be something of a "noob trap"; that being because it's an item which _seems_ attractive and valuable for its ability to break into areas rapidly, but which actually mostly just signals as an indicator that someone should be looking for you because you leave a trail of visibly busted doors behind you.

The fact that the doorjack is worse than just hacking using tools is intentional so this change isn't intended to make it a replacement for manual effort, but now it's a little better for breaking in as well as for busting out as if you are sneaky about it then it might be some time before someone realises what has happened.
If you do it in front of someone they will still see you do it and it still leaves the examine notice that there's something up with the electronics, so it's still not a tool of first resort.

## Changelog

:cl:
balance: Doorjacks (including the one Ninjas have) now unbolt doors, render them unboltable, and remove all access requirements, rather than permanently bolting them open.
balance: Doorjacks cannot be used to open the vault door.
/:cl:
