### PR TITLE
Folders and paper biscuits no longer share their color with their contents

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -67,7 +67,15 @@
 /obj/item/folder/update_overlays()
 	. = ..()
 	if(contents.len)
-		. += "folder_paper"
+		var/to_add = get_paper_overlay()
+		if (to_add)
+			. += to_add
+
+/obj/item/folder/proc/get_paper_overlay()
+	var/mutable_appearance/paper_overlay = mutable_appearance(icon, "folder_paper", offset_spokesman = src)
+	paper_overlay.appearance_flags |= KEEP_APART
+	paper_overlay = contents[1].color_atom_overlay(paper_overlay)
+	return paper_overlay
 
 /obj/item/folder/attackby(obj/item/weapon, mob/user, params)
 	if(burn_paper_product_attackby_check(weapon, user))

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -72,8 +72,7 @@
 			. += to_add
 
 /obj/item/folder/proc/get_paper_overlay()
-	var/mutable_appearance/paper_overlay = mutable_appearance(icon, "folder_paper", offset_spokesman = src)
-	paper_overlay.appearance_flags |= KEEP_APART
+	var/mutable_appearance/paper_overlay = mutable_appearance(icon, "folder_paper", offset_spokesman = src, appearance_flags = KEEP_APART)
 	paper_overlay = contents[1].color_atom_overlay(paper_overlay)
 	return paper_overlay
 

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -17,6 +17,8 @@
 	))
 	/// Do we hide the contents on examine?
 	var/contents_hidden = FALSE
+	/// icon_state of overlay for papers inside of this folder
+	var/paper_overlay_state = "folder_paper"
 
 /obj/item/folder/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins filing an imaginary death warrant! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -72,7 +74,7 @@
 			. += to_add
 
 /obj/item/folder/proc/get_paper_overlay()
-	var/mutable_appearance/paper_overlay = mutable_appearance(icon, "folder_paper", offset_spokesman = src, appearance_flags = KEEP_APART)
+	var/mutable_appearance/paper_overlay = mutable_appearance(icon, paper_overlay_state, offset_spokesman = src, appearance_flags = KEEP_APART)
 	paper_overlay = contents[1].color_atom_overlay(paper_overlay)
 	return paper_overlay
 

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -48,12 +48,6 @@
 	biscuit_overlay = contents[1].color_atom_overlay(biscuit_overlay)
 	return biscuit_overlay
 
-/obj/item/folder/biscuit/update_overlays()
-	. = ..()
-	if(contents.len) //This is to prevent the unsealed biscuit from having the folder_paper overlay when it gets sealed
-		. -= "folder_paper"
-
-
 ///Checks if the biscuit has been already cracked.
 /obj/item/folder/biscuit/proc/crack_check(mob/user)
 	if (cracked)

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -8,6 +8,7 @@
 	drop_sound = 'sound/items/handling/disk_drop.ogg'
 	pickup_sound = 'sound/items/handling/disk_pickup.ogg'
 	contents_hidden = TRUE
+	paper_overlay_state = "paperbiscuit_paper"
 	/// Is biscuit cracked open or not?
 	var/cracked = FALSE
 	/// The paper slip inside, if there is one
@@ -41,11 +42,7 @@
 /obj/item/folder/biscuit/get_paper_overlay()
 	if(!cracked)
 		return null
-
-	//Shows overlay only when it has contents and is cracked open
-	var/mutable_appearance/biscuit_overlay = mutable_appearance(icon, "paperbiscuit_paper", offset_spokesman = src, appearance_flags = KEEP_APART)
-	biscuit_overlay = contents[1].color_atom_overlay(biscuit_overlay)
-	return biscuit_overlay
+	return ..()
 
 ///Checks if the biscuit has been already cracked.
 /obj/item/folder/biscuit/proc/crack_check(mob/user)

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -38,12 +38,21 @@
 	playsound(get_turf(user), 'sound/effects/wounds/crackandbleed.ogg', 40, TRUE) //Don't eat plastic cards kids, they get really sharp if you chew on them.
 	return BRUTELOSS
 
+/obj/item/folder/biscuit/get_paper_overlay()
+	if(!cracked)
+		return null
+
+	//Shows overlay only when it has contents and is cracked open
+	var/mutable_appearance/biscuit_overlay = mutable_appearance(icon, "paperbiscuit_paper", offset_spokesman = src)
+	biscuit_overlay.appearance_flags |= KEEP_APART
+	biscuit_overlay = contents[1].color_atom_overlay(biscuit_overlay)
+	return biscuit_overlay
+
 /obj/item/folder/biscuit/update_overlays()
 	. = ..()
 	if(contents.len) //This is to prevent the unsealed biscuit from having the folder_paper overlay when it gets sealed
 		. -= "folder_paper"
-		if(cracked) //Shows overlay only when it has contents and is cracked open
-			. += "paperbiscuit_paper"
+
 
 ///Checks if the biscuit has been already cracked.
 /obj/item/folder/biscuit/proc/crack_check(mob/user)

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -43,8 +43,7 @@
 		return null
 
 	//Shows overlay only when it has contents and is cracked open
-	var/mutable_appearance/biscuit_overlay = mutable_appearance(icon, "paperbiscuit_paper", offset_spokesman = src)
-	biscuit_overlay.appearance_flags |= KEEP_APART
+	var/mutable_appearance/biscuit_overlay = mutable_appearance(icon, "paperbiscuit_paper", offset_spokesman = src, appearance_flags = KEEP_APART)
 	biscuit_overlay = contents[1].color_atom_overlay(biscuit_overlay)
 	return biscuit_overlay
 


### PR DESCRIPTION

## About The Pull Request
Paper overlays for folders and paper biscuits are now KEEP_APART and get colored in their item's (paper or paper slip respectively) colors.

## Why It's Good For The Game

Consistency for item visuals.

## Changelog
:cl:
fix: Folders and paper biscuits no longer share their color with their contents
/:cl:
