### PR TITLE
Paper actually resets its icon state to the clear one when cleared

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -306,6 +306,8 @@
 /obj/item/paper/update_icon_state()
 	if(LAZYLEN(raw_text_inputs) && show_written_words)
 		icon_state = "[initial(icon_state)]_words"
+	else
+		icon_state = initial(icon_state)
 	return ..()
 
 /obj/item/paper/verb/rename()


### PR DESCRIPTION

## About The Pull Request

Paper wasn't resetting its icon state to its cleared version when cleared.
This was because it was only setting it to the written state when written on, but never back.
Here we add a line to reset it to the initial icon state when the written state isn't applicable.
This fixes our issue.
## Why It's Good For The Game

Good if cleared paper actually looks cleared.
## Changelog
:cl:
fix: Clearing paper, like by splashing it with ethanol, actually resets its icon state to the cleared version.
/:cl:
