### PR TITLE
Fixes Boulder Desyncing

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -248,8 +248,10 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			start_conveying(movable)
 	return TRUE
 
-/obj/machinery/conveyor/proc/conveyable_enter(datum/source, atom/convayable)
+/obj/machinery/conveyor/proc/conveyable_enter(datum/source, atom/movable/convayable)
 	SIGNAL_HANDLER
+	if(convayable.loc != loc) // If we are not on the same turf (order of operations memes) go to hell
+		return
 	if(operating == CONVEYOR_OFF)
 		GLOB.move_manager.stop_looping(convayable, SSconveyors)
 		return


### PR DESCRIPTION

## About The Pull Request

Resolves conveyor moveloops persisting through being input into a smelting machine.
The problem is conveyors are smart enough to cancel a move attempt if you enter say, a smelter afterwards, but they are not smart enough to not START one if your loc is changed by the entered signal.

This meant this bug was dependant on signal registration order.

If the conveyor was placed first everything was fine, because it started the moveloop, and then immediately stopped it.

But if it was placed second then the ore was moved into the processing machine, and THEN the moveloop started (and because moveloops don't care about exact loc we are then immediately moved out of the processing machine)

We stay winning


## Why It's Good For The Game

Closes #84051
Closes #85081
IDK if this hits anything else yell at me if I missed something 
## Changelog
:cl:
fix: Boulders will no longer randomly run free from smelting pipelines! We have enslaved them once more. 
/:cl:
