### PR TITLE
Adds command access requirement to the door between EVA and bridge on Nebula's escape shuttle

### DIFF
--- a/_maps/shuttles/emergency_nebula.dmm
+++ b/_maps/shuttles/emergency_nebula.dmm
@@ -864,6 +864,7 @@
 	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "sI" = (


### PR DESCRIPTION

## About The Pull Request

Closes #88632
Similarly to Delta's escape shuttle, EVA can be accessed from space but the door between EVA and bridge requires command access

## Changelog
:cl:
fix: Added command access requirement to the door between EVA and bridge on Nebula's escape shuttle
/:cl:
