### PR TITLE
Fire Alarm In Meta's Customs

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67095,10 +67095,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"xBX" = (
-/obj/machinery/firealarm/directional/east,
-/turf/closed/wall,
-/area/station/security/checkpoint/customs)
 "xCf" = (
 /obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/electropack,
@@ -83046,7 +83042,7 @@ wdr
 fcq
 xfI
 fcq
-xBX
+xjh
 qhW
 xjh
 yme


### PR DESCRIPTION
## About The Pull Request

Removes an obsolete (suspected to be misplaced) fire alarm at (055, 141) from MetaStation

Fixes the following bug report:
https://github.com/tgstation/tgstation/issues/88241#issue-2696529590

## Why It's Good For The Game

The alarm in question achieves nothing useful in its current state, and isn't even reachable without climbing up on the tables. A functional fire alarm sits next to it in the Arrival Shuttle Hallway, and opposite it in the Customs office. Hidden below a Space Law book, it appears to be a mapping issue that was missed due to object layering. Wrangling up this fire alarm would be Quite Good(TM) for cleaning up the station of unintentional electronics.

## Changelog

:cl:
fix: Alarm ranchers have wrangled up a rogue fire alarm in Meta class station custom offices and relocated it to a safe habitat
/:cl: