### PR TITLE
living mobs will display an examine message if they look at another mob

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -525,6 +525,11 @@
 	face_atom(examinify)
 	var/result_combined
 	if(client)
+		if(isliving(examinify) && isliving(src) && !issilicon(src) && TIMER_COOLDOWN_FINISHED(src, "[src]_examine_message_cooldown_for_[examinify]"))
+			var/mob/living/examiner = src
+			var/combat_intent_active = examiner.combat_mode
+			examiner.visible_message(span_notice("[examiner] [combat_intent_active ? pick("stares at", "glares at", "oggles at") : pick("glances at", "looks at", "takes a look at", "examines", "inspects")] [examinify][combat_intent_active ? "!" : "."]"))
+			TIMER_COOLDOWN_START(examiner, "[src]_examine_message_cooldown_for_[examinify]", 1.5 SECONDS)
 		LAZYINITLIST(client.recent_examines)
 		var/ref_to_atom = REF(examinify)
 		var/examine_time = client.recent_examines[ref_to_atom]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -525,11 +525,11 @@
 	face_atom(examinify)
 	var/result_combined
 	if(client)
-		if(isliving(examinify) && isliving(src) && !issilicon(src) && TIMER_COOLDOWN_FINISHED(src, "[src]_examine_message_cooldown_for_[examinify]"))
+		if(isliving(examinify) && isliving(src) && !issilicon(src) && TIMER_COOLDOWN_FINISHED(src, "[src.name]_examine_message_cooldown_for_[examinify.name]"))
 			var/mob/living/examiner = src
 			var/combat_intent_active = examiner.combat_mode
 			examiner.visible_message(span_notice("[examiner] [combat_intent_active ? pick("stares at", "glares at", "oggles at") : pick("glances at", "looks at", "takes a look at", "examines", "inspects")] [examinify][combat_intent_active ? "!" : "."]"))
-			TIMER_COOLDOWN_START(examiner, "[src]_examine_message_cooldown_for_[examinify]", 1.5 SECONDS)
+			TIMER_COOLDOWN_START(examiner, "[examiner.name]_examine_message_cooldown_for_[examinify.name]", 1.5 SECONDS)
 		LAZYINITLIST(client.recent_examines)
 		var/ref_to_atom = REF(examinify)
 		var/examine_time = client.recent_examines[ref_to_atom]


### PR DESCRIPTION

## About The Pull Request
- examining in combat mode will display one of these: `"stares at", "glares at", "oggles at"` and appends `!` to the end.
- examining in help mode will display one of these: `"glances at", "looks at", "takes a look at", "examines", "inspects"` and appends `.` to the end.
- examining as a silicon will not play the message (because they're using a camera).
- for example: `"John Smith takes a look at Nyapuru Uzaza."`, or in combat mode: `"John Smith glares at Nyapuru Uzaza!"`
- there is a cooldown for displaying this message of 1.5 seconds.
## Why It's Good For The Game
Neat lil' thing for immersion.
![black-stare](https://github.com/user-attachments/assets/90fb2ac9-cd32-4cb1-9a75-1d00084973ff)
## Changelog
:cl: grungussuss
qol: examining someone now plays a message to others around you
/:cl:
