### PR TITLE
Fixes .357 Heartseeker not homing in on people

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -22,6 +22,11 @@
 	name = ".357 heartseeker bullet casing"
 	projectile_type = /obj/projectile/bullet/c357/heartseeker
 
+/obj/item/ammo_casing/c357/heartseeker/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)
+	. = ..()
+	if(!isturf(target))
+		loaded_projectile.set_homing_target(target)
+
 // 7.62x38mmR (Nagant Revolver)
 
 /obj/item/ammo_casing/n762

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -298,17 +298,17 @@
 
 /obj/item/ammo_casing/energy/duel/ready_proj(atom/target, mob/living/user, quiet, zone_override)
 	. = ..()
-	var/obj/projectile/energy/duel/D = loaded_projectile
-	D.setting = setting
-	D.update_appearance()
+	var/obj/projectile/energy/duel/dueling_projectile = loaded_projectile
+	dueling_projectile.setting = setting
+	dueling_projectile.update_appearance()
 	if(!isturf(target))
-		D.loaded_projectile.set_homing_target(target)
+		dueling_projectile.set_homing_target(target)
 
 /obj/item/ammo_casing/energy/duel/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
 	. = ..()
-	var/obj/effect/temp_visual/dueling_chaff/C = new(get_turf(user))
-	C.setting = setting
-	C.update_appearance()
+	var/obj/effect/temp_visual/dueling_chaff/chaff = new(get_turf(user))
+	chaff.setting = setting
+	chaff.update_appearance()
 
 //Projectile
 

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -301,6 +301,8 @@
 	var/obj/projectile/energy/duel/D = loaded_projectile
 	D.setting = setting
 	D.update_appearance()
+	if(!isturf(target))
+		D.loaded_projectile.set_homing_target(target)
 
 /obj/item/ammo_casing/energy/duel/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
 	. = ..()
@@ -314,7 +316,6 @@
 	name = "dueling beam"
 	icon_state = "declone"
 	reflectable = FALSE
-	homing = TRUE
 	var/setting
 
 /obj/projectile/energy/duel/update_icon()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -169,8 +169,9 @@
 	var/impact_light_color_override
 
 	// Homing
-	/// If the projectile is homing. Warning - this changes projectile's processing logic, reverting it to segmented processing instead of new raymarching logic
-	var/homing = FALSE
+	/// If the projectile is currently homing. Warning - this changes projectile's processing logic, reverting it to segmented processing instead of new raymarching logic
+	/// This does not actually set up the projectile to home in on a target - you need to set that up with set_homing_target() on the projectile!
+	VAR_FINAL/homing = FALSE
 	/// Target the projectile is homing on
 	var/atom/homing_target
 	/// Angles per move segment, distance is based on SSprojectiles.pixels_per_decisecond

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -149,7 +149,6 @@
 	name = ".357 heartseeker bullet"
 	icon_state = "gauss"
 	damage = 50
-	homing = TRUE
 	homing_turn_speed = 120
 
 // admin only really, for ocelot memes


### PR DESCRIPTION
## About The Pull Request
Title. (Note: homing is now tied to clicking on your target, since I just reused the homing setup code from the Abielle smart SMG.)

## Why It's Good For The Game
.357 Heartseeker's homing should probably actually home in on people.

## Changelog
:cl:
fix: .357 Heartseeker homes in on people if you click on them, instead of not homing in at all.
/:cl: