### PR TITLE
Iron material tiles can now be used to tile lattice to make plating (same for other similar interactions)

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -303,6 +303,9 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 #define isbook(O) (is_type_in_typecache(O, GLOB.book_types))
 
+// Is this an iron tile, or a material tile made from iron?
+#define ismetaltile(tile_thing) (istype(tile_thing, /obj/item/stack/tile/iron) || istype(tile_thing, /obj/item/stack/tile/material) && tile_thing.has_material_type(/datum/material/iron))
+
 GLOBAL_LIST_INIT(book_types, typecacheof(list(
 	/obj/item/book,
 	/obj/item/spellbook,

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -162,7 +162,7 @@
 
 /obj/structure/lattice/lava/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()
-	if(!istype(attacking_item, /obj/item/stack/tile/iron))
+	if(!ismetaltile(attacking_item))
 		return
 	var/obj/item/stack/tile/iron/attacking_tiles = attacking_item
 	if(!attacking_tiles.use(1))

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -55,22 +55,26 @@
 	return TRUE
 
 /turf/open/chasm/attackby(obj/item/C, mob/user, params, area/area_restriction)
-	..()
-	if(istype(C, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = C
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(L)
-			return
-		if(!R.use(1))
-			to_chat(user, span_warning("You need one rod to build a lattice."))
-			return
-		to_chat(user, span_notice("You construct a lattice."))
-		playsound(src, 'sound/items/weapons/genhit.ogg', 50, TRUE)
-		// Create a lattice, without reverting to our baseturf
-		new /obj/structure/lattice(src)
-		return
-	else if(istype(C, /obj/item/stack/tile/iron))
+	. = ..()
+	if(ismetaltile(C))
 		build_with_floor_tiles(C, user)
+		return
+
+	if(!istype(C, /obj/item/stack/rods))
+		return
+
+	var/obj/item/stack/rods/R = C
+	var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+	if(L)
+		return
+	if(!R.use(1))
+		to_chat(user, span_warning("You need one rod to build a lattice."))
+		return
+	to_chat(user, span_notice("You construct a lattice."))
+	playsound(src, 'sound/items/weapons/genhit.ogg', 50, TRUE)
+	// Create a lattice, without reverting to our baseturf
+	new /obj/structure/lattice(src)
+
 
 /// Handles adding the chasm component to the turf (So stuff falls into it!)
 /turf/open/chasm/proc/apply_components(mapload)
@@ -137,6 +141,6 @@
 /turf/open/chasm/true/no_smooth/attackby(obj/item/item, mob/user, params, area/area_restriction)
 	if(istype(item, /obj/item/stack/rods))
 		return
-	else if(istype(item, /obj/item/stack/tile/iron))
+	else if(ismetaltile(item))
 		return
 	return ..()

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -135,26 +135,28 @@
 /turf/open/floor/plating/foam/break_tile()
 	return //jetfuel can't break steel foam...
 
-/turf/open/floor/plating/foam/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/stack/tile/iron))
-		var/obj/item/stack/tile/iron/P = I
-		if(P.use(1))
-			var/obj/L = locate(/obj/structure/lattice) in src
-			if(L)
-				qdel(L)
-			to_chat(user, span_notice("You reinforce the foamed plating with tiling."))
-			playsound(src, 'sound/items/weapons/Genhit.ogg', 50, TRUE)
-			ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+/turf/open/floor/plating/foam/attackby(obj/item/attacking_item, mob/user, params)
+	if(ismetaltile(attacking_item))
+		var/obj/item/stack/tile/tiles = attacking_item
+		if(!tiles.use(1))
+			return
+		var/obj/lattice = locate(/obj/structure/lattice) in src
+		if(lattice)
+			qdel(lattice)
+		to_chat(user, span_notice("You reinforce the foamed plating with tiling."))
+		playsound(src, 'sound/items/weapons/Genhit.ogg', 50, TRUE)
+		ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return
+
+	playsound(src, 'sound/items/weapons/tap.ogg', 100, TRUE) //The attack sound is muffled by the foam itself
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(src)
+	if(prob(attacking_item.force * 20 - 25))
+		user.visible_message(span_danger("[user] smashes through [src]!"), \
+						span_danger("You smash through [src] with [attacking_item]!"))
+		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	else
-		playsound(src, 'sound/items/weapons/tap.ogg', 100, TRUE) //The attack sound is muffled by the foam itself
-		user.changeNext_move(CLICK_CD_MELEE)
-		user.do_attack_animation(src)
-		if(prob(I.force * 20 - 25))
-			user.visible_message(span_danger("[user] smashes through [src]!"), \
-							span_danger("You smash through [src] with [I]!"))
-			ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
-		else
-			to_chat(user, span_danger("You hit [src], to no effect!"))
+		to_chat(user, span_danger("You hit [src], to no effect!"))
 
 /turf/open/floor/plating/foam/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_TURF && the_rcd.rcd_design_path == /turf/open/floor/plating/rcd)

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -21,16 +21,17 @@
 	heat_capacity = 20000
 	tiled_dirt = TRUE
 
-/turf/open/misc/attackby(obj/item/W, mob/user, params)
+/turf/open/misc/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()
 	if(.)
 		return TRUE
 
-	if(istype(W, /obj/item/stack/rods))
-		build_with_rods(W, user)
+	if(istype(attacking_item, /obj/item/stack/rods))
+		build_with_rods(attacking_item, user)
 		return TRUE
-	else if(istype(W, /obj/item/stack/tile/iron))
-		build_with_floor_tiles(W, user)
+
+	if(ismetaltile(attacking_item))
+		build_with_floor_tiles(attacking_item, user)
 		return TRUE
 
 /turf/open/misc/attack_paw(mob/user, list/modifiers)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -113,18 +113,18 @@
 /turf/open/openspace/proc/CanBuildHere()
 	return can_build_on
 
-/turf/open/openspace/attackby(obj/item/C, mob/user, params)
+/turf/open/openspace/attackby(obj/item/attacking_item, mob/user, params)
 	..()
 	if(!CanBuildHere())
 		return
-	if(istype(C, /obj/item/stack/rods))
-		build_with_rods(C, user)
-	else if(istype(C, /obj/item/stack/tile/iron))
-		build_with_floor_tiles(C, user)
-	else if(istype(C, /obj/item/stack/thermoplastic))
-		build_with_transport_tiles(C, user)
-	else if(istype(C, /obj/item/stack/sheet/mineral/titanium))
-		build_with_titanium(C, user)
+	if(istype(attacking_item, /obj/item/stack/rods))
+		build_with_rods(attacking_item, user)
+	else if(ismetaltile(attacking_item))
+		build_with_floor_tiles(attacking_item, user)
+	else if(istype(attacking_item, /obj/item/stack/thermoplastic))
+		build_with_transport_tiles(attacking_item, user)
+	else if(istype(attacking_item, /obj/item/stack/sheet/mineral/titanium))
+		build_with_titanium(attacking_item, user)
 
 /turf/open/openspace/build_with_floor_tiles(obj/item/stack/tile/iron/used_tiles)
 	if(!CanCoverUp())

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -138,14 +138,14 @@ GLOBAL_LIST_EMPTY(starlight)
 /turf/open/space/handle_slip()
 	return
 
-/turf/open/space/attackby(obj/item/C, mob/user, params)
+/turf/open/space/attackby(obj/item/attacking_item, mob/user, params)
 	..()
 	if(!CanBuildHere())
 		return
-	if(istype(C, /obj/item/stack/rods))
-		build_with_rods(C, user)
-	else if(istype(C, /obj/item/stack/tile/iron) || istype(C, /obj/item/stack/tile/material) && C.has_material_type(/datum/material/iron))
-		build_with_floor_tiles(C, user)
+	if(istype(attacking_item, /obj/item/stack/rods))
+		build_with_rods(attacking_item, user)
+	else if(ismetaltile(attacking_item))
+		build_with_floor_tiles(attacking_item, user)
 
 
 /turf/open/space/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)


### PR DESCRIPTION

## About The Pull Request

Added a helper to check if something is a tile made out of iron, and changed all plating placement code to use it.

## Why It's Good For The Game

Its very easy to misclick or get confused and make the wrong type of tile in the crafting menu, and since material tiles made from iron aren't a subtype of ***iron*** tiles, you won't be able to use them to make plating. Space already accounts for this, but lattice, chasms, openspace and foam plating do not.

## Changelog
:cl:
qol: Iron material tiles can now be used to tile lattice to make plating 
/:cl:
