### PR TITLE
Improved dooting for spectral instruments. New fantasy suffix.

### DIFF
--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -285,8 +285,8 @@
 
 /datum/fantasy_affix/doot/apply(datum/component/fantasy/comp, newName)
 	. = ..()
-	comp.parent.AddElement(/datum/element/spooky, stam_damage_mult = comp.quality * 0.1)
+	comp.parent.AddElement(/datum/element/spooky, too_spooky = comp.quality > 17, stam_damage_mult = comp.quality * 0.1)
 	return "[newName] of [pick("dooting", "spooks", "rattling", "the bones")]"
 
 /datum/fantasy_affix/doot/remove(datum/component/fantasy/comp)
-	comp.parent.RemoveElement(/datum/element/spooky, stam_damage_mult = comp.quality * 0.1)
+	comp.parent.RemoveElement(/datum/element/spooky, too_spooky = comp.quality > 17, stam_damage_mult = comp.quality * 0.1)

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -276,3 +276,17 @@
 /datum/fantasy_affix/speed/remove(datum/component/fantasy/comp)
 	var/obj/item/master = comp.parent
 	master.slowdown = initial(master.slowdown)
+
+/datum/fantasy_affix/doot
+	name = "of dooting"
+	placement = AFFIX_SUFFIX
+	alignment = AFFIX_GOOD
+	weight = 1
+
+/datum/fantasy_affix/doot/apply(datum/component/fantasy/comp, newName)
+	. = ..()
+	comp.parent.AddElement(/datum/element/spooky, stam_damage_mult = comp.quality * 0.1)
+	return "[newName] of [pick("dooting", "spooks", "rattling", "the bones")]"
+
+/datum/fantasy_affix/doot/remove(datum/component/fantasy/comp)
+	comp.parent.RemoveElement(/datum/element/spooky, stam_damage_mult = comp.quality * 0.1)

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -285,8 +285,8 @@
 
 /datum/fantasy_affix/doot/apply(datum/component/fantasy/comp, newName)
 	. = ..()
-	comp.parent.AddElement(/datum/element/spooky, too_spooky = comp.quality > 17, stam_damage_mult = comp.quality * 0.1)
+	comp.parent.AddElement(/datum/element/spooky, too_spooky = comp.quality > 17, stam_damage_mult = comp.quality * 0.15)
 	return "[newName] of [pick("dooting", "spooks", "rattling", "the bones")]"
 
 /datum/fantasy_affix/doot/remove(datum/component/fantasy/comp)
-	comp.parent.RemoveElement(/datum/element/spooky, too_spooky = comp.quality > 17, stam_damage_mult = comp.quality * 0.1)
+	comp.parent.RemoveElement(/datum/element/spooky, too_spooky = comp.quality > 17, stam_damage_mult = comp.quality * 0.15)

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -72,10 +72,11 @@
 	human.set_species(/datum/species/skeleton)
 	human.visible_message(span_warning("[human] has given up on life as a mortal."))
 	to_chat(human, span_boldnotice("You are a spooky skeleton!"))
-	to_chat(human, span_boldnotice("A new life and identity has begun.\
+	to_chat(human,
+		span_boldnotice("A new life and identity has begun.\
 		[too_spooky ? "Help your fellow skeletons into bringing out the spooky-pocalypse." : ""] \
-		You haven't forgotten your past life, and are still beholden to past loyalties."
-	))
+		You haven't forgotten your past life, and are still beholden to past loyalties.")
+	)
 	INVOKE_ASYNC(src, PROC_REF(change_name), human) //time for a new name!
 
 	if(!too_spooky)

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -72,7 +72,7 @@
 		to_chat(user, span_warning("You feel like [source] has lost its spookiness..."))
 		Detach(source)
 
-	human.Paralyze(20)
+	human.Paralyze(2 SECONDS)
 	human.set_species(/datum/species/skeleton)
 	human.visible_message(span_warning("[human] has given up on life as a mortal."))
 	to_chat(human, span_boldnotice("You are a spooky skeleton!"))

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -27,12 +27,12 @@
 	if(ishuman(user) && !isskeleton(target)) //this weapon wasn't meant for mortals.
 		var/mob/living/carbon/human/human = user
 		if(rattle_bones(human, stam_dam_mult = stam_damage_mult * 2))
-			to_chat(human, "<font color ='red', size ='4'><B>Your ears weren't meant for this spectral sound.</B></font>")
+			to_chat(human, span_userdanger("Your ears weren't meant for this spectral sound."))
 			INVOKE_ASYNC(src, PROC_REF(spectral_change), human, user, source)
 		return
 
 	target.add_mood_event("spooked", /datum/mood_event/spooked)
-	to_chat(target, "<font color='red' size='4'><B>DOOT</B></font>")
+	to_chat(target, span_userdanger("<b>DOOT</b"))
 
 	if(!ishuman(target))//the sound will spook basic mobs.
 		target.set_jitter_if_lower(30 SECONDS)
@@ -58,7 +58,7 @@
 	if(iszombie(human))
 		human.adjustStaminaLoss(25)
 		human.Paralyze(15) //zombies can't resist the doot
-	return bone_amount ? TRUE : FALSE
+	return bone_amount
 
 /datum/element/spooky/proc/spectral_change(mob/living/carbon/human/human, mob/living/user, obj/item/source)
 	if(human.getStaminaLoss() <= 95)
@@ -82,15 +82,15 @@
 	if(!too_spooky)
 		return
 	var/turf/turf = get_turf(human)
-	if(prob(90))
-		var/obj/item/instrument = pick(
-			/obj/item/instrument/saxophone/spectral,
-			/obj/item/instrument/trumpet/spectral,
-			/obj/item/instrument/trombone/spectral,
-		)
-		new instrument(turf)
-	else
+	if(!prob(90))
 		to_chat(human, span_boldwarning("The spooky gods forgot to ship your instrument. Better luck next unlife."))
+		return
+	var/obj/item/instrument = pick(
+		/obj/item/instrument/saxophone/spectral,
+		/obj/item/instrument/trumpet/spectral,
+		/obj/item/instrument/trombone/spectral,
+	)
+	new instrument(turf)
 
 /datum/element/spooky/proc/change_name(mob/living/carbon/human/spooked)
 	var/skeleton_name = spooked.client ? sanitize_name(tgui_input_text(spooked, "Enter your new skeleton name", "Spookifier", spooked.real_name, MAX_NAME_LEN)) : null

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -24,15 +24,19 @@
 /datum/element/spooky/proc/spectral_attack(datum/source, mob/living/carbon/target, mob/user)
 	SIGNAL_HANDLER
 
-	if(ishuman(user) && !isskeleton(target)) //this weapon wasn't meant for mortals.
-		var/mob/living/carbon/human/human = user
-		if(rattle_bones(human, stam_dam_mult = stam_damage_mult * 2))
-			to_chat(human, span_userdanger("Your ears weren't meant for this spectral sound."))
-			INVOKE_ASYNC(src, PROC_REF(spectral_change), human, user, source)
+	if(ishuman(user) && !isskeleton(user)) //this weapon wasn't meant for mortals.
+		var/mob/living/carbon/human/human_user = user
+		if(rattle_bones(human_user, stam_dam_mult = stam_damage_mult * 2))
+			to_chat(human_user, span_userdanger("Your ears weren't meant for this spectral sound."))
+			INVOKE_ASYNC(src, PROC_REF(spectral_change), human_user, user, source)
+		return
+
+	to_chat(target, span_userdanger("<b>DOOT</b"))
+
+	if(isskeleton(target)) // skeletons are totally immune, no redundant skeletonization or bad mood event.
 		return
 
 	target.add_mood_event("spooked", /datum/mood_event/spooked)
-	to_chat(target, span_userdanger("<b>DOOT</b"))
 
 	if(!ishuman(target))//the sound will spook basic mobs.
 		target.set_jitter_if_lower(30 SECONDS)

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -3,81 +3,90 @@
 	argument_hash_start_idx = 2
 	///will it spawn a new instrument
 	var/too_spooky = TRUE
-	///Once used, the element is detached
+	///If, once someone is skeletonized, the element is detached
 	var/single_use = FALSE
+	///The base multiplier of stamina damage applied by the item
+	var/stam_damage_mult
 
-/datum/element/spooky/Attach(datum/target, too_spooky = TRUE, single_use = FALSE)
+/datum/element/spooky/Attach(datum/target, too_spooky = TRUE, single_use = FALSE, stam_damage_mult = 1)
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 	src.too_spooky = too_spooky
 	src.single_use = single_use
+	src.stam_damage_mult = stam_damage_mult
 	RegisterSignal(target, COMSIG_ITEM_ATTACK, PROC_REF(spectral_attack))
 
 /datum/element/spooky/Detach(datum/source)
 	UnregisterSignal(source, COMSIG_ITEM_ATTACK)
 	return ..()
 
-/datum/element/spooky/proc/spectral_attack(datum/source, mob/living/carbon/C, mob/user)
+/datum/element/spooky/proc/spectral_attack(datum/source, mob/living/carbon/target, mob/user)
 	SIGNAL_HANDLER
 
-	if(ishuman(user)) //this weapon wasn't meant for mortals.
-		var/mob/living/carbon/human/U = user
-		if(!istype(U.dna.species, /datum/species/skeleton))
-			U.adjustStaminaLoss(35) //Extra Damage
-			U.set_jitter_if_lower(70 SECONDS)
-			U.set_stutter(40 SECONDS)
-			if(U.getStaminaLoss() > 95)
-				to_chat(U, "<font color ='red', size ='4'><B>Your ears weren't meant for this spectral sound.</B></font>")
-				INVOKE_ASYNC(src, PROC_REF(spectral_change), U)
-			if(single_use)
-				to_chat(user, span_warning("You feel like [source] has lost its spookiness..."))
-				Detach(source)
-			return
+	if(ishuman(user) && !isskeleton(target)) //this weapon wasn't meant for mortals.
+		var/mob/living/carbon/human/human = user
+		if(rattle_bones(human, stam_dam_mult = stam_damage_mult * 2))
+			to_chat(human, "<font color ='red', size ='4'><B>Your ears weren't meant for this spectral sound.</B></font>")
+			INVOKE_ASYNC(src, PROC_REF(spectral_change), human, user, source)
+		return
 
-	if(ishuman(C))
-		var/mob/living/carbon/human/H = C
-		if(istype(H.dna.species, /datum/species/skeleton))
-			return //undeads are unaffected by the spook-pocalypse.
-		if(istype(H.dna.species, /datum/species/zombie))
-			H.adjustStaminaLoss(25)
-			H.Paralyze(15) //zombies can't resist the doot
-		C.set_jitter_if_lower(70 SECONDS)
-		C.set_stutter(40 SECONDS)
-		if((!istype(H.dna.species, /datum/species/skeleton)) && (!istype(H.dna.species, /datum/species/golem)) && (!istype(H.dna.species, /datum/species/android)) && (!istype(H.dna.species, /datum/species/jelly)))
-			C.adjustStaminaLoss(18) //boneless humanoids don't lose the will to live
-		to_chat(C, "<font color='red' size='4'><B>DOOT</B></font>")
-		to_chat(C, span_robot("<font size='4'>You're feeling more bony.</font>"))
-		INVOKE_ASYNC(src, PROC_REF(spectral_change), H)
-		if(single_use)
-			to_chat(user, span_warning("You feel like [source] has lost its spookiness..."))
-			Detach(source)
+	target.add_mood_event("spooked", /datum/mood_event/spooked)
+	to_chat(target, "<font color='red' size='4'><B>DOOT</B></font>")
 
-	else //the sound will spook monkeys.
-		C.set_jitter_if_lower(30 SECONDS)
-		C.set_stutter(40 SECONDS)
+	if(!ishuman(target))//the sound will spook basic mobs.
+		target.set_jitter_if_lower(30 SECONDS)
+		target.set_stutter(40 SECONDS)
+		return
 
-	C.add_mood_event("spooked", /datum/mood_event/spooked)
+	var/mob/living/carbon/human/human = target
+	if(rattle_bones(human))
+		INVOKE_ASYNC(src, PROC_REF(spectral_change), human, user, source)
 
-/datum/element/spooky/proc/spectral_change(mob/living/carbon/human/H, mob/user)
-	if((H.getStaminaLoss() > 95) && (!istype(H.dna.species, /datum/species/skeleton)) && (!istype(H.dna.species, /datum/species/golem)) && (!istype(H.dna.species, /datum/species/android)) && (!istype(H.dna.species, /datum/species/jelly)))
-		H.Paralyze(20)
-		H.set_species(/datum/species/skeleton)
-		H.visible_message(span_warning("[H] has given up on life as a mortal."))
-		var/T = get_turf(H)
-		if(too_spooky)
-			if(prob(90))
-				var/obj/item/instrument = pick(
-					/obj/item/instrument/saxophone/spectral,
-					/obj/item/instrument/trumpet/spectral,
-					/obj/item/instrument/trombone/spectral,
-				)
-				new instrument(T)
-			else
-				to_chat(H, span_boldwarning("The spooky gods forgot to ship your instrument. Better luck next unlife."))
-		to_chat(H, span_boldnotice("You are a spooky skeleton!"))
-		to_chat(H, span_boldnotice("A new life and identity has begun. Help your fellow skeletons into bringing out the spooky-pocalypse. You haven't forgotten your past life, and are still beholden to past loyalties."))
-		change_name(H) //time for a new name!
+///Cause jitteriness and stamina to the target relative to the amount of their bodyparts made of flesh and bone.
+/datum/element/spooky/proc/rattle_bones(mob/living/carbon/human/human, stam_dam_mult = stam_damage_mult)
+	if(isskeleton(human))
+		return FALSE //undeads are unaffected by the spook-pocalypse.
+	var/bone_amount = 0
+	for(var/obj/item/bodypart/part as anything in human.bodyparts)
+		if((part.biological_state & BIO_FLESH_BONE) == BIO_FLESH_BONE)
+			bone_amount++
+	if(bone_amount)
+		human.set_jitter_if_lower(12 SECONDS * bone_amount)
+		human.set_stutter(6.5 SECONDS * bone_amount)
+		human.adjustStaminaLoss(3 * bone_amount * stam_dam_mult)
+	if(iszombie(human))
+		human.adjustStaminaLoss(25)
+		human.Paralyze(15) //zombies can't resist the doot
+	return bone_amount ? TRUE : FALSE
+
+/datum/element/spooky/proc/spectral_change(mob/living/carbon/human/human, mob/living/user, obj/item/source)
+	if(human.getStaminaLoss() <= 95)
+		return
+
+	if(single_use)
+		to_chat(user, span_warning("You feel like [source] has lost its spookiness..."))
+		Detach(source)
+
+	human.Paralyze(20)
+	human.set_species(/datum/species/skeleton)
+	human.visible_message(span_warning("[human] has given up on life as a mortal."))
+	to_chat(human, span_boldnotice("You are a spooky skeleton!"))
+	to_chat(human, span_boldnotice("A new life and identity has begun. Help your fellow skeletons into bringing out the spooky-pocalypse. You haven't forgotten your past life, and are still beholden to past loyalties."))
+	INVOKE_ASYNC(src, PROC_REF(change_name), human) //time for a new name!
+
+	if(!too_spooky)
+		return
+	var/turf/turf = get_turf(human)
+	if(prob(90))
+		var/obj/item/instrument = pick(
+			/obj/item/instrument/saxophone/spectral,
+			/obj/item/instrument/trumpet/spectral,
+			/obj/item/instrument/trombone/spectral,
+		)
+		new instrument(turf)
+	else
+		to_chat(human, span_boldwarning("The spooky gods forgot to ship your instrument. Better luck next unlife."))
 
 /datum/element/spooky/proc/change_name(mob/living/carbon/human/spooked)
 	var/skeleton_name = spooked.client ? sanitize_name(tgui_input_text(spooked, "Enter your new skeleton name", "Spookifier", spooked.real_name, MAX_NAME_LEN)) : null

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -72,7 +72,10 @@
 	human.set_species(/datum/species/skeleton)
 	human.visible_message(span_warning("[human] has given up on life as a mortal."))
 	to_chat(human, span_boldnotice("You are a spooky skeleton!"))
-	to_chat(human, span_boldnotice("A new life and identity has begun. Help your fellow skeletons into bringing out the spooky-pocalypse. You haven't forgotten your past life, and are still beholden to past loyalties."))
+	to_chat(human, span_boldnotice("A new life and identity has begun.\
+		[too_spooky ? "Help your fellow skeletons into bringing out the spooky-pocalypse." : ""] \
+		You haven't forgotten your past life, and are still beholden to past loyalties."
+	))
 	INVOKE_ASYNC(src, PROC_REF(change_name), human) //time for a new name!
 
 	if(!too_spooky)


### PR DESCRIPTION
## About The Pull Request
The spooky element is quite old with a lot of single-letter variables. Had too many species typechecks, and there's an issue that's been bothering me, so I had to bring the code a bit up to date.

Furthermore the element wasn't used anywhere but on a couple of very rare instruments, so I've been thinking a likewise very rare fantasy suffix (mythril and wizard rpg event) would've been cool.

## Why It's Good For The Game
This will fix #88474. I believe the single-use versions of the spectral instruments should be spent once someone is skeletonized, not before. It was my fault for not noticing it earlier.

## Changelog

:cl:
fix: Fixed single-use spectral instruments losing their powers before skeletonizing anyone.
add: A very rare spooky suffix for mythril items and the wizard RPG event. 
/:cl:
