### PR TITLE
Centcom Officers have a new outfit, which gives them admin access

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -15,6 +15,22 @@
 	shoes = /obj/item/clothing/shoes/combat/swat
 	r_pocket = /obj/item/lighter
 
+/datum/outfit/centcom/admin
+	name = "Department Officer"
+
+	id = /obj/item/card/id/advanced/debug
+	uniform = /obj/item/clothing/under/rank/centcom/commander
+	suit = /obj/item/clothing/suit/space/officer
+	back = /obj/item/storage/backpack/satchel/leather
+	belt = /obj/item/gun/energy/pulse/pistol/m1911
+	ears = /obj/item/radio/headset/headset_cent/commander
+	glasses = /obj/item/clothing/glasses/thermal/eyepatch
+	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
+	head = /obj/item/clothing/head/helmet/space/beret
+	mask = /obj/item/cigarette/cigar/havana
+	shoes = /obj/item/clothing/shoes/combat/swat
+	r_pocket = /obj/item/lighter
+
 /datum/outfit/centcom/spec_ops/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
 		return


### PR DESCRIPTION
## About The Pull Request
Centcom Officers, who are admin-only, now have truly all access.

(I've also added a little bit of flavour about the department of opposition. I can remove it if need be)

## Why It's Good For The Game
It's admins. They can open any door anyway.

## Changelog
:cl:
admin: CentCom Officers can now open any door; as they should have been able to anyway!
:cl:
