### PR TITLE
last resort works as monkey or animal

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -10,7 +10,9 @@
 	disabled_by_fire = FALSE
 
 /datum/action/changeling/headcrab/can_be_used_by(mob/living/user)
-	if(!istype(user, /mob/living/basic/headslug) && isanimal_or_basicmob(user))
+	if(HAS_TRAIT(user, TRAIT_TEMPORARY_BODY))
+		return FALSE
+	if(isanimal_or_basicmob(user) && !istype(user, /mob/living/basic/headslug) && !isconstruct(user) && !(user.mob_biotypes & MOB_SPIRIT))
 		return TRUE
 	return ..()
 

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -5,10 +5,14 @@
 	button_icon_state = "last_resort"
 	chemical_cost = 20
 	dna_cost = CHANGELING_POWER_INNATE
-	req_human = TRUE
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
 	disabled_by_fire = FALSE
+
+/datum/action/changeling/headcrab/can_be_used_by(mob/living/user)
+	if(!istype(user, /mob/living/basic/headslug) && isanimal_or_basicmob(user))
+		return TRUE
+	return ..()
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE


### PR DESCRIPTION
## About The Pull Request
changeling last resort works if youre a monkey or animal
any reasonably organic animal that is (golems included) so no constructs, no spirits (shades, etc), no deathmatch/bitrunning body and also not a headslug

## Why It's Good For The Game

for a "last resort" ability you cant use it if you got monkified which is something that can happen fucking you over which is not great
or perhaps due to some foul magicks you became a rat or whatever youre basically fucked because you cant do anything and all you can do is bumrush people

this fixes both

## Changelog
:cl:
balance: changeling last resort works as a monkey or animal
/:cl:
