### PR TITLE
Makes `drop_everything()` actually safe

### DIFF
--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -144,7 +144,7 @@ ADMIN_VERB(cmd_admin_check_player_exp, R_ADMIN, "Player Playtime", "View player 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-ADMIN_VERB(drop_everything, R_ADMIN, "Drop Everything", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, mob/dropee in GLOB.mob_list)
+ADMIN_VERB(drop_everything, R_ADMIN, "Drop Everything", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, mob/living/dropee in GLOB.mob_list)
 	var/confirm = tgui_alert(user, "Make [dropee] drop everything?", "Message", list("Yes", "No"))
 	if(confirm != "Yes")
 		return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -601,7 +601,7 @@
 /mob/living/proc/drop_everything(del_on_drop, force, del_if_nodrop)
 	. = list() //list of items that were successfully dropped
 
-	var/list/obj/item/all_gear = get_all_gear(recursive = FALSE)
+	var/list/all_gear = get_all_gear(recursive = FALSE)
 	for(var/obj/item/item in all_gear)
 		if(dropItemToGround(item, force))
 			if(del_on_drop)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -607,6 +607,7 @@
 			if(del_on_drop)
 				qdel(item)
 				continue
-			. += item
+			if(!QDELETED(item)) //DROP_DEL can cause this tiem to be deleted
+				. += item
 		else if(del_if_nodrop && !(item.item_flags & ABSTRACT))
 			qdel(item)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -608,5 +608,5 @@
 				qdel(item)
 				continue
 			. += item
-		else if(del_if_nodrop)
+		else if(del_if_nodrop && !(item.item_flags & ABSTRACT))
 			qdel(item)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -548,19 +548,6 @@
 
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(execute_quick_equip)))
 
-/// Safely drop everything, without deconstructing the mob
-/mob/proc/drop_everything(del_on_drop, force, del_if_nodrop)
-	. = list()
-	for(var/obj/item/item in src)
-		if(!dropItemToGround(item, force))
-			if(del_if_nodrop && !(item.item_flags & ABSTRACT))
-				qdel(item)
-		if(del_on_drop)
-			qdel(item)
-		//Anything thats not deleted and isn't in the mob, so everything that is succesfully dropped to the ground, is returned
-		if(!QDELETED(item) && !(item in src))
-			. += item
-
 ///proc extender of [/mob/verb/quick_equip] used to make the verb queuable if the server is overloaded
 /mob/proc/execute_quick_equip()
 	var/obj/item/I = get_active_held_item()
@@ -609,3 +596,18 @@
 	for (var/obj/item/implant/storage/internal_bag in implants)
 		belongings += internal_bag.contents
 	return belongings
+
+/// Safely drop everything, without deconstructing the mob
+/mob/living/proc/drop_everything(del_on_drop, force, del_if_nodrop)
+	. = list()
+
+	var/list/obj/item/all_gear = get_all_gear(recursive = FALSE)
+	for(var/obj/item/item in all_gear)
+		if(!dropItemToGround(item, force))
+			if(del_if_nodrop && !(item.item_flags & ABSTRACT))
+				qdel(item)
+		if(del_on_drop)
+			qdel(item)
+		//Anything thats not deleted and isn't in the mob, so everything that is succesfully dropped to the ground, is returned
+		if(!QDELETED(item) && !(item in all_gear))
+			. += item

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -599,15 +599,14 @@
 
 /// Safely drop everything, without deconstructing the mob
 /mob/living/proc/drop_everything(del_on_drop, force, del_if_nodrop)
-	. = list()
+	. = list() //list of items that were successfully dropped
 
 	var/list/obj/item/all_gear = get_all_gear(recursive = FALSE)
 	for(var/obj/item/item in all_gear)
-		if(!dropItemToGround(item, force))
-			if(del_if_nodrop && !(item.item_flags & ABSTRACT))
+		if(dropItemToGround(item, force))
+			if(del_on_drop)
 				qdel(item)
-		if(del_on_drop)
-			qdel(item)
-		//Anything thats not deleted and isn't in the mob, so everything that is succesfully dropped to the ground, is returned
-		if(!QDELETED(item) && !(item in all_gear))
+				continue
 			. += item
+		else if(del_if_nodrop)
+			qdel(item)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -604,10 +604,11 @@
 	var/list/all_gear = get_all_gear(recursive = FALSE)
 	for(var/obj/item/item in all_gear)
 		if(dropItemToGround(item, force))
+			if(QDELETED(item)) //DROPDEL can cause this item to be deleted
+				continue
 			if(del_on_drop)
 				qdel(item)
 				continue
-			if(!QDELETED(item)) //DROP_DEL can cause this tiem to be deleted
-				. += item
+			. += item
 		else if(del_if_nodrop && !(item.item_flags & ABSTRACT))
 			qdel(item)


### PR DESCRIPTION
## About The Pull Request
- Fixes #88740

It now only drops what's on the mob(retrived by `get_all_gear()`) & not in it.

Had to move this down to `mob/living` level because `get_all_gear()` is located there but that shouldn't be an issue because everyone in game is a subtype of that anyway

## Changelog
:cl:
fix: dropping all the mobs' contents in some special admin cases won't gib the player
/:cl:

