### PR TITLE
Fixes produce/bitrunning/mining order console icon and stretching jank

### DIFF
--- a/tgui/packages/tgui/interfaces/ProduceConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.tsx
@@ -118,8 +118,8 @@ const ShoppingTab = (props) => {
         <Section fill scrollable>
           <Stack vertical mt={-2}>
             <Divider />
-            {goods.map((item, key) => (
-              <Stack.Item key={key}>
+            {goods.map((item) => (
+              <Stack.Item key={item.ref}>
                 <Stack>
                   <span
                     style={{

--- a/tgui/packages/tgui/interfaces/ProduceConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.tsx
@@ -138,8 +138,8 @@ const ShoppingTab = (props) => {
                       />
                     </Stack.Item>
                   )}
-                  <Stack.Item>{capitalize(item.name)}</Stack.Item>
-                  <Stack.Item grow color="label" fontSize="10px">
+                  <Stack.Item grow>{capitalize(item.name)}</Stack.Item>
+                  <Stack.Item color="label" fontSize="10px">
                     <Button
                       mt={-1}
                       color="transparent"


### PR DESCRIPTION
## About The Pull Request

While adding some new orderable bitrunning items I noticed the icons would be entirely wrong when swapping into any new tab.
Melbert determined this to likely be an issue with keys and caching, and so proposed the included solution of using the `item.ref` as the key, which fixes our primary issue.

In the process, however, I noticed there was a secondary issue with the orderables with especially long item names causing the information tooltip button and item order buttons to get all scrunched together.
We solve this by simply just making the stack item with the text grow instead of the tooltip button, having the tooltip button sit nice and statically next to the order buttons.


<details>
  <summary>Images</summary>
  
![image](https://github.com/user-attachments/assets/19e7260b-f3e9-4ab3-9af8-d580f85039cf)
![image](https://github.com/user-attachments/assets/16ca80a1-3985-4181-b834-b832134e94bf)
![image](https://github.com/user-attachments/assets/282838c0-0c96-4100-aebb-5c3cec08deb9)


</details>

## Why It's Good For The Game

Nice when icons don't look like this:
![image](https://github.com/user-attachments/assets/a54a9b49-189a-4eee-8c56-f2e52e21d8f0)
Or the buttons like this:
![image](https://github.com/user-attachments/assets/2578e812-e34c-4617-ac73-8aea26ea7d3b)
## Changelog
:cl:
fix: Produce, bitrunning, and mining order consoles no longer have broken icons when swapping tabs.
fix: Items in produce, bitrunning, and mining order consoles with especially long names no longer make the information tooltip and item order buttons wonky.
qol: The information tooltip button for items in produce, bitrunning, and mining order consoles no longer moves with the item name, and instead sits next to the item order buttons.
/:cl:
