### PR TITLE
picking up items will now respect the sound vary settings of the item

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -762,9 +762,9 @@
 	item_flags |= IN_INVENTORY
 	if(!initial)
 		if(equip_sound && (slot_flags & slot))
-			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE)
+			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, sound_vary, ignore_walls = FALSE)
 		else if(slot & ITEM_SLOT_HANDS)
-			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, ignore_walls = FALSE)
+			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, sound_vary, ignore_walls = FALSE)
 	user.update_equipment_speed_mods()
 
 /// Gives one of our item actions to a mob, when equipped to a certain slot

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -762,7 +762,7 @@
 	item_flags |= IN_INVENTORY
 	if(!initial)
 		if(equip_sound && (slot_flags & slot))
-			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, sound_vary, ignore_walls = FALSE)
+			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE)
 		else if(slot & ITEM_SLOT_HANDS)
 			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, sound_vary, ignore_walls = FALSE)
 	user.update_equipment_speed_mods()


### PR DESCRIPTION

## About The Pull Request
I missed this when adding sound_vary
## Why It's Good For The Game
intended to be this way + there's a reason this var exists
## Changelog
:cl: grungussuss
fix: picking stuff up actually respects the vary settings of an item
/:cl:
