### PR TITLE
The Extradimensional Blade no longer infinitely scales damage also the nullblade can be sharpened

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -839,9 +839,11 @@
 	//We do this because our force could have been changed by things like whetstones and RPG stats.
 	force += old_force - initial(force)
 
+	//Record change to our force in case something modifies it down the chain
+	var/force_diff = force - old_force
 	. = ..()
 	//Reapply our old force.
-	force = old_force
+	force -= force_diff
 
 /obj/item/nullrod/nullblade/afterattack(atom/target, mob/user, click_parameters)
 	if(!isliving(target))

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -190,10 +190,10 @@
 	menu_description = "An odd sharp blade which provides a low chance of blocking incoming melee attacks and deals a random amount of damage, which can range from almost nothing to very high. Can be worn on the back."
 
 /obj/item/nullrod/claymore/multiverse/melee_attack_chain(mob/user, atom/target, params)
-	var/old_force = force
-	force += rand(-14, 15)
+	var/force_mod = rand(-14, 15)
+	force += force_mod
 	. = ..()
-	force = old_force
+	force -= force_mod
 
 /obj/item/nullrod/claymore/saber
 	name = "light energy sword"


### PR DESCRIPTION
## About The Pull Request

the sword lowers its force by 3 as part of the secondary attack but resets its damage to default values before the 3 is re-added, resulting in +3 force every time a secondary attack is used.

also sharpened nullblades didn't increase in damage, now they do.
## Why It's Good For The Game
500 force roundstart weapons are a bad idea

## Changelog
:cl: Namelessfairy and SmArtKar
fix: The Extradimensional Blade no longer infinitely scales damage
fix: The nullblade correctly does increased damage when sharpened
/:cl:
