### PR TITLE
Fixes xenos shifting up when enabling seethrough

### DIFF
--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -56,7 +56,7 @@
 		seethrough.unhide_plane(fool)
 
 	render_source_atom.pixel_x = -fool.pixel_x
-	render_source_atom.pixel_y = (fool.get_cached_height() - ICON_SIZE_Y * 0.5)
+	render_source_atom.pixel_y = ((fool.get_cached_height() - ICON_SIZE_Y) * 0.5)
 
 	initial_render_target_value = fool.render_target
 	fool.render_target = "*transparent_bigmob[personal_uid]"

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -40,8 +40,6 @@
 	armour_penetration = 30
 	pixel_x = -16
 	base_pixel_x = -16
-	maptext_height = 64
-	maptext_width = 64
 	mouse_opacity = MOUSE_OPACITY_ICON
 	death_sound = 'sound/mobs/non-humanoids/space_dragon/space_dragon_roar.ogg'
 	death_message = "screeches in agony as it collapses to the floor, its life extinguished."

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -40,6 +40,8 @@
 	armour_penetration = 30
 	pixel_x = -16
 	base_pixel_x = -16
+	maptext_height = 64
+	maptext_width = 64
 	mouse_opacity = MOUSE_OPACITY_ICON
 	death_sound = 'sound/mobs/non-humanoids/space_dragon/space_dragon_roar.ogg'
 	death_message = "screeches in agony as it collapses to the floor, its life extinguished."


### PR DESCRIPTION

## About The Pull Request

Partially handles #88579 - only the xenos part.
Xenos are my fault (maff is hard), dragons broke due to KEEP_TOGETHER being added. Need to talk this over with potato
## Changelog
:cl:
fix: Fixed xenos shifting up when enabling seethrough
/:cl:
