### PR TITLE
Removes organ "refreshing" from multiple heal sources

### DIFF
--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -31,7 +31,7 @@
 		trigger_organ_action(TRIGGER_FORCE_AVAILABLE)
 
 /obj/item/organ/monster_core/regenerative_core/on_triggered_internal()
-	owner.revive(HEAL_ALL)
+	owner.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	qdel(src)
 
 /// Log applications and apply moodlet.

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -37,7 +37,7 @@
 	if(isliving(target))
 		var/mob/living/victim = target
 		if(victim.mob_biotypes & MOB_UNDEAD) //negative energy heals the undead
-			if(victim.revive(ADMIN_HEAL_ALL, force_grab_ghost = TRUE)) // This heals suicides
+			if(victim.revive(ADMIN_HEAL_ALL & ~HEAL_REFRESH_ORGANS , force_grab_ghost = TRUE)) // This heals suicides
 				victim.grab_ghost(force = TRUE)
 				to_chat(victim, span_notice("You rise with a start, you're undead!!!"))
 			else if(victim.stat != DEAD)
@@ -68,7 +68,7 @@
 			victim.death()
 			return
 
-		if(victim.revive(ADMIN_HEAL_ALL, force_grab_ghost = TRUE)) // This heals suicides
+		if(victim.revive(ADMIN_HEAL_ALL & ~HEAL_REFRESH_ORGANS , force_grab_ghost = TRUE)) // This heals suicides
 			to_chat(victim, span_notice("You rise with a start, you're alive!!!"))
 		else if(victim.stat != DEAD)
 			to_chat(victim, span_notice("You feel great!"))

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -77,7 +77,7 @@
 			if(3) //VICTORY ROYALE
 				to_chat(affected_mob, span_hierophant("You win, and the malevolent spirits fade away as well as your wounds."))
 				affected_mob.client.give_award(/datum/award/achievement/jobs/helbitaljanken, affected_mob)
-				affected_mob.revive(HEAL_ALL)
+				affected_mob.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 				holder.del_reagent(type)
 				return
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -43,7 +43,7 @@
 	chemical_flags = REAGENT_DEAD_PROCESS
 	metabolized_traits = list(TRAIT_ANALGESIA)
 	/// Flags to fullheal every metabolism tick
-	var/full_heal_flags = ~(HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_REFRESH_ORGANS)
+	var/full_heal_flags = ~(HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_ORGANS)
 
 // The best stuff there is. For testing/debugging.
 /datum/reagent/medicine/adminordrazine/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
@@ -76,7 +76,7 @@
 	name = "Quantum Medicine"
 	description = "Rare and experimental particles, that apparently swap the user's body with one from an alternate dimension where it's completely healthy."
 	taste_description = "science"
-	full_heal_flags = ~(HEAL_ADMIN|HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_ALL_REAGENTS|HEAL_REFRESH_ORGANS)
+	full_heal_flags = ~(HEAL_ADMIN|HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_RESTRAINTS|HEAL_ALL_REAGENTS|HEAL_ORGANS)
 
 /datum/reagent/medicine/synaptizine
 	name = "Synaptizine"

--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -198,7 +198,7 @@ Slimecrossing Potions
 		to_chat(user, span_warning("The slime is too unstable to return!"))
 		return ITEM_INTERACT_BLOCKING
 	user.do_attack_animation(interacting_with)
-	revive_target.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
+	revive_target.revive(HEAL_ALL)
 	revive_target.set_stat(CONSCIOUS)
 	revive_target.visible_message(span_notice("[revive_target] is filled with renewed vigor and blinks awake!"))
 	revive_target.maxHealth -= 10 //Revival isn't healthy.

--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -198,7 +198,7 @@ Slimecrossing Potions
 		to_chat(user, span_warning("The slime is too unstable to return!"))
 		return ITEM_INTERACT_BLOCKING
 	user.do_attack_animation(interacting_with)
-	revive_target.revive(HEAL_ALL)
+	revive_target.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	revive_target.set_stat(CONSCIOUS)
 	revive_target.visible_message(span_notice("[revive_target] is filled with renewed vigor and blinks awake!"))
 	revive_target.maxHealth -= 10 //Revival isn't healthy.

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -30,7 +30,7 @@ Regenerative extracts:
 			span_notice("You squeeze [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!"))
 	core_effect_before(H, user)
 	user.do_attack_animation(interacting_with)
-	H.revive(HEAL_ALL)
+	H.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	core_effect(H, user)
 	playsound(H, 'sound/effects/splat.ogg', 40, TRUE)
 	qdel(src)
@@ -270,7 +270,7 @@ Regenerative extracts:
 	if(target == user)
 		return
 	var/mob/living/U = user
-	U.revive(HEAL_ALL)
+	U.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	to_chat(U, span_notice("Some of the milky goo sprays onto you, as well!"))
 
 /obj/item/slimecross/regenerative/adamantine


### PR DESCRIPTION
## About The Pull Request

Removed HEAL_REFRESH_ORGANS flag from:
 * Legion cores
 * Helbital janken achievement
 * Adminodrazine (just annoying to deal with in practice)
 * Regenerative slime extracts
 * Wands of healing/death (for undead)

Closes #87520
Closes #87007

## Why It's Good For The Game

HEAL_REFRESH_ORGANS forces the species datum to delete and re-create all of mob's organs, deleting all non-natural organs. This leads to loss of augmentations or non-standard organs, and is usually excluded from most revives (but was intentionally, or unintentionally, missing from these). This should stop miners and scientists from losing their implants/infusions/augmentations, and make it easier for testers to heal themselves without losing organs (since this allows you to heal self by spawning adminodrazine, as normal aheal still refreshes your organs)

## Changelog
:cl:
balance: Removed organ "refreshing" from legion cores, magic wands and regenerative crossbreeds so they no longer get rid of your implants
/:cl:
