### PR TITLE
Computers can act like cover and will no longer never allow projectiles to pass over them (much l like barricades)

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -19,6 +19,8 @@
 	var/time_to_unscrew = 2 SECONDS
 	/// Are we authenticated to use this? Used by things like comms console, security and medical data, and apc controller.
 	var/authenticated = FALSE
+	/// Will projectiles be able to pass over this computer?
+	var/projectiles_pass_chance = 75
 
 /datum/armor/machinery_computer
 	fire = 40
@@ -27,6 +29,19 @@
 /obj/machinery/computer/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
 	power_change()
+
+/obj/machinery/computer/CanAllowThrough(atom/movable/mover, border_dir) // allows projectiles to fly over the computer
+	. = ..()
+	if(!projectiles_pass_chance)
+		return FALSE
+	if(!isprojectile(mover))
+		return FALSE
+	var/obj/projectile/proj = mover
+	if(proj.firer && Adjacent(proj.firer))
+		return TRUE
+	if(prob(proj_pass_chance))
+		return TRUE
+	return FALSE
 
 /obj/machinery/computer/process()
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -20,7 +20,7 @@
 	/// Are we authenticated to use this? Used by things like comms console, security and medical data, and apc controller.
 	var/authenticated = FALSE
 	/// Will projectiles be able to pass over this computer?
-	var/projectiles_pass_chance = 75
+	var/projectiles_pass_chance = 65
 
 /datum/armor/machinery_computer
 	fire = 40
@@ -41,7 +41,7 @@
 	var/obj/projectile/proj = mover
 	if(!anchored)
 		return TRUE
-	if(proj.firer && Adjacent(proj.firer) && projectiles_pass_chance) // projectiles_pass_chance check is here in case you don't want a computer to act like a barricade
+	if(proj.firer && Adjacent(proj.firer)) // projectiles_pass_chance check is here in case you don't want a computer to act like a barricade
 		return TRUE
 	if(prob(projectiles_pass_chance))
 		return TRUE

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -37,9 +37,9 @@
 	if(!isprojectile(mover))
 		return FALSE
 	var/obj/projectile/proj = mover
-	if(proj.firer && Adjacent(proj.firer))
+	if(proj.firer && Adjacent(proj.firer) && projectiles_pass_chance) // projectiles_pass_chance check is here in case you don't want a computer to act like a barricade
 		return TRUE
-	if(prob(proj_pass_chance))
+	if(prob(projectiles_pass_chance))
 		return TRUE
 	return FALSE
 

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -41,7 +41,7 @@
 	var/obj/projectile/proj = mover
 	if(!anchored)
 		return TRUE
-	if(proj.firer && Adjacent(proj.firer)) // projectiles_pass_chance check is here in case you don't want a computer to act like a barricade
+	if(proj.firer && Adjacent(proj.firer))
 		return TRUE
 	if(prob(projectiles_pass_chance))
 		return TRUE

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -37,6 +37,8 @@
 	if(!isprojectile(mover))
 		return FALSE
 	var/obj/projectile/proj = mover
+	if(!anchored)
+		return TRUE
 	if(proj.firer && Adjacent(proj.firer) && projectiles_pass_chance) // projectiles_pass_chance check is here in case you don't want a computer to act like a barricade
 		return TRUE
 	if(prob(projectiles_pass_chance))

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -32,6 +32,8 @@
 
 /obj/machinery/computer/CanAllowThrough(atom/movable/mover, border_dir) // allows projectiles to fly over the computer
 	. = ..()
+	if(.)
+		return
 	if(!projectiles_pass_chance)
 		return FALSE
 	if(!isprojectile(mover))

--- a/code/game/machinery/computer/arcade/_arcade.dm
+++ b/code/game/machinery/computer/arcade/_arcade.dm
@@ -7,6 +7,7 @@
 	icon_screen = "invaders"
 	light_color = LIGHT_COLOR_GREEN
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_REQUIRES_LITERACY
+	proj_pass_chance = 0 // I guess gambling can save your life huh?
 
 	///If set, will dispense these as prizes instead of the default GLOB.arcade_prize_pool
 	///Like prize pool, it must be a list of the prize and the weight of being selected.

--- a/code/game/machinery/computer/arcade/_arcade.dm
+++ b/code/game/machinery/computer/arcade/_arcade.dm
@@ -7,7 +7,7 @@
 	icon_screen = "invaders"
 	light_color = LIGHT_COLOR_GREEN
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_REQUIRES_LITERACY
-	proj_pass_chance = 0 // I guess gambling can save your life huh?
+	projectiles_pass_chance = 0 // I guess gambling can save your life huh?
 
 	///If set, will dispense these as prizes instead of the default GLOB.arcade_prize_pool
 	///Like prize pool, it must be a list of the prize and the weight of being selected.

--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -18,6 +18,7 @@
 	icon_screen = "medlaptop"
 	icon_keyboard = "laptop_key"
 	pass_flags = PASSTABLE
+	projectiles_pass_chance = 100
 
 /obj/machinery/computer/records/medical/attacked_by(obj/item/attacking_item, mob/living/user)
 	. = ..()

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -27,6 +27,7 @@
 	icon_screen = "seclaptop"
 	icon_keyboard = "laptop_key"
 	pass_flags = PASSTABLE
+	projectiles_pass_chance = 100
 
 /obj/machinery/computer/records/security/laptop/syndie
 	desc = "A cheap, jailbroken security laptop. It functions as a security records console. It's bolted to the table."

--- a/code/game/machinery/computer/telescreen.dm
+++ b/code/game/machinery/computer/telescreen.dm
@@ -12,7 +12,7 @@
 	light_power = 0
 	/// The kind of wallframe that this telescreen drops
 	var/frame_type = /obj/item/wallframe/telescreen
-	proj_pass_chance = 100
+	projectiles_pass_chance = 100
 
 /obj/item/wallframe/telescreen
 	name = "telescreen frame"

--- a/code/game/machinery/computer/telescreen.dm
+++ b/code/game/machinery/computer/telescreen.dm
@@ -12,6 +12,7 @@
 	light_power = 0
 	/// The kind of wallframe that this telescreen drops
 	var/frame_type = /obj/item/wallframe/telescreen
+	proj_pass_chance = 100
 
 /obj/item/wallframe/telescreen
 	name = "telescreen frame"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -22,6 +22,11 @@
 	if(circuit)
 		. += "It has \a [circuit] installed."
 
+/obj/structure/frame/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(isprojectile(mover))
+		return TRUE
+
 /obj/structure/frame/atom_deconstruct(disassembled = TRUE)
 	var/atom/movable/drop_loc = drop_location()
 	new /obj/item/stack/sheet/iron(drop_loc, 5)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -23,9 +23,9 @@
 		. += "It has \a [circuit] installed."
 
 /obj/structure/frame/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
 	if(isprojectile(mover))
 		return TRUE
+	return ..()
 
 /obj/structure/frame/atom_deconstruct(disassembled = TRUE)
 	var/atom/movable/drop_loc = drop_location()


### PR DESCRIPTION
## About The Pull Request
- computers now act like barricades (sandbags) and allow you to shoot over them if adjacent.
- added a var to computers called `projectiles_pass_chance` that determines the chance a projectile will pass over a computer if the firer is not adjacent.
- this var is by default 75 on computers (worse than real barricades, whose chance is 50)
- arcade machines have this on 0. (never pass over)
- telescreens have this on 100. (always pass over)
- medical and security laptops have this on 100. (always pass over)

- construction frames (machine frames and computer frames) will now allow projectiles to pass through).
- unanchored computers will always allow projectiles to pass through
## Why It's Good For The Game
- we have computers in the game that are indestructible (for good reason) and they provide invincible cover, which can be very frustrating for both parties (standing behind the computer and the one attacking). (for example shuttle consoles)
- it's intuitive being able to shoot over computers, as for a proper balance reason? It's really stupid that a bunch of computers will save the hop in his office, or make the captain impossible to hit behind his 3 computers at the helm (comms console and cams console on metastation for example)
- as for why arcade machines don't do this - gambling saves your life! Also because they're big and bulky, it wouldn't be intuitive if they would allow projectiles over.
- for laptops and telescreens - they don't make sense to block projectiles at all.
- for why frames allow projectiles through - they're frames, there's nothing to block with, and they're easy to abuse as you can move them unanchored for mobile cover, same for unanchored computers.
## Changelog
:cl: grungussuss
balance: computers can now be used as cover, firing a projectile over them is now possible, while they may block projectiles if you are not adjacent to them when firing.
fix: computer laptops will not block projectiles
/:cl:
