### PR TITLE
Gives engineers the kinesis module

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -64,11 +64,13 @@
 		/obj/item/mod/module/tether,
 		/obj/item/mod/module/magboot,
 		/obj/item/mod/module/headprotector,
+		/obj/item/mod/module/anomaly_locked/kinesis/weak,
 	)
 	default_pins = list(
 		/obj/item/mod/module/magboot,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/tether,
+		/obj/item/mod/module/anomaly_locked/kinesis/weak,
 	)
 
 /obj/item/mod/control/pre_equipped/atmospheric
@@ -99,12 +101,14 @@
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/headprotector,
 		/obj/item/mod/module/tether,
+		/obj/item/mod/module/anomaly_locked/kinesis/upgraded,
 	)
 	default_pins = list(
 		/obj/item/mod/module/magboot/advanced,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/tether,
+		/obj/item/mod/module/anomaly_locked/kinesis/upgraded,
 	)
 
 /obj/item/mod/control/pre_equipped/loader
@@ -603,14 +607,14 @@
 		/obj/item/mod/module/timestopper,
 		/obj/item/mod/module/rewinder,
 		/obj/item/mod/module/tem,
-		/obj/item/mod/module/anomaly_locked/kinesis/plus,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus/prebuilt,
 	)
 	default_pins = list(
 		/obj/item/mod/module/timestopper,
 		/obj/item/mod/module/timeline_jumper,
 		/obj/item/mod/module/rewinder,
 		/obj/item/mod/module/tem,
-		/obj/item/mod/module/anomaly_locked/kinesis/plus,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus/prebuilt,
 	)
 
 /obj/item/mod/control/pre_equipped/debug

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -427,6 +427,8 @@
 	var/prebuilt = FALSE
 	/// If the core is removable once socketed.
 	var/core_removable = TRUE
+	/// If true, removes all mentions of the anomaly core inside and interactions with the core inside. This is done so subtypes can inherit behaviors and become anomaly locked.
+	var/dummy_cored = FALSE
 
 /obj/item/mod/module/anomaly_locked/Initialize(mapload)
 	. = ..()
@@ -442,7 +444,7 @@
 
 /obj/item/mod/module/anomaly_locked/examine(mob/user)
 	. = ..()
-	if(!length(accepted_anomalies))
+	if(!length(accepted_anomalies) || dummy_cored) // don't add mentions of a core if it's dummy cored
 		return
 	if(core)
 		. += span_notice("There is a [core.name] installed in it. [core_removable ? "You could remove it with a <b>screwdriver</b>..." : "Unfortunately, due to a design quirk, it's unremovable."]")
@@ -457,6 +459,8 @@
 
 /obj/item/mod/module/anomaly_locked/on_select()
 	if(!core)
+		if(dummy_cored)
+			stack_trace("[src] is dummy cored but doesn't have a core! this is never supposed to happen, please report this bug.")
 		balloon_alert(mod.wearer, "no core!")
 		return
 	return ..()
@@ -472,7 +476,7 @@
 	return TRUE
 
 /obj/item/mod/module/anomaly_locked/attackby(obj/item/item, mob/living/user, params)
-	if(item.type in accepted_anomalies)
+	if(item.type in accepted_anomalies && !dummy_cored) // no need for this if it's dummy cored
 		if(core)
 			balloon_alert(user, "core already in!")
 			return
@@ -487,6 +491,8 @@
 
 /obj/item/mod/module/anomaly_locked/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()
+	if(dummy_cored) // no need for core interactions if it's dummy cored
+		return
 	if(!core)
 		balloon_alert(user, "no core!")
 		return

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -476,7 +476,7 @@
 	return TRUE
 
 /obj/item/mod/module/anomaly_locked/attackby(obj/item/item, mob/living/user, params)
-	if(item.type in accepted_anomalies && !dummy_cored) // no need for this if it's dummy cored
+	if((item.type in accepted_anomalies) && !dummy_cored) // no need for this if it's dummy cored
 		if(core)
 			balloon_alert(user, "core already in!")
 			return

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -8,7 +8,7 @@
 		Oddly enough, it doesn't seem to work on living creatures."
 	icon_state = "kinesis"
 	module_type = MODULE_ACTIVE
-	complexity = 3
+	complexity = 2
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 3
 	incompatible_modules = list(/obj/item/mod/module/anomaly_locked/kinesis)
 	cooldown_time = 0.5 SECONDS
@@ -16,7 +16,7 @@
 	overlay_state_active = "module_kinesis_on"
 	accepted_anomalies = list(/obj/item/assembly/signaler/anomaly/grav)
 	required_slots = list(ITEM_SLOT_GLOVES)
-	/// Range of the knesis grab.
+	/// Range of the kinesis grab.
 	var/grab_range = 8
 	/// Time between us hitting objects with kinesis.
 	var/hit_cooldown_time = 1 SECONDS
@@ -34,6 +34,8 @@
 	var/datum/looping_sound/gravgen/kinesis/soundloop
 	/// The cooldown between us hitting objects with kinesis.
 	COOLDOWN_DECLARE(hit_cooldown)
+	/// Can this module launch grabbed items?
+	var/can_launch = TRUE
 
 /obj/item/mod/module/anomaly_locked/kinesis/Initialize(mapload)
 	. = ..()
@@ -223,6 +225,8 @@
 		clear_grab()
 
 /obj/item/mod/module/anomaly_locked/kinesis/proc/launch(atom/movable/launched_object)
+	if(!can_launch)
+		return
 	playsound(launched_object, 'sound/effects/magic/repulse.ogg', 100, TRUE)
 	RegisterSignal(launched_object, COMSIG_MOVABLE_IMPACT, PROC_REF(launch_impact))
 	var/turf/target_turf = get_turf_in_angle(get_angle(mod.wearer, launched_object), get_turf(src), 10)
@@ -262,19 +266,46 @@
 	removable = FALSE
 	core_removable = FALSE
 
+/// weak version of the kinesis module for engineers
+/obj/item/mod/module/anomaly_locked/kinesis/weak
+	name = "MOD magnalock module"
+	desc = "A modular plug-in to the forearm, an experimental unit used for handling cargo and heavy objects. \
+		This piece of technology allows the user to generate precise magnetic fields, \
+		letting them move objects objects at a limited range. \
+		Oddly enough, it doesn't seem to work on living creatures."
+	grab_range = 3
+	can_launch = FALSE
+	dummy_cored = TRUE
+	prebuilt = TRUE
+
+/// researchable and printable
+/obj/item/mod/module/anomaly_locked/kinesis/upgraded
+	name = "MOD experimental kinesis module"
+	desc = "A modular plug-in to the forearm, recently developed in Nanotrasen labs based off the magnalock module using miniature gravity generators. \
+		This piece of technology allows the user to generate precise anti-gravity fields, \
+		letting them move objects as small as a titanium rod to as large as industrial machinery from a longer range! \
+		Oddly enough, conscious beings are able to resist out of its fields."
+	can_launch = FALSE
+	dummy_cored = TRUE
+	prebuilt = TRUE
+	stat_required = UNCONSCIOUS
+
+/// requires an anomaly core, but can grab live people
 /obj/item/mod/module/anomaly_locked/kinesis/plus
-	name = "MOD kinesis+ module"
-	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
+	name = "MOD kinesis module"
+	desc = "A modular plug-in to the forearm, this module was developed with the technology of an anomaly core. \
 		The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user \
 		to manipulate the world around them. Like its older counterpart, it's capable of manipulating \
-		structures, machinery, vehicles, and, thanks to the fruitful efforts of its creators - living beings."
-	complexity = 0
-	prebuilt = TRUE
+		structures, machinery, vehicles, and, thanks to the fruitful efforts of its creators - living beings. \
+		can trap objects in a gravity field and launch them at high speeds!"
 	stat_required = CONSCIOUS
+
+/obj/item/mod/module/anomaly_locked/kinesis/plus/prebuilt
+	prebuilt = TRUE
 
 /// Admin suit version of kinesis. Can grab anything at any range, may enable phasing through walls.
 /obj/item/mod/module/anomaly_locked/kinesis/admin
-	name = "MOD kinesis++ module"
+	name = "MOD omega kinesis module"
 	desc = "A modular plug-in to the forearm, this module was recently reredeveloped in super secret. \
 		This one can force some of the grasped objects to phase through walls. Oh no."
 	complexity = 0

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -2757,18 +2757,29 @@
 	)
 
 /datum/design/module/mod_kinesis
-	name = "Kinesis Module"
-	id = "mod_kinesis"
+	name = "Experimental Kinesis Module"
+	id = "mod_kinesis_experimental"
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT *1.25,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT,
 		/datum/material/uranium =HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/bluespace =HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	build_path = /obj/item/mod/module/anomaly_locked/kinesis
+	build_path = /obj/item/mod/module/anomaly_locked/kinesis/upgraded
 	category = list(
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_ENGINEERING
 	)
+
+/datum/design/module/mod_kinesis/anomaly_cored
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT *2,
+		/datum/material/glass =SHEET_MATERIAL_AMOUNT *3,
+		/datum/material/uranium =SHEET_MATERIAL_AMOUNT,
+		/datum/material/bluespace =SHEET_MATERIAL_AMOUNT,
+	)
+	name = "Kinesis Module"
+	id = "mod_kinesis"
+	build_path = /obj/item/mod/module/anomaly_locked/kinesis/upgraded
 
 /datum/design/module/fishing_glove
 	name = "MOD Fishing Glove Module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary> Video </summary>

https://github.com/user-attachments/assets/14fbae12-f844-4a81-bb81-a8245689286d

</details>

### A nerfed kinesis module named the `"MOD magnalock module"` is now by default in an engineering MODsuit.
- It has less range (3 tiles)
- It can't throw objects
- It doesn't require an anomaly core to function
### A slightly better kinesis module named the `"MOD experimental kinesis module"` is given to the Chief engineer's MODsuit.
The same as the magnalock module but:
- 8 range
- Can pickup unconsious mobs

- The `"MOD experimental kinesis module"` can be crafted after researching `engineering MODules` and `MODsuit modules`.
- The `"MOD kinesis module"` can now pick up conscious mobs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Anomaly items have been cleared to be more powerful and the balancing on this module was far outdated
- It fits engineers and could lead to some fun gameplay uses
- Plays into the sci-fi futuristic aspects of the game
- Looks very cool when you have only your arms deployed and gives more uses to MODsuits
- Gives more incentive for players to play engineer, one of the most important jobs in a round for round health.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: grungussuss
add: the magnalock module has been added to engineering MODsuits.
add: the experimental kinesis module has been added to the Chief Engineer's MODsuit.
balance: kinesis module can now grab conscious mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
