### PR TITLE
General maintenance for mecha RCD

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -571,7 +571,7 @@
 
 	var/obj/item/mecha_parts/mecha_equipment/rcd/module = loc
 
-	//construction can be cancelled from ui changes
+	//deconstruction can't be cancelled by ui changes
 	if(mode != RCD_DECONSTRUCT)
 		blueprint_changed = FALSE
 

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -565,6 +565,18 @@
 		return owner.ui_status(user)
 	return UI_CLOSE
 
+/obj/item/construction/rcd/exosuit/build_delay(mob/user, delay, atom/target)
+	if(delay <= 0)
+		return TRUE
+
+	var/obj/item/mecha_parts/mecha_equipment/rcd/module = loc
+
+	//construction can be cancelled from ui changes
+	if(mode != RCD_DECONSTRUCT)
+		blueprint_changed = FALSE
+
+	return module.do_after_mecha(target, user, delay)
+
 /obj/item/construction/rcd/exosuit/get_matter(mob/user)
 	if(silo_link)
 		return ..()

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -63,6 +63,8 @@
 	return do_after(user, delay, target, extra_checks = CALLBACK(src, PROC_REF(blueprint_change)))
 
 /obj/item/construction/proc/blueprint_change()
+	PRIVATE_PROC(TRUE)
+
 	return !blueprint_changed
 
 ///used for examining the RCD and for its UI

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -217,31 +217,29 @@
 			attempt_refill(usr)
 			return TRUE
 
+///Maximum range the RCD can construct at.
+#define RCD_RANGE 3
+
 /obj/item/mecha_parts/mecha_equipment/rcd
 	name = "mounted RCD"
 	desc = "An exosuit-mounted Rapid Construction Device."
 	icon_state = "mecha_rcd"
 	equip_cooldown = 0 // internal RCD already handles it
 	energy_drain = 0 // internal RCD handles power consumption based on matter use
-	range = MECHA_MELEE|MECHA_RANGED
+	range = MECHA_MELEE | MECHA_RANGED
 	item_flags = NO_MAT_REDEMPTION
-	///Maximum range the RCD can construct at.
-	var/rcd_range = 3
+
 	///Whether or not to deconstruct instead.
 	var/deconstruct_active = FALSE
-	///The type of internal RCD this equipment uses.
-	var/rcd_type = /obj/item/construction/rcd/exosuit
 	///The internal RCD item used by this equipment.
-	var/obj/item/construction/rcd/internal_rcd
+	var/obj/item/construction/rcd/exosuit/internal_rcd
 
 /obj/item/mecha_parts/mecha_equipment/rcd/Initialize(mapload)
 	. = ..()
-	internal_rcd = new rcd_type(src)
-	GLOB.rcd_list += src
+	internal_rcd = new(src)
 
 /obj/item/mecha_parts/mecha_equipment/rcd/Destroy()
-	GLOB.rcd_list -= src
-	qdel(internal_rcd)
+	QDEL_NULL(internal_rcd)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/rcd/get_snowflake_data()
@@ -277,15 +275,21 @@
 				internal_rcd.ui_interact(driver)
 			return TRUE
 
+/obj/item/mecha_parts/mecha_equipment/rcd/do_after_checks(atom/target)
+	// Gotta be close to the target
+	if(get_dist(chassis, target) > RCD_RANGE)
+		return FALSE
+	// Cancel build if design changes
+	if(deconstruct_active && internal_rcd.blueprint_changed)
+		return FALSE
+	return ..()
+
 /obj/item/mecha_parts/mecha_equipment/rcd/action(mob/source, atom/target, list/modifiers)
 	if(!action_checks(target))
 		return
-	if(get_dist(chassis, target) > rcd_range)
+	if(get_dist(chassis, target) > RCD_RANGE)
 		balloon_alert(source, "out of range!")
 		return
-	if(!internal_rcd) // if it somehow went missing
-		internal_rcd = new rcd_type(src)
-		stack_trace("Exosuit-mounted RCD had no internal RCD!")
 	..() // do this now because the do_after can take a while
 	var/construction_mode = internal_rcd.mode
 	if(deconstruct_active) // deconstruct isn't in the RCD menu so switch it to deconstruct mode and set it back when it's done
@@ -294,11 +298,13 @@
 	internal_rcd.mode = construction_mode
 	return TRUE
 
-/obj/item/mecha_parts/mecha_equipment/rcd/attackby(obj/item/attacking_item, mob/user, params)
+/obj/item/mecha_parts/mecha_equipment/rcd/interact_with_atom(obj/item/attacking_item, mob/living/user, list/modifiers)
+	. = NONE
 	if(istype(attacking_item, /obj/item/rcd_upgrade))
 		internal_rcd.install_upgrade(attacking_item, user)
-		return
-	return ..()
+		return ITEM_INTERACT_SUCCESS
+
+#undef RCD_RANGE
 
 //Dunno where else to put this so shrug
 /obj/item/mecha_parts/mecha_equipment/ripleyupgrade

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -229,7 +229,7 @@
 	range = MECHA_MELEE | MECHA_RANGED
 	item_flags = NO_MAT_REDEMPTION
 
-	///The location the mech is when it began using the rcd
+	///The location the mech was when it began using the rcd
 	var/atom/initial_location = FALSE
 	///Whether or not to deconstruct instead.
 	var/deconstruct_active = FALSE
@@ -281,7 +281,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/rcd/do_after_checks(atom/target)
 	// Checks if mech moved during operation
-	if(chassis.loc != initial_location) //mech moved
+	if(chassis.loc != initial_location)
 		return FALSE
 
 	// Cancel build if design changes


### PR DESCRIPTION
## About The Pull Request
**1. Code Improvements**
 - Converted `rcd_range` from a var into a define to save memory
 - Removed var `rcd_type` as it was redundant with the type of `internal_rcd` var
 - Moved attack chain code from `attackby()` to `interact_with_atom()` when installing disk upgrade

**2. Fixes**
 Fixes https://github.com/tgstation/tgstation/pull/88589#issuecomment-2552405018, https://github.com/tgstation/tgstation/pull/88589#issuecomment-2552294674. i.e. the RCD cancels it's construction & deconstruction action if
   - The mech rotates away from where its building
   - The mech moves

## Changelog
:cl:
code: improved code for mecha rcd
fix: mecha rcd will cancel its action when the mech is rotated or moves during the action
/:cl:
