### PR TITLE
Abductor doohickeys now properly unlock alien tech

### DIFF
--- a/code/modules/research/techweb/nodes/alien_nodes.dm
+++ b/code/modules/research/techweb/nodes/alien_nodes.dm
@@ -1,3 +1,11 @@
+// Simple define to avoid copy-pasting the same code 3 times
+#define ABDUCTOR_SUBTYPE_UNLOCKS(X) \
+	##X/New() { \
+		. = ..(); \
+		required_items_to_unlock += subtypesof(/obj/item/abductor); \
+		required_items_to_unlock += subtypesof(/obj/item/circuitboard/machine/abductor); \
+	}
+
 /datum/techweb_node/alientech //AYYYYYYYYLMAOO tech
 	id = TECHWEB_NODE_ALIENTECH
 	display_name = "Alien Technology"
@@ -5,9 +13,7 @@
 	prereq_ids = list(TECHWEB_NODE_BLUESPACE_TRAVEL)
 	required_items_to_unlock = list(
 		/obj/item/stack/sheet/mineral/abductor,
-		/obj/item/abductor,
 		/obj/item/cautery/alien,
-		/obj/item/circuitboard/machine/abductor,
 		/obj/item/circular_saw/alien,
 		/obj/item/crowbar/abductor,
 		/obj/item/gun/energy/alien,
@@ -29,6 +35,8 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 	hidden = TRUE
 
+ABDUCTOR_SUBTYPE_UNLOCKS(/datum/techweb_node/alientech)
+
 /datum/techweb_node/alientech/on_station_research()
 	. = ..()
 	SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_ALIENTECH] = TRUE
@@ -47,8 +55,6 @@
 		"alien_wrench",
 	)
 	required_items_to_unlock = list(
-		/obj/item/abductor,
-		/obj/item/circuitboard/machine/abductor,
 		/obj/item/crowbar/abductor,
 		/obj/item/gun/energy/shrink_ray,
 		/obj/item/melee/baton/abductor,
@@ -61,6 +67,8 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 	hidden = TRUE
 	announce_channels = list(RADIO_CHANNEL_ENGINEERING)
+
+ABDUCTOR_SUBTYPE_UNLOCKS(/datum/techweb_node/alien_engi)
 
 /datum/techweb_node/alien_surgery
 	id = TECHWEB_NODE_ALIEN_SURGERY
@@ -80,9 +88,7 @@
 		"surgery_zombie",
 	)
 	required_items_to_unlock = list(
-		/obj/item/abductor,
 		/obj/item/cautery/alien,
-		/obj/item/circuitboard/machine/abductor,
 		/obj/item/circular_saw/alien,
 		/obj/item/crowbar/abductor,
 		/obj/item/gun/energy/alien,
@@ -102,3 +108,7 @@
 	discount_experiments = list(/datum/experiment/scanning/points/slime/hard = TECHWEB_TIER_5_POINTS)
 	hidden = TRUE
 	announce_channels = list(RADIO_CHANNEL_MEDICAL)
+
+ABDUCTOR_SUBTYPE_UNLOCKS(/datum/techweb_node/alien_surgery)
+
+#undef ABDUCTOR_SUBTYPE_UNLOCKS


### PR DESCRIPTION

## About The Pull Request

It seems the abductor tech `required_items_to_unlock` assumed that subtypes of the given typepaths were included. This is not the case - as a result, things like the abductor device circuit boards, mental interface device, silencer, science tool, and omnitool would not unlock alien tech in the experimentor..

## Why It's Good For The Game

stuff working as intended is good.

## Changelog
:cl:
fix: Abductor doohickeys (i.e abductor device circuit boards, mental interface device, silencer, science tool, and omnitool) now properly unlock alien tech via the experimentor.
/:cl:
