### PR TITLE
[NO GBP] Gives tiziran water turfs their own fish again

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -92,6 +92,7 @@
 	icon_state = "tizira_water"
 	base_icon_state = "tizira_water"
 	baseturfs = /turf/open/water/beach/tizira
+	fishing_datum = /datum/fish_source/tizira
 
 /**
  * A special subtype of water with steam particles and a status effect similar to showers, that's however only applied if


### PR DESCRIPTION
## About The Pull Request
Just noticed a little fuck up while testing things.

## Why It's Good For The Game
You should be once again able to fish moonfish and other fish used in lizard cuisine from tiziran water turfs.

## Changelog

:cl:
fix: You should be once again able to fish moonfish and other fish used in lizard cuisine from tiziran water turfs.
/:cl: