### PR TITLE
[NO GBP] Small boxed messages tweaks

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -983,7 +983,7 @@ em {
   position: relative;
   max-width: 95%;
   font-size: 120%;
-  padding: 0.2em 0.33em;
+  padding: 0.2em 0.5em;
   background: #151515; // Chat background color
   border: 1px solid;
   border-color: inherit;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -988,7 +988,7 @@ em {
   border: 1px solid;
   border-color: inherit;
   border-radius: 0.33em;
-  z-index: 1;
+  z-index: 0;
 
   // "Mask" a half of the border
   // It very rough but it only possible way i see with IE compat

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -774,7 +774,7 @@ em {
 }
 
 .smaller {
-  font-size: 80%;
+  font-size: 90%;
 }
 
 .slightly_larger {
@@ -983,7 +983,7 @@ em {
   position: relative;
   max-width: 95%;
   font-size: 120%;
-  padding: 0.2em 0.5em;
+  padding: 0.2em 0.33em;
   background: #151515; // Chat background color
   border: 1px solid;
   border-color: inherit;


### PR DESCRIPTION
## About The Pull Request
Makes ticket control buttons in chat slightly bigger
Fixed z-index on fieldset title, which causes weird black rectangle on title, if first one being highlighted
And reduce sides padding on title

## Images
![image](https://github.com/user-attachments/assets/592f1fc5-3cd6-4dd2-9f9a-d3cbac4184d7)
![image](https://github.com/user-attachments/assets/ae75e08c-0eb5-42c3-9adf-dfb930b57c5e)

## Changelog

:cl:
admin: Ticket actions buttons in chat got a little bigger
fix: Highlighted PMs, vote results and examine will not have weird black title
/:cl:
