### PR TITLE
Fixes a runtime that occurs when attempting to suture a missing limb

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -382,7 +382,7 @@
 		target_zone = get_bodypart(check_zone(user.zone_selected)) //try to find a bodypart. if there isn't one, target_zone will be null, and check_zone in the next line will default to the chest.
 	var/obj/item/bodypart/the_part = isbodypart(target_zone) ? target_zone : get_bodypart(check_zone(target_zone)) //keep these synced
 	// Loop through the clothing covering this bodypart and see if there's any thiccmaterials
-	if(!(injection_flags & INJECT_CHECK_PENETRATE_THICK))
+	if(the_part && !(injection_flags & INJECT_CHECK_PENETRATE_THICK))
 		for(var/obj/item/clothing/iter_clothing in get_clothing_on_part(the_part))
 			if(iter_clothing.clothing_flags & THICKMATERIAL)
 				. = FALSE


### PR DESCRIPTION

## About The Pull Request

can_inject, which is used by a ton of stuff but most prominent user is sutures, tries to check for all clothing on a limb. Including missing limbs. Should probably ensure that the limb exists in the first place - not sure if we should block injecting entirely in such a scenario, it'd be pretty frustrating to have to swap limbs when trying to inject someone with a hypo if they're missing an arm.

## Changelog
:cl:
fix: Fixed a runtime that occurs when attempting to suture a missing limb
/:cl:
