### PR TITLE
Fix vent clog event triggering on non-station areas

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -14,7 +14,8 @@
 		return
 	for(var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/atmospherics/components/unary/vent_pump))
 		var/turf/vent_turf = get_turf(vent)
-		if(vent_turf && is_station_level(vent_turf.z) && !vent.welded)
+		var/area/vent_area = get_area(vent)
+		if(vent_turf && is_station_level(vent_turf.z) && !vent.welded && istype(vent_area, /area/station))
 			return TRUE //make sure we have a valid vent to spawn from.
 	return FALSE
 
@@ -92,7 +93,8 @@
 	var/list/vent_list = list()
 	for(var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/atmospherics/components/unary/vent_pump))
 		var/turf/vent_turf = get_turf(vent)
-		if(vent_turf && is_station_level(vent_turf.z) && !vent.welded && !vent_turf.is_blocked_turf_ignore_climbable())
+		var/area/vent_area = get_area(vent)
+		if(vent_turf && is_station_level(vent_turf.z) && !vent.welded && istype(vent_area, /area/station) && !vent_turf.is_blocked_turf_ignore_climbable())
 			vent_list += vent
 
 	if(!length(vent_list))


### PR DESCRIPTION

## About The Pull Request
- Fixes #88723

This fixes the vent clog event triggering on non-station areas.

## Why It's Good For The Game
Station events should only trigger on station areas.

## Changelog
:cl:
fix: Fix vent clog event triggering on non-station areas
/:cl:
