### PR TITLE
Flatten skin sidebar

### DIFF
--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -104,6 +104,11 @@ img {
 	background-color: #eeeeee;
 }
 
+#under-content {
+	height: calc(0.5em - 4px);
+	background-color: #eeeeee;
+}
+
 #statcontent {
 	flex: 1;
 	padding: 0.75em 0.5em;
@@ -239,7 +244,8 @@ body.dark {
 	border-bottom-color: #d4dfec;
 }
 
-.dark #under-menu {
+.dark #under-menu,
+.dark #under-content {
 	background-color: #202020;
 }
 

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -2,4 +2,5 @@
 	<div id="menu" class="button-container"></div>
 	<div id="under-menu"></div>
 	<div id="statcontent"></div>
+	<div id="under-content"></div>
 </div>

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -159,17 +159,17 @@ window "infowindow"
 		is-vert = false
 	elem "changelog"
 		type = BUTTON
-		pos = 5,5
-		size = 90x20
-		anchor1 = 1,0
+		pos = 0,5
+		size = 87x20
+		anchor1 = 0,0
 		anchor2 = 15,0
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "changelog"
 	elem "rules"
 		type = BUTTON
-		pos = 95,5
-		size = 90x20
+		pos = 92,5
+		size = 87x20
 		anchor1 = 15,0
 		anchor2 = 29,0
 		saved-params = "is-checked"
@@ -177,8 +177,8 @@ window "infowindow"
 		command = "rules"
 	elem "wiki"
 		type = BUTTON
-		pos = 185,5
-		size = 90x20
+		pos = 184,5
+		size = 87x20
 		anchor1 = 29,0
 		anchor2 = 43,0
 		saved-params = "is-checked"
@@ -186,8 +186,8 @@ window "infowindow"
 		command = "wiki"
 	elem "forum"
 		type = BUTTON
-		pos = 275,5
-		size = 90x20
+		pos = 276,5
+		size = 87x20
 		anchor1 = 43,0
 		anchor2 = 57,0
 		saved-params = "is-checked"
@@ -195,8 +195,8 @@ window "infowindow"
 		command = "forum"
 	elem "github"
 		type = BUTTON
-		pos = 365,5
-		size = 90x20
+		pos = 368,5
+		size = 87x20
 		anchor1 = 57,0
 		anchor2 = 71,0
 		saved-params = "is-checked"
@@ -204,8 +204,8 @@ window "infowindow"
 		command = "github"
 	elem "report-issue"
 		type = BUTTON
-		pos = 455,5
-		size = 90x20
+		pos = 460,5
+		size = 87x20
 		anchor1 = 71,0
 		anchor2 = 85,0
 		saved-params = "is-checked"
@@ -213,10 +213,10 @@ window "infowindow"
 		command = "report-issue"
 	elem "fullscreen-toggle"
 		type = BUTTON
-		pos = 545,5
-		size = 90x20
+		pos = 552,5
+		size = 88x20
 		anchor1 = 85,0
-		anchor2 = 99,0
+		anchor2 = 100,0
 		saved-params = "is-checked"
 		text = "Fullscreen"
 		command = "fullscreen"

--- a/tgui/packages/tgui-panel/themes.ts
+++ b/tgui/packages/tgui-panel/themes.ts
@@ -8,16 +8,16 @@ export const THEMES = ['light', 'dark'];
 
 const COLORS = {
   DARK: {
-    BG_BASE: '#202020',
-    BG_SECOND: '#171717',
-    BUTTON: '#494949',
-    TEXT: '#A4BAD6',
+    BG_BASE: '#212020',
+    BG_SECOND: '#161515',
+    BUTTON: '#161515',
+    TEXT: '#8A8A8A',
   },
   LIGHT: {
-    BG_BASE: '#EEEEEE',
+    BG_BASE: '#EFEEEE',
     BG_SECOND: '#FFFFFF',
-    BUTTON: 'none',
-    TEXT: '#000000',
+    BUTTON: '#FEFFFF',
+    TEXT: '#7F7F7F',
   },
 };
 

--- a/tgui/packages/tgui-panel/themes.ts
+++ b/tgui/packages/tgui-panel/themes.ts
@@ -10,14 +10,14 @@ const COLORS = {
   DARK: {
     BG_BASE: '#212020',
     BG_SECOND: '#161515',
-    BUTTON: '#161515',
-    TEXT: '#8A8A8A',
+    BUTTON: '#414040',
+    TEXT: '#A6A6A6',
   },
   LIGHT: {
     BG_BASE: '#EFEEEE',
     BG_SECOND: '#FFFFFF',
-    BUTTON: '#FEFFFF',
-    TEXT: '#7F7F7F',
+    BUTTON: '#FFFEFE',
+    TEXT: '#000000',
   },
 };
 


### PR DESCRIPTION
## About The Pull Request
I have used a small hidden 515 feature, that disables white borders on elements, if the colour of the element deviates even slightly from the greyscale

For example, if you set color for skin button #FFFFFF (Pure white), Byond will add "3D" effect to button. BUT, if you set color to #FEFFFF, Byond makes it flat

## Why It's Good For The Game
Little more stylish imo

| Dark | Light |
| - | - |
| ![image](https://github.com/user-attachments/assets/e05adb43-7a6e-4ff4-a212-097cdf623764) | ![image](https://github.com/user-attachments/assets/726cfa86-f28b-4fdf-9c93-666184c22b36) |

## Changelog

:cl:
qol: Sidebar has lost its bulging white lines. And top right buttons now flat
/:cl:
