### PR TITLE
Debug crew admin verb now adds mobs to clients list

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -555,6 +555,8 @@ ADMIN_VERB(spawn_debug_full_crew, R_DEBUG, "Spawn Debug Full Crew", "Creates a f
 		if(ishuman(character))
 			GLOB.manifest.inject(character)
 
+		SSmobs.clients_by_zlevel[destination.z] += character
+
 		number_made++
 		CHECK_TICK
 


### PR DESCRIPTION

## About The Pull Request
There is an admin verb that is used to spawn a full crew that is mainly used for debugging. One thing it was missing was adding the mobs to the client list which is used by a few parts of the code to determine if a mob is an actual player or NPC.

In my case I discovered it while debugging sound optimizations in:
- #88517


## Why It's Good For The Game
N/A

## Changelog
:cl:
code: When using the debug crew admin verb, it now adds all the mobs to the client list for the z level.
/:cl:
