### PR TITLE
Add power efficiency when stasis bed stock parts are upgraded

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -14,6 +14,9 @@
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 	interaction_flags_click = ALLOW_SILICON_REACH
+	use_power = IDLE_POWER_USE
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 3
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 3
 	var/stasis_enabled = TRUE
 	var/last_stasis_sound = FALSE
 	var/stasis_can_toggle = 0
@@ -24,6 +27,20 @@
 	. = ..()
 	AddElement(/datum/element/elevation, pixel_shift = 6)
 	update_buckle_vars(dir)
+
+/obj/machinery/stasis/RefreshParts()
+	. = ..()
+
+	var/energy_rating = 0
+	for(var/datum/stock_part/part in component_parts)
+		energy_rating += part.energy_rating()
+
+	for(var/obj/item/stock_parts/part in component_parts)
+		energy_rating += part.energy_rating
+
+	idle_power_usage = initial(idle_power_usage) / (energy_rating/2)
+	active_power_usage = initial(active_power_usage) / (energy_rating/2)
+	update_current_power_usage()
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Upgrading a stasis bed caused it to drain a massive amount of power without ANY benefit.

The roundstart power draw is 300/3,000 when inactive/active. If you max upgrade the stock parts it results in 2,100/21,000 power draw which is insane since it does nothing! Seeing as how there is no other effects, I just made the upgrades divide power (instead of multiply) resultings in better efficiency.

Roundstart is still 300/3,000 but now at max upgrade it is 30/300.

## Why It's Good For The Game
Upgrading a machine should have some upside.

## Changelog
:cl:
add: Add power efficiency when stasis bed stock parts are upgraded
/:cl:
