### PR TITLE
Fixes two mech power issues caused by megacell rework

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -274,7 +274,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	flick("shield_impact", src)
 	if(!.)
 		return
-	if(!chassis.use_energy(. * (STANDARD_CELL_CHARGE / 15)))
+	if(!chassis.use_energy(. * (STANDARD_CELL_CHARGE / 150)))
 		chassis.cell?.charge = 0
 		for(var/O in chassis.occupants)
 			var/mob/living/occupant = O

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -285,7 +285,7 @@
 	///Maximum fuel capacity of the generator, in units
 	var/max_fuel = 75 * SHEET_MATERIAL_AMOUNT
 	///Energy recharged per second
-	var/rechargerate = 0.005 * STANDARD_CELL_RATE
+	var/rechargerate = 0.05 * STANDARD_CELL_RATE
 
 /obj/item/mecha_parts/mecha_equipment/generator/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
…'s production in line with the megacell rework.
## About The Pull Request

The durand's shield and the mech plasma generator never got their values adjusted with the power rework. this led to 15 shots (a mag from a laser smg) instantly draining the cell if it hits the durand's shield, ten times more than normal. Also, the plasma generator's power never got increased proportionally, meaning every second it recharged a tenth of what it was meant to.

## Why It's Good For The Game

Fixes yet another thing broken by making the base power unit ten times higher than previously.

## Changelog


:cl: WebcomicArtist
fix: Durand shield now uses proper amount of power upon taking damage
fix: Mech plasma generator now produces the correct amount of charge, previously bugged to be 10% of intended.
/:cl:
