### PR TITLE
Fix tgui chat panel z-fighting on BYOND 516

### DIFF
--- a/code/modules/tgui_panel/external.dm
+++ b/code/modules/tgui_panel/external.dm
@@ -19,22 +19,19 @@
 	// Failed to fix, using tgalert as fallback
 	action = tgalert(src, "Did that work?", "", "Yes", "No, switch to old ui")
 	if (action == "No, switch to old ui")
-		winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
-		winset(src, "browseroutput", "is-disabled=1;is-visible=0")
+		winset(src, "legacy_output_selector", "left=output_legacy")
 		log_tgui(src, "Failed to fix.", context = "verb/fix_tgui_panel")
 
 /client/proc/nuke_chat()
 	// Catch all solution (kick the whole thing in the pants)
-	winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
-	winset(src, "browseroutput", "is-disabled=1;is-visible=0")
+	winset(src, "legacy_output_selector", "left=output_legacy")
 	if(!tgui_panel || !istype(tgui_panel))
 		log_tgui(src, "tgui_panel datum is missing",
 			context = "verb/fix_tgui_panel")
 		tgui_panel = new(src)
 	tgui_panel.initialize(force = TRUE)
 	// Force show the panel to see if there are any errors
-	winset(src, "output", "is-disabled=1&is-visible=0")
-	winset(src, "browseroutput", "is-disabled=0;is-visible=1")
+	winset(src, "legacy_output_selector", "left=output_browser")
 
 /client/verb/refresh_tgui()
 	set name = "Refresh TGUI"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -224,7 +224,7 @@ window "infowindow"
 window "outputwindow"
 	elem "outputwindow"
 		type = MAIN
-		pos = 281,0
+		pos = 0,0
 		size = 640x480
 		anchor1 = -1,-1
 		anchor2 = -1,-1
@@ -281,15 +281,26 @@ window "outputwindow"
 		command = ".winset \"mebutton.is-checked=true ? input.command=\"!me \\\"\" : input.command=\"\"mebutton.is-checked=true ? saybutton.is-checked=false\"\"mebutton.is-checked=true ? oocbutton.is-checked=false\""
 		is-flat = true
 		button-type = pushbox
-	elem "browseroutput"
-		type = BROWSER
+	elem "legacy_output_selector"
+		type = CHILD
 		pos = 0,0
 		size = 640x456
 		anchor1 = 0,0
 		anchor2 = 100,100
-		is-visible = false
-		is-disabled = true
-		saved-params = ""
+		saved-params = "splitter"
+		left = "output_legacy"
+		is-vert = false
+
+window "output_legacy"
+	elem "output_legacy"
+		type = MAIN
+		pos = 0,0
+		size = 640x456
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		background-color = none
+		saved-params = "pos;size;is-minimized;is-maximized"
+		is-pane = true
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
@@ -297,6 +308,25 @@ window "outputwindow"
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
+		saved-params = ""
+
+window "output_browser"
+	elem "output_browser"
+		type = MAIN
+		pos = 0,0
+		size = 640x456
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		background-color = none
+		saved-params = "pos;size;is-minimized;is-maximized"
+		is-pane = true
+	elem "browseroutput"
+		type = BROWSER
+		pos = 0,0
+		size = 640x456
+		anchor1 = 0,0
+		anchor2 = 100,100
+		background-color = none
 		saved-params = ""
 
 window "popupwindow"

--- a/tgui/packages/tgui-panel/index.tsx
+++ b/tgui/packages/tgui-panel/index.tsx
@@ -75,14 +75,8 @@ const setupApp = () => {
   Byond.subscribe((type, payload) => store.dispatch({ type, payload }));
 
   // Unhide the panel
-  Byond.winset('output', {
-    'is-visible': false,
-  });
-  Byond.winset('browseroutput', {
-    'is-visible': true,
-    'is-disabled': false,
-    pos: '0x0',
-    size: '0x0',
+  Byond.winset('legacy_output_selector', {
+    left: 'output_browser',
   });
 
   // Resize the panel to match the non-browser output


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/ParadiseSS13/Paradise/pull/27676 and https://github.com/VOREStation/VOREStation/pull/16734

> Instead of relying on `is-disabled` and `is-visible`, which BYOND happily will automatically change for you whenever you send a client text, we now use a Child element to swap between the legacy output and browser output in separate preset panes.
> 
> TL;DR: chat would flash white under 516, now doesn't

I cleared cache before each test video below, just to be 100% sure

<details>
<summary>Testing Evidence: BYOND 515</summary>

https://github.com/user-attachments/assets/8d661cc3-585e-4f8e-9399-76df8bc0a281

</details>

<details>
<summary>Testing Evidence: BYOND 516</summary>

https://github.com/user-attachments/assets/c0d31fb4-6ef5-4d49-81a8-c767c5e24cc2

</details>

## Why It's Good For The Game

flickering chat hurts my eyes

## Changelog
:cl: Absolucy, ShadowLarkens, S34N
fix: Fixed chat rapidly flickering in BYOND 516.
/:cl:
