### PR TITLE
Makes all antags visible to an admin in the orbit menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -104,7 +104,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		if(isliving(mob_poi))
 			serialized += get_living_data(mob_poi)
 
-		var/list/antag_data = get_antag_data(mob_poi.mind)
+		var/list/antag_data = get_antag_data(mob_poi.mind, user?.client?.holder)
 		if(length(antag_data))
 			serialized += antag_data
 			antagonists += list(serialized)
@@ -151,11 +151,11 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 
 /// Helper function to get threat type, group, overrides for job and icon
-/datum/orbit_menu/proc/get_antag_data(datum/mind/poi_mind) as /list
+/datum/orbit_menu/proc/get_antag_data(datum/mind/poi_mind, is_admin) as /list
 	var/list/serialized = list()
 
 	for(var/datum/antagonist/antag as anything in poi_mind.antag_datums)
-		if(!antag.show_to_ghosts)
+		if(!antag.show_to_ghosts && !is_admin)
 			continue
 
 		serialized["antag"] = antag.name


### PR DESCRIPTION
## About The Pull Request

As the title says, makes all antags visible to an admin in the orbit menu.

## Why It's Good For The Game

Makes it easier for admins to observe the round and act preventive in case an antagonist goes too far. A nice QOL addition.  

![cooltext471483565189453](https://github.com/user-attachments/assets/c0842cd6-5b4f-4abb-980e-1e7f9d404098)

## Changelog

:cl:
qol: Now all antagonists are visible to an admin in the orbit menu!
/:cl: 