### PR TITLE
[TM ONLY] Autorifles crates are no longer contraband

### DIFF
--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -131,33 +131,6 @@
 	)
 	crate_name = "crate"
 
-/datum/supply_pack/imports/wt550
-	name = "Smuggled WT-550 Autorifle Crate"
-	desc = "(*!&@#GOOD NEWS, OPERATIVE! WE CAN'T GET YOU THE BIG LEAGUE AUTOMATIC WEAPONS. BUT, BY \
-		SMUGGLING THIS CRATE THROUGH A FEW OUTDATED CUSTOMS CHECKPOINTS, WE'VE THE NEXT BEST THING! \
-		SERVICE AUTORIFLES. DON'T WORRY, THE RUMORS ABOUT THE GUN MELTING YOU ARE JUST THAT! RUMORS! \
-		THESE THINGS WORK FINE! MIGHT BE SLIGHTLY DIRTY.!#@*$"
-	hidden = TRUE
-	cost = CARGO_CRATE_VALUE * 7
-	contains = list(
-		/obj/item/gun/ballistic/automatic/wt550 = 2,
-		/obj/item/ammo_box/magazine/wt550m9 = 2,
-	)
-	crate_type = /obj/structure/closet/crate/secure/syndicate/gorlex/weapons/bustedlock
-
-/datum/supply_pack/imports/wt550ammo
-	name = "Smuggled WT-550 Ammo Crate"
-	desc = "(*!&@#OPERATIVE, YOU LIKE THAT WT-550? THEN WHY NOT EQUIP YOURSELF WITH SOME MORE AMMO!!#@*$"
-	hidden = TRUE
-	cost = CARGO_CRATE_VALUE * 4
-	contains = list(
-		/obj/item/ammo_box/magazine/wt550m9 = 2,
-		/obj/item/ammo_box/magazine/wt550m9/wtap = 2,
-		/obj/item/ammo_box/magazine/wt550m9/wtic = 2,
-	)
-	crate_name = "emergency crate"
-	crate_type = /obj/structure/closet/crate/secure/syndicate/gorlex/weapons/bustedlock
-
 /datum/supply_pack/imports/shocktrooper
 	name = "Shocktrooper Crate"
 	desc = "(*!&@#WANT TO PUT THE FEAR OF DEATH INTO YOUR ENEMIES? THIS CRATE OF GOODIES CAN HELP MAKE THAT A REALITY. \

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -340,6 +340,23 @@
 	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
 	crate_name = "thermal pistol crate"
 
+/datum/supply_pack/security/armory/wt550
+	name = "WT-550 Auto Rifle Crate"
+	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 7
+	contains = list(
+		/obj/item/gun/ballistic/automatic/wt550 = 2,
+		/obj/item/ammo_box/magazine/wt550m9 = 2,
+	)
+	crate_name = "wt-550 auto rifle crate"
+
+/datum/supply_pack/security/armory/wt550ammo
+	name = "WT-550 Standard Ammo Crate"
+	desc = "Contains four 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 4
+	contains = list(/obj/item/ammo_box/magazine/wt550m9 = 4)
+	crate_name = "wt-550 standard ammo crate"
+
 /datum/supply_pack/security/sunglasses
 	name = "Sunglasses Crate"
 	desc = "A single pair of flash-proof sunglasses."


### PR DESCRIPTION

## About The Pull Request

Autorifle crates are no longer locked behind an emag in the cargo order console. Instead, they are now in the armory category, same as disabler SMG crates and other non-basic weapons.

## Why It's Good For The Game

There was a long discussion earlier today on discord about cargo and why people don't interact with it. The core issue is that nothing that people can purchase from cargo is desirable enough for people to regularly order things. A while ago, though, an april fools PR added a bunch of guns to cargo, and I've never seen it as busy as it was during that week. 

Obviously, making powerful guns easily available from cargo has some balance implications, which is why this PR is test-merge only. This PR is mainly intended as a proof of concept, to demonstrate that people will willingly interact with cargo if they think there's a reason to do so.

## Changelog
:cl:
bal: Autorifle crates are no longer considered contraband. Armory access is required to purchase them, however.
/:cl:
