### PR TITLE
Fixes *me emote running when using *help

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -671,6 +671,8 @@
 		to_chat(user, span_boldwarning("You cannot send IC messages (muted)."))
 		return FALSE
 
+/datum/emote/living/custom/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
 	var/our_message = params ? params : get_custom_emote_from_user()
 
 	if(!emote_is_valid(user, our_message))


### PR DESCRIPTION

## About The Pull Request
The code for running the *me emote was in the `can_run_emote` proc, which the *help emote uses to see if you can use an emote
closes https://github.com/tgstation/tgstation/issues/88323
## Changelog
:cl: grungussuss
fix: fixed *me emote being called when using the *help emote
/:cl:
