### PR TITLE
Clipboards no longer share their color with their contents

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -92,13 +92,22 @@
 
 /obj/item/clipboard/update_overlays()
 	. = ..()
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-	if(toppaper)
-		. += toppaper.icon_state
-		. += toppaper.overlays
+	var/paper_to_add = get_paper_overlay()
+	if(paper_to_add)
+		. += paper_to_add
 	if(pen)
 		. += "clipboard_pen"
 	. += "clipboard_over"
+
+/obj/item/clipboard/proc/get_paper_overlay()
+	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
+	if(isnull(toppaper))
+		return
+
+	var/mutable_appearance/paper_overlay = mutable_appearance(icon, toppaper.icon_state, offset_spokesman = src, appearance_flags = KEEP_APART)
+	paper_overlay = toppaper.color_atom_overlay(paper_overlay)
+	paper_overlay.overlays += toppaper.overlays
+	return paper_overlay
 
 /obj/item/clipboard/attack_hand(mob/user, list/modifiers)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))


### PR DESCRIPTION

## About The Pull Request

Saw #88759 pop up, mentioned clipboards, did it for clipboards.
The top paper overlay for clipboards now uses `KEEP_APART` and uses the paper in question's own color.
## Why It's Good For The Game

Consistency for item visuals.
## Changelog
:cl: 00-Steven, SmArtKar
fix: Paper on clipboards uses its own colour rather than that of the clipboard.
/:cl:
