### PR TITLE
[NO GBP] brings fishing difficulty of all fishing spots closer to their pre-refactor values

### DIFF
--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -29,7 +29,7 @@
 		/obj/item/fish/swordfish = 5 MINUTES,
 		/obj/structure/mystery_box/fishing = 32 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
 /datum/fish_source/ocean/beach
@@ -48,7 +48,7 @@
 		/obj/item/fish/chasm_crab/ice = 2,
 		/obj/item/fish/boned = 1,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 30
 
 /datum/fish_source/river
 	catalog_description = "River water"
@@ -74,7 +74,7 @@
 	fish_count_regen = list(
 		/obj/item/fish/pike = 4 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
 /datum/fish_source/sand
@@ -87,7 +87,7 @@
 		/obj/item/fish/bumpy = 10,
 		/obj/item/coin/gold = 3,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 30
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
 /datum/fish_source/cursed_spring
@@ -102,7 +102,7 @@
 	fish_counts = list(
 		/obj/item/fishing_rod/telescopic/master = 1,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 25
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 35
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
 /datum/fish_source/portal
@@ -154,7 +154,7 @@
 		/obj/item/stack/sheet/bone = 5,
 	)
 	catalog_description = "Chasm dimension (Fishing portal generator)"
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 	radial_name = "Chasm"
 	overlay_state = "portal_chasm"
 	radial_state = "ground_hole"
@@ -182,7 +182,7 @@
 		/obj/item/fish/swordfish = 5 MINUTES,
 	)
 	catalog_description = "Ocean dimension (Fishing portal generator)"
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 	radial_name = "Ocean"
 	overlay_state = "portal_ocean"
 	radial_state = "seaboat"
@@ -205,7 +205,7 @@
 		/obj/item/stack/ore/bluespace_crystal = 10,
 	)
 	catalog_description = "Hyperspace dimension (Fishing portal generator)"
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 	radial_name = "Hyperspace"
 	overlay_state = "portal_hyperspace"
 	radial_state = "space_rocket"
@@ -231,7 +231,7 @@
 	)
 	catalog_description = "Syndicate dimension (Fishing portal generator)"
 	radial_name = "Syndicate"
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 25
 	overlay_state = "portal_syndicate"
 	radial_state = "syndi_snake"
 
@@ -324,7 +324,7 @@
 		/obj/item/fish/chasm_crab = 15,
 		/datum/chasm_detritus = 30,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
 
 /datum/fish_source/chasm/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	. = ..()
@@ -362,7 +362,7 @@
 	fish_count_regen = list(
 		/obj/structure/closet/crate/necropolis/tendril = 27 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
 /datum/fish_source/lavaland/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
@@ -404,7 +404,7 @@
 		/obj/item/fish/ratfish = 10,
 		/obj/item/fish/slimefish = 4,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 
 /datum/fish_source/toilet
 	catalog_description = "Station toilets"
@@ -422,7 +422,7 @@
 		/obj/item/storage/wallet/money = 2,
 		/obj/item/survivalcapsule/fishing = 1,
 	)
-	fishing_difficulty = FISHING_EASY_DIFFICULTY //For beginners
+	fishing_difficulty = FISHING_EASY_DIFFICULTY + 10
 
 /datum/fish_source/holographic
 	catalog_description = "Holographic water"
@@ -435,7 +435,7 @@
 		/obj/item/fish/holo/checkered = 5,
 		/obj/item/fish/holo/halffish = 5,
 	)
-	fishing_difficulty = FISHING_EASY_DIFFICULTY
+	fishing_difficulty = FISHING_EASY_DIFFICULTY + 10
 	fish_source_flags = FISH_SOURCE_FLAG_NO_BLUESPACE_ROD
 
 /datum/fish_source/holographic/on_fishing_spot_init(datum/component/fishing_spot/spot)
@@ -492,7 +492,7 @@
 	fish_count_regen = list(
 		/obj/item/fish/mastodon = 8 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 25
 
 /datum/fish_source/hydro_tray
 	catalog_description = "Hydroponics trays"
@@ -515,7 +515,7 @@
 		/mob/living/basic/frog = 1,
 		/mob/living/basic/axolotl = 1,
 	)
-	fishing_difficulty = FISHING_EASY_DIFFICULTY - 5
+	fishing_difficulty = FISHING_EASY_DIFFICULTY + 5
 
 /datum/fish_source/hydro_tray/generate_wiki_contents(datum/autowiki/fish_sources/wiki)
 	var/list/data = list()
@@ -624,7 +624,7 @@
 	fish_count_regen = list(
 		/mob/living/basic/carp/mega = 9 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 18
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 28
 
 /datum/fish_source/deepfryer
 	catalog_description = "Deep Fryers"
@@ -647,7 +647,7 @@
 		/obj/item/fish/fryish/fritterish = 6 MINUTES,
 		/obj/item/fish/fryish/nessie = 22 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 13
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 23
 
 /datum/fish_source/surgery
 	catalog_description = "Surgery"
@@ -656,7 +656,7 @@
 	background = "background_lavaland" //Kinda red.
 	fish_table = list(FISHING_RANDOM_ORGAN = 10)
 	//This should get you below zero difficulty and skip the minigame phase, unless you're wearing something that counteracts this.
-	fishing_difficulty = -20
+	fishing_difficulty = -10
 	//The range for waiting is also a bit narrower, so it cannot take as few as 3 seconds or as many as 25 to snatch an organ.
 	wait_time_range = list(6 SECONDS, 12 SECONDS)
 
@@ -706,7 +706,7 @@
 		FISHING_DUD = 10,
 	)
 	fish_source_flags = FISH_SOURCE_FLAG_NO_BLUESPACE_ROD|FISH_SOURCE_FLAG_IGNORE_HIDDEN_ON_CATALOG
-	fishing_difficulty = FISHING_EASY_DIFFICULTY - 5
+	fishing_difficulty = FISHING_EASY_DIFFICULTY + 5
 
 #undef RANDOM_AQUARIUM_FISH
 
@@ -756,7 +756,7 @@
 	fish_count_regen = list(
 		/obj/item/fish/sacabambaspis = 4 MINUTES,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 30
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
 
 /datum/fish_source/tizira
@@ -771,5 +771,5 @@
 		/obj/item/fish/moonfish/dwarf = 2,
 		/obj/item/fish/moonfish = 2,
 	)
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 10
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS


### PR DESCRIPTION
## About The Pull Request
Two months ago I pushed #86175, which refactored how difficulty and reward were calculated, however that ended up unintentionally reducing the difficulty of the minigame by about 15 points, since in the older version of the datum, the difficulty value that belonged to the fishing spot was summed to a fixed difficulty of the minigame, while now it's entirely from the fishing spot (and skills, and equipment). So I'm bumping up the difficulty across the board by 10. Not 15 because I'm sure that would be frustating for some.

## Why It's Good For The Game
That was an unintentional balance change. Also bonuses from skills, equipment and material rods are a tad more viable now so it shouldn't be a problem.

## Changelog

:cl:
balance: brought fishing difficulty of all fishing spots a bit closer to their original value following a small oopsie that made them unexpectingly easier for more than two months.
/:cl:
