### PR TITLE
Teleporter Deus Vault

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -72,7 +72,7 @@
 	data["target"] = !target ? "None" : "[get_area(target)] [(regime_set != REGIME_GATE) ? "" : REGIME_TELEPORTER]"
 	data["calibrating"] = calibrating
 
-	if(power_station?.teleporter_hub?.calibrated || power_station?.teleporter_hub?.accuracy >= 3)
+	if(power_station?.teleporter_hub?.calibrated || power_station?.teleporter_hub?.accuracy >= 4)
 		data["calibrated"] = TRUE
 	else
 		data["calibrated"] = FALSE
@@ -113,10 +113,10 @@
 				say("Hub is already calibrated!")
 				return
 
-			say("Processing hub calibration to target...")
+			say("Processing hub calibration to target in [10 * (4 - power_station.teleporter_hub.accuracy)] seconds...")
 			calibrating = TRUE
 			power_station.update_appearance()
-			addtimer(CALLBACK(src, PROC_REF(finish_calibration)), 50 * (3 - power_station.teleporter_hub.accuracy)) //Better parts mean faster calibration
+			addtimer(CALLBACK(src, PROC_REF(finish_calibration)), 10 SECONDS * (4 - power_station.teleporter_hub.accuracy)) //Better parts mean faster calibration
 			return TRUE
 
 /obj/machinery/computer/teleporter/proc/set_teleport_target(new_target)
@@ -143,10 +143,13 @@
 	power_station.update_appearance()
 
 /obj/machinery/computer/teleporter/proc/check_hub_connection()
-	if(!power_station)
+	if(!power_station || !power_station.teleporter_hub)
 		return FALSE
-	if(!power_station.teleporter_hub)
+	if(power_station.teleporter_hub.panel_open || (power_station.teleporter_hub.machine_stat & (BROKEN|NOPOWER)))
 		return FALSE
+	if(power_station.panel_open || (power_station.machine_stat & (BROKEN|NOPOWER)))
+		return FALSE
+
 	return TRUE
 
 /obj/machinery/computer/teleporter/proc/reset_regime()
@@ -237,7 +240,6 @@
 	if(!A || (A.area_flags & NOTELEPORT))
 		return FALSE
 	return TRUE
-
 
 #undef REGIME_TELEPORTER
 #undef REGIME_GATE

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -12,7 +12,7 @@
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 25 // only used when teleporting (same as gateway)
 	var/accuracy = 0
 	var/obj/machinery/teleport/station/power_station
-	var/calibrated = FALSE//Calibration prevents mutation
+	var/calibrated = FALSE // Calibration prevents mutation
 	var/teleport_radius = 9 // T1 9x9, T2 6x6, T3 3x3, T4 exact turf
 
 /obj/machinery/teleport/hub/Initialize(mapload)
@@ -94,7 +94,6 @@
 				to_chat(M, span_hear("You hear a buzzing in your ears."))
 				human.set_species(species_to_transform)
 				human.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)
-	calibrated = FALSE
 
 /obj/machinery/teleport/hub/update_icon_state()
 	icon_state = "[base_icon_state][panel_open ? "-o" : (is_ready() ? 1 : 0)]"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -36,7 +36,7 @@
 /obj/machinery/teleport/hub/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: Error of margin is <b>±[teleport_radius] radius</b>.")
+		. += span_notice("The status display reads: Error of margin is <b>±[teleport_radius] radius</b> for target destination.")
 
 /obj/machinery/teleport/hub/proc/link_power_station()
 	if(power_station)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -112,6 +112,8 @@
 	icon_state = "controller"
 	base_icon_state = "controller"
 	circuit = /obj/item/circuitboard/machine/teleporter_station
+	use_power = IDLE_POWER_USE
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 3
 	var/engaged = FALSE
 	var/obj/machinery/computer/teleporter/teleporter_console
 	var/obj/machinery/teleport/hub/teleporter_hub

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -179,7 +179,7 @@
 		var/area/computer_area = get_area(target)
 		if(!computer_area || (computer_area.area_flags & NOTELEPORT))
 			continue
-		if(computer.power_station?.teleporter_hub && computer.power_station.engaged)
+		if(computer.check_hub_connection() && computer.power_station.engaged)
 			locations["[get_area(target)]"] = computer
 
 	locations["None (Dangerous)"] = PORTAL_LOCATION_DANGEROUS
@@ -215,6 +215,7 @@
 		return
 
 	var/atom/teleport_target
+	var/teleport_radius = 0
 
 	if (teleport_location == PORTAL_LOCATION_DANGEROUS)
 		var/list/dangerous_turfs = list()
@@ -234,6 +235,9 @@
 		var/atom/target = computer.target_ref?.resolve()
 		if(!target)
 			computer.target_ref = null
+		var/obj/machinery/teleport/hub/hub = computer.power_station.teleporter_hub
+		hub.use_energy(hub.active_power_usage)
+		teleport_radius = hub.teleport_radius + 3 // T1 12x12, T2 9x9, T3 6x6, T4 3x3
 		teleport_target = target
 
 	if (teleport_target == null)
@@ -248,7 +252,7 @@
 	if (!can_teleport_notifies(user))
 		return
 
-	var/list/obj/effect/portal/created = create_portal_pair(get_turf(user), get_teleport_turf(get_turf(teleport_target)), 300, 1, null)
+	var/list/obj/effect/portal/created = create_portal_pair(get_turf(user), get_teleport_turf(get_turf(teleport_target), precision = teleport_radius), 300, 1, null)
 	if(LAZYLEN(created) != 2)
 		return
 

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -180,9 +180,7 @@
 		if(!computer_area || (computer_area.area_flags & NOTELEPORT))
 			continue
 		if(computer.power_station?.teleporter_hub && computer.power_station.engaged)
-			locations["[get_area(target)] (Active)"] = computer
-		else
-			locations["[get_area(target)] (Inactive)"] = computer
+			locations["[get_area(target)]"] = computer
 
 	locations["None (Dangerous)"] = PORTAL_LOCATION_DANGEROUS
 

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -273,6 +273,8 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 		return
 	AM.forceMove(target.get_target_turf())
 	target.post_transfer(AM)
+	if(!isobserver(AM)) // ghosts can teleport using the gateway
+		use_energy(active_power_usage * 10)
 
 /obj/machinery/gateway/attack_ghost(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/restaurant/_venue.dm
+++ b/code/modules/food_and_drinks/restaurant/_venue.dm
@@ -37,6 +37,7 @@
 	COOLDOWN_START(src, visit_cooldown, rand(min_time_between_visitor, max_time_between_visitor))
 	if(current_visitors.len < max_guests && current_visitors.len < linked_seats.len + 1) //Not above max guests, and not more than one waiting customer.
 		create_new_customer()
+		restaurant_portal.use_energy(restaurant_portal.active_power_usage * 2)
 
 ///Spawns a new customer at the portal
 /datum/venue/proc/create_new_customer()
@@ -147,6 +148,7 @@
 	restaurant_portal.update_icon()
 	COOLDOWN_START(src, visit_cooldown, 4 SECONDS) //First one comes faster
 	START_PROCESSING(SSobj, src)
+	restaurant_portal.update_use_power(ACTIVE_POWER_USE)
 
 /datum/venue/proc/close()
 	open = FALSE
@@ -154,6 +156,7 @@
 	STOP_PROCESSING(SSobj, src)
 	for(var/mob/living/basic/robot_customer as anything in current_visitors)
 		robot_customer.ai_controller.set_blackboard_key(BB_CUSTOMER_LEAVING, TRUE) //LEAVEEEEEE
+	restaurant_portal.update_use_power(IDLE_POWER_USE)
 
 /obj/machinery/restaurant_portal
 	name = "restaurant portal"
@@ -165,6 +168,7 @@
 	circuit = /obj/item/circuitboard/machine/restaurant_portal
 	layer = BELOW_OBJ_LAYER
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2.5
 	///What venue is this portal for? Uses a typepath which is turned into an instance on Initialize
 	var/datum/venue/linked_venue = /datum/venue
 


### PR DESCRIPTION

## About The Pull Request
This adds some hefty power requirements to teleporter related machinery and devices. It also changes the behavior of using the teleporter and will require upgrades or planning to put them to good use.

#### Power Requirements
- Teleporter requires 6 kW of power while active. (previously 0.5 kW)
- Gateway requires 5 kW of power while active. (unchanged)
- Restaurant portal requires 2.5 kW of power while active. (previously 1 kW)

#### Power Use
- Teleporter costs 50 kW to teleport. (previously 0 kW)
- Gateway costs 50 kW to teleport. (previously 0 kW)
- Restaurant portal costs 5 kW to teleport a robot (previously 0 kW)

#### Stock parts
- Teleporter error of margin for target destination radius is affected by the stock parts inside the teleport hub
- The radius when using the teleporter machine in the room is (T1 9x9, T2 6x6, T3 3x3, T4 exact) (previously exact)
- The radius when using the hand tele is +3x3 of whatever the teleporter machine range is (T1 12x12, T2 9x9, T3 6x6, T4 3x3) (previously exact)
- Calibrating a teleporter machine now takes longer (T1 30 sec, T2 20 sec, T3 10 sec, T4 instant) (previously 10 sec)

#### Teleporter Requirements
- The computer console for the teleporter MUST be calibrated
- After calibration, the teleport station MUST be toggled on (aka when the blue portal appears)
- All the equipment must remain powered

#### Hand Teleport Requirements
- The hand tele needs to have an active and calibrated teleporter to use
- Teleporting to None is still possible and unaffected

## Why It's Good For The Game
Perpetual motion machines are not real... _well at least not anymore!_

Initially I was digging through power code when I came across this. The default roundstart station with a basic SM setups uses 400/570 kW of power. That leaves 170 kW of extra power and I was thinking hmmm... wouldn't it be rewarding to make non-critical elements of the station require a big chunk of extra power? We already do it for the Gateway. But the key thing is it is optional and not required for essential station functions.

Teleporter machinery is a good candidate for this. Working on it also allowed me to add tier part upgrades that actually achieve a decent effect. (faster calibration, closer range to target beacon, etc.)

I don't doubt it will annoy some people who are used to have the teleporter instantly function. (calibration/accuracy previously did nothing and were fluff features) Not to mention that teleporting is now more dangerous since you won't land on the beacon exactly. However people can still use it, just not as effectively or without risk.

Ideally both engineering and science have an incentive to provide more power and better stock part upgrades! Win-win.

## Changelog
:cl:
add: Upgrading teleporter machinery stock parts now affects how close in range it can get to the target beacon. (T1 9x9, T2 6x6, T3 3x3, T4 exact) This affects hand teleporters that select the teleporter as well. (hand tele has worse range with an increased +3x3 radius)
balance: Teleporting machinery (Teleporter room, Gateway, Restaurant Portals) now require a substantial amount of power to remain active. When teleporting, the machinery drains a massive amount of power on use.
balance: Teleport computer calibration now takes 30 seconds but can be lowered by upgraded parts. (-10 sec per tier)
balance: Teleporting now requires for the teleport equipment to be properly calibrated, powered, and toggled on. This affects handheld teleporters as well but there is still no requirement to teleport to None locations.
fix: TELEPORTING PERPETUAL MOTION MACHINES NOT REQUIRING POWER
/:cl:
