### PR TITLE
[NO GBP] Fixes the date of when a trophy fish is caught

### DIFF
--- a/code/controllers/subsystem/persistence/trophy_fishes.dm
+++ b/code/controllers/subsystem/persistence/trophy_fishes.dm
@@ -32,10 +32,9 @@
 		fish.set_custom_materials(mat_list)
 	fish.persistence_load(data)
 	fish.name = data[PERSISTENCE_FISH_NAME]
-	mount.catcher_name = data[PERSISTENCE_FISH_CATCHER]
-	mount.catch_date = data[PERSISTENCE_FISH_CATCH_DATE]
 	fish.set_status(FISH_DEAD, silent = TRUE)
 	mount.add_fish(fish, from_persistence = TRUE, catcher = data[PERSISTENCE_FISH_CATCHER])
+	mount.catch_date = data[PERSISTENCE_FISH_CATCH_DATE]
 
 /datum/controller/subsystem/persistence/proc/save_trophy_fish(obj/structure/fish_mount/mount)
 	var/obj/item/fish/fish = mount.mounted_fish


### PR DESCRIPTION
## About The Pull Request
Small oversight, currently examining a trophy fish always shows the current day instead of the actual day when it was caught.

## Why It's Good For The Game
Fixing a small oversight.

## Changelog

:cl:
fix: Examining a trophy fish no longer shows the current day instead of when it was actually caught and put on the mount.
/:cl:
