### PR TITLE
Fix pAIs interacting with machinery

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -867,6 +867,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define NOT_INSIDE_TARGET (1<<10)
 /// Checks for base adjacency, but silences the error
 #define SILENT_ADJACENCY (1<<11)
+/// Allows pAIs to perform an action
+#define ALLOW_PAI (1<<12)
 
 /// The default mob sprite size (used for shrinking or enlarging the mob sprite to regular size)
 #define RESIZE_DEFAULT_SIZE 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1398,8 +1398,7 @@
 			return FALSE
 
 	if(!(action_bitflags & ALLOW_PAI) && ispAI(src))
-		if(!(action_bitflags & SILENT_ADJACENCY))
-			to_chat(src, span_warning("Your holochasis does not allow you to do this!"))
+		to_chat(src, span_warning("Your holochasis does not allow you to do this!"))
 		return FALSE
 
 	if(!(action_bitflags & BYPASS_ADJACENCY) && ((action_bitflags & NOT_INSIDE_TARGET) || !recursive_loc_check(src, target)) && !CanReach(target))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1397,6 +1397,11 @@
 			to_chat(src, span_warning("You don't have the hands for this action!"))
 			return FALSE
 
+	if(!(action_bitflags & ALLOW_PAI) && ispAI(src))
+		if(!(action_bitflags & SILENT_ADJACENCY))
+			to_chat(src, span_warning("Your holochasis does not allow you to do this!"))
+		return FALSE
+
 	if(!(action_bitflags & BYPASS_ADJACENCY) && ((action_bitflags & NOT_INSIDE_TARGET) || !recursive_loc_check(src, target)) && !CanReach(target))
 		if(HAS_SILICON_ACCESS(src) && !ispAI(src))
 			if(!(action_bitflags & ALLOW_SILICON_REACH)) // silicons can ignore range checks (except pAIs)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1090,6 +1090,7 @@
  * * BYPASS_ADJACENCY - The target does not have to be adjacent
  * * SILENT_ADJACENCY - Adjacency is required but errors are not printed
  * * NOT_INSIDE_TARGET - The target maybe adjacent but the mob should not be inside the target
+ * * ALLOW_PAI - Allows pAIs to perform an action
  *
  * silence_adjacency: Sometimes we want to use this proc to check interaction without allowing it to throw errors for base case adjacency
  * Alt click uses this, as otherwise you can detect what is interactable from a distance via the error message


### PR DESCRIPTION

## About The Pull Request
- Fixes #76977

pAIs were able to interact with machinery via ctrl_click/alt_click behavior. Notably this applied to atmos pumps and thermomachines which allowed a pAI to do harmful actions like overload the SM or flood the station with gas.

I added a `ALLOW_PAI` flag so that if someone wants to in the future they can enable certain actions as a whitelist... but right now there isn't anything that would make sense to let them interact with.

## Why It's Good For The Game
Holograms should not be able to directly interact with stuff.

## Changelog
:cl:
fix: Fix pAIs interacting with machinery via alt/ctrl clicking.
/:cl:
