### PR TITLE
[NO GBP] Fixes toolboxes automatically using the first item, allows placing them on/into tables/racks/closets/crates

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -26,7 +26,7 @@
 	/// How many interactions are we currently performing
 	var/current_interactions = 0
 	/// Items we should not interact with when left clicking
-	var/static/list/lmb_exception_typecache = list(typecacheof(
+	var/static/list/lmb_exception_typecache = typecacheof(list(
 		/obj/structure/table,
 		/obj/structure/rack,
 		/obj/structure/closet,

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -30,6 +30,7 @@
 		/obj/structure/table,
 		/obj/structure/rack,
 		/obj/structure/closet,
+		/obj/structure/disposal,
 	))
 
 /obj/item/storage/toolbox/Initialize(mapload)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -25,6 +25,12 @@
 	wound_bonus = 5
 	/// How many interactions are we currently performing
 	var/current_interactions = 0
+	/// Items we should not interact with when left clicking
+	var/static/list/lmb_exception_typecache = list(typecacheof(
+		/obj/structure/table,
+		/obj/structure/rack,
+		/obj/structure/closet,
+	))
 
 /obj/item/storage/toolbox/Initialize(mapload)
 	. = ..()
@@ -45,6 +51,9 @@
 	if (user.combat_mode || !user.has_hand_for_held_index(user.get_inactive_hand_index()))
 		return NONE
 
+	if (is_type_in_typecache(interacting_with, lmb_exception_typecache) && !LAZYACCESS(modifiers, RIGHT_CLICK))
+		return NONE
+
 	if (current_interactions)
 		var/obj/item/other_tool = user.get_inactive_held_item()
 		if (!istype(other_tool)) // what even
@@ -60,7 +69,6 @@
 	for (var/obj/item/tool in atom_storage.real_location)
 		if(is_type_in_list(tool, GLOB.tool_items))
 			item_radial[tool] = tool.appearance
-			break
 
 	if (!length(item_radial))
 		return NONE

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -30,7 +30,7 @@
 		/obj/structure/table,
 		/obj/structure/rack,
 		/obj/structure/closet,
-		/obj/structure/disposal,
+		/obj/machinery/disposal,
 	))
 
 /obj/item/storage/toolbox/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

Closes #88446	
I swear to god I should stop listening to webedit suggestions

## Changelog
:cl:
fix: Toolboxes can now be placed onto tables/into crates
fix: Fixed toolboxes automatically using the first item in them
/:cl:
