### PR TITLE
[no gbp] manufacturing assembling machine fixes and stuff

### DIFF
--- a/code/datums/components/crafting/chemistry.dm
+++ b/code/datums/components/crafting/chemistry.dm
@@ -150,6 +150,8 @@
 	category = CAT_CHEMISTRY
 
 /datum/crafting_recipe/improvised_chem_heater/on_craft_completion(mob/user, atom/result)
+	if(!istype(user))
+		return
 	var/obj/item/stock_parts/power_store/cell/cell = locate(/obj/item/stock_parts/power_store/cell) in range(1)
 	if(!cell)
 		return

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -5,7 +5,7 @@
 /datum/crafting_recipe/food/on_craft_completion(mob/user, atom/result)
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
-	if(istype(result) && !isnull(user.mind))
+	if(istype(result) && istype(user) && !isnull(user.mind))
 		ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(user.mind))
 
 /datum/crafting_recipe/food/New()

--- a/code/modules/manufactorio/_manufacturing.dm
+++ b/code/modules/manufactorio/_manufacturing.dm
@@ -1,9 +1,5 @@
-#define MANUFACTURING_FAIL_FULL -1
 #define MANUFACTURING_FAIL 0
 #define MANUFACTURING_SUCCESS 1
-
-#define POCKET_INPUT "Input"
-#define POCKET_OUTPUT "Output"
 
 #define MANUFACTURING_TURF_LAG_LIMIT 10 // max items on a turf before we consider it full
 
@@ -108,8 +104,8 @@
 		return manufactury.receive_resource(sending, src, isturf(what_or_dir) ? get_dir(src, what_or_dir) : what_or_dir)
 	if(next_turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = sending) && !ischasm(next_turf))
 		return MANUFACTURING_FAIL
-	if(length(next_turf.contents) >= MANUFACTURING_TURF_LAG_LIMIT)
-		return MANUFACTURING_FAIL_FULL
+	if(length(get_overfloor_objects(next_turf)) >= MANUFACTURING_TURF_LAG_LIMIT)
+		return MANUFACTURING_FAIL
 	if(isnull(sending))
 		return MANUFACTURING_SUCCESS // for the sake of being used as a check
 	if(isnull(sending.loc) || !sending.Move(next_turf, get_dir(src, next_turf)))
@@ -132,3 +128,11 @@
 		return
 	return stack.merge(merging_into)
 
+/obj/machinery/power/manufacturing/proc/get_overfloor_objects(turf/target)
+	. = list()
+	if(isnull(target))
+		target = get_turf(src)
+	for(var/atom/movable/thing as anything in target.contents)
+		if(thing == src || isliving(thing) || iseffect(thing) || thing.invisibility >= INVISIBILITY_ABSTRACT || HAS_TRAIT(thing, TRAIT_UNDERFLOOR))
+			continue
+		. += thing

--- a/code/modules/manufactorio/machines/crafter.dm
+++ b/code/modules/manufactorio/machines/crafter.dm
@@ -6,8 +6,8 @@
 	circuit = /obj/item/circuitboard/machine/manucrafter
 	/// power used per process() spent crafting
 	var/power_cost = 5 KILO WATTS
-	/// our output, if the way out was blocked is held here
-	var/atom/movable/withheld
+	/// list of weakrefs to crafted items still on the machine that we failed to send forward
+	var/list/datum/weakref/withheld = list()
 	/// current recipe
 	var/datum/crafting_recipe/recipe
 	/// crafting component
@@ -45,7 +45,7 @@
 /obj/machinery/power/manufacturing/crafter/receive_resource(obj/receiving, atom/from, receive_dir)
 	var/turf/machine_turf = get_turf(src)
 	if(length(machine_turf.contents) >= MANUFACTURING_TURF_LAG_LIMIT)
-		return MANUFACTURING_FAIL_FULL
+		return MANUFACTURING_FAIL
 	receiving.forceMove(machine_turf)
 	return MANUFACTURING_SUCCESS
 
@@ -53,10 +53,8 @@
 	. = NONE
 	var/list/unavailable = list()
 	for(var/datum/crafting_recipe/potential_recipe as anything in cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes)
-		if(craftsman.is_recipe_available(potential_recipe, user))
-			continue
-		var/obj/result = initial(potential_recipe.result)
-		if(istype(result) && initial(result.anchored))
+		var/obj/as_obj = potential_recipe.result
+		if(!(ispath(as_obj, /obj) && !ispath(as_obj, /obj/effect) && initial(as_obj.anchored)) && craftsman.is_recipe_available(potential_recipe, user))
 			continue
 		unavailable += potential_recipe
 	var/result = tgui_input_list(usr, "Recipe", "Select Recipe", (cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes) - unavailable)
@@ -66,24 +64,14 @@
 	balloon_alert(user, "set")
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/power/manufacturing/crafter/Exited(atom/movable/gone, direction)
-	. = ..()
-	if(gone == withheld)
-		withheld = null
-
-/obj/machinery/power/manufacturing/crafter/atom_destruction(damage_flag)
-	. = ..()
-	withheld?.Move(drop_location(src))
-
 /obj/machinery/power/manufacturing/crafter/Destroy()
 	. = ..()
 	recipe = null
 	craftsman = null
-	QDEL_NULL(withheld)
+	withheld.Cut()
 
 /obj/machinery/power/manufacturing/crafter/process(seconds_per_tick)
-	if(!isnull(withheld) && !send_resource(withheld, dir))
-		return
+	send_withheld() // try send any pending stuff
 	if(!isnull(craft_timer))
 		if(surplus() >= power_cost)
 			add_load()
@@ -97,19 +85,37 @@
 	flick_overlay_view(mutable_appearance(icon, "crafter_printing"), recipe.time)
 	craft_timer = addtimer(CALLBACK(src, PROC_REF(craft), recipe), recipe.time, TIMER_STOPPABLE)
 
+/obj/machinery/power/manufacturing/crafter/proc/send_withheld()
+	if(!length(withheld))
+		return FALSE
+	for(var/datum/weakref/weakref as anything in withheld)
+		var/atom/movable/resolved = weakref?.resolve()
+		if(isnull(resolved))
+			withheld -= weakref
+			continue
+		if(resolved.loc != loc || send_resource(resolved, dir))
+			withheld -= weakref
+	return length(withheld)
+
 /obj/machinery/power/manufacturing/crafter/proc/craft(datum/crafting_recipe/recipe)
 	if(QDELETED(src))
 		return
 	craft_timer = null
-	var/atom/movable/result = craftsman.construct_item(src, recipe)
-	if(istype(result))
-		if(isitem(result))
-			result.pixel_x += rand(-4, 4)
-			result.pixel_y += rand(-4, 4)
-		result.Move(src)
-		send_resource(result, dir)
-	else
-		say(result)
+	var/list/prediff = get_overfloor_objects()
+	var/result = craftsman.construct_item(src, recipe)
+	if(istext(result))
+		say("Crafting failed,[result]")
+		return
+	var/list/diff = get_overfloor_objects() - prediff
+	for(var/atom/movable/diff_result as anything in diff)
+		if(iseffect(diff_result) || ismob(diff_result)) // PLEASE dont stuff cats (or other mobs) into the cat grinder 9000
+			continue
+		if(isitem(diff_result))
+			diff_result.pixel_x += rand(-4, 4)
+			diff_result.pixel_y += rand(-4, 4)
+		withheld += WEAKREF(diff_result)
+		recipe.on_craft_completion(src, diff_result)
+	send_withheld()
 
 /obj/machinery/power/manufacturing/crafter/cooker
 	name = "manufacturing cooking machine" // maybe this shouldnt be available dont wanna make chef useless, though otherwise it would need a sprite

--- a/code/modules/manufactorio/machines/crusher.dm
+++ b/code/modules/manufactorio/machines/crusher.dm
@@ -29,7 +29,7 @@
 	if(istype(receiving, /obj/item/stack/ore) || receiving.resistance_flags & INDESTRUCTIBLE || !isitem(receiving) || surplus() < crush_cost  || receive_dir != REVERSE_DIR(dir))
 		return MANUFACTURING_FAIL
 	if(length(contents - circuit) >= capacity && may_merge_in_contents_and_do_so(receiving))
-		return MANUFACTURING_FAIL_FULL
+		return MANUFACTURING_FAIL
 	receiving.Move(src, get_dir(receiving, src))
 	START_PROCESSING(SSmanufacturing, src)
 	return MANUFACTURING_SUCCESS

--- a/code/modules/manufactorio/machines/router.dm
+++ b/code/modules/manufactorio/machines/router.dm
@@ -52,7 +52,7 @@
 			dir = receive_dir
 			update_appearance(UPDATE_OVERLAYS) // im sorry
 			return MANUFACTURING_SUCCESS
-	return MANUFACTURING_FAIL_FULL
+	return MANUFACTURING_FAIL
 
 /obj/machinery/power/manufacturing/router/proc/handle_stack(obj/item/stack/stack, direction)
 	if(stack.amount <= 1) // last implementation was just not good so lets cheap out

--- a/code/modules/manufactorio/machines/smelter.dm
+++ b/code/modules/manufactorio/machines/smelter.dm
@@ -18,7 +18,7 @@
 		return MANUFACTURING_FAIL
 	var/list/stacks = contents - circuit
 	if(length(stacks) >= 5 && !may_merge_in_contents_and_do_so(receiving))
-		return MANUFACTURING_FAIL_FULL
+		return MANUFACTURING_FAIL
 	receiving.Move(src, get_dir(receiving, src))
 	START_PROCESSING(SSmanufacturing, src)
 	return MANUFACTURING_SUCCESS

--- a/code/modules/manufactorio/machines/sorter.dm
+++ b/code/modules/manufactorio/machines/sorter.dm
@@ -42,7 +42,7 @@
 
 /obj/machinery/power/manufacturing/sorter/receive_resource(atom/movable/receiving, atom/from, receive_dir)
 	if(length(loc.contents) >= MANUFACTURING_TURF_LAG_LIMIT)
-		return MANUFACTURING_FAIL_FULL
+		return MANUFACTURING_FAIL
 	receiving.Move(loc)
 	return MANUFACTURING_SUCCESS
 

--- a/code/modules/manufactorio/machines/storagebox.dm
+++ b/code/modules/manufactorio/machines/storagebox.dm
@@ -15,7 +15,7 @@
 	if(iscloset(receiving) && length(receiving.contents))
 		return MANUFACTURING_FAIL
 	if(length(contents - circuit) >= max_stuff && !may_merge_in_contents_and_do_so(receiving))
-		return MANUFACTURING_FAIL_FULL
+		return MANUFACTURING_FAIL
 	receiving.Move(src,receive_dir)
 	return MANUFACTURING_SUCCESS
 

--- a/code/modules/manufactorio/machines/unloader.dm
+++ b/code/modules/manufactorio/machines/unloader.dm
@@ -32,7 +32,7 @@
 		return MANUFACTURING_FAIL
 	var/list/real_contents = contents - circuit
 	if(length(real_contents))
-		return MANUFACTURING_FAIL_FULL
+		return MANUFACTURING_FAIL
 
 	var/obj/structure/closet/as_closet = receiving
 	var/obj/structure/ore_box/as_orebox = receiving


### PR DESCRIPTION

## About The Pull Request

ok idk how to structure this but
basically the crafter (assembling machine) crafts stuff on top of it now again items created by the crafter are tracked and will be attempted to sent forward at once everytime it processes or crafts
this means junk shells and lizard boot recipes work
additionally, you can no longer have it craft initially anchored objects. this was already a thing the check just never worked

also fixed some dumb define stuff and i made it call recipe completion

## Why It's Good For The Game

fixes #87876
the MANUFACTURING_FAIL_FULL define was basically just useless and if statements thinks its a true value which makes certain things harder to read
pockets defines got left in by accident because i tried to rework it at some point (spoiler: did not work)

## Changelog
:cl:
fix: manufacturing assembling machine crafts junk shells and lizard boots properly, may no longer craft anchored objects (broken check), and sends its crafted stuff at once
/:cl:
