### PR TITLE
Fixes emotes done via the emote keybind tgui window being only visible instead of audible and visible

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -733,6 +733,9 @@
 	if(!emote_is_valid(user, our_message))
 		return FALSE
 
+	if(type_override)
+		emote_type = type_override
+
 	if(!params)
 		var/user_emote_type = get_custom_emote_type_from_user()
 


### PR DESCRIPTION

## About The Pull Request

A recent pr moved around some of the custom emote code to fix it running on `*help`, but this made it so custom emotes done via the custom emote keybind tgui window defaulted to only visible.

The emotes do get called with a `type_override`, here `EMOTE_VISIBLE|EMOTE_AUDIBLE`:
https://github.com/tgstation/tgstation/blob/30e5499bce23961bd29f87519d914a9c78e895cc/code/modules/mob/mob_say.dm#L53
However, the proc itself doesn't actually *care* for a type override and so instead just defaults to `EMOTE_VISIBLE`.
This pr just makes it set the emote type to `type_override` if applicable, fixing our problem.
## Why It's Good For The Game

Fixes bug.
## Changelog
:cl:
fix: Custom emotes done via the custom emote keybind default to both audible and visible again.
/:cl:
