### PR TITLE
Golem buffs: Golems innately resist pressure and cold (not heat), plasteel gives nocritdamage instead, plastitanium is basically penthrite+, uranium gives radioactive punches

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -16,6 +16,9 @@
 		TRAIT_NO_UNDERWEAR,
 		TRAIT_PIERCEIMMUNE,
 		TRAIT_RADIMMUNE,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_RESISTCOLD,
 		TRAIT_SNOWSTORM_IMMUNE, // Shared with plasma river... but I guess if you can survive a plasma river a blizzard isn't a big deal
 		TRAIT_UNHUSKABLE,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes around some of the golem traits and innates, as well as the effects the get from some minerals. The now resist pressure and cold innately (high or low pressure), however, they do not resist heat, so if they want to put out plasma fires, they would still need to eat plasma or find some way to deal with the burn damage.

Plasteel instead makes them not take critdamage; a bit boring, but considering the (current) uranium literally just temporarily removes their mineral feeding gimmick, I'm guessing being really boring isn't off the table for a mineral effect.

Plastitanium, however, gives the same, but additionally gives them traits so that they don't fall into crit; instead, they'll go from standing and fighting (or more likely, desperately fleeing automatic laser fire from a validhunting sec officer) to stone (plastitanium...?) dead. Note: they can't heal with iron while using a mineral effect, so they'd have to find some other way to get out of crit if they fell into it under this effect. The same goes for plasteel.

I also added dealing small amounts of rads to their punches when they're using uranium, because it's painfully boring for one of the effects to literally just be "you don't have to deal with this micromanagement for ~5 minutes".

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Golems are in a seemingly sorry state according to most of the playerbase. The pendulum swung too far in the other direction from the tales I hear of their powergaming glory days; I don't know the extent to which they were unholy terrors for xenobiologists to dominate the station in yet another way, but I'm actually inclined to agree that they kinda suck to play right now.

I think these changes will make them more attractive for ghost roles and intrepid scientists. The buffs are meaningful, but are easily balanced by grossly incompetent miners and golems being kill-on-sight for any crime whatsoever.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Bisar
add: Golems now deal radiation when punching while using uranium mineral effects, and get no damage in-crit with plasteel, and no-crit with plastitanium (don't forget; you can't heal with iron while using mineral effects!)
balance: Golems are now innately resistant to pressure and cold; they still are not immune to heat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
