### PR TITLE
Tram spoiler/malf fix

### DIFF
--- a/code/modules/events/tram_malfunction.dm
+++ b/code/modules/events/tram_malfunction.dm
@@ -42,7 +42,7 @@
 
 /datum/round_event/tram_malfunction/end()
 	for(var/datum/transport_controller/linear/tram/malfunctioning_controller as anything in SStransport.transports_by_type[TRANSPORT_TYPE_TRAM])
-		if(malfunctioning_controller.specific_transport_id == specific_transport_id && malfunctioning_controller.malf_active)
+		if(malfunctioning_controller.specific_transport_id == specific_transport_id && malfunctioning_controller.malf_active != TRANSPORT_SYSTEM_NORMAL)
 			malfunctioning_controller.end_malf_event()
 			return
 

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -606,8 +606,8 @@
  */
 /datum/transport_controller/linear/tram/proc/start_malf_event()
 	malf_active = TRANSPORT_LOCAL_WARNING
-	throw_chance *= 1.25
 	paired_cabinet.update_appearance()
+	throw_chance *= 1.25
 	log_transport("TC: [specific_transport_id] starting Tram Malfunction event.")
 
 /**
@@ -620,6 +620,7 @@
 	if(!(malf_active))
 		return
 	malf_active = TRANSPORT_SYSTEM_NORMAL
+	paired_cabinet.update_appearance()
 	throw_chance = initial(throw_chance)
 	log_transport("TC: [specific_transport_id] ending Tram Malfunction event.")
 

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -419,6 +419,7 @@
  * Performs a reset of the tram's position data by finding a predetermined reference landmark, then driving to it.
  */
 /datum/transport_controller/linear/tram/proc/reset_position()
+	malf_active = TRANSPORT_SYSTEM_NORMAL
 	if(idle_platform)
 		if(get_turf(idle_platform) == get_turf(nav_beacon))
 			set_status_code(SYSTEM_FAULT, FALSE)
@@ -606,6 +607,7 @@
 /datum/transport_controller/linear/tram/proc/start_malf_event()
 	malf_active = TRANSPORT_LOCAL_WARNING
 	throw_chance *= 1.25
+	paired_cabinet.update_appearance()
 	log_transport("TC: [specific_transport_id] starting Tram Malfunction event.")
 
 /**
@@ -1081,7 +1083,7 @@
 		"recoveryMode" = controller_datum.recovery_mode,
 		"currentSpeed" = controller_datum.current_speed,
 		"currentLoad" = controller_datum.current_load,
-		"statusSF" = controller_datum.controller_status & SYSTEM_FAULT,
+		"statusSF" = controller_datum.controller_status & SYSTEM_FAULT || controller_datum.malf_active != TRANSPORT_SYSTEM_NORMAL,
 		"statusCE" = controller_datum.controller_status & COMM_ERROR,
 		"statusES" = controller_datum.controller_status & EMERGENCY_STOP,
 		"statusPD" = controller_datum.controller_status & PRE_DEPARTURE,

--- a/code/modules/transport/tram/tram_structures.dm
+++ b/code/modules/transport/tram/tram_structures.dm
@@ -474,8 +474,8 @@
 	canSmoothWith = null
 	/// Position of the spoiler
 	var/deployed = FALSE
-	/// Malfunctioning due to tampering or emag
-	var/malfunctioning = FALSE
+	/// Locked in position
+	var/locked = FALSE
 	/// Weakref to the tram piece we control
 	var/datum/weakref/tram_ref
 	/// The tram we're attached to
@@ -494,7 +494,7 @@
 		context[SCREENTIP_CONTEXT_LMB] = "repair"
 
 	if(held_item?.tool_behaviour == TOOL_WELDER && atom_integrity >= max_integrity)
-		context[SCREENTIP_CONTEXT_LMB] = "[malfunctioning ? "repair" : "lock"]"
+		context[SCREENTIP_CONTEXT_LMB] = "[locked ? "repair" : "sabotage"]"
 
 	return CONTEXTUAL_SCREENTIP_SET
 
@@ -503,22 +503,19 @@
 	if(obj_flags & EMAGGED)
 		. += span_warning("The electronics panel is sparking occasionally. It can be reset with a [EXAMINE_HINT("multitool.")]")
 
-	if(malfunctioning)
+	if(locked)
 		. += span_warning("The spoiler is [EXAMINE_HINT("welded")] in place!")
 	else
-		. += span_notice("The spoiler can be locked in to place with a [EXAMINE_HINT("welder.")]")
+		. += span_notice("The spoiler can be locked in place with a [EXAMINE_HINT("welder.")]")
 
 /obj/structure/tram/spoiler/proc/set_spoiler(source, controller, controller_active, controller_status, travel_direction)
 	SIGNAL_HANDLER
 
 	var/spoiler_direction = travel_direction
-	if(obj_flags & EMAGGED && !malfunctioning)
-		malfunctioning = TRUE
-
-	if(malfunctioning || controller_status & COMM_ERROR)
+	if(locked || controller_status & COMM_ERROR || obj_flags & EMAGGED)
 		if(!deployed)
 			// Bring out the blades
-			if(malfunctioning)
+			if(locked)
 				visible_message(span_danger("\the [src] locks up due to its servo overheating!"))
 			do_sparks(3, cardinal_only = FALSE, source = src)
 			deploy_spoiler()
@@ -583,14 +580,14 @@
 		return FALSE
 
 	if(atom_integrity >= max_integrity)
-		to_chat(user, span_warning("You begin to weld \the [src], [malfunctioning ? "repairing damage" : "preventing retraction"]."))
+		to_chat(user, span_warning("You begin to weld \the [src], [locked ? "repairing damage" : "preventing retraction"]."))
 		if(!tool.use_tool(src, user, 4 SECONDS, volume = 50))
 			return
-		malfunctioning = !malfunctioning
-		user.visible_message(span_warning("[user] [malfunctioning ? "welds \the [src] in place" : "repairs \the [src]"] with [tool]."), \
-			span_warning("You finish welding \the [src], [malfunctioning ? "locking it in place." : "it can move freely again!"]"), null, COMBAT_MESSAGE_RANGE)
+		locked = !locked
+		user.visible_message(span_warning("[user] [locked ? "welds \the [src] in place" : "repairs \the [src]"] with [tool]."), \
+			span_warning("You finish welding \the [src], [locked ? "locking it in place." : "it can move freely again!"]"), null, COMBAT_MESSAGE_RANGE)
 
-		if(malfunctioning)
+		if(locked)
 			deploy_spoiler()
 
 		update_appearance()
@@ -606,7 +603,7 @@
 
 /obj/structure/tram/spoiler/update_overlays()
 	. = ..()
-	if(deployed && malfunctioning)
+	if(deployed && locked)
 		. += mutable_appearance(icon, "tram-spoiler-welded")
 
 /obj/structure/chair/sofa/bench/tram

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -171,6 +171,13 @@
 		if(!(movable_contents.loc in locs))
 			remove_item_from_transport(movable_contents)
 
+/obj/structure/transport/linear/proc/check_for_humans()
+	for(var/atom/movable/movable_contents as anything in transport_contents)
+		if(ishuman(movable_contents))
+			return TRUE
+
+	return FALSE
+
 ///signal handler for COMSIG_MOVABLE_UPDATE_GLIDE_SIZE: when a movable in transport_contents changes its glide_size independently.
 ///adds that movable to a lazy list, movables in that list have their glide_size updated when the tram next moves
 /obj/structure/transport/linear/proc/on_changed_glide_size(atom/movable/moving_contents, new_glide_size)


### PR DESCRIPTION
## About The Pull Request

- Fixes emagged tram spoilers from appearing welded/displaying weld hints
- Tram malfunction checks for humans before throwing
- Tram control panel flashes orange when malfunction can be fixed

## Why It's Good For The Game

- Better visual indicator that the tram is malfunctioning and can be reset
- You're correctly told welder or multitool hints depending on if the tram is welded or emagged
- Don't bother running a tram malfunction if nobody is around

## Changelog

:cl: LT3
fix: Tram spoilers correctly provide welder or multitool hints depending on their damage
fix: Malfunctioning tram controller flashes orange and can be preemptively fixed before it crashes
/:cl: