### PR TITLE
add laptop interact on RMB click, screentips

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -37,8 +37,7 @@
 	else
 		context[SCREENTIP_CONTEXT_RMB] = "Open"
 
-	. = CONTEXTUAL_SCREENTIP_SET
-	return .
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/modular_computer/laptop/Initialize(mapload)
 	. = ..()
@@ -101,7 +100,7 @@
 /obj/item/modular_computer/laptop/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
-		return .
+		return
 
 	attack_self(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -29,6 +29,17 @@
 	if(screen_on)
 		. += span_notice("Alt-click to close it.")
 
+/obj/item/modular_computer/laptop/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+	if(screen_on)
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Close"
+		context[SCREENTIP_CONTEXT_RMB] = "Interact"
+	else
+		context[SCREENTIP_CONTEXT_RMB] = "Open"
+
+	. = CONTEXTUAL_SCREENTIP_SET
+	return .
+
 /obj/item/modular_computer/laptop/Initialize(mapload)
 	. = ..()
 
@@ -70,13 +81,6 @@
 			return
 		user.put_in_hand(src, H.held_index)
 
-/obj/item/modular_computer/laptop/attack_hand(mob/user, list/modifiers)
-	. = ..()
-	if(.)
-		return
-	if(screen_on && isturf(loc))
-		return attack_self(user)
-
 /obj/item/modular_computer/laptop/proc/try_toggle_open(mob/living/user)
 	if(issilicon(user))
 		return
@@ -93,6 +97,14 @@
 		return CLICK_ACTION_BLOCKING
 	try_toggle_open(user) // Close it.
 	return CLICK_ACTION_SUCCESS
+
+/obj/item/modular_computer/laptop/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return .
+
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/modular_computer/laptop/proc/toggle_open(mob/living/user=null)
 	if(screen_on)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Modular computer laptops can now be interacted with RMB when open, or opened with RMB when closed.
Also screentips for  this added.
It was inteded for laptops to be interactable when open. but didn't work because old code was not adjusted for attack chains.


## Why It's Good For The Game

Laptop usage is more user friendly :D

<details>
<summary>Demonstration :D</summary>

![image](https://github.com/user-attachments/assets/59b125af-2c2a-4948-a0ba-1289005a03fa)

</details>

## Changelog

:cl:
fix: modular computer laptops can now be interacted with RMB, instead of picked up 
qol: modular computer laptops can now be interacted with RMB when open, or opened with RMB when closed. Also screentips for  this added
/:cl:
