### PR TITLE
Reduce Carpenter hammer force (this thing can open locked gun crates!)

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -441,12 +441,12 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
 	desc = "Uncanny looking hammer."
-	force = 15
-	throwforce = 12
+	force = 17
+	throwforce = 14
 	throw_range = 4
 	w_class = WEIGHT_CLASS_NORMAL
 	wound_bonus = 20
-	demolition_mod = 1.25
+	demolition_mod = 1.15
 	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/carpenter_hammer/Initialize(mapload)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -441,8 +441,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
 	desc = "Uncanny looking hammer."
-	force = 20
-	throwforce = 20
+	force = 15
+	throwforce = 12
 	throw_range = 4
 	w_class = WEIGHT_CLASS_NORMAL
 	wound_bonus = 20


### PR DESCRIPTION
## About The Pull Request

Carpenter hammer force 20 -> 17
Carpenter hammer throwforce 20 -> 14
Carpenter hammer demo mod 1.25 -> 1.15

## Why It's Good For The Game

You can buy this thing in the black market for 250 credits and it's strong enough to open gun crates from cargo

![image](https://github.com/user-attachments/assets/c8a352c6-dfc3-40fd-90fd-a1d0a0b4ba0b)

## Changelog

:cl: Melbert
balance: Carpenter hammer force 20 -> 17
balance: Carpenter hammer throwforce 20 -> 14
balance: Carpenter hammer demo mod 1.25 -> 1.15
/:cl:
