### PR TITLE
Fixes c38 not misfiring when chambered in c357

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -477,7 +477,7 @@
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
 	if(isnull(chambered))
 		return ..()
-	if(can_misfire && chambered.can_misfire != FALSE)
+	if(can_misfire)
 		misfire_probability += misfire_percentage_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
 	if(chambered.can_misfire)


### PR DESCRIPTION

## About The Pull Request
Closes #88535
what

## Changelog
:cl:
fix: Fixed c38 not misfiring when chambered in c357
/:cl:
