### PR TITLE
Fixes some instances of PostTransfer not using new_parent argument

### DIFF
--- a/code/datums/components/COMPONENT_TEMPLATE.md
+++ b/code/datums/components/COMPONENT_TEMPLATE.md
@@ -40,10 +40,10 @@ See _component.dm for detailed explanations
 */
 
 /*
-/datum/component/mycomponent/PreTransfer()
-	send_to_playing_players("Goodbye [parent], I'm getting adopted")
+/datum/component/mycomponent/PreTransfer(datum/new_parent)
+	send_to_playing_players("Goodbye [new_parent], I'm getting adopted")
 
-/datum/component/mycomponent/PostTransfer()
+/datum/component/mycomponent/PostTransfer(datum/new_parent)
 	send_to_playing_players("Hello my new parent, [parent]! It's nice to meet you!")
 */
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -218,7 +218,7 @@
  *
  * Do not call `qdel(src)` from this function, `return COMPONENT_INCOMPATIBLE` instead
  */
-/datum/component/proc/PostTransfer()
+/datum/component/proc/PostTransfer(datum/new_parent)
 	return COMPONENT_INCOMPATIBLE //Do not support transfer by default as you must properly support it
 
 /**

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -32,8 +32,8 @@
 	REMOVE_TRAIT(parent, TRAIT_LIVING_HEART, REF(src))
 	UnregisterSignal(parent, list(COMSIG_ORGAN_REMOVED, COMSIG_ORGAN_BEING_REPLACED))
 
-/datum/component/living_heart/PostTransfer()
-	if(!isorgan(parent))
+/datum/component/living_heart/PostTransfer(datum/new_parent)
+	if(!isorgan(new_parent))
 		return COMPONENT_INCOMPATIBLE
 
 /**

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -76,15 +76,15 @@
 	avatar.set_temp_blindness(1 SECONDS) // I'm in
 
 
-/datum/component/avatar_connection/PostTransfer()
+/datum/component/avatar_connection/PostTransfer(datum/new_parent)
 	var/obj/machinery/netpod/pod = netpod_ref?.resolve()
 	if(isnull(pod))
 		return COMPONENT_INCOMPATIBLE
 
-	if(!isliving(parent))
+	if(!isliving(new_parent))
 		return COMPONENT_INCOMPATIBLE
 
-	pod.avatar_ref = WEAKREF(parent)
+	pod.avatar_ref = WEAKREF(new_parent)
 
 
 /datum/component/avatar_connection/RegisterWithParent()

--- a/code/modules/capture_the_flag/ctf_player_component.dm
+++ b/code/modules/capture_the_flag/ctf_player_component.dm
@@ -24,10 +24,10 @@
 	ckey_reference = player_mob.ckey
 	register_mob()
 
-/datum/component/ctf_player/PostTransfer()
-	if(!istype(parent, /datum/mind))
+/datum/component/ctf_player/PostTransfer(datum/new_parent)
+	if(!istype(new_parent, /datum/mind))
 		return COMPONENT_INCOMPATIBLE
-	var/datum/mind/true_parent = parent
+	var/datum/mind/true_parent = new_parent
 	player_mob = true_parent.current
 	register_mob()
 


### PR DESCRIPTION
## About The Pull Request

Since #87866 PostTransfer now has it's parent set to nil, and instead has a `datum/new_parent` argument supplied to it.
Why does the ***post*** transfer proc not have it's parent set yet? Not sure, but some procs (and the documentation) haven't been adjusted yet and this PR fixes that

also:
fixes #88156 
fixes #88325 

## Why It's Good For The Game

Fix man good...

## Changelog

:cl:
fix: /datum/component/PostTransfer() procs that didn't have their new_parent arguments have now been fixed
fix: This means that turning into a Domain gondola shouldn't RR people anymore
/:cl: