### PR TITLE
Holodeck grammar tweak & Teleporter fix

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -179,7 +179,17 @@
 		var/area/computer_area = get_area(target)
 		if(!computer_area || (computer_area.area_flags & NOTELEPORT))
 			continue
-		if(computer.power_station?.teleporter_hub && computer.power_station.engaged)
+
+		if(!computer.power_station || !computer.power_station.teleporter_hub)
+			continue
+
+		if((computer.power_station.machine_stat & (NOPOWER|BROKEN|MAINT)) || computer.power_station.panel_open)
+			continue
+
+		if((computer.power_station.teleporter_hub.machine_stat & (NOPOWER|BROKEN|MAINT)) || computer.power_station.teleporter_hub.panel_open)
+			continue
+
+		if(computer.power_station.engaged)
 			locations["[get_area(target)] (Active)"] = computer
 		else
 			locations["[get_area(target)] (Inactive)"] = computer

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -434,8 +434,8 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	playsound(src, SFX_SPARKS, 75, TRUE)
 	obj_flags |= EMAGGED
 	if (user)
-		balloon_alert(user, "safety protocols destroyed") // im gonna keep this once since this perfectly describes it, and the to_chat is just flavor
-		to_chat(user, span_warning("You vastly increase projector power and override the safety and security protocols."))
+		balloon_alert(user, "safety protocols destroyed") // im gonna keep this once since this perfectly describes it
+		to_chat(user, span_warning("You override the safety and security protocols."))
 		user.log_message("emagged the Holodeck Control Console.", LOG_GAME)
 		message_admins("[ADMIN_LOOKUPFLW(user)] emagged the Holodeck Control Console.")
 


### PR DESCRIPTION
## About The Pull Request
Apparently adding a tiny coffee machine worth of power to make this accurate:

`to_chat(user, span_warning("You vastly increase projector power and override the safety and security protocols."))`

was too much. So let's just do a grammar tweak to fix it.

edit - Due to a bad commit split off from another branch this also does:
- Broken, unpowered, or maint settings on teleporter machinery still allowed a hand tele to function with the machine.

## Why It's Good For The Game
Accurate descriptions.
Edit - Also teleporter fix.

## Changelog
:cl:
spellcheck: Fix holodeck emag message claiming to increase power
/:cl:
