### PR TITLE
Nuclear Operatives can buy a vintage pinpointer from the Badassery shop section

### DIFF
--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -106,3 +106,9 @@
 		Contains enough special solution to spray a single super-size seditious symbol, subjecting station staff to slippery suffering."
 	item = /obj/item/traitor_spraycan
 	cost = 1
+
+/datum/uplink_item/badass/pinpointer
+	name = "Surplus Pinpointer"
+	desc = "Provides a surplus pinpointer, left over from the previous models that were abandoned in favor of a SAAS cloud-based PDA app."
+	item = /obj/item/pinpointer/nuke
+	cost = 2

--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -110,5 +110,5 @@
 /datum/uplink_item/badass/pinpointer
 	name = "Surplus Pinpointer"
 	desc = "Provides a surplus pinpointer, left over from the previous models that were abandoned in favor of a SAAS cloud-based PDA app."
-	item = /obj/item/pinpointer/nuke
+	item = /obj/item/pinpointer/nuke/syndicate
 	cost = 2


### PR DESCRIPTION

## About The Pull Request

This adds a "surplus" pinpointer to the nukie badassery shop section.

For 2tc, this spawns you a standard nukie pinpointer, functionally identical to the one given to the captain/HOS at roundstart. Visually (and to a very minor degree mechanically), it is identical to the one given with the clownop default costume (likely as the result of that role's antiquity).

![image](https://github.com/user-attachments/assets/116c0502-6ddb-4240-8c2f-17ad73ff7e32)

Look at that. So cool. Imagine telling all of the other INFERIOR and ROOKIE operatives about how you used to use these old clunky things back in the day. Let them know how much harder it was before everyone decided that PDAs are the future and that everything needs to be done on them. When they get robusted by the crew, advise them that they died because they spent too much time on their damn PDA. Make sure you're pointing at your surplus pinpointer the entire time so they get the idea.
## Why It's Good For The Game

Gives a backup option for nukies who (remember, ss13 is a chaotic sandbox where anything can happen) lose their pinpointer. Also could be useful for keeping trusted individuals in the loop when uneasy antag-antag alliances unfold.

On the less mechanic-oriented side of things, it provides an alternative to the PDA app for the boomers among us. Myself included.

And on a completely unrelated note, having these still in the reach of players is a fun callback to "how things once were" with nukies -- One that I hope will provide material for both IC and OOC conversations.
## Changelog
:cl: Rhials
add: Nukie uplinks now offer an OG-style nuke pinpointer in their Badassery shop section.
/:cl:
