### PR TITLE
Fixes spelling/grammatical errors/inconsistencies in Funeral Supplies / Religious Supplies cargo crates

### DIFF
--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -139,7 +139,7 @@
 /datum/supply_pack/misc/funeral
 	name = "Funeral Supplies Crate"
 	desc = "At the end of the day, someone's gonna want someone dead. Give them a proper send-off with these \
-		funeral supplies! Contains a coffin, burial garments and flowers."
+		funeral supplies! Contains a coffin with burial garments and flowers."
 	cost = CARGO_CRATE_VALUE * 1.6
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/clothing/under/misc/burial,

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -139,7 +139,7 @@
 /datum/supply_pack/misc/funeral
 	name = "Funeral Supply crate"
 	desc = "At the end of the day, someone's gonna want someone dead. Give them a proper send-off with these \
-		funeral supplies! Contains a coffin with burial garmets and flowers."
+		funeral supplies! Contains a coffin with burial garments and flowers."
 	cost = CARGO_CRATE_VALUE * 1.6
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/clothing/under/misc/burial,
@@ -165,7 +165,7 @@
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"
 	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your \
-		cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garmets."
+		cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garments."
 	cost = CARGO_CRATE_VALUE * 6 // it costs so much because the Space Church needs funding to build a cathedral
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/reagent_containers/cup/glass/bottle/holywater = 2,

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -137,9 +137,9 @@
 
 
 /datum/supply_pack/misc/funeral
-	name = "Funeral Supply crate"
+	name = "Funeral Supplies Crate"
 	desc = "At the end of the day, someone's gonna want someone dead. Give them a proper send-off with these \
-		funeral supplies! Contains a coffin with burial garments and flowers."
+		funeral supplies! Contains a coffin, burial garments and flowers."
 	cost = CARGO_CRATE_VALUE * 1.6
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/clothing/under/misc/burial,
@@ -165,7 +165,7 @@
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"
 	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your \
-		cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garments."
+		cargo bay. Contains two bottles of holy water, bibles, chaplain robes, and burial garments."
 	cost = CARGO_CRATE_VALUE * 6 // it costs so much because the Space Church needs funding to build a cathedral
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/reagent_containers/cup/glass/bottle/holywater = 2,


### PR DESCRIPTION
## About The Pull Request

Corrects "garmets" to "garments" and some minor grammatical errors or inconsistencies for for readability.

## Why It's Good For The Game

Spelling errors bad

## Changelog

:cl:
fix: fixes a minor spelling/grammatical error in the Funeral Supply and Religious Supplies crates.
/:cl: