### PR TITLE
Fix Syndicate Spacesuit Names

### DIFF
--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -143,12 +143,12 @@ GLOBAL_LIST_INIT(syndicate_space_suits_to_helmets,list(
 
 //Black medical syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/med
-	name = "black space helmet"
+	name = "black medical space helmet"
 	icon_state = "syndicate-helm-black-med"
 	inhand_icon_state = "syndicate-helm-black"
 
 /obj/item/clothing/suit/space/syndicate/black/med
-	name = "green space suit"
+	name = "black medical space suit"
 	icon_state = "syndicate-black-med"
 	inhand_icon_state = "syndicate-black"
 	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/black/med
@@ -198,7 +198,7 @@ GLOBAL_LIST_INIT(syndicate_space_suits_to_helmets,list(
 
 //Black with yellow/red engineering syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/engie
-	name = "black space helmet"
+	name = "black engineering space helmet"
 	icon_state = "syndicate-helm-black-engie"
 	inhand_icon_state = "syndicate-helm-black"
 


### PR DESCRIPTION
## About The Pull Request

Fixes the names of the engineering and medical syndicate space helmets referring to them as a generic 'black space helmet', despite being separate items, and fixes the medical syndicate space suit inexplicably being called a 'green space suit' despite objectively not being green.

Naming schemes follow the only-correctly-named Black Engineering Space Suit's naming pattern.

## Why It's Good For The Game

Accurate labels and consistent naming schemes are good and prevent confusion among players. Also, I'm making a downstream PR that involves these, and if I see a black and white spacesuit called 'green spacesuit' one more time, I'm going to commit a felony.

## Changelog

:cl:
fix: The Syndicate Medical Space Suit is no longer labelled a 'green space suit' despite being a noticeably non-green color.
fix: Syndicate Medical and Engineering space helmets now display themselves as such.
/:cl:
