### PR TITLE
Crowbars can be recycled in lathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -88,7 +88,7 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/autolathe/crowbar_act(mob/living/user, obj/item/tool)
-	. = ITEM_INTERACT_BLOCKING
+	. = NONE
 	if(default_deconstruction_crowbar(tool))
 		return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #88654

Only when the panel is closed else it deconstructs it as normal

## Changelog
:cl:
fix: crowbars can be recycled in lathes only when the panel is closed
/:cl:

