### PR TITLE
Fix paper stamp overlays inheriting colour and sometimes sliding below the paper.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -278,7 +278,7 @@
 	if(LAZYLEN(stamp_cache) > MAX_PAPER_STAMPS_OVERLAYS)
 		return
 
-	var/mutable_appearance/stamp_overlay = mutable_appearance('icons/obj/service/bureaucracy.dmi', "paper_[stamp_icon_state]")
+	var/mutable_appearance/stamp_overlay = mutable_appearance('icons/obj/service/bureaucracy.dmi', "paper_[stamp_icon_state]", appearance_flags = KEEP_APART | RESET_COLOR)
 	stamp_overlay.pixel_w = rand(-2, 2)
 	stamp_overlay.pixel_z = rand(-3, 2)
 	add_overlay(stamp_overlay)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -279,8 +279,8 @@
 		return
 
 	var/mutable_appearance/stamp_overlay = mutable_appearance('icons/obj/service/bureaucracy.dmi', "paper_[stamp_icon_state]")
-	stamp_overlay.pixel_x = rand(-2, 2)
-	stamp_overlay.pixel_y = rand(-3, 2)
+	stamp_overlay.pixel_w = rand(-2, 2)
+	stamp_overlay.pixel_z = rand(-3, 2)
 	add_overlay(stamp_overlay)
 	LAZYADD(stamp_cache, stamp_icon_state)
 


### PR DESCRIPTION

## About The Pull Request

The stamp overlay was getting randomly offset on `pixel_y`, which caused it to sometimes render below the paper.
We instead make it use `pixel_z`, and additionally `pixel_w` instead of `pixel_x` for sanity's sake.
This fixes our first issue.

Then, stamps were taking the color of the paper, which caused the stamp overlays to look gross and made it hard to distinguish which kind of stamp was even on there.
We instead make it use `KEEP_APART` and `RESET_COLOR` here. `RESET_COLOR` is needed as the paper uses the `color` var.
This fixes our second issue.
## Why It's Good For The Game

Stamps being actually visible and readable on the icon state is good.
## Changelog
:cl:
fix: Stamps no longer render below the paper sometimes.
fix: Stamps no longer inherit the color of the paper they're on.
/:cl:
