### PR TITLE
Restore Spear's Ability to Destroy Lockers

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -11,6 +11,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 20
 	throw_speed = 4
+	demolition_mod = 0.75
 	embed_type = /datum/embed_data/spear
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass= HALF_SHEET_MATERIAL_AMOUNT * 2)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -11,7 +11,6 @@
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 20
 	throw_speed = 4
-	demolition_mod = 0.75
 	embed_type = /datum/embed_data/spear
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass= HALF_SHEET_MATERIAL_AMOUNT * 2)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1225,8 +1225,8 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 /obj/structure/closet/attacked_by(obj/item/attacking_item, mob/living/user)
 	if(istype(attacking_item, /obj/item/spear))
 		take_damage(attacking_item.force * 2, attacking_item.damtype, MELEE, 1, get_dir(src, user))
-		user.visible_message(span_danger("[user] stabs with precision [src]'s electronics with [attacking_item]!"), \
-			span_danger("You stab with precision [src]'s electronics with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
+		user.visible_message(span_danger("[user] stabs with precision [src]'s electronics with [attacking_item]!"),
+		span_danger("You stab with precision [src]'s electronics with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
 		log_combat(user, src, "attacked", attacking_item)
 		return
 	return ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1221,4 +1221,14 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 /obj/structure/closet/proc/add_to_roundstart_list()
 	GLOB.roundstart_station_closets += src
 
+///Spears deal bonus damages to lockers
+/obj/structure/closet/attacked_by(obj/item/attacking_item, mob/living/user)
+	if(istype(attacking_item, /obj/item/spear))
+		take_damage(attacking_item.force * 2, attacking_item.damtype, MELEE, 1, get_dir(src, user))
+		user.visible_message(span_danger("[user] stabs with precision [src]'s electronics with [attacking_item]!"), \
+			span_danger("You stab with precision [src]'s electronics with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
+		log_combat(user, src, "attacked", attacking_item)
+		return
+	return ..()
+
 #undef LOCKER_FULL

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -227,6 +227,7 @@ Basketball requires skill. Spinning drains stamina, reduces accuracy, but gives 
 Basketball requires teamwork. Passing the ball with LMB is instant and costs no stamina.
 Clicking on a windoor rather then bumping into it will keep it open, you can click it again to close it.
 Different weapons have different strengths. Some weapons, such as spears, floor tiles, and throwing stars, deal more damage when thrown compared to when attacked normally.
+Spears are capable of breaking into secure lockers by striking them in melee!
 Don't be afraid to ask for help, whether from your peers or from admins.
 Experiment with different setups of the Supermatter engine to maximize output, but don't risk the crew's safety to do so!
 Felinids get temporarily distracted by laser pointers. Use this to your advantage when being pursued by one.


### PR DESCRIPTION
## About The Pull Request
This change make the lockers "electronics" weaker to the spear, restoring its ability to destroy lockers. While this functionality was not originally intended (throwing spears on lockers) ( #88141 ), it has been present for so long that it has effectively become a feature. This pull request rework that feature by making the spear do damage by hitting lockers in melee.


https://github.com/user-attachments/assets/67058342-57e2-4670-9c68-df4c3b6d6193



## Why It's Good For The Game
Restoring the spear's ability to destroy lockers maintains its previous utility and aligns with player expectations, preserving and  reworking feature that has become a staple of gameplay and lower the burden on antagonist to open security or command lockers.

## Changelog
:cl: UnokiAs
add: Make spears able to break open lockers in melee.
/:cl:
