### PR TITLE
Fixes wendigo lag at cost of its attacks' visuals

### DIFF
--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -376,9 +376,9 @@
 /datum/action/cooldown/mob_cooldown/projectile_attack/alternating_circle/attack_sequence(mob/living/firer, atom/target)
 	wendigo_scream(firer)
 	if(enraged)
-		projectile_speed_multiplier = 1
+		projectile_type = /obj/projectile/colossus/wendigo_shockwave/enraged
 	else
-		projectile_speed_multiplier = 0.66
+		projectile_type = /obj/projectile/colossus/wendigo_shockwave
 	var/shots_per = 24
 	for(var/shoot_times in 1 to 8)
 		var/offset = shoot_times % 2
@@ -399,7 +399,7 @@
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/wave/attack_sequence(mob/living/firer, atom/target)
 	wendigo_scream(firer)
-	var/shots_per = 7
+	var/shots_per = 6
 	var/difference = 360 / shots_per
 	var/wave_direction = pick(-1, 1)
 	switch(wave_direction)
@@ -407,9 +407,9 @@
 			projectile_type = /obj/projectile/colossus/wendigo_shockwave/wave/alternate
 		if(1)
 			projectile_type = /obj/projectile/colossus/wendigo_shockwave/wave
-	for(var/shoot_times in 1 to 32)
+	for(var/shoot_times in 1 to 16)
 		for(var/shot in 1 to shots_per)
 			var/angle = shot * difference + shoot_times * 5 * wave_direction * -1
 			shoot_projectile(firer, target, angle, firer, null, null)
-		SLEEP_CHECK_DEATH(2, firer)
+		SLEEP_CHECK_DEATH(0.6 SECONDS, firer)
 	SLEEP_CHECK_DEATH(3 SECONDS, firer)

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -376,9 +376,9 @@
 /datum/action/cooldown/mob_cooldown/projectile_attack/alternating_circle/attack_sequence(mob/living/firer, atom/target)
 	wendigo_scream(firer)
 	if(enraged)
-		projectile_type = /obj/projectile/colossus/wendigo_shockwave/enraged
+		projectile_speed_multiplier = 1
 	else
-		projectile_type = /obj/projectile/colossus/wendigo_shockwave
+		projectile_speed_multiplier = 0.66
 	var/shots_per = 24
 	for(var/shoot_times in 1 to 8)
 		var/offset = shoot_times % 2

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -407,7 +407,7 @@
 			projectile_type = /obj/projectile/colossus/wendigo_shockwave/wave/alternate
 		if(1)
 			projectile_type = /obj/projectile/colossus/wendigo_shockwave/wave
-	for(var/shoot_times in 1 to 16)
+	for(var/shoot_times in 1 to 12)
 		for(var/shot in 1 to shots_per)
 			var/angle = shot * difference + shoot_times * 5 * wave_direction * -1
 			shoot_projectile(firer, target, angle, firer, null, null)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -198,15 +198,12 @@ Difficulty: Hard
 
 /obj/projectile/colossus/wendigo_shockwave
 	name = "wendigo shockwave"
-	speed = 0.3
+	speed = 0.5
 
 	/// Amount the angle changes every pixel move
 	var/wave_speed = 0.5
 	/// Amount of movements this projectile has made
 	var/pixel_moves = 0
-
-/obj/projectile/colossus/wendigo_shockwave/enraged
-	speed = 0.5
 
 /obj/projectile/colossus/wendigo_shockwave/spiral
 	damage = 15

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -198,25 +198,31 @@ Difficulty: Hard
 
 /obj/projectile/colossus/wendigo_shockwave
 	name = "wendigo shockwave"
-	speed = 0.5
+	speed = 0.3
+
 	/// Amount the angle changes every pixel move
 	var/wave_speed = 0.5
 	/// Amount of movements this projectile has made
 	var/pixel_moves = 0
+
+/obj/projectile/colossus/wendigo_shockwave/enraged
+	speed = 0.5
 
 /obj/projectile/colossus/wendigo_shockwave/spiral
 	damage = 15
 
 /obj/projectile/colossus/wendigo_shockwave/wave
 	speed = 0.125
-	homing = TRUE
 	wave_speed = 0.3
 
 /obj/projectile/colossus/wendigo_shockwave/wave/alternate
 	wave_speed = -0.3
 
-/obj/projectile/colossus/wendigo_shockwave/process_homing()
-	pixel_moves++
+/obj/projectile/colossus/wendigo_shockwave/process_movement(pixels_to_move, hitscan, tile_limit)
+	. = ..()
+	if (QDELETED(src))
+		return
+	pixel_moves += .
 	set_angle(original_angle + pixel_moves * wave_speed)
 
 /obj/item/wendigo_blood

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -198,7 +198,7 @@ Difficulty: Hard
 
 /obj/projectile/colossus/wendigo_shockwave
 	name = "wendigo shockwave"
-	speed = 0.3
+	speed = 0.5
 
 	/// Amount the angle changes every pixel move
 	var/wave_speed = 0.5

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -198,7 +198,7 @@ Difficulty: Hard
 
 /obj/projectile/colossus/wendigo_shockwave
 	name = "wendigo shockwave"
-	speed = 0.5
+	speed = 0.3
 
 	/// Amount the angle changes every pixel move
 	var/wave_speed = 0.5


### PR DESCRIPTION
## About The Pull Request

This is very ugly but we're trading in-loop angle setting/refreshing and animates in favor of out-loop ones, doing so should cut down on the amount of animates we're calling which are all sent to clients which ramps up their ping into thousands and lags them clientside to all hell.
I've also significantly (x3) increased the delay between shots, since they move so slow the distance between them won't get large enough for you to squeeze through in a tiny arena, which should also help with lag massively.

Ideally we should get rid of projectiles here and make it use some other way, maybe dust clouds?

https://github.com/user-attachments/assets/0480cd3a-4e82-4d80-833c-a2ca4eefed53

Downside of this approach: the attack now looks significantly jankier
The upside of this approach: You can somewhat clearly see which tile the projectile is on

## Why It's Good For The Game

It lags everyone who sees it

Closes #88395

## Changelog
:cl:
fix: Made wendigo's bullet hell lag less, at cost of its visuals.
/:cl:
