### PR TITLE
Fixes "Leave Body" escape menu tab runtiming

### DIFF
--- a/code/modules/escape_menu/leave_body.dm
+++ b/code/modules/escape_menu/leave_body.dm
@@ -9,7 +9,8 @@
 			stack_trace("The leave body menu was opened before the atoms SS. This shouldn't be possible, as the leave body menu should only be accessible when you have a body.")
 
 	page_holder.give_screen_object(new /atom/movable/screen/escape_menu/leave_body_button(
-		src,
+		null,
+		/* hud_owner = */ null,
 		"Suicide",
 		"Perform a dramatic suicide in game",
 		/* pixel_offset = */ -105,
@@ -19,7 +20,8 @@
 
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/leave_body_button(
-			src,
+			null,
+			/* hud_owner = */ null,
 			"Ghost",
 			"Exit quietly, leaving your body",
 			/* pixel_offset = */ 0,
@@ -30,7 +32,8 @@
 
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/leave_body_button(
-			src,
+			null,
+			/* hud_owner = */ null,
 			"Back",
 			/* tooltip_text = */ null,
 			/* pixel_offset = */ 105,
@@ -84,6 +87,7 @@
 
 /atom/movable/screen/escape_menu/leave_body_button/Initialize(
 	mapload,
+	datum/hud/hud_owner,
 	button_text,
 	tooltip_text,
 	pixel_offset,


### PR DESCRIPTION

## About The Pull Request
Improper tags were being passed around which left a blank menu on player's side and a bunch of runtimes on server's side

## Changelog
:cl:
fix: Fixed "Leave Body" escape menu tab runtiming
/:cl:
