### PR TITLE
Adds a chemical to the chem kit

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -461,7 +461,7 @@
 
 /obj/item/storage/box/syndie_kit/chemical/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 14
+	atom_storage.max_slots = 15
 
 /obj/item/storage/box/syndie_kit/chemical/PopulateContents()
 	new /obj/item/reagent_containers/cup/bottle/polonium(src)
@@ -469,6 +469,7 @@
 	new /obj/item/reagent_containers/cup/bottle/fentanyl(src)
 	new /obj/item/reagent_containers/cup/bottle/formaldehyde(src)
 	new /obj/item/reagent_containers/cup/bottle/spewium(src)
+	new /obj/item/reagent_containers/cup/bottle/syndol(src)
 	new /obj/item/reagent_containers/cup/bottle/cyanide(src)
 	new /obj/item/reagent_containers/cup/bottle/histamine(src)
 	new /obj/item/reagent_containers/cup/bottle/initropidril(src)

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -230,6 +230,22 @@
 
 	return ..()
 
+/datum/hallucination/delusion/preset/seccies
+	dynamic_delusion = TRUE
+	random_hallucination_weight = 0
+	delusion_name = "Security"
+	affects_others = TRUE
+	affects_us = FALSE
+
+/datum/hallucination/delusion/preset/seccies/make_delusion_image(mob/over_who)
+	delusion_appearance = get_dynamic_human_appearance(
+		outfit_path = /datum/outfit/job/security,
+		bloody_slots = prob(5) ? ALL : NONE,
+		r_hand = prob(15) ? /obj/item/melee/baton/security/loaded : null,
+		l_hand = prob(15) ? /obj/item/melee/baton/security/loaded : null,
+	)
+	return ..()
+
 /// Hallucination used by the nightmare vision goggles to turn everyone except you into mares
 /datum/hallucination/delusion/preset/mare
 	delusion_icon_file = 'icons/obj/clothing/masks.dmi'

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -886,7 +886,7 @@
 	if(isnull(liver) || !(liver.organ_flags & affected_organ_flags))
 		return
 	// non-trivial but not immediately dangerous liver damage
-	liver.apply_organ_damage(0.33 * REM * seconds_per_tick)
+	liver.apply_organ_damage(0.5 * REM * seconds_per_tick)
 	// anti-hallucinogens can counteract the effects
 	if(HAS_TRAIT(affected_mob, TRAIT_HALLUCINATION_IMMUNE) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/haloperidol, amount = 3, needs_metabolizing = TRUE))
 		QDEL_NULL(active_hallucination_weakref)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -874,7 +874,7 @@
 	color = "#c90000"
 	taste_description = "metallic"
 	ph = 7
-	overdose_threshold = 30
+	overdose_threshold = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/hallucinogens = 20)
 	/// Track the active hallucination we're giving out so we don't replace it by accident
@@ -892,10 +892,6 @@
 		QDEL_NULL(active_hallucination_weakref)
 		return
 
-	// cause a small amount of fatigue
-	if(affected_mob.getStaminaLoss() < 20)
-		affected_mob.adjustStaminaLoss(3 * REM * seconds_per_tick)
-
 	// and the main event, funny hallucinations
 	if(active_hallucination_weakref?.resolve())
 		return
@@ -907,16 +903,16 @@
 
 	if(greatest_fear)
 		// 5 minutes = 15 units, roughly. we cancel the hallucination early when we exit the mob, anyway
-		active_hallucination_weakref = WEAKREF(affected_mob.cause_hallucination(greatest_fear, name, duration = 5 MINUTES, skip_nearby = TRUE))
+		active_hallucination_weakref = WEAKREF(affected_mob.cause_hallucination(greatest_fear, name, duration = 5 MINUTES, skip_nearby = !overdosed))
 	else
 		// if they're just some random schmuck, give them random hallucinations
 		affected_mob.adjust_hallucinations_up_to(4 SECONDS * REM * seconds_per_tick, 20 SECONDS)
 
 /datum/reagent/drug/syndol/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
-	affected_mob.adjust_hallucinations(-20 SECONDS)
+	affected_mob.adjust_hallucinations(-16 SECONDS)
 	QDEL_NULL(active_hallucination_weakref)
 
-/datum/reagent/drug/syndol/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
-	. = ..()
-	affected_mob.adjust_hallucinations_up_to(10 SECONDS * REM * seconds_per_tick, 3 MINUTES)
+/datum/reagent/drug/syndol/overdose_start(mob/living/affected_mob)
+	// no message, just refresh the hallucination
+	QDEL_NULL(active_hallucination_weakref)

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -37,6 +37,11 @@
 	desc = "A small bottle of spewium."
 	list_reagents = list(/datum/reagent/toxin/spewium = 30)
 
+/obj/item/reagent_containers/cup/bottle/syndol
+	name = "syndol bottle"
+	desc = "A small bottle of syndol."
+	list_reagents = list(/datum/reagent/drug/syndol = 30)
+
 /obj/item/reagent_containers/cup/bottle/morphine
 	name = "morphine bottle"
 	desc = "A small bottle of morphine."


### PR DESCRIPTION
## About The Pull Request

Adds Syndol to the chemical kit

- It deals minor liver damage
- It is a very addictive hallucinogen
- When a security officer is exposed, they will hallucinate other mobs as Nuke Ops
- When an assistant or clown is exposed, they will hallucinate other mobs as Security Officers
- When exposed to less than ten units, these unique hallucinations will only apply to all mobs *outside* of the view of the victim. 
- When exposed to more than ten units (an overdose), it applies to *all* mobs, not just those in view.
- All other members of the crew will just get normal hallucinations.
- Exposure is completely silent (until the liver damage kicks in, which takes a while)

![image](https://github.com/user-attachments/assets/7c47b735-dec7-464b-849c-cf5a8fff10ff)

## Why It's Good For The Game

Someone dropped the idea in Discord and I thought it was pretty funny. It also gives syndies a way to temporarily disorient a security officer a la the old chaos holoparasite  (oh god who was I chasing everyone is a syndie?).

## Changelog

:cl: Melbert
add: Adds Syndol to the chemical kit, an addictive hallucinogen that applies bonus effects when security officers, assistants, or clowns are exposed.
/:cl:

