### PR TITLE
Removes empty overlay from airlocks when lights not needed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -545,7 +545,7 @@
 	else
 		. += get_airlock_overlay("fill_[frame_state]", icon, src, em_block = TRUE)
 
-	if(lights && hasPower())
+	if(lights && hasPower() && light_state)
 		. += get_airlock_overlay("lights_[light_state]", overlays_file, src, em_block = FALSE)
 
 	if(panel_open)


### PR DESCRIPTION

## About The Pull Request
Adds a check if there should be light_state overlay present. It was adding an empty overlay `lights_`.
Found by adding a "no_name" error icon_state for overlays.

## Why It's Good For The Game
Bug fixing good