### PR TITLE
Gives nukies beakers

### DIFF
--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -68,6 +68,17 @@
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
 	},
+/obj/structure/closet/syndicate/personal,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "bo" = (


### PR DESCRIPTION

## About The Pull Request

This gives the chemical section in the nukie base some large beakers

## Why It's Good For The Game

It's a bit mad that a nukie can pay TC to get access to this area and then they get, like, 3 small beakers? I've had to intervene as an admin to give them more.

## Changelog
:cl:
map: In the new year's budget the syndicate have decided that chemists need beakers to do their job properly.
/:cl:
