### PR TITLE
Fix lead acid cell being rated as megacell

### DIFF
--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -33,19 +33,19 @@
 	desc = "A primitive battery. It is quite large and feels unexpectedly heavy."
 	icon = 'icons/obj/maintenance_loot.dmi'
 	icon_state = "lead_battery"
+	force = 10 // double the force of a normal cell
 	throwforce = 10
-	maxcharge = STANDARD_BATTERY_VALUE //decent max charge
-	chargerate = STANDARD_BATTERY_RATE * 0.3 //charging is about 70% less efficient than lithium batteries.
+	w_class = WEIGHT_CLASS_NORMAL
+	maxcharge = STANDARD_CELL_CHARGE * 60 // initial charge reduced on init
+	chargerate = STANDARD_CELL_RATE * 0.3 //charging is about 70% less efficient than lithium batteries.
 	charge_light_type = null
 	connector_type = "leadacid"
-	rating = 2 //Kind of a mid-tier battery
-	w_class = WEIGHT_CLASS_NORMAL
 	grind_results = list(/datum/reagent/lead = 15, /datum/reagent/toxin/acid = 15, /datum/reagent/water = 20)
 
 //starts partially discharged
 /obj/item/stock_parts/power_store/cell/lead/Initialize(mapload)
 	AddElement(/datum/element/update_icon_blocker)
 	. = ..()
-	var/initial_percent = rand(20, 80) / 100
+	var/initial_percent = rand(40, 60) / 100 // 250kJ to 350kJ
 	charge = initial_percent * maxcharge
 	ADD_TRAIT(src, TRAIT_FISHING_BAIT, INNATE_TRAIT)

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -201,7 +201,7 @@
 	. = ..()
 	if(rigged)
 		. += span_danger("This [name] seems to be faulty!")
-	else
+	else if(!isnull(charge_light_type))
 		. += "The charge meter reads [CEILING(percent(), 0.1)]%." //so it doesn't say 0% charge when the overlay indicates it still has charge
 
 /obj/item/stock_parts/power_store/proc/on_reagent_change(datum/reagents/holder, ...)


### PR DESCRIPTION
## About The Pull Request

Fixes lead acid battery being overlooked in the split between cell and megacell. It still remains a very good battery fitting of being rare maintenance loot, but it's no longer equivalent to several bluespace cells combined.

It is a cell with a maximum charge of 600kJ, more than a bluespace cell, but a lower charge rate and no charge indicator.

It spawns with 250kJ to 350kJ in starting charge, between super and hyper.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/88573

## Changelog

:cl: LT3
fix: Fixed lead acid cell having extremely high max charge
/:cl: