### PR TITLE
[NO GBP] Fixing fishing lures

### DIFF
--- a/code/controllers/subsystem/processing/fishing.dm
+++ b/code/controllers/subsystem/processing/fishing.dm
@@ -37,7 +37,7 @@ PROCESSING_SUBSYSTEM_DEF(fishing)
 		unknown_icon.Blend(questionmark, ICON_OVERLAY, x = width, y = height)
 		cached_unknown_fish_icons[fish_type] = icon2base64(unknown_icon)
 
-		var/obj/item/fish/fish = new fish_type(null, FALSE)
+		var/obj/item/fish/fish = new fish_type
 		spawned_fish += fish
 		var/list/properties = list()
 		fish_properties[fish_type] = properties


### PR DESCRIPTION
## About The Pull Request
Fish spawned during init didn't initialize their traits because of some args, so this was a problem for fishing lures, which code was slightly changed by #88243.

## Why It's Good For The Game
This will fix #88295.

## Changelog

:cl:
fix: Fixed fishing lures.
/:cl:
