### PR TITLE
fixes the museum cafeteria puzzle and some other things related to the museum

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -17,13 +17,13 @@
 /obj/effect/step_trigger/proc/Trigger(atom/movable/A)
 	return 0
 
-/obj/effect/step_trigger/proc/on_entered(datum/source, H as mob|obj)
+/obj/effect/step_trigger/proc/on_entered(datum/source, entering as mob|obj)
 	SIGNAL_HANDLER
-	if(!H || H == src)
+	if(!entering || entering == src || entering.invisibility == INVISIBILITY_ABSTRACT || istype(entering, /atom/movable/mirage_holder)) //dont teleport ourselves, abstract objects, and mirage holders due to init shenanigans
 		return
-	if(isobserver(H) && !affect_ghosts)
+	if(isobserver(entering) && !affect_ghosts)
 		return
-	if(!ismob(H) && mobs_only)
+	if(!ismob(entering) && mobs_only)
 		return
 	INVOKE_ASYNC(src, PROC_REF(Trigger), H)
 

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -17,15 +17,15 @@
 /obj/effect/step_trigger/proc/Trigger(atom/movable/A)
 	return 0
 
-/obj/effect/step_trigger/proc/on_entered(datum/source, entering as mob|obj)
+/obj/effect/step_trigger/proc/on_entered(datum/source, atom/movable/entering)
 	SIGNAL_HANDLER
-	if(!entering || entering == src || entering.invisibility == INVISIBILITY_ABSTRACT || istype(entering, /atom/movable/mirage_holder)) //dont teleport ourselves, abstract objects, and mirage holders due to init shenanigans
+	if(!entering || entering == src || entering.invisibility >= INVISIBILITY_ABSTRACT || istype(entering, /atom/movable/mirage_holder)) //dont teleport ourselves, abstract objects, and mirage holders due to init shenanigans
 		return
 	if(isobserver(entering) && !affect_ghosts)
 		return
 	if(!ismob(entering) && mobs_only)
 		return
-	INVOKE_ASYNC(src, PROC_REF(Trigger), H)
+	INVOKE_ASYNC(src, PROC_REF(Trigger), entering)
 
 
 /obj/effect/step_trigger/singularity_act()
@@ -144,7 +144,7 @@
 	var/teleport_x_offset = 0
 	var/teleport_y_offset = 0
 
-/obj/effect/step_trigger/teleporter/offset/on_entered(datum/source, H as mob|obj, atom/old_loc)
+/obj/effect/step_trigger/teleporter/offset/on_entered(datum/source, atom/movable/entered, atom/old_loc)
 	if(!old_loc?.Adjacent(loc)) // prevents looping, if we were teleported into this then the old loc is usually not adjacent
 		return
 	return ..()

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -416,6 +416,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/keycardpad, 32)
 	var/pass_input = tgui_input_text(user, tgui_text, tgui_title, max_length = input_max_len_is_pass ? length(password) : MAX_NAME_LEN)
 	if(isnull(pass_input) || !user.can_perform_action(src, ALLOW_SILICON_REACH) || !user.can_interact_with(src))
 		return
+	to_chat(world, "the password is supposed to be [password] (t:[istext(password)] n:[isnum(password)]), inputted password was [pass_input] (t:[istext(pass_input)] n:[isnum(pass_input)])")
 	var/correct = pass_input == password
 	balloon_alert_to_viewers("[correct ? "correct" : "wrong"] password[correct ? "" : "!"]")
 	if(!correct)
@@ -454,9 +455,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/password, 32)
 			"green",
 			"blue",
 			"yellow",
-			"orange",
-			"brown",
+			COLOR_ORANGE, // orange is also not valid
+			COLOR_BROWN, // brown is NOT a valid byond color
 			"gray",
+			"purple",
 		)
 	for(var/digit in 0 to 9)
 		digit_to_color["[digit]"] = pick_n_take(possible_colors)

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -416,7 +416,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/puzzle/keycardpad, 32)
 	var/pass_input = tgui_input_text(user, tgui_text, tgui_title, max_length = input_max_len_is_pass ? length(password) : MAX_NAME_LEN)
 	if(isnull(pass_input) || !user.can_perform_action(src, ALLOW_SILICON_REACH) || !user.can_interact_with(src))
 		return
-	to_chat(world, "the password is supposed to be [password] (t:[istext(password)] n:[isnum(password)]), inputted password was [pass_input] (t:[istext(pass_input)] n:[isnum(pass_input)])")
 	var/correct = pass_input == password
 	balloon_alert_to_viewers("[correct ? "correct" : "wrong"] password[correct ? "" : "!"]")
 	if(!correct)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -53,7 +53,8 @@
 
 /obj/structure/grille/examine(mob/user)
 	. = ..()
-
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
 	if(anchored)
 		. += span_notice("It's secured in place with <b>screws</b>. The rods look like they could be <b>cut</b> through.")
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -513,6 +513,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 	return FALSE
 
 /obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
+	if(resistance_flags & INDESTRUCTIBLE)
+		balloon_alert(user, "too resilient!")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	switch(state)
 		if(RWINDOW_SECURE)
 			if(tool.tool_behaviour == TOOL_WELDER)
@@ -591,7 +594,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 
 /obj/structure/window/reinforced/examine(mob/user)
 	. = ..()
-
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
 	switch(state)
 		if(RWINDOW_SECURE)
 			. += span_notice("It's been screwed in with one way screws, you'd need to <b>heat them</b> to have any chance of backing them out.")

--- a/code/modules/awaymissions/mission_code/murderdome.dm
+++ b/code/modules/awaymissions/mission_code/murderdome.dm
@@ -1,19 +1,14 @@
 
 /obj/structure/window/reinforced/fulltile/indestructible
 	name = "robust window"
+	move_resist = MOVE_FORCE_OVERPOWERING
 	flags_1 = PREVENT_CLICK_UNDER_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/structure/window/reinforced/fulltile/indestructible/screwdriver_act(mob/living/user, obj/item/tool)
-	return NONE
-
-/obj/structure/window/reinforced/fulltile/indestructible/wrench_act(mob/living/user, obj/item/tool)
-	return NONE
-
-/obj/structure/window/reinforced/fulltile/indestructible/crowbar_act(mob/living/user, obj/item/tool)
-	return NONE
 
 /obj/structure/grille/indestructible
+	desc = "A STRONG framework of hardened plasteel rods, that you cannot possibly get through. If you were an engineer you would be drooling over its construction right now."
+	move_resist = MOVE_FORCE_OVERPOWERING
 	obj_flags = CONDUCTS_ELECTRICITY
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 

--- a/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
@@ -78,7 +78,7 @@
 	desc = /obj/machinery/atmospherics/components/unary/vent_scrubber::desc
 	icon = /obj/machinery/atmospherics/components/unary/vent_scrubber::icon
 	layer = /obj/machinery/atmospherics/components/unary/vent_scrubber::layer
-	plane = /obj/machinery/atmospherics/components/unary/vent_scrubber::plane
+	plane = FLOOR_PLANE
 	icon_state = "scrub_on"
 
 /obj/structure/fluff/fake_vent
@@ -86,7 +86,7 @@
 	desc = /obj/machinery/atmospherics/components/unary/vent_pump::desc
 	icon = /obj/machinery/atmospherics/components/unary/vent_pump::icon
 	layer = /obj/machinery/atmospherics/components/unary/vent_pump::layer
-	plane = /obj/machinery/atmospherics/components/unary/vent_pump::plane
+	plane = FLOOR_PLANE
 	icon_state = "vent_out"
 
 /turf/open/mirage

--- a/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
@@ -77,7 +77,7 @@
 	name = /obj/machinery/atmospherics/components/unary/vent_scrubber::name
 	desc = /obj/machinery/atmospherics/components/unary/vent_scrubber::desc
 	icon = /obj/machinery/atmospherics/components/unary/vent_scrubber::icon
-	layer = /obj/machinery/atmospherics/components/unary/vent_scrubber::layer
+	layer = ABOVE_OPEN_TURF_LAYER
 	plane = FLOOR_PLANE
 	icon_state = "scrub_on"
 
@@ -85,7 +85,7 @@
 	name = /obj/machinery/atmospherics/components/unary/vent_pump::name
 	desc = /obj/machinery/atmospherics/components/unary/vent_pump::desc
 	icon = /obj/machinery/atmospherics/components/unary/vent_pump::icon
-	layer = /obj/machinery/atmospherics/components/unary/vent_pump::layer
+	layer = ABOVE_OPEN_TURF_LAYER
 	plane = FLOOR_PLANE
 	icon_state = "vent_out"
 


### PR DESCRIPTION

## About The Pull Request

the dotted color board was missing a color for the 10th digit, and orange and brown were not valid byond colors (damn you ghommie)
fake scrubbers and vents use the correct layer and plane
you may no longer deconstruct indestructible windows
you can no longer push indestructible grilles and robust windows if you have a strong move force

step teleporters may not teleport abstract objects or mirage holders (due to init shenanigans this sometimes teleported a mirage holder messing the visuals up)

## Why It's Good For The Game

bug bad also i didnt make these bugs ok

## Changelog
:cl:
fix: fixed the museum password puzzle (to the cafeteria), and the scrubbers and vents there now look correctly (also fixed a rare visual bug)
fix: it is now harder to bypass indestructible windows and grilles (those are placed there for a reason, you know!)
/:cl:
