### PR TITLE
Honor-riffic: Adds toggleable honorific titles to certain job ID trims

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -111,6 +111,9 @@
 	///The index of the name part
 	#define NAME_PART_INDEX 1
 
+/// Sent from /atom/movable/proc/compose_message() to find an honorific. Compatible with NAME_PART_INDEX: (list/stored_name, mob/living/carbon/carbon_human)
+#define COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC "movable_message_get_honorific"
+
 /// From /datum/element/immerse/proc/add_submerge_overlay(): (visual_overlay)
 #define COMSIG_MOVABLE_EDIT_UNIQUE_IMMERSE_OVERLAY "movable_edit_unique_submerge_overlay"
 /// From base of area/Exited(): (area/left, direction)

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -111,9 +111,6 @@
 	///The index of the name part
 	#define NAME_PART_INDEX 1
 
-/// Sent from /atom/movable/proc/compose_message() to find an honorific. Compatible with NAME_PART_INDEX: (list/stored_name, mob/living/carbon/carbon_human)
-#define COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC "movable_message_get_honorific"
-
 /// From /datum/element/immerse/proc/add_submerge_overlay(): (visual_overlay)
 #define COMSIG_MOVABLE_EDIT_UNIQUE_IMMERSE_OVERLAY "movable_edit_unique_submerge_overlay"
 /// From base of area/Exited(): (area/left, direction)

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -44,8 +44,12 @@
 #define ID_ICON_BORDERS 1, 9, 32, 24
 
 ///Honorific will display next to the first name.
-#define HONORIFIC_POSITION_FIRST "first_name"
+#define HONORIFIC_POSITION_FIRST "Display first name"
 ///Honorific will display next to the last name.
-#define HONORIFIC_POSITION_LAST "last_name"
-///Honorific will not be displayed
-#define HONORIFIC_POSITION_NONE "none"
+#define HONORIFIC_POSITION_LAST "Display last name"
+///Honorific will not be displayed.
+#define HONORIFIC_POSITION_NONE "No honorific"
+///Honorific will be appended to the full name at the start.
+#define HONORIFIC_POSITION_FIRST_FULL "Start of full name"
+///Honorific will be appended to the full name at the end.
+#define HONORIFIC_POSITION_LAST_FULL "End of full name"

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -44,9 +44,9 @@
 #define ID_ICON_BORDERS 1, 9, 32, 24
 
 ///Honorific will display next to the first name.
-#define HONORIFIC_POSITION_FIRST "Display first name"
+#define HONORIFIC_POSITION_FIRST "Replace last name"
 ///Honorific will display next to the last name.
-#define HONORIFIC_POSITION_LAST "Display last name"
+#define HONORIFIC_POSITION_LAST "Replace first name"
 ///Honorific will not be displayed.
 #define HONORIFIC_POSITION_NONE "No honorific"
 ///Honorific will be appended to the full name at the start.

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -44,9 +44,9 @@
 #define ID_ICON_BORDERS 1, 9, 32, 24
 
 ///Honorific will display next to the first name.
-#define HONORIFIC_POSITION_FIRST "Replace last name"
+#define HONORIFIC_POSITION_FIRST "Include first name"
 ///Honorific will display next to the last name.
-#define HONORIFIC_POSITION_LAST "Replace first name"
+#define HONORIFIC_POSITION_LAST "Include last name"
 ///Honorific will not be displayed.
 #define HONORIFIC_POSITION_NONE "No honorific"
 ///Honorific will be appended to the full name at the start.

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -42,3 +42,10 @@
  * Used to crop the ID card's transparency away when chaching the icon for better use in tgui chat.
  */
 #define ID_ICON_BORDERS 1, 9, 32, 24
+
+///Honorific will display next to the first name.
+#define HONORIFIC_POSITION_FIRST "first_name"
+///Honorific will display next to the last name.
+#define HONORIFIC_POSITION_LAST "last_name"
+///Honorific will not be displayed
+#define HONORIFIC_POSITION_NONE "none"

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -54,10 +54,10 @@
 ///Honorific will be appended to the full name at the end.
 #define HONORIFIC_POSITION_LAST_FULL (1<<4)
 
-DEFINE_BITFIELD(honorific_positions, list(
-	"Honorific + First Name" = HONORIFIC_POSITION_FIRST,
-	"Honorific + Last Name" = HONORIFIC_POSITION_LAST,
-	"Remove Honorific" = HONORIFIC_POSITION_NONE,
-	"Honorific + Full Name" = HONORIFIC_POSITION_FIRST_FULL,
-	"Full Name + Honorific" = HONORIFIC_POSITION_LAST_FULL,
-))
+#define HONORIFIC_POSITION_BITFIELDS(...) list( \
+	"Honorific + First Name" = HONORIFIC_POSITION_FIRST, \
+	"Honorific + Last Name" = HONORIFIC_POSITION_LAST, \
+	"Honorific + Full Name" = HONORIFIC_POSITION_FIRST_FULL, \
+	"Full Name + Honorific" = HONORIFIC_POSITION_LAST_FULL, \
+	"Disable Honorific" = HONORIFIC_POSITION_NONE, \
+)

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -44,12 +44,20 @@
 #define ID_ICON_BORDERS 1, 9, 32, 24
 
 ///Honorific will display next to the first name.
-#define HONORIFIC_POSITION_FIRST "Include first name"
+#define HONORIFIC_POSITION_FIRST (1<<0)
 ///Honorific will display next to the last name.
-#define HONORIFIC_POSITION_LAST "Include last name"
+#define HONORIFIC_POSITION_LAST (1<<1)
 ///Honorific will not be displayed.
-#define HONORIFIC_POSITION_NONE "No honorific"
+#define HONORIFIC_POSITION_NONE (1<<2)
 ///Honorific will be appended to the full name at the start.
-#define HONORIFIC_POSITION_FIRST_FULL "Start of full name"
+#define HONORIFIC_POSITION_FIRST_FULL (1<<3)
 ///Honorific will be appended to the full name at the end.
-#define HONORIFIC_POSITION_LAST_FULL "End of full name"
+#define HONORIFIC_POSITION_LAST_FULL (1<<4)
+
+DEFINE_BITFIELD(honorific_positions, list(
+	"Honorific + First Name" = HONORIFIC_POSITION_FIRST,
+	"Honorific + Last Name" = HONORIFIC_POSITION_LAST,
+	"Remove Honorific" = HONORIFIC_POSITION_NONE,
+	"Honorific + Full Name" = HONORIFIC_POSITION_FIRST_FULL,
+	"Full Name + Honorific" = HONORIFIC_POSITION_LAST_FULL,
+))

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -126,3 +126,6 @@
 ///Defines for priorities for the bubble_icon_override comp
 #define BUBBLE_ICON_PRIORITY_ACCESSORY 2
 #define BUBBLE_ICON_PRIORITY_ORGAN 1
+
+/// Sent from /atom/movable/proc/compose_message() to find an honorific. Compatible with NAME_PART_INDEX: (list/stored_name, mob/living/carbon/carbon_human)
+#define COMSIG_ID_GET_HONORIFIC "id_get_honorific"

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -375,14 +375,21 @@ GLOBAL_DATUM(syndicate_code_response_regex, /regex)
 		else
 			return "something... but the gods didn't set this up right (Please report this bug)"
 
-///Find the first name of a mob from the real name with regex
+///Find the first name of a mob from a passed string with regex
 /proc/first_name(given_name)
 	var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace or "-"
 	firstname.Find(given_name)
 	return firstname.match
 
-/// Find the last name of a mob from the real name with regex
+/// Find the last name of a mob from a passed string with regex
 /proc/last_name(given_name)
 	var/static/regex/lasttname = new("\[^\\s-\]+$") //First word before whitespace or "-"
 	lasttname.Find(given_name)
 	return lasttname.match
+
+/// Find whitespace or dashes in the passed string with regex and returns TRUE if found
+/proc/is_mononym(given_name)
+	var/static/regex/breaks = regex(@"\s")
+	if(breaks.Find(given_name))
+		return FALSE
+	return TRUE

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -374,3 +374,15 @@ GLOBAL_DATUM(syndicate_code_response_regex, /regex)
 			return "a rolling pin"
 		else
 			return "something... but the gods didn't set this up right (Please report this bug)"
+
+///Find the first name of a mob from the real name with regex
+/proc/first_name(given_name)
+	var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace or "-"
+	firstname.Find(given_name)
+	return firstname.match
+
+/// Find the last name of a mob from the real name with regex
+/proc/last_name(given_name)
+	var/static/regex/lasttname = new("\[^\\s-\]+$") //First word before whitespace or "-"
+	lasttname.Find(given_name)
+	return lasttname.match

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -28,6 +28,8 @@
 	var/big_pointer = FALSE
 	///If set, IDs with this trim will give wearers arrows of different colors when pointing
 	var/pointer_color
+	/// What honorific, if any, will we set our wearer's name to when worn?
+	var/honorific
 
 /datum/id_trim/proc/find_job()
 	return null

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -30,6 +30,8 @@
 	var/pointer_color
 	/// What honorific, if any, will we set our wearer's name to when worn?
 	var/honorific
+	/// What positions can our honorific take? To prevent names like "Peter Dr."
+	var/list/honorific_positions
 
 /datum/id_trim/proc/find_job()
 	return null

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -32,8 +32,6 @@
 	var/list/honorifics
 	/// What positions can our honorific take? To prevent names like "Peter Dr."
 	var/honorific_positions = NONE
-	/// What is our selected honorific?
-	var/chosen_honorific
 
 /datum/id_trim/proc/find_job()
 	return null

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -31,7 +31,7 @@
 	/// What honorifics, if any, will we set our wearer's name to when worn?
 	var/list/honorifics
 	/// What positions can our honorific take? To prevent names like "Peter Dr."
-	var/list/honorific_positions
+	var/honorific_positions = NONE
 	/// What is our selected honorific?
 	var/chosen_honorific
 

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -28,10 +28,12 @@
 	var/big_pointer = FALSE
 	///If set, IDs with this trim will give wearers arrows of different colors when pointing
 	var/pointer_color
-	/// What honorific, if any, will we set our wearer's name to when worn?
-	var/honorific
+	/// What honorifics, if any, will we set our wearer's name to when worn?
+	var/list/honorifics
 	/// What positions can our honorific take? To prevent names like "Peter Dr."
 	var/list/honorific_positions
+	/// What is our selected honorific?
+	var/chosen_honorific
 
 /datum/id_trim/proc/find_job()
 	return null

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -23,6 +23,8 @@
 	department_color = COLOR_CENTCOM_BLUE
 	subdepartment_color = COLOR_SERVICE_LIME
 	big_pointer = FALSE
+	honorific = "Custodian"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Thunderdome Overseers.
 /datum/id_trim/centcom/thunderdome_overseer
@@ -39,11 +41,16 @@
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_WEAPONS)
 	assignment = "CentCom Intern"
 	big_pointer = FALSE
+	honorific = "Intern"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Head Interns. Different assignment, common station access added on.
 /datum/id_trim/centcom/intern/head
 	assignment = "CentCom Head Intern"
 	big_pointer = TRUE
+	honorific = "Head Intern"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/centcom/intern/head/New()
 	. = ..()
@@ -66,6 +73,8 @@
 /datum/id_trim/centcom/medical_officer
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL)
 	assignment = JOB_CENTCOM_MEDICAL_DOCTOR
+	honorific = "Doctor"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Research Officers.
 /datum/id_trim/centcom/research_officer
@@ -94,6 +103,9 @@
 /// Trim for Centcom Commanders. All Centcom and Station Access.
 /datum/id_trim/centcom/commander
 	assignment = JOB_CENTCOM_COMMANDER
+	honorific = "Commander"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/centcom/commander/New()
 	. = ..()
@@ -105,6 +117,9 @@
 	assignment = JOB_ERT_DEATHSQUAD
 	trim_state = "trim_deathcommando"
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
+	honorific = "Commando"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/centcom/deathsquad/New()
 	. = ..()
@@ -138,6 +153,8 @@
 	subdepartment_color = COLOR_SECURITY_RED
 	sechud_icon_state = SECHUD_SECURITY_RESPONSE_OFFICER
 	big_pointer = FALSE
+	honorific = "Officer"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/security/New()
 	. = ..()
@@ -164,6 +181,9 @@
 	subdepartment_color = COLOR_MEDICAL_BLUE
 	sechud_icon_state = SECHUD_MEDICAL_RESPONSE_OFFICER
 	big_pointer = FALSE
+	honorific = "Doctor"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/centcom/ert/medical/New()
 	. = ..()
@@ -177,6 +197,9 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	sechud_icon_state = SECHUD_RELIGIOUS_RESPONSE_OFFICER
 	big_pointer = FALSE
+	honorific = "Chaplain"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/centcom/ert/chaplain/New()
 	. = ..()
@@ -190,6 +213,9 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	sechud_icon_state = SECHUD_JANITORIAL_RESPONSE_OFFICER
 	big_pointer = FALSE
+	honorific = "Custodian"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/centcom/ert/janitor/New()
 	. = ..()
@@ -212,7 +238,11 @@
 /datum/id_trim/centcom/ert/militia
 	assignment = "Frontier Militia"
 	big_pointer = FALSE
+	honorific = "Minuteman"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/militia/general
 	assignment = "Frontier Militia General"
 	big_pointer = TRUE
+	honorific = "Minuteman General"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -24,7 +24,7 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	big_pointer = FALSE
 	honorific = "Custodian"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Thunderdome Overseers.
 /datum/id_trim/centcom/thunderdome_overseer
@@ -42,14 +42,14 @@
 	assignment = "CentCom Intern"
 	big_pointer = FALSE
 	honorific = "Intern"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Head Interns. Different assignment, common station access added on.
 /datum/id_trim/centcom/intern/head
 	assignment = "CentCom Head Intern"
 	big_pointer = TRUE
 	honorific = "Head Intern"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/intern/head/New()
@@ -74,7 +74,7 @@
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL)
 	assignment = JOB_CENTCOM_MEDICAL_DOCTOR
 	honorific = "Doctor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Research Officers.
 /datum/id_trim/centcom/research_officer
@@ -104,7 +104,7 @@
 /datum/id_trim/centcom/commander
 	assignment = JOB_CENTCOM_COMMANDER
 	honorific = "Commander"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/commander/New()
@@ -118,7 +118,7 @@
 	trim_state = "trim_deathcommando"
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
 	honorific = "Commando"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/deathsquad/New()
@@ -154,7 +154,7 @@
 	sechud_icon_state = SECHUD_SECURITY_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Officer"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/security/New()
 	. = ..()
@@ -182,7 +182,7 @@
 	sechud_icon_state = SECHUD_MEDICAL_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Doctor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/ert/medical/New()
@@ -198,7 +198,7 @@
 	sechud_icon_state = SECHUD_RELIGIOUS_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Chaplain"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/ert/chaplain/New()
@@ -214,7 +214,7 @@
 	sechud_icon_state = SECHUD_JANITORIAL_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Custodian"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/ert/janitor/New()
@@ -239,10 +239,10 @@
 	assignment = "Frontier Militia"
 	big_pointer = FALSE
 	honorific = "Minuteman"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/militia/general
 	assignment = "Frontier Militia General"
 	big_pointer = TRUE
 	honorific = "Minuteman General"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -23,7 +23,7 @@
 	department_color = COLOR_CENTCOM_BLUE
 	subdepartment_color = COLOR_SERVICE_LIME
 	big_pointer = FALSE
-	honorific = "Custodian"
+	honorifics = list("Custodian")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Thunderdome Overseers.
@@ -41,14 +41,14 @@
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_WEAPONS)
 	assignment = "CentCom Intern"
 	big_pointer = FALSE
-	honorific = "Intern"
+	honorifics = list("Intern")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Head Interns. Different assignment, common station access added on.
 /datum/id_trim/centcom/intern/head
 	assignment = "CentCom Head Intern"
 	big_pointer = TRUE
-	honorific = "Head Intern"
+	honorifics = list("Head Intern")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/intern/head/New()
@@ -72,7 +72,7 @@
 /datum/id_trim/centcom/medical_officer
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL)
 	assignment = JOB_CENTCOM_MEDICAL_DOCTOR
-	honorific = "Doctor"
+	honorifics = list("Doctor", "Dr.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Research Officers.
@@ -102,7 +102,7 @@
 /// Trim for Centcom Commanders. All Centcom and Station Access.
 /datum/id_trim/centcom/commander
 	assignment = JOB_CENTCOM_COMMANDER
-	honorific = "Commander"
+	honorifics = list("Commander", "CMDR.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/commander/New()
@@ -115,7 +115,7 @@
 	assignment = JOB_ERT_DEATHSQUAD
 	trim_state = "trim_deathcommando"
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
-	honorific = "Commando"
+	honorifics = list("Commando")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
@@ -127,6 +127,8 @@
 /// Trim for generic ERT interns. No universal ID card changing access.
 /datum/id_trim/centcom/ert
 	assignment = "Emergency Response Team Intern"
+	honorifics = list("Intern")
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/New()
 	. = ..()
@@ -151,7 +153,7 @@
 	subdepartment_color = COLOR_SECURITY_RED
 	sechud_icon_state = SECHUD_SECURITY_RESPONSE_OFFICER
 	big_pointer = FALSE
-	honorific = "Officer"
+	honorifics = list("Officer")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/security/New()
@@ -179,7 +181,7 @@
 	subdepartment_color = COLOR_MEDICAL_BLUE
 	sechud_icon_state = SECHUD_MEDICAL_RESPONSE_OFFICER
 	big_pointer = FALSE
-	honorific = "Doctor"
+	honorifics = list("Doctor", "Dr.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
@@ -195,7 +197,7 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	sechud_icon_state = SECHUD_RELIGIOUS_RESPONSE_OFFICER
 	big_pointer = FALSE
-	honorific = "Chaplain"
+	honorifics = list("Chaplain")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
@@ -211,7 +213,7 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	sechud_icon_state = SECHUD_JANITORIAL_RESPONSE_OFFICER
 	big_pointer = FALSE
-	honorific = "Custodian"
+	honorifics = list("Custodian")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
@@ -236,11 +238,11 @@
 /datum/id_trim/centcom/ert/militia
 	assignment = "Frontier Militia"
 	big_pointer = FALSE
-	honorific = "Minuteman"
+	honorifics = list("Minuteman")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/militia/general
 	assignment = "Frontier Militia General"
 	big_pointer = TRUE
-	honorific = "Minuteman General"
+	honorifics = list("Minuteman General", "General")
 	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -24,7 +24,7 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	big_pointer = FALSE
 	honorifics = list("Custodian")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /// Trim for Centcom Thunderdome Overseers.
 /datum/id_trim/centcom/thunderdome_overseer
@@ -42,14 +42,14 @@
 	assignment = "CentCom Intern"
 	big_pointer = FALSE
 	honorifics = list("Intern")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /// Trim for Centcom Head Interns. Different assignment, common station access added on.
 /datum/id_trim/centcom/intern/head
 	assignment = "CentCom Head Intern"
 	big_pointer = TRUE
 	honorifics = list("Head Intern")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/centcom/intern/head/New()
 	. = ..()
@@ -73,7 +73,7 @@
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL)
 	assignment = JOB_CENTCOM_MEDICAL_DOCTOR
 	honorifics = list("Doctor", "Dr.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /// Trim for Centcom Research Officers.
 /datum/id_trim/centcom/research_officer
@@ -103,7 +103,7 @@
 /datum/id_trim/centcom/commander
 	assignment = JOB_CENTCOM_COMMANDER
 	honorifics = list("Commander", "CMDR.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/centcom/commander/New()
 	. = ..()
@@ -116,7 +116,7 @@
 	trim_state = "trim_deathcommando"
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
 	honorifics = list("Commando")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 
 /datum/id_trim/centcom/deathsquad/New()
@@ -128,7 +128,7 @@
 /datum/id_trim/centcom/ert
 	assignment = "Emergency Response Team Intern"
 	honorifics = list("Intern")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/centcom/ert/New()
 	. = ..()
@@ -154,7 +154,7 @@
 	sechud_icon_state = SECHUD_SECURITY_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorifics = list("Officer")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/centcom/ert/security/New()
 	. = ..()
@@ -182,7 +182,7 @@
 	sechud_icon_state = SECHUD_MEDICAL_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorifics = list("Doctor", "Dr.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 
 /datum/id_trim/centcom/ert/medical/New()
@@ -198,7 +198,7 @@
 	sechud_icon_state = SECHUD_RELIGIOUS_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorifics = list("Chaplain")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 
 /datum/id_trim/centcom/ert/chaplain/New()
@@ -214,7 +214,7 @@
 	sechud_icon_state = SECHUD_JANITORIAL_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorifics = list("Custodian")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 
 /datum/id_trim/centcom/ert/janitor/New()
@@ -239,10 +239,10 @@
 	assignment = "Frontier Militia"
 	big_pointer = FALSE
 	honorifics = list("Minuteman")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/centcom/ert/militia/general
 	assignment = "Frontier Militia General"
 	big_pointer = TRUE
 	honorifics = list("Minuteman General", "General")
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -24,7 +24,7 @@
 	subdepartment_color = COLOR_SERVICE_LIME
 	big_pointer = FALSE
 	honorific = "Custodian"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Thunderdome Overseers.
 /datum/id_trim/centcom/thunderdome_overseer
@@ -42,15 +42,14 @@
 	assignment = "CentCom Intern"
 	big_pointer = FALSE
 	honorific = "Intern"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Head Interns. Different assignment, common station access added on.
 /datum/id_trim/centcom/intern/head
 	assignment = "CentCom Head Intern"
 	big_pointer = TRUE
 	honorific = "Head Intern"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
-
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/intern/head/New()
 	. = ..()
@@ -74,7 +73,7 @@
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL)
 	assignment = JOB_CENTCOM_MEDICAL_DOCTOR
 	honorific = "Doctor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /// Trim for Centcom Research Officers.
 /datum/id_trim/centcom/research_officer
@@ -104,8 +103,7 @@
 /datum/id_trim/centcom/commander
 	assignment = JOB_CENTCOM_COMMANDER
 	honorific = "Commander"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
-
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/commander/New()
 	. = ..()
@@ -118,7 +116,7 @@
 	trim_state = "trim_deathcommando"
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
 	honorific = "Commando"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/deathsquad/New()
@@ -154,7 +152,7 @@
 	sechud_icon_state = SECHUD_SECURITY_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Officer"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/security/New()
 	. = ..()
@@ -182,7 +180,7 @@
 	sechud_icon_state = SECHUD_MEDICAL_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Doctor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/ert/medical/New()
@@ -198,7 +196,7 @@
 	sechud_icon_state = SECHUD_RELIGIOUS_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Chaplain"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/ert/chaplain/New()
@@ -214,7 +212,7 @@
 	sechud_icon_state = SECHUD_JANITORIAL_RESPONSE_OFFICER
 	big_pointer = FALSE
 	honorific = "Custodian"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/centcom/ert/janitor/New()
@@ -239,10 +237,10 @@
 	assignment = "Frontier Militia"
 	big_pointer = FALSE
 	honorific = "Minuteman"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/centcom/ert/militia/general
 	assignment = "Frontier Militia General"
 	big_pointer = TRUE
 	honorific = "Minuteman General"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -568,6 +568,8 @@
 		ACCESS_HOS,
 	)
 	job = /datum/job/detective
+	honorific = "Detective"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/detective/refresh_trim_access()
 	. = ..()
@@ -1168,6 +1170,8 @@
 		ACCESS_SURGERY,
 		ACCESS_VIROLOGY,
 	)
+	honorific = "Orderly"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/security_officer/science
 	assignment = JOB_SECURITY_OFFICER_SCIENCE

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -448,7 +448,7 @@
 	job = /datum/job/chief_medical_officer
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
-	honorific = ", PhD"
+	honorific = ", PhD."
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/clown

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -181,6 +181,9 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/pun_pun
+	honorific = ", Almighty Scourge"
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_LAST_FULL)
+
 
 /datum/id_trim/job/bitrunner
 	assignment = JOB_BITRUNNER
@@ -250,6 +253,9 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/bridge_assistant
+	honorific = "Underling"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+
 
 /datum/id_trim/job/captain
 	assignment = JOB_CAPTAIN
@@ -266,7 +272,8 @@
 	job = /datum/job/captain
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
-	honorific = "Cpt."
+	honorific = "Captain"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
 /datum/id_trim/job/captain/New()
@@ -432,6 +439,8 @@
 	job = /datum/job/chief_medical_officer
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
+	honorific = ", PhD"
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_LAST_FULL)
 
 /datum/id_trim/job/clown
 	assignment = JOB_CLOWN
@@ -474,10 +483,15 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/cook
+	honorific = "Head Chef"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF
 	sechud_icon_state = SECHUD_CHEF
+	honorific = "Chef"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
 
 /datum/id_trim/job/coroner
 	assignment = JOB_CORONER
@@ -728,6 +742,9 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/janitor
+	honorific = "Custodian"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+
 
 /datum/id_trim/job/lawyer
 	assignment = JOB_LAWYER
@@ -749,6 +766,8 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/lawyer
+	honorific = ", Esq."
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_LAST_FULL)
 
 /datum/id_trim/job/medical_doctor
 	assignment = JOB_MEDICAL_DOCTOR
@@ -774,6 +793,8 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/doctor
+	honorific = "Doctor"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
 
 /datum/id_trim/job/mime
 	assignment = JOB_MIME
@@ -1067,6 +1088,8 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/security_officer
+	honorific = "Officer"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
 	/// List of bonus departmental accesses that departmental security officers can in relation to how many overall security officers there are if the scaling system is set up. These can otherwise be granted via config settings.
@@ -1248,6 +1271,8 @@
 	template_access = list()
 	job = /datum/job/veteran_advisor
 	big_pointer = TRUE
+	honorific = "General"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
 
 /datum/id_trim/job/veteran_advisor/refresh_trim_access()
 	. = ..()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -134,6 +134,8 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/atmospheric_technician
+	honorific = "Technician"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bartender
 	assignment = JOB_BARTENDER
@@ -182,8 +184,7 @@
 		)
 	job = /datum/job/pun_pun
 	honorific = ", Almighty Scourge"
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
-
+	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bitrunner
 	assignment = JOB_BITRUNNER
@@ -208,6 +209,8 @@
 		ACCESS_QM,
 	)
 	job = /datum/job/bitrunner
+	honorific = "Bitrunner"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/botanist
 	assignment = JOB_BOTANIST
@@ -231,6 +234,9 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/botanist
+	honorific = "Botanist"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/job/bridge_assistant
 	assignment = JOB_BRIDGE_ASSISTANT
@@ -255,7 +261,6 @@
 	job = /datum/job/bridge_assistant
 	honorific = "Underling"
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
-
 
 /datum/id_trim/job/captain
 	assignment = JOB_CAPTAIN
@@ -308,6 +313,9 @@
 		ACCESS_QM,
 		)
 	job = /datum/job/cargo_technician
+	honorific = "Courier"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/job/chaplain
 	assignment = JOB_CHAPLAIN
@@ -330,6 +338,8 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/chaplain
+	honorific = "Chaplain"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/chemist
 	assignment = JOB_CHEMIST
@@ -440,7 +450,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
 	honorific = ", PhD"
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/clown
 	assignment = JOB_CLOWN
@@ -714,6 +724,8 @@
 	job = /datum/job/head_of_security
 	big_pointer = TRUE
 	pointer_color = COLOR_SECURITY_RED
+	honorific = "Chief Officer"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
 	. = ..()
@@ -747,7 +759,6 @@
 	honorific = "Custodian"
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
-
 /datum/id_trim/job/lawyer
 	assignment = JOB_LAWYER
 	trim_state = "trim_lawyer"
@@ -769,7 +780,7 @@
 		)
 	job = /datum/job/lawyer
 	honorific = ", Esq."
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/medical_doctor
 	assignment = JOB_MEDICAL_DOCTOR
@@ -848,6 +859,8 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/paramedic
+	honorific = "EMT"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner
 	assignment = JOB_PRISONER
@@ -863,6 +876,8 @@
 		)
 	job = /datum/job/prisoner
 	threat_modifier = 1 // I'm watching you
+	honorific = "Convict"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner/one
 	trim_state = "trim_prisoner_1"
@@ -915,6 +930,8 @@
 		ACCESS_HOP,
 	)
 	job = /datum/job/psychologist
+	honorific = ", PhD."
+	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/quartermaster
 	assignment = JOB_QUARTERMASTER
@@ -955,6 +972,8 @@
 	job = /datum/job/quartermaster
 	big_pointer = TRUE
 	pointer_color = COLOR_CARGO_BROWN
+	honorific = "Manager"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/research_director
 	assignment = JOB_RESEARCH_DIRECTOR
@@ -1005,6 +1024,8 @@
 	job = /datum/job/research_director
 	big_pointer = TRUE
 	pointer_color = COLOR_SCIENCE_PINK
+	honorific = "Director"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/roboticist
 	assignment = JOB_ROBOTICIST
@@ -1062,6 +1083,8 @@
 		ACCESS_RD,
 		)
 	job = /datum/job/scientist
+	honorific = "Researcher"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
 /datum/id_trim/job/security_officer
@@ -1254,6 +1277,8 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/station_engineer
+	honorific = "Engineer"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/veteran_advisor
 	assignment = JOB_VETERAN_ADVISOR
@@ -1288,7 +1313,6 @@
 	if(CONFIG_GET(flag/security_has_maint_access))
 		access |= list(ACCESS_MAINT_TUNNELS)
 
-
 /datum/id_trim/job/warden
 	assignment = JOB_WARDEN
 	trim_state = "trim_warden"
@@ -1316,6 +1340,8 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/warden
+	honorific = "Watchman"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/warden/refresh_trim_access()
 	. = ..()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -182,7 +182,7 @@
 		)
 	job = /datum/job/pun_pun
 	honorific = ", Almighty Scourge"
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_LAST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/job/bitrunner
@@ -254,7 +254,7 @@
 	)
 	job = /datum/job/bridge_assistant
 	honorific = "Underling"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/job/captain
@@ -273,7 +273,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
 	honorific = "Captain"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
 /datum/id_trim/job/captain/New()
@@ -440,7 +440,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
 	honorific = ", PhD"
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_LAST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/clown
 	assignment = JOB_CLOWN
@@ -484,14 +484,14 @@
 		)
 	job = /datum/job/cook
 	honorific = "Head Chef"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF
 	sechud_icon_state = SECHUD_CHEF
 	honorific = "Chef"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/coroner
 	assignment = JOB_CORONER
@@ -743,7 +743,7 @@
 		)
 	job = /datum/job/janitor
 	honorific = "Custodian"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/job/lawyer
@@ -767,7 +767,7 @@
 		)
 	job = /datum/job/lawyer
 	honorific = ", Esq."
-	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_LAST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/medical_doctor
 	assignment = JOB_MEDICAL_DOCTOR
@@ -794,7 +794,7 @@
 		)
 	job = /datum/job/doctor
 	honorific = "Doctor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/mime
 	assignment = JOB_MIME
@@ -1089,7 +1089,7 @@
 		)
 	job = /datum/job/security_officer
 	honorific = "Officer"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
 	/// List of bonus departmental accesses that departmental security officers can in relation to how many overall security officers there are if the scaling system is set up. These can otherwise be granted via config settings.
@@ -1272,7 +1272,7 @@
 	job = /datum/job/veteran_advisor
 	big_pointer = TRUE
 	honorific = "General"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE, HONORIFIC_POSITION_FIRST_FULL)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/veteran_advisor/refresh_trim_access()
 	. = ..()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -135,7 +135,7 @@
 		)
 	job = /datum/job/atmospheric_technician
 	honorific = "Technician"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bartender
 	assignment = JOB_BARTENDER
@@ -210,7 +210,7 @@
 	)
 	job = /datum/job/bitrunner
 	honorific = "Bitrunner"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/botanist
 	assignment = JOB_BOTANIST
@@ -235,8 +235,7 @@
 		)
 	job = /datum/job/botanist
 	honorific = "Botanist"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
-
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bridge_assistant
 	assignment = JOB_BRIDGE_ASSISTANT
@@ -260,7 +259,7 @@
 	)
 	job = /datum/job/bridge_assistant
 	honorific = "Underling"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/captain
 	assignment = JOB_CAPTAIN
@@ -278,7 +277,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
 	honorific = "Captain"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
 /datum/id_trim/job/captain/New()
@@ -314,7 +313,7 @@
 		)
 	job = /datum/job/cargo_technician
 	honorific = "Courier"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/job/chaplain
@@ -339,7 +338,7 @@
 		)
 	job = /datum/job/chaplain
 	honorific = "Chaplain"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/chemist
 	assignment = JOB_CHEMIST
@@ -494,14 +493,14 @@
 		)
 	job = /datum/job/cook
 	honorific = "Head Chef"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF
 	sechud_icon_state = SECHUD_CHEF
 	honorific = "Chef"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/coroner
 	assignment = JOB_CORONER
@@ -579,7 +578,7 @@
 	)
 	job = /datum/job/detective
 	honorific = "Detective"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/detective/refresh_trim_access()
 	. = ..()
@@ -725,7 +724,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_SECURITY_RED
 	honorific = "Chief Officer"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
 	. = ..()
@@ -757,7 +756,7 @@
 		)
 	job = /datum/job/janitor
 	honorific = "Custodian"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/lawyer
 	assignment = JOB_LAWYER
@@ -807,7 +806,7 @@
 		)
 	job = /datum/job/doctor
 	honorific = "Doctor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/mime
 	assignment = JOB_MIME
@@ -860,7 +859,7 @@
 		)
 	job = /datum/job/paramedic
 	honorific = "EMT"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner
 	assignment = JOB_PRISONER
@@ -877,7 +876,7 @@
 	job = /datum/job/prisoner
 	threat_modifier = 1 // I'm watching you
 	honorific = "Convict"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner/one
 	trim_state = "trim_prisoner_1"
@@ -973,7 +972,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_CARGO_BROWN
 	honorific = "Manager"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/research_director
 	assignment = JOB_RESEARCH_DIRECTOR
@@ -1025,7 +1024,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_SCIENCE_PINK
 	honorific = "Director"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/roboticist
 	assignment = JOB_ROBOTICIST
@@ -1084,7 +1083,7 @@
 		)
 	job = /datum/job/scientist
 	honorific = "Researcher"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
 /datum/id_trim/job/security_officer
@@ -1114,7 +1113,7 @@
 		)
 	job = /datum/job/security_officer
 	honorific = "Officer"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
 	/// List of bonus departmental accesses that departmental security officers can in relation to how many overall security officers there are if the scaling system is set up. These can otherwise be granted via config settings.
@@ -1194,7 +1193,7 @@
 		ACCESS_VIROLOGY,
 	)
 	honorific = "Orderly"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/security_officer/science
 	assignment = JOB_SECURITY_OFFICER_SCIENCE
@@ -1278,7 +1277,7 @@
 		)
 	job = /datum/job/station_engineer
 	honorific = "Engineer"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/veteran_advisor
 	assignment = JOB_VETERAN_ADVISOR
@@ -1301,7 +1300,7 @@
 	job = /datum/job/veteran_advisor
 	big_pointer = TRUE
 	honorific = "General"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/veteran_advisor/refresh_trim_access()
 	. = ..()
@@ -1341,7 +1340,7 @@
 		)
 	job = /datum/job/warden
 	honorific = "Watchman"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/warden/refresh_trim_access()
 	. = ..()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -266,6 +266,7 @@
 	job = /datum/job/captain
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
+	honorific = "Cpt."
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
 /datum/id_trim/job/captain/New()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -135,7 +135,7 @@
 		)
 	job = /datum/job/atmospheric_technician
 	honorifics = list("Technician")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/bartender
 	assignment = JOB_BARTENDER
@@ -184,7 +184,7 @@
 		)
 	job = /datum/job/pun_pun
 	honorifics = list(", Almighty Scourge")
-	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/bitrunner
 	assignment = JOB_BITRUNNER
@@ -404,7 +404,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_ENGINEERING_ORANGE
 	honorifics = list("Chief")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/chief_medical_officer
 	assignment = JOB_CHIEF_MEDICAL_OFFICER
@@ -491,13 +491,13 @@
 		)
 	job = /datum/job/cook
 	honorifics = list("Cook")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF
 	sechud_icon_state = SECHUD_CHEF
 	honorifics = list("Chef")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/coroner
 	assignment = JOB_CORONER
@@ -575,7 +575,7 @@
 	)
 	job = /datum/job/detective
 	honorifics = list("Detective", "Investigator")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/detective/refresh_trim_access()
 	. = ..()
@@ -721,7 +721,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_SECURITY_RED
 	honorifics = list("Chief Officer", "Chief", "Officer")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
 	. = ..()
@@ -753,7 +753,7 @@
 		)
 	job = /datum/job/janitor
 	honorifics = list("Custodian")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/lawyer
 	assignment = JOB_LAWYER
@@ -776,7 +776,7 @@
 		)
 	job = /datum/job/lawyer
 	honorifics = list(", Esq.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/medical_doctor
 	assignment = JOB_MEDICAL_DOCTOR
@@ -803,7 +803,7 @@
 		)
 	job = /datum/job/doctor
 	honorifics = list("Doctor", "Dr.")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/mime
 	assignment = JOB_MIME
@@ -856,7 +856,7 @@
 		)
 	job = /datum/job/paramedic
 	honorifics = list("EMT")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/prisoner
 	assignment = JOB_PRISONER
@@ -873,7 +873,7 @@
 	job = /datum/job/prisoner
 	threat_modifier = 1 // I'm watching you
 	honorifics = list("Convict")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/prisoner/one
 	trim_state = "trim_prisoner_1"
@@ -927,7 +927,7 @@
 	)
 	job = /datum/job/psychologist
 	honorifics = list(", PhD.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/quartermaster
 	assignment = JOB_QUARTERMASTER
@@ -969,7 +969,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_CARGO_BROWN
 	honorifics = list("Manager")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/research_director
 	assignment = JOB_RESEARCH_DIRECTOR
@@ -1021,7 +1021,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_SCIENCE_PINK
 	honorifics = list("Director", "Dir.")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/roboticist
 	assignment = JOB_ROBOTICIST
@@ -1080,7 +1080,7 @@
 		)
 	job = /datum/job/scientist
 	honorifics = list("Researcher")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
 /datum/id_trim/job/security_officer
@@ -1110,7 +1110,7 @@
 		)
 	job = /datum/job/security_officer
 	honorifics = list("Officer")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
 	/// List of bonus departmental accesses that departmental security officers can in relation to how many overall security officers there are if the scaling system is set up. These can otherwise be granted via config settings.
@@ -1190,7 +1190,6 @@
 		ACCESS_VIROLOGY,
 	)
 	honorifics = list("Orderly", "Officer")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/security_officer/science
 	assignment = JOB_SECURITY_OFFICER_SCIENCE
@@ -1274,7 +1273,7 @@
 		)
 	job = /datum/job/station_engineer
 	honorifics = list("Engineer")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/veteran_advisor
 	assignment = JOB_VETERAN_ADVISOR
@@ -1297,7 +1296,7 @@
 	job = /datum/job/veteran_advisor
 	big_pointer = TRUE
 	honorifics = list("General", "Gen.")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/veteran_advisor/refresh_trim_access()
 	. = ..()
@@ -1337,7 +1336,7 @@
 		)
 	job = /datum/job/warden
 	honorifics = list("Officer", "Watchman", "Lieutenant", "Lt.")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/warden/refresh_trim_access()
 	. = ..()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -855,7 +855,7 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/paramedic
-	honorifics = list("EMT", "Doctor", "Dr.")
+	honorifics = list("EMT")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -134,7 +134,7 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/atmospheric_technician
-	honorific = "Technician"
+	honorifics = list("Technician")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bartender
@@ -183,7 +183,7 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/pun_pun
-	honorific = ", Almighty Scourge"
+	honorifics = list(", Almighty Scourge")
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bitrunner
@@ -209,8 +209,6 @@
 		ACCESS_QM,
 	)
 	job = /datum/job/bitrunner
-	honorific = "Bitrunner"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/botanist
 	assignment = JOB_BOTANIST
@@ -234,8 +232,6 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/botanist
-	honorific = "Botanist"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/bridge_assistant
 	assignment = JOB_BRIDGE_ASSISTANT
@@ -258,7 +254,7 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/bridge_assistant
-	honorific = "Underling"
+	honorifics = list("Underling", "Assistant", "Mate")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/captain
@@ -276,7 +272,7 @@
 	job = /datum/job/captain
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
-	honorific = "Captain"
+	honorifics = list("Captain", "Cpt.")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
@@ -312,7 +308,7 @@
 		ACCESS_QM,
 		)
 	job = /datum/job/cargo_technician
-	honorific = "Courier"
+	honorifics = list("Courier")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
@@ -337,7 +333,7 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/chaplain
-	honorific = "Chaplain"
+	honorifics = list("Chaplain", "Reverend")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/chemist
@@ -407,6 +403,8 @@
 	job = /datum/job/chief_engineer
 	big_pointer = TRUE
 	pointer_color = COLOR_ENGINEERING_ORANGE
+	honorifics = list("Chief")
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/chief_medical_officer
 	assignment = JOB_CHIEF_MEDICAL_OFFICER
@@ -448,7 +446,7 @@
 	job = /datum/job/chief_medical_officer
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
-	honorific = ", PhD."
+	honorifics = list(", PhD.", ", MD.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/clown
@@ -492,13 +490,13 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/cook
-	honorific = "Cook"
+	honorifics = list("Cook")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF
 	sechud_icon_state = SECHUD_CHEF
-	honorific = "Chef"
+	honorifics = list("Chef")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/coroner
@@ -576,7 +574,7 @@
 		ACCESS_HOS,
 	)
 	job = /datum/job/detective
-	honorific = "Detective"
+	honorifics = list("Detective", "Investigator")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/detective/refresh_trim_access()
@@ -722,7 +720,7 @@
 	job = /datum/job/head_of_security
 	big_pointer = TRUE
 	pointer_color = COLOR_SECURITY_RED
-	honorific = "Chief Officer"
+	honorifics = list("Chief Officer", "Chief", "Officer")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
@@ -754,7 +752,7 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/janitor
-	honorific = "Custodian"
+	honorifics = list("Custodian")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/lawyer
@@ -777,7 +775,7 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/lawyer
-	honorific = ", Esq."
+	honorifics = list(", Esq.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/medical_doctor
@@ -804,7 +802,7 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/doctor
-	honorific = "Doctor"
+	honorifics = list("Doctor", "Dr.")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/mime
@@ -857,7 +855,7 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/paramedic
-	honorific = "EMT"
+	honorifics = list("EMT", "Doctor", "Dr.")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner
@@ -874,7 +872,7 @@
 		)
 	job = /datum/job/prisoner
 	threat_modifier = 1 // I'm watching you
-	honorific = "Convict"
+	honorifics = list("Convict")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/prisoner/one
@@ -928,7 +926,7 @@
 		ACCESS_HOP,
 	)
 	job = /datum/job/psychologist
-	honorific = ", PhD."
+	honorifics = list(", PhD.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/quartermaster
@@ -970,7 +968,7 @@
 	job = /datum/job/quartermaster
 	big_pointer = TRUE
 	pointer_color = COLOR_CARGO_BROWN
-	honorific = "Manager"
+	honorifics = list("Manager")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/research_director
@@ -1022,7 +1020,7 @@
 	job = /datum/job/research_director
 	big_pointer = TRUE
 	pointer_color = COLOR_SCIENCE_PINK
-	honorific = "Director"
+	honorifics = list("Director", "Dir.")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/roboticist
@@ -1081,7 +1079,7 @@
 		ACCESS_RD,
 		)
 	job = /datum/job/scientist
-	honorific = "Researcher"
+	honorifics = list("Researcher")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
@@ -1111,7 +1109,7 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/security_officer
-	honorific = "Officer"
+	honorifics = list("Officer")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
@@ -1191,7 +1189,7 @@
 		ACCESS_SURGERY,
 		ACCESS_VIROLOGY,
 	)
-	honorific = "Orderly"
+	honorifics = list("Orderly", "Officer")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/security_officer/science
@@ -1275,7 +1273,7 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/station_engineer
-	honorific = "Engineer"
+	honorifics = list("Engineer")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/veteran_advisor
@@ -1298,7 +1296,7 @@
 	template_access = list()
 	job = /datum/job/veteran_advisor
 	big_pointer = TRUE
-	honorific = "General"
+	honorifics = list("General", "Gen.")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/veteran_advisor/refresh_trim_access()
@@ -1338,7 +1336,7 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/warden
-	honorific = "Watchman"
+	honorifics = list("Officer", "Watchman", "Lieutenant", "Lt.")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/job/warden/refresh_trim_access()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -492,9 +492,8 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/cook
-	honorific = "Head Chef"
+	honorific = "Cook"
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
-
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -255,7 +255,7 @@
 	)
 	job = /datum/job/bridge_assistant
 	honorifics = list("Underling", "Assistant", "Mate")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/captain
 	assignment = JOB_CAPTAIN
@@ -273,7 +273,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
 	honorifics = list("Captain", "Cpt.")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
 /datum/id_trim/job/captain/New()
@@ -309,7 +309,7 @@
 		)
 	job = /datum/job/cargo_technician
 	honorifics = list("Courier")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 
 /datum/id_trim/job/chaplain
@@ -334,7 +334,7 @@
 		)
 	job = /datum/job/chaplain
 	honorifics = list("Chaplain", "Reverend")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/chemist
 	assignment = JOB_CHEMIST

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -447,7 +447,7 @@
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
 	honorifics = list(", PhD.", ", MD.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/clown
 	assignment = JOB_CLOWN

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -71,6 +71,8 @@
 	department_color = COLOR_BLACK
 	subdepartment_color = COLOR_GREEN
 	threat_modifier = -1 // Cops recognise cops
+	honorific = "CISO"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/cyber_police/New()
 	. = ..()

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -72,7 +72,7 @@
 	subdepartment_color = COLOR_GREEN
 	threat_modifier = -1 // Cops recognise cops
 	honorific = "CISO"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/cyber_police/New()
 	. = ..()

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -72,7 +72,7 @@
 	subdepartment_color = COLOR_GREEN
 	threat_modifier = -1 // Cops recognise cops
 	honorifics = list("CISO")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/cyber_police/New()
 	. = ..()

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -71,7 +71,7 @@
 	department_color = COLOR_BLACK
 	subdepartment_color = COLOR_GREEN
 	threat_modifier = -1 // Cops recognise cops
-	honorific = "CISO"
+	honorifics = list("CISO")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/cyber_police/New()

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -17,6 +17,10 @@
 	big_pointer = FALSE
 
 /// Interdyne medical Staff
+/datum/id_trim/syndicom/Interdyne
+	honorific = ", PhD"
+	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+
 /datum/id_trim/syndicom/Interdyne/pharmacist
 	assignment = "Interdyne Pharmacist"
 	trim_state = "trim_medicaldoctor"
@@ -46,6 +50,9 @@
 	access = list(ACCESS_SYNDICATE, ACCESS_MAINT_TUNNELS)
 	big_pointer = FALSE
 	pointer_color = null
+	honorific = "Auditor"
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+
 
 /datum/id_trim/syndicom/irs/auditor
 	assignment = "Internal Revenue Service Head Auditor"

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -18,7 +18,7 @@
 
 /// Interdyne medical Staff
 /datum/id_trim/syndicom/Interdyne
-	honorific = ", PhD"
+	honorific = ", PhD."
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/syndicom/Interdyne/pharmacist

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -51,7 +51,7 @@
 	big_pointer = FALSE
 	pointer_color = null
 	honorific = "Auditor"
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 
 /datum/id_trim/syndicom/irs/auditor

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -19,7 +19,7 @@
 /// Interdyne medical Staff
 /datum/id_trim/syndicom/Interdyne
 	honorifics = list(", PhD.")
-	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/syndicom/Interdyne/pharmacist
 	assignment = "Interdyne Pharmacist"
@@ -51,7 +51,7 @@
 	big_pointer = FALSE
 	pointer_color = null
 	honorifics = list("Auditor")
-	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 
 /datum/id_trim/syndicom/irs/auditor

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -18,7 +18,7 @@
 
 /// Interdyne medical Staff
 /datum/id_trim/syndicom/Interdyne
-	honorific = ", PhD."
+	honorifics = list(", PhD.")
 	honorific_positions = list(HONORIFIC_POSITION_LAST_FULL, HONORIFIC_POSITION_NONE)
 
 /datum/id_trim/syndicom/Interdyne/pharmacist
@@ -50,7 +50,7 @@
 	access = list(ACCESS_SYNDICATE, ACCESS_MAINT_TUNNELS)
 	big_pointer = FALSE
 	pointer_color = null
-	honorific = "Auditor"
+	honorifics = list("Auditor")
 	honorific_positions = list(HONORIFIC_POSITION_FIRST, HONORIFIC_POSITION_LAST, HONORIFIC_POSITION_FIRST_FULL, HONORIFIC_POSITION_NONE)
 
 

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -52,12 +52,12 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 			listeners += candidate
 
 			//Let's ensure the listener's name is not matched within another word or command (and viceversa). e.g. "Saul" in "somersault"
-			var/their_first_name = candidate.first_name()
+			var/their_first_name = first_name(candidate.real_name)
 			if(!GLOB.all_voice_of_god_triggers.Find(their_first_name) && findtext(message, regex("(\\L|^)[their_first_name](\\L|$)", "i")))
 				specific_listeners += candidate //focus on those with the specified name
 				to_remove_string += "[to_remove_string ? "|" : null][their_first_name]"
 				continue
-			var/their_last_name = candidate.last_name()
+			var/their_last_name = last_name(candidate)
 			if(their_last_name != their_first_name && !GLOB.all_voice_of_god_triggers.Find(their_last_name) && findtext(message, regex("(\\L|^)[their_last_name](\\L|$)", "i")))
 				specific_listeners += candidate // Ditto
 				to_remove_string += "[to_remove_string ? "|" : null][their_last_name]"

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 			listeners += candidate
 
 			//Let's ensure the listener's name is not matched within another word or command (and viceversa). e.g. "Saul" in "somersault"
-			var/their_first_name = first_name(candidate.real_name)
+			var/their_first_name = first_name(candidate)
 			if(!GLOB.all_voice_of_god_triggers.Find(their_first_name) && findtext(message, regex("(\\L|^)[their_first_name](\\L|$)", "i")))
 				specific_listeners += candidate //focus on those with the specified name
 				to_remove_string += "[to_remove_string ? "|" : null][their_first_name]"

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -52,12 +52,12 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 			listeners += candidate
 
 			//Let's ensure the listener's name is not matched within another word or command (and viceversa). e.g. "Saul" in "somersault"
-			var/their_first_name = first_name(candidate)
+			var/their_first_name = first_name(candidate.name)
 			if(!GLOB.all_voice_of_god_triggers.Find(their_first_name) && findtext(message, regex("(\\L|^)[their_first_name](\\L|$)", "i")))
 				specific_listeners += candidate //focus on those with the specified name
 				to_remove_string += "[to_remove_string ? "|" : null][their_first_name]"
 				continue
-			var/their_last_name = last_name(candidate)
+			var/their_last_name = last_name(candidate.name)
 			if(their_last_name != their_first_name && !GLOB.all_voice_of_god_triggers.Find(their_last_name) && findtext(message, regex("(\\L|^)[their_last_name](\\L|$)", "i")))
 				specific_listeners += candidate // Ditto
 				to_remove_string += "[to_remove_string ? "|" : null][their_last_name]"

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -85,7 +85,7 @@
 /obj/machinery/computer/arcade/orion_trail/proc/newgame()
 	// Set names of settlers in crew
 	var/mob/living/player = usr
-	var/player_crew_name = first_name(player.real_name)
+	var/player_crew_name = first_name(player)
 	settlers = list()
 	for(var/i in 1 to ORION_STARTING_CREW_COUNT - 1) //one reserved to be YOU
 		add_crewmember(update = FALSE)

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -85,7 +85,7 @@
 /obj/machinery/computer/arcade/orion_trail/proc/newgame()
 	// Set names of settlers in crew
 	var/mob/living/player = usr
-	var/player_crew_name = player.first_name()
+	var/player_crew_name = first_name(player.real_name)
 	settlers = list()
 	for(var/i in 1 to ORION_STARTING_CREW_COUNT - 1) //one reserved to be YOU
 		add_crewmember(update = FALSE)

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -85,7 +85,7 @@
 /obj/machinery/computer/arcade/orion_trail/proc/newgame()
 	// Set names of settlers in crew
 	var/mob/living/player = usr
-	var/player_crew_name = first_name(player)
+	var/player_crew_name = first_name(player.name)
 	settlers = list()
 	for(var/i in 1 to ORION_STARTING_CREW_COUNT - 1) //one reserved to be YOU
 		add_crewmember(update = FALSE)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -892,12 +892,12 @@
 			honorific_title = "[trim.honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
 			honorific_title = "[trim.honorific] [last_name(registered_name)]"
-		if(HONORIFIC_POSITION_NONE)
-			honorific_title = null
 		if(HONORIFIC_POSITION_FIRST_FULL)
 			honorific_title = "[trim.honorific] [first_name(registered_name)] [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST_FULL)
 			honorific_title = "[first_name(registered_name)] [last_name(registered_name)][trim.honorific]"
+		if(HONORIFIC_POSITION_NONE)
+			honorific_title = null
 	return honorific_title
 
 /// Returns the trim assignment name.
@@ -932,19 +932,19 @@
 	switch(honorific_position_to_use)
 		if(HONORIFIC_POSITION_FIRST)
 			honorific_position = HONORIFIC_POSITION_FIRST
-			balloon_alert(user, "honorific set: first name")
+			balloon_alert(user, "honorific set: display first name")
 		if(HONORIFIC_POSITION_LAST)
 			honorific_position = HONORIFIC_POSITION_LAST
-			balloon_alert(user, "honorific set: last name")
+			balloon_alert(user, "honorific set: display last name")
+		if(HONORIFIC_POSITION_FIRST_FULL)
+			honorific_position = HONORIFIC_POSITION_FIRST_FULL
+			balloon_alert(user, "honorific set: start of full name")
+		if(HONORIFIC_POSITION_LAST_FULL)
+			honorific_position = HONORIFIC_POSITION_LAST_FULL
+			balloon_alert(user, "honorific set: end of full name")
 		if(HONORIFIC_POSITION_NONE)
 			honorific_position = HONORIFIC_POSITION_NONE
 			balloon_alert(user, "honorific disabled")
-		if(HONORIFIC_POSITION_FIRST_FULL)
-			honorific_position = HONORIFIC_POSITION_FIRST_FULL
-			balloon_alert(user, "honorific set: start of name")
-		if(HONORIFIC_POSITION_LAST_FULL)
-			honorific_position = HONORIFIC_POSITION_LAST_FULL
-			balloon_alert(user, "honorific set: end of name")
 
 	update_label()
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -4,13 +4,6 @@
 /// Max time interval between projecting holopays
 #define HOLOPAY_PROJECTION_INTERVAL (7 SECONDS)
 
-///Honorific will display next to the first name.
-#define HONORIFIC_POSITION_FIRST "first_name"
-///Honorific will display next to the last name.
-#define HONORIFIC_POSITION_LAST "last_name"
-///Honorific will not be displayed
-#define HONORIFIC_POSITION_NONE "none"
-
 /* Cards
  * Contains:
  * DATA CARD
@@ -39,6 +32,8 @@
 
 	/// Cached icon that has been built for this card. Intended to be displayed in chat. Cardboards IDs and actual IDs use it.
 	var/icon/cached_flat_icon
+	///What is our honorific name/title combo to be displayed?
+	var/honorific_title
 
 /obj/item/card/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins to swipe [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -857,13 +852,7 @@
 	var/name_string
 	if(registered_name)
 		if(trim && honorific_position != HONORIFIC_POSITION_NONE)
-			switch(honorific_position)
-				if(HONORIFIC_POSITION_FIRST)
-					name_string = "[trim.honorific] [first_name(registered_name)]'s ID Card"
-				if(HONORIFIC_POSITION_LAST)
-					name_string = "[trim.honorific] [last_name(registered_name)]'s ID Card"
-				else
-					stack_trace("Invalid honorific position given! Uh oh!")
+			name_string = update_honorific()
 		else
 			name_string = "[registered_name]'s ID Card"
 	else
@@ -880,6 +869,17 @@
 		assignment_string = assignment
 
 	name = "[name_string] ([assignment_string])"
+
+/// Re-generates the honorific title. Returns the compiled honorific_title value
+/obj/item/card/id/proc/update_honorific()
+	switch(honorific_position)
+		if(HONORIFIC_POSITION_FIRST)
+			honorific_title = "[trim.honorific] [first_name(registered_name)]'s ID Card"
+		if(HONORIFIC_POSITION_LAST)
+			honorific_title = "[trim.honorific] [last_name(registered_name)]'s ID Card"
+		else
+			honorific_title = null
+	return honorific_title
 
 /// Returns the trim assignment name.
 /obj/item/card/id/proc/get_trim_assignment()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -790,7 +790,7 @@
 	for(var/mob/living/carbon/human/viewing_mob in viewers(user, 2))
 		if(viewing_mob.stat || viewing_mob == user)
 			continue
-		viewing_mob.say("Is something wrong? [first_name(user)]... you're sweating.", forced = "psycho")
+		viewing_mob.say("Is something wrong? [first_name(user.name)]... you're sweating.", forced = "psycho")
 		break
 
 /obj/item/card/id/examine_more(mob/user)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -4,6 +4,11 @@
 /// Max time interval between projecting holopays
 #define HOLOPAY_PROJECTION_INTERVAL (7 SECONDS)
 
+///Honorific will display next to the first name.
+#define HONORIFIC_POSITION_FIRST "first_name"
+///Honorific will display next to the last name.
+#define HONORIFIC_POSITION_LAST "last_name"
+
 /* Cards
  * Contains:
  * DATA CARD
@@ -111,6 +116,10 @@
 	var/big_pointer = FALSE
 	///If set, the arrow will have a different color.
 	var/pointer_color
+	/// What honorific, if any, will we set our wearer's name to when worn?
+	var/honorific
+	/// Will this ID card use the first or last name as the name displayed with the honorific?
+	var/honorific_position = HONORIFIC_POSITION_LAST
 
 /datum/armor/card_id
 	fire = 100
@@ -845,7 +854,18 @@
 
 /// Updates the name based on the card's vars and state.
 /obj/item/card/id/proc/update_label()
-	var/name_string = registered_name ? "[registered_name]'s ID Card" : initial(name)
+	var/name_string
+	if(registered_name)
+		if(honorific)
+			switch(honorific_position)
+				if(HONORIFIC_POSITION_FIRST)
+					name_string = "[registered_name.first_name]'s ID Card"
+				if(HONORIFIC_POSITION_LAST)
+		else
+			name_string = "[registered_name]'s ID Card"
+	else
+		name_string = initial(name)
+
 	var/assignment_string
 
 	if(is_intern)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -160,6 +160,21 @@
 	. = ..()
 	if(slot == ITEM_SLOT_ID)
 		RegisterSignal(user, COMSIG_MOVABLE_POINTED, PROC_REF(on_pointed))
+		RegisterSignal(user, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(return_message_name_part))
+
+/obj/item/card/id/proc/return_message_name_part(mob/living/carbon/human/source, list/stored_name, visible_name)
+	SIGNAL_HANDLER
+	var/voice_name = source.GetVoice()
+	var/end_string = ""
+	var/return_string = ""
+	if(source.name != voice_name)
+		end_string += " (as [registered_name])"
+	if(trim && honorific_position != HONORIFIC_POSITION_NONE)
+		return_string += honorific_title
+	else
+		return_string += voice_name
+	return_string += end_string
+	stored_name[NAME_PART_INDEX] = return_string
 
 /obj/item/card/id/proc/on_pointed(mob/living/user, atom/pointed, obj/effect/temp_visual/point/point)
 	SIGNAL_HANDLER
@@ -176,7 +191,7 @@
 		point.add_overlay(highlight)
 
 /obj/item/card/id/dropped(mob/user)
-	UnregisterSignal(user, COMSIG_MOVABLE_POINTED)
+	UnregisterSignal(user, list(COMSIG_MOVABLE_POINTED, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART))
 	return ..()
 
 /obj/item/card/id/get_id_examine_strings(mob/user)
@@ -852,7 +867,7 @@
 	var/name_string
 	if(registered_name)
 		if(trim && honorific_position != HONORIFIC_POSITION_NONE)
-			name_string = update_honorific()
+			name_string = "[update_honorific()]'s ID Card"
 		else
 			name_string = "[registered_name]'s ID Card"
 	else
@@ -874,9 +889,9 @@
 /obj/item/card/id/proc/update_honorific()
 	switch(honorific_position)
 		if(HONORIFIC_POSITION_FIRST)
-			honorific_title = "[trim.honorific] [first_name(registered_name)]'s ID Card"
+			honorific_title = "[trim.honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
-			honorific_title = "[trim.honorific] [last_name(registered_name)]'s ID Card"
+			honorific_title = "[trim.honorific] [last_name(registered_name)]"
 		else
 			honorific_title = null
 	return honorific_title
@@ -896,11 +911,11 @@
 
 /obj/item/card/id/item_ctrl_click(mob/user)
 	if(!trim)
-		balloon_alert("card has no trim!")
+		balloon_alert(user, "card has no trim!")
 		return
 
 	if(!trim.honorific)
-		balloon_alert("card has no honorific to use!")
+		balloon_alert(user, "card has no honorific to use!")
 		return
 
 	switch(honorific_position)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -169,10 +169,10 @@
 	var/return_string = ""
 	if(carbon_human.name != voice_name)
 		end_string += " (as [registered_name])"
-	if(trim && honorific_position != HONORIFIC_POSITION_NONE)
+	if(trim && honorific_position != HONORIFIC_POSITION_NONE && (carbon_human.name == voice_name)) //The voice and name are the same, so we display the title.
 		return_string += honorific_title
 	else
-		return_string += voice_name
+		return_string += voice_name //Name on the ID ain't the same as the speaker, so we display their real name with no title.
 	return_string += end_string
 	stored_name[NAME_PART_INDEX] = return_string
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -162,12 +162,12 @@
 	if(slot == ITEM_SLOT_ID)
 		RegisterSignal(user, COMSIG_MOVABLE_POINTED, PROC_REF(on_pointed))
 
-/obj/item/card/id/proc/return_message_name_part(mob/living/carbon/human/source, list/stored_name, visible_name)
+/obj/item/card/id/proc/return_message_name_part(datum/source, list/stored_name, visible_name, mob/living/carbon/carbon_human)
 	SIGNAL_HANDLER
-	var/voice_name = source.GetVoice()
+	var/voice_name = carbon_human.GetVoice()
 	var/end_string = ""
 	var/return_string = ""
-	if(source.name != voice_name)
+	if(carbon_human.name != voice_name)
 		end_string += " (as [registered_name])"
 	if(trim && honorific_position != HONORIFIC_POSITION_NONE)
 		return_string += honorific_title

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -146,6 +146,7 @@
 	register_context()
 
 	RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, PROC_REF(update_in_wallet))
+	RegisterSignal(src, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(return_message_name_part))
 	if(prob(1))
 		ADD_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD, ROUNDSTART_TRAIT)
 
@@ -160,7 +161,6 @@
 	. = ..()
 	if(slot == ITEM_SLOT_ID)
 		RegisterSignal(user, COMSIG_MOVABLE_POINTED, PROC_REF(on_pointed))
-		RegisterSignal(user, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(return_message_name_part))
 
 /obj/item/card/id/proc/return_message_name_part(mob/living/carbon/human/source, list/stored_name, visible_name)
 	SIGNAL_HANDLER
@@ -922,9 +922,9 @@
 		balloon_alert(user, "card has no honorific to use!")
 		return
 
-	if(!honorific_positions)
+	if(!trim.honorific_positions)
 		balloon_alert(user, "no honorific positions! Error!")
-		stack_trace("ID card with honorifics found with no potential positions!")
+		stack_trace("ID card with honorifics found with no potential honorific positions!")
 		return
 
 	var/honorific_position_to_use = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", trim.honorific_positions)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -892,8 +892,12 @@
 			honorific_title = "[trim.honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
 			honorific_title = "[trim.honorific] [last_name(registered_name)]"
-		else
+		if(HONORIFIC_POSITION_NONE)
 			honorific_title = null
+		if(HONORIFIC_POSITION_FIRST_FULL)
+			honorific_title = "[trim.honorific] [first_name(registered_name)] [last_name(registered_name)]"
+		if(HONORIFIC_POSITION_LAST_FULL)
+			honorific_title = "[first_name(registered_name)] [last_name(registered_name)][trim.honorific]"
 	return honorific_title
 
 /// Returns the trim assignment name.
@@ -918,16 +922,29 @@
 		balloon_alert(user, "card has no honorific to use!")
 		return
 
-	switch(honorific_position)
+	if(!honorific_positions)
+		balloon_alert(user, "no honorific positions! Error!")
+		stack_trace("ID card with honorifics found with no potential positions!")
+		return
+
+	var/honorific_position_to_use = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", trim.honorific_positions)
+
+	switch(honorific_position_to_use)
 		if(HONORIFIC_POSITION_FIRST)
-			honorific_position = HONORIFIC_POSITION_LAST
-			balloon_alert(user, "honorific set: last name")
-		if(HONORIFIC_POSITION_LAST)
-			honorific_position = HONORIFIC_POSITION_NONE
-			balloon_alert(user, "honorific set: none")
-		if(HONORIFIC_POSITION_NONE)
 			honorific_position = HONORIFIC_POSITION_FIRST
 			balloon_alert(user, "honorific set: first name")
+		if(HONORIFIC_POSITION_LAST)
+			honorific_position = HONORIFIC_POSITION_LAST
+			balloon_alert(user, "honorific set: last name")
+		if(HONORIFIC_POSITION_NONE)
+			honorific_position = HONORIFIC_POSITION_NONE
+			balloon_alert(user, "honorific disabled")
+		if(HONORIFIC_POSITION_FIRST_FULL)
+			honorific_position = HONORIFIC_POSITION_FIRST_FULL
+			balloon_alert(user, "honorific set: start of name")
+		if(HONORIFIC_POSITION_LAST_FULL)
+			honorific_position = HONORIFIC_POSITION_LAST_FULL
+			balloon_alert(user, "honorific set: end of name")
 
 	update_label()
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -146,7 +146,7 @@
 	register_context()
 
 	RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, PROC_REF(update_in_wallet))
-	RegisterSignal(src, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(return_message_name_part))
+	RegisterSignal(src, COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC, PROC_REF(return_message_name_part))
 	if(prob(1))
 		ADD_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD, ROUNDSTART_TRAIT)
 
@@ -162,7 +162,7 @@
 	if(slot == ITEM_SLOT_ID)
 		RegisterSignal(user, COMSIG_MOVABLE_POINTED, PROC_REF(on_pointed))
 
-/obj/item/card/id/proc/return_message_name_part(datum/source, list/stored_name, visible_name, mob/living/carbon/carbon_human)
+/obj/item/card/id/proc/return_message_name_part(datum/source, list/stored_name, mob/living/carbon/carbon_human)
 	SIGNAL_HANDLER
 	var/voice_name = carbon_human.GetVoice()
 	var/end_string = ""
@@ -191,7 +191,7 @@
 		point.add_overlay(highlight)
 
 /obj/item/card/id/dropped(mob/user)
-	UnregisterSignal(user, list(COMSIG_MOVABLE_POINTED, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART))
+	UnregisterSignal(user, list(COMSIG_MOVABLE_POINTED, COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC))
 	return ..()
 
 /obj/item/card/id/get_id_examine_strings(mob/user)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -497,6 +497,8 @@
 		context[SCREENTIP_CONTEXT_ALT_RMB] = "Assign account"
 	else if(registered_account.account_balance > 0)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"
+	if(trim && trim.honorific)
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle honorific"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/proc/try_project_paystand(mob/user, turf/target)
@@ -887,15 +889,22 @@
 
 /// Re-generates the honorific title. Returns the compiled honorific_title value
 /obj/item/card/id/proc/update_honorific()
+	var/is_mononym = FALSE
+	if(is_mononym(registered_name))
+		is_mononym = TRUE
 	switch(honorific_position)
 		if(HONORIFIC_POSITION_FIRST)
 			honorific_title = "[trim.honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
 			honorific_title = "[trim.honorific] [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_FIRST_FULL)
-			honorific_title = "[trim.honorific] [first_name(registered_name)] [last_name(registered_name)]"
+			honorific_title = "[trim.honorific] [first_name(registered_name)]"
+			if(!is_mononym)
+				honorific_title += " [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST_FULL)
-			honorific_title = "[first_name(registered_name)] [last_name(registered_name)][trim.honorific]"
+			if(!is_mononym)
+				honorific_title += "[first_name(registered_name)] "
+			honorific_title += "[last_name(registered_name)][trim.honorific]"
 		if(HONORIFIC_POSITION_NONE)
 			honorific_title = null
 	return honorific_title

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -194,7 +194,7 @@
 		point.add_overlay(highlight)
 
 /obj/item/card/id/dropped(mob/user)
-	UnregisterSignal(user, list(COMSIG_MOVABLE_POINTED))
+	UnregisterSignal(user, COMSIG_MOVABLE_POINTED)
 	return ..()
 
 /obj/item/card/id/get_id_examine_strings(mob/user)
@@ -892,9 +892,7 @@
 
 /// Re-generates the honorific title. Returns the compiled honorific_title value
 /obj/item/card/id/proc/update_honorific()
-	var/is_mononym = FALSE
-	if(is_mononym(registered_name))
-		is_mononym = TRUE
+	var/is_mononym = is_mononym(registered_name)
 	switch(honorific_position)
 		if(HONORIFIC_POSITION_FIRST)
 			honorific_title = "[chosen_honorific] [first_name(registered_name)]"
@@ -952,9 +950,10 @@
 	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
 		balloon_alert(user, "honorific disabled")
 	else
-		chosen_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
-		if(!chosen_honorific || user.incapacitated || !in_contents_of(user))
+		var/new_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
+		if(!new_honorific || user.incapacitated || !in_contents_of(user))
 			return
+		chosen_honorific = new_honorific
 		switch(honorific_position_to_use)
 			if(HONORIFIC_POSITION_FIRST)
 				honorific_position = HONORIFIC_POSITION_FIRST

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -115,6 +115,9 @@
 	var/pointer_color
 	/// Will this ID card use the first or last name as the name displayed with the honorific?
 	var/honorific_position = HONORIFIC_POSITION_NONE
+	/// What is our selected honorific?
+	var/chosen_honorific
+
 
 /datum/armor/card_id
 	fire = 100
@@ -146,7 +149,7 @@
 	register_context()
 
 	RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, PROC_REF(update_in_wallet))
-	RegisterSignal(src, COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC, PROC_REF(return_message_name_part))
+	RegisterSignal(src, COMSIG_ID_GET_HONORIFIC, PROC_REF(return_message_name_part))
 	if(prob(1))
 		ADD_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD, ROUNDSTART_TRAIT)
 
@@ -191,7 +194,7 @@
 		point.add_overlay(highlight)
 
 /obj/item/card/id/dropped(mob/user)
-	UnregisterSignal(user, list(COMSIG_MOVABLE_POINTED, COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC))
+	UnregisterSignal(user, list(COMSIG_MOVABLE_POINTED))
 	return ..()
 
 /obj/item/card/id/get_id_examine_strings(mob/user)
@@ -894,17 +897,17 @@
 		is_mononym = TRUE
 	switch(honorific_position)
 		if(HONORIFIC_POSITION_FIRST)
-			honorific_title = "[trim.chosen_honorific] [first_name(registered_name)]"
+			honorific_title = "[chosen_honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
-			honorific_title = "[trim.chosen_honorific] [last_name(registered_name)]"
+			honorific_title = "[chosen_honorific] [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_FIRST_FULL)
-			honorific_title = "[trim.chosen_honorific] [first_name(registered_name)]"
+			honorific_title = "[chosen_honorific] [first_name(registered_name)]"
 			if(!is_mononym)
 				honorific_title += " [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST_FULL)
 			if(!is_mononym)
 				honorific_title += "[first_name(registered_name)] "
-			honorific_title += "[last_name(registered_name)][trim.chosen_honorific]"
+			honorific_title += "[last_name(registered_name)][chosen_honorific]"
 	return honorific_title
 
 /// Returns the trim assignment name.
@@ -943,8 +946,9 @@
 		honorific_title = null
 		balloon_alert(user, "honorific disabled")
 	else
-		trim.chosen_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
-
+		chosen_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
+		if(!chosen_honorific)
+			return
 		switch(honorific_position_to_use)
 			if(HONORIFIC_POSITION_FIRST)
 				honorific_position = HONORIFIC_POSITION_FIRST

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -868,7 +868,7 @@
 /obj/item/card/id/proc/update_label()
 	var/name_string
 	if(registered_name)
-		if(trim && honorific_position != HONORIFIC_POSITION_NONE)
+		if(trim && (honorific_position & ~HONORIFIC_POSITION_NONE))
 			name_string = "[update_honorific()]'s ID Card"
 		else
 			name_string = "[registered_name]'s ID Card"
@@ -905,8 +905,6 @@
 			if(!is_mononym)
 				honorific_title += "[first_name(registered_name)] "
 			honorific_title += "[last_name(registered_name)][trim.chosen_honorific]"
-		if(HONORIFIC_POSITION_NONE)
-			honorific_title = null
 	return honorific_title
 
 /// Returns the trim assignment name.
@@ -936,13 +934,19 @@
 		stack_trace("ID card with honorifics found with no potential honorific positions!")
 		return
 
-	var/list/readable_names = list()
+	var/list/choices = list()
+	var/list/readable_names = HONORIFIC_POSITION_BITFIELDS()
+	for(var/i in readable_names) //Filter out the options you don't have on your ID.
+		if(trim.honorific_positions & readable_names[i]) //If the positions list has the same bit value as the readable list.
+			choices += i
 
-	var/honorific_position_to_use = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", trim.honorific_positions)
+	var/chosen_position = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", choices)
+	var/honorific_position_to_use = readable_names[chosen_position]
 
 	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
 		honorific_position = initial(honorific_position) //In case you want to force an honorific on an ID, set a default that isn't NONE.
-		balloon_alert(user, "honorific reset")
+		honorific_title = null
+		balloon_alert(user, "honorific disabled")
 	else
 		trim.chosen_honorific = tgui_input_list(user, "what honorific do you want to use?", "Flair!!!", trim.honorifics)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -924,7 +924,7 @@
 	return NONE
 
 /obj/item/card/id/item_ctrl_click(mob/user)
-	if(!in_contents_of(user)) //Check if the ID is in the ID slot, so it can be changed from there too.
+	if(!in_contents_of(user) || user.incapacitated) //Check if the ID is in the ID slot, so it can be changed from there too.
 		return
 
 	if(!trim)
@@ -942,7 +942,7 @@
 			choices += i
 
 	var/chosen_position = tgui_input_list(user, "What position do you want your honorific in?", "Flair!", choices)
-	if(user.stat < CONSCIOUS || !in_contents_of(user))
+	if(user.incapacitated || !in_contents_of(user))
 		return
 	var/honorific_position_to_use = readable_names[chosen_position]
 
@@ -953,7 +953,7 @@
 		balloon_alert(user, "honorific disabled")
 	else
 		chosen_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
-		if(!chosen_honorific || user.stat < CONSCIOUS || !in_contents_of(user))
+		if(!chosen_honorific || user.incapacitated || !in_contents_of(user))
 			return
 		switch(honorific_position_to_use)
 			if(HONORIFIC_POSITION_FIRST)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -924,6 +924,9 @@
 	return NONE
 
 /obj/item/card/id/item_ctrl_click(mob/user)
+	if(!in_contents_of(user)) //Check if the ID is in the ID slot, so it can be changed from there too.
+		return
+
 	if(!trim)
 		balloon_alert(user, "card has no trim!")
 		return
@@ -939,15 +942,18 @@
 			choices += i
 
 	var/chosen_position = tgui_input_list(user, "What position do you want your honorific in?", "Flair!", choices)
+	if(user.stat < CONSCIOUS || !in_contents_of(user))
+		return
 	var/honorific_position_to_use = readable_names[chosen_position]
 
+	honorific_position = initial(honorific_position) //In case you want to force an honorific on an ID, set a default that won't always be NONE.
+	honorific_title = null //We reset this regardless so that we don't stack titles on accident.
+
 	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
-		honorific_position = initial(honorific_position) //In case you want to force an honorific on an ID, set a default that isn't NONE.
-		honorific_title = null
 		balloon_alert(user, "honorific disabled")
 	else
 		chosen_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
-		if(!chosen_honorific)
+		if(!chosen_honorific || user.stat < CONSCIOUS || !in_contents_of(user))
 			return
 		switch(honorific_position_to_use)
 			if(HONORIFIC_POSITION_FIRST)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -929,11 +929,6 @@
 		balloon_alert(user, "card has no honorific to use!")
 		return
 
-	if(trim.honorific_positions == NONE)
-		balloon_alert(user, "no honorific positions! Error!")
-		stack_trace("ID card with honorifics found with no potential honorific positions!")
-		return
-
 	var/list/choices = list()
 	var/list/readable_names = HONORIFIC_POSITION_BITFIELDS()
 	for(var/i in readable_names) //Filter out the options you don't have on your ID.

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -936,11 +936,13 @@
 		stack_trace("ID card with honorifics found with no potential honorific positions!")
 		return
 
+	var/list/readable_names = list()
+
 	var/honorific_position_to_use = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", trim.honorific_positions)
 
 	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
-		honorific_position = HONORIFIC_POSITION_NONE
-		balloon_alert(user, "honorific disabled")
+		honorific_position = initial(honorific_position) //In case you want to force an honorific on an ID, set a default that isn't NONE.
+		balloon_alert(user, "honorific reset")
 	else
 		trim.chosen_honorific = tgui_input_list(user, "what honorific do you want to use?", "Flair!!!", trim.honorifics)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -497,7 +497,7 @@
 		context[SCREENTIP_CONTEXT_ALT_RMB] = "Assign account"
 	else if(registered_account.account_balance > 0)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"
-	if(trim && trim.honorific)
+	if(trim && length(trim.honorifics))
 		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle honorific"
 	return CONTEXTUAL_SCREENTIP_SET
 
@@ -894,17 +894,17 @@
 		is_mononym = TRUE
 	switch(honorific_position)
 		if(HONORIFIC_POSITION_FIRST)
-			honorific_title = "[trim.honorific] [first_name(registered_name)]"
+			honorific_title = "[trim.chosen_honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
-			honorific_title = "[trim.honorific] [last_name(registered_name)]"
+			honorific_title = "[trim.chosen_honorific] [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_FIRST_FULL)
-			honorific_title = "[trim.honorific] [first_name(registered_name)]"
+			honorific_title = "[trim.chosen_honorific] [first_name(registered_name)]"
 			if(!is_mononym)
 				honorific_title += " [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST_FULL)
 			if(!is_mononym)
 				honorific_title += "[first_name(registered_name)] "
-			honorific_title += "[last_name(registered_name)][trim.honorific]"
+			honorific_title += "[last_name(registered_name)][trim.chosen_honorific]"
 		if(HONORIFIC_POSITION_NONE)
 			honorific_title = null
 	return honorific_title
@@ -927,7 +927,7 @@
 		balloon_alert(user, "card has no trim!")
 		return
 
-	if(!trim.honorific)
+	if(!length(trim.honorifics))
 		balloon_alert(user, "card has no honorific to use!")
 		return
 
@@ -938,22 +938,25 @@
 
 	var/honorific_position_to_use = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", trim.honorific_positions)
 
-	switch(honorific_position_to_use)
-		if(HONORIFIC_POSITION_FIRST)
-			honorific_position = HONORIFIC_POSITION_FIRST
-			balloon_alert(user, "honorific set: display first name")
-		if(HONORIFIC_POSITION_LAST)
-			honorific_position = HONORIFIC_POSITION_LAST
-			balloon_alert(user, "honorific set: display last name")
-		if(HONORIFIC_POSITION_FIRST_FULL)
-			honorific_position = HONORIFIC_POSITION_FIRST_FULL
-			balloon_alert(user, "honorific set: start of full name")
-		if(HONORIFIC_POSITION_LAST_FULL)
-			honorific_position = HONORIFIC_POSITION_LAST_FULL
-			balloon_alert(user, "honorific set: end of full name")
-		if(HONORIFIC_POSITION_NONE)
-			honorific_position = HONORIFIC_POSITION_NONE
-			balloon_alert(user, "honorific disabled")
+	if(honorific_position_to_use == HONORIFIC_POSITION_NONE)
+		honorific_position = HONORIFIC_POSITION_NONE
+		balloon_alert(user, "honorific disabled")
+	else
+		trim.chosen_honorific = tgui_input_list(user, "what honorific do you want to use?", "Flair!!!", trim.honorifics)
+
+		switch(honorific_position_to_use)
+			if(HONORIFIC_POSITION_FIRST)
+				honorific_position = HONORIFIC_POSITION_FIRST
+				balloon_alert(user, "honorific set: display first name")
+			if(HONORIFIC_POSITION_LAST)
+				honorific_position = HONORIFIC_POSITION_LAST
+				balloon_alert(user, "honorific set: display last name")
+			if(HONORIFIC_POSITION_FIRST_FULL)
+				honorific_position = HONORIFIC_POSITION_FIRST_FULL
+				balloon_alert(user, "honorific set: start of full name")
+			if(HONORIFIC_POSITION_LAST_FULL)
+				honorific_position = HONORIFIC_POSITION_LAST_FULL
+				balloon_alert(user, "honorific set: end of full name")
 
 	update_label()
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -935,7 +935,7 @@
 		if(trim.honorific_positions & readable_names[i]) //If the positions list has the same bit value as the readable list.
 			choices += i
 
-	var/chosen_position = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", choices)
+	var/chosen_position = tgui_input_list(user, "What position do you want your honorific in?", "Flair!", choices)
 	var/honorific_position_to_use = readable_names[chosen_position]
 
 	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
@@ -943,7 +943,7 @@
 		honorific_title = null
 		balloon_alert(user, "honorific disabled")
 	else
-		trim.chosen_honorific = tgui_input_list(user, "what honorific do you want to use?", "Flair!!!", trim.honorifics)
+		trim.chosen_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
 
 		switch(honorific_position_to_use)
 			if(HONORIFIC_POSITION_FIRST)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -931,14 +931,14 @@
 		balloon_alert(user, "card has no honorific to use!")
 		return
 
-	if(!trim.honorific_positions)
+	if(trim.honorific_positions == NONE)
 		balloon_alert(user, "no honorific positions! Error!")
 		stack_trace("ID card with honorifics found with no potential honorific positions!")
 		return
 
 	var/honorific_position_to_use = tgui_input_list(user, "what position do you want your honorific in?", "Flair!", trim.honorific_positions)
 
-	if(honorific_position_to_use == HONORIFIC_POSITION_NONE)
+	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
 		honorific_position = HONORIFIC_POSITION_NONE
 		balloon_alert(user, "honorific disabled")
 	else

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -147,7 +147,17 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	//Speaker name
 	var/namepart
 	var/list/stored_name = list(null)
-	SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
+
+	if(iscarbon(speaker)) //First, try to pull the modified title from a carbon's ID. This will hopefully override both visual and audible names.
+		var/mob/living/carbon/carbon_human = speaker
+		var/obj/item/id_slot = carbon_human.get_item_by_slot(ITEM_SLOT_ID)
+		if(id_slot)
+			var/obj/item/card/id/id_card = id_slot.GetID()
+			SEND_SIGNAL(id_card, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
+
+	if(!stored_name[NAME_PART_INDEX]) //Otherwise, we just use whatever the name signal gives us.
+		SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
+
 	namepart = stored_name[NAME_PART_INDEX] || "[speaker.GetVoice()]"
 
 	//End name span.

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/namepart
 	var/list/stored_name = list(null)
 
-	if(iscarbon(speaker)) //First, try to pull the modified title from a carbon's ID. This will hopefully override both visual and audible names.
+	if(iscarbon(speaker)) //First, try to pull the modified title from a carbon's ID. This will override both visual and audible names.
 		var/mob/living/carbon/carbon_human = speaker
 		var/obj/item/id_slot = carbon_human.get_item_by_slot(ITEM_SLOT_ID)
 		if(id_slot)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -154,7 +154,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		if(id_slot)
 			var/obj/item/card/id/id_card = id_slot.GetID()
 			if(id_card)
-				SEND_SIGNAL(id_card, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name, carbon_human)
+				SEND_SIGNAL(id_card, COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC, stored_name, carbon_human)
 
 	if(!stored_name[NAME_PART_INDEX]) //Otherwise, we just use whatever the name signal gives us.
 		SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -153,7 +153,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		var/obj/item/id_slot = carbon_human.get_item_by_slot(ITEM_SLOT_ID)
 		if(id_slot)
 			var/obj/item/card/id/id_card = id_slot.GetID()
-			SEND_SIGNAL(id_card, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
+			if(id_card)
+				SEND_SIGNAL(id_card, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name, carbon_human)
 
 	if(!stored_name[NAME_PART_INDEX]) //Otherwise, we just use whatever the name signal gives us.
 		SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -152,9 +152,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		var/mob/living/carbon/carbon_human = speaker
 		var/obj/item/id_slot = carbon_human.get_item_by_slot(ITEM_SLOT_ID)
 		if(id_slot)
-			var/obj/item/card/id/id_card = id_slot.GetID()
+			var/obj/item/card/id/id_card = id_slot?.GetID()
 			if(id_card)
-				SEND_SIGNAL(id_card, COMSIG_MOVABLE_MESSAGE_GET_HONORIFIC, stored_name, carbon_human)
+				SEND_SIGNAL(id_card, COMSIG_ID_GET_HONORIFIC, stored_name, carbon_human)
 
 	if(!stored_name[NAME_PART_INDEX]) //Otherwise, we just use whatever the name signal gives us.
 		SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -50,7 +50,7 @@
 			chosen = pick(list("Help!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "people")] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] in [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]",
-				"[pick("Where's [first_name(hallucinator)]?", "Set [first_name(hallucinator)] to arrest!")]",
+				"[pick("Where's [first_name(hallucinator.name)]?", "Set [first_name(hallucinator.name)] to arrest!")]",
 				"[pick("C","Ai, c","Someone c","Rec")]all the shuttle!",
 				"AI [pick("rogue", "is dead")]!!",
 				"Borgs rogue!",
@@ -58,7 +58,7 @@
 		else
 			chosen = pick(list("[pick_list_replacements(HALLUCINATION_FILE, "suspicion")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "conversation")]",
-				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][first_name(hallucinator)]!",
+				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][first_name(hallucinator.name)]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "getout")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "weird")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "didyouhearthat")]",
@@ -71,7 +71,7 @@
 
 		chosen = capitalize(chosen)
 
-	chosen = replacetext(chosen, "%TARGETNAME%", first_name(hallucinator))
+	chosen = replacetext(chosen, "%TARGETNAME%", first_name(hallucinator.name))
 
 	// Log the message
 	feedback_details += "Type: [is_radio ? "Radio" : "Talk"], Source: [speaker.real_name], Message: [chosen]"

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -50,7 +50,7 @@
 			chosen = pick(list("Help!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "people")] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] in [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]",
-				"[pick("Where's [hallucinator.first_name()]?", "Set [hallucinator.first_name()] to arrest!")]",
+				"[pick("Where's [first_name(hallucinator)]?", "Set [first_name(hallucinator)] to arrest!")]",
 				"[pick("C","Ai, c","Someone c","Rec")]all the shuttle!",
 				"AI [pick("rogue", "is dead")]!!",
 				"Borgs rogue!",
@@ -58,7 +58,7 @@
 		else
 			chosen = pick(list("[pick_list_replacements(HALLUCINATION_FILE, "suspicion")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "conversation")]",
-				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][hallucinator.first_name()]!",
+				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][first_name(hallucinator)]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "getout")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "weird")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "didyouhearthat")]",
@@ -71,7 +71,7 @@
 
 		chosen = capitalize(chosen)
 
-	chosen = replacetext(chosen, "%TARGETNAME%", hallucinator.first_name())
+	chosen = replacetext(chosen, "%TARGETNAME%", first_name(hallucinator))
 
 	// Log the message
 	feedback_details += "Type: [is_radio ? "Radio" : "Talk"], Source: [speaker.real_name], Message: [chosen]"

--- a/code/modules/hallucination/fake_death.dm
+++ b/code/modules/hallucination/fake_death.dm
@@ -59,7 +59,7 @@
 				"FUCK",
 				"git gud",
 				"god damn it",
-				"hey [hallucinator.first_name()]",
+				"hey [first_name(hallucinator)]",
 				"i[prob(50) ? " fucking" : ""] hate [pick(things_to_hate)]",
 				"is the AI rogue?",
 				"rip",

--- a/code/modules/hallucination/fake_death.dm
+++ b/code/modules/hallucination/fake_death.dm
@@ -59,7 +59,7 @@
 				"FUCK",
 				"git gud",
 				"god damn it",
-				"hey [first_name(hallucinator)]",
+				"hey [first_name(hallucinator.name)]",
 				"i[prob(50) ? " fucking" : ""] hate [pick(things_to_hate)]",
 				"is the AI rogue?",
 				"rip",

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -45,7 +45,7 @@
 		return signal_face // no need to null-check, because force_set will always set a signal_face
 	var/face_name = !isnull(signal_face) ? signal_face : get_face_name("")
 	var/id_name = !isnull(signal_id) ? signal_id : get_id_name("")
-	if (force_real_name) //HERE
+	if(force_real_name)
 		var/fake_name
 		if (face_name && face_name != real_name)
 			fake_name = face_name
@@ -89,7 +89,7 @@
 /mob/living/carbon/proc/get_id_name(if_no_id = "Unknown")
 	return
 
-/mob/living/carbon/human/get_id_name(if_no_id = "Unknown") //HERE
+/mob/living/carbon/human/get_id_name(if_no_id = "Unknown")
 	var/obj/item/storage/wallet/wallet = wear_id
 	var/obj/item/modular_computer/pda = wear_id
 	var/obj/item/card/id/id = wear_id

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -45,7 +45,7 @@
 		return signal_face // no need to null-check, because force_set will always set a signal_face
 	var/face_name = !isnull(signal_face) ? signal_face : get_face_name("")
 	var/id_name = !isnull(signal_id) ? signal_id : get_id_name("")
-	if (force_real_name)
+	if (force_real_name) //HERE
 		var/fake_name
 		if (face_name && face_name != real_name)
 			fake_name = face_name
@@ -60,8 +60,11 @@
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN))
 		return "Unknown"
 	if(face_name)
-		if(add_id_name && id_name && (id_name != face_name))
+		if(add_id_name && id_name && (id_name != face_name)) //Make sure honorific position resets when inserted into computers/manhandled.
 			return "[face_name] (as [id_name])"
+		var/obj/item/card/id/worn_id = get_idcard(FALSE) //If the wearer is who they say they are, and have their honorific tag active, we return the modified name instead.
+		if(worn_id && worn_id.honorific_position != HONORIFIC_POSITION_NONE)
+			return worn_id.update_honorific() //We can assume there's a trim since you can't change honorifics without one.
 		return face_name
 	if(id_name)
 		return id_name

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -89,7 +89,7 @@
 /mob/living/carbon/proc/get_id_name(if_no_id = "Unknown")
 	return
 
-/mob/living/carbon/human/get_id_name(if_no_id = "Unknown")
+/mob/living/carbon/human/get_id_name(if_no_id = "Unknown") //HERE
 	var/obj/item/storage/wallet/wallet = wear_id
 	var/obj/item/modular_computer/pda = wear_id
 	var/obj/item/card/id/id = wear_id

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -61,7 +61,8 @@
 		return "Unknown"
 	if(face_name)
 		if(add_id_name && id_name && (id_name != face_name))
-			return face_name
+			return "[face_name] (as [id_name])"
+		return face_name
 	if(id_name)
 		return id_name
 	return "Unknown"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -60,12 +60,8 @@
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN))
 		return "Unknown"
 	if(face_name)
-		if(add_id_name && id_name && (id_name != face_name)) //Make sure honorific position resets when inserted into computers/manhandled.
-			return "[face_name] (as [id_name])"
-		var/obj/item/card/id/worn_id = get_idcard(FALSE) //If the wearer is who they say they are, and have their honorific tag active, we return the modified name instead.
-		if(worn_id && worn_id.honorific_position != HONORIFIC_POSITION_NONE)
-			return worn_id.update_honorific() //We can assume there's a trim since you can't change honorifics without one.
-		return face_name
+		if(add_id_name && id_name && (id_name != face_name))
+			return face_name
 	if(id_name)
 		return id_name
 	return "Unknown"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -216,18 +216,6 @@
 			return M
 	return 0
 
-///Find the first name of a mob from the real name with regex
-/mob/proc/first_name()
-	var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace or "-"
-	firstname.Find(real_name)
-	return firstname.match
-
-/// Find the last name of a mob from the real name with regex
-/mob/proc/last_name()
-	var/static/regex/lasttname = new("\[^\\s-\]+$") //First word before whitespace or "-"
-	lasttname.Find(real_name)
-	return lasttname.match
-
 ///Returns a mob's real name between brackets. Useful when you want to display a mob's name alongside their real name
 /mob/proc/get_realname_string()
 	if(real_name && real_name != name)


### PR DESCRIPTION
## About The Pull Request

This implements a new, minor, but flavorful system to IDs -- Honorifics. Does going by your full name not suit you? Do you demand respect for the position on Space Station 13 that you've earned and want to be addressed by your title? Do you take yourself WAY too seriously? This is for you.

Toggled by ctrl-clicking your ID, honorifics append a title to your name depending on your position. Certain titles (Captain, Officer, Doctor, etc.) will only append to the start (replacing or including the first/last name), while others (PhD., Esq.) can only be appended at the end.

![image](https://github.com/user-attachments/assets/3ae22744-5f6e-4d12-9ea8-ecd60456b5a9)

Each job TRIM has a set honorific and positions it can be assigned to. A doctor can be "Doctor Peterson" or "Doctor Peterson Bungle" or "Doctor Bungle". A Lawyer can only choose to be "Peterson Bungle, Esq.".

This will only occur when the speaker's voice is the same identity as the one written on the ID's registered name. This should not interfere with Unknown voice obfuscation, stolen ID shenanigans, or anything gameplay-oriented. Hopefully.

This feature is also mononym friendly!

![image](https://github.com/user-attachments/assets/21555023-5dd0-49e0-acd5-2dd0a06ae621)

This also makes `first_name()` and `last_name()` global procs, and adds one to check if a passed string has spaces/dashes/whitespace/whatever.

All of this is compatible with ID name changes, but the voice name must align with the card name to display the honorific. If you are "Peter Stinkypants" with your honorific set to display "Doctor Stinkypants", and your ID's registered name is changed to "Peter Stinker", you show up as "Peter Stinkypants (as Peter Stinker)" with no honorific provided. If you become "Peter Stinker" and have a "Peter Stinker" ID, you will show up as "Doctor Stinker" once again.

That all make sense? Great.

I'm posting this as a draft because I want to make this a roundstart preference, but that is probably going to be a lot of work. This entire PR has been way more work than it was ever meant to be. Argh.

<details>
<summary>So about the ID name stuff...</summary>
<br>
So, when you activate an honorific on your ID, it DOES change the actual object's name. Not the registered name, but the ID's name will go from "Peter Dawson's ID card" to "Captain Dawson's ID card" when an honorific is applied. This, as far as I've tested, does not mess with anything important, but I can totally see it doing so in a way that makes ctrl-Fing through logs harder than it needs to be. This could probably be changed without too much effort so if the issue does arise I can fix it. If not I am totally fine with reverting this PR until I can make it work (if I can at all).
<br>


Admittedly this doesn't have much testing with holopads/radios, but I'm confident the message composure is handled well enough to only display the right names under the right circumstances. If this fucks up logging or naming in any way tell me ASAP because I have a sinking feeling it will in a way more catastrophic than I could ever predict. This PR has been tested thoroughly but I have my limits.
</details>


## Why It's Good For The Game

Having silly little titles to go by is a nice bit of flavor that some players/characters can design around.

These are optional of course, but I fondly recall other servers with similar job-based name displays that I found endearing enough to try out here.

I don't foresee this making chat too noisy. Unless some maniac is constantly swapping title positions, I expect players will decide on an honorific position (if any) and use that for ensuing rounds.
## Changelog
:cl: Rhials
add: You can now ctrl-click IDs to set your Honorific, which will change your display name to reflect your TITLE as a WORKING MAN on SPACE STATION 13.
/:cl:
