### PR TITLE
Fixes cryo pod's shuttleMove() runtime, remedying constant CI fails

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
@@ -57,8 +57,12 @@
 /**
  * Called when the machine has been moved, reconnect to the pipe network
  */
-/datum/gas_machine_connector/proc/moved_connected_machine()
+/datum/gas_machine_connector/proc/moved_connected_machine(obj/machinery/source, atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	SIGNAL_HANDLER
+	if(forced) // Called from parent doing abstract_move()
+		gas_connector.abstract_move(get_turf(connected_machine))
+		return // No side-effects means no disconnections
+
 	gas_connector.forceMove(get_turf(connected_machine))
 	reconnect_connector()
 


### PR DESCRIPTION
## About The Pull Request
Cryo pods use a `/datum/gas_machine_connector` component that lets non-atmospheric machine subtypes still have a means of interfacing with the pipenet.

When a machine gets `shuttleMove()` called, it does an `abstract_move()` to a loc, then calls `Moved()`, which our gas connector listens to. The problem is that our connector would always attempt a `doMove()`, which would runtime since it would attempt checks that the parent object ignored.

This PR makes connectors `abstract_move()` if the signal they received was forced, skipping checks that the parent also skipped.

Issues:
fixes #88406
fixes #88436

## Somewhat Small Cat
![image](https://github.com/user-attachments/assets/b2b040fc-1b4f-4ced-88a1-054164358569)

## Changelog

:cl:
fix: /datum/gas_machine_connector will abstract_move() if their parent also abstract_move()s, preventing a runtime
/:cl: