### PR TITLE
Fixes rolling table being able to carry an infinite amount of dwarves

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -382,7 +382,6 @@
 /obj/structure/table/rolling/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noisy_movement)
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_our_moved))
 
 /obj/structure/table/rolling/Destroy()
 	for(var/item in attached_items)
@@ -398,13 +397,14 @@
 	if(rable.loaded)
 		to_chat(user, span_warning("You already have \a [rable.loaded] docked!"))
 		return ITEM_INTERACT_FAILURE
-	if(locate(/mob/living) in get_turf(src))
+
+	if(locate(/mob/living) in loc.get_all_contents())
 		to_chat(user, span_warning("You can't collect \the [src] with that much on top!"))
 		return ITEM_INTERACT_FAILURE
 
 	rable.loaded = src
 	forceMove(rable)
-	user.visible_message(span_notice("[user] collects \the [src]."), span_notice("you collect \the [src]."))
+	user.visible_message(span_notice("[user] collects \the [src]."), span_notice("You collect \the [src]."))
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/table/rolling/AfterPutItemOnTable(obj/item/thing, mob/living/user)
@@ -423,8 +423,9 @@
 	clear_item_reference(thing)
 
 /// Handles movement of the table itself, as well as moving along any atoms we have on our surface.
-/obj/structure/table/rolling/proc/on_our_moved(datum/source, atom/old_loc, dir, forced, list/old_locs, momentum_change)
-	SIGNAL_HANDLER
+/obj/structure/table/rolling/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
+	. = ..()
+
 	if(isnull(loc)) // aw hell naw
 		return
 


### PR DESCRIPTION
## About The Pull Request

Swapped direct loc checks with recursive contents to prevent extreme bluespace bodybag cheese + removed self comsig reg and fixed lowercase you

## Changelog
:cl:
fix: Fixed rolling table being able to carry an infinite amount of dwarves
grammar: Improved rolling table grammar
/:cl:
