### PR TITLE
Chemmaster no longer rounds reagent amounts when trying to transfer a custom amount

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -415,7 +415,7 @@
 
 			if(amount == -1) // Set custom amount
 				var/mob/user = ui.user //Hold a reference of the user if the UI is closed
-				amount = tgui_input_number(user, "Enter amount to transfer", "Transfer amount")
+				amount = tgui_input_number(user, "Enter amount to transfer", "Transfer amount", round_value = FALSE)
 				if(!amount || !user.can_perform_action(src))
 					return FALSE
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -415,7 +415,7 @@
 
 			if(amount == -1) // Set custom amount
 				var/mob/user = ui.user //Hold a reference of the user if the UI is closed
-				amount = tgui_input_number(user, "Enter amount to transfer", "Transfer amount", round_value = FALSE)
+				amount = FLOOR(tgui_input_number(user, "Enter amount to transfer", "Transfer amount", round_value = FALSE), CHEMICAL_VOLUME_ROUNDING)
 				if(!amount || !user.can_perform_action(src))
 					return FALSE
 


### PR DESCRIPTION

## About The Pull Request

#82002 changed custom transfer amount into a TGUI popup, which has rounding on by default. This prevents players from being able to transfer decimal amounts of reagents like they could previously.

## Why It's Good For The Game

This is useful for high-purity recipes, or when you REALLY want to microdose something. Right now the only way to do this is by printing tiny pills and dissolving those which is very bootleg.

## Changelog
:cl:
fix: Chemmaster no longer rounds reagent amounts when trying to transfer a custom amount
/:cl:
