### PR TITLE
Various mob attack procs treat their attacks as unarmed attacks instead of melee attacks when checking blocking.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -191,7 +191,7 @@
 			var/damage = HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) ? monkey_mouth.unarmed_damage_high : rand(monkey_mouth.unarmed_damage_low, monkey_mouth.unarmed_damage_high)
 			if(!damage)
 				return FALSE
-			if(check_block(user, damage, "the [user.name]"))
+			if(check_block(user, damage, "the [user.name]", attack_type = UNARMED_ATTACK))
 				return FALSE
 			apply_damage(damage, BRUTE, affecting, run_armor_check(affecting, MELEE))
 		return TRUE
@@ -248,9 +248,6 @@
 			return TRUE
 		apply_damage(damage, BRUTE, affecting, armor_block)
 
-
-
-
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L, list/modifiers)
 	. = ..()
 	if(!.)
@@ -258,7 +255,7 @@
 	var/damage = rand(L.melee_damage_lower, L.melee_damage_upper)
 	if(!damage)
 		return
-	if(check_block(L, damage, "the [L.name]"))
+	if(check_block(L, damage, "the [L.name]", attack_type = UNARMED_ATTACK))
 		return FALSE
 	if(stat != DEAD)
 		L.amount_grown = min(L.amount_grown + damage, L.max_grown)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -289,7 +289,7 @@
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_GRAB, target) & (COMPONENT_CANCEL_ATTACK_CHAIN|COMPONENT_SKIP_ATTACK))
 		return FALSE
-	if(target.check_block(src, 0, "[src]'s grab"))
+	if(target.check_block(src, 0, "[src]'s grab", UNARMED_ATTACK))
 		return FALSE
 	target.grabbedby(src)
 	return TRUE
@@ -396,7 +396,7 @@
 		return FALSE
 
 	var/damage = rand(user.melee_damage_lower, user.melee_damage_upper)
-	if(check_block(user, damage, "[user]'s [user.attack_verb_simple]", MELEE_ATTACK/*or UNARMED_ATTACK?*/, user.armour_penetration, user.melee_damage_type))
+	if(check_block(user, damage, "[user]'s [user.attack_verb_simple]", UNARMED_ATTACK, user.armour_penetration, user.melee_damage_type))
 		return FALSE
 
 	if(user.attack_sound)
@@ -511,7 +511,7 @@
 /mob/living/attack_alien(mob/living/carbon/alien/adult/user, list/modifiers)
 	SEND_SIGNAL(src, COMSIG_MOB_ATTACK_ALIEN, user, modifiers)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		if(check_block(user, 0, "[user]'s tackle", MELEE_ATTACK, 0, BRUTE))
+		if(check_block(user, 0, "[user]'s tackle", UNARMED_ATTACK, 0, BRUTE))
 			return FALSE
 		user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 		return TRUE
@@ -520,7 +520,7 @@
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, span_warning("You don't want to hurt anyone!"))
 			return FALSE
-		if(check_block(user, user.melee_damage_upper, "[user]'s slash", MELEE_ATTACK, 0, BRUTE))
+		if(check_block(user, user.melee_damage_upper, "[user]'s slash", UNARMED_ATTACK, 0, BRUTE))
 			return FALSE
 		user.do_attack_animation(src)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/88476

What it says on the tin really.

## Why It's Good For The Game

Melbert had a good reason for why it worked like this, arguing that there does exist mobs that visibly use baked-in weapons to attack (that is, the sprites are depicted with weapons). However, the issue is that we don't have the granularity to pass multiple attack types down to block checks, which would require refactoring attack types into bitflags. That'll apparently happen eventually, but I wanna just deal with this sooner than later.

Rather than account for the outliers, I argue we should probably operate with the assumption that these procs are for what they say they are; an attack from a mob directly and not from an object. We can treat this as an UNARMED_ATTACK for convenience, since it covers the greater majority of possible mob attackers and the use cases for these procs. 

Does that mean some sword wielding simple mobs get blocked by chairs? I guess so. Does it matter? Well, I'll make sure it isn't a problem [here](https://github.com/tgstation/tgstation/pull/88480) for specifically chairs. I think in any other instance, it doesn't matter, and I think it is probably better to assume they're using UNARMED_ATTACK than weaponless mobs assumed to be attacking with an object. These attacks need to keep consistent so that we don't end up with unexpected outcomes, like Hunter Boxing being unable to block mobs. At least, until we can add the necessary granularity anyway to account for all outliers.

## Changelog
:cl:
code: Various mob attack procs are treated as unarmed attacks as a baseline assumption, rather than melee attacks.
/:cl:
