### PR TITLE
Fixes certain food buffs not applying, preemtively makes it less annoying

### DIFF
--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -1,6 +1,7 @@
 /// Used to apply certain speech patterns
 /// Can be used on organs, wearables, mutations and mobs
 /datum/component/speechmod
+	dupe_mode = COMPONENT_DUPE_ALLOWED
 	/// Assoc list for strings/regexes and their replacements. Should be lowercase, as case will be automatically changed
 	var/list/replacements = list()
 	/// String added to the end of the message

--- a/code/datums/elements/food/love_food_buff.dm
+++ b/code/datums/elements/food/love_food_buff.dm
@@ -14,7 +14,7 @@
 		return ELEMENT_INCOMPATIBLE
 
 	src.love_buff_type = love_buff_type
-	RegisterSignal(food.reagents, list(
+	RegisterSignals(food.reagents, list(
 		COMSIG_REAGENTS_ADD_REAGENT,
 		COMSIG_REAGENTS_CLEAR_REAGENTS,
 		COMSIG_REAGENTS_DEL_REAGENT,

--- a/code/datums/elements/food/love_food_buff.dm
+++ b/code/datums/elements/food/love_food_buff.dm
@@ -1,0 +1,47 @@
+/// Changes a food item's food buff to something else when it has "love" reagent within
+/datum/element/love_food_buff
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// Buff typepath to add when our food has love within
+	var/love_buff_type
+
+/datum/element/love_food_buff/Attach(datum/target, love_buff_type)
+	. = ..()
+	if(!istype(target, /obj/item/food))
+		return ELEMENT_INCOMPATIBLE
+	var/obj/item/food/food = target
+	if(isnull(food.reagents))
+		return ELEMENT_INCOMPATIBLE
+
+	src.love_buff_type = love_buff_type
+	RegisterSignal(food.reagents, list(
+		COMSIG_REAGENTS_ADD_REAGENT,
+		COMSIG_REAGENTS_CLEAR_REAGENTS,
+		COMSIG_REAGENTS_DEL_REAGENT,
+		COMSIG_REAGENTS_NEW_REAGENT,
+		COMSIG_REAGENTS_REM_REAGENT,
+	), PROC_REF(on_reagents_changed))
+
+/datum/element/love_food_buff/Detach(datum/source, ...)
+	var/obj/item/food/food = source
+	if(istype(food) && !isnull(food.reagents))
+		UnregisterSignal(food.reagents, list(
+			COMSIG_REAGENTS_ADD_REAGENT,
+			COMSIG_REAGENTS_CLEAR_REAGENTS,
+			COMSIG_REAGENTS_DEL_REAGENT,
+			COMSIG_REAGENTS_NEW_REAGENT,
+			COMSIG_REAGENTS_REM_REAGENT,
+		))
+	return ..()
+
+/datum/element/love_food_buff/proc/on_reagents_changed(datum/reagents/source, ...)
+	SIGNAL_HANDLER
+
+	var/obj/item/food/food = source.my_atom
+	if(!istype(food))
+		return
+
+	if(source.has_reagent(/datum/reagent/love))
+		food.crafted_food_buff = love_buff_type
+	else
+		food.crafted_food_buff = initial(food.crafted_food_buff)

--- a/code/datums/elements/food/love_food_buff.dm
+++ b/code/datums/elements/food/love_food_buff.dm
@@ -21,6 +21,7 @@
 		COMSIG_REAGENTS_NEW_REAGENT,
 		COMSIG_REAGENTS_REM_REAGENT,
 	), PROC_REF(on_reagents_changed))
+	RegisterSignal(food, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
 /datum/element/love_food_buff/Detach(datum/source, ...)
 	var/obj/item/food/food = source
@@ -32,6 +33,7 @@
 			COMSIG_REAGENTS_NEW_REAGENT,
 			COMSIG_REAGENTS_REM_REAGENT,
 		))
+		UnregisterSignal(food, COMSIG_ATOM_EXAMINE)
 	return ..()
 
 /datum/element/love_food_buff/proc/on_reagents_changed(datum/reagents/source, ...)
@@ -41,7 +43,9 @@
 	if(!istype(food))
 		return
 
-	if(source.has_reagent(/datum/reagent/love))
-		food.crafted_food_buff = love_buff_type
-	else
-		food.crafted_food_buff = initial(food.crafted_food_buff)
+	food.crafted_food_buff = source.has_reagent(/datum/reagent/love) ? love_buff_type : initial(food.crafted_food_buff)
+
+/datum/element/love_food_buff/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	examine_list += span_notice("Delivering a chef's kiss to [source] will alter [source.p_their()] effects.")

--- a/code/datums/status_effects/buffs/food/speech.dm
+++ b/code/datums/status_effects/buffs/food/speech.dm
@@ -3,9 +3,13 @@
 
 /datum/status_effect/food/speech/italian
 	alert_type = /atom/movable/screen/alert/status_effect/italian_speech
+	on_remove_on_mob_delete = TRUE
+	/// Ref to the component so we can clear it
+	var/datum/component/speechmod
 
 /datum/status_effect/food/speech/italian/on_apply()
-	AddComponent( \
+	. = ..()
+	speechmod = AddComponent( \
 		/datum/component/speechmod, \
 		replacements = strings("italian_replacement.json", "italian"), \
 		end_string = list(
@@ -16,7 +20,10 @@
 			), \
 		end_string_chance = 3 \
 		)
-	return ..()
+
+/datum/status_effect/food/speech/italian/on_remove()
+	. = ..()
+	QDEL_NULL(speechmod)
 
 /atom/movable/screen/alert/status_effect/italian_speech
 	name = "Linguini Embrace"
@@ -25,9 +32,13 @@
 
 /datum/status_effect/food/speech/french
 	alert_type = /atom/movable/screen/alert/status_effect/french_speech
+	on_remove_on_mob_delete = TRUE
+	/// Ref to the component so we can clear it
+	var/datum/component/speechmod
 
 /datum/status_effect/food/speech/french/on_apply()
-	AddComponent( \
+	. = ..()
+	speechmod = owner.AddComponent( \
 		/datum/component/speechmod, \
 		replacements = strings("french_replacement.json", "french"), \
 		end_string = list(
@@ -37,7 +48,10 @@
 			), \
 		end_string_chance = 3, \
 		)
-	return ..()
+
+/datum/status_effect/food/speech/french/on_remove()
+	. = ..()
+	QDEL_NULL(speechmod)
 
 /atom/movable/screen/alert/status_effect/french_speech
 	name = "Café Chic"

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -277,7 +277,10 @@ GLOBAL_VAR_INIT(chicks_from_eggs, 0)
 	foodtypes = MEAT | BREAKFAST | DAIRY
 	venue_value = FOOD_PRICE_CHEAP
 	crafting_complexity = FOOD_COMPLEXITY_2
-	crafted_food_buff = /datum/status_effect/food/speech/french
+
+/obj/item/food/omelette/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/love_food_buff, /datum/status_effect/food/speech/french)
 
 /obj/item/food/omelette/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/kitchen/fork))

--- a/code/game/objects/items/food/spaghetti.dm
+++ b/code/game/objects/items/food/spaghetti.dm
@@ -262,4 +262,7 @@
 	tastes = list("spaghetti" = 1, "parmigiano reggiano" = 1,  "guanciale" = 1)
 	foodtypes = GRAIN | MEAT | DAIRY
 	crafting_complexity = FOOD_COMPLEXITY_4
-	crafted_food_buff = /datum/status_effect/food/speech/italian
+
+/obj/item/food/spaghetti/carbonara/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/love_food_buff, /datum/status_effect/food/speech/italian)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1612,6 +1612,7 @@
 #include "code\datums\elements\food\foodlike_drink.dm"
 #include "code\datums\elements\food\fried_item.dm"
 #include "code\datums\elements\food\grilled_item.dm"
+#include "code\datums\elements\food\love_food_buff.dm"
 #include "code\datums\elements\food\microwavable.dm"
 #include "code\datums\elements\food\processable.dm"
 #include "code\datums\elements\food\venue_price.dm"


### PR DESCRIPTION
## About The Pull Request

Omelettes and Carbonara made you French and Italian when you eat it but it was broken because it was trying to make the status effect speak different instead of the mob

I fixed it but I also imagined this would just be like really freaking annoying, like forced to speak Italian for 5 minutes just because you ate spaghetti? Cmon

So I made it so these food items only apply these buffs if they are made with love (via the chef skillchip) 

## Changelog

:cl: Melbert
fix: Fixes Omelettes and Carbonara not making you speak French or Italian, buuut...
qol: Omelettes and Carbonara will now only make you speak French or Italian if they were prepared with love (via chef's kiss) 
/:cl:
