### PR TITLE
Triple Holodeck Power Requirements while Emagged

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 	spawning_simulation = TRUE
 	active = (map_id != offline_program)
-	update_use_power(active + IDLE_POWER_USE)
+	update_mode_power_usage(ACTIVE_POWER_USE, initial(active_power_usage))
 	program = map_id
 
 	clear_projection()
@@ -242,6 +242,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 	program = offline_program
 	clear_projection()
+	update_use_power(IDLE_POWER_USE)
 
 	template = SSmapping.holodeck_templates[offline_program]
 	INVOKE_ASYNC(template, TYPE_PROC_REF(/datum/map_template, load), bottom_left) //this is what actually loads the holodeck simulation into the map
@@ -365,6 +366,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 				return
 	. = ..()
 	if(!. || program == offline_program)//we dont need to scan the holodeck if the holodeck is offline
+		update_use_power(IDLE_POWER_USE)
 		return
 
 	if(!floorcheck()) //if any turfs in the floor of the holodeck are broken
@@ -383,7 +385,11 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 				derez(item)
 	for(var/obj/effect/holodeck_effect/holo_effect as anything in effects)
 		holo_effect.tick()
-	update_mode_power_usage(ACTIVE_POWER_USE, initial(active_power_usage) + spawned.len * 3 + effects.len * 5)
+
+	// holo objects now deal real damage and can exist outside the holodeck area so more energy as well
+	var/emagged_power_multiplier = obj_flags & EMAGGED ? 3 : 1
+	update_use_power(ACTIVE_POWER_USE)
+	update_mode_power_usage(ACTIVE_POWER_USE, initial(active_power_usage) + (spawned.len * 3 + effects.len * 5) * emagged_power_multiplier)
 
 /obj/machinery/computer/holodeck/proc/toggle_power(toggleOn = FALSE)
 	if(active == toggleOn)


### PR DESCRIPTION

## About The Pull Request
This triples the power requirement for holodeck items when it is emagged. Despite having this message:

`to_chat(user, span_warning("You vastly increase projector power and override the safety and security protocols."))`

There was no power changes implemented. Considering that emagged holodeck items can: 
- Deal damage
- Move outside the holodeck
- Load dangerous templates 

It would be make logical sense to increase the power requirement. 

Also I fixed power update bugs with the holodeck not updating when it was in offline mode (should be idle) or if you were inactive/active on the computer since technically that drains power as an active state but it wouldn't switch back.

_Disclaimer - This is not a big enough deal to affect gameplay in the slightest. More than anything it's just flavor._

## Why It's Good For The Game
Bugs bad. Code that says it should increase the power should actually fuckin increase the power!

## Changelog
:cl:
fix: Fix holodeck not updating power state to idle/active/inactive when offline, looking at holodeck computer, and when the offline template is loaded.
fix: Fix holodeck not using extra power despite the emag message saying it vastly increases the power.
/:cl:
