### PR TITLE
[no gbp] fixes being able to tell animals to commit atrocious acts

### DIFF
--- a/code/datums/components/pet_commands/pet_command.dm
+++ b/code/datums/components/pet_commands/pet_command.dm
@@ -174,13 +174,12 @@
 	SIGNAL_HANDLER
 	if(!can_see(source, target, 9))
 		return COMSIG_MOB_CANCEL_CLICKON
-	on_target_set(source, target)
+	var/manual_emote_text = generate_emote_command(target)
+	if(on_target_set(source, target) && !isnull(manual_emote_text))
+		INVOKE_ASYNC(source, TYPE_PROC_REF(/atom, manual_emote), manual_emote_text)
 	UnregisterSignal(source, COMSIG_MOB_CLICKON)
 	source.client?.mouse_override_icon = source.client::mouse_override_icon
 	source.update_mouse_pointer()
-	var/manual_emote_text = generate_emote_command(target)
-	if(!isnull(manual_emote_text))
-		INVOKE_ASYNC(source, TYPE_PROC_REF(/atom, manual_emote), manual_emote_text)
 	return COMSIG_MOB_CANCEL_CLICKON
 
 /datum/pet_command/proc/point_on_target(mob/living/friend, atom/potential_target)
@@ -214,11 +213,12 @@
 /datum/pet_command/proc/on_target_set(mob/living/friend, atom/potential_target)
 	var/mob/living/parent = weak_parent.resolve()
 	if (!parent)
-		return
+		return FALSE
 
 	parent.ai_controller.CancelActions()
 	if(!look_for_target(friend, potential_target) || !set_command_target(parent, potential_target))
-		return
+		return FALSE
 	parent.visible_message(span_warning("[parent] follows [friend]'s gesture towards [potential_target] [pointed_reaction]!"))
+	return TRUE
 
 

--- a/code/datums/components/pet_commands/pet_commands_basic.dm
+++ b/code/datums/components/pet_commands/pet_commands_basic.dm
@@ -147,16 +147,16 @@
 // Refuse to target things we can't target, chiefly other friends
 /datum/pet_command/attack/set_command_target(mob/living/parent, atom/target)
 	if (!target)
-		return
+		return FALSE
 	var/mob/living/living_parent = parent
 	if (!living_parent.ai_controller)
-		return
+		return FALSE
 	var/datum/targeting_strategy/targeter = GET_TARGETING_STRATEGY(living_parent.ai_controller.blackboard[targeting_strategy_key])
 	if (!targeter)
-		return
+		return FALSE
 	if (!targeter.can_attack(living_parent, target))
 		refuse_target(parent, target)
-		return
+		return FALSE
 	return ..()
 
 /datum/pet_command/attack/retrieve_command_text(atom/living_pet, atom/target)
@@ -186,16 +186,16 @@
 
 /datum/pet_command/breed/set_command_target(mob/living/parent, atom/target)
 	if(isnull(target) || !isliving(target))
-		return
+		return FALSE
 	if(!HAS_TRAIT(parent, TRAIT_MOB_BREEDER) || !HAS_TRAIT(target, TRAIT_MOB_BREEDER))
-		return
+		return FALSE
 	if(isnull(parent.ai_controller))
-		return
+		return FALSE
 	if(!parent.ai_controller.blackboard[BB_BREED_READY] || isnull(parent.ai_controller.blackboard[BB_BABIES_PARTNER_TYPES]))
-		return
+		return FALSE
 	var/mob/living/living_target = target
 	if(!living_target.ai_controller?.blackboard[BB_BREED_READY])
-		return
+		return FALSE
 	return ..()
 
 /datum/pet_command/breed/execute_action(datum/ai_controller/controller)

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -210,11 +210,11 @@
 
 /datum/pet_command/clean/set_command_target(mob/living/parent, atom/target)
 	if(isnull(target) || !istype(target, /obj/effect/decal/cleanable))
-		return
+		return FALSE
 	if(isnull(parent.ai_controller))
-		return
+		return FALSE
 	if(LAZYACCESS(parent.ai_controller.blackboard[BB_TEMPORARY_IGNORE_LIST], target))
-		return
+		return FALSE
 	return ..()
 
 /datum/pet_command/clean/execute_action(datum/ai_controller/basic_controller/bot/controller)

--- a/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers_ai.dm
@@ -131,7 +131,7 @@
 /datum/pet_command/breed/gutlunch/set_command_target(mob/living/parent, atom/target)
 	if(GLOB.gutlunch_count >= MAXIMUM_GUTLUNCH_POP)
 		parent.balloon_alert_to_viewers("can't reproduce anymore!")
-		return
+		return FALSE
 	return ..()
 
 #undef MAXIMUM_GUTLUNCH_POP

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -268,7 +268,7 @@
 
 /datum/pet_command/use_ability/lob_charge/set_command_target(mob/living/parent, atom/target)
 	if (!target)
-		return
+		return FALSE
 	var/datum/targeting_strategy/targeter = GET_TARGETING_STRATEGY(parent.ai_controller.blackboard[targeting_strategy_key])
 	if(!targeter?.can_attack(parent, target))
 		parent.balloon_alert_to_viewers("shakes head!")

--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -350,9 +350,10 @@
 
 /datum/pet_command/protect_owner/minebot/set_command_target(mob/living/parent, atom/target)
 	if(!parent.ai_controller.blackboard[BB_MINEBOT_AUTO_DEFEND])
-		return
+		return FALSE
 	if(!parent.ai_controller.blackboard_key_exists(BB_BASIC_MOB_CURRENT_TARGET) && !QDELETED(target)) //we are already dealing with something,
 		parent.ai_controller.set_blackboard_key(BB_BASIC_MOB_CURRENT_TARGET, target)
+	return TRUE
 
 /datum/pet_command/protect_owner/minebot/execute_action(datum/ai_controller/controller)
 	if(controller.blackboard[BB_MINEBOT_AUTO_DEFEND])


### PR DESCRIPTION

## About The Pull Request
closes #88743 . the issue is while they'd ignore ur command since its impossible, the emote would still appear, which i now realize was a mistake

## Why It's Good For The Game
fixes being able to tell animals to commit atrocious acts

## Changelog
:cl:
fix: radial pet commanding emotes will now not appear if the command is impossible to execute
/:cl:
