### PR TITLE
Fix anomaly shifter deleting global themes

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -828,7 +828,6 @@
 	var/datum/dimension_theme/shifter = SSmaterials.dimensional_themes[new_theme_path]
 	for(var/turf/shiftee in range(1, user))
 		shifter.apply_theme(shiftee, show_effect = TRUE)
-	qdel(shifter)
 	// prevent *total* spam conversion
 	min_cooldown += 2 SECONDS
 	max_cooldown += 2 SECONDS


### PR DESCRIPTION

## About The Pull Request
Makes the dimensional shifter relic not delete global data.
## Why It's Good For The Game
We need those. Please don't delete those.
## Changelog
:cl:
fix: Dimensional shifter relics work more reliably.
/:cl:
