### PR TITLE
thud only thuds on carbons

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -246,9 +246,6 @@
 
 /mob/living/carbon/on_fall()
 	. = ..()
-	loc?.handle_fall(src)
-	SHOULD_CALL_PARENT(TRUE)
-	SEND_SIGNAL(src, COMSIG_LIVING_THUD)
 	loc?.handle_fall(src) //it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/resist_buckle()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -245,9 +245,8 @@
 		paper_note.show_through_camera(usr)
 
 /mob/living/carbon/on_fall()
-	..()
+	. = ..()
 	loc?.handle_fall(src)
-	return
 
 /mob/living/carbon/resist_buckle()
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -247,6 +247,9 @@
 /mob/living/carbon/on_fall()
 	. = ..()
 	loc?.handle_fall(src)
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(src, COMSIG_LIVING_THUD)
+	loc?.handle_fall(src) //it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/resist_buckle()
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -244,6 +244,11 @@
 
 		paper_note.show_through_camera(usr)
 
+/mob/living/carbon/on_fall()
+	..()
+	loc?.handle_fall(src)
+	return
+
 /mob/living/carbon/resist_buckle()
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED))
 		buckled.user_unbuckle_mob(src, src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1923,7 +1923,6 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 /mob/living/proc/on_fall()
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_LIVING_THUD)
-	loc?.handle_fall(src)//it's loc so it doesn't call the mob's handle_fall which does nothing
 	return
 
 /mob/living/forceMove(atom/destination)


### PR DESCRIPTION

## About The Pull Request

soft revert: thud only thuds on carbons

@lemon's dumbasss username
## Why It's Good For The Game

fixes roaches thudding on death & similar bugs. non carbons dont support handle_fall() yet
## Changelog
none
