### PR TITLE
Removes an extra proc override in digitigrade pref logic

### DIFF
--- a/code/modules/client/preferences/species_features/lizard.dm
+++ b/code/modules/client/preferences/species_features/lizard.dm
@@ -128,17 +128,6 @@
 	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	return initial(species_type.digitigrade_customization) == DIGITIGRADE_OPTIONAL
 
-
-/datum/preference/choiced/lizard_legs/is_accessible(datum/preferences/preferences)
-	. = ..()
-
-	if(!.)
-		return
-
-	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
-
-	return initial(species_type.digitigrade_customization) & DIGITIGRADE_OPTIONAL
-
 /datum/preference/choiced/lizard_snout
 	savefile_key = "feature_lizard_snout"
 	savefile_identifier = PREFERENCE_CHARACTER


### PR DESCRIPTION

## About The Pull Request
they're doing the same thing and this one does a bitfield check when the value it's checking is a number, technically it works as intended right now but if we ever added more - it would break.
## Changelog
:cl: grungussuss
code: removed an extra proc override in digitigrade legs preference logic code
/:cl:
