### PR TITLE
The Chairening: Chairs can break when used to block. Alters how chairs stun when smashed over someones head.

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -165,7 +165,7 @@
 	name = "wooden chair"
 	desc = "Old is never too old to not be in fashion."
 	resistance_flags = FLAMMABLE
-	max_integrity = 50
+	max_integrity = 40
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 3
 	item_chair = /obj/item/chair/wood
@@ -306,7 +306,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	desc = "A makeshift bamboo stool with a rustic look."
 	icon_state = "bamboo_stool"
 	resistance_flags = FLAMMABLE
-	max_integrity = 50
+	max_integrity = 40
 	buildstacktype = /obj/item/stack/sheet/mineral/bamboo
 	buildstackamount = 2
 	item_chair = /obj/item/chair/stool/bamboo
@@ -402,7 +402,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	var/mob/living/carbon/human/give_this_fucker_the_chair = target
 
 	// Here we determine if our attack is against a vulnerable target
-	var/vulnerable_hit = (check_behind(user, give_this_fucker_the_chair) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
+	var/vulnerable_hit = check_behind(user, give_this_fucker_the_chair)
 
 	// If our attack is against a vulnerable target, we do additional damage to the chair
 	var/damage_to_inflict = vulnerable_hit ? (force * 5) : (force * 2.5)
@@ -411,12 +411,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 		return
 
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [give_this_fucker_the_chair]"))
-	if(!HAS_TRAIT(give_this_fucker_the_chair, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) && vulnerable_hit)
-		give_this_fucker_the_chair.Knockdown(2 SECONDS)
-		if(give_this_fucker_the_chair.health < give_this_fucker_the_chair.maxHealth*0.5)
-			give_this_fucker_the_chair.adjust_confusion(10 SECONDS)
-		if(inflicts_stun_vulnerability)
-			give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
+	if(!HAS_TRAIT(give_this_fucker_the_chair, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
+		if(vulnerable_hit | give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
+			give_this_fucker_the_chair.Knockdown(2 SECONDS)
+			if(give_this_fucker_the_chair.health < give_this_fucker_the_chair.maxHealth*0.5)
+				give_this_fucker_the_chair.adjust_confusion(10 SECONDS)
+			if(inflicts_stun_vulnerability)
+				give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
 
 	smash(user)
 
@@ -449,7 +450,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "stool_bamboo"
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
-	max_integrity = 50 //Submissive and breakable unlike the chad iron stool
+	max_integrity = 40 //Submissive and breakable unlike the chad iron stool
 	inflicts_stun_vulnerability = FALSE //Not hard enough to cause them to become vulnerable to a shove
 
 /obj/item/chair/stool/narsie_act()
@@ -460,7 +461,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	icon_state = "wooden_chair_toppled"
 	inhand_icon_state = "woodenchair"
 	resistance_flags = FLAMMABLE
-	max_integrity = 50
+	max_integrity = 40
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/wood
 	custom_materials = null

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -328,7 +328,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	hit_reaction_chance = 50
 	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
 	item_flags = SKIP_FANTASY_ON_SPAWN
-	var/break_chance = 5 //Likely hood of smashing the chair.
+	// THe likelihood for the chair to be smashed to pieces, either from hitting something or being hit while used as a shield.
+	var/break_chance = 5
+
+	// Whether or not the chair causes the target to become shove stun vulnerable if smashed against someone from behind.
+	var/inflicts_stun_vulnerability = TRUE
+
+	// What structure type does this chair become when placed?
 	var/obj/structure/chair/origin_type = /obj/structure/chair
 
 /obj/item/chair/suicide_act(mob/living/carbon/user)
@@ -398,7 +404,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
 		if(check_behind(user, give_this_fucker_the_chair) && !HAS_TRAIT(give_this_fucker_the_chair, TRAIT_NO_SIDE_KICK))
 			give_this_fucker_the_chair.Knockdown(2 SECONDS)
-			give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
+			if(inflicts_stun_vulnerability)
+				give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
 	smash(user)
 
 /obj/item/chair/greyscale
@@ -425,6 +432,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
 	break_chance = 50	//Submissive and breakable unlike the chad iron stool
+	inflicts_stun_vulnerability = FALSE //Not hard enough to cause them to become vulnerable to a shove
 
 /obj/item/chair/stool/narsie_act()
 	return //sturdy enough to ignore a god
@@ -439,6 +447,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	origin_type = /obj/structure/chair/wood
 	custom_materials = null
 	break_chance = 50
+	inflicts_stun_vulnerability = FALSE
 
 /obj/item/chair/wood/narsie_act()
 	return
@@ -560,6 +569,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	throw_range = 5 //Lighter Weight --> Flies Farther.
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	break_chance = 25
+	inflicts_stun_vulnerability = FALSE
 	origin_type = /obj/structure/chair/plastic
 
 /obj/structure/chair/musical

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -165,7 +165,7 @@
 	name = "wooden chair"
 	desc = "Old is never too old to not be in fashion."
 	resistance_flags = FLAMMABLE
-	max_integrity = 10
+	max_integrity = 50
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 3
 	item_chair = /obj/item/chair/wood
@@ -306,7 +306,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	desc = "A makeshift bamboo stool with a rustic look."
 	icon_state = "bamboo_stool"
 	resistance_flags = FLAMMABLE
-	max_integrity = 60
+	max_integrity = 50
 	buildstacktype = /obj/item/stack/sheet/mineral/bamboo
 	buildstackamount = 2
 	item_chair = /obj/item/chair/stool/bamboo
@@ -396,17 +396,28 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	return FALSE
 
 /obj/item/chair/afterattack(atom/target, mob/user, click_parameters)
-	if(!take_chair_damage(force, damtype, MELEE))
+	if(!ishuman(target))
 		return
+
+	var/mob/living/carbon/human/give_this_fucker_the_chair = target
+
+	// Here we determine if our attack is against a vulnerable target
+	var/vulnerable_hit = (check_behind(user, give_this_fucker_the_chair) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
+
+	// If our attack is against a vulnerable target, we do additional damage to the chair
+	var/damage_to_inflict = vulnerable_hit ? (force * 2.5) : force
+
+	if(!take_chair_damage(damage_to_inflict, damtype, MELEE)) // If we would do enough damage to bring our chair's integrity to 0, we instead go past the check to smash it against our target
+		return
+
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
-	if(ishuman(target) && !HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
-		var/mob/living/carbon/human/give_this_fucker_the_chair = target
-		if(check_behind(user, give_this_fucker_the_chair) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
-			give_this_fucker_the_chair.Knockdown(2 SECONDS)
-			if(give_this_fucker_the_chair.health < give_this_fucker_the_chair.maxHealth*0.5)
-				give_this_fucker_the_chair.adjust_confusion(10 SECONDS)
-			if(inflicts_stun_vulnerability)
-				give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
+	if(!HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) && vulnerable_hit)
+		give_this_fucker_the_chair.Knockdown(2 SECONDS)
+		if(give_this_fucker_the_chair.health < give_this_fucker_the_chair.maxHealth*0.5)
+			give_this_fucker_the_chair.adjust_confusion(10 SECONDS)
+		if(inflicts_stun_vulnerability)
+			give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
+
 	smash(user)
 
 /obj/item/chair/proc/take_chair_damage(damage_to_inflict, damage_type, armor_flag)
@@ -438,7 +449,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "stool_bamboo"
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
-	max_integrity = 10 //Submissive and breakable unlike the chad iron stool
+	max_integrity = 50 //Submissive and breakable unlike the chad iron stool
 	inflicts_stun_vulnerability = FALSE //Not hard enough to cause them to become vulnerable to a shove
 
 /obj/item/chair/stool/narsie_act()
@@ -449,7 +460,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	icon_state = "wooden_chair_toppled"
 	inhand_icon_state = "woodenchair"
 	resistance_flags = FLAMMABLE
-	max_integrity = 10
+	max_integrity = 50
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/wood
 	custom_materials = null
@@ -538,7 +549,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	name = "folding plastic chair"
 	desc = "No matter how much you squirm, it'll still be uncomfortable."
 	resistance_flags = FLAMMABLE
-	max_integrity = 30
+	max_integrity = 70
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	buildstacktype = /obj/item/stack/sheet/plastic
 	buildstackamount = 2
@@ -574,7 +585,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	force = 7
 	throw_range = 5 //Lighter Weight --> Flies Farther.
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
-	max_integrity = 30
+	max_integrity = 70
 	inflicts_stun_vulnerability = FALSE
 	origin_type = /obj/structure/chair/plastic
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -165,7 +165,8 @@
 	name = "wooden chair"
 	desc = "Old is never too old to not be in fashion."
 	resistance_flags = FLAMMABLE
-	max_integrity = 70
+	max_integrity = 10
+	atom_integrity = 10
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 3
 	item_chair = /obj/item/chair/wood
@@ -324,6 +325,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	throwforce = 10
 	demolition_mod = 1.25
 	throw_range = 3
+	max_integrity = 100
+	atom_integrity = 100
 	hitsound = 'sound/items/trayhit/trayhit1.ogg'
 	hit_reaction_chance = 50
 	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
@@ -424,6 +427,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "stool"
 	origin_type = /obj/structure/chair/stool
 	max_integrity = 300 //It's too sturdy.
+	atom_integrity = 300
 
 /obj/item/chair/stool/bar
 	name = "bar stool"
@@ -438,6 +442,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
 	max_integrity = 10 //Submissive and breakable unlike the chad iron stool
+	atom_integrity = 10
 	inflicts_stun_vulnerability = FALSE //Not hard enough to cause them to become vulnerable to a shove
 
 /obj/item/chair/stool/narsie_act()
@@ -449,6 +454,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "woodenchair"
 	resistance_flags = FLAMMABLE
 	max_integrity = 10
+	atom_integrity = 10
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/wood
 	custom_materials = null
@@ -538,6 +544,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	desc = "No matter how much you squirm, it'll still be uncomfortable."
 	resistance_flags = FLAMMABLE
 	max_integrity = 30
+	atom_integrity = 30
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	buildstacktype = /obj/item/stack/sheet/plastic
 	buildstackamount = 2
@@ -574,6 +581,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	throw_range = 5 //Lighter Weight --> Flies Farther.
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	max_integrity = 30
+	atom_integrity = 30
 	inflicts_stun_vulnerability = FALSE
 	origin_type = /obj/structure/chair/plastic
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -396,8 +396,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
 	if(ishuman(target) && !HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
-		if(prob(force) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
-			give_this_fucker_the_chair.Paralyze(2 SECONDS)
+		if(check_behind(user, give_this_fucker_the_chair) && !HAS_TRAIT(give_this_fucker_the_chair, TRAIT_NO_SIDE_KICK))
+			give_this_fucker_the_chair.Knockdown(2 SECONDS)
+			give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
 	smash(user)
 
 /obj/item/chair/greyscale

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -412,7 +412,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [give_this_fucker_the_chair]"))
 	if(!HAS_TRAIT(give_this_fucker_the_chair, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
-		if(vulnerable_hit | give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
+		if(vulnerable_hit || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
 			give_this_fucker_the_chair.Knockdown(2 SECONDS)
 			if(give_this_fucker_the_chair.health < give_this_fucker_the_chair.maxHealth*0.5)
 				give_this_fucker_the_chair.adjust_confusion(10 SECONDS)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -328,8 +328,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	hit_reaction_chance = 50
 	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
 	item_flags = SKIP_FANTASY_ON_SPAWN
-	// The chairs durability. Reduced by hitting stuff with it and using it to block attacks.
-	var/chair_impact_durability = 50
 
 	// Whether or not the chair causes the target to become shove stun vulnerable if smashed against someone from behind.
 	var/inflicts_stun_vulnerability = TRUE
@@ -391,13 +389,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 /obj/item/chair/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	if(attack_type == UNARMED_ATTACK && prob(hit_reaction_chance) || attack_type == LEAP_ATTACK && prob(hit_reaction_chance))
 		owner.visible_message(span_danger("[owner] fends off [attack_text] with [src]!"))
-		if(take_chair_damage(damage)) // Our chair takes our incoming damage for us, which can result in it smashing.
+		if(take_chair_damage(damage, damage_type, MELEE)) // Our chair takes our incoming damage for us, which can result in it smashing.
 			smash(owner)
 		return TRUE
 	return FALSE
 
 /obj/item/chair/afterattack(atom/target, mob/user, click_parameters)
-	if(!take_chair_damage(force))
+	if(!take_chair_damage(force, damtype, MELEE))
 		return
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
 	if(ishuman(target) && !HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
@@ -410,11 +408,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 				give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)
 	smash(user)
 
-/obj/item/chair/proc/take_chair_damage(damage_to_inflict)
-	chair_impact_durability = clamp(chair_impact_durability - damage_to_inflict, 0, 100)
-	if(chair_impact_durability == 0)
-		return FALSE
-	return TRUE
+/obj/item/chair/proc/take_chair_damage(damage_to_inflict, damage_type, armor_flag)
+	if(damage_to_inflict >= atom_integrity)
+		return TRUE
+	take_damage(damage_to_inflict, damage_type, armor_flag)
+	return FALSE
 
 /obj/item/chair/greyscale
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
@@ -425,7 +423,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	icon_state = "stool_toppled"
 	inhand_icon_state = "stool"
 	origin_type = /obj/structure/chair/stool
-	chair_impact_durability = 100 //It's too sturdy.
+	max_integrity = 300 //It's too sturdy.
 
 /obj/item/chair/stool/bar
 	name = "bar stool"
@@ -439,7 +437,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "stool_bamboo"
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
-	chair_impact_durability = 20 //Submissive and breakable unlike the chad iron stool
+	max_integrity = 10 //Submissive and breakable unlike the chad iron stool
 	inflicts_stun_vulnerability = FALSE //Not hard enough to cause them to become vulnerable to a shove
 
 /obj/item/chair/stool/narsie_act()
@@ -450,11 +448,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	icon_state = "wooden_chair_toppled"
 	inhand_icon_state = "woodenchair"
 	resistance_flags = FLAMMABLE
-	max_integrity = 70
+	max_integrity = 10
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/wood
 	custom_materials = null
-	chair_impact_durability = 20
 	inflicts_stun_vulnerability = FALSE
 
 /obj/item/chair/wood/narsie_act()
@@ -540,7 +537,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	name = "folding plastic chair"
 	desc = "No matter how much you squirm, it'll still be uncomfortable."
 	resistance_flags = FLAMMABLE
-	max_integrity = 50
+	max_integrity = 30
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	buildstacktype = /obj/item/stack/sheet/plastic
 	buildstackamount = 2
@@ -576,7 +573,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	force = 7
 	throw_range = 5 //Lighter Weight --> Flies Farther.
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
-	chair_impact_durability = 40
+	max_integrity = 30
 	inflicts_stun_vulnerability = FALSE
 	origin_type = /obj/structure/chair/plastic
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -405,7 +405,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	var/vulnerable_hit = (check_behind(user, give_this_fucker_the_chair) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
 
 	// If our attack is against a vulnerable target, we do additional damage to the chair
-	var/damage_to_inflict = vulnerable_hit ? (force * 2.5) : force
+	var/damage_to_inflict = vulnerable_hit ? (force * 5) : (force * 2.5)
 
 	if(!take_chair_damage(damage_to_inflict, damtype, MELEE)) // If we would do enough damage to bring our chair's integrity to 0, we instead go past the check to smash it against our target
 		return

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -7,7 +7,7 @@
 	can_buckle = TRUE
 	buckle_lying = 0 //you sit in a chair, not lay
 	resistance_flags = NONE
-	max_integrity = 250
+	max_integrity = 100
 	integrity_failure = 0.1
 	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
 	layer = OBJ_LAYER
@@ -260,6 +260,7 @@
 	can_buckle = FALSE
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool
+	max_integrity = 300
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 
@@ -280,6 +281,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 	var/obj/item/chair_item = new item_chair(loc)
 	chair_item.set_custom_materials(custom_materials)
 	TransferComponents(chair_item)
+	chair_item.update_integrity(get_integrity())
 	user.put_in_hands(chair_item)
 	qdel(src)
 
@@ -372,6 +374,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	chair.set_custom_materials(custom_materials)
 	TransferComponents(chair)
 	chair.setDir(user.dir)
+	chair.update_integrity(get_integrity())
 	qdel(src)
 
 /obj/item/chair/proc/smash(mob/living/user)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -394,9 +394,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	if(!prob(break_chance))
 		return
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
-	if(ishuman(target))
+	if(ishuman(target) && !HAS_TRAIT (target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
-		if(!HAS_TRAIT (give_this_fucker_the_chair, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) && (prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair)))
+		if(prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
 			give_this_fucker_the_chair.Paralyze(2 SECONDS)
 	smash(user)
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -394,7 +394,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	if(!prob(break_chance))
 		return
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
-	if(ishuman(target) && !HAS_TRAIT (target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
+	if(ishuman(target) && !HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
 		if(prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
 			give_this_fucker_the_chair.Paralyze(2 SECONDS)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -402,7 +402,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
 	if(ishuman(target) && !HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
-		if(check_behind(user, give_this_fucker_the_chair) && !HAS_TRAIT(give_this_fucker_the_chair, TRAIT_NO_SIDE_KICK))
+		if(check_behind(user, give_this_fucker_the_chair) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered))
 			give_this_fucker_the_chair.Knockdown(2 SECONDS)
 			if(inflicts_stun_vulnerability)
 				give_this_fucker_the_chair.apply_status_effect(/datum/status_effect/next_shove_stuns)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -166,7 +166,6 @@
 	desc = "Old is never too old to not be in fashion."
 	resistance_flags = FLAMMABLE
 	max_integrity = 10
-	atom_integrity = 10
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 3
 	item_chair = /obj/item/chair/wood
@@ -326,7 +325,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	demolition_mod = 1.25
 	throw_range = 3
 	max_integrity = 100
-	atom_integrity = 100
 	hitsound = 'sound/items/trayhit/trayhit1.ogg'
 	hit_reaction_chance = 50
 	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
@@ -427,7 +425,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "stool"
 	origin_type = /obj/structure/chair/stool
 	max_integrity = 300 //It's too sturdy.
-	atom_integrity = 300
 
 /obj/item/chair/stool/bar
 	name = "bar stool"
@@ -442,7 +439,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
 	max_integrity = 10 //Submissive and breakable unlike the chad iron stool
-	atom_integrity = 10
 	inflicts_stun_vulnerability = FALSE //Not hard enough to cause them to become vulnerable to a shove
 
 /obj/item/chair/stool/narsie_act()
@@ -454,7 +450,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	inhand_icon_state = "woodenchair"
 	resistance_flags = FLAMMABLE
 	max_integrity = 10
-	atom_integrity = 10
 	hitsound = 'sound/items/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/wood
 	custom_materials = null
@@ -544,7 +539,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	desc = "No matter how much you squirm, it'll still be uncomfortable."
 	resistance_flags = FLAMMABLE
 	max_integrity = 30
-	atom_integrity = 30
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	buildstacktype = /obj/item/stack/sheet/plastic
 	buildstackamount = 2
@@ -581,7 +575,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	throw_range = 5 //Lighter Weight --> Flies Farther.
 	custom_materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
 	max_integrity = 30
-	atom_integrity = 30
 	inflicts_stun_vulnerability = FALSE
 	origin_type = /obj/structure/chair/plastic
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -410,8 +410,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	if(!take_chair_damage(damage_to_inflict, damtype, MELEE)) // If we would do enough damage to bring our chair's integrity to 0, we instead go past the check to smash it against our target
 		return
 
-	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
-	if(!HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) && vulnerable_hit)
+	user.visible_message(span_danger("[user] smashes [src] to pieces against [give_this_fucker_the_chair]"))
+	if(!HAS_TRAIT(give_this_fucker_the_chair, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) && vulnerable_hit)
 		give_this_fucker_the_chair.Knockdown(2 SECONDS)
 		if(give_this_fucker_the_chair.health < give_this_fucker_the_chair.maxHealth*0.5)
 			give_this_fucker_the_chair.adjust_confusion(10 SECONDS)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -396,7 +396,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
 	if(ishuman(target))
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
-		if(prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
+		if(!HAS_TRAIT (give_this_fucker_the_chair, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) && (prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair)))
 			give_this_fucker_the_chair.Paralyze(2 SECONDS)
 	smash(user)
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -385,6 +385,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 /obj/item/chair/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	if(attack_type == UNARMED_ATTACK && prob(hit_reaction_chance) || attack_type == LEAP_ATTACK && prob(hit_reaction_chance))
 		owner.visible_message(span_danger("[owner] fends off [attack_text] with [src]!"))
+		if(prob(break_chance + damage + 10)) //We want to at least ensure that there is always a minimum chance of it breaking to prevent infinite blocks
+			smash(owner)
 		return TRUE
 	return FALSE
 
@@ -392,10 +394,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	if(!prob(break_chance))
 		return
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(C.health < C.maxHealth*0.5)
-			C.Paralyze(20)
+	if(ishuman(target))
+		var/mob/living/carbon/human/give_this_fucker_the_chair = target
+		if(prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
+			give_this_fucker_the_chair.Paralyze(2 SECONDS)
 	smash(user)
 
 /obj/item/chair/greyscale

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -396,7 +396,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	user.visible_message(span_danger("[user] smashes [src] to pieces against [target]"))
 	if(ishuman(target) && !HAS_TRAIT(target, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
 		var/mob/living/carbon/human/give_this_fucker_the_chair = target
-		if(prob(force + break_chance) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
+		if(prob(force) || give_this_fucker_the_chair.get_timed_status_effect_duration(/datum/status_effect/staggered) && check_behind(user, give_this_fucker_the_chair))
 			give_this_fucker_the_chair.Paralyze(2 SECONDS)
 	smash(user)
 


### PR DESCRIPTION
## About The Pull Request

Chairs, on block and when used as a weapon, take damage. Once they run out of impact health, they break.

Rather than using health to determine if breaking a chair on someone's head will stun them, smashing a chair on someone from behind or while they're staggered will cause them to be knocked down for a few seconds. Some chairs also make you shove stun vulnerable if they break against someone.

## Why It's Good For The Game

You can turtle behind a chair while someone struggles to punch the shit out of you. Chairs are literally everywhere, so this probably shouldn't be too reliable. Also it's kind of a cool image to think that someone just fucking punched through an iron chair.

There is a point at which some subtypes of chairs, being easier to break, can chain stun people at half health. We've changed how the chair handles stuns, and mostly making it a more environmental tool than straight up just bottle smash all over again.

## Changelog
:cl:
balance: A new maint-kata has taken shape in the periphery of Spinward control. Borrowing techniques from an ancient Martian martial artist, as well as an entire franchise of extremely muscular acrobats and performance artists, talented assistants have discovered that a swift application of a flimsy chair to the back of the head can end fights more promptly than just bashing the opponent's head in with their foot. That, and it looks awesome.
balance: Chairs start to break apart when you hit someone with them or block an attack with them.
balance: Breaking a chair against a target while attacking from behind or while they're staggered will cause them to get knocked down. Chairs made of more sturdy materials can even cause them to become vulnerable to shove stuns.
/:cl:
