### PR TITLE
Central Commanders now really have ALL access

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1246,7 +1246,7 @@
 
 /obj/item/card/id/advanced/debug
 	name = "\improper Debug ID"
-	desc = "A debug ID card. Has ALL the all access and a boatload of money, you really shouldn't have this."
+	desc = "A debug ID card. Has ALL the all access and a boatload of money. This is only available to members of the Department of Opposition"
 	icon_state = "card_centcom"
 	assigned_icon_state = "assigned_centcom"
 	trim = /datum/id_trim/admin

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -235,7 +235,7 @@
 /datum/outfit/centcom/commander
 	name = "CentCom Commander"
 
-	id = /obj/item/card/id/advanced/centcom
+	id = /obj/item/card/id/advanced/debug
 	id_trim = /datum/id_trim/centcom/commander
 	uniform = /obj/item/clothing/under/rank/centcom/commander
 	suit = /obj/item/clothing/suit/armor/centcom_formal


### PR DESCRIPTION
## About The Pull Request
Centcom Officers, who are admin-only, now have truly all access.

(I've also added a little bit of flavour about the department of opposition. I can remove it if need be)

## Why It's Good For The Game
It's admins. They can open any door anyway.

## Changelog
:cl:
admin: CentCom Officers can now open any door; as they should have been able to anyway!
:cl:
