### PR TITLE
Improve and extend `fieldset_block` and `examine_block`

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -47,7 +47,7 @@
 #define boxed_message(str) ("<div class='boxed_message'>" + str + "</div>")
 /// Adds a box around whatever message you're sending in chat. Can apply color and/or additional classes. Available colors: red, green, blue, purple.
 #define custom_boxed_message(classes, str) ("<div class='boxed_message " + classes + "'>" + str + "</div>")
-/// Makes a fieldset with a name in the middle top part. Can apply additional classes
+/// Makes a fieldset with a neaty styled name. Can apply additional classes.
 #define fieldset_block(title, content, classes) ("<fieldset class='fieldset " + classes + "'><legend class='fieldset_legend'>" + title + "</legend>" + content + "</fieldset>")
 /// Makes a horizontal line with text in the middle
 #define separator_hr(str) ("<div class='separator'>" + str + "</div>")

--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -45,7 +45,7 @@
 #define debug_world_log(msg) if (GLOB.Debug2) log_world("DEBUG: [msg]")
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define boxed_message(str) ("<div class='boxed_message'>" + str + "</div>")
-/// Adds a box around whatever message you're sending in chat. Can apply color and/or additional classes. Available colors: red, green, blue, purple.
+/// Adds a box around whatever message you're sending in chat. Can apply color and/or additional classes. Available colors: red, green, blue, purple. Use it like red_box
 #define custom_boxed_message(classes, str) ("<div class='boxed_message " + classes + "'>" + str + "</div>")
 /// Makes a fieldset with a neaty styled name. Can apply additional classes.
 #define fieldset_block(title, content, classes) ("<fieldset class='fieldset " + classes + "'><legend class='fieldset_legend'>" + title + "</legend>" + content + "</fieldset>")

--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -44,7 +44,7 @@
 /// Used for debug messages to the server
 #define debug_world_log(msg) if (GLOB.Debug2) log_world("DEBUG: [msg]")
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
-#define examine_block(str) ("<div class='examine_block'>" + str + "</div>")
+#define boxed_message(str) ("<div class='boxed_message'>" + str + "</div>")
 /// Makes a custom fieldset with a name in the middle top part. Can apply additional classes
 #define fieldset_block(title, content, classes) ("<div class='custom_fieldset " + classes + "'><legend align='center' class='fieldset_legend'>" + title + "</legend>" + content + "</div>")
 /// Makes a horizontal line with text in the middle

--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -45,8 +45,8 @@
 #define debug_world_log(msg) if (GLOB.Debug2) log_world("DEBUG: [msg]")
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define examine_block(str) ("<div class='examine_block'>" + str + "</div>")
-/// Makes a fieldset with a name in the middle top part. Can apply additional classes
-#define fieldset_block(title, content, classes) ("<fieldset class='" + classes + "'><legend align='center' style='max-width: 95%; text-align: center;'><div style='margin: 0em 0.2em -0.4em 0.2em;' >" + title + "</div></legend>" + content + "</fieldset>")
+/// Makes a custom fieldset with a name in the middle top part. Can apply additional classes
+#define fieldset_block(title, content, classes) ("<div class='custom_fieldset " + classes + "'><legend align='center' class='fieldset_legend'>" + title + "</legend>" + content + "</div>")
 /// Makes a horizontal line with text in the middle
 #define separator_hr(str) ("<div class='separator'>" + str + "</div>")
 /// Emboldens runechat messages

--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -45,8 +45,10 @@
 #define debug_world_log(msg) if (GLOB.Debug2) log_world("DEBUG: [msg]")
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define boxed_message(str) ("<div class='boxed_message'>" + str + "</div>")
-/// Makes a custom fieldset with a name in the middle top part. Can apply additional classes
-#define fieldset_block(title, content, classes) ("<div class='custom_fieldset " + classes + "'><legend align='center' class='fieldset_legend'>" + title + "</legend>" + content + "</div>")
+/// Adds a box around whatever message you're sending in chat. Can apply color and/or additional classes. Available colors: red, green, blue, purple.
+#define custom_boxed_message(classes, str) ("<div class='boxed_message " + classes + "'>" + str + "</div>")
+/// Makes a fieldset with a name in the middle top part. Can apply additional classes
+#define fieldset_block(title, content, classes) ("<fieldset class='fieldset " + classes + "'><legend class='fieldset_legend'>" + title + "</legend>" + content + "</fieldset>")
 /// Makes a horizontal line with text in the middle
 #define separator_hr(str) ("<div class='separator'>" + str + "</div>")
 /// Emboldens runechat messages

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -349,4 +349,4 @@
 		message = html_encode(message)
 	else
 		message = copytext(message, 2)
-	to_chat(target, span_purple(examine_block("<span class='oocplain'><b>[source]: </b>[message]</span>")))
+	to_chat(target, span_purple(boxed_message("<span class='oocplain'><b>[source]: </b>[message]</span>")))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -349,4 +349,4 @@
 		message = html_encode(message)
 	else
 		message = copytext(message, 2)
-	to_chat(target, custom_boxed_message("purple", span_purple("<span class='oocplain'><b>[source]: </b>[message]</span>")))
+	to_chat(target, custom_boxed_message("purple_box", span_purple("<span class='oocplain'><b>[source]: </b>[message]</span>")))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -349,4 +349,4 @@
 		message = html_encode(message)
 	else
 		message = copytext(message, 2)
-	to_chat(target, span_purple(boxed_message("<span class='oocplain'><b>[source]: </b>[message]</span>")))
+	to_chat(target, custom_boxed_message("purple", span_purple("<span class='oocplain'><b>[source]: </b>[message]</span>")))

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -1136,7 +1136,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
-		to_chat(usr, examine_block(jointext(examine(usr), "\n")))
+		to_chat(usr, boxed_message(jointext(examine(usr), "\n")))
 		return FALSE
 	var/datum/our_master = master_ref?.resolve()
 	if(our_master && click_master)

--- a/code/controllers/subsystem/map_vote.dm
+++ b/code/controllers/subsystem/map_vote.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(map_vote)
 	last_message_at = world.time
 
 	var/list/messages = args.Copy()
-	to_chat(world, span_purple(examine_block("Map Vote\n<hr>[messages.Join("\n")]")))
+	to_chat(world, span_purple(boxed_message("Map Vote\n<hr>[messages.Join("\n")]")))
 
 /datum/controller/subsystem/map_vote/proc/finalize_map_vote(datum/vote/map_vote/map_vote)
 	if(already_voted)
@@ -170,4 +170,4 @@ SUBSYSTEM_DEF(map_vote)
 	for(var/map_id in map_vote_cache)
 		var/datum/map_config/map = config.maplist[map_id]
 		data += "[map.map_name] - [map_vote_cache[map_id]]"
-	tally_printout = examine_block("Current Tallies\n<hr>[data.Join("\n")]")
+	tally_printout = boxed_message("Current Tallies\n<hr>[data.Join("\n")]")

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -165,7 +165,7 @@ SUBSYSTEM_DEF(polling)
 				else
 					surrounding_image = image(chat_text_border_icon)
 				surrounding_icon = icon2html(surrounding_image, candidate_mob, extra_classes = "bigicon")
-			var/final_message =  examine_block("<span style='text-align:center;display:block'>[surrounding_icon] <span style='font-size:1.2em'>[span_ooc(question)]</span> [surrounding_icon]\n[act_jump]      [act_signup]      [act_never]</span>")
+			var/final_message =  boxed_message("<span style='text-align:center;display:block'>[surrounding_icon] <span style='font-size:1.2em'>[span_ooc(question)]</span> [surrounding_icon]\n[act_jump]      [act_signup]      [act_never]</span>")
 			to_chat(candidate_mob, final_message)
 
 		// Start processing it so it updates visually the timer

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -230,7 +230,7 @@ SUBSYSTEM_DEF(vote)
 	var/to_display = current_vote.initiate_vote(vote_initiator_name, duration)
 
 	log_vote(to_display)
-	to_chat(world, custom_boxed_message("purple center", span_infoplain(vote_font("[span_bold(to_display)]<br>\
+	to_chat(world, custom_boxed_message("purple_box center", span_infoplain(vote_font("[span_bold(to_display)]<br>\
 		Type <b>vote</b> or click <a href='byond://winset?command=vote'>here</a> to place your votes.\n\
 		You have [DisplayTimeText(duration)] to vote."))))
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -119,7 +119,7 @@ SUBSYSTEM_DEF(vote)
 	)
 	log_vote("vote finalized", vote_log_data)
 	if(to_display)
-		to_chat(world, span_infoplain(vote_font("\n[to_display]")))
+		to_chat(world, span_infoplain(vote_font("[to_display]")))
 
 	// Finally, doing any effects on vote completion
 	current_vote.finalize_vote(final_winner)
@@ -230,9 +230,9 @@ SUBSYSTEM_DEF(vote)
 	var/to_display = current_vote.initiate_vote(vote_initiator_name, duration)
 
 	log_vote(to_display)
-	to_chat(world, span_infoplain(vote_font("\n[span_bold(to_display)]\n\
+	to_chat(world, custom_boxed_message("purple center", span_infoplain(vote_font("[span_bold(to_display)]<br>\
 		Type <b>vote</b> or click <a href='byond://winset?command=vote'>here</a> to place your votes.\n\
-		You have [DisplayTimeText(duration)] to vote.")))
+		You have [DisplayTimeText(duration)] to vote."))))
 
 	// And now that it's going, give everyone a voter action
 	for(var/client/new_voter as anything in GLOB.clients)

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -442,7 +442,7 @@ GLOBAL_VAR(round_default_lawset)
 
 /datum/ai_laws/proc/show_laws(mob/to_who)
 	var/list/printable_laws = get_law_list(include_zeroth = TRUE)
-	to_chat(to_who, examine_block(jointext(printable_laws, "\n")))
+	to_chat(to_who, boxed_message(jointext(printable_laws, "\n")))
 
 /datum/ai_laws/proc/associate(mob/living/silicon/M)
 	if(owner)

--- a/code/datums/components/trader/trader.dm
+++ b/code/datums/components/trader/trader.dm
@@ -394,7 +394,7 @@ Can accept both a type path, and an instance of a datum. Type path has priority.
 		else
 			buy_info += span_notice("&bull; [initial(thing.name)] for [product_info[TRADER_PRODUCT_INFO_PRICE]] [trader_data.currency_name][product_info[TRADER_PRODUCT_INFO_PRICE_MOD_DESCRIPTION]]; willing to buy [span_green("[tern_op_result]")]")
 
-	to_chat(customer, examine_block(buy_info.Join("\n")))
+	to_chat(customer, boxed_message(buy_info.Join("\n")))
 
 ///Displays to the customer what the trader is selling and how much is in stock
 /datum/component/trader/proc/trader_sells_what(mob/customer)
@@ -413,7 +413,7 @@ Can accept both a type path, and an instance of a datum. Type path has priority.
 			sell_info += span_notice("&bull; [span_red("(OUT OF STOCK)")] [initial(thing.name)] for [product_info[TRADER_PRODUCT_INFO_PRICE]] [trader_data.currency_name]; [span_red("[tern_op_result]")] left in stock")
 		else
 			sell_info += span_notice("&bull; [initial(thing.name)] for [product_info[TRADER_PRODUCT_INFO_PRICE]] [trader_data.currency_name]; [span_green("[tern_op_result]")] left in stock")
-	to_chat(customer, examine_block(sell_info.Join("\n")))
+	to_chat(customer, boxed_message(sell_info.Join("\n")))
 
 ///Sets quantity of all products to initial(quanity); this proc is currently called during initialize
 /datum/component/trader/proc/restock_products()

--- a/code/datums/elements/slapcrafting.dm
+++ b/code/datums/elements/slapcrafting.dm
@@ -180,7 +180,7 @@
 	// If we did find ingredients then add them onto the list.
 	if(length(string_ingredient_list))
 		to_chat(user, span_boldnotice("Extra Ingredients:"))
-		to_chat(user, examine_block(span_notice(string_ingredient_list)))
+		to_chat(user, boxed_message(span_notice(string_ingredient_list)))
 
 	var/list/tool_list = ""
 
@@ -194,7 +194,7 @@
 
 	if(length(tool_list))
 		to_chat(user, span_boldnotice("Required Tools:"))
-		to_chat(user, examine_block(span_notice(tool_list)))
+		to_chat(user, boxed_message(span_notice(tool_list)))
 
 	qdel(cur_recipe)
 

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -57,7 +57,7 @@
 	SIGNAL_HANDLER
 
 	if(href_list["examine"])
-		to_chat(user, span_notice(examine_block("[build_label_text(source)]")))
+		to_chat(user, span_notice(boxed_message("[build_label_text(source)]")))
 
 /**
  *

--- a/code/datums/mind/skills.dm
+++ b/code/datums/mind/skills.dm
@@ -75,4 +75,4 @@
 		var/datum/skill/the_skill = i
 		msg += "[initial(the_skill.name)] - [get_skill_level_name(the_skill)]\n"
 	msg += "</span>"
-	to_chat(user, examine_block(msg))
+	to_chat(user, boxed_message(msg))

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -389,7 +389,7 @@
 					msg += span_boldnicegreen(event.description + "\n")
 	else
 		msg += "[span_grey("I don't have much of a reaction to anything right now.")]\n"
-	to_chat(user, examine_block(msg))
+	to_chat(user, boxed_message(msg))
 
 /// Updates the mob's moodies, if the area provides a mood bonus
 /datum/mood/proc/check_area_mood(datum/source, area/new_area)

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -170,13 +170,14 @@
  * Return a formatted string of text to be displayed to everyone.
  */
 /datum/vote/proc/get_result_text(list/all_winners, real_winner, list/non_voters)
+	var/title_text = ""
 	var/returned_text = ""
 	if(override_question)
-		returned_text += span_bold(override_question)
+		title_text += span_bold(override_question)
 	else
-		returned_text += span_bold("[capitalize(name)] Vote")
+		title_text += span_bold("[capitalize(name)] Vote")
 
-	returned_text += "\nWinner Selection: "
+	returned_text += "Winner Selection: "
 	switch(winner_method)
 		if(VOTE_WINNER_METHOD_NONE)
 			returned_text += "None"
@@ -215,7 +216,7 @@
 	returned_text += "\n"
 	returned_text += get_winner_text(all_winners, real_winner, non_voters)
 
-	return returned_text
+	return fieldset_block(title_text, returned_text, "boxed_message purple")
 
 /**
  * Gets the text that displays the winning options within the result text.

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -216,7 +216,7 @@
 	returned_text += "\n"
 	returned_text += get_winner_text(all_winners, real_winner, non_voters)
 
-	return fieldset_block(title_text, returned_text, "boxed_message purple")
+	return fieldset_block(title_text, returned_text, "boxed_message purple_box")
 
 /**
  * Gets the text that displays the winning options within the result text.

--- a/code/game/objects/items/AI_modules/_AI_modules.dm
+++ b/code/game/objects/items/AI_modules/_AI_modules.dm
@@ -36,7 +36,7 @@
 
 /obj/item/ai_module/attack_self(mob/user as mob)
 	..()
-	to_chat(user, examine_block(display_laws()))
+	to_chat(user, boxed_message(display_laws()))
 
 /// Returns a text display of the laws for the module.
 /obj/item/ai_module/proc/display_laws()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -267,7 +267,7 @@
 
 	if(length(render_list))
 		//display our packaged information in an examine block for easy reading
-		to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
+		to_chat(user, boxed_message(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 		return ITEM_INTERACT_SUCCESS
 	return ITEM_INTERACT_BLOCKING
 

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -220,7 +220,7 @@
 			message += span_notice("Volume: [volume] L") // don't want to change the order volume appears in, suck it
 
 	// we let the join apply newlines so we do need handholding
-	to_chat(user, examine_block(jointext(message, "\n")), type = MESSAGE_TYPE_INFO)
+	to_chat(user, boxed_message(jointext(message, "\n")), type = MESSAGE_TYPE_INFO)
 	return TRUE
 
 /obj/item/analyzer/ranged

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -81,7 +81,7 @@
 		floor_text += "<span class='info ml-1'>Body temperature: [scan_turf?.return_air()?.return_temperature() || "???"]</span><br>"
 
 		if(user.can_read(src) && !user.is_blind())
-			to_chat(user, examine_block(floor_text))
+			to_chat(user, boxed_message(floor_text))
 		last_scan_text = floor_text
 		return
 
@@ -410,7 +410,7 @@
 
 	. = jointext(render_list, "")
 	if(tochat)
-		to_chat(user, examine_block(.), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		to_chat(user, boxed_message(.), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 	return .
 
 /obj/item/healthanalyzer/click_ctrl_shift(mob/user)
@@ -507,7 +507,7 @@
 				render_list += "<span class='alert ml-2'>[allergies]</span><br>"
 
 		// we handled the last <br> so we don't need handholding
-		to_chat(user, examine_block(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		to_chat(user, boxed_message(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /obj/item/healthanalyzer/click_alt(mob/user)
 	if(mode == SCANNER_NO_MODE)
@@ -558,7 +558,7 @@
 			simple_scanner.show_emotion(AID_EMOTION_HAPPY)
 		to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
 	else
-		to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
+		to_chat(user, boxed_message(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 		if(simple_scan)
 			var/obj/item/healthanalyzer/simple/simple_scanner = scanner
 			simple_scanner.show_emotion(AID_EMOTION_WARN)

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -81,7 +81,7 @@
 		floor_text += "<span class='info ml-1'>Body temperature: [scan_turf?.return_air()?.return_temperature() || "???"]</span><br>"
 
 		if(user.can_read(src) && !user.is_blind())
-			to_chat(user, boxed_message(floor_text))
+			to_chat(user, custom_boxed_message("blue_box", floor_text))
 		last_scan_text = floor_text
 		return
 
@@ -410,7 +410,7 @@
 
 	. = jointext(render_list, "")
 	if(tochat)
-		to_chat(user, boxed_message(.), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		to_chat(user, custom_boxed_message("blue_box", .), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 	return .
 
 /obj/item/healthanalyzer/click_ctrl_shift(mob/user)
@@ -507,7 +507,7 @@
 				render_list += "<span class='alert ml-2'>[allergies]</span><br>"
 
 		// we handled the last <br> so we don't need handholding
-		to_chat(user, boxed_message(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		to_chat(user, custom_boxed_message("blue_box", jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /obj/item/healthanalyzer/click_alt(mob/user)
 	if(mode == SCANNER_NO_MODE)
@@ -558,7 +558,7 @@
 			simple_scanner.show_emotion(AID_EMOTION_HAPPY)
 		to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
 	else
-		to_chat(user, boxed_message(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
+		to_chat(user, custom_boxed_message("blue_box", jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 		if(simple_scan)
 			var/obj/item/healthanalyzer/simple/simple_scanner = scanner
 			simple_scanner.show_emotion(AID_EMOTION_WARN)

--- a/code/game/objects/items/devices/scanners/slime_scanner.dm
+++ b/code/game/objects/items/devices/scanners/slime_scanner.dm
@@ -57,4 +57,4 @@
 		to_render += "\n[span_notice("Core mutation in progress: [scanned_slime.crossbreed_modification]")]\
 					  \n[span_notice("Progress in core mutation: [scanned_slime.applied_crossbreed_amount] / [SLIME_EXTRACT_CROSSING_REQUIRED]")]"
 
-	to_chat(user, examine_block(jointext(to_render,"")))
+	to_chat(user, boxed_message(jointext(to_render,"")))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -847,7 +847,7 @@
 		exportable_text += "[special_role_description]<br>"
 		exportable_text += ADMIN_FULLMONTY_NONAME(subject)
 
-		to_chat(src.owner, examine_block(exportable_text), confidential = TRUE)
+		to_chat(src.owner, boxed_message(exportable_text), confidential = TRUE)
 
 	else if(href_list["addjobslot"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -432,7 +432,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	to_chat(
 		initiator,
 		type = MESSAGE_TYPE_ADMINPM,
-		html = span_notice("PM to - <b>Admins</b>: [span_linkify(message)]"),
+		html = span_notice("PM to-<b>Admins</b>: [span_linkify(message)]"),
 		confidential = TRUE,
 	)
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -407,8 +407,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		span_adminhelp("Ticket [TicketHref("#[id]", ref_src)]"),
 		"<b>[LinkedReplyName(ref_src)]</b>\n\n\
 		[span_linkify(keywords_lookup(msg))]\n\n\
-		<b>[FullMonty(ref_src)]</b>",
-		"boxed_message red")
+		<b class='smaller'>[FullMonty(ref_src)]</b>",
+		"boxed_message red_box")
 
 	AddInteraction("<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>", player_message = "<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [msg]")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -403,7 +403,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
 	var/ref_src = "[REF(src)]"
 	//Message to be sent to all admins
-	var/admin_msg = span_adminnotice(span_adminhelp("Ticket [TicketHref("#[id]", ref_src)]</span><b>: [LinkedReplyName(ref_src)] [FullMonty(ref_src)]:</b> [span_linkify(keywords_lookup(msg))]"))
+	var/admin_msg = fieldset_block(
+		span_adminhelp("Ticket [TicketHref("#[id]", ref_src)]"),
+		"<b>[LinkedReplyName(ref_src)]</b>\n\n\
+		[span_linkify(keywords_lookup(msg))]\n\n\
+		<b>[FullMonty(ref_src)]</b>",
+		"boxed_message red")
 
 	AddInteraction("<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>", player_message = "<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [msg]")
@@ -427,7 +432,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	to_chat(
 		initiator,
 		type = MESSAGE_TYPE_ADMINPM,
-		html = span_notice("PM to-<b>Admins</b>: [span_linkify(message)]"),
+		html = span_notice("PM to - <b>Admins</b>: [span_linkify(message)]"),
 		confidential = TRUE,
 	)
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -387,23 +387,14 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 			recipient_ticket_id = recipient_ticket?.id
 			SSblackbox.LogAhelp(recipient_ticket_id, "Ticket Opened", send_message, recipient.ckey, src.ckey)
 
-		to_chat(recipient,
-			type = MESSAGE_TYPE_ADMINPM,
-			html = "<font color='red' size='4'><b>-- Administrator private message --</b></font>",
-			confidential = TRUE)
-
 		recipient.receive_ahelp(
 			link_to_us,
 			span_linkify(send_message),
 		)
 
-		to_chat(recipient,
-			type = MESSAGE_TYPE_ADMINPM,
-			html = span_adminsay("<i>Click on the administrator's name to reply.</i>"),
-			confidential = TRUE)
 		to_chat(src,
 			type = MESSAGE_TYPE_ADMINPM,
-			html = span_notice("Admin PM to-<b>[their_name_with_link]</b>: [span_linkify(send_message)]"),
+			html = span_notice("Admin PM to - <b>[their_name_with_link]</b>: [span_linkify(send_message)]"),
 			confidential = TRUE)
 
 		admin_ticket_log(recipient,
@@ -466,12 +457,12 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 
 		to_chat(src,
 			type = MESSAGE_TYPE_ADMINPM,
-			html = span_notice("Admin PM to-<b>[their_name_with_link]</b>: [span_linkify(keyword_parsed_msg)]"),
+			html = span_notice("Admin PM to - <b>[their_name_with_link]</b>: [span_linkify(keyword_parsed_msg)]"),
 			confidential = TRUE)
 
 		//omg this is dumb, just fill in both their logs
-		var/interaction_message = "<font color='purple'>PM from-<b>[name_key_with_link]</b> to-<b>[their_name_with_link]</b>: [keyword_parsed_msg]</font>"
-		var/player_interaction_message = "<font color='purple'>PM from-<b>[link_to_us]</b> to-<b>[link_to_their]</b>: [send_message]</font>"
+		var/interaction_message = "<font color='purple'>PM from - <b>[name_key_with_link]</b> to - <b>[their_name_with_link]</b>: [keyword_parsed_msg]</font>"
+		var/player_interaction_message = "<font color='purple'>PM from - <b>[link_to_us]</b> to - <b>[link_to_their]</b>: [send_message]</font>"
 		admin_ticket_log(src,
 			interaction_message,
 			log_in_blackbox = FALSE,
@@ -486,8 +477,8 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 		return TRUE
 
 	// This is us (a player) trying to talk to the recipient (an admin)
-	var/replymsg = "Reply PM from-<b>[name_key_with_link]</b>: [span_linkify(keyword_parsed_msg)]"
-	var/player_replymsg = "Reply PM from-<b>[link_to_us]</b>: [span_linkify(send_message)]"
+	var/replymsg = "Reply PM from - <b>[name_key_with_link]</b>: [span_linkify(keyword_parsed_msg)]"
+	var/player_replymsg = "Reply PM from - <b>[link_to_us]</b>: [span_linkify(send_message)]"
 	admin_ticket_log(src,
 		"<font color='red'>[replymsg]</font>",
 		log_in_blackbox = FALSE,
@@ -707,20 +698,10 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 	message_admins("External message from [sender] to [recipient_name_linked] : [message]")
 	log_admin_private("External PM: [sender] -> [recipient_name] : [message]")
 
-	to_chat(recipient,
-		type = MESSAGE_TYPE_ADMINPM,
-		html = "<font color='red' size='4'><b>-- Administrator private message --</b></font>",
-		confidential = TRUE)
-
 	recipient.receive_ahelp(
 		"<a href='?priv_msg=[stealthkey]'>[adminname]</a>",
 		message,
 	)
-
-	to_chat(recipient,
-		type = MESSAGE_TYPE_ADMINPM,
-		html = span_adminsay("<i>Click on the administrator's name to reply.</i>"),
-		confidential = TRUE)
 
 	admin_ticket_log(recipient, "<font color='purple'>PM From [tgs_tagged]: [message]</font>", log_in_blackbox = FALSE)
 
@@ -766,8 +747,13 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 	to_chat(
 		src,
 		type = MESSAGE_TYPE_ADMINPM,
-		html = "<span class='[span_class]'>Admin PM from-<b>[reply_to]</b>: [message]</span>",
-		confidential = TRUE,
+		html = fieldset_block(
+			"<b>Administrator private message</b>",
+			"<span class='[span_class]'>Admin PM from - <b>[reply_to]</b></span>\n\n\
+			<span class='[span_class]'>[message]</span>\n\n\
+			<i class='adminsay'>Click on the administrator's name to reply.</i>",
+			"boxed_message red"),
+		confidential = TRUE
 	)
 
 	current_ticket?.player_replied = FALSE

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -394,7 +394,7 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 
 		to_chat(src,
 			type = MESSAGE_TYPE_ADMINPM,
-			html = span_notice("Admin PM to - <b>[their_name_with_link]</b>: [span_linkify(send_message)]"),
+			html = span_notice("Admin PM to-<b>[their_name_with_link]</b>: [span_linkify(send_message)]"),
 			confidential = TRUE)
 
 		admin_ticket_log(recipient,
@@ -457,12 +457,12 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 
 		to_chat(src,
 			type = MESSAGE_TYPE_ADMINPM,
-			html = span_notice("Admin PM to - <b>[their_name_with_link]</b>: [span_linkify(keyword_parsed_msg)]"),
+			html = span_notice("Admin PM to-<b>[their_name_with_link]</b>: [span_linkify(keyword_parsed_msg)]"),
 			confidential = TRUE)
 
 		//omg this is dumb, just fill in both their logs
-		var/interaction_message = "<font color='purple'>PM from - <b>[name_key_with_link]</b> to - <b>[their_name_with_link]</b>: [keyword_parsed_msg]</font>"
-		var/player_interaction_message = "<font color='purple'>PM from - <b>[link_to_us]</b> to - <b>[link_to_their]</b>: [send_message]</font>"
+		var/interaction_message = "<font color='purple'>PM from-<b>[name_key_with_link]</b> to-<b>[their_name_with_link]</b>: [keyword_parsed_msg]</font>"
+		var/player_interaction_message = "<font color='purple'>PM from-<b>[link_to_us]</b> to-<b>[link_to_their]</b>: [send_message]</font>"
 		admin_ticket_log(src,
 			interaction_message,
 			log_in_blackbox = FALSE,
@@ -477,8 +477,8 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 		return TRUE
 
 	// This is us (a player) trying to talk to the recipient (an admin)
-	var/replymsg = "Reply PM from - <b>[name_key_with_link]</b>: [span_linkify(keyword_parsed_msg)]"
-	var/player_replymsg = "Reply PM from - <b>[link_to_us]</b>: [span_linkify(send_message)]"
+	var/replymsg = "Reply PM from-<b>[name_key_with_link]</b>: [span_linkify(keyword_parsed_msg)]"
+	var/player_replymsg = "Reply PM from-<b>[link_to_us]</b>: [span_linkify(send_message)]"
 	admin_ticket_log(src,
 		"<font color='red'>[replymsg]</font>",
 		log_in_blackbox = FALSE,
@@ -749,7 +749,7 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 		type = MESSAGE_TYPE_ADMINPM,
 		html = fieldset_block(
 			span_adminhelp("Administrator private message"),
-			"<span class='[span_class]'>Admin PM from - <b>[reply_to]</b></span>\n\n\
+			"<span class='[span_class]'>Admin PM from-<b>[reply_to]</b></span>\n\n\
 			<span class='[span_class]'>[message]</span>\n\n\
 			<i class='adminsay'>Click on the administrator's name to reply.</i>",
 			"boxed_message red_box"),

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -748,11 +748,11 @@ ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM
 		src,
 		type = MESSAGE_TYPE_ADMINPM,
 		html = fieldset_block(
-			"<b>Administrator private message</b>",
+			span_adminhelp("Administrator private message"),
 			"<span class='[span_class]'>Admin PM from - <b>[reply_to]</b></span>\n\n\
 			<span class='[span_class]'>[message]</span>\n\n\
 			<i class='adminsay'>Click on the administrator's name to reply.</i>",
-			"boxed_message red"),
+			"boxed_message red_box"),
 		confidential = TRUE
 	)
 

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -224,7 +224,7 @@ ADMIN_VERB(create_mapping_job_icons, R_DEBUG, "Generate job landmarks icons", "G
 
 ADMIN_VERB_VISIBILITY(debug_z_levels, ADMIN_VERB_VISIBLITY_FLAG_MAPPING_DEBUG)
 ADMIN_VERB(debug_z_levels, R_DEBUG, "Debug Z-Levels", "Displays a list of all z-levels and their linkages.", ADMIN_CATEGORY_MAPPING)
-	to_chat(user, examine_block(gather_z_level_information(append_grid = TRUE)), confidential = TRUE)
+	to_chat(user, boxed_message(gather_z_level_information(append_grid = TRUE)), confidential = TRUE)
 
 /// Returns all necessary z-level information. Argument `append_grid` allows the user to see a table showing all of the z-level linkages, which is only visible and useful in-game.
 /proc/gather_z_level_information(append_grid = FALSE)

--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -3,7 +3,7 @@
 	var/atom/objholder = null
 
 /datum/buildmode_mode/advanced/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Set object type")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Copy object type")] -> Left Mouse Button + Alt on turf/obj\n\
 		[span_bold("Place objects")] -> Left Mouse Button on turf/obj\n\

--- a/code/modules/buildmode/submodes/area_edit.dm
+++ b/code/modules/buildmode/submodes/area_edit.dm
@@ -9,7 +9,7 @@
 	..()
 
 /datum/buildmode_mode/area_edit/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select corner")] -> Left Mouse Button on obj/turf/mob\n\
 		[span_bold("Paint area")] -> Left Mouse Button + Alt on turf/obj/mob\n\
 		[span_bold("Select area to paint")] -> Right Mouse Button on obj/turf/mob\n\

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -2,7 +2,7 @@
 	key = "basic"
 
 /datum/buildmode_mode/basic/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Construct / Upgrade")] -> Left Mouse Button\n\
 		[span_bold("Deconstruct / Delete / Downgrade")] -> Right Mouse Button\n\
 		[span_bold("R-Window")] -> Left Mouse Button + Ctrl\n\

--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -16,7 +16,7 @@
 	)
 
 /datum/buildmode_mode/boom/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Set explosion destructiveness")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Kaboom")] -> Mouse Button on obj\n\n\
 		[span_warning("NOTE:")] Using the \"Config/Launch Supplypod\" verb allows you to do this in an IC way (i.e., making a cruise missile come down from the sky and explode wherever you click!)"))

--- a/code/modules/buildmode/submodes/copy.dm
+++ b/code/modules/buildmode/submodes/copy.dm
@@ -7,7 +7,7 @@
 	return ..()
 
 /datum/buildmode_mode/copy/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Spawn a copy of selected target")] -> Left Mouse Button on obj/turf/mob\n\
 		[span_bold("Select target to copy")] -> Right Mouse Button on obj/mob"))
 	)

--- a/code/modules/buildmode/submodes/delete.dm
+++ b/code/modules/buildmode/submodes/delete.dm
@@ -2,7 +2,7 @@
 	key = "delete"
 
 /datum/buildmode_mode/delete/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Delete an object")] -> Left Mouse Button on obj/turf/mob\n\
 		[span_bold("Delete all objects of a type")] -> Right Mouse Button on obj/turf/mob"))
 	)

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -7,7 +7,7 @@
 	var/atom/objholder = null
 
 /datum/buildmode_mode/fill/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select corner")] -> Left Mouse Button on turf/obj/mob\n\
 		[span_bold("Delete region")] -> Left Mouse Button + Alt on turf/obj/mob\n\
 		[span_bold("Select object type")] -> Right Mouse Button on buildmode button"))

--- a/code/modules/buildmode/submodes/map_export.dm
+++ b/code/modules/buildmode/submodes/map_export.dm
@@ -22,7 +22,7 @@
 	to_chat(builder, span_notice("[what_to_change] is now [save_flag & options[what_to_change] ? "ENABLED" : "DISABLED"]."))
 
 /datum/buildmode_mode/map_export/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select corner")] -> Left Mouse Button on obj/turf/mob\n\
 		[span_bold("Set export options")] -> Right Mouse Button on buildmode button"))
 	)

--- a/code/modules/buildmode/submodes/mapgen.dm
+++ b/code/modules/buildmode/submodes/mapgen.dm
@@ -5,7 +5,7 @@
 	var/generator_path
 
 /datum/buildmode_mode/mapgen/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select corner")] -> Left Mouse Button on turf/obj/mob\n\
 		[span_bold("Select generator")] -> Right Mouse Button on buildmode button"))
 	)

--- a/code/modules/buildmode/submodes/outfit.dm
+++ b/code/modules/buildmode/submodes/outfit.dm
@@ -7,7 +7,7 @@
 	return ..()
 
 /datum/buildmode_mode/outfit/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select outfit to equip")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Equip the selected outfit")] -> Left Mouse Button on mob/living/carbon/human\n\
 		[span_bold("Strip and delete current outfit")] -> Right Mouse Button on mob/living/carbon/human"))

--- a/code/modules/buildmode/submodes/proccall.dm
+++ b/code/modules/buildmode/submodes/proccall.dm
@@ -6,7 +6,7 @@
 	var/list/proc_args = null
 
 /datum/buildmode_mode/proccall/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Choose procedure and arguments")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Apply procedure on object")] -> Left Mouse Button on machinery"))
 	)

--- a/code/modules/buildmode/submodes/smite.dm
+++ b/code/modules/buildmode/submodes/smite.dm
@@ -7,7 +7,7 @@
 	return ..()
 
 /datum/buildmode_mode/smite/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select smite to use")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Smite the mob")] -> Left Mouse Button on mob/living"))
 	)

--- a/code/modules/buildmode/submodes/throwing.dm
+++ b/code/modules/buildmode/submodes/throwing.dm
@@ -8,7 +8,7 @@
 	return ..()
 
 /datum/buildmode_mode/throwing/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select")] -> Left Mouse Button on turf/obj/mob\n\
 		[span_bold("Throw")] -> Right Mouse Button on turf/obj/mob"))
 	)

--- a/code/modules/buildmode/submodes/tweakcomps.dm
+++ b/code/modules/buildmode/submodes/tweakcomps.dm
@@ -4,7 +4,7 @@
 	var/rating = null
 
 /datum/buildmode_mode/tweakcomps/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Choose the rating of the components")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Sets the chosen rating of the components on the machinery")] -> Left Mouse Button on machinery"))
 	)

--- a/code/modules/buildmode/submodes/variable_edit.dm
+++ b/code/modules/buildmode/submodes/variable_edit.dm
@@ -10,7 +10,7 @@
 	return ..()
 
 /datum/buildmode_mode/varedit/show_help(client/builder)
-	to_chat(builder, span_purple(examine_block(
+	to_chat(builder, span_purple(boxed_message(
 		"[span_bold("Select var(type) & value")] -> Right Mouse Button on buildmode button\n\
 		[span_bold("Set var(type) & value")] -> Left Mouse Button on turf/obj/mob\n\
 		[span_bold("Reset var's value")] -> Right Mouse Button on turf/obj/mob"))

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -85,7 +85,7 @@
 	lines += span_bold(header)
 	lines += payload_string
 
-	var/finalized_string = examine_block(jointext(lines, "\n"))
+	var/finalized_string = boxed_message(jointext(lines, "\n"))
 	to_chat(src, finalized_string)
 
 /// Proc that generates the applicable string to dispatch to the client for adminwho.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -456,7 +456,7 @@
 			readout += "No armor or durability information available."
 
 		var/formatted_readout = span_notice("<b>PROTECTION CLASSES</b><hr>[jointext(readout, "\n")]")
-		to_chat(usr, examine_block(formatted_readout))
+		to_chat(usr, boxed_message(formatted_readout))
 
 /**
  * Rounds armor_value down to the nearest 10, divides it by 10 and then converts it to Roman numerals.

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -336,7 +336,7 @@
 				render_list += "<span class='notice ml-1'>[target.p_Their()] pulse is [pulse_pressure] and [heart_strength].</span>\n"
 
 	//display our packaged information in an examine block for easy reading
-	to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
+	to_chat(user, boxed_message(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 
 ///////////
 //SCARVES//

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -150,7 +150,7 @@
 	block += get_stat_info(get_percent, gravity_mult, "The lure will sink", "faster", "slower", span_info = TRUE)
 
 	list_clear_nulls(block)
-	. += examine_block(block.Join("\n"))
+	. += boxed_message(block.Join("\n"))
 
 	if(get_percent && (material_flags & MATERIAL_EFFECTS) && length(custom_materials))
 		block = list()
@@ -159,7 +159,7 @@
 		if(material.fish_weight_modifier != 1)
 			var/heavier = material.fish_weight_modifier > 1 ? "heavier" : "lighter"
 			block += span_info("Fish made of the same material as this rod tend to be [abs(material.fish_weight_modifier - 1) * 100]% [heavier].")
-		. += examine_block(block.Join("\n"))
+		. += boxed_message(block.Join("\n"))
 
 	block = list()
 	if(HAS_TRAIT(src, TRAIT_ROD_ATTRACT_SHINY_LOVERS))
@@ -171,7 +171,7 @@
 	if(HAS_TRAIT(src, TRAIT_ROD_LAVA_USABLE))
 		block += span_info("This fishing rod can be used to fish on lava.")
 	if(length(block))
-		. += examine_block(block.Join("\n"))
+		. += boxed_message(block.Join("\n"))
 
 ///Used in examine_more to reduce all the copypasta when getting more information about the various stats of the fishing rod.
 /obj/item/fishing_rod/proc/get_stat_info(get_percent, value, prefix, easier, harder, suffix = "with this fishing rod", span_info = FALSE, less_is_better = FALSE, offset = 1)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -75,22 +75,22 @@
 /obj/item/plant_analyzer/proc/do_plant_stats_scan(atom/scan_target, mob/user)
 	if(istype(scan_target, /obj/machinery/hydroponics))
 		playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
-		to_chat(user, examine_block(scan_tray_stats(scan_target)))
+		to_chat(user, boxed_message(scan_tray_stats(scan_target)))
 		return TRUE
 	if(istype(scan_target, /obj/structure/glowshroom))
 		playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
 		var/obj/structure/glowshroom/shroom_plant = scan_target
-		to_chat(user, examine_block(scan_plant_stats(shroom_plant.myseed)))
+		to_chat(user, boxed_message(scan_plant_stats(shroom_plant.myseed)))
 		return TRUE
 	if(istype(scan_target, /obj/item/graft))
 		playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
-		to_chat(user, examine_block(get_graft_text(scan_target)))
+		to_chat(user, boxed_message(get_graft_text(scan_target)))
 		return TRUE
 	if(isitem(scan_target))
 		playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
 		var/obj/item/scanned_object = scan_target
 		if(scanned_object.get_plant_seed() || istype(scanned_object, /obj/item/seeds))
-			to_chat(user, examine_block(scan_plant_stats(scanned_object)))
+			to_chat(user, boxed_message(scan_plant_stats(scanned_object)))
 			return TRUE
 	if(isliving(scan_target))
 		playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
@@ -112,19 +112,19 @@
  */
 /obj/item/plant_analyzer/proc/do_plant_chem_scan(atom/scan_target, mob/user)
 	if(istype(scan_target, /obj/machinery/hydroponics))
-		to_chat(user, examine_block(scan_tray_chems(scan_target)))
+		to_chat(user, boxed_message(scan_tray_chems(scan_target)))
 		return TRUE
 	if(istype(scan_target, /obj/structure/glowshroom))
 		var/obj/structure/glowshroom/shroom_plant = scan_target
-		to_chat(user, examine_block(scan_plant_chems(shroom_plant.myseed)))
+		to_chat(user, boxed_message(scan_plant_chems(shroom_plant.myseed)))
 		return TRUE
 	if(istype(scan_target, /obj/item/graft))
-		to_chat(user, examine_block(get_graft_text(scan_target)))
+		to_chat(user, boxed_message(get_graft_text(scan_target)))
 		return TRUE
 	if(isitem(scan_target))
 		var/obj/item/scanned_object = scan_target
 		if(scanned_object.get_plant_seed() || istype(scanned_object, /obj/item/seeds))
-			to_chat(user, examine_block(scan_plant_chems(scanned_object)))
+			to_chat(user, boxed_message(scan_plant_chems(scanned_object)))
 			return TRUE
 	if(isliving(scan_target))
 		var/mob/living/L = scan_target

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -299,7 +299,7 @@
 /// Gets the message that shows up when spawning as this job
 /datum/job/proc/get_spawn_message()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	return examine_block(span_infoplain(jointext(get_spawn_message_information(), "\n&bull; ")))
+	return boxed_message(span_infoplain(jointext(get_spawn_message_information(), "\n&bull; ")))
 
 /// Returns a list of strings that correspond to chat messages sent to this mob when they join the round.
 /datum/job/proc/get_spawn_message_information()

--- a/code/modules/lootpanel/misc.dm
+++ b/code/modules/lootpanel/misc.dm
@@ -7,7 +7,7 @@
 		var/build = owner.byond_build
 		var/version = owner.byond_version
 		if(build < 515 || (build == 515 && version < 1635))
-			to_chat(owner.mob, examine_block(span_info("\
+			to_chat(owner.mob, boxed_message(span_info("\
 				<span class='bolddanger'>Your version of Byond doesn't support fast image loading.</span>\n\
 				Detected: [version].[build]\n\
 				Required version for this feature: <b>515.1635</b> or later.\n\

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -72,7 +72,7 @@
 	message += keys.Join(", ")
 	message += "."
 	message = message.Join("")
-	to_chat(user, examine_block(message))
+	to_chat(user, boxed_message(message))
 
 /datum/emote/flip
 	key = "flip"

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -117,7 +117,7 @@
 
 	var/static/cached_string = null
 	if(isnull(cached_string))
-		cached_string = examine_block(jointext(create_login_string(), "\n"))
+		cached_string = boxed_message(jointext(create_login_string(), "\n"))
 
 	to_chat(src, cached_string, type = MESSAGE_TYPE_INFO)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -141,7 +141,7 @@
 		id_examine += "</div>" // container
 		id_examine += "</div>" // text
 
-		to_chat(viewer, examine_block(span_info(id_examine)))
+		to_chat(viewer, boxed_message(span_info(id_examine)))
 
 ///////HUDs///////
 	if(href_list["hud"])
@@ -318,7 +318,7 @@
 						sec_record_message += "\n<b>Crime:</b> [crime.name]"
 						sec_record_message += "\n<b>Details:</b> [crime.details]"
 						sec_record_message += "\nAdded by [crime.author] at [crime.time]"
-				to_chat(human_or_ghost_user, examine_block(sec_record_message))
+				to_chat(human_or_ghost_user, boxed_message(sec_record_message))
 				return
 			if(ishuman(human_or_ghost_user))
 				var/mob/living/carbon/human/human_user = human_or_ghost_user

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -676,7 +676,7 @@
 	if(quirks.len)
 		combined_msg += span_notice("You have these quirks: [get_quirk_string(FALSE, CAT_QUIRK_ALL)].")
 
-	to_chat(src, examine_block(combined_msg.Join("\n")))
+	to_chat(src, boxed_message(combined_msg.Join("\n")))
 
 /mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -31,5 +31,5 @@
 	if(LAZYLEN(afk_thefts) >= AFK_THEFT_MAX_MESSAGES)
 		print_msg += span_warning("There may have been more, but that's all you can remember...")
 
-	to_chat(src, examine_block(print_msg.Join("\n")))
+	to_chat(src, boxed_message(print_msg.Join("\n")))
 	LAZYNULL(afk_thefts)

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -2,7 +2,7 @@
 	laws_sanity_check()
 	var/list/law_box = list(span_bold("Obey these laws:"))
 	law_box += laws.get_law_list(include_zeroth = TRUE)
-	to_chat(src, examine_block(jointext(law_box, "\n")))
+	to_chat(src, boxed_message(jointext(law_box, "\n")))
 
 /mob/living/silicon/proc/try_sync_laws()
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -532,7 +532,7 @@
 			var/list/result = examinify.examine_more(src)
 			if(!length(result))
 				result += span_notice("<i>You examine [examinify] closer, but find nothing of interest...</i>")
-			result_combined = examine_block(jointext(result, "<br>"))
+			result_combined = boxed_message(jointext(result, "<br>"))
 
 		else
 			client.recent_examines[ref_to_atom] = world.time // set to when we last normal examine'd them
@@ -543,7 +543,7 @@
 		var/list/result = examinify.examine(src)
 		var/atom_title = examinify.examine_title(src, thats = TRUE)
 		SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result)
-		result_combined = (atom_title ? fieldset_block("[atom_title].", jointext(result, "<br>"), "examine_block") : examine_block(jointext(result, "<br>")))
+		result_combined = (atom_title ? fieldset_block("[atom_title].", jointext(result, "<br>"), "boxed_message") : boxed_message(jointext(result, "<br>")))
 
 	to_chat(src, span_infoplain(result_combined))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -543,7 +543,7 @@
 		var/list/result = examinify.examine(src)
 		var/atom_title = examinify.examine_title(src, thats = TRUE)
 		SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result)
-		result_combined = (atom_title ? fieldset_block("[atom_title].", jointext(result, "<br>"), "boxed_message") : boxed_message(jointext(result, "<br>")))
+		result_combined = (atom_title ? fieldset_block("[atom_title]", jointext(result, "<br>"), "boxed_message") : boxed_message(jointext(result, "<br>")))
 
 	to_chat(src, span_infoplain(result_combined))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -543,7 +543,7 @@
 		var/list/result = examinify.examine(src)
 		var/atom_title = examinify.examine_title(src, thats = TRUE)
 		SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result)
-		result_combined = (atom_title ? fieldset_block("[span_slightly_larger(atom_title)].", jointext(result, "<br>"), "examine_block") : examine_block(jointext(result, "<br>")))
+		result_combined = (atom_title ? fieldset_block("[atom_title].", jointext(result, "<br>"), "examine_block") : examine_block(jointext(result, "<br>")))
 
 	to_chat(src, span_infoplain(result_combined))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -132,7 +132,7 @@
 			out_message += "<b>[round(reagent.volume, 0.01)]u of [reagent.name]</b>, <b>Purity:</b> [round(reagent.purity, 0.000001)*100]%, [(scanmode?"[(reagent.overdose_threshold?"<b>Overdose:</b> [reagent.overdose_threshold]u, ":"")]<b>Base pH:</b> [initial(reagent.ph)], <b>Current pH:</b> [reagent.ph].":"<b>Current pH:</b> [reagent.ph].")]\n"
 		if(scanmode)
 			out_message += "<b>Analysis:</b> [reagent.description]\n"
-	to_chat(user, examine_block(span_notice("[out_message.Join()]")))
+	to_chat(user, boxed_message(span_notice("[out_message.Join()]")))
 	desc = "An electrode attached to a small circuit box that will display details of a solution. Can be toggled to provide a description of each of the reagents. The screen currently displays detected vol: [round(cont.volume, 0.01)] detected pH:[round(cont.reagents.ph, 0.1)]."
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -387,7 +387,7 @@
 		if("mix")
 			mix(5 SECONDS, user)
 		if("examine")
-			to_chat(user, examine_block(jointext(examine(user), "\n")))
+			to_chat(user, boxed_message(jointext(examine(user), "\n")))
 
 /**
  * Checks if the radial menu can interact with this machine

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -350,7 +350,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 	render_list += "&bull; Alt-click a slime to feed it a potion."
 	render_list += "&bull; Ctrl-click or a dead monkey to recycle it, or the floor to place a new monkey."
 
-	to_chat(owner, examine_block(jointext(render_list, "\n")))
+	to_chat(owner, boxed_message(jointext(render_list, "\n")))
 
 //
 // Alternate clicks for slime, monkey and open turf if using a xenobio console

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -967,10 +967,30 @@ em {
 }
 
 .examine_block {
-  background: hsl(220, 5.3%, 11.2%);
-  border: 1px solid hsl(213.6, 37.9%, 74.1%);
-  margin: 0.5em;
+  background: hsl(220, 10%, 10%);
+  border: 1px solid hsla(220, 40%, 75%, 0.25);
+  border-width: 1em * calc(1px / 12px) 1em * calc(5px / 12px);
+  margin: 0.5em 0;
   padding: 0.5em 0.75em;
+  border-radius: 0.5em;
+}
+
+.custom_fieldset {
+  margin: 1.5em 0 0.5em;
+  padding: 1em 0.75em 0.5em;
+}
+
+.fieldset_legend {
+  max-width: 95%;
+  font-size: 120%;
+  text-align: center;
+  padding: 0.25rem 0.75rem;
+  margin-bottom: -1.5em;
+  background: inherit;
+  border: 1px solid;
+  border-color: inherit;
+  border-radius: 0.33em;
+  transform: translateY(-100%);
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1015,22 +1015,22 @@ em {
   padding: 0.5em 0.75em;
   border-radius: 0.5em;
 
-  &.red {
+  &.red_box {
     background: hsl(0, 20%, 10%);
     border-color: hsla(0, 100%, 50%, 0.5);
   }
 
-  &.green {
+  &.green_box {
     background: hsl(140, 20%, 10%);
     border-color: hsla(120, 100%, 50%, 0.5);
   }
 
-  &.blue {
+  &.blue_box {
     background: hsl(220, 20%, 10%);
     border-color: hsla(225, 90%, 65%, 0.5);
   }
 
-  &.purple {
+  &.purple_box {
     background: hsl(260, 25%, 12.5%);
     border-color: hsla(260, 100%, 75%, 0.5);
   }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -966,7 +966,7 @@ em {
   margin-left: 2.5em;
 }
 
-.examine_block {
+.boxed_message {
   background: hsl(220, 10%, 10%);
   border: 1px solid hsla(220, 40%, 75%, 0.25);
   border-width: 1em * calc(1px / 12px) 1em * calc(5px / 12px);

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1034,6 +1034,11 @@ em {
     background: hsl(260, 25%, 12.5%);
     border-color: hsla(260, 100%, 75%, 0.5);
   }
+
+  hr {
+    margin: 0.5em -0.75em;
+    border-color: inherit;
+  }
 }
 
 // Provides a horizontal bar with text in the middle

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -983,7 +983,6 @@ em {
   position: relative;
   max-width: 95%;
   font-size: 120%;
-  text-align: center;
   padding: 0.2em 0.5em;
   background: #151515; // Chat background color
   border: 1px solid;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -987,7 +987,9 @@ em {
   border-radius: 0.5em;
   z-index: 1;
 
-  // Cutting off 50% of border
+  // "Mask" a half of the border
+  // It very rough but it only possible way i see with IE compat
+  // Replace it with normal mask-image when 516 got stable
   &:before {
     content: '';
     position: absolute;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -987,7 +987,7 @@ em {
   background: #151515; // Chat background color
   border: 1px solid;
   border-color: inherit;
-  border-radius: 0.5em;
+  border-radius: 0.33em;
   z-index: 1;
 
   // "Mask" a half of the border
@@ -1012,7 +1012,7 @@ em {
   border-color: hsla(220, 40%, 75%, 0.25);
   margin: 0.5em 0;
   padding: 0.5em 0.75em;
-  border-radius: 0.5em;
+  border-radius: 0.33em;
 
   &.red_box {
     background: hsl(0, 20%, 10%);

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -972,7 +972,7 @@ em {
 
 .tooltip {
   font-style: italic;
-  border-bottom: 1px dashed #fff;
+  border-bottom: 1px dashed;
 }
 
 .fieldset_legend {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -773,6 +773,10 @@ em {
   font-size: 60%;
 }
 
+.smaller {
+  font-size: 80%;
+}
+
 .slightly_larger {
   font-size: 115%;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -42,6 +42,10 @@ a.popt {
   text-decoration: none;
 }
 
+.center {
+  text-align: center;
+}
+
 /* POPUPS */
 
 .popup {
@@ -966,36 +970,64 @@ em {
   margin-left: 2.5em;
 }
 
-.boxed_message {
-  background: hsl(220, 10%, 10%);
-  border: 1px solid hsla(220, 40%, 75%, 0.25);
-  border-width: 1em * calc(1px / 12px) 1em * calc(5px / 12px);
-  margin: 0.5em 0;
-  padding: 0.5em 0.75em;
-  border-radius: 0.5em;
-}
-
-.custom_fieldset {
-  margin: 1.5em 0 0.5em;
-  padding: 1em 0.75em 0.5em;
-}
-
-.fieldset_legend {
-  max-width: 95%;
-  font-size: 120%;
-  text-align: center;
-  padding: 0.25rem 0.75rem;
-  margin-bottom: -1.5em;
-  background: inherit;
-  border: 1px solid;
-  border-color: inherit;
-  border-radius: 0.33em;
-  transform: translateY(-100%);
-}
-
 .tooltip {
   font-style: italic;
   border-bottom: 1px dashed #fff;
+}
+
+.fieldset_legend {
+  position: relative;
+  max-width: 95%;
+  font-size: 120%;
+  text-align: center;
+  padding: 0.2em 0.5em;
+  background: #151515; // Chat background color
+  border: 1px solid;
+  border-color: inherit;
+  border-radius: 0.5em;
+  z-index: 1;
+
+  // Cutting off 50% of border
+  &:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    height: 1.15em;
+    width: 100%;
+    background: #151515; // Chat background color
+    transform: translateY(-50%) scaleX(1.05);
+    z-index: -1;
+  }
+}
+
+.boxed_message {
+  background: hsl(220, 10%, 10%);
+  border: 1em * calc(1px / 12px) solid;
+  border-left: 1em * calc(4px / 12px) solid;
+  border-color: hsla(220, 40%, 75%, 0.25);
+  margin: 0.5em 0;
+  padding: 0.5em 0.75em;
+  border-radius: 0.5em;
+
+  &.red {
+    background: hsl(0, 20%, 10%);
+    border-color: hsla(0, 100%, 50%, 0.5);
+  }
+
+  &.green {
+    background: hsl(140, 20%, 10%);
+    border-color: hsla(120, 100%, 50%, 0.5);
+  }
+
+  &.blue {
+    background: hsl(220, 20%, 10%);
+    border-color: hsla(225, 90%, 65%, 0.5);
+  }
+
+  &.purple {
+    background: hsl(260, 25%, 12.5%);
+    border-color: hsla(260, 100%, 75%, 0.5);
+  }
 }
 
 // Provides a horizontal bar with text in the middle

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -985,10 +985,8 @@ h2.alert {
 }
 
 .examine_block {
-  background: hsl(202.5, 44.4%, 96.5%);
-  border: 1px solid hsl(215.5, 39.3%, 11%);
-  margin: 0.5em;
-  padding: 0.5em 0.75em;
+  background: hsl(220, 100%, 97.5%);
+  border-color: hsla(220, 75%, 25%, 0.5);
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -984,7 +984,7 @@ h2.alert {
   margin-left: 3em;
 }
 
-.examine_block {
+.boxed_message {
   background: hsl(220, 100%, 97.5%);
   border-color: hsla(220, 75%, 25%, 0.5);
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -984,14 +984,42 @@ h2.alert {
   margin-left: 3em;
 }
 
-.boxed_message {
-  background: hsl(220, 100%, 97.5%);
-  border-color: hsla(220, 75%, 25%, 0.5);
-}
-
 .tooltip {
   font-style: italic;
   border-bottom: 1px dashed #000;
+}
+
+.fieldset_legend {
+  background: #ffffff; // Chat background color
+
+  &:before {
+    background: #ffffff; // Chat background color
+  }
+}
+
+.boxed_message {
+  background: hsl(220, 100%, 97.5%);
+  border-color: hsla(220, 75%, 25%, 0.5);
+
+  &.red {
+    background: hsl(0, 100%, 97.5%);
+    border-color: hsla(0, 100%, 50%, 0.5);
+  }
+
+  &.green {
+    background: hsl(140, 100%, 97.5%);
+    border-color: hsl(120, 100%, 33%, 0.5);
+  }
+
+  &.blue {
+    background: hsl(220, 100%, 97.5%);
+    border-color: hsla(225, 100%, 50%, 0.5);
+  }
+
+  &.purple {
+    background: hsl(260, 100%, 97.5%);
+    border-color: hsla(260, 100%, 50%, 0.5);
+  }
 }
 
 // Provides a horizontal bar with text in the middle

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1001,22 +1001,22 @@ h2.alert {
   background: hsl(220, 100%, 97.5%);
   border-color: hsla(220, 75%, 25%, 0.5);
 
-  &.red {
+  &.red_box {
     background: hsl(0, 100%, 97.5%);
     border-color: hsla(0, 100%, 50%, 0.5);
   }
 
-  &.green {
+  &.green_box {
     background: hsl(140, 100%, 97.5%);
     border-color: hsl(120, 100%, 33%, 0.5);
   }
 
-  &.blue {
+  &.blue_box {
     background: hsl(220, 100%, 97.5%);
     border-color: hsla(225, 100%, 50%, 0.5);
   }
 
-  &.purple {
+  &.purple_box {
     background: hsl(260, 100%, 97.5%);
     border-color: hsla(260, 100%, 50%, 0.5);
   }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -986,7 +986,7 @@ h2.alert {
 
 .tooltip {
   font-style: italic;
-  border-bottom: 1px dashed #000;
+  border-bottom: 1px dashed;
 }
 
 .fieldset_legend {


### PR DESCRIPTION
## About The Pull Request
Maked `fieldset_block` and `examine_block` more stylish and neat, also `fieldset_block` no longer has a centred title.
Renamed `examine_block` to `boxed_message` and adds `custom_boxed_message` which can be colored.

- AdminPMs, admin tickets and vote results has been wrapped into `fieldset_block` for comfort and visibility
- Health Analyzer results painted to blue
- Vote notice and tips of the round wrapped to purple  `custom_boxed_message`
- Tooltip text border color, now uses text color, not just white

## Why It's Good For The Game
Demonstration in both themes

<details><summary>Dark</summary>

![image](https://github.com/user-attachments/assets/7175379b-b053-4fb7-bd25-65c744a21c56)
![image](https://github.com/user-attachments/assets/1728e72b-0110-4b81-9d61-8779f5fdc3a0)
![image](https://github.com/user-attachments/assets/5e6f9604-35b8-4840-b6b4-35a68f49a997)

</details>

<details><summary>Light</summary>

![image](https://github.com/user-attachments/assets/6a3d693b-e0dc-4a4b-b4d7-2ded54ce0d67)
![image](https://github.com/user-attachments/assets/c4f5e089-180f-4d13-806a-fa64f01740a3)
![image](https://github.com/user-attachments/assets/a46d52c4-ad37-4637-8cae-c4b00139efc1)

</details>

## Changelog

:cl:
qol: AdminPMs, admin tickets, vote results and started vote notification are now much more visible in the chat.
qol: Boxed messages in chat (like examine), has been restyled.
/:cl:

