### PR TITLE
fixes crafting menu rice dough

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_martian.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_martian.dm
@@ -67,6 +67,7 @@
 		/datum/reagent/water = 10,
 	)
 	result = /obj/item/food/rice_dough
+	crafting_flags = CRAFT_CHECK_DENSITY
 	category = CAT_MARTIAN
 
 /datum/crafting_recipe/food/hurricane_rice


### PR DESCRIPTION

## About The Pull Request

Making rice dough through the crafting menu would make it inherit all the reagents of it's ingredients... which were the ingredients to make rice dough. This means that when you baked the dough in an oven, it would react the reagents and make a new rice dough, while removing all the reagents in the newly made reispan. This made it inedible, and thus impossible to make edible reispan.
## Why It's Good For The Game

Infinite inedible bread is probably bad :+1:
## Changelog
:cl:
fix: fixes crafting menu-made rice dough being unusable for bread
/:cl:
