### PR TITLE
Prevents vibechecking budget insuls via examine tags

### DIFF
--- a/code/modules/clothing/gloves/insulated.dm
+++ b/code/modules/clothing/gloves/insulated.dm
@@ -105,6 +105,13 @@
 	. = ..()
 	siemens_coefficient = pick(0,0.5,0.5,0.5,0.5,0.75,1.5)
 
+/obj/item/clothing/gloves/color/fyellow/examine_tags(mob/user)
+	. = ..()
+	// Pretend we're always insulated
+	if (.["partially insulated"])
+		. -= "partially insulated"
+	.["insulated"] = "It is made from a robust electrical insulator and will block any electricity passing through it!"
+
 /obj/item/clothing/gloves/color/fyellow/old
 	desc = "Old and worn out insulated gloves, hopefully they still work."
 	name = "worn out insulated gloves"


### PR DESCRIPTION

## About The Pull Request

Closes #88634
You can no longer vibecheck budget insuls, as they'll always show up as fully insulated.

## Why It's Good For The Game

Kinda ruins the point of random insulation on these.

## Changelog
:cl:
balance: You can no longer check if budget insuls work via examine tags
/:cl:
