### PR TITLE
multitile airlock assemblies from a broken multitile airlock are the same direction

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1549,6 +1549,7 @@
 	assembly.previous_assembly = previous_airlock
 	assembly.update_name()
 	assembly.update_appearance()
+	assembly.dir = dir
 
 /obj/machinery/door/airlock/on_deconstruction(disassembled)
 	var/obj/structure/door_assembly/A
@@ -2464,6 +2465,10 @@
 	multi_tile = TRUE
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/multi_tile/setDir(newdir)
+	. = ..()
+	set_bounds()
 
 /obj/structure/fluff/airlock_filler
 	name = "airlock fluff"


### PR DESCRIPTION

## About The Pull Request

multitile airlock assemblies from a broken multitile airlock are the same direction

## Why It's Good For The Game

fixes #81406

## Changelog
:cl:
fix: multitile airlock assemblies from a broken multitile airlock are the same direction
/:cl:
