### PR TITLE
Fixes combat mecha fortnite gameplay by flagging the mecha RCD for Ripley-class mecha only

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -228,6 +228,7 @@
 	energy_drain = 0 // internal RCD handles power consumption based on matter use
 	range = MECHA_MELEE | MECHA_RANGED
 	item_flags = NO_MAT_REDEMPTION
+	mech_flags = EXOSUIT_MODULE_RIPLEY
 
 	///The location the mech was when it began using the rcd
 	var/atom/initial_location = FALSE


### PR DESCRIPTION
## About The Pull Request

Fixes combat mecha fortnite gameplay by flagging the mecha RCD for Ripley-class mecha only

## Why It's Good For The Game

https://github.com/user-attachments/assets/896ef77f-6946-42fc-acc3-d16796f1507d


## Changelog
:cl:
balance: Fixes combat mecha fortnite gameplay by flagging the mecha RCD for Ripley-class mecha only
/:cl:
