### PR TITLE
Aloe now gives you more than one process tick to take it out of the oven

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -475,6 +475,10 @@
 	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 	merge_type = /obj/item/stack/medical/aloe
 
+/obj/item/stack/medical/aloe/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
+	. = ..()
+	AddComponent(/datum/component/bakeable, /obj/item/food/badrecipe, rand(10 SECONDS, 15 SECONDS), FALSE)
+
 /obj/item/stack/medical/aloe/fresh
 	amount = 2
 


### PR DESCRIPTION
## About The Pull Request

See name, aloe cream now has the bakeable component on it so it doesn't get instantly burned by the oven upon creation, and correctly creates the particles as well

## Why It's Good For The Game

Makes some primitive medicine a bit more viable by making it actually primitively easy to make instead of requiring spider-like reflexes

## Changelog
:cl:
fix: Aloe cream no longer catches fire seconds after finishing baking
/:cl:
