### PR TITLE
pointing DLC, neurodivergency edition

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -303,14 +303,14 @@
 	key_third_person = "points"
 	message = "points."
 	message_param = "points at %t."
-	cooldown = 3 SECONDS
+	cooldown = 1 SECONDS
 	// don't put hands use check here, everything is handled in run_emote
 
 /datum/emote/living/point/run_emote(mob/user, params, type_override, intentional)
 	message_param = initial(message_param) // reset
 	if(iscarbon(user))
 		var/mob/living/carbon/our_carbon = user
-		if(our_carbon.usable_hands <= 0)
+		if(our_carbon.usable_hands <= 0 || user.incapacitated & INCAPABLE_RESTRAINTS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 			if(our_carbon.usable_legs > 0)
 				var/one_leg = FALSE
 				var/has_shoes = our_carbon.get_item_by_slot(ITEM_SLOT_FEET)
@@ -326,16 +326,20 @@
 				else
 					message_param = "[one_leg ? "jumps into the air and " : ""]tries to point at %t with their [has_shoes ? "leg" : "toes"], [span_userdanger("falling down")] in the process!"
 					our_carbon.Paralyze(2 SECONDS)
+				TIMER_COOLDOWN_START(user, "point_verb_emote_cooldown", 1 SECONDS)
 			else
 				if(our_carbon.get_organ_slot(ORGAN_SLOT_EYES))
 					message_param = "gives a meaningful glance at %t!"
+					TIMER_COOLDOWN_START(src, "point_verb_emote_cooldown", 1.5 SECONDS)
 				else
 					if(our_carbon.get_organ_slot(ORGAN_SLOT_TONGUE))
 						message_param = "motions their tongue towards %t!"
+						TIMER_COOLDOWN_START(src, "point_verb_emote_cooldown", 2 SECONDS)
 					else
 						message_param = "[span_userdanger("bumps [user.p_their()] head on the ground")] trying to motion towards %t."
 						our_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 						playsound(user, 'sound/effects/glass/glassbash.ogg', 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+						TIMER_COOLDOWN_START(src, "point_verb_emote_cooldown", 2.5 SECONDS)
 	return ..()
 
 /datum/emote/living/sneeze

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -324,7 +324,7 @@
 				if(prob(success_prob))
 					message_param = "[one_leg ? "jumps into the air and " : ""]points at %t with their [has_shoes ? "leg" : "toes"]!"
 				else
-					message_param = "[one_leg ? "jumps into the air and " : ""]tries to point at %t with their [has_shoes ? "leg" : "toes"], [span_userdanger("falling down")] in the process!"
+					message_param = "[one_leg ? "jumps into the air and " : ""]tries to point at %t with their [has_shoes ? "leg" : "toes"], falling down in the process!"
 					our_carbon.Paralyze(2 SECONDS)
 				TIMER_COOLDOWN_START(user, "point_verb_emote_cooldown", 1 SECONDS)
 			else

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -335,6 +335,7 @@
 					else
 						message_param = "[span_userdanger("bumps [user.p_their()] head on the ground")] trying to motion towards %t."
 						our_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+						playsound(user, 'sound/effects/glass/glassbash.ogg', 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()
 
 /datum/emote/living/sneeze

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -518,7 +518,7 @@
 
 //same as above
 /mob/living/pointed(atom/A as mob|obj|turf in view(client.view, src))
-	if(INCAPACITATED_IGNORING(src, INCAPABLE_RESTRAINTS|INCAPABLE_GRAB))
+	if(INCAPACITATED_IGNORING(src, INCAPABLE_RESTRAINTS))
 		return FALSE
 
 	return ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -518,7 +518,7 @@
 
 //same as above
 /mob/living/pointed(atom/A as mob|obj|turf in view(client.view, src))
-	if(incapacitated)
+	if(INCAPACITATED_IGNORING(src, INCAPABLE_RESTRAINTS|INCAPABLE_GRAB))
 		return FALSE
 
 	return ..()

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -126,7 +126,7 @@
 		var/mob/living/carbon/our_carbon = src
 		if(our_carbon.usable_hands <= 0)
 			if(TIMER_COOLDOWN_FINISHED(user, "point_verb_emote_cooldown"))
-				TIMER_COOLDOWN_START(user, "point_verb_emote_cooldown", 2 SECONDS)
+				TIMER_COOLDOWN_START(src, "point_verb_emote_cooldown", 2 SECONDS)
 				our_carbon.emote("point [pointing_at]")
 			else
 				to_chat(src, "you need to wait before doing that again!")

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -125,7 +125,11 @@
 	if(iscarbon(src)) // special interactions for carbons
 		var/mob/living/carbon/our_carbon = src
 		if(our_carbon.usable_hands <= 0 || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
-			our_carbon.emote("point [pointing_at]")
+			if(TIMER_COOLDOWN_FINISHED(user, "point_verb_emote_cooldown"))
+				TIMER_COOLDOWN_START(user, "point_verb_emote_cooldown", 2 SECONDS)
+				our_carbon.emote("point [pointing_at]")
+			else
+				to_chat(src, "you need to wait before doing that again!")
 			return FALSE
 	point_at(pointing_at, TRUE)
 

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -122,7 +122,7 @@
 
 		if(!(pointing_at in view(client.view, src)))
 			return FALSE
-	if(iscarbon(src)) //check for hands to point with if carbon
+	if(iscarbon(src)) // special interactions for carbons
 		var/mob/living/carbon/our_carbon = src
 		if(our_carbon.usable_hands <= 0 || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 			our_carbon.emote("point [pointing_at]")

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -122,7 +122,11 @@
 
 		if(!(pointing_at in view(client.view, src)))
 			return FALSE
-
+	if(iscarbon(src)) //check for hands to point with if carbon
+		var/mob/living/carbon/our_carbon = src
+		if(our_carbon.usable_hands <= 0 || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
+			our_carbon.emote("point [pointing_at]")
+			return FALSE
 	point_at(pointing_at, TRUE)
 
 	return TRUE

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -129,7 +129,7 @@
 				//cooldown handled in the emote.
 				our_carbon.emote("point [pointing_at]")
 			else
-				to_chat(src, "you need to wait before doing that again!")
+				to_chat(src, span_notice("you need to wait before pointing again!"))
 				return FALSE
 	point_at(pointing_at, TRUE)
 

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -124,7 +124,7 @@
 			return FALSE
 	if(iscarbon(src)) // special interactions for carbons
 		var/mob/living/carbon/our_carbon = src
-		if(our_carbon.usable_hands <= 0 || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
+		if(our_carbon.usable_hands <= 0)
 			if(TIMER_COOLDOWN_FINISHED(user, "point_verb_emote_cooldown"))
 				TIMER_COOLDOWN_START(user, "point_verb_emote_cooldown", 2 SECONDS)
 				our_carbon.emote("point [pointing_at]")

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -124,13 +124,13 @@
 			return FALSE
 	if(iscarbon(src)) // special interactions for carbons
 		var/mob/living/carbon/our_carbon = src
-		if(our_carbon.usable_hands <= 0)
-			if(TIMER_COOLDOWN_FINISHED(user, "point_verb_emote_cooldown"))
-				TIMER_COOLDOWN_START(src, "point_verb_emote_cooldown", 2 SECONDS)
+		if(our_carbon.usable_hands <= 0 || src.incapacitated & INCAPABLE_RESTRAINTS || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
+			if(TIMER_COOLDOWN_FINISHED(src, "point_verb_emote_cooldown"))
+				//cooldown handled in the emote.
 				our_carbon.emote("point [pointing_at]")
 			else
 				to_chat(src, "you need to wait before doing that again!")
-			return FALSE
+				return FALSE
 	point_at(pointing_at, TRUE)
 
 	return TRUE

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -129,7 +129,7 @@
 				//cooldown handled in the emote.
 				our_carbon.emote("point [pointing_at]")
 			else
-				to_chat(src, span_notice("you need to wait before pointing again!"))
+				to_chat(src, span_warning("You need to wait before pointing again!"))
 				return FALSE
 	point_at(pointing_at, TRUE)
 


### PR DESCRIPTION
## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/88327
- if a carbon has their hands blocked or missing, they will instead try to point with their legs with probability to fail
- if they have the freerunning trait they get a lower probability to fail
- if they have 1 leg they get higher probability to fail
- if they have no shoes on they will point with their toes
- if they have no legs - they will `gives meaningful glance at %t!`
- if they have no eyes - they will motion with their tongue
- if they have no tongue - they will bump their head on the floor towards the target, getting brain damage
<details>

https://github.com/user-attachments/assets/9363e184-64dc-4890-9673-5d9fe9cc1b7e


https://github.com/user-attachments/assets/192b2503-887f-43ee-afa9-80b49060e9c2


https://github.com/user-attachments/assets/ed54dc4a-0308-4088-ada4-fc343cbe6844


https://github.com/user-attachments/assets/b88f2bc8-4762-4cd7-b60b-0ac039e52853


https://github.com/user-attachments/assets/a248d0af-09ec-498a-9c46-50ab2611b62b


https://github.com/user-attachments/assets/d65e9674-ffc7-4263-89b4-0d743b0a7f2d

</details>

## Why It's Good For The Game

![spongebob-tongue](https://github.com/user-attachments/assets/265beac2-1547-48da-ad46-9d454e897482)

also for the balance change, I think it's silly that you can't point while cuffed, I don't think it'll impact powergaming much at all
## Changelog
:cl: grungussuss
add: pointing now has interactions with the amount of limbs/organs you have
balance: you can now point while restrained
sound: pointing with your head makes a sound
/:cl:
