### PR TITLE
Fix chewing gum not deleting when flavor is gone

### DIFF
--- a/code/datums/elements/chewable.dm
+++ b/code/datums/elements/chewable.dm
@@ -43,10 +43,17 @@
 		return PROCESS_KILL
 
 	for (var/obj/item/item as anything in processing)
-		var/mob/chewer = item.loc
+		var/mob/living/chewer = item.loc
+		var/is_out_of_flavor = !item.reagents?.total_volume
 
-		if (!istype(chewer) || !item.reagents?.total_volume)
+		if(!istype(chewer))
 			processing -= item
+			continue
+
+		if(is_out_of_flavor)
+			processing -= item
+			to_chat(chewer, span_notice("\The [item] you are chewing runs out of flavor."))
+			qdel(item)
 			continue
 
 		handle_reagents(item, seconds_per_tick)


### PR DESCRIPTION

## About The Pull Request
If you chew gum long enough it loses all reagents and the edible component gets removed. I decided to take this a step further and make it behave like cigarettes that get deleted when it runs out.

## Why It's Good For The Game
Consistency. 

## Changelog
:cl:
fix: Fix chewing gum not deleting when flavor is gone.
/:cl:
