### PR TITLE
display actual round time in stat panel and ESC menu, replace all round time calculation with existing macro

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -2,7 +2,7 @@
 #define MIDNIGHT_ROLLOVER 864000
 
 ///displays the current time into the round, with a lot of extra code just there for ensuring it looks okay after an entire day passes
-#define ROUND_TIME(...) ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
+#define ROUND_TIME(...) ( "[STATION_TIME_PASSED() > MIDNIGHT_ROLLOVER ? "[round((STATION_TIME_PASSED())/MIDNIGHT_ROLLOVER)]:[roundtime2text()]" : roundtime2text()]" )
 
 ///Returns the time that has passed since the game started
 #define STATION_TIME_PASSED(...) (world.time - SSticker.round_start_time)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -337,7 +337,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 		var/statspage = CONFIG_GET(string/roundstatsurl)
 		var/info = statspage ? "<a href='?action=openLink&link=[url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
 		parts += "[FOURSPACES]Round ID: <b>[info]</b>"
-	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B>"
+	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(STATION_TIME_PASSED())]</B>"
 	parts += "[FOURSPACES]Station Integrity: <B>[GLOB.station_was_nuked ? span_redtext("Destroyed") : "[popcount["station_integrity"]]%"]</B>"
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -2,6 +2,9 @@
 /proc/worldtime2text()
 	return gameTimestamp("hh:mm:ss", world.time)
 
+/proc/roundtime2text()
+	return gameTimestamp("hh:mm:ss", STATION_TIME_PASSED())
+
 /proc/time_stamp(format = "hh:mm:ss", show_ds)
 	var/time_string = time2text(world.timeofday, format)
 	return show_ds ? "[time_string]:[world.timeofday % 10]" : time_string

--- a/code/controllers/subsystem/dynamic/dynamic_midround_rolling.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_midround_rolling.dm
@@ -56,8 +56,8 @@
 			log_dynamic("FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
 			continue
 
-		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)
-			log_dynamic("FAIL: [ruleset] is trying to run too early. Minimum round time: [ruleset.minimum_round_time], current round time: [world.time - SSticker.round_start_time]")
+		if (ruleset.minimum_round_time > STATION_TIME_PASSED())
+			log_dynamic("FAIL: [ruleset] is trying to run too early. Minimum round time: [ruleset.minimum_round_time], current round time: [STATION_TIME_PASSED()]")
 			continue
 
 		// If admins have disabled dynamic from picking from the ghost pool

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
@@ -214,7 +214,7 @@
 	// As a consequence, latejoin heretics start out at a massive
 	// disadvantage if the round's been going on for a while.
 	// Let's give them some influence points when they arrive.
-	new_heretic.knowledge_points += round((world.time - SSticker.round_start_time) / new_heretic.passive_gain_timer)
+	new_heretic.knowledge_points += round((STATION_TIME_PASSED()) / new_heretic.passive_gain_timer)
 	// BUT let's not give smugglers a million points on arrival.
 	// Limit it to four missed passive gain cycles (4 points).
 	new_heretic.knowledge_points = min(new_heretic.knowledge_points, 5)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -655,11 +655,11 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 	var/rampupdelta = 5
 
 /datum/dynamic_ruleset/roundstart/meteor/rule_process()
-	if(nometeors || meteordelay > world.time - SSticker.round_start_time)
+	if(nometeors || meteordelay > STATION_TIME_PASSED())
 		return
 
 	var/list/wavetype = GLOB.meteors_normal
-	var/meteorminutes = (world.time - SSticker.round_start_time - meteordelay) / 10 / 60
+	var/meteorminutes = (STATION_TIME_PASSED() - meteordelay) / 10 / 60
 
 	if (prob(meteorminutes))
 		wavetype = GLOB.meteors_threatening

--- a/code/controllers/subsystem/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_unfavorable_situation.dm
@@ -42,7 +42,7 @@
 		if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
 			continue
 
-		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)
+		if (ruleset.minimum_round_time > STATION_TIME_PASSED())
 			continue
 
 		if(istype(ruleset, /datum/dynamic_ruleset/midround/from_ghosts) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -605,7 +605,7 @@ SUBSYSTEM_DEF(job)
 	var/timegate_expired = FALSE
 	// allow only forcing deadminning in the first X seconds of the round if auto_deadmin_timegate is set in config
 	var/timegate = CONFIG_GET(number/auto_deadmin_timegate)
-	if(timegate && (world.time - SSticker.round_start_time > timegate))
+	if(timegate && (STATION_TIME_PASSED() > timegate))
 		timegate_expired = TRUE
 
 	if(!job)

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(nightshift)
 	if(resumed)
 		update_nightshift(resumed = TRUE)
 		return
-	if(world.time - SSticker.round_start_time < nightshift_first_check)
+	if(STATION_TIME_PASSED() < nightshift_first_check)
 		return
 	check_nightshift()
 

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -318,8 +318,8 @@ SUBSYSTEM_DEF(shuttle)
 /// Returns TRUE if we can. Otherwise, returns a string detailing the problem.
 /datum/controller/subsystem/shuttle/proc/canEvac()
 	var/shuttle_refuel_delay = CONFIG_GET(number/shuttle_refuel_delay)
-	if(world.time - SSticker.round_start_time < shuttle_refuel_delay)
-		return "The emergency shuttle is refueling. Please wait [DisplayTimeText(shuttle_refuel_delay - (world.time - SSticker.round_start_time))] before attempting to call."
+	if(STATION_TIME_PASSED() < shuttle_refuel_delay)
+		return "The emergency shuttle is refueling. Please wait [DisplayTimeText(shuttle_refuel_delay - (STATION_TIME_PASSED()))] before attempting to call."
 
 	switch(emergency.mode)
 		if(SHUTTLE_RECALL)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(statpanels)
 			cached ? "Next Map: [cached.map_name]" : null,
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
-			"Round Time: [ROUND_TIME()]",
+			"[SSticker.round_start_time ? "Round Time" : "Lobby Time"]: [ROUND_TIME()]",
 			"Station Time: [station_time_timestamp()]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
 		)

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -288,8 +288,8 @@
 		return
 
 	if(ispath(rune_to_scribe, /obj/effect/rune/apocalypse))
-		if((world.time - SSticker.round_start_time) <= 6000)
-			var/wait = 6000 - (world.time - SSticker.round_start_time)
+		if((STATION_TIME_PASSED()) <= 6000)
+			var/wait = 6000 - (STATION_TIME_PASSED())
 			to_chat(cultist, span_cult_italic("The veil is not yet weak enough for this rune - it will be available in [DisplayTimeText(wait)]."))
 			return
 		if(!check_if_in_ritual_site(cultist, user_team, TRUE))

--- a/code/datums/components/evolutionary_leap.dm
+++ b/code/datums/components/evolutionary_leap.dm
@@ -24,7 +24,7 @@
 		return
 
 	//if the round has already taken long enough, just leap right away.
-	if((world.time - SSticker.round_start_time) > evolve_mark)
+	if((STATION_TIME_PASSED()) > evolve_mark)
 		leap(silent = TRUE)
 		return
 
@@ -44,8 +44,8 @@
 	setup_timer()
 
 /datum/component/evolutionary_leap/proc/setup_timer()
-	//in cases where this is calculating roundstart, world.time - SSticker.round_start_time should equal 0
-	var/sum = (world.time - SSticker.round_start_time)
+	//in cases where this is calculating roundstart, STATION_TIME_PASSED() should equal 0
+	var/sum = (STATION_TIME_PASSED())
 	var/mark = evolve_mark - sum
 	timer_id = addtimer(CALLBACK(src, PROC_REF(leap), FALSE), mark, TIMER_STOPPABLE)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -561,7 +561,7 @@ Behavior that's still missing from this component that original food items had t
 			gourmand.add_mob_memory(/datum/memory/good_food, food = parent)
 
 	//Bruh this breakfast thing is cringe and shouldve been handled separately from food-types, remove this in the future (Actually, just kill foodtypes in general)
-	if((foodtypes & BREAKFAST) && world.time - SSticker.round_start_time < STOP_SERVING_BREAKFAST)
+	if((foodtypes & BREAKFAST) && STATION_TIME_PASSED() < STOP_SERVING_BREAKFAST)
 		gourmand.add_mood_event("breakfast", /datum/mood_event/breakfast)
 	last_check_time = world.time
 

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -96,7 +96,7 @@
 		return
 	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Round Status</title></head><body><h1><B>Round Status</B></h1>")
 	dat += "<a href='?_src_=holder;[HrefToken()];gamemode_panel=1'>Game Mode Panel</a><br>"
-	dat += "Round Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B><BR>"
+	dat += "Round Duration: <B>[DisplayTimeText(STATION_TIME_PASSED())]</B><BR>"
 	dat += "<B>Emergency shuttle</B><BR>"
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		dat += "<a href='?_src_=holder;[HrefToken()];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time - SSticker.round_start_time)] to decide.", "Declare war?", list("Yes", "No"))
+	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - STATION_TIME_PASSED())] to decide.", "Declare war?", list("Yes", "No"))
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
@@ -152,7 +152,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(!user.onSyndieBase())
 		to_chat(user, span_boldwarning("You have to be at your base to use this."))
 		return FALSE
-	if(world.time - SSticker.round_start_time > CHALLENGE_TIME_LIMIT)
+	if(STATION_TIME_PASSED() > CHALLENGE_TIME_LIMIT)
 		to_chat(user, span_boldwarning("It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."))
 		return FALSE
 	for(var/obj/item/circuitboard/computer/syndicate_shuttle/board as anything in GLOB.syndicate_shuttle_boards)

--- a/code/modules/antagonists/wizard/grand_ritual/finales/grand_ritual_finale.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/finales/grand_ritual_finale.dm
@@ -27,8 +27,8 @@
 	if (!name || !desc || !icon || !icon_state)
 		return
 	var/time_remaining_desc = ""
-	if (minimum_time >= world.time - SSticker.round_start_time)
-		time_remaining_desc = " <i>This ritual will be available to begin invoking in [DisplayTimeText(minimum_time - world.time - SSticker.round_start_time)]</i>"
+	if (minimum_time >= STATION_TIME_PASSED())
+		time_remaining_desc = " <i>This ritual will be available to begin invoking in [DisplayTimeText(minimum_time - STATION_TIME_PASSED())]</i>"
 	var/datum/radial_menu_choice/choice = new()
 	choice.name = name
 	choice.image = image(icon = icon, icon_state = icon_state)

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -308,7 +308,7 @@
 	if (!chosen_effect)
 		select_finale(user)
 		return
-	var/round_time_passed = world.time - SSticker.round_start_time
+	var/round_time_passed = STATION_TIME_PASSED()
 	if (chosen_effect && finale_effect.minimum_time >= round_time_passed)
 		to_chat(user, span_warning("The chosen grand finale will only be available in <b>[DisplayTimeText(finale_effect.minimum_time - round_time_passed)]</b>!"))
 		return

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -16,12 +16,12 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 
 /* Can a gateway link to this destination right now. */
 /datum/gateway_destination/proc/is_available()
-	return enabled && (world.time - SSticker.round_start_time >= wait)
+	return enabled && (STATION_TIME_PASSED() >= wait)
 
 /* Returns user-friendly description why you can't connect to this destination, displayed in UI */
 /datum/gateway_destination/proc/get_available_reason()
 	. = "Unreachable"
-	if(world.time - SSticker.round_start_time < wait)
+	if(STATION_TIME_PASSED() < wait)
 		playsound(src, 'sound/machines/gateway/gateway_calibrating.ogg', 80, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		. = "Connection desynchronized. Recalibration in progress."
 
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 	.["available"] = is_available()
 	.["reason"] = get_available_reason()
 	if(wait)
-		.["timeout"] = max(1 - (wait - (world.time - SSticker.round_start_time)) / wait, 0)
+		.["timeout"] = max(1 - (wait - (STATION_TIME_PASSED())) / wait, 0)
 
 /* Destination is another gateway */
 /datum/gateway_destination/gateway

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -314,7 +314,7 @@
 		return
 	// We only allow people to actually buy the shuttle once the round gets going - otherwise you'd just be able to do it roundstart (Not really intended)
 	var/minimum_allowed_purchase_time = (CONFIG_GET(number/shuttle_refuel_delay) * 0.6)
-	if((world.time - SSticker.round_start_time) > minimum_allowed_purchase_time)
+	if((STATION_TIME_PASSED()) > minimum_allowed_purchase_time)
 		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_SCRAPHEAP] = TRUE
 	else
 		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_SCRAPHEAP] = FALSE

--- a/code/modules/escape_menu/details.dm
+++ b/code/modules/escape_menu/details.dm
@@ -34,7 +34,7 @@ GLOBAL_DATUM(escape_menu_details, /atom/movable/screen/escape_menu/details)
 	var/new_maptext = {"
 		<span style='text-align: right; line-height: 0.7'>
 			Round ID: [GLOB.round_id || "Unset"]<br />
-			Round Time: [ROUND_TIME()]<br />
+			[SSticker.round_start_time ? "Round Time" : "Lobby Time"]: [ROUND_TIME()]<br />
 			Map: [SSmapping.current_map.map_name || "Loading..."]<br />
 			Time Dilation: [round(SStime_track.time_dilation_current,1)]%<br />
 		</span>

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -43,7 +43,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 	var/list/departments = list()
 	var/list/data = list(
 		"disable_jobs_for_non_observers" = SSlag_switch.measures[DISABLE_NON_OBSJOBS],
-		"round_duration" = DisplayTimeText(world.time - SSticker.round_start_time, round_seconds_to = 1),
+		"round_duration" = DisplayTimeText(STATION_TIME_PASSED(), round_seconds_to = 1),
 		"departments" = departments,
 	)
 	if(SSshuttle.emergency)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -42,7 +42,7 @@
 		return FALSE
 	var/mob/living/carbon/human/gourmand = eater
 	//Bruh this breakfast thing is cringe and shouldve been handled separately from food-types, remove this in the future (Actually, just kill foodtypes in general)
-	if((drink_type & BREAKFAST) && world.time - SSticker.round_start_time < STOP_SERVING_BREAKFAST)
+	if((drink_type & BREAKFAST) && STATION_TIME_PASSED() < STOP_SERVING_BREAKFAST)
 		gourmand.add_mood_event("breakfast", /datum/mood_event/breakfast)
 	last_check_time = world.time
 


### PR DESCRIPTION
## About The Pull Request

ROUND_TIME() macro will now return actual time into the round, not the `world.time`
All calculations of round time were replaced with existing `STATION_TIME_PASSED()` macro

Replaced `Round time` in stat panel and ESC menu to `Lobby time`, if round hasn't started yet.

<details>

![image](https://github.com/user-attachments/assets/806b071a-f308-47f9-b8b9-a7af00cdb321)
<summary>
Lobby time in stat panel and ESC menu
</summary>
</details>

<details>

![image](https://github.com/user-attachments/assets/efdd5fd6-32fa-47ab-a709-6605ce50bb18)

<summary>
Round time in stat panel and lobby menu
</summary>
</details>

## Why It's Good For The Game

Almost nothing player facing, but `round time` will not include time spent in the lobby.
When in lobby - `Round time` is replaced with `Lobby time`

## Changelog

:cl:
qol: `Round time` in stat panel and ESC menu will display actual time into the round, and is replaced with `Lobby time`, if round hasn't started yet
code: ROUND_TIME() macro will now return actual time into the round, not the `world.time`
code: All calculations of round time were replaced with existing `STATION_TIME_PASSED()` macro
/:cl:
