### PR TITLE
Removes "Prefer multiplication over division" Standard

### DIFF
--- a/.github/guides/STANDARDS.md
+++ b/.github/guides/STANDARDS.md
@@ -68,8 +68,6 @@ var/path_type = "/obj/item/baseball_bat"
 
 * You are expected to help maintain the code that you add, meaning that if there is a problem then you are likely to be approached in order to fix any issues, runtimes, or bugs.
 
-* Do not divide when you can easily convert it to multiplication. (ie `4/2` should be done as `4*0.5`)
-
 * Separating single lines into more readable blocks is not banned, however you should use it only where it makes new information more accessible, or aids maintainability. We do not have a column limit, and mass conversions will not be received well.
 
 * If you used regex to replace code during development of your code, post the regex in your PR for the benefit of future developers and downstream users.


### PR DESCRIPTION
## About The Pull Request

I haven't profiled this and I don't need to. It doesn't matter to me if it's slower to divide or multiply (it likely is to some extent because byond).
Any cost associated is going to be on the scale of micro-ops, a level of optimization I think we should deliberately avoid documenting.
Micro-ops are so minor and potentially variable that writing them down poisons the well that is our greater contributor base's practices.

`*` and `/` imply different things. As an example the move from `/ 2` to `* 0.5` obfuscates intent slightly. That intention is more important then the optimization I think.

Hence, yeet

@tgstation/commit-access requesting input