### PR TITLE
Admins can now return the shuttle back to the station without ending the round

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -363,7 +363,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Send Shuttle Back"))
 			message_admins("[key_name_admin(holder)] sent the escape shuttle back to the station")
-			if (make_announcement != "No")
+			if (make_announcement && make_announcement != "No")
 				priority_announce(
 					text = announcement_text,
 					title = "Shuttle Trajectory Override",
@@ -707,7 +707,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 		message_admins("Emergency shuttle was unable to dock back to the station!")
 		SSshuttle.emergency.timer = 1 // Prevents softlocks
 		return
-	if (make_announcement != "No")
+	if (make_announcement && make_announcement != "No")
 		priority_announce(
 			text = "[SSshuttle.emergency] has returned to the station.",
 			title = "Emergency Shuttle Override",

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -354,7 +354,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			if (SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
 				to_chat(usr, span_warning("Emergency shuttle not currently in transit!"), confidential = TRUE)
 				return
-			var/make_announcement = tgui_alert(usr, "Make a CentCom announcement?", "Emergency shuttle return", list("Yes", "Custom Text", "No"))
+			var/make_announcement = tgui_alert(usr, "Make a CentCom announcement?", "Emergency shuttle return", list("Yes", "Custom Text", "No")) || "No"
 			var/announcement_text = "Emergency shuttle trajectory overriden, rerouting course back to [station_name()]."
 			if (make_announcement == "Custom Text")
 				announcement_text = tgui_input_text(usr, "Custom CentCom announcement", "Emergency shuttle return", multiline = TRUE) || announcement_text
@@ -363,7 +363,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Send Shuttle Back"))
 			message_admins("[key_name_admin(holder)] sent the escape shuttle back to the station")
-			if (make_announcement && make_announcement != "No")
+			if (make_announcement != "No")
 				priority_announce(
 					text = announcement_text,
 					title = "Shuttle Trajectory Override",
@@ -707,7 +707,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 		message_admins("Emergency shuttle was unable to dock back to the station!")
 		SSshuttle.emergency.timer = 1 // Prevents softlocks
 		return
-	if (make_announcement && make_announcement != "No")
+	if (make_announcement != "No")
 		priority_announce(
 			text = "[SSshuttle.emergency] has returned to the station.",
 			title = "Emergency Shuttle Override",

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -348,6 +348,31 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				priority_announce("The NAP is now in full effect.", null, SSstation.announcer.get_rand_report_sound())
 			else
 				priority_announce("The NAP has been revoked.", null, SSstation.announcer.get_rand_report_sound())
+		if("send_shuttle_back")
+			if(!is_funmin)
+				return
+			if(SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
+				to_chat(usr, span_warning("Emergency shuttle not currently in transit!"), confidential = TRUE)
+				return
+			var/make_announcement = tgui_alert(user, "Make a CentCom announcement?", "Emergency shuttle return", list("Yes", "No"))
+			var/new_timer = tgui_input_number(usr, "How long should the shuttle remain in transit?", "When are we droppin' boys?", 3 MINUTES, 10 MINUTES)
+			if (isnull(new_timer) || SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
+				return
+			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Send Shuttle Back"))
+			message_admins("[key_name_admin(holder)] sent the escape shuttle back to the station")
+			if (make_announcement)
+				priority_announce(
+					text = "Emergency shuttle trajectory overriden, rerouting course back to [station_name()].",
+					title = "Shuttle Trajectory Override",
+					sound =  'sound/announcer/announcement/announce_dig.ogg',
+					sender_override = "Emergency Shuttle Uplink Alert",
+					color_override = "grey",
+				)
+			SSshuttle.emergency.timer = INFINITY
+			if (new_timer > 0)
+				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement), new_timer)
+			else
+				INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement)
 		if("blackout")
 			if(!is_funmin)
 				return
@@ -672,6 +697,27 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 	var/turf/T = get_step(loc, SOUTHWEST)
 	T.flick_overlay_static(portal_appearance[GET_TURF_PLANE_OFFSET(T) + 1], 15)
 	playsound(T, 'sound/effects/magic/lightningbolt.ogg', rand(80, 100), TRUE)
+
+/// Docks the emergency shuttle back to the station and resets its' state
+/proc/return_escape_shuttle(make_announcement = TRUE)
+	if (SSshuttle.emergency.initiate_docking(SSshuttle.getDock("emergency_home"), force = TRUE) != DOCKING_SUCCESS)
+		message_admins("Emergency shuttle was unable to dock back to the station!")
+		SSshuttle.emergency.timer = 1 // Prevents softlocks
+		return
+	if (make_announcement)
+		priority_announce(
+			text = "[SSshuttle.emergency] has returned to the station.",
+			title = "Emergency Shuttle Override",
+			sound = ANNOUNCER_SHUTTLEDOCK,
+			sender_override = "Emergency Shuttle Uplink Alert",
+			color_override = "grey",
+		)
+	SSshuttle.emergency.mode = SHUTTLE_IDLE
+	SSshuttle.emergency.timer = 0
+	// Docks the pods back (don't ask about physics)
+	for (var/obj/docking_port/mobile/pod/pod in SSshuttle.mobile_docking_ports)
+		if (pod.previous)
+			pod.initiate_docking(pod.previous, force = TRUE)
 
 /datum/everyone_is_an_antag_controller
 	var/chosen_antag = ""

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -358,7 +358,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			var/announcement_text = "Emergency shuttle trajectory overriden, rerouting course back to [station_name()]."
 			if (make_announcement == "Custom Text")
 				announcement_text = tgui_input_text(usr, "Custom CentCom announcement", "Emergency shuttle return", multiline = TRUE) || announcement_text
-			var/new_timer = tgui_input_number(usr, "How long should the shuttle remain in transit?", "When are we droppin' boys?", 3 MINUTES, 10 MINUTES)
+			var/new_timer = tgui_input_number(usr, "How long should the shuttle remain in transit?", "When are we droppin' boys?", 180, 600)
 			if (isnull(new_timer) || SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Send Shuttle Back"))
@@ -373,7 +373,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				)
 			SSshuttle.emergency.timer = INFINITY
 			if (new_timer > 0)
-				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement), new_timer)
+				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement), new_timer SECONDS)
 			else
 				INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement)
 		if("blackout")

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -349,20 +349,23 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			else
 				priority_announce("The NAP has been revoked.", null, SSstation.announcer.get_rand_report_sound())
 		if("send_shuttle_back")
-			if(!is_funmin)
+			if (!is_funmin)
 				return
-			if(SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
+			if (SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
 				to_chat(usr, span_warning("Emergency shuttle not currently in transit!"), confidential = TRUE)
 				return
-			var/make_announcement = tgui_alert(user, "Make a CentCom announcement?", "Emergency shuttle return", list("Yes", "No"))
+			var/make_announcement = tgui_alert(usr, "Make a CentCom announcement?", "Emergency shuttle return", list("Yes", "Custom Text", "No"))
+			var/announcement_text = "Emergency shuttle trajectory overriden, rerouting course back to [station_name()]."
+			if (make_announcement == "Custom Text")
+				announcement_text = tgui_input_text(usr, "Custom CentCom announcement", "Emergency shuttle return", multiline = TRUE) || announcement_text
 			var/new_timer = tgui_input_number(usr, "How long should the shuttle remain in transit?", "When are we droppin' boys?", 3 MINUTES, 10 MINUTES)
 			if (isnull(new_timer) || SSshuttle.emergency.mode != SHUTTLE_ESCAPE)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Send Shuttle Back"))
 			message_admins("[key_name_admin(holder)] sent the escape shuttle back to the station")
-			if (make_announcement)
+			if (make_announcement != "No")
 				priority_announce(
-					text = "Emergency shuttle trajectory overriden, rerouting course back to [station_name()].",
+					text = announcement_text,
 					title = "Shuttle Trajectory Override",
 					sound =  'sound/announcer/announcement/announce_dig.ogg',
 					sender_override = "Emergency Shuttle Uplink Alert",
@@ -699,12 +702,12 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 	playsound(T, 'sound/effects/magic/lightningbolt.ogg', rand(80, 100), TRUE)
 
 /// Docks the emergency shuttle back to the station and resets its' state
-/proc/return_escape_shuttle(make_announcement = TRUE)
+/proc/return_escape_shuttle(make_announcement)
 	if (SSshuttle.emergency.initiate_docking(SSshuttle.getDock("emergency_home"), force = TRUE) != DOCKING_SUCCESS)
 		message_admins("Emergency shuttle was unable to dock back to the station!")
 		SSshuttle.emergency.timer = 1 // Prevents softlocks
 		return
-	if (make_announcement)
+	if (make_announcement != "No")
 		priority_announce(
 			text = "[SSshuttle.emergency] has returned to the station.",
 			title = "Emergency Shuttle Override",

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -425,13 +425,13 @@ const FunTab = (props) => {
             />
           </Stack.Item>
           <Stack.Item>
-            <NoticeBox
-              mb={-0.5}
+            <Button
+              icon="house"
+              lineHeight={lineHeightNormal}
               width={buttonWidthNormal}
-              height={lineHeightNormal}
-            >
-              Your admin button here, coder!
-            </NoticeBox>
+              content="Send Shuttle Back"
+              onClick={() => act('send_shuttle_back')}
+            />
           </Stack.Item>
         </Stack>
       </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Per DarkenedEarth's request on discord, adds a new Fun menu secret which makes the shuttle go back to the station after a configurable delay with an announcement (also configurable). After docking at the station it behaves like BYOS (still requiring to wait for it's arrival despite it being docked).

## Why It's Good For The Game

Admins want it to hunt early EORGers or make events or something like that.

## Changelog
:cl:
admin: Admins can now return the shuttle back to the station without ending the round
/:cl:
