### PR TITLE
Add run_all_tests and run_alternate_tests to the completion gate needs

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -287,7 +287,7 @@ jobs:
   completion_gate: # Serves as a non-moving target for branch rulesets
     if: always() && !cancelled()
     name: Completion Gate
-    needs: [ test_windows, compare_screenshots, compile_all_maps, run_linters ]
+    needs: [ test_windows, compare_screenshots, compile_all_maps, run_all_tests, run_alternate_tests, run_linters ]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
Long story short: tgstation/tgstation#88417 let stuff be merged even if the tests didn't pass.

Long story: because the final, completion gate step didn't need them. It's actually the compare screenshot step - in turn needed by the completion gate - that needs those, but it would so happen that if the tests failed, it would be skipped, and since that PR made it possible for PRs to be merged even if the compare screenshots steps is skipped... you can see where this goes:

![immagine](https://github.com/user-attachments/assets/06cd6625-4a7e-4e45-87cd-78209cc60f1c)


This is basically a better solution than reverting a good faith change.