### PR TITLE
Fixes various misspellings

### DIFF
--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -62,7 +62,7 @@
 /area/shuttle/escape)
 "bV" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
 	dir = 8
@@ -125,7 +125,7 @@
 /area/shuttle/escape)
 "dW" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -287,7 +287,7 @@
 /area/shuttle/escape)
 "jo" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
 	dir = 8
@@ -533,7 +533,7 @@
 /area/shuttle/escape)
 "pu" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -573,7 +573,7 @@
 /area/shuttle/escape)
 "qe" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -609,7 +609,7 @@
 /area/shuttle/escape)
 "rw" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -682,7 +682,7 @@
 /area/shuttle/escape)
 "uK" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -868,7 +868,7 @@
 /area/shuttle/escape)
 "Cx" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -887,7 +887,7 @@
 /area/shuttle/escape)
 "CR" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -1199,7 +1199,7 @@
 /area/shuttle/escape)
 "LD" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -742,7 +742,7 @@
 /area/shuttle/escape)
 "cd" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -1456,7 +1456,7 @@
 /area/shuttle/escape)
 "eo" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emegency Shuttle External Airlock"
+	name = "Emergency Shuttle External Airlock"
 	},
 /obj/docking_port/mobile/emergency{
 	name = "CentCom Raven Cruiser"

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -329,7 +329,7 @@ effective or pretty fucking useless.
 
 /obj/item/jammer
 	name = "radio jammer"
-	desc = "Device used to disrupt nearby radio communication. Alternate function creates a powerful distruptor wave which disables all nearby listening devices."
+	desc = "Device used to disrupt nearby radio communication. Alternate function creates a powerful disruptor wave which disables all nearby listening devices."
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
 	icon_state = "jammer"
 	var/active = FALSE
@@ -342,7 +342,7 @@ effective or pretty fucking useless.
 	register_context()
 
 /obj/item/jammer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
-	context[SCREENTIP_CONTEXT_LMB] = "Release distruptor wave"
+	context[SCREENTIP_CONTEXT_LMB] = "Release disruptor wave"
 	context[SCREENTIP_CONTEXT_RMB] = "Toggle"
 	return CONTEXTUAL_SCREENTIP_SET
 
@@ -352,8 +352,8 @@ effective or pretty fucking useless.
 		user.balloon_alert(user, "on cooldown!")
 		return
 
-	user.balloon_alert(user, "distruptor wave released!")
-	to_chat(user, span_notice("You release a distruptor wave, disabling all nearby radio devices."))
+	user.balloon_alert(user, "disruptor wave released!")
+	to_chat(user, span_notice("You release a disruptor wave, disabling all nearby radio devices."))
 	for (var/atom/potential_owner in view(7, user))
 		disable_radios_on(potential_owner)
 	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
@@ -379,8 +379,8 @@ effective or pretty fucking useless.
 		user.balloon_alert(user, "out of reach!")
 		return
 
-	interacting_with.balloon_alert(user, "radio distrupted!")
-	to_chat(user, span_notice("You release a directed distruptor wave, disabling all radio devices on [interacting_with]."))
+	interacting_with.balloon_alert(user, "radio disrupted!")
+	to_chat(user, span_notice("You release a directed disruptor wave, disabling all radio devices on [interacting_with]."))
 	disable_radios_on(interacting_with)
 
 	return ITEM_INTERACT_SUCCESS

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -467,9 +467,9 @@
 /obj/item/organ/brain/felinid //A bit smaller than average
 	brain_size = 0.8
 
-/obj/item/organ/brain/lizard //A bit smaller than average
+/obj/item/organ/brain/lizard
 	name = "lizard brain"
-	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect it's owner to be pretty cold blooded."
+	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."
 	organ_traits = list(TRAIT_TACKLING_TAILED_DEFENDER)
 
 /obj/item/organ/brain/abductor


### PR DESCRIPTION

## About The Pull Request
Fixes an instance of "it's" (where it should be "its") in the lizard brain description, also removing a comment left as a relic from copying the felinid brain item.
Fixes the radio jammer's usage texts to say disruptor, rather than distruptor, which is incorrect.
The Raven and Lance emergency shuttle airlocks were misspelled, saying "Emegency..." rather than "Emergency..."
## Why It's Good For The Game
Proper spelling is a good thing
## Changelog
:cl:
spellcheck: The Lance and Raven shuttle airlocks are now properly labelled emergency airlocks, rather than emegency airlocks.
spellcheck: The radio jammer now releases disruptor waves, rather than distruptor waves.
/:cl:
