### PR TITLE
Reverted beheading removal

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -140,8 +140,9 @@
 			. += span_info("[real_name]'s tongue has been removed.")
 
 /obj/item/bodypart/head/can_dismember(obj/item/item)
-	if (!can_dismember)
+	if(owner.stat < HARD_CRIT)
 		return FALSE
+	return ..()
 
 	if(!HAS_TRAIT(owner, TRAIT_CURSED) && owner.stat < HARD_CRIT)
 		return FALSE

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -142,7 +142,6 @@
 /obj/item/bodypart/head/can_dismember(obj/item/item)
 	if(owner.stat < HARD_CRIT)
 		return FALSE
-	return ..()
 
 	if(!HAS_TRAIT(owner, TRAIT_CURSED) && owner.stat < HARD_CRIT)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Reintroduces beheading to /TG/ Station

## Why It's Good For The Game

Reverts https://github.com/tgstation/tgstation/pull/80439
Beheading is cool and awesome and seems to be something the people want back, I got pressured to be the change I wanted.

When the servers first rolled these changes I thought it was a joke/temporary measure, now the beheading removal PR is about a year old and I still think it is pandering to those who can't handle being round removed. Dying is part of the game.
Other servers already had more blood and body parts flying around during fights, but TG has somehow been the only one to regress and the addition of plasteel reinforced necks is not only very lame but nonsensical. I open this PR to see what other players think about not being able to hack people's heads off, and space ninjas and the sort not being able to decapitate. In my opinion it's a very fun feature to do and see in the game that has been long gone. I still see new players/old players attempt to decapitate and get frustrated at the lack of intuitiveness regarding sword to neck not chopping off someone's head.

Didn't revert the beheading traitor objectives, may look into reverting them depending on the feedback this revert gets.

https://youtu.be/OLvz5E61UNs

## Changelog

:cl: 
balance: Heads can once again be dismembered using conventional weapon attacks.
/:cl:

![Beheading](https://github.com/user-attachments/assets/9358c175-59f9-4a0f-a5be-5cf1ccd5fe6d)
