### PR TITLE
Fix unique AI lawset station trait leaving the config default lawset in

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -79,8 +79,15 @@ GLOBAL_VAR(round_default_lawset)
 /proc/pick_weighted_lawset()
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
+	var/list/specified_law_ids = CONFIG_GET(keyed_list/specified_laws)
+
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
-		law_weights -= AI_LAWS_ASIMOV
+		switch(CONFIG_GET(number/default_laws))
+			if(CONFIG_ASIMOV)
+				law_weights -= AI_LAWS_ASIMOV
+			if(CONFIG_CUSTOM)
+				law_weights -= specified_law_ids
+
 	while(!lawtype && law_weights.len)
 		var/possible_id = pick_weight(law_weights)
 		lawtype = lawid_to_type(possible_id)


### PR DESCRIPTION
## About The Pull Request
Fix unique AI lawset station trait not removing the current config lawset
This means that the unique AI trait, where it should cause a non-usual lawset to be used, instead can still use the default one.

## Why It's Good For The Game
The station trait working as it should and giving a unique lawset is a good thing.

## Changelog

:cl:
fix: The unique AI station trait will no longer be able to choose lawsets set as default in the config.
/:cl:

