### PR TITLE
Carbons and Robots indicate they can be dragged onto (with a slight mouse cursor change)

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,6 +11,7 @@
 	usable_hands = 0 //Populated on init through list/bodyparts
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT
 	blocks_emissive = EMISSIVE_BLOCK_NONE
+	mouse_drop_zone = TRUE
 	// STOP_OVERLAY_UPDATE_BODY_PARTS is removed after we call update_body_parts() during init.
 	living_flags = ALWAYS_DEATHGASP|STOP_OVERLAY_UPDATE_BODY_PARTS
 	///List of [/obj/item/organ]s in the mob. They don't go in the contents for some reason I don't want to know.

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -16,6 +16,7 @@
 	has_limbs = TRUE
 	hud_type = /datum/hud/robot
 	unique_name = TRUE
+	mouse_drop_zone = TRUE
 
 	///Represents the cyborg's model (engineering, medical, etc.)
 	var/obj/item/robot_model/model = null


### PR DESCRIPTION
## About The Pull Request

While dragging another object (with your cursor, not physically), your mouse cursor updates when hovering over carbons(humans) and robots(cyborgs)

https://github.com/user-attachments/assets/47b664c4-a599-450d-a473-18e1b539ced4


## Why It's Good For The Game

Attempts to better signpost when you're hovering over your player character, rather than the floor. Reduces pixelhunting and mis-drops

## Changelog

:cl: Melbert
qol: When dragging an item (like, with your mouse cursor. not physically), your cursor updates when hovering humans or cyborgs to indicate you're hovering over a human or cyborg. 
/:cl:

