### PR TITLE
Adds better combined colour check for greyscale modify menu

### DIFF
--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -241,14 +241,24 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 			config.EnableAutoRefresh(config_owner_type)
 
 /datum/greyscale_modify_menu/proc/ReadColorsFromString(colorString)
-	var/list/new_split_colors = list()
+	//length validation
 	var/list/colors = splittext(colorString, "#")
-	for(var/index in 2 to min(length(colors), config.expected_colors + 1))
+	if(length(colors) <= 1) //doesn't even begin with a # so isn't even a color
+		return FALSE
+	colors.Cut(1, 2) //removes the white space as a consequence of the string beginning with a #
+	if(colors.len != config.expected_colors) //not the expected length
+		return FALSE
+
+	//value validation
+	var/list/new_split_colors = list()
+	for(var/index in 1 to config.expected_colors)
 		var/color = "#[colors[index]]"
 		if(!findtext(color, GLOB.is_color) && (!unlocked || !findtext(color, GLOB.is_alpha_color)))
 			return FALSE
 		new_split_colors += color
 	split_colors = new_split_colors
+
+	//all good
 	return TRUE
 
 /datum/greyscale_modify_menu/proc/randomize_color(color_index)


### PR DESCRIPTION
## About The Pull Request
- Fixes #87829

Ensures we can't enter invalid values that actually run timed in this specific case

## Changelog
:cl:
fix: greyscale modify menu has better validation for player entered colours
/:cl:

