### PR TITLE
Buffs blob attacks vs mechs

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -105,7 +105,7 @@
 
 /obj/vehicle/sealed/mecha/blob_act(obj/structure/blob/B)
 	log_message("Attack by blob. Attacker - [B].", LOG_MECHA, color="red")
-	take_damage(30, BRUTE, MELEE, 0, get_dir(src, B))
+	take_damage(damage_amount = 30, damage_type = BRUTE, damage_flag = MELEE, sound_effect = FALSE, armour_penetration = 50)
 
 /obj/vehicle/sealed/mecha/attack_tk()
 	return


### PR DESCRIPTION

## About The Pull Request

Alternative PR to #88776.

Since you can't choose which adjacent blob tile tries to attack, blob attacks are no longer affected by mech directional armor. In addition, blobs now get an extra 50 armor penetration when attacking mechs. This means that they have the same base damage as an esword but with more armor penetration (50 vs only 35).
## Why It's Good For The Game

Rather than nerfing mechs across the board, it makes much more sense to simply buff blob damage against mechs, especially when such changes are so easy to make.
## Changelog
:cl:
bal: Blobs now have armor penetration when attacking mechs, and are not subject to mech directional armor.
/:cl:
