### PR TITLE
Fix photocopying removing stamp overlays from the original instead of copying them to the copy

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -162,7 +162,7 @@
 	new_paper.raw_stamp_data = copy_raw_stamps()
 	new_paper.stamp_cache = stamp_cache?.Copy()
 	new_paper.update_icon_state()
-	copy_overlays(new_paper, TRUE)
+	new_paper.copy_overlays(src)
 	return new_paper
 
 /**


### PR DESCRIPTION

## About The Pull Request

Photocopiers were trying to copy the stamp overlays from the new blank paper onto the original, and cutting the original's old overlays in the process.
This inverts that statement and removes the cutting part.
## Why It's Good For The Game

Nice if photocopying doesn't remove the stamp overlays on the original just cause it feels like it.
## Changelog
:cl:
fix: Photocopying no longer removes the stamp overlays from the original paper, and actually copies them to the copy.
/:cl:
