### PR TITLE
[NO GBP] Fixes moths only being able to fly if they spawn in zero gravity

### DIFF
--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -206,7 +206,7 @@
 	if (get_dir(source, backup) == movement_dir || source.loc == backup.loc)
 		return
 
-	if (!source.client?.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
+	if (!source.client?.intended_direction || source.client.intended_direction == get_dir(source, backup))
 		return
 
 	if (isnull(source.drift_handler))

--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -3,8 +3,10 @@
 // So propulsion through space on move, that sort of thing
 /datum/component/jetpack
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	/// Checks to ensure if we can move & if we can activate
+	/// Checks to ensure if we can move
 	var/datum/callback/check_on_move
+	/// Checks to ensure we can activate
+	var/datum/callback/check_on_activation
 	/// If we should stabilize ourselves when not drifting
 	var/stabilize = FALSE
 	/// The signal we listen for as an activation
@@ -39,7 +41,7 @@
  * * check_on_move - Callback we call each time we attempt a move, we expect it to retun true if the move is ok, false otherwise. It expects an arg, TRUE if fuel should be consumed, FALSE othewise
  * * effect_type - Type of trail_follow to spawn
  */
-/datum/component/jetpack/Initialize(stabilize, drift_force = 1 NEWTONS, stabilization_force = 1 NEWTONS, activation_signal, deactivation_signal, return_flag, datum/callback/check_on_move, datum/effect_system/trail_follow/effect_type)
+/datum/component/jetpack/Initialize(stabilize, drift_force = 1 NEWTONS, stabilization_force = 1 NEWTONS, activation_signal, deactivation_signal, return_flag, datum/callback/check_on_move, datum/callback/check_on_activation, datum/effect_system/trail_follow/effect_type)
 	. = ..()
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -52,6 +54,7 @@
 
 	src.stabilize = stabilize
 	src.check_on_move = check_on_move
+	src.check_on_activation = check_on_activation
 	src.activation_signal = activation_signal
 	src.deactivation_signal = deactivation_signal
 	src.return_flag = return_flag
@@ -59,7 +62,7 @@
 	src.drift_force = drift_force
 	src.stabilization_force = stabilization_force
 
-/datum/component/jetpack/InheritComponent(datum/component/component, original, stabilize, drift_force = 1 NEWTONS, stabilization_force = 1 NEWTONS, activation_signal, deactivation_signal, return_flag, datum/callback/check_on_move, datum/effect_system/trail_follow/effect_type)
+/datum/component/jetpack/InheritComponent(datum/component/component, original, stabilize, drift_force = 1 NEWTONS, stabilization_force = 1 NEWTONS, activation_signal, deactivation_signal, return_flag, datum/callback/check_on_move, datum/callback/check_on_activation, datum/effect_system/trail_follow/effect_type)
 	UnregisterSignal(parent, src.activation_signal)
 	if(src.deactivation_signal)
 		UnregisterSignal(parent, src.deactivation_signal)
@@ -69,6 +72,7 @@
 
 	src.stabilize = stabilize
 	src.check_on_move = check_on_move
+	src.check_on_activation = check_on_activation
 	src.activation_signal = activation_signal
 	src.deactivation_signal = deactivation_signal
 	src.return_flag = return_flag
@@ -84,6 +88,7 @@
 		QDEL_NULL(trail)
 	user = null
 	check_on_move = null
+	check_on_activation = null
 	return ..()
 
 /datum/component/jetpack/proc/setup_trail(mob/user)
@@ -97,7 +102,7 @@
 /datum/component/jetpack/proc/activate(datum/source, mob/new_user)
 	SIGNAL_HANDLER
 
-	if(!check_on_move.Invoke(TRUE))
+	if(!isnull(check_on_activation) && !check_on_activation.Invoke())
 		return return_flag
 
 	user = new_user
@@ -202,6 +207,9 @@
 		return
 
 	if (!source.client?.intended_direction || (source.client.intended_direction & get_dir(source, backup)))
+		return
+
+	if (isnull(source.drift_handler))
 		return
 
 	if (!should_trigger(source) || !check_on_move.Invoke(FALSE))

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -53,6 +53,7 @@
 		COMSIG_JETPACK_DEACTIVATED, \
 		JETPACK_ACTIVATION_FAILED, \
 		thrust_callback, \
+		thrust_callback, \
 		/datum/effect_system/trail_follow/ion, \
 	)
 

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -143,6 +143,7 @@
 		COMSIG_MODULE_DEACTIVATED, \
 		MOD_ABORT_USE, \
 		thrust_callback, \
+		thrust_callback, \
 		/datum/effect_system/trail_follow/ion/grav_allowed, \
 	)
 

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -43,6 +43,7 @@
 		COMSIG_WINGS_CLOSED, \
 		null, \
 		CALLBACK(src, PROC_REF(can_fly)), \
+		CALLBACK(src, PROC_REF(can_fly)), \
 	)
 
 /obj/item/organ/wings/functional/Destroy()

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -30,6 +30,7 @@
 		COMSIG_ORGAN_REMOVED, \
 		null, \
 		CALLBACK(src, PROC_REF(allow_flight)), \
+		null, \
 	)
 
 /obj/item/organ/wings/moth/on_mob_insert(mob/living/carbon/receiver)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -175,6 +175,7 @@
 		COMSIG_THRUSTER_DEACTIVATED, \
 		THRUSTER_ACTIVATION_FAILED, \
 		CALLBACK(src, PROC_REF(allow_thrust), 0.01), \
+		CALLBACK(src, PROC_REF(allow_thrust), 0.01), \
 		/datum/effect_system/trail_follow/ion, \
 	)
 


### PR DESCRIPTION
## About The Pull Request
Moth wings prevent you from flying in gravity -> same check is used for activation -> they're activated upon implanting -> unless you spawn or get wings in zero-g you're screwed
Closes #88460
Closes #88457

## Changelog
:cl:
fix: Fixed moths only being able to fly if they spawn in zero gravity
/:cl:
