### PR TITLE
Fixes shoes slot being semi-transparent when you have digitigrade legs

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -322,8 +322,6 @@
 		var/obj/item/organ/eyes/eyes = human_mob.get_organ_slot(ORGAN_SLOT_EYES)
 		if(eyes?.no_glasses)
 			blocked_slots |= ITEM_SLOT_EYES
-		if(human_mob.bodyshape & BODYSHAPE_DIGITIGRADE)
-			blocked_slots |= ITEM_SLOT_FEET
 
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
 		if(!inv.slot_id)


### PR DESCRIPTION

## About The Pull Request

You can now wear shoes with digitigrade legs thanks to #88096, but UI slots weren't informed of this change.

## Changelog
:cl:
fix: Fixed shoes slot being semi-transparent when you have digitigrade legs
/:cl:
