### PR TITLE
Reduces synthflesh required for unhusk. unhusk now depends on purity

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -46,7 +46,8 @@
 ///Health threshold for synthflesh and rezadone to unhusk someone
 #define UNHUSK_DAMAGE_THRESHOLD 50
 ///Amount of synthflesh required to unhusk someone
-#define SYNTHFLESH_UNHUSK_AMOUNT 40
+#define SYNTHFLESH_UNHUSK_AMOUNT 60
+#define SYNTHFLESH_UNHUSK_MAX 100
 
 //used by chem masters and pill presses
 // The categories of reagent packaging

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -46,7 +46,7 @@
 ///Health threshold for synthflesh and rezadone to unhusk someone
 #define UNHUSK_DAMAGE_THRESHOLD 50
 ///Amount of synthflesh required to unhusk someone
-#define SYNTHFLESH_UNHUSK_AMOUNT 100
+#define SYNTHFLESH_UNHUSK_AMOUNT 40
 
 //used by chem masters and pill presses
 // The categories of reagent packaging

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -533,8 +533,10 @@
 	if (carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD)
 		return
 
-	var/current_volume = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh)
-	var/current_purity = carbies.reagents.get_reagent_purity(/datum/reagent/medicine/c2/synthflesh)
+	var/datum/reagent/synthflesh = carbies.reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh)
+	var/current_volume = synthflesh ? synthflesh.volume : 0
+	var/current_purity = synthflesh ? synthflesh.purity : 0
+
 	if (methods & TOUCH)	//touch does not apply chems to blood, we want to combine the two volumes before attempting to unhusk
 		current_purity = current_volume > 0 ? (current_volume * current_purity + reac_volume * creation_purity) / (current_volume + reac_volume) : creation_purity
 		current_volume += reac_volume

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -533,9 +533,11 @@
 	if (carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD)
 		return
 
-	var/pure_units = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh) * carbies.reagents.get_reagent_purity(/datum/reagent/medicine/c2/synthflesh)
+	var/volume = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh)
+	var/purity = carbies.reagents.get_reagent_purity(/datum/reagent/medicine/c2/synthflesh)
 
-	if(pure_units >= SYNTHFLESH_UNHUSK_AMOUNT)
+	//when purity = 100%, 60u to unhusk, when purity = 60%, 100u to unhusk.
+	if(volume * purity >= SYNTHFLESH_UNHUSK_AMOUNT || volume >= SYNTHFLESH_UNHUSK_MAX)
 		carbies.cure_husk(BURN)
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!")) //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -525,19 +525,22 @@
 
 	carbies.add_mood_event("painful_medicine", /datum/mood_event/painful_medicine)
 
-	//if mob is not husked, don't try to unhusk
+	//don't unhusked non husked mobs
 	if (!HAS_TRAIT_FROM(exposed_mob, TRAIT_HUSK, BURN))
 		return
 
-	//if mob is above damage threshold for unhusk, don't try to unhusk
+	//don't try to unhusk mobs above burn damage threshold
 	if (carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD)
 		return
 
-	var/volume = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh)
-	var/purity = carbies.reagents.get_reagent_purity(/datum/reagent/medicine/c2/synthflesh)
+	var/current_volume = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh)
+	var/current_purity = carbies.reagents.get_reagent_purity(/datum/reagent/medicine/c2/synthflesh)
+	if (methods & TOUCH)	//touch does not apply chems to blood, we want to combine the two volumes before attempting to unhusk
+		current_purity = current_volume > 0 ? (current_volume * current_purity + reac_volume * creation_purity) / (current_volume + reac_volume) : creation_purity
+		current_volume += reac_volume
 
 	//when purity = 100%, 60u to unhusk, when purity = 60%, 100u to unhusk.
-	if(volume * purity >= SYNTHFLESH_UNHUSK_AMOUNT || volume >= SYNTHFLESH_UNHUSK_MAX)
+	if(current_volume * current_purity >= SYNTHFLESH_UNHUSK_AMOUNT || current_volume >= SYNTHFLESH_UNHUSK_MAX)
 		carbies.cure_husk(BURN)
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!")) //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -542,7 +542,7 @@
 		current_volume += reac_volume
 
 	//when purity = 100%, 60u to unhusk, when purity = 60%, 100u to unhusk.
-	if(current_volume * current_purity >= SYNTHFLESH_UNHUSK_AMOUNT || current_volume >= SYNTHFLESH_UNHUSK_MAX)
+	if(current_volume >= SYNTHFLESH_UNHUSK_MAX || current_volume * current_purity >= SYNTHFLESH_UNHUSK_AMOUNT)
 		carbies.cure_husk(BURN)
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!")) //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -524,7 +524,18 @@
 		to_chat(carbies, span_danger("You feel your burns and bruises healing! It stings like hell!"))
 
 	carbies.add_mood_event("painful_medicine", /datum/mood_event/painful_medicine)
-	if(HAS_TRAIT_FROM(exposed_mob, TRAIT_HUSK, BURN) && carbies.getFireLoss() < UNHUSK_DAMAGE_THRESHOLD && (carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh) + reac_volume >= SYNTHFLESH_UNHUSK_AMOUNT))
+
+	//if mob is not husked, don't try to unhusk
+	if (!HAS_TRAIT_FROM(exposed_mob, TRAIT_HUSK, BURN))
+		return
+
+	//if mob is above damage threshold for unhusk, don't try to unhusk
+	if (carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD)
+		return
+
+	var/pure_units = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh) * carbies.reagents.get_reagent_purity(/datum/reagent/medicine/c2/synthflesh)
+
+	if(pure_units >= SYNTHFLESH_UNHUSK_AMOUNT)
 		carbies.cure_husk(BURN)
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!")) //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
 


### PR DESCRIPTION
## About The Pull Request

The amount of synthflesh required to unhusk now changes based on the purity of synthflesh
60u for 100% purity, 80u for 75% purity, 100u for 60% purity and below.

## Why It's Good For The Game

Encourages people to interact with the purity system a bit more. Most of the time, players only use synthflesh for unhusking with no regard for the purity of the chem.

## Changelog

:cl:
balance: Synthflesh required for unhusking now between 60u and 100u depending on purity.
/:cl:
