### PR TITLE
Your CQC is sloppy ( CQC costs 30 stamina to block, instead of 25% chance to fail)

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -13,7 +13,7 @@
 	/// Weakref to a mob we're currently restraining (with grab-grab combo)
 	VAR_PRIVATE/datum/weakref/restraining_mob
 	/// Probability of successfully blocking attacks while on throw mode
-	var/block_chance = 75
+	var/block_stamina = 30
 
 /datum/martial_art/cqc/on_teach(mob/living/new_holder)
 	. = ..()
@@ -50,8 +50,6 @@
 		return NONE
 	if(attack_type == PROJECTILE_ATTACK)
 		return NONE
-	if(!prob(block_chance))
-		return NONE
 
 	var/mob/living/attacker = GET_ASSAILANT(hitby)
 	if(istype(attacker) && cqc_user.Adjacent(attacker))
@@ -59,6 +57,7 @@
 			span_danger("[cqc_user] blocks [attack_text] and twists [attacker]'s arm behind [attacker.p_their()] back!"),
 			span_userdanger("You block [attack_text]!"),
 		)
+		cqc_user.adjustStaminaLoss(block_stamina)
 		attacker.Stun(4 SECONDS)
 	else
 		cqc_user.visible_message(

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -12,7 +12,7 @@
 	display_combos = TRUE
 	/// Weakref to a mob we're currently restraining (with grab-grab combo)
 	VAR_PRIVATE/datum/weakref/restraining_mob
-	/// Probability of successfully blocking attacks while on throw mode
+	/// How much stamina it costs to block
 	var/block_stamina = 30
 
 /datum/martial_art/cqc/on_teach(mob/living/new_holder)


### PR DESCRIPTION

## About The Pull Request

CQC has a 25% to fail any given block, which seems kind of lame for someone who is supposed to be a master of close quarters combat. In the spirit of sleeping carp being totally immune to projectile attacks, I did the same for CQC and melee attacks, with a caveat; blocking costs 30 stamina instead.

You begin to take slowdown at 40 stamina/total damage (10 brute/30 stamina for instance), so if you're totally unharmed, you can block one attack without taking any slowdown for the effort.
## Why It's Good For The Game

If you try to attack a CQC user in melee combat, alone, you should be totally and completely fucked. But, we don't want CQC users to be immune to stun batons or something equally ridiculous, so adding a stamina cost to a successful block seems like a fair trade. If a nukie wants to get stimmed to the tits and remember the basics of close quarters combat, that sounds fucking sick actually. They would still need to account for projectile weapons in this hypothetical power fantasy. This would also be the case for the chef inside their kitchen; if I leap the counter and try to baton the chef, I shouldn't have a 25% chance to succeed at a close quarters attack against a close quarters combat master. I'll just chuck a CLF3 foam in there or something because fuck that.
## Changelog
:cl: Bisar
balance: CQC users have remembered the basics; they no longer have a 25% chance to fail a block, and instead spend 30 stamina for a successful block.
/:cl:
