### PR TITLE
Fixes items not falling from a lattice's loc after it's deconstructed

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -34,6 +34,13 @@
 	. = ..()
 	. += deconstruction_hints(user)
 
+/obj/structure/lattice/Destroy(force)
+	var/turf/turfloc = loc
+	. = ..()
+	if(isturf(turfloc))
+		for(var/atom/movable/thing_that_falls in turfloc)
+			turfloc.zFall((thing_that_falls))
+
 /obj/structure/lattice/proc/deconstruction_hints(mob/user)
 	return span_notice("The rods look like they could be <b>cut</b>. There's space for more <i>rods</i> or a <i>tile</i>.")
 

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -38,7 +38,7 @@
 	var/turf/turfloc = loc
 	. = ..()
 	if(isturf(turfloc))
-		for(var/thing_that_falls as anything in turfloc) // as anything because loc can only contain movables
+		for(var/thing_that_falls as anything in turfloc) // as anything because turfloc can only contain movables
 			turfloc.zFall((thing_that_falls))
 
 /obj/structure/lattice/proc/deconstruction_hints(mob/user)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -34,11 +34,11 @@
 	. = ..()
 	. += deconstruction_hints(user)
 
-/obj/structure/lattice/Destroy(force)
+/obj/structure/lattice/Destroy(force) // so items on the lattice fall when the lattice is destroyed
 	var/turf/turfloc = loc
 	. = ..()
 	if(isturf(turfloc))
-		for(var/atom/movable/thing_that_falls in turfloc)
+		for(var/thing_that_falls as anything in turfloc) // as anything because loc can only contain movables
 			turfloc.zFall((thing_that_falls))
 
 /obj/structure/lattice/proc/deconstruction_hints(mob/user)


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/81060
## Changelog
:cl: grungussuss
fix: fixed items not falling from a lattice after being deconstructed/destroyed
/:cl:
