### PR TITLE
[NO GBP] Hotfix for CI flaky due to the spacemove fix

### DIFF
--- a/code/controllers/subsystem/movement/newtonian_movement.dm
+++ b/code/controllers/subsystem/movement/newtonian_movement.dm
@@ -38,6 +38,9 @@ MOVEMENT_SUBSYSTEM_DEF(newtonian_movement)
 		pour_bucket(bucket_info)
 
 /datum/controller/subsystem/movement/newtonian_movement/proc/fire_moveloop(datum/move_loop/loop)
+	// Loop isn't even running right now
+	if(!(loop.status & MOVELOOP_STATUS_QUEUED) || isnull(loop.queued_time))
+		return
 	// Drop the loop, process it, and if its still valid - queue it again
 	dequeue_loop(loop)
 	loop.process()


### PR DESCRIPTION
## About The Pull Request

We don't check if the loop is actually queued as we attempt to remove, fire and queue it, which makes our loop potentially run in parallel with a higher priority loop, which (for some reason specifically on during engiborg tests and specifically on wawa) was causing a flaky CI failure.

Closes #88400

## Changelog
:cl:
/:cl:
