### PR TITLE
Fixes inconsistent behavior in tgui checkboxes

### DIFF
--- a/tgui/packages/tgui/interfaces/CheckboxInput.tsx
+++ b/tgui/packages/tgui/interfaces/CheckboxInput.tsx
@@ -52,8 +52,8 @@ export const CheckboxInput = (props) => {
     setSelections(newSelections);
   };
 
-  const selectionsWithIndexes =
-  (selections: string[], items: string[]): [string, number][] => selections.map((selected) => [selected, items.indexOf(selected) + 1]);
+  const selectionsWithIndexes = (selections: string[], items: string[]): [string, number][] =>
+    selections.map((selected) => [selected, items.indexOf(selected) + 1]);
 
   return (
     <Window title={title} width={425} height={300}>

--- a/tgui/packages/tgui/interfaces/CheckboxInput.tsx
+++ b/tgui/packages/tgui/interfaces/CheckboxInput.tsx
@@ -52,8 +52,8 @@ export const CheckboxInput = (props) => {
     setSelections(newSelections);
   };
 
-  const selectionsWithIndexes: (selections: string[], items: string[]) => [string, number][] =
-  (selections, items) => selections.map((selected) => [selected, items.indexOf(selected) + 1]);
+  const selectionsWithIndexes =
+  (selections: string[], items: string[]): [string, number][] => selections.map((selected) => [selected, items.indexOf(selected) + 1]);
 
   return (
     <Window title={title} width={425} height={300}>

--- a/tgui/packages/tgui/interfaces/CheckboxInput.tsx
+++ b/tgui/packages/tgui/interfaces/CheckboxInput.tsx
@@ -51,9 +51,9 @@ export const CheckboxInput = (props) => {
 
     setSelections(newSelections);
   };
-  const selectionIndexes = selections.map(
-    (selected: string) => items.indexOf(selected) + 1,
-  );
+
+  const selectionsWithIndexes: (selections: string[], items: string[]) => [string, number][] =
+  (selections, items) => selections.map((selected) => [selected, items.indexOf(selected) + 1]);
 
   return (
     <Window title={title} width={425} height={300}>
@@ -106,7 +106,7 @@ export const CheckboxInput = (props) => {
           </Stack>
           <Stack.Item mt={0.7}>
             <Section>
-              <InputButtons input={[selections, selectionIndexes]} />
+              <InputButtons input={selectionsWithIndexes(selections, items)} />
             </Section>
           </Stack.Item>
         </Stack>

--- a/tgui/packages/tgui/interfaces/CheckboxInput.tsx
+++ b/tgui/packages/tgui/interfaces/CheckboxInput.tsx
@@ -52,7 +52,10 @@ export const CheckboxInput = (props) => {
     setSelections(newSelections);
   };
 
-  const selectionsWithIndexes = (selections: string[], items: string[]): [string, number][] =>
+  const selectionsWithIndexes = (
+    selections: string[],
+    items: string[],
+  ): [string, number][] =>
     selections.map((selected) => [selected, items.indexOf(selected) + 1]);
 
   return (

--- a/tgui/packages/tgui/interfaces/common/InputButtons.tsx
+++ b/tgui/packages/tgui/interfaces/common/InputButtons.tsx
@@ -7,7 +7,7 @@ type InputButtonsData = {
 };
 
 type InputButtonsProps = {
-  input: string | number | string[] | [string[], number[]];
+  input: string | number | string[] | [string, number][];
   on_submit?: () => void;
   on_cancel?: () => void;
   message?: string;


### PR DESCRIPTION

## About The Pull Request

I fixed up some functionality I added to tgui checkboxes to make them more ergonomic to use; I made them EVEN MORE ergonomic to use, which is to say my first implementation would break if you only selected one thing. This implementation has the same behavior no matter how many choices you make.
## Why It's Good For The Game

I made it work gooder
## Changelog
:cl: Bisar Metek
code: Fixed up the return value of checkbox-input for tgui to behave consistently.
/:cl:
