### PR TITLE
Bioscrambler no longer informs you about "your armor softening the blow!"

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -662,7 +662,8 @@
 	if (HAS_TRAIT(src, TRAIT_GENELESS))
 		return FALSE
 
-	if (run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [scramble_source]!") >= 100)
+	if (run_armor_check(attack_flag = BIO, silent = TRUE) >= 100)
+		to_chat(src, span_warning("Your armor shields you from [scramble_source]!"))
 		return FALSE
 
 	if (!length(GLOB.bioscrambler_valid_organs) || !length(GLOB.bioscrambler_valid_parts))


### PR DESCRIPTION

## About The Pull Request

Made bioscrabmle() proc's armor check silent and moved text from a successful block into its early return.

## Why It's Good For The Game

Less than 100 protection from bioscramblers doesn't do anything, so text about "armor softening the blow" is nonsensical, both as there is no blow to soften, and as armor below 100 doesn't actually do anything. A bit of a nitpick, but its been annoying me to all hell every time I encounter one (as RD's coat provides some protection). Only other source of BIO armor checks is Phazon, but the text makes sense there and nothing runs armor checks against FIRE and ACID, so there's nothing else to fix.

## Changelog
:cl:
spellcheck: Bioscrambler no longer informs you about "your armor softening the blow!"
/:cl:
