### PR TITLE
Fix quiver max_slots var not actually setting storage max_slots

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_quivers.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_quivers.dm
@@ -14,7 +14,7 @@
 	. = ..()
 	atom_storage.numerical_stacking = TRUE
 	atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
-	atom_storage.max_slots = 40
+	atom_storage.max_slots = max_slots
 	atom_storage.max_total_storage = 100
 	atom_storage.set_holdable(/obj/item/ammo_casing/arrow)
 


### PR DESCRIPTION

## About The Pull Request

So yeah quivers had a `max_slots` var, and a subtype that changed it, but never actually set the atom storage's `max_slots` to that.

This fixes that.
## Why It's Good For The Game

yeah 👍 
## Changelog
:cl:
fix: Lesser quiver actually has less slots as intended.
/:cl:
