### PR TITLE
Destructive scanner no longer attempts to destroy itself

### DIFF
--- a/code/modules/experisci/destructive_scanner.dm
+++ b/code/modules/experisci/destructive_scanner.dm
@@ -46,6 +46,8 @@
 		return
 	var/atom/pickup_zone = drop_location()
 	for(var/atom/movable/to_pickup in pickup_zone)
+		if(to_pickup == src)
+			continue
 		to_pickup.forceMove(src)
 	flick("tube_down", src)
 	scanning = TRUE


### PR DESCRIPTION
Never actually did anything thanks to byond magic, but now it runtimes so might as well fix it.