### PR TITLE
Restores SOUL to Cargo by making gun crates no longer open when hit by blunt or ballistic weapons. Return to Emitters.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -38,11 +38,16 @@
 	explosion(src, heavy_impact_range = 1, light_impact_range = 5, flash_range = 5)
 	qdel(src)
 
+/datum/armor/crate_secure/weapons // return to emitters
+	melee = 100
+	bullet = 100
+
 /obj/structure/closet/crate/secure/weapon
-	desc = "A secure weapons crate."
+	desc = "A secure weapons crate. The specially alloyed material hardens in response to physical trauma."
 	name = "weapons crate"
 	icon_state = "weaponcrate"
 	base_icon_state = "weaponcrate"
+	armor_type = /datum/armor/crate_secure/weapons
 
 /obj/structure/closet/crate/secure/plasma
 	desc = "A secure plasma crate."


### PR DESCRIPTION
## About The Pull Request

Restores SOUL to Cargo by making gun crates no longer open when hit by blunt or ballistic weapons. Return to Emitters.

## Why It's Good For The Game

Chainsaws and the proliferation of weapons to destroy crates have made cargonians weak, lazy, and not have to worry about getting caught breaking open weapons crates. This brings us back to the good old days where Cargo needed to steal some emitters and wire them up on the grid if they wanted to acquire firearms for Cargonia. 

## Changelog

:cl:
balance: Restores SOUL to Cargo by making gun crates no longer open when hit by blunt or ballistic weapons. Return to Emitters.
/:cl:
