### PR TITLE
Mr sam frisher no longer completely breaks mechs in one shot

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -836,7 +836,7 @@
 
 /obj/vehicle/sealed/mecha/on_saboteur(datum/source, disrupt_duration)
 	. = ..()
-	if(mecha_flags & HAS_LIGHTS && light_on)
+	if((mecha_flags & HAS_LIGHTS) && light_on)
 		set_light_on(FALSE)
 		return TRUE
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -836,7 +836,7 @@
 
 /obj/vehicle/sealed/mecha/on_saboteur(datum/source, disrupt_duration)
 	. = ..()
-	if(mecha_flags &= HAS_LIGHTS && light_on)
+	if(mecha_flags & HAS_LIGHTS && light_on)
 		set_light_on(FALSE)
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Fixes the SC pistol completely breaking mecha's flags in one shot.

## Why It's Good For The Game

The way this was coded, meant that hitting a mech with the sam fisher pistol completely deleted the mech's flags, caused enclosed, strafe-able, MMI-compatible and lights-capable mechs to suddenly become none of that. This has a fairly big impact on mechs in gameplay, because losing one's flags mean a mech is no longer capable of doing what it's supposed to do. (Eg: a Durand can't have a MMI pilot, doesn't protect its occupant from ranged attacks, can't strafe).

## Changelog

:cl:
fix: fixes splinter cell pistols causing mechs to suddenly have all their flags deleted
/:cl:
