### PR TITLE
Rust heretic healing now uses delta time

### DIFF
--- a/code/datums/elements/leeching_walk.dm
+++ b/code/datums/elements/leeching_walk.dm
@@ -24,9 +24,8 @@
 	var/turf/mover_turf = get_turf(source)
 	if(HAS_TRAIT(mover_turf, TRAIT_RUSTY))
 		ADD_TRAIT(source, TRAIT_BATON_RESISTANCE, type)
-		return
-
-	REMOVE_TRAIT(source, TRAIT_BATON_RESISTANCE, type)
+	else
+		REMOVE_TRAIT(source, TRAIT_BATON_RESISTANCE, type)
 
 /**
  * Signal proc for [COMSIG_LIVING_LIFE].
@@ -43,17 +42,18 @@
 
 	// Heals all damage + Stamina
 	var/need_mob_update = FALSE
-	need_mob_update += source.adjustBruteLoss(-3, updating_health = FALSE)
-	need_mob_update += source.adjustFireLoss(-3, updating_health = FALSE)
-	need_mob_update += source.adjustToxLoss(-3, updating_health = FALSE, forced = TRUE) // Slimes are people to
-	need_mob_update += source.adjustOxyLoss(-1.5, updating_health = FALSE)
-	need_mob_update += source.adjustStaminaLoss(-10, updating_stamina = FALSE)
+	var/delta_time = DELTA_WORLD_TIME(SSmobs)
+	need_mob_update += source.adjustBruteLoss(-3 * delta_time, updating_health = FALSE)
+	need_mob_update += source.adjustFireLoss(-3 * delta_time, updating_health = FALSE)
+	need_mob_update += source.adjustToxLoss(-3 * delta_time, updating_health = FALSE, forced = TRUE) // Slimes are people to
+	need_mob_update += source.adjustOxyLoss(-1.5 * delta_time, updating_health = FALSE)
+	need_mob_update += source.adjustStaminaLoss(-10 * delta_time, updating_stamina = FALSE)
 	if(need_mob_update)
 		source.updatehealth()
 	// Reduces duration of stuns/etc
-	source.AdjustAllImmobility(-0.5 SECONDS)
+	source.AdjustAllImmobility((-0.5 SECONDS) * delta_time)
 	// Heals blood loss
 	if(source.blood_volume < BLOOD_VOLUME_NORMAL)
-		source.blood_volume += 2.5 * seconds_per_tick
+		source.blood_volume += 2.5 * delta_time
 	// Slowly regulates your body temp
-	source.adjust_bodytemperature((source.get_body_temp_normal() - source.bodytemperature)/5)
+	source.adjust_bodytemperature((source.get_body_temp_normal() - source.bodytemperature) / 5)

--- a/code/datums/elements/leeching_walk.dm
+++ b/code/datums/elements/leeching_walk.dm
@@ -45,7 +45,7 @@
 	var/delta_time = DELTA_WORLD_TIME(SSmobs)
 	need_mob_update += source.adjustBruteLoss(-3 * delta_time, updating_health = FALSE)
 	need_mob_update += source.adjustFireLoss(-3 * delta_time, updating_health = FALSE)
-	need_mob_update += source.adjustToxLoss(-3 * delta_time, updating_health = FALSE, forced = TRUE) // Slimes are people to
+	need_mob_update += source.adjustToxLoss(-3 * delta_time, updating_health = FALSE, forced = TRUE) // Slimes are people too
 	need_mob_update += source.adjustOxyLoss(-1.5 * delta_time, updating_health = FALSE)
 	need_mob_update += source.adjustStaminaLoss(-10 * delta_time, updating_stamina = FALSE)
 	if(need_mob_update)

--- a/code/datums/elements/leeching_walk.dm
+++ b/code/datums/elements/leeching_walk.dm
@@ -42,7 +42,7 @@
 
 	// Heals all damage + Stamina
 	var/need_mob_update = FALSE
-	var/delta_time = DELTA_WORLD_TIME(SSmobs)
+	var/delta_time = DELTA_WORLD_TIME(SSmobs) * 0.5 // SSmobs.wait is 2 secs, so this should be halved.
 	need_mob_update += source.adjustBruteLoss(-3 * delta_time, updating_health = FALSE)
 	need_mob_update += source.adjustFireLoss(-3 * delta_time, updating_health = FALSE)
 	need_mob_update += source.adjustToxLoss(-3 * delta_time, updating_health = FALSE, forced = TRUE) // Slimes are people too

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -287,7 +287,7 @@
 		return
 
 	var/need_mob_update = FALSE
-	var/base_heal_amt = 5 * DELTA_WORLD_TIME(SSmobs)
+	var/base_heal_amt = 2.5 * DELTA_WORLD_TIME(SSmobs)
 	need_mob_update += source.adjustBruteLoss(-base_heal_amt, updating_health = FALSE)
 	need_mob_update += source.adjustFireLoss(-base_heal_amt, updating_health = FALSE)
 	need_mob_update += source.adjustToxLoss(-base_heal_amt, updating_health = FALSE, forced = TRUE)

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -287,12 +287,13 @@
 		return
 
 	var/need_mob_update = FALSE
-	need_mob_update += source.adjustBruteLoss(-5, updating_health = FALSE)
-	need_mob_update += source.adjustFireLoss(-5, updating_health = FALSE)
-	need_mob_update += source.adjustToxLoss(-5, updating_health = FALSE, forced = TRUE)
-	need_mob_update += source.adjustOxyLoss(-5, updating_health = FALSE)
-	need_mob_update += source.adjustStaminaLoss(-20, updating_stamina = FALSE)
+	var/base_heal_amt = 5 * DELTA_WORLD_TIME(SSmobs)
+	need_mob_update += source.adjustBruteLoss(-base_heal_amt, updating_health = FALSE)
+	need_mob_update += source.adjustFireLoss(-base_heal_amt, updating_health = FALSE)
+	need_mob_update += source.adjustToxLoss(-base_heal_amt, updating_health = FALSE, forced = TRUE)
+	need_mob_update += source.adjustOxyLoss(-base_heal_amt, updating_health = FALSE)
+	need_mob_update += source.adjustStaminaLoss(-base_heal_amt * 4, updating_stamina = FALSE)
 	if(source.blood_volume < BLOOD_VOLUME_NORMAL)
-		source.blood_volume += 5 * seconds_per_tick
+		source.blood_volume += base_heal_amt
 	if(need_mob_update)
 		source.updatehealth()


### PR DESCRIPTION

## About The Pull Request

This makes it so leeching walk and ascended rust heretic healing effects (the healing that occurs during life ticks) have the healing amount multiplied by `DELTA_WORLD_TIME(SSmobs)`, to compensate for skipped/delayed fires.

## Why It's Good For The Game

Delays in SSmobs firing (i.e explosions pausing all non-ticker subsystems) can very easily get you killed if you're relying on the rust heretic healing mid-combat.

## Changelog
:cl:
qol: Rust heretic healing (leeching walk, rust ascension) now, so server lag shouldn't fuck you over nearly as much if you're relying on the healing.
/:cl:
