### PR TITLE
fix radio sound output when receiving a message

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -439,7 +439,7 @@
 		COOLDOWN_START(src, audio_cooldown, 0.5 SECONDS)
 		var/sound/radio_receive = sound('sound/items/radio/radio_receive.ogg', volume = volume_modifier)
 		radio_receive.frequency = get_rand_frequency_low_range()
-		SEND_SOUND(holder, radio_noise)
+		SEND_SOUND(holder, radio_receive)
 	if((SPAN_COMMAND in spans) && COOLDOWN_FINISHED(src, important_audio_cooldown))
 		COOLDOWN_START(src, important_audio_cooldown, 0.5 SECONDS)
 		var/sound/radio_important = sound('sound/items/radio/radio_important.ogg', volume = volume_modifier)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -351,7 +351,8 @@
 	if(isliving(talking_movable))
 		var/mob/living/talking_living = talking_movable
 		var/volume_modifier = (talking_living.client?.prefs.read_preference(/datum/preference/numeric/sound_radio_noise))
-		if(radio_noise && talking_living.can_hear() && volume_modifier && signal.frequency != FREQ_COMMON && !LAZYACCESS(message_mods, MODE_SEQUENTIAL))
+		if(radio_noise && talking_living.can_hear() && volume_modifier && signal.frequency != FREQ_COMMON && !LAZYACCESS(message_mods, MODE_SEQUENTIAL) && COOLDOWN_FINISHED(src, audio_cooldown))
+			COOLDOWN_START(src, audio_cooldown, 0.5 SECONDS)
 			var/sound/radio_noise = sound('sound/items/radio/radio_talk.ogg', volume = volume_modifier)
 			radio_noise.frequency = get_rand_frequency_low_range()
 			SEND_SOUND(talking_living, radio_noise)


### PR DESCRIPTION
## About The Pull Request

There were two variables mixed up. It was `SEND_SOUND(holder, radio_noise)`, though it should be `SEND_SOUND(holder, radio_receive)`. Now everything is in place
And also added `COOLDOWN_START(src, audio_cooldown, 0.5 SECONDS)` so that you don't hear two sounds at the same time when you talk into the radio

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/1afc1b36-4b6e-41d0-825d-aab6d9bdf694

</details>

## Why It's Good For The Game

it's just a code issue
## Changelog
:cl:
fix: fix radio sound output when receiving a message
sound: the sound of receiving your own messages over the radio is no longer played
/:cl:
