### PR TITLE
Fixes mech KA AOE dealing full damage in pressurized environments

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -208,10 +208,10 @@
 	if(is_type_in_typecache(target, kinetic_gun?.ignored_mob_types))
 		return PROJECTILE_PIERCE_PHASE
 	. = ..()
-
+	if(. == PROJECTILE_PIERCE_PHASE)
+			return
 	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in kinetic_gun?.modkits)
 		modkit_upgrade.projectile_prehit(src, target, kinetic_gun)
-
 	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
 		name = "weakened [name]"
 		damage = damage * pressure_decrease

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -208,10 +208,10 @@
 	if(is_type_in_typecache(target, kinetic_gun?.ignored_mob_types))
 		return PROJECTILE_PIERCE_PHASE
 	. = ..()
-	if(. == PROJECTILE_PIERCE_PHASE)
-		return
+
 	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in kinetic_gun?.modkits)
 		modkit_upgrade.projectile_prehit(src, target, kinetic_gun)
+
 	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
 		name = "weakened [name]"
 		damage = damage * pressure_decrease
@@ -225,6 +225,11 @@
 	update_appearance()
 
 /obj/projectile/kinetic/on_range()
+	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(src)))
+		name = "weakened [name]"
+		damage = damage * pressure_decrease
+		pressure_decrease_active = TRUE
+
 	strike_thing(loc)
 	..()
 

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -209,7 +209,7 @@
 		return PROJECTILE_PIERCE_PHASE
 	. = ..()
 	if(. == PROJECTILE_PIERCE_PHASE)
-			return
+		return
 	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in kinetic_gun?.modkits)
 		modkit_upgrade.projectile_prehit(src, target, kinetic_gun)
 	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))


### PR DESCRIPTION

## About The Pull Request
Technically applied to normal KAs too? Damage was not reduced on on_range, so if you hit someone with the AOE blast at the end of projectile's lifetime you'd deal full 80 bomb damage

## Changelog
:cl:
fix: Fixed mech KA AOE dealing full damage in pressurized environments
/:cl:
