### PR TITLE
Removes the sec record computer from the icemoons agent

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
@@ -993,9 +993,6 @@
 /area/ruin/comms_agent)
 "UI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/records/security/laptop/syndie{
-	dir = 1
-	},
 /obj/item/paper/monitorkey{
 	pixel_x = -15;
 	pixel_y = 7


### PR DESCRIPTION

## About The Pull Request

it is gone, no more record deletion.

## Why It's Good For The Game

i made this map but i'm pretty sure i didn't add this computer there, having the opwer to delete records just completely fucks over sec and isn't fun to go against

## Changelog

:cl:
map: removed the sec record computer from the Icemoon Listening Post.
/:cl:

