### PR TITLE
Third Time's the Spessman: Solves jetpack struggles once and for all

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -546,3 +546,8 @@
 
 ///Sent from /obj/item/skillchip/on_remove()
 #define COMSIG_SKILLCHIP_REMOVED "skillchip_removed"
+
+/// Sent from /obj/item/organ/wings/functional/proc/open_wings(): (mob/living/carbon/owner)
+#define COMSIG_WINGS_OPENED "wings_opened"
+/// Sent from /obj/item/organ/wings/functional/proc/close_wings(): (mob/living/carbon/owner)
+#define COMSIG_WINGS_CLOSED "wings_closed"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -208,7 +208,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 	var/atom/target_loc = target?.loc
 
 	var/drifting = FALSE
-	if(GLOB.move_manager.processing_on(user, SSnewtonian_movement))
+	if(!isnull(user.drift_handler))
 		drifting = TRUE
 
 	var/holding = user.get_active_held_item()
@@ -237,7 +237,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 		if(!QDELETED(progbar))
 			progbar.update(world.time - starttime)
 
-		if(drifting && !GLOB.move_manager.processing_on(user, SSnewtonian_movement))
+		if(drifting && isnull(user.drift_handler))
 			drifting = FALSE
 			user_loc = user.loc
 

--- a/code/__HELPERS/movement.dm
+++ b/code/__HELPERS/movement.dm
@@ -1,2 +1,5 @@
 /// Converts w_class into newtons from throwing it, in (0.6 ~ 2.2) range
 #define WEIGHT_TO_NEWTONS(w_class, arguments...) 0.2 NEWTONS + w_class * 0.4 NEWTONS
+
+/// Converts movement delay into drift force required to achieve that speed
+#define MOVE_DELAY_TO_DRIFT(move_delay) ((DEFAULT_INERTIA_SPEED / move_delay - 1) / INERTIA_SPEED_COEF + 1)

--- a/code/controllers/subsystem/movement/newtonian_movement.dm
+++ b/code/controllers/subsystem/movement/newtonian_movement.dm
@@ -13,9 +13,10 @@ MOVEMENT_SUBSYSTEM_DEF(newtonian_movement)
 	return ..()
 
 /datum/controller/subsystem/movement/newtonian_movement/fire(resumed = FALSE)
-	. = ..()
-	if (!resumed)
+	if(!resumed)
+		canonical_time = world.time
 		currentrun = processing.Copy()
+
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = currentrun
 
@@ -29,6 +30,12 @@ MOVEMENT_SUBSYSTEM_DEF(newtonian_movement)
 			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)
 			return
+
+	for(var/list/bucket_info as anything in sorted_buckets)
+		var/time = bucket_info[MOVEMENT_BUCKET_TIME]
+		if(time > canonical_time || MC_TICK_CHECK)
+			return
+		pour_bucket(bucket_info)
 
 /datum/controller/subsystem/movement/newtonian_movement/proc/fire_moveloop(datum/move_loop/loop)
 	// Drop the loop, process it, and if its still valid - queue it again

--- a/code/controllers/subsystem/movement/newtonian_movement.dm
+++ b/code/controllers/subsystem/movement/newtonian_movement.dm
@@ -29,3 +29,12 @@ MOVEMENT_SUBSYSTEM_DEF(newtonian_movement)
 			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)
 			return
+
+/datum/controller/subsystem/movement/newtonian_movement/proc/fire_moveloop(datum/move_loop/loop)
+	// Drop the loop, process it, and if its still valid - queue it again
+	dequeue_loop(loop)
+	loop.process()
+	if(QDELETED(loop))
+		return
+	loop.timer = world.time + loop.delay
+	queue_loop(loop)

--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -107,7 +107,8 @@
 	RegisterSignal(user, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE, PROC_REF(on_pushoff))
 	last_stabilization_tick = world.time
 	START_PROCESSING(SSnewtonian_movement, src)
-	setup_trail(user)
+	if (effect_type)
+		setup_trail(user)
 
 /datum/component/jetpack/proc/deactivate(datum/source, mob/old_user)
 	SIGNAL_HANDLER
@@ -124,7 +125,7 @@
 	if (!should_trigger(source))
 		return
 
-	if(source.client.intended_direction && check_on_move.Invoke(FALSE))//You use jet when press keys. yes.
+	if(source.client.intended_direction && check_on_move.Invoke(FALSE) && trail) //You use jet when press keys. yes.
 		trail.generate_effect()
 
 /datum/component/jetpack/proc/should_trigger(mob/source)

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -49,6 +49,9 @@
 		visual_delay = start_delay
 
 	apply_initial_visuals(visual_delay)
+	// Fire the engines!
+	if (drifting_loop.timer <= world.time)
+		SSnewtonian_movement.fire_moveloop(drifting_loop)
 
 /datum/drift_handler/Destroy()
 	inertia_last_loc = null

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -79,7 +79,7 @@
 	//It's ok if it's not, it's just important if it is.
 	mob_parent.client?.visual_delay = MOVEMENT_ADJUSTED_GLIDE_SIZE(visual_delay, SSnewtonian_movement.visual_delay)
 
-/datum/drift_handler/proc/newtonian_impulse(inertia_angle, start_delay, additional_force, controlled_cap)
+/datum/drift_handler/proc/newtonian_impulse(inertia_angle, start_delay, additional_force, controlled_cap, force_loop = TRUE)
 	SIGNAL_HANDLER
 	inertia_last_loc = parent.loc
 	// We've been told to move in the middle of deletion process, tell parent to create a new handler instead
@@ -100,7 +100,7 @@
 	drifting_loop.set_angle(delta_to_angle(force_x, force_y))
 	drifting_loop.set_delay(get_loop_delay(parent))
 	// We have to forcefully fire it here to avoid stuttering in case of server lag
-	if (drifting_loop.timer <= world.time)
+	if (drifting_loop.timer <= world.time && force_loop)
 		SSnewtonian_movement.fire_moveloop(drifting_loop)
 	return TRUE
 

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -96,6 +96,9 @@
 
 	drifting_loop.set_angle(delta_to_angle(force_x, force_y))
 	drifting_loop.set_delay(get_loop_delay(parent))
+	// We have to forcefully fire it here to avoid stuttering in case of server lag
+	if (drifting_loop.timer <= world.time)
+		SSnewtonian_movement.fire_moveloop(drifting_loop)
 	return TRUE
 
 /datum/drift_handler/proc/drifting_start()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1272,12 +1272,12 @@
 /// Only moves the object if it's under no gravity
 /// Accepts the direction to move, if the push should be instant, and an optional parameter to fine tune the start delay
 /// Drift force determines how much acceleration should be applied. Controlled cap, if set, will ensure that if the object was moving slower than the cap before, it cannot accelerate past the cap from this move.
-/atom/movable/proc/newtonian_move(inertia_angle, instant = FALSE, start_delay = 0, drift_force = 1 NEWTONS, controlled_cap = null)
+/atom/movable/proc/newtonian_move(inertia_angle, instant = FALSE, start_delay = 0, drift_force = 1 NEWTONS, controlled_cap = null, force_loop = TRUE)
 	if(!isturf(loc) || Process_Spacemove(angle2dir(inertia_angle), continuous_move = TRUE))
 		return FALSE
 
 	if (!isnull(drift_handler))
-		if (drift_handler.newtonian_impulse(inertia_angle, start_delay, drift_force, controlled_cap))
+		if (drift_handler.newtonian_impulse(inertia_angle, start_delay, drift_force, controlled_cap, force_loop))
 			return TRUE
 
 	new /datum/drift_handler(src, inertia_angle, instant, start_delay, drift_force)

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -11,7 +11,7 @@
 /datum/action/innate/flight/Activate()
 	var/mob/living/carbon/human/human = owner
 	var/obj/item/organ/wings/functional/wings = human.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
-	if(wings?.can_fly(human))
+	if(wings?.can_fly())
 		wings.toggle_flight(human)
 
 ///The true wings that you can use to fly and shit (you cant actually shit with them)
@@ -28,6 +28,22 @@
 
 	// grind_results = list(/datum/reagent/flightpotion = 5)
 	food_reagents = list(/datum/reagent/flightpotion = 5)
+
+	var/drift_force = FUNCTIONAL_WING_FORCE
+	var/stabilizer_force = FUNCTIONAL_WING_STABILIZATION
+
+/obj/item/organ/wings/functional/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/jetpack, \
+		TRUE, \
+		drift_force, \
+		stabilizer_force, \
+		COMSIG_WINGS_OPENED, \
+		COMSIG_WINGS_CLOSED, \
+		null, \
+		CALLBACK(src, PROC_REF(can_fly)), \
+	)
 
 /obj/item/organ/wings/functional/Destroy()
 	QDEL_NULL(fly)
@@ -54,14 +70,14 @@
 /obj/item/organ/wings/functional/proc/handle_flight(mob/living/carbon/human/human)
 	if(!HAS_TRAIT_FROM(human, TRAIT_MOVE_FLOATING, SPECIES_FLIGHT_TRAIT))
 		return FALSE
-	if(!can_fly(human))
+	if(!can_fly())
 		toggle_flight(human)
 		return FALSE
 	return TRUE
 
-
 ///Check if we're still eligible for flight (wings covered, atmosphere too thin, etc)
-/obj/item/organ/wings/functional/proc/can_fly(mob/living/carbon/human/human)
+/obj/item/organ/wings/functional/proc/can_fly()
+	var/mob/living/carbon/human/human = owner
 	if(human.stat || human.body_position == LYING_DOWN || isnull(human.client))
 		return FALSE
 	//Jumpsuits have tail holes, so it makes sense they have wing holes too
@@ -105,13 +121,10 @@
 /obj/item/organ/wings/functional/proc/toggle_flight(mob/living/carbon/human/human)
 	if(!HAS_TRAIT_FROM(human, TRAIT_MOVE_FLOATING, SPECIES_FLIGHT_TRAIT))
 		human.physiology.stun_mod *= 2
-		human.add_traits(list(TRAIT_NO_FLOATING_ANIM, TRAIT_MOVE_FLOATING, TRAIT_IGNORING_GRAVITY, TRAIT_NOGRAV_ALWAYS_DRIFT), SPECIES_FLIGHT_TRAIT)
+		human.add_traits(list(TRAIT_MOVE_FLOATING, TRAIT_IGNORING_GRAVITY, TRAIT_NOGRAV_ALWAYS_DRIFT), SPECIES_FLIGHT_TRAIT)
 		human.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/wings)
 		human.AddElement(/datum/element/forced_gravity, 0)
 		passtable_on(human, SPECIES_FLIGHT_TRAIT)
-		RegisterSignal(human, COMSIG_MOB_CLIENT_MOVE_NOGRAV, PROC_REF(on_client_move))
-		RegisterSignal(human, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE, PROC_REF(on_pushoff))
-		START_PROCESSING(SSnewtonian_movement, src)
 		open_wings()
 		to_chat(human, span_notice("You beat your wings and begin to hover gently above the ground..."))
 		human.set_resting(FALSE, TRUE)
@@ -119,50 +132,13 @@
 		return
 
 	human.physiology.stun_mod *= 0.5
-	human.remove_traits(list(TRAIT_NO_FLOATING_ANIM, TRAIT_MOVE_FLOATING, TRAIT_IGNORING_GRAVITY, TRAIT_NOGRAV_ALWAYS_DRIFT), SPECIES_FLIGHT_TRAIT)
+	human.remove_traits(list(TRAIT_MOVE_FLOATING, TRAIT_IGNORING_GRAVITY, TRAIT_NOGRAV_ALWAYS_DRIFT), SPECIES_FLIGHT_TRAIT)
 	human.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/wings)
 	human.RemoveElement(/datum/element/forced_gravity, 0)
 	passtable_off(human, SPECIES_FLIGHT_TRAIT)
-	UnregisterSignal(human, list(COMSIG_MOB_CLIENT_MOVE_NOGRAV, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE))
-	STOP_PROCESSING(SSnewtonian_movement, src)
 	to_chat(human, span_notice("You settle gently back onto the ground..."))
 	close_wings()
 	human.refresh_gravity()
-
-/obj/item/organ/wings/functional/proc/on_client_move(mob/source, list/move_args)
-	SIGNAL_HANDLER
-
-	if (!can_fly(source))
-		return
-
-	var/max_drift_force = MOVE_DELAY_TO_DRIFT(source.cached_multiplicative_slowdown)
-	var/applied_force = FUNCTIONAL_WING_FORCE
-	var/move_dir = source.client.intended_direction
-	// We're not moving anywhere, try to see if we can simulate pushing off a wall
-	if (isnull(source.drift_handler))
-		var/atom/movable/backup = source.get_spacemove_backup(move_dir, FALSE)
-		if (backup && !(backup.dir & move_dir))
-			applied_force = max_drift_force
-	source.newtonian_move(dir2angle(move_dir), instant = TRUE, drift_force = applied_force, controlled_cap = max_drift_force)
-	source.setDir(move_dir)
-
-/obj/item/organ/wings/functional/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
-	SIGNAL_HANDLER
-
-	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
-		return
-
-	if (!can_fly(source) || !source.client.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
-		return
-
-	return COMPONENT_PREVENT_SPACEMOVE_HALT
-
-/obj/item/organ/wings/functional/process(seconds_per_tick)
-	if (!owner || !can_fly(owner) || isnull(owner.drift_handler))
-		return
-
-	var/max_drift_force = MOVE_DELAY_TO_DRIFT(owner.cached_multiplicative_slowdown)
-	owner.drift_handler.stabilize_drift(owner.client.intended_direction ? dir2angle(owner.client.intended_direction) : null, owner.client.intended_direction ? max_drift_force : 0, FUNCTIONAL_WING_STABILIZATION * (seconds_per_tick * 1 SECONDS))
 
 ///SPREAD OUR WINGS AND FLLLLLYYYYYY
 /obj/item/organ/wings/functional/proc/open_wings()
@@ -170,6 +146,7 @@
 	overlay.open_wings()
 	wings_open = TRUE
 	owner.update_body_parts()
+	SEND_SIGNAL(src, COMSIG_WINGS_OPENED, owner)
 
 ///close our wings
 /obj/item/organ/wings/functional/proc/close_wings()
@@ -181,6 +158,8 @@
 	if(isturf(owner?.loc))
 		var/turf/location = loc
 		location.Entered(src, NONE)
+
+	SEND_SIGNAL(src, COMSIG_WINGS_CLOSED, owner)
 
 ///Bodypart overlay of function wings, including open and close functionality!
 /datum/bodypart_overlay/mutant/wings/functional

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -135,9 +135,16 @@
 	if (!can_fly(source))
 		return
 
-	var/max_drift_force = (DEFAULT_INERTIA_SPEED / source.cached_multiplicative_slowdown - 1) / INERTIA_SPEED_COEF + 1
-	source.newtonian_move(dir2angle(source.client.intended_direction), instant = TRUE, drift_force = FUNCTIONAL_WING_FORCE, controlled_cap = max_drift_force)
-	source.setDir(source.client.intended_direction)
+	var/max_drift_force = MOVE_DELAY_TO_DRIFT(source.cached_multiplicative_slowdown)
+	var/applied_force = FUNCTIONAL_WING_FORCE
+	var/move_dir = source.client.intended_direction
+	// We're not moving anywhere, try to see if we can simulate pushing off a wall
+	if (isnull(source.drift_handler))
+		var/atom/movable/backup = source.get_spacemove_backup(move_dir, FALSE)
+		if (backup && !(backup.dir & move_dir))
+			applied_force = max_drift_force
+	source.newtonian_move(dir2angle(move_dir), instant = TRUE, drift_force = applied_force, controlled_cap = max_drift_force)
+	source.setDir(move_dir)
 
 /obj/item/organ/wings/functional/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
 	SIGNAL_HANDLER
@@ -154,7 +161,7 @@
 	if (!owner || !can_fly(owner) || isnull(owner.drift_handler))
 		return
 
-	var/max_drift_force = (DEFAULT_INERTIA_SPEED / owner.cached_multiplicative_slowdown - 1) / INERTIA_SPEED_COEF + 1
+	var/max_drift_force = MOVE_DELAY_TO_DRIFT(owner.cached_multiplicative_slowdown)
 	owner.drift_handler.stabilize_drift(owner.client.intended_direction ? dir2angle(owner.client.intended_direction) : null, owner.client.intended_direction ? max_drift_force : 0, FUNCTIONAL_WING_STABILIZATION * (seconds_per_tick * 1 SECONDS))
 
 ///SPREAD OUR WINGS AND FLLLLLYYYYYY

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -16,18 +16,30 @@
 	///Store our old datum here for if our burned wings are healed
 	var/original_sprite_datum
 
+	var/drift_force = MOTH_WING_FORCE
+	var/stabilizer_force = MOTH_WING_FORCE
+
+/obj/item/organ/wings/moth/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/jetpack, \
+		TRUE, \
+		drift_force, \
+		stabilizer_force, \
+		COMSIG_ORGAN_IMPLANTED, \
+		COMSIG_ORGAN_REMOVED, \
+		null, \
+		CALLBACK(src, PROC_REF(allow_flight)), \
+	)
+
 /obj/item/organ/wings/moth/on_mob_insert(mob/living/carbon/receiver)
 	. = ..()
 	RegisterSignal(receiver, COMSIG_HUMAN_BURNING, PROC_REF(try_burn_wings))
 	RegisterSignal(receiver, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(heal_wings))
-	RegisterSignal(receiver, COMSIG_MOB_CLIENT_MOVE_NOGRAV, PROC_REF(on_client_move))
-	RegisterSignal(receiver, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE, PROC_REF(on_pushoff))
-	START_PROCESSING(SSnewtonian_movement, src)
 
 /obj/item/organ/wings/moth/on_mob_remove(mob/living/carbon/organ_owner)
 	. = ..()
-	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOB_CLIENT_MOVE_NOGRAV, COMSIG_MOB_ATTEMPT_HALT_SPACEMOVE))
-	STOP_PROCESSING(SSnewtonian_movement, src)
+	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL))
 
 /obj/item/organ/wings/moth/make_flap_sound(mob/living/carbon/wing_owner)
 	playsound(wing_owner, 'sound/mobs/humanoids/moth/moth_flutter.ogg', 50, TRUE)
@@ -37,14 +49,6 @@
 
 /obj/item/organ/wings/moth/proc/allow_flight()
 	if(!owner || !owner.client)
-		return FALSE
-	if(!isturf(owner.loc))
-		return FALSE
-	if(!(owner.movement_type & FLOATING) || owner.buckled)
-		return FALSE
-	if(owner.pulledby)
-		return FALSE
-	if(owner.throwing)
 		return FALSE
 	if(owner.has_gravity())
 		return FALSE
@@ -58,41 +62,6 @@
 	if(current && (current.return_pressure() >= ONE_ATMOSPHERE*0.85))
 		return TRUE
 	return FALSE
-
-/obj/item/organ/wings/moth/process(seconds_per_tick)
-	if (!owner || !allow_flight() || isnull(owner.drift_handler))
-		return
-
-	var/max_drift_force = MOVE_DELAY_TO_DRIFT(owner.cached_multiplicative_slowdown)
-	owner.drift_handler.stabilize_drift(owner.client.intended_direction ? dir2angle(owner.client.intended_direction) : null, owner.client.intended_direction ? max_drift_force : 0, MOTH_WING_FORCE * (seconds_per_tick * 1 SECONDS))
-
-/obj/item/organ/wings/moth/proc/on_client_move(mob/source, list/move_args)
-	SIGNAL_HANDLER
-
-	if (!allow_flight())
-		return
-
-	var/max_drift_force = MOVE_DELAY_TO_DRIFT(source.cached_multiplicative_slowdown)
-	var/applied_force = MOTH_WING_FORCE
-	var/move_dir = source.client.intended_direction
-	// We're not moving anywhere, try to see if we can simulate pushing off a wall
-	if (isnull(source.drift_handler))
-		var/atom/movable/backup = source.get_spacemove_backup(move_dir, FALSE)
-		if (backup && !(backup.dir & move_dir))
-			applied_force = max_drift_force
-	source.newtonian_move(dir2angle(move_dir), instant = TRUE, drift_force = applied_force, controlled_cap = max_drift_force)
-	source.setDir(move_dir)
-
-/obj/item/organ/wings/moth/proc/on_pushoff(mob/source, movement_dir, continuous_move, atom/backup)
-	SIGNAL_HANDLER
-
-	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
-		return
-
-	if (!allow_flight() || !source.client.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
-		return
-
-	return COMPONENT_PREVENT_SPACEMOVE_HALT
 
 ///check if our wings can burn off ;_;
 /obj/item/organ/wings/moth/proc/try_burn_wings(mob/living/carbon/human/human)


### PR DESCRIPTION
## About The Pull Request

This PR improves our jetpacks in 2 major ways: partially decoupling them and intentional space movement from SSnewphys, and implementing consistent pushoff speeds.

Currently jetpacks work by applying constant newtonian force whenever an input key is held down by a client and stabilizing the movement every time they get processed by SSnewphys which is an SS_TICKER subsystem, which means that it attempts to fire prior to everything else and has a wait of a single tick. This would be fine if we could guarantee that there isn't another SS_TICKER subsystem with a higher priority that constantly overtimes... oh right, that'd be the most important subsystem of SSinput. 

Newtonian impulses, both when starting a drift and when applying continious force rely on SSnewphys to fire the loop, which can end up not happening due to overtime in input (and is a frequent issue on highpop). To circumvent this, newtonian impulses now forcefully fire their drift loop regardless of SSnewphys, thus ensuring that the movement always happens in the tick it was called (If you ask something to move with an ``instant`` flag you'd expect it to move the same tick).

Second issue stems from the fact that jetpacks try to move you at your movement speed, except when pushing you off objects they hijack normal movement code that would've ran, resulting in a single tile of slow, janky movement (Or, when moving along walls, making the controls feel "sticky" and worse than what you'd have without a jetpack in the first place). By forcefully applying enough force to make players move at expected speeds, we can solve that issue.

Third issue stems from a minor mistake in SSnewphys processing order - process() on jetpacks ran **after** moveloops have fired, so all stabilization only applied next tick. I swapped fire orders around which solves this problem too, although it won't be triggering much as stabilization would now forcefully fire the related loop by itself.

https://github.com/user-attachments/assets/1068f68b-2cd1-49b0-bff0-1f79ed0aed5a

Also I've refactored wings to be jetpacks since they behave exactly the same, which is a bit cursed if you think about it.

## Why It's Good For The Game

Jetpack movement is highly inconsistent in speed/smoothness, janky and gets ruined by even a slightest amount of overtime in subsystems above it - this should solve all of those issues.

## Changelog
:cl:
qol: Jetpacks are significantly smoother and nicer to use now - and not affected by lag anymore!
code: Cleaned up spacemove/jetpack code a bit and moved some common code to helpers.
refactor: Wings are now... jetpacks. They behave exactly the same and this should reduce the amount of copypaste code in spacemove significantly.
/:cl:
