### PR TITLE
Repaths heavy crowbar so people don't map it in accidentally

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
@@ -311,7 +311,7 @@
 	},
 /obj/structure/rack,
 /obj/item/wrench,
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/twenty_force,
 /obj/machinery/light/small/built/directional/south,
 /turf/open/floor/plating/icemoon,
 /area/ruin/powered/shuttle)

--- a/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+++ b/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
@@ -63,7 +63,7 @@
 /obj/structure/chair/old{
 	dir = 1
 	},
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/twenty_force,
 /turf/open/floor/oldshuttle,
 /area/ruin/space/has_grav/powered)
 "o" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -33933,7 +33933,7 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/old,
 /obj/item/wirecutters,
 /obj/item/wrench,
 /turf/open/floor/iron,
@@ -43772,7 +43772,7 @@
 /area/station/science/ordnance/burnchamber)
 "oZL" = (
 /obj/structure/table,
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/old,
 /obj/item/stack/cable_coil,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -33933,7 +33933,7 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
-/obj/item/crowbar/large/old,
+/obj/item/crowbar/large,
 /obj/item/wirecutters,
 /obj/item/wrench,
 /turf/open/floor/iron,
@@ -43772,7 +43772,7 @@
 /area/station/science/ordnance/burnchamber)
 "oZL" = (
 /obj/structure/table,
-/obj/item/crowbar/large/old,
+/obj/item/crowbar/large,
 /obj/item/stack/cable_coil,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -68229,7 +68229,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/item/crowbar/large/old,
+/obj/item/crowbar/large,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "ybh" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -65380,7 +65380,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "wZU" = (
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/old,
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "xad" = (
@@ -68229,7 +68229,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/old,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "ybh" = (

--- a/_maps/modular_generic/ice_l_storage.dmm
+++ b/_maps/modular_generic/ice_l_storage.dmm
@@ -213,7 +213,7 @@
 "M" = (
 /obj/effect/turf_decal/bot/right,
 /obj/structure/closet/crate/large,
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/twenty_force,
 /turf/open/floor/plating,
 /area/template_noop)
 "N" = (

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -88,7 +88,7 @@
 	custom_materials = list(/datum/material/wood=SMALL_MATERIAL_AMOUNT*0.5, /datum/material/iron=SMALL_MATERIAL_AMOUNT*0.7)
 	wound_bonus = 35
 
-/obj/item/crowbar/large/heavy //from space ruin
+/obj/item/crowbar/large/twenty_force //from space ruin
 	name = "heavy crowbar"
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big. It feels oddly heavy.."
 	force = 20


### PR DESCRIPTION
## About The Pull Request

Remaps `/obj/item/crowbar/large/heavy` -> `/obj/item/crowbar/large/twenty_force`

Replaces uses of `/obj/item/crowbar/large/heavy` on station maps (which is incorrect) with `/obj/item/crowbar/large` (or the old subtype)

Let me know if you (dear reader) want an updatepaths script

## Why It's Good For The Game

See #64317

## Changelog

:cl: Melbert
del: Some crowbars on Wawa, Nebula, and Birdboat are significantly less heavy
/:cl:
