### PR TITLE
Fix kidnapping pod going to unsafe location

### DIFF
--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -259,7 +259,10 @@
 	return
 
 ///Called by the drop pods that return captured crewmembers from the ninja den.
-/obj/structure/closet/supplypod/proc/return_from_capture(mob/living/victim, turf/destination = get_safe_random_station_turf())
+/obj/structure/closet/supplypod/proc/return_from_capture(
+	mob/living/victim,
+	turf/destination = find_safe_turf(extended_safety_checks = TRUE, dense_atoms = FALSE)
+)
 	if(isnull(destination)) //Uuuuh, something went wrong. This is gonna hurt.
 		to_chat(victim, span_hypnophrase("A million voices echo in your head... \"Seems where you got sent won't \
 			be able to handle our pod... as if we wanted the occupant to survive. Brace yourself, corporate dog.\""))


### PR DESCRIPTION

## About The Pull Request
- Fixes #76813

When a mob was returned from the kidnap objective they would sometimes be sent to a turf that was unsafe. In the bug report it was the pressurized atmos chambers rooms that can crush a person.

## Why It's Good For The Game
Dying is bad.

## Changelog
:cl:
fix: Fix kidnapping pod returning a player to unsafe location where air is bad
/:cl:
