### PR TITLE
Add a notice to the stat panel for clients on 516

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -92,11 +92,14 @@ SUBSYSTEM_DEF(statpanels)
 			return
 
 /datum/controller/subsystem/statpanels/proc/set_status_tab(client/target)
+#if MIN_COMPILER_VERSION > 515
+	#warn 516 is most certainly out of beta, remove this beta notice if you haven't already
+#endif
+	var/static/list/beta_notice = list("", "You are on the BYOND 516 beta, various UIs and such may be broken!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
 	if(!global_data)//statbrowser hasnt fired yet and we were called from immediate_send_stat_data()
 		return
-
 	target.stat_panel.send_message("update_stat", list(
-		"global_data" = global_data,
+		"global_data" = (target.byond_version < 516) ? global_data : (global_data + beta_notice),
 		"ping_str" = "Ping: [round(target.lastping, 1)]ms (Average: [round(target.avgping, 1)]ms)",
 		"other_str" = target.mob?.get_status_tab_items(),
 	))


### PR DESCRIPTION

## About The Pull Request

This adds a constant notice to the stat panel for clients on BYOND 516.

![2024-12-20 (1734739281) ~ dreamseeker](https://github.com/user-attachments/assets/af220a22-241d-4456-9b5c-652dc0953be0)

## Why It's Good For The Game

Best to make sure everyone knows that various UIs will likely be janky/borked on BYOND 516. Hopefully this is hard to miss.

## Changelog
:cl:
add: Added a notice for clients on BYOND 516 that 516 is still in beta, and UI elements may not be fully compatible yet.
/:cl:
