### PR TITLE
Adds a doMove() safeguard in case of cyclic contents

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1178,6 +1178,7 @@
 				// when attempting to move an atom A into an atom B which already contains A, BYOND seems
 				// to silently refuse to move A to the new loc. This can really break stuff (see #77067)
 				stack_trace("Failed to move atom to new loc, possibly due to cyclic contents")
+				return FALSE
 
 		. = TRUE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1146,33 +1146,38 @@
 		loc = destination
 
 		if(!same_loc)
-			if(is_multi_tile && isturf(destination))
-				var/list/new_locs = block(
-					destination,
-					locate(
-						min(world.maxx, destination.x + ROUND_UP(bound_width / ICON_SIZE_X)),
-						min(world.maxy, destination.y + ROUND_UP(bound_height / ICON_SIZE_Y)),
-						destination.z
+			if(loc != oldloc)
+				if(is_multi_tile && isturf(destination))
+					var/list/new_locs = block(
+						destination,
+						locate(
+							min(world.maxx, destination.x + ROUND_UP(bound_width / ICON_SIZE_X)),
+							min(world.maxy, destination.y + ROUND_UP(bound_height / ICON_SIZE_Y)),
+							destination.z
+						)
 					)
-				)
-				if(old_area && old_area != destarea)
-					old_area.Exited(src, movement_dir)
-				for(var/atom/left_loc as anything in locs - new_locs)
-					left_loc.Exited(src, movement_dir)
-
-				for(var/atom/entering_loc as anything in new_locs - locs)
-					entering_loc.Entered(src, movement_dir)
-
-				if(old_area && old_area != destarea)
-					destarea.Entered(src, movement_dir)
-			else
-				if(oldloc)
-					oldloc.Exited(src, movement_dir)
 					if(old_area && old_area != destarea)
 						old_area.Exited(src, movement_dir)
-				destination.Entered(src, oldloc)
-				if(destarea && old_area != destarea)
-					destarea.Entered(src, old_area)
+					for(var/atom/left_loc as anything in locs - new_locs)
+						left_loc.Exited(src, movement_dir)
+
+					for(var/atom/entering_loc as anything in new_locs - locs)
+						entering_loc.Entered(src, movement_dir)
+
+					if(old_area && old_area != destarea)
+						destarea.Entered(src, movement_dir)
+				else
+					if(oldloc)
+						oldloc.Exited(src, movement_dir)
+						if(old_area && old_area != destarea)
+							old_area.Exited(src, movement_dir)
+					destination.Entered(src, oldloc)
+					if(destarea && old_area != destarea)
+						destarea.Entered(src, old_area)
+			else
+				// when attempting to move an atom A into an atom B which already contains A, BYOND seems
+				// to silently refuse to move A to the new loc. This can really break stuff (see #77067)
+				stack_trace("Failed to move atom to new loc, possibly due to cyclic contents")
 
 		. = TRUE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1145,40 +1145,40 @@
 
 		loc = destination
 
+		if(!same_loc && loc == oldloc)
+			// when attempting to move an atom A into an atom B which already contains A, BYOND seems
+			// to silently refuse to move A to the new loc. This can really break stuff (see #77067)
+			stack_trace("Attempt to move [src] to [destination] was rejected by BYOND, possibly due to cyclic contents")
+			return FALSE
+
 		if(!same_loc)
-			if(loc != oldloc)
-				if(is_multi_tile && isturf(destination))
-					var/list/new_locs = block(
-						destination,
-						locate(
-							min(world.maxx, destination.x + ROUND_UP(bound_width / ICON_SIZE_X)),
-							min(world.maxy, destination.y + ROUND_UP(bound_height / ICON_SIZE_Y)),
-							destination.z
-						)
+			if(is_multi_tile && isturf(destination))
+				var/list/new_locs = block(
+					destination,
+					locate(
+						min(world.maxx, destination.x + ROUND_UP(bound_width / ICON_SIZE_X)),
+						min(world.maxy, destination.y + ROUND_UP(bound_height / ICON_SIZE_Y)),
+						destination.z
 					)
+				)
+				if(old_area && old_area != destarea)
+					old_area.Exited(src, movement_dir)
+				for(var/atom/left_loc as anything in locs - new_locs)
+					left_loc.Exited(src, movement_dir)
+
+				for(var/atom/entering_loc as anything in new_locs - locs)
+					entering_loc.Entered(src, movement_dir)
+
+				if(old_area && old_area != destarea)
+					destarea.Entered(src, movement_dir)
+			else
+				if(oldloc)
+					oldloc.Exited(src, movement_dir)
 					if(old_area && old_area != destarea)
 						old_area.Exited(src, movement_dir)
-					for(var/atom/left_loc as anything in locs - new_locs)
-						left_loc.Exited(src, movement_dir)
-
-					for(var/atom/entering_loc as anything in new_locs - locs)
-						entering_loc.Entered(src, movement_dir)
-
-					if(old_area && old_area != destarea)
-						destarea.Entered(src, movement_dir)
-				else
-					if(oldloc)
-						oldloc.Exited(src, movement_dir)
-						if(old_area && old_area != destarea)
-							old_area.Exited(src, movement_dir)
-					destination.Entered(src, oldloc)
-					if(destarea && old_area != destarea)
-						destarea.Entered(src, old_area)
-			else
-				// when attempting to move an atom A into an atom B which already contains A, BYOND seems
-				// to silently refuse to move A to the new loc. This can really break stuff (see #77067)
-				stack_trace("Failed to move atom to new loc, possibly due to cyclic contents")
-				return FALSE
+				destination.Entered(src, oldloc)
+				if(destarea && old_area != destarea)
+					destarea.Entered(src, old_area)
 
 		. = TRUE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1137,6 +1137,7 @@
 			pulledby.stop_pulling()
 
 		var/same_loc = oldloc == destination
+		var/movement_successful = TRUE
 		var/area/old_area = get_area(oldloc)
 		var/area/destarea = get_area(destination)
 		var/movement_dir = get_dir(src, destination)
@@ -1149,9 +1150,9 @@
 			// when attempting to move an atom A into an atom B which already contains A, BYOND seems
 			// to silently refuse to move A to the new loc. This can really break stuff (see #77067)
 			stack_trace("Attempt to move [src] to [destination] was rejected by BYOND, possibly due to cyclic contents")
-			return FALSE
+			movement_successful = FALSE
 
-		if(!same_loc)
+		if(movement_successful && !same_loc)
 			if(is_multi_tile && isturf(destination))
 				var/list/new_locs = block(
 					destination,
@@ -1180,7 +1181,7 @@
 				if(destarea && old_area != destarea)
 					destarea.Entered(src, old_area)
 
-		. = TRUE
+		. = movement_successful
 
 	//If no destination, move the atom into nullspace (don't do this unless you know what you're doing)
 	else


### PR DESCRIPTION
## About The Pull Request

One weird thing about loc assignments is that BYOND silently rejects the assignment if moving an atom somewhere would result in cyclic contents. This PR adds a safeguard together with a stacktrace in case this happens, preventing Entered and Exited from getting called

The safeguard might cause a few bugs to pop out in the codebase, I could reduce the PR to the stack_trace only, so the PR only adds diagnostics

## Why It's Good For The Game

Failing doMove() but still calling Entered and Exited causes unintended behavior (#77067)

## Changelog

:cl:
code: Fixed rare cases where moving an object somewhere could silently fail, but still run unintended code. Report any weird issues on Github
/:cl:
