### PR TITLE
[NO GBP] Fixed aquariums auto-feeding

### DIFF
--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -244,8 +244,7 @@
 /datum/component/aquarium/proc/start_autofeed(datum/reagents/source, new_reagent, amount, reagtemp, data, no_react)
 	SIGNAL_HANDLER
 	START_PROCESSING(SSobj, src)
-	var/atom/movable/movable = parent
-	UnregisterSignal(movable.reagents, COMSIG_REAGENTS_NEW_REAGENT)
+	UnregisterSignal(source, COMSIG_REAGENTS_NEW_REAGENT)
 
 ///Feed the fish at defined intervals until the feed storage is empty.
 /datum/component/aquarium/process(seconds_per_tick)

--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -100,11 +100,12 @@
 	ADD_KEEP_TOGETHER(movable, AQUARIUM_TRAIT) //render the fish on the same layer of the aquarium.
 
 	if(reagents_size > 0)
-		RegisterSignal(movable.reagents, COMSIG_REAGENTS_NEW_REAGENT, PROC_REF(start_autofeed))
 		if(!movable.reagents)
 			movable.create_reagents(reagents_size, SEALED_CONTAINER)
-		else if(movable.reagents.total_volume)
+		if(movable.reagents.total_volume)
 			start_autofeed(movable.reagents)
+		else
+			RegisterSignal(movable.reagents, COMSIG_REAGENTS_NEW_REAGENT, PROC_REF(start_autofeed))
 		RegisterSignal(movable, COMSIG_PLUNGER_ACT, PROC_REF(on_plunger_act))
 
 	RegisterSignal(movable, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(on_item_interaction))

--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -241,10 +241,11 @@
 	return ITEM_INTERACT_SUCCESS
 
 ///Called when the feed storage is no longer empty.
-/datum/component/aquarium/proc/start_autofeed(atom/movable/source, new_reagent, amount, reagtemp, data, no_react)
+/datum/component/aquarium/proc/start_autofeed(datum/reagents/source, new_reagent, amount, reagtemp, data, no_react)
 	SIGNAL_HANDLER
 	START_PROCESSING(SSobj, src)
-	UnregisterSignal(source.reagents, COMSIG_REAGENTS_NEW_REAGENT)
+	var/atom/movable/movable = parent
+	UnregisterSignal(movable.reagents, COMSIG_REAGENTS_NEW_REAGENT)
 
 ///Feed the fish at defined intervals until the feed storage is empty.
 /datum/component/aquarium/process(seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request
We were trying to register the signal on the reagents holder of the movable before it was even initialized which for some reason didn't throw errors.

## Why It's Good For The Game
This will fix https://github.com/tgstation/tgstation/issues/88653

## Changelog

:cl:
fix: Fixed aquariums auto-feeding.
/:cl:
