### PR TITLE
Give alert spelling fix

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -319,7 +319,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	/// The offer we're linked to, yes this is suspiciously like a status effect alert
 	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
-	var/additional_desc_text = "Click this alert to take it, or shift click it to examiante it."
+	var/additional_desc_text = "Click this alert to take it, or shift click it to examine it."
 	/// Text to override what appears in screentips for the alert
 	var/screentip_override_text
 	/// Whether the offered item can be examined by shift-clicking the alert


### PR DESCRIPTION

## About The Pull Request

Changes `examiante` to `examine` in the give alert description.
## Why It's Good For The Game

`examiante` ain't a word and, uh, `examinate` I don't think actually fits here either.
## Changelog
:cl:
spellcheck: Give alert 'examiante' > 'examine'.
/:cl:
