### PR TITLE
makes resin sprayers use the right interact with atom proc

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -287,7 +287,7 @@
 			return
 	return
 
-/obj/item/extinguisher/mini/nozzle/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+/obj/item/extinguisher/mini/nozzle/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(AttemptRefill(interacting_with, user))
 		return NONE
 	if(nozzle_mode == EXTINGUISHER)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -287,9 +287,12 @@
 			return
 	return
 
-/obj/item/extinguisher/mini/nozzle/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+/obj/item/extinguisher/mini/nozzle/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(AttemptRefill(interacting_with, user))
 		return NONE
+	return ..()
+
+/obj/item/extinguisher/mini/nozzle/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(nozzle_mode == EXTINGUISHER)
 		return ..()
 


### PR DESCRIPTION

## About The Pull Request

Changes resin sprayers to do all their behavior on ranged_interact_with_atom rather than interact_with_atom, which makes resin sprayers actually do their intended behavior if you click on any tile more than one away from you.
## Why It's Good For The Game

Resin sprayers don't work at all unless you click a tile next to you without this.
## Changelog
:cl:
fix: Fixes resin sprayers not working if the target is more than one tile away from you
/:cl:
