### PR TITLE
Trainers can now verify admins above their weight class

### DIFF
--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -141,6 +141,10 @@ ADMIN_VERB(edit_admin_permissions, R_PERMISSIONS, "Permissions Panel", "Edit adm
 	var/admin_key = href_list["key"]
 	var/admin_ckey = ckey(admin_key)
 	var/datum/admins/D = GLOB.admin_datums[admin_ckey]
+	if(!D)
+		D = GLOB.deadmins[admin_ckey]
+	if (!D && task != "add")
+		return
 	var/use_db
 	var/task = href_list["editrights"]
 	var/skip
@@ -173,16 +177,11 @@ ADMIN_VERB(edit_admin_permissions, R_PERMISSIONS, "Permissions Panel", "Edit adm
 					use_db = FALSE
 			if(QDELETED(usr))
 				return
-	if(task != "add")
-		D = GLOB.admin_datums[admin_ckey]
-		if(!D)
-			D = GLOB.deadmins[admin_ckey]
-		if(!D)
-			return
-		if((task != "sync") && !check_if_greater_rights_than_holder(D))
-			message_admins("[key_name_admin(usr)] attempted to change the rank of [admin_key] without sufficient rights.")
-			log_admin("[key_name(usr)] attempted to change the rank of [admin_key] without sufficient rights.")
-			return
+	
+	if(D && (task != "sync" && task != "verify") && !check_if_greater_rights_than_holder(D))
+		message_admins("[key_name_admin(usr)] attempted to change the rank of [admin_key] without sufficient rights.")
+		log_admin("[key_name(usr)] attempted to change the rank of [admin_key] without sufficient rights.")
+		return
 	switch(task)
 		if("add")
 			admin_ckey = add_admin(admin_ckey, admin_key, use_db)

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -140,13 +140,14 @@ ADMIN_VERB(edit_admin_permissions, R_PERMISSIONS, "Permissions Panel", "Edit adm
 	permissions_assets.send(usr.client)
 	var/admin_key = href_list["key"]
 	var/admin_ckey = ckey(admin_key)
+	
+	var/task = href_list["editrights"]
 	var/datum/admins/target_admin_datum = GLOB.admin_datums[admin_ckey]
 	if(!target_admin_datum)
 		target_admin_datum = GLOB.deadmins[admin_ckey]
 	if (!target_admin_datum && task != "add")
 		return
 	var/use_db
-	var/task = href_list["editrights"]
 	var/skip
 	var/legacy_only
 	if(task == "activate" || task == "deactivate" || task == "sync" || task == "verify")


### PR DESCRIPTION
bounty pr


## About The Pull Request

Lets anyone with permissions verify any admin past 2fa, not just ones lower than them on the ~totem~ permission pole.

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/22b70b52-ffca-4b10-a8c5-f7a3cae2f452)

(also fixes an exploit where you could action protected admins who were deadmined because `D` wouldn't be set by that point.)