### PR TITLE
Lava ignores thrown mobs

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -266,12 +266,9 @@
 /turf/open/lava/proc/can_burn_stuff(atom/movable/burn_target)
 	if(QDELETED(burn_target))
 		return LAVA_BE_IGNORING
-	if(burn_target.movement_type & MOVETYPES_NOT_TOUCHING_GROUND || !burn_target.has_gravity()) //you're flying over it.
+	if((burn_target.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || burn_target.throwing || !burn_target.has_gravity()) //you're flying over it.
 		return LAVA_BE_IGNORING
-
 	if(isobj(burn_target))
-		if(burn_target.throwing) // to avoid gulag prisoners easily escaping, throwing only works for objects.
-			return LAVA_BE_IGNORING
 		var/obj/burn_obj = burn_target
 		if((burn_obj.resistance_flags & immunity_resistance_flags))
 			return LAVA_BE_PROCESSING
@@ -285,7 +282,7 @@
 	var/mob/living/burn_living = burn_target
 	var/atom/movable/burn_buckled = burn_living.buckled
 	if(burn_buckled)
-		if(burn_buckled.movement_type & MOVETYPES_NOT_TOUCHING_GROUND || !burn_buckled.has_gravity())
+		if((burn_buckled.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || burn_buckled.throwing || !burn_buckled.has_gravity())
 			return LAVA_BE_PROCESSING
 		if(isobj(burn_buckled))
 			var/obj/burn_buckled_obj = burn_buckled


### PR DESCRIPTION
## About The Pull Request

Mobs thrown over lava don't get toasted no more

## Why It's Good For The Game

More fun? If prisoners work together that's peak storytelling anyways

## Changelog

:cl: Melbert
balance: Lava no longer burns mobs thrown over it
/:cl:

