### PR TITLE
Allow experimental destructive scanner to scan multiple items.

### DIFF
--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -148,7 +148,6 @@
 	for(var/scan_target in scanned_atoms)
 		if(action_experiment(source, scan_target))
 			successful_scan = TRUE
-			break
 	if(successful_scan)
 		playsound(our_scanner, 'sound/machines/ping.ogg', 25)
 		to_chat(our_scanner, span_notice("The scan succeeds."))


### PR DESCRIPTION

## About The Pull Request

Causes the experimental destructuve scanner to scan all items in its inventory even after one matching an experiment is found.

## Why It's Good For The Game

Fixes #84728 and reduces tedium in scanning multiple items.

## Changelog
:cl:
qol: experimental destructive scanner now scans multiple items at once.
/:cl:
