### PR TITLE
Fixes incorrect order of boulder refinery machines on multiple maps, adds BRBs to maps without them.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -3164,8 +3164,14 @@
 /area/station/science/xenobiology)
 "bll" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/engineering/flashlight,
+/obj/structure/rack,
+/obj/item/stack/conveyor/thirty,
+/obj/item/conveyor_switch_construct{
+	pixel_x = 10
+	},
+/obj/item/boulder_beacon{
+	pixel_x = -5
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "blt" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14896,6 +14896,10 @@
 /obj/structure/noticeboard/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ehs" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ehD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -23890,6 +23894,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"gQr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "gQw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32708,6 +32718,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"jwp" = (
+/obj/machinery/light/directional/west,
+/obj/item/stack/conveyor/thirty,
+/obj/item/boulder_beacon{
+	pixel_x = -5
+	},
+/obj/item/conveyor_switch_construct{
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jwt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51336,6 +51359,14 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Cargo Bay South"
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard{
+	pixel_x = 3
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oMq" = (
@@ -55601,6 +55632,7 @@
 /area/station/service/janitor)
 "pYT" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pZh" = (
@@ -67865,6 +67897,7 @@
 	cycle_id = "miner-passthrough"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "tAT" = (
@@ -69879,6 +69912,7 @@
 /obj/machinery/computer/order_console/bitrunning{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ugq" = (
@@ -234460,7 +234494,7 @@ jjk
 jjk
 sOm
 uEI
-ajw
+jhy
 maT
 maT
 qjQ
@@ -234717,11 +234751,11 @@ wam
 wam
 wam
 mWD
-ajw
+jhy
 pYT
-ajw
+ehs
 tAS
-hoD
+gQr
 hoD
 hoD
 wjZ
@@ -235231,7 +235265,7 @@ wam
 wam
 wam
 wxT
-ajw
+jwp
 maT
 bln
 qjQ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21572,6 +21572,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"hMR" = (
+/obj/structure/lattice/catwalk,
+/obj/item/boulder_beacon{
+	pixel_x = -5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "hNb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window,
@@ -64206,7 +64213,7 @@
 	dir = 8;
 	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/bouldertech/refinery,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "wyV" = (
@@ -65532,7 +65539,7 @@
 	dir = 10;
 	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery,
+/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "wZw" = (
@@ -85065,7 +85072,7 @@ aaa
 aaa
 aaa
 aaa
-aox
+hMR
 aox
 jXu
 jXu

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -49566,11 +49566,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "qzh" = (
-/obj/machinery/bouldertech/refinery/smelter,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining"
 	},
+/obj/machinery/bouldertech/refinery,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "qzn" = (
@@ -54268,11 +54268,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "siF" = (
-/obj/machinery/bouldertech/refinery,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining"
 	},
+/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "siL" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -22929,12 +22929,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iee" = (
-/obj/machinery/bouldertech/refinery/smelter,
 /obj/machinery/conveyor{
 	dir = 6;
 	id = "brm"
 	},
 /obj/effect/turf_decal/sand/plating,
+/obj/machinery/bouldertech/refinery,
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "ief" = (
@@ -38044,12 +38044,12 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "nuu" = (
-/obj/machinery/bouldertech/refinery,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "brm"
 	},
 /obj/effect/turf_decal/sand/plating,
+/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "nuC" = (

--- a/code/modules/mining/boulder_processing/beacon.dm
+++ b/code/modules/mining/boulder_processing/beacon.dm
@@ -21,8 +21,8 @@
 		if(3)
 			new /obj/machinery/brm(drop_location())
 		if(2)
-			new /obj/machinery/bouldertech/refinery(drop_location())
-		if(1)
 			new /obj/machinery/bouldertech/refinery/smelter(drop_location())
+		if(1)
+			new /obj/machinery/bouldertech/refinery(drop_location())
 			qdel(src)
 	uses--


### PR DESCRIPTION

## About The Pull Request

Swapped refinery and smelter on Meta, Nebula, Tram and Wawa, and added boulder beacons to Birdshot and Icebox. Also swapped spawn order in BRBs to be receiver -> smelter -> refinery.

## Why It's Good For The Game

Currently all boulder refineries are mapped in incorrectly, producing "magical boulders" from time to time (and always when manually deployed) which try to constantly move right, even escaping your inventories (and putting themselves into superposition, possibly even existing in multiple players' inventories at once). This should stop that from happening roundstart until the issue is located and fixed. Players usually assume that mapped in machines would always work correctly, which they do.

As for putting beacons on those 2 maps, miners usually assume that boulder refinery either exists or will be set up by cargo, which leads to them often not producing nearly enough materials (especially metal and glass) on those two maps. Map parity is good.

## Changelog
:cl:
fix: Fixes incorrect order of boulder refinery machines on multiple maps and in boulder refinery beacons
map: Added boulder refinery beacons to Birdshot and Icebox
/:cl:
