### PR TITLE
 Recovered crew no longer show up on roundend report,

### DIFF
--- a/code/modules/lost_crew/recovered_crew.dm
+++ b/code/modules/lost_crew/recovered_crew.dm
@@ -7,3 +7,4 @@
 	show_to_ghosts = FALSE
 	silent = TRUE
 	block_midrounds = FALSE
+	show_in_roundend = FALSE


### PR DESCRIPTION

## About The Pull Request

Recovered crew no longer show up on roundend report, they are technically antags, but they are not antags
![image](https://github.com/user-attachments/assets/255e26bb-acb0-419e-91bd-d203897dc26a)
## Why It's Good For The Game

Too easy to get greentexts. we don't want players to feel accomplished too often
## Changelog
:cl:
fix: Recovered crew no longer show up on roundend report
/:cl:
