### PR TITLE
Enable Reagent Dartgun for traitor MDs

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -250,7 +250,7 @@
 	progression_minimum = 15 MINUTES
 	item = /obj/item/gun/chem
 	cost = 12
-	restricted_roles = list(JOB_CHEMIST, JOB_CHIEF_MEDICAL_OFFICER, JOB_BOTANIST)
+	restricted_roles = list(JOB_CHEMIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_BOTANIST)
 
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"


### PR DESCRIPTION

## About The Pull Request

Reagent Dartgun was added back when doctors did less chemistry than botanists, hence the role-lock to Chemists and Botanists excluding MDs. Now that doctors usually do more than botanists they should get access to the fun chem gun too.
## Why It's Good For The Game

Improves consistency & gives traitor MDs one more fun tool to combine with surgery, which is nice because the others can be a bit esoteric.
## Changelog
:cl:
balance: medical doctors can buy Reagent Dartgun from traitor uplink
/:cl:
