### PR TITLE
Ensures that mice don't spawn in unsafe atmos from garbage spawners

### DIFF
--- a/code/game/objects/effects/spawners/random/trash.dm
+++ b/code/game/objects/effects/spawners/random/trash.dm
@@ -53,6 +53,12 @@
 		/obj/effect/spawner/random/entertainment/cigar = 1,
 		/obj/item/stack/ore/gold = 1,
 	)
+/obj/effect/spawner/random/trash/grime/Initialize(mapload)
+	if(mapload)
+		var/turf/location = get_turf(loc)
+		if(location.initial_gas_mix != OPENTURF_DEFAULT_ATMOS && location.initial_gas_mix != OPENTURF_DIRTY_ATMOS)
+			loot -= /mob/living/basic/mouse
+	return ..()
 
 /obj/effect/spawner/random/trash/cigbutt
 	name = "cigarette butt spawner"

--- a/code/game/objects/effects/spawners/random/trash.dm
+++ b/code/game/objects/effects/spawners/random/trash.dm
@@ -53,7 +53,7 @@
 		/obj/effect/spawner/random/entertainment/cigar = 1,
 		/obj/item/stack/ore/gold = 1,
 	)
-/obj/effect/spawner/random/trash/grime/Initialize(mapload)
+/obj/effect/spawner/random/trash/deluxe_garbage/Initialize(mapload)
 	if(mapload)
 		var/turf/location = get_turf(loc)
 		if(location.initial_gas_mix != OPENTURF_DEFAULT_ATMOS && location.initial_gas_mix != OPENTURF_DIRTY_ATMOS)


### PR DESCRIPTION

## About The Pull Request

Similarly to grime spawners, mice get removed from the "loot" pool when the trash spawner is placed in unsafe conditions.
Closes #88769

## Changelog
:cl:
fix: Mice no longer can spawn in unsafe atmos from garbage spawners
/:cl:
