### PR TITLE
Fixes access nesting for personal ordered crates

### DIFF
--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -106,7 +106,7 @@
 	name = "mining order"
 	hidden = TRUE
 	crate_name = "shaft mining delivery crate"
-	access = list(ACCESS_MINING)
+	access = ACCESS_MINING
 
 /datum/supply_pack/custom/New(purchaser, cost, list/contains)
 	. = ..()
@@ -117,7 +117,6 @@
 /datum/supply_pack/custom/minerals
 	name = "materials order"
 	crate_name = "galactic materials market delivery crate"
-	access = list()
 	crate_type = /obj/structure/closet/crate/cardboard
 
 /datum/supply_pack/custom/minerals/New(purchaser, cost, list/contains)

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -117,6 +117,7 @@
 /datum/supply_pack/custom/minerals
 	name = "materials order"
 	crate_name = "galactic materials market delivery crate"
+	access = FALSE
 	crate_type = /obj/structure/closet/crate/cardboard
 
 /datum/supply_pack/custom/minerals/New(purchaser, cost, list/contains)


### PR DESCRIPTION
## About The Pull Request
- Fixes #87235

Nested access levels after you unlock the crate for the 2nd time was too much even for the captain to deal with

## Changelog
:cl:
fix: personal ordered crates can be unlocked & relocked as many times again after the 1st attempt
/:cl:
