### PR TITLE
fixes access on that one engineering maintenance door on birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -47524,7 +47524,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "qmz" = (


### PR DESCRIPTION

## About The Pull Request
fixes #88383

## Why It's Good For The Game

fixes #88383

## Changelog
:cl:
fix: The Men in Grey may no longer access birdshots engineering via a certain maintenance airlock
/:cl:
