### PR TITLE
Adds removing singular crusher trophies (+relevant screentips)

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -51,6 +51,17 @@
 	)
 	//technically it's huge and bulky, but this provides an incentive to use it
 	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
+	register_context()
+
+/obj/item/kinetic_crusher/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(!held_item)
+		context[SCREENTIP_CONTEXT_RMB] = "Detach trophy"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item) && held_item.tool_behaviour == TOOL_CROWBAR)
+		context[SCREENTIP_CONTEXT_LMB] = "Detach all trophies"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)
@@ -84,6 +95,46 @@
 	for(var/obj/item/crusher_trophy/crusher_trophy as anything in trophies)
 		crusher_trophy.remove_from(src, user)
 	return ITEM_INTERACT_SUCCESS
+
+// adapted from kinetic accelerator attack_hand_secodary
+/obj/item/kinetic_crusher/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(!LAZYLEN(trophies))
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+
+	var/list/display_names = list()
+	var/list/items = list()
+	for(var/trophies_length in 1 to length(trophies))
+		var/obj/item/crusher_trophy/trophy = trophies[trophies_length]
+		display_names[trophy.name] = REF(trophy)
+		var/image/item_image = image(icon = trophy.icon, icon_state = trophy.icon_state)
+		if(length(trophy.overlays))
+			item_image.copy_overlays(trophy)
+		items["[trophy.name]"] = item_image
+
+	var/pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), radius = 36, require_near = TRUE, tooltips = TRUE)
+	if(!pick)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	var/trophy_reference = display_names[pick]
+	var/obj/item/crusher_trophy/trophy_to_remove = locate(trophy_reference) in trophies
+	if(!istype(trophy_to_remove))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	trophy_to_remove.remove_from(src, user)
+	if(!user.put_in_hands(trophy_to_remove))
+		trophy_to_remove.forceMove(drop_location())
+
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/kinetic_crusher/proc/check_menu(mob/living/carbon/human/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated)
+		return FALSE
+	return TRUE
 
 /obj/item/kinetic_crusher/pre_attack(atom/A, mob/living/user, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Reuses the kinetic accelerator's right-click radial menu for removing modkits for a radial that allows removing trophies from kinetic crushers.
![image](https://github.com/user-attachments/assets/44d3d8dd-332f-49b1-8e9d-15c1613a962b)
Also adds relevant screentips for the crusher in regards to removing trophies with a crowbar and an empty hand.
with crowbar:
![image](https://github.com/user-attachments/assets/3dfb352d-7604-4fc5-9a0a-00b5ce0e6807)
with empty-hand RMB:
![image](https://github.com/user-attachments/assets/1cbcfd06-261f-478f-9733-310f44a3c188)

## Why It's Good For The Game

maybe i don't want to remove all my trophies at once actually

## Changelog

:cl:
qol: You can now pull singular trophies off kinetic crushers with RMB.
qol: Kinetic crushers now have screentips informing people that they can remove trophies via empty hand (RMB) or crowbar (LMB).
/:cl: