### PR TITLE
makes the plasma visor overlay a lighter color and also actually work for modsuits

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -667,11 +667,9 @@
 	required_slots = list(ITEM_SLOT_HEAD)
 
 /obj/item/mod/module/plasma_stabilizer/generate_worn_overlay(mutable_appearance/standing)
-	if (!active)
-		return list()
 	var/mutable_appearance/visor_overlay = mod.get_visor_overlay(standing)
 	visor_overlay.appearance_flags |= RESET_COLOR
-	visor_overlay.color = COLOR_VOID_PURPLE
+	visor_overlay.color = COLOR_VIOLET
 	return list(visor_overlay)
 
 /obj/item/mod/module/plasma_stabilizer/on_equip()

--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -131,8 +131,6 @@
 	SEND_SOUND(mod.wearer, sound('sound/machines/terminal/terminal_off.ogg', volume = 50, channel = CHANNEL_JUKEBOX))
 
 /obj/item/mod/module/visor/rave/generate_worn_overlay(mutable_appearance/standing)
-	if (!active)
-		return list()
 	var/mutable_appearance/visor_overlay = mod.get_visor_overlay(standing)
 	visor_overlay.appearance_flags |= RESET_COLOR
 	if (!isnull(music_player.active_song_sound))


### PR DESCRIPTION
## About The Pull Request

the module doesn't actually show the visor thanks to the fact that the module is not actually active at any point, which the visor attempts to check for

also the color of purple was like WAY too dark it was practically black on every modsuit
## Why It's Good For The Game

it'd be cool if it actually worked and you could actually see it
## Changelog
:cl:
fix: fixes plasma stabilizer module not showing a visor on modsuits
fix: makes the plasma stabilizer module actually visible
fix: makes rave module grey by default as it was meant to be
/:cl:
