### PR TITLE
ethereal hunger fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -452,7 +452,7 @@
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_DISCHARGE_RATE (8e-3 * STANDARD_CELL_CHARGE) // Rate at which ethereal stomach charge decreases
+#define ETHEREAL_DISCHARGE_RATE (2e-3 * STANDARD_BATTERY_CHARGE) // Rate at which ethereal stomach charge decreases 
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.


### PR DESCRIPTION

## About The Pull Request
Change made from standard cell charge to standard battery charge makes ethereal food/charging/hunger work as intended instead of never ticking down, or ticking down at such a rate where you do not become hungry in a period of less than 8 hours. As said in an issue i made before someone pointed out that all other ethereal hunger values are based on standard battery charge.

8 is adjusted to 2, resulting in ethereals becoming hungry from full charge (just below overcharge) after around 4 minutes of running as opposed to having to recharge every 1 minute before the hunger was broken assuming you are running

## Why It's Good For The Game
Ethereals are supposed to need to drain electricity periodically for food so this is a fix, and the hunger rate change is done because I felt that this is more in-line with how fast humans get hungry, while still being shorter than that because of electricity feeding

## Changelog
:cl: mallocB
fix: Ethereal hunger drain fixed
balance: Ethereal hunger drain is 1/4 rate of previous drain
/:cl:
