### PR TITLE
Fix language scramble cache nuking(?)(maybe 10 years old bug?)

### DIFF
--- a/code/modules/language/_language.dm
+++ b/code/modules/language/_language.dm
@@ -120,7 +120,7 @@
 	// Add it to cache, cutting old entries if the list is too long
 	scramble_cache[input] = scrambled_text
 	if(scramble_cache.len > SCRAMBLE_CACHE_LEN)
-		scramble_cache.Cut(1, scramble_cache.len-SCRAMBLE_CACHE_LEN-1)
+		scramble_cache.Cut(1, 2)
 
 /datum/language/proc/scramble(input)
 


### PR DESCRIPTION
## About The Pull Request

I was looking at a bay code base's language and saw this
```dm
	// Add it to cache, cutting old entries if the list is too long
	scramble_cache[input] = scrambled_text
	if(scramble_cache.len > SCRAMBLE_CACHE_LEN)
		scramble_cache.Cut(1, scramble_cache.len-SCRAMBLE_CACHE_LEN-1)
```
Then I noticed "Wait isn't this broken? 51 - 50 - 1 = 0, so it's doing `Cut(1, 0)` which cuts the whole list, what's the point of all this arithmetic?"

Then I saw we have the same code so this is probably very old

At this point I'm not sure if it's a bug or not, but I've reasoned it as one: 

- If it was NOT a bug, and we just wanted to clear the entire list, why do we over-complicate it (why is it not just `.Cut()`)?
`scramble_cache.len` *will never be larger than* `SCRAMBLE_CACHE_LEN + 1` because this proc only ever adds entries one at a time, meaning the result will always be `0` 

- And if it's not a bug, why do we bother putting most recent items at the bottom of the list? We do all this effort for no reason, it's just wiped at the end of the day.
```dm
/datum/language/proc/check_cache(input)
	var/lookup = scramble_cache[input]
	if(lookup)
		scramble_cache -= input
		scramble_cache[input] = lookup
	. = lookup
```

Thus I am running with the assumption that this code was meant to be `scramble_cache.len - SCRAMBLE_CACHE_LEN + 1` - that's a `+1` at the end not a `-1`

But that would still just be an overly complicated way to say `51 - 50 + 1`, or, just `2`

So I'm just changing it to cut the first element out

## Changelog

:cl: Melbert
fix: Words in other languages will be randomized far less often (depending on how commonly they are used). This bug was 10 years old.
/:cl:
