### PR TITLE
Slashes exosuit repair droids and impact cushion plates on mecha with a machete to fix conventionally unkillable durands

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -175,7 +175,7 @@
 	armor_mod = /datum/armor/mecha_equipment_ccw_boost
 
 /datum/armor/mecha_equipment_ccw_boost
-	melee = 15
+	melee = 5
 
 /obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster
 	name = "Projectile Shielding"
@@ -202,7 +202,7 @@
 	active = FALSE
 	equipment_slot = MECHA_UTILITY
 	/// Repaired health per second
-	var/health_boost = 0.5
+	var/health_boost = 0.16
 	var/icon/droid_overlay
 	var/list/repairable_damage = list(MECHA_INT_TEMP_CONTROL,MECHA_CABIN_AIR_BREACH)
 


### PR DESCRIPTION
## About The Pull Request

Slashes exosuit repair droids and impact cushion plates on mecha with a machete to fix conventionally unkillable durands.
The maximum armor you can get from three cushion plates is now 15% melee resistance.
The maximum amount of per tick healing you can get from three repair droids is now 0.5 healing a tick.

## Why It's Good For The Game

![dreamseeker_TXvAarNjEq](https://github.com/user-attachments/assets/636c658c-c0e7-4ed4-8ef4-9ce984b4cc6d)

This shit was absolutely decimating blobs along with generally being unhealthy for the balance of the game. Therefore, these changes are needed.

## Changelog
:cl:
balance: Slashes exosuit repair droids and impact cushion plates on mecha with a machete to fix conventionally unkillable durands.
balance: The maximum armor you can get from three cushion plates is now 15% melee resistance.
balance: The maximum amount of per tick healing you can get from three repair droids is now 0.5 healing a tick.
/:cl: