### PR TITLE
Resecure Delta's Xenobio Chamber.dmm

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -84092,10 +84092,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal/delivery_chute{
+/obj/effect/turf_decal/box/red,
+/obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/effect/turf_decal/box/red,
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "uYg" = (


### PR DESCRIPTION
## About The Pull Request

Replaces the disposal chute at (076, 095) in the Xenobiology Lab with a disposal outlet

## Why It's Good For The Game

Xenos are dangerous goobers and them escaping is Quite Bad(TM). Having access to a disposals inlet on Delta-class stations piped directly outside of the "secure" chamber is also Quite Bad(TM). We've got enough problems with the cute little face eaters and keeping them safe and sound and away from the evil murderous crew, so maintaining a basic level of containment would be Quite Good(TM).

## Changelog

:cl:
fix: NanoTrasen has shown a xenobiology containment engineer for Delta class stations a very important lesson between inlets and outlets
/:cl:
