### PR TITLE
Fixes the mail sorter runtiming processing assistant mail

### DIFF
--- a/code/modules/vending/mail.dm
+++ b/code/modules/vending/mail.dm
@@ -66,6 +66,10 @@
 	drop_all_mail()
 	. = ..()
 
+/obj/machinery/mailsorter/deconstruct(disassembled)
+	drop_all_mail()
+	. = ..()
+
 /// Drops all enevlopes on the machine turf. Only occurs when the machine is broken.
 /obj/machinery/mailsorter/proc/drop_all_mail(damage_flag)
 	if(!isturf(get_turf(src)))
@@ -151,7 +155,7 @@
 		if (some_recipient)
 			var/datum/job/recipient_job = some_recipient.assigned_role
 			var/datum/job_department/primary_department = recipient_job.departments_list?[1]
-			var/datum/job_department/main_department = primary_department.department_name
+			var/datum/job_department/main_department = primary_department.department_name?
 			if (main_department == sorting_dept)
 				sorted_mail.Add(some_mail)
 				sorted ++

--- a/code/modules/vending/mail.dm
+++ b/code/modules/vending/mail.dm
@@ -46,11 +46,13 @@
 /obj/machinery/mailsorter/proc/get_unload_turf()
 	return get_step(src, output_dir)
 
+/// Opening the maintenance panel.
 /obj/machinery/mailsorter/screwdriver_act(mob/living/user, obj/item/tool)
 	default_deconstruction_screwdriver(user, "[base_icon_state]-off", base_icon_state, tool)
 	update_appearance(UPDATE_OVERLAYS)
 	return ITEM_INTERACT_SUCCESS
 
+/// Deconstructing the mail sorter.
 /obj/machinery/mailsorter/crowbar_act(mob/living/user, obj/item/tool)
 	default_deconstruction_crowbar(tool)
 	return ITEM_INTERACT_SUCCESS
@@ -63,15 +65,15 @@
 		. += span_notice("Alt-click to rotate the output direction.")
 
 /obj/machinery/mailsorter/Destroy()
-	drop_all_mail()
+	QDEL_LIST(mail_list)
 	. = ..()
 
 /obj/machinery/mailsorter/on_deconstruction(disassembled)
 	drop_all_mail()
 	. = ..()
 
-/// Drops all enevlopes on the machine turf. Only occurs when the machine is broken.
-/obj/machinery/mailsorter/proc/drop_all_mail(damage_flag)
+/// Drops all enevlopes on the machine turf.
+/obj/machinery/mailsorter/proc/drop_all_mail()
 	if(!isturf(get_turf(src)))
 		QDEL_LIST(mail_list)
 		return
@@ -94,10 +96,6 @@
 /obj/machinery/mailsorter/proc/accept_check(obj/item/weapon)
 	var/static/list/accepted_items = list(
 		/obj/item/mail,
-		/obj/item/mail/envelope,
-		/obj/item/mail/junkmail,
-		/obj/item/mail/mail_strike,
-		/obj/item/mail/traitor,
 		/obj/item/paper,
 	)
 	return is_type_in_list(weapon, accepted_items)

--- a/code/modules/vending/mail.dm
+++ b/code/modules/vending/mail.dm
@@ -66,7 +66,7 @@
 	drop_all_mail()
 	. = ..()
 
-/obj/machinery/mailsorter/deconstruct(disassembled)
+/obj/machinery/mailsorter/on_deconstruction(disassembled)
 	drop_all_mail()
 	. = ..()
 
@@ -155,10 +155,13 @@
 		if (some_recipient)
 			var/datum/job/recipient_job = some_recipient.assigned_role
 			var/datum/job_department/primary_department = recipient_job.departments_list?[1]
-			var/datum/job_department/main_department = primary_department.department_name?
-			if (main_department == sorting_dept)
-				sorted_mail.Add(some_mail)
-				sorted ++
+			if (primary_department == null)	// permabrig is temporary, tide is forever
+				unable_to_sort ++
+			else
+				var/datum/job_department/main_department = primary_department.department_name
+				if (main_department == sorting_dept)
+					sorted_mail.Add(some_mail)
+					sorted ++
 		else
 			unable_to_sort ++
 	if (length(sorted_mail) == 0)


### PR DESCRIPTION
## About The Pull Request

The mail sorter doesn't runtime when processing assistant mail now. Also now it properly ejects envelopes upon deconstruction.

## Why It's Good For The Game

Because that caused the mail sorter to freeze, not even being able to get the mail back.

Closes https://github.com/tgstation/tgstation/issues/88549.

## Changelog
:cl:
fix: The mail sorter no longer runtimes processing assistant mail
/:cl:
