### PR TITLE
Fixes a Honkerblast 5000 runtime

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -193,6 +193,7 @@
 	icon_state = "mecha_honker"
 	energy_drain = 200
 	equip_cooldown = 150
+	projectiles_per_shot = 0
 	range = MECHA_MELEE|MECHA_RANGED
 	kickback = FALSE
 	mech_flags = EXOSUIT_MODULE_HONK


### PR DESCRIPTION

## About The Pull Request

Mech code is ass, projectiles_per_shot is 1 by default so honkerblast was trying to fire nonexistent projectiles in its parent call and runtimed, preventing target logging (Paddy claw does this correctly)

## Changelog
:cl:
fix: Fixed a Honkerblast 5000 runtime
/:cl:
