### PR TITLE
Fixing remote/ghost alt-click on aquariums + missing plasma tetra

### DIFF
--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -189,6 +189,8 @@
 
 /datum/component/aquarium/proc/on_click_alt(atom/movable/source, mob/living/user)
 	SIGNAL_HANDLER
+	if(!user.can_perform_action(src))
+		return
 	var/closing = HAS_TRAIT(parent, TRAIT_AQUARIUM_PANEL_OPEN)
 	if(closing)
 		REMOVE_TRAIT(parent, TRAIT_AQUARIUM_PANEL_OPEN, AQUARIUM_TRAIT)

--- a/code/modules/fishing/fish/types/freshwater.dm
+++ b/code/modules/fishing/fish/types/freshwater.dm
@@ -108,11 +108,15 @@
 	icon_state = "plastetra"
 	sprite_width = 4
 	sprite_height = 2
-	average_size = 30
-	average_weight = 500
+	average_size = 20
+	average_weight = 180
 	stable_population = 3
 	required_temperature_min = MIN_AQUARIUM_TEMP+20
 	required_temperature_max = MIN_AQUARIUM_TEMP+28
+
+/obj/item/fish/plasmatetra/Initialize(mapload, apply_qualities = TRUE)
+	. = ..()
+	add_traits(list(TRAIT_FISHING_BAIT, TRAIT_GOOD_QUALITY_BAIT), INNATE_TRAIT)
 
 /obj/item/fish/catfish
 	name = "catfish"

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -58,10 +58,10 @@
 		FISHING_DUD = 4,
 		/obj/item/fish/goldfish = 5,
 		/obj/item/fish/guppy = 5,
+		/obj/item/fish/plasmatetra = 4,
 		/obj/item/fish/perch = 4,
 		/obj/item/fish/angelfish = 4,
 		/obj/item/fish/catfish = 4,
-		/obj/item/fish/perch = 5,
 		/obj/item/fish/slimefish = 2,
 		/obj/item/fish/sockeye_salmon = 1,
 		/obj/item/fish/arctic_char = 1,
@@ -113,6 +113,7 @@
 		/obj/item/fish/angelfish = 10,
 		/obj/item/fish/perch = 5,
 		/obj/item/fish/goldfish/three_eyes = 3,
+		/obj/item/fish/plasmatetra = 3,
 	)
 	catalog_description = "Aquarium dimension (Fishing portal generator)"
 	radial_state = "fish_tank"


### PR DESCRIPTION
## About The Pull Request
I'm adding a `can_perform_action` check to the aquarium alt-click function, and a plasma tetra that was missing from the freshwater fishing spots. Plasmatetra are also a tad smaller now and qualify as baitfish.

## Why It's Good For The Game
Fixing a couple issues.

## Changelog

:cl:
fix: Fixing remote/ghost alt-click functioning on aquariums
fix: Added missing plasma tetra to freshwater fishing spots.
balance: plasma tetra is now smaller and qualifies as baitfish.
/:cl:
