### PR TITLE
Implement byondStorage backend for tgui

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -249,6 +249,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	GLOB.clients += src
 	GLOB.directory[ckey] = src
 
+	if(byond_version >= 516)
+		winset(src, null, list("browser-options" = "find,refresh,byondstorage"))
+
 	// Instantiate stat panel
 	stat_panel = new(src, "statbrowser")
 	stat_panel.subscribe(src, PROC_REF(on_stat_panel_message))

--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -42,6 +42,21 @@ type ByondType = {
   windowId: string;
 
   /**
+   * True if javascript is running in BYOND.
+   */
+  IS_BYOND: boolean;
+
+  /**
+   * Version of Trident engine of Internet Explorer. Null if N/A.
+   */
+  TRIDENT: number | null;
+
+  /**
+   * Version of Blink engine of WebView2. Null if N/A.
+   */
+  BLINK: number | null;
+
+  /**
    * If `true`, unhandled errors and common mistakes result in a blue screen
    * of death, which stops this window from handling incoming messages and
    * closes the active instance of tgui datum if there was one.
@@ -175,4 +190,13 @@ interface Window {
   Byond: ByondType;
   __store__: Store<unknown, AnyAction>;
   __augmentStack__: (store: Store) => StackAugmentor;
+
+  // IE IndexedDB stuff.
+  msIndexedDB: IDBFactory;
+  msIDBTransaction: IDBTransaction;
+
+  // 516 byondstorage API.
+  hubStorage: Storage;
+  byondStorage: Storage;
+  serverStorage: Storage;
 }

--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -197,6 +197,6 @@ interface Window {
 
   // 516 byondstorage API.
   hubStorage: Storage;
-  byondStorage: Storage;
+  domainStorage: Storage;
   serverStorage: Storage;
 }

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -6,12 +6,6 @@
  * @license MIT
  */
 
-declare interface Window {
-  hubStorage: Storage;
-  msIndexedDB: IDBFactory;
-  msIDBTransaction: IDBTransaction;
-}
-
 export const IMPL_MEMORY = 0;
 export const IMPL_HUB_STORAGE = 1;
 export const IMPL_INDEXED_DB = 2;

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -6,18 +6,37 @@
  * @license MIT
  */
 
+declare interface Window {
+  hubStorage: Storage;
+  msIndexedDB: IDBFactory;
+  msIDBTransaction: IDBTransaction;
+}
+
 export const IMPL_MEMORY = 0;
-export const IMPL_LOCAL_STORAGE = 1;
+export const IMPL_HUB_STORAGE = 1;
 export const IMPL_INDEXED_DB = 2;
+
+type StorageImplementation =
+  | typeof IMPL_MEMORY
+  | typeof IMPL_HUB_STORAGE
+  | typeof IMPL_INDEXED_DB;
 
 const INDEXED_DB_VERSION = 1;
 const INDEXED_DB_NAME = 'tgui';
 const INDEXED_DB_STORE_NAME = 'storage-v1';
 
-const READ_ONLY = 'readonly';
-const READ_WRITE = 'readwrite';
+const READ_ONLY = 'readonly' as const;
+const READ_WRITE = 'readwrite' as const;
 
-const testGeneric = (testFn) => () => {
+interface StorageBackend {
+  impl: StorageImplementation;
+  get(key: string): Promise<any>;
+  set(key: string, value: any): Promise<void>;
+  remove(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+const testGeneric = (testFn: () => boolean) => (): boolean => {
   try {
     return Boolean(testFn());
   } catch {
@@ -25,72 +44,77 @@ const testGeneric = (testFn) => () => {
   }
 };
 
-// Localstorage can sometimes throw an error, even if DOM storage is not
-// disabled in IE11 settings.
-// See: https://superuser.com/questions/1080011
-// prettier-ignore
-const testLocalStorage = testGeneric(() => (
-  window.localStorage && window.localStorage.getItem
-));
+const testHubStorage = testGeneric(
+  () => window.hubStorage && !!window.hubStorage.getItem,
+);
 
+// TODO: Remove with 516
 // prettier-ignore
 const testIndexedDb = testGeneric(() => (
   (window.indexedDB || window.msIndexedDB)
-  && (window.IDBTransaction || window.msIDBTransaction)
+  && !!(window.IDBTransaction || window.msIDBTransaction)
 ));
 
-class MemoryBackend {
+class MemoryBackend implements StorageBackend {
+  private store: Record<string, any>;
+  public impl: StorageImplementation;
+
   constructor() {
     this.impl = IMPL_MEMORY;
     this.store = {};
   }
 
-  get(key) {
+  async get(key: string): Promise<any> {
     return this.store[key];
   }
 
-  set(key, value) {
+  async set(key: string, value: any): Promise<void> {
     this.store[key] = value;
   }
 
-  remove(key) {
+  async remove(key: string): Promise<void> {
     this.store[key] = undefined;
   }
 
-  clear() {
+  async clear(): Promise<void> {
     this.store = {};
   }
 }
 
-class LocalStorageBackend {
+class HubStorageBackend implements StorageBackend {
+  public impl: StorageImplementation;
+
   constructor() {
-    this.impl = IMPL_LOCAL_STORAGE;
+    this.impl = IMPL_HUB_STORAGE;
   }
 
-  get(key) {
-    const value = localStorage.getItem(key);
+  async get(key: string): Promise<any> {
+    const value = await window.hubStorage.getItem(key);
     if (typeof value === 'string') {
       return JSON.parse(value);
     }
+    return undefined;
   }
 
-  set(key, value) {
-    localStorage.setItem(key, JSON.stringify(value));
+  async set(key: string, value: any): Promise<void> {
+    window.hubStorage.setItem(key, JSON.stringify(value));
   }
 
-  remove(key) {
-    localStorage.removeItem(key);
+  async remove(key: string): Promise<void> {
+    window.hubStorage.removeItem(key);
   }
 
-  clear() {
-    localStorage.clear();
+  async clear(): Promise<void> {
+    window.hubStorage.clear();
   }
 }
 
-class IndexedDbBackend {
+class IndexedDbBackend implements StorageBackend {
+  public impl: StorageImplementation;
+  public dbPromise: Promise<IDBDatabase>;
+
   constructor() {
     this.impl = IMPL_INDEXED_DB;
-    /** @type {Promise<IDBDatabase>} */
     this.dbPromise = new Promise((resolve, reject) => {
       const indexedDB = window.indexedDB || window.msIndexedDB;
       const req = indexedDB.open(INDEXED_DB_NAME, INDEXED_DB_VERSION);
@@ -98,7 +122,12 @@ class IndexedDbBackend {
         try {
           req.result.createObjectStore(INDEXED_DB_STORE_NAME);
         } catch (err) {
-          reject(new Error('Failed to upgrade IDB: ' + req.error));
+          reject(
+            new Error(
+              'Failed to upgrade IDB: ' +
+                (err instanceof Error ? err.message : String(err)),
+            ),
+          );
         }
       };
       req.onsuccess = () => resolve(req.result);
@@ -108,14 +137,14 @@ class IndexedDbBackend {
     });
   }
 
-  getStore(mode) {
-    // prettier-ignore
-    return this.dbPromise.then((db) => db
+  private async getStore(mode: IDBTransactionMode): Promise<IDBObjectStore> {
+    const db = await this.dbPromise;
+    return db
       .transaction(INDEXED_DB_STORE_NAME, mode)
-      .objectStore(INDEXED_DB_STORE_NAME));
+      .objectStore(INDEXED_DB_STORE_NAME);
   }
 
-  async get(key) {
+  async get(key: string): Promise<any> {
     const store = await this.getStore(READ_ONLY);
     return new Promise((resolve, reject) => {
       const req = store.get(key);
@@ -124,26 +153,19 @@ class IndexedDbBackend {
     });
   }
 
-  async set(key, value) {
-    // The reason we don't _save_ null is because IE 10 does
-    // not support saving the `null` type in IndexedDB. How
-    // ironic, given the bug below!
-    // See: https://github.com/mozilla/localForage/issues/161
-    if (value === null) {
-      value = undefined;
-    }
+  async set(key: string, value: any): Promise<void> {
     // NOTE: We deliberately make this operation transactionless
     const store = await this.getStore(READ_WRITE);
     store.put(value, key);
   }
 
-  async remove(key) {
+  async remove(key: string): Promise<void> {
     // NOTE: We deliberately make this operation transactionless
     const store = await this.getStore(READ_WRITE);
     store.delete(key);
   }
 
-  async clear() {
+  async clear(): Promise<void> {
     // NOTE: We deliberately make this operation transactionless
     const store = await this.getStore(READ_WRITE);
     store.clear();
@@ -154,9 +176,16 @@ class IndexedDbBackend {
  * Web Storage Proxy object, which selects the best backend available
  * depending on the environment.
  */
-class StorageProxy {
+class StorageProxy implements StorageBackend {
+  private backendPromise: Promise<StorageBackend>;
+  public impl: StorageImplementation = IMPL_MEMORY;
+
   constructor() {
     this.backendPromise = (async () => {
+      if (!Byond.TRIDENT && testHubStorage()) {
+        return new HubStorageBackend();
+      }
+      // TODO: Remove with 516
       if (testIndexedDb()) {
         try {
           const backend = new IndexedDbBackend();
@@ -164,29 +193,29 @@ class StorageProxy {
           return backend;
         } catch {}
       }
-      if (testLocalStorage()) {
-        return new LocalStorageBackend();
-      }
+      console.warn(
+        'No supported storage backend found. Using in-memory storage.',
+      );
       return new MemoryBackend();
     })();
   }
 
-  async get(key) {
+  async get(key: string): Promise<any> {
     const backend = await this.backendPromise;
     return backend.get(key);
   }
 
-  async set(key, value) {
+  async set(key: string, value: any): Promise<void> {
     const backend = await this.backendPromise;
     return backend.set(key, value);
   }
 
-  async remove(key) {
+  async remove(key: string): Promise<void> {
     const backend = await this.backendPromise;
     return backend.remove(key);
   }
 
-  async clear() {
+  async clear(): Promise<void> {
     const backend = await this.backendPromise;
     return backend.clear();
   }

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -19,16 +19,16 @@ const INDEXED_DB_VERSION = 1;
 const INDEXED_DB_NAME = 'tgui';
 const INDEXED_DB_STORE_NAME = 'storage-v1';
 
-const READ_ONLY = 'readonly' as const;
-const READ_WRITE = 'readwrite' as const;
+const READ_ONLY = 'readonly';
+const READ_WRITE = 'readwrite';
 
-interface StorageBackend {
+type StorageBackend = {
   impl: StorageImplementation;
   get(key: string): Promise<any>;
   set(key: string, value: any): Promise<void>;
   remove(key: string): Promise<void>;
   clear(): Promise<void>;
-}
+};
 
 const testGeneric = (testFn: () => boolean) => (): boolean => {
   try {


### PR DESCRIPTION

## About The Pull Request

This implements a byondstorage backend for TGUI, via porting the relevant portion of these PRs from Paradise:
- https://github.com/ParadiseSS13/Paradise/pull/25363
- https://github.com/ParadiseSS13/Paradise/pull/26423
- https://github.com/ParadiseSS13/Paradise/pull/26617

Also rewrote `storage.js` to TypeScript

## Proof that it works
<details>
<summary>Screenshots</summary>

![2024-12-20 (1734741983) ~ dreamseeker](https://github.com/user-attachments/assets/8affd7a7-f0bb-4f4f-9017-b279efbdbdfc)

![2024-12-20 (1734742600) ~ dreamseeker](https://github.com/user-attachments/assets/20bf5063-6bf4-4e44-a6a2-0a04d543c164)

</details>

## Why It's Good For The Game

saving chat settings is good

## Changelog
:cl: Absolucy, S34NW
fix: Chat settings properly save on BYOND 516 now. Settings still won't carry over from 515 tho, 515 and 516 settings will be separate.
/:cl:
