### PR TITLE
(Re?-) Adds Welcome sound to lobby after initialization completes

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -162,6 +162,7 @@ SUBSYSTEM_DEF(ticker)
 			to_chat(world, span_notice("<b>Welcome to [station_name()]!</b>"))
 			send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), CONFIG_GET(string/channel_announce_new_game))
 			current_state = GAME_STATE_PREGAME
+			SEND_SOUND(world, sound(SSstation.announcer.get_rand_welcome_sound()))
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
 
 			fire()


### PR DESCRIPTION

## About The Pull Request

(Re?-) Adds Welcome sound to lobby after initialization completes!

I am fairly certain this was added at some point recently but it's not playing anymore. git blame isnt showing anything. maybe i shifted into an alternate dimension

## Why It's Good For The Game

Lets people know when the round's started up and they can change around their character or ready up. It's honestly crazy that lobby has no sounds to give a heads up if you're alt tabed coding or discording or something.

## Changelog

:cl:
sound: (Re?-) Adds Welcome sound to lobby after initialization completes
/:cl:

