### PR TITLE
fixes smartvend on item tile mode

### DIFF
--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -122,6 +122,19 @@ const ItemTile = ({ item }) => {
         textAlign="right"
         disabled={item.amount < 1}
       >
+        <Box
+          position="absolute"
+          right="2px"
+          // in case you click on this instead, let it work as a regular click.
+          onClick={() =>
+            act('Release', {
+              path: item.path,
+              amount: itemCount,
+            })
+          }
+        >
+          x{item.amount}
+        </Box>
         <DmIcon
           fallback={fallback}
           icon={item.icon}

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -146,27 +146,29 @@ const ItemTile = ({ item }) => {
             left="0"
             bottom="0"
             fontWeight="bold"
-            fontSize="14px">
+            fontSize="14px"
+          >
             <NumberInput
               width="25px"
               minValue={1}
               maxValue={item.amount}
               step={1}
               value={itemCount}
-              onChange={(value) => setItemCount(value)} />
-            </Box>
+              onChange={(value) => setItemCount(value)}
+            />
+          </Box>
         )}
       </Button>
       <Box
-          style={{
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-            textAlign: 'center',
-          }}
-        >
-          {item.name}
-        </Box>
+        style={{
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          textAlign: 'center',
+        }}
+      >
+        {item.name}
+      </Box>
     </Box>
   ) as any;
 };

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -107,6 +107,7 @@ export const SmartVend = (props) => {
 
 const ItemTile = ({ item }) => {
   const { act } = useBackend<Data>();
+  const [itemCount, setItemCount] = useState(1);
   const fallback = (
     <Icon name="spinner" lineHeight="64px" size={3} spin color="gray" />
   );
@@ -123,7 +124,7 @@ const ItemTile = ({ item }) => {
         onClick={() =>
           act('Release', {
             path: item.path,
-            amount: 1,
+            amount: itemCount,
           })
         }
       >
@@ -135,7 +136,7 @@ const ItemTile = ({ item }) => {
           width="64px"
         />
         {item.amount > 1 && (
-          <Button
+          <Box
             color="transparent"
             minWidth="24px"
             height="24px"
@@ -145,29 +146,27 @@ const ItemTile = ({ item }) => {
             left="0"
             bottom="0"
             fontWeight="bold"
-            fontSize="14px"
-            onClick={(e) => {
-              act('Release', {
-                path: item.path,
-                amount: item.amount,
-              });
-              e.stopPropagation();
-            }}
-          >
-            {item.amount}
-          </Button>
+            fontSize="14px">
+            <NumberInput
+              width="25px"
+              minValue={1}
+              maxValue={item.amount}
+              step={1}
+              value={itemCount}
+              onChange={(value) => setItemCount(value)} />
+            </Box>
         )}
       </Button>
       <Box
-        style={{
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
-          textAlign: 'center',
-        }}
-      >
-        {item.name}
-      </Box>
+          style={{
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            textAlign: 'center',
+          }}
+        >
+          {item.name}
+        </Box>
     </Box>
   ) as any;
 };

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -121,12 +121,6 @@ const ItemTile = ({ item }) => {
         tooltipPosition="bottom"
         textAlign="right"
         disabled={item.amount < 1}
-        onClick={() =>
-          act('Release', {
-            path: item.path,
-            amount: itemCount,
-          })
-        }
       >
         <DmIcon
           fallback={fallback}
@@ -134,6 +128,12 @@ const ItemTile = ({ item }) => {
           icon_state={item.icon_state}
           height="64px"
           width="64px"
+          onClick={() =>
+            act('Release', {
+              path: item.path,
+              amount: itemCount,
+            })
+          }
         />
         {item.amount > 1 && (
           <Box


### PR DESCRIPTION
## About The Pull Request

Fixes tile mode for vending machines not spitting items out properly, they now use number input as the list mode does and spits out whatever is set to it when you click on the icon, which will be 1 by default even if you just swap list mode or close/reopen instantly.

https://github.com/user-attachments/assets/e08461fa-ca18-442e-9863-8c963fbc7883

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/88672

## Changelog

:cl:
fix: Smartfridges on grid mode (like botany's) will no longer instantly spit out all the items it has when you try to set how many it should spit out.
/:cl: