### PR TITLE
Fix a balloon alert runtime with folding paper planes

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -394,7 +394,7 @@
  * * plane_type - what it will be folded into (path)
  */
 /obj/item/paper/proc/make_plane(mob/living/user, plane_type = /obj/item/paperplane)
-	balloon_alert(user, "folded into a plane")
+	loc.balloon_alert(user, "folded into a plane")
 	user.temporarilyRemoveItemFromInventory(src)
 	var/obj/item/paperplane/new_plane = new plane_type(loc, src)
 	if(user.Adjacent(new_plane))


### PR DESCRIPTION

## About The Pull Request

This fixes an `addtimer called with a callback assigned to a qdeleted object` runtime with paper planes

Honestly at this point, it'd prolly be a good idea to stick a check to just automatically use the parent's loc if the alerting atom is being qdeleted

## Why It's Good For The Game

meow

## Changelog
:cl:
fix: Fixed a runtime error related to the balloon alert from folding a paper plane.
/:cl:
