### PR TITLE
Fix holoparasite using gas ability while not summoned

### DIFF
--- a/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
@@ -122,9 +122,11 @@
 	if(isnull(picked_gas) || isnull(gas_type))
 		return
 
-	if(!owner.is_deployed())
-		to_chat(owner, span_warning("You cannot release gas without being summoned!"))
-		return
+	if(isguardian(owner))
+		var/mob/living/basic/guardian/guardian_owner = owner
+		if(!guardian_owner.is_deployed())
+			to_chat(owner, span_warning("You cannot release gas without being summoned!"))
+			return
 
 	to_chat(owner, span_bolddanger("You start releasing [picked_gas]."))
 	owner.investigate_log("set their gas type to [picked_gas].", INVESTIGATE_ATMOS)
@@ -154,9 +156,12 @@
 	SIGNAL_HANDLER
 	if (isnull(active_gas))
 		return // We shouldn't even be registered at this point but just in case
-	if(!owner.is_deployed())
-		stop_gas()
-		return
+
+	if(isguardian(owner))
+		var/mob/living/basic/guardian/guardian_owner = owner
+		if(!guardian_owner.is_deployed())
+			stop_gas()
+			return
 
 	var/datum/gas_mixture/mix_to_spawn = new()
 	mix_to_spawn.add_gas(active_gas)

--- a/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
@@ -122,6 +122,10 @@
 	if(isnull(picked_gas) || isnull(gas_type))
 		return
 
+	if(!is_deployed())
+		to_chat(owner, span_warning("You cannot release gas without being summoned!"))
+		return
+
 	to_chat(owner, span_bolddanger("You start releasing [picked_gas]."))
 	owner.investigate_log("set their gas type to [picked_gas].", INVESTIGATE_ATMOS)
 	var/had_gas = !isnull(active_gas)
@@ -150,6 +154,10 @@
 	SIGNAL_HANDLER
 	if (isnull(active_gas))
 		return // We shouldn't even be registered at this point but just in case
+	if(!is_deployed())
+		stop_gas()
+		return
+
 	var/datum/gas_mixture/mix_to_spawn = new()
 	mix_to_spawn.add_gas(active_gas)
 	mix_to_spawn.gases[active_gas][MOLES] = possible_gases[active_gas] * seconds_per_tick

--- a/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
@@ -122,7 +122,7 @@
 	if(isnull(picked_gas) || isnull(gas_type))
 		return
 
-	if(!is_deployed())
+	if(!owner.is_deployed())
 		to_chat(owner, span_warning("You cannot release gas without being summoned!"))
 		return
 
@@ -154,7 +154,7 @@
 	SIGNAL_HANDLER
 	if (isnull(active_gas))
 		return // We shouldn't even be registered at this point but just in case
-	if(!is_deployed())
+	if(!owner.is_deployed())
 		stop_gas()
 		return
 


### PR DESCRIPTION

## About The Pull Request
- Fixes #88686

Holoparasites were able to use the gas ability while not directly summoned. This fixes that so they need to be summoned to use the ability properly.

## Why It's Good For The Game
No more cheap exploits.

## Changelog
:cl:
fix: Fix holoparasite using gas ability while not summoned
/:cl:
