### PR TITLE
Improves code for leaning

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -82,12 +82,11 @@
 
 /obj/structure/window/mouse_drop_receive(atom/dropping, mob/user, params)
 	. = ..()
-	if (added_leaning || (flags_1 & ON_BORDER_1))
+	if (flags_1 & ON_BORDER_1)
 		return
-	/// For performance reasons and to cut down on init times we are "lazy-loading" the leaning component when someone drags their sprite onto us, and then calling dragging code again to trigger the component
-	AddComponent(/datum/component/leanable, 11)
-	added_leaning = TRUE
-	dropping.base_mouse_drop_handler(src, null, null, params)
+
+	///Lazy load the leaning component to save init times
+	LoadComponent(/datum/component/leanable, dropping)
 
 /obj/structure/window/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -85,7 +85,7 @@
 	if (flags_1 & ON_BORDER_1)
 		return
 
-	///Lazy load the leaning component to save init times
+	//Adds the component only once. We do it here & not in Initialize() because there are tons of windows & we don't want to add to their init times
 	LoadComponent(/datum/component/leanable, dropping)
 
 /obj/structure/window/examine(mob/user)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -51,7 +51,7 @@
 		underlays += underlay_appearance
 
 /turf/closed/wall/mouse_drop_receive(atom/dropping, mob/user, params)
-	/// Lazy load the leaning component to save init times
+	//Adds the component only once. We do it here & not in Initialize() because there are tons of walls & we don't want to add to their init times
 	LoadComponent(/datum/component/leanable, dropping)
 
 /turf/closed/wall/atom_destruction(damage_flag)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -51,13 +51,8 @@
 		underlays += underlay_appearance
 
 /turf/closed/wall/mouse_drop_receive(atom/dropping, mob/user, params)
-	. = ..()
-	if (added_leaning)
-		return
-	/// For performance reasons and to cut down on init times we are "lazy-loading" the leaning component when someone drags their sprite onto us, and then calling dragging code again to trigger the component
-	AddComponent(/datum/component/leanable, 11)
-	added_leaning = TRUE
-	dropping.base_mouse_drop_handler(src, null, null, params)
+	/// Lazy load the leaning component to save init times
+	LoadComponent(/datum/component/leanable, dropping)
 
 /turf/closed/wall/atom_destruction(damage_flag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
- Removed unused vars `click_mods`, `lean_check` & `same_turf` from the leaning component. Walls & windows the only two atoms that support leaning don't use these vars so its unused code
- Leaning component now starts leaning inside its `Initialize()` proc, which means we don't have to call `base_mouse_drop_handler()` manually
- Because of point 2 we can now properly lazy load the leaning component via `LoadComponent()` proc instead of keeping track of a boolean var to check if we added the component or not.

Just cleaner & lesser code overall

## Changelog
:cl:
code: improved code for leaning
/:cl:

