### PR TITLE
removes time dilation from hub text

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -422,8 +422,6 @@ GLOBAL_PROTECT(tracy_init_reason)
 			new_status += "<br>Time: <b>[time2text(STATION_TIME_PASSED(), "hh:mm", 0)]</b>"
 			if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
 				new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
-			if(SStime_track?.time_dilation_avg > 0)
-				new_status += " | Time Dilation: <b>[round(SStime_track?.time_dilation_avg)]%</b>"
 		else if(SSticker.current_state == GAME_STATE_FINISHED)
 			new_status += "<br><b>RESTARTING</b>"
 	if(SSmapping.current_map)


### PR DESCRIPTION


## Why It's Good For The Game
The hub text has a limited (255) amount of characters. Time Dilation being in there makes it so that the "Next Map" is cut off and doesn't show.

I get that Time Dilation was added to show off the new TG server. But it's not necessary now and as a player looking at the hub I care way more about the next map than "time dilation" especially when no other server displays their lag rate in the hub so we have nothing to compare it to
## Changelog
:cl:
del: Time Dilation no longer shows in the hub text
/:cl:
