### PR TITLE
Smartfridge vending revert and list UI simplification

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -396,39 +396,43 @@
 	if(. || !ui.user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
 
+	. = TRUE
 	var/mob/living_mob = ui.user
 
 	switch(action)
 		if("Release")
 			var/amount = text2num(params["amount"])
-			if(isnull(amount) || !isnum(amount))
-				return TRUE
+			var/desired = 1
 			var/dispensed_amount = 0
 
 			if(isAI(living_mob))
 				to_chat(living_mob, span_warning("[src] does not respect your authority!"))
-				return TRUE
+				return
 
-			for(var/obj/item/dispensed_item in contents)
-				if(amount <= 0)
+			if (amount > 1)
+				desired = tgui_input_number(living_mob, "How many items would you like to take out?", "Release", default = min(amount, 50), max_value = min(amount, 50))
+				if(!desired)
+					return
+
+			for(var/obj/item/dispensed_item in src)
+				if(desired <= 0)
 					break
 				var/item_name = "[dispensed_item.type]-[replacetext(replacetext(dispensed_item.name, "\proper", ""), "\improper", "")]"
-				if(params["path"] != item_name)
-					continue
-				if(dispensed_item in component_parts)
-					CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
-				//dispense the item
-				if(!living_mob.put_in_hands(dispensed_item))
-					dispensed_item.forceMove(drop_location())
-					adjust_item_drop_location(dispensed_item)
-				use_energy(active_power_usage)
-				dispensed_amount++
-				amount--
+				if(params["path"] == item_name)
+					if(dispensed_item in component_parts)
+						CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
+					//dispense the item
+					if(!living_mob.put_in_hands(dispensed_item))
+						dispensed_item.forceMove(drop_location())
+						adjust_item_drop_location(dispensed_item)
+					use_energy(active_power_usage)
+					dispensed_amount++
+					desired--
 			if(dispensed_amount && vend_sound)
 				playsound(src, vend_sound, 50, TRUE, extrarange = -3)
 			if (visible_contents)
 				update_appearance()
-			return TRUE
+			return
 
 	return FALSE
 

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -410,7 +410,7 @@
 				return
 
 			if (amount > 1)
-				desired = tgui_input_number(living_mob, "How many items would you like to take out?", "Release", default = min(amount, 50), max_value = min(amount, 50))
+				desired = tgui_input_number(living_mob, "How many items would you like to take out?", "Release", default = min(amount, 50), max_value = min(amount, 50), min_value = 1)
 				if(!desired)
 					return
 

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -4,15 +4,7 @@ import { useState } from 'react';
 import { DmIcon, Icon } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
-import {
-  Box,
-  Button,
-  Input,
-  NoticeBox,
-  NumberInput,
-  Section,
-  Stack,
-} from '../components';
+import { Box, Button, Input, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 type Item = {
@@ -177,7 +169,6 @@ const ItemList = ({ item }) => {
   const fallback = (
     <Icon name="spinner" lineHeight="32px" size={3} spin color="gray" />
   );
-  const [itemCount, setItemCount] = useState(1);
   return (
     <Stack>
       <Stack.Item>
@@ -245,20 +236,29 @@ const ItemList = ({ item }) => {
           onClick={() =>
             act('Release', {
               path: item.path,
-              amount: itemCount,
+              amount: 1,
             })
           }
         >
           Vend
         </Button>
-        <NumberInput
-          width="25px"
-          minValue={1}
-          maxValue={item.amount}
-          step={1}
-          value={itemCount}
-          onChange={(value) => setItemCount(value)}
-        />
+      </Stack.Item>
+      <Stack.Item>
+        <Button
+          py="4px"
+          mt="4px"
+          height="24px"
+          lineHeight="16px"
+          disabled={item.amount <= 1}
+          onClick={(e) => {
+            act('Release', {
+              path: item.path,
+              amount: item.amount,
+            });
+          }}
+        >
+          Amount
+        </Button>
       </Stack.Item>
     </Stack>
   ) as any;

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -128,7 +128,7 @@ const ItemTile = ({ item }) => {
         />
         {item.amount > 1 && (
           <Button
-            color="transparent"
+            backgroundColor="transparent"
             minWidth="24px"
             height="24px"
             lineHeight="24px"
@@ -218,38 +218,13 @@ const ItemList = ({ item }) => {
           }}
         />
       </Stack.Item>
-      {item.amount > 1 && (
-        <Stack.Item
-          style={{
-            lineHeight: '32px',
-          }}
-        >
-          {`x${item.amount}`}
-        </Stack.Item>
-      )}
       <Stack.Item>
         <Button
+          color="transparent"
           py="4px"
           mt="4px"
           height="24px"
           lineHeight="16px"
-          onClick={() =>
-            act('Release', {
-              path: item.path,
-              amount: 1,
-            })
-          }
-        >
-          Vend
-        </Button>
-      </Stack.Item>
-      <Stack.Item>
-        <Button
-          py="4px"
-          mt="4px"
-          height="24px"
-          lineHeight="16px"
-          disabled={item.amount <= 1}
           onClick={(e) => {
             act('Release', {
               path: item.path,
@@ -257,7 +232,7 @@ const ItemList = ({ item }) => {
             });
           }}
         >
-          Amount
+          {`x${item.amount}`}
         </Button>
       </Stack.Item>
     </Stack>


### PR DESCRIPTION
## About The Pull Request

<img src="https://github.com/user-attachments/assets/32aa900c-d9e5-45e5-9e80-eaabd3a7679a" />

<img src="https://github.com/user-attachments/assets/5beae768-0472-4c6c-b20d-91e3956d1998" />

Reverts #85970 also simplifying the list UI.
Conflicts with #88691
Resolves #88672

## Why It's Good For The Game

The pop-ups removal made UX worse (it requires more clicks) just for the sake of not having a number popup.
It also introduced an issue #88672

There is an attempt to address the issue in #88691, but it tries to solve it by requiring even more clicks from people.

Bringing number input back as it has better UX than the current solution.

## Changelog

:cl:
fix: Smart fridges on tile view now ask the user for the number instead of dumping everything out
qol: Smart fridge list view got simpler
/:cl:
