### PR TITLE
Shifts the escape menu stat panel down a bit

### DIFF
--- a/code/modules/escape_menu/details.dm
+++ b/code/modules/escape_menu/details.dm
@@ -9,7 +9,7 @@ GLOBAL_DATUM(escape_menu_details, /atom/movable/screen/escape_menu/details)
 	return GLOB.escape_menu_details
 
 /atom/movable/screen/escape_menu/details
-	screen_loc = "EAST:-180,NORTH:-25"
+	screen_loc = "EAST:-180,NORTH:-34"
 	maptext_height = 100
 	maptext_width = 200
 


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/e90e5fda-5305-430b-89a8-d92e3b82b599)

Escape menu details no longer hug the top border of the screen.

## Why It's Good For The Game

This has been triggering my OCD for months.

## Changelog
:cl:
qol: Shifted the escape menu stat panel down a bit
/:cl:
