### PR TITLE
Fixes necropolis gates being pushable by fauna

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -16,6 +16,7 @@
 	light_range = 8
 	light_color = LIGHT_COLOR_LAVA
 	can_atmos_pass = ATMOS_PASS_DENSITY
+	move_resist = INFINITY
 	var/open = FALSE
 	var/changing_openness = FALSE
 	var/locked = FALSE


### PR DESCRIPTION
## About The Pull Request

Turns out some fauna can walk their way over to the necropolis gates an shove them aside. This should prevent that, or any other force of nature, from moving these ancient gates anywhere.

## Why It's Good For The Game

It's silly that this is even possible

## Changelog

:cl:
fix: Fauna can no longer push necropolis gates
/:cl:
