### PR TITLE
Gets rid of spamming during closet breakout

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1053,8 +1053,9 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		user.visible_message(span_danger("[user] successfully broke out of [src]!"),
 							span_notice("You successfully break out of [src]!"))
 		bust_open()
-	else if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
-		to_chat(user, span_warning("You fail to break out of [src]!"))
+	else
+		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
+			to_chat(user, span_warning("You fail to break out of [src]!"))
 		began_resisting = FALSE
 
 /obj/structure/closet/relay_container_resist_act(mob/living/user, obj/container)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1033,28 +1033,29 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		open()
 		return
 
-	if(!began_resisting)
-		//okay, so the closet is either welded or locked... resist!!!
-		user.changeNext_move(CLICK_CD_BREAKOUT)
-		user.last_special = world.time + CLICK_CD_BREAKOUT
-		user.visible_message(span_warning("[src] begins to shake violently!"), \
-			span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
-			span_hear("You hear banging from [src]."))
+	if(began_resisting)
+		return
+	//okay, so the closet is either welded or locked... resist!!!
+	user.changeNext_move(CLICK_CD_BREAKOUT)
+	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.visible_message(span_warning("[src] begins to shake violently!"), \
+		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
+		span_hear("You hear banging from [src]."))
 
-		addtimer(CALLBACK(src, PROC_REF(check_if_shake)), 1 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(check_if_shake)), 1 SECONDS)
 
-		began_resisting = TRUE
-		if(do_after(user,(breakout_time), target = src))
-			began_resisting = FALSE
-			if(!user || user.stat != CONSCIOUS || (loc_required && (user.loc != src)) || opened || (!locked && !welded) )
-				return
-			//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
-			user.visible_message(span_danger("[user] successfully broke out of [src]!"),
-								span_notice("You successfully break out of [src]!"))
-			bust_open()
-		else if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
-			to_chat(user, span_warning("You fail to break out of [src]!"))
-			began_resisting = FALSE
+	began_resisting = TRUE
+	if(do_after(user,(breakout_time), target = src))
+		began_resisting = FALSE
+		if(!user || user.stat != CONSCIOUS || (loc_required && (user.loc != src)) || opened || (!locked && !welded) )
+			return
+		//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
+		user.visible_message(span_danger("[user] successfully broke out of [src]!"),
+							span_notice("You successfully break out of [src]!"))
+		bust_open()
+	else if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
+		to_chat(user, span_warning("You fail to break out of [src]!"))
+		began_resisting = FALSE
 
 /obj/structure/closet/relay_container_resist_act(mob/living/user, obj/container)
 	container.container_resist_act(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -36,7 +36,6 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	/// Paint jobs for this closet, crates are a subtype of closet so they override these values
 	var/list/paint_jobs = TRUE
 	/// Controls whether a door overlay should be applied using the icon_door value as the icon state
-	var/began_resisting = FALSE
 	var/enable_door_overlay = TRUE
 	var/has_opened_overlay = TRUE
 	var/has_closed_overlay = TRUE
@@ -1033,7 +1032,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		open()
 		return
 
-	if(began_resisting)
+	if(DOING_INTERACTION_WITH_TARGET(user, src))
 		return
 	//okay, so the closet is either welded or locked... resist!!!
 	user.changeNext_move(CLICK_CD_BREAKOUT)
@@ -1044,9 +1043,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 
 	addtimer(CALLBACK(src, PROC_REF(check_if_shake)), 1 SECONDS)
 
-	began_resisting = TRUE
 	if(do_after(user,(breakout_time), target = src))
-		began_resisting = FALSE
 		if(!user || user.stat != CONSCIOUS || (loc_required && (user.loc != src)) || opened || (!locked && !welded) )
 			return
 		//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
@@ -1056,7 +1053,6 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	else
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, span_warning("You fail to break out of [src]!"))
-		began_resisting = FALSE
 
 /obj/structure/closet/relay_container_resist_act(mob/living/user, obj/container)
 	container.container_resist_act(user)


### PR DESCRIPTION
## About The Pull Request
- Fixes #88657

When you begin resisting you can't resist again till either the breakout was successful or failed. This also lead to the shake animation being reapplied multiple times causing additional shaking on top of it already shaking

## Changelog
:cl:
fix: breaking out of a closet won't spam chat or shake like it's having a seizure
/:cl:
