### PR TITLE
like 5 tiny deathmatch changes

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -49,7 +49,8 @@
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
 		addtimer(CALLBACK(src, PROC_REF(drop_stuff)), 0)
-	parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
+	if(!istype(target_turf.loc, /area/deathmatch)) // there are so so so many explosives in deathmatch and i dont think anyone is going to fish in the *death*match arena
+		parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
 
 /datum/component/chasm/UnregisterFromParent()
 	storage = null

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -49,7 +49,7 @@
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
 		addtimer(CALLBACK(src, PROC_REF(drop_stuff)), 0)
-	if(!istype(target_turf.loc, /area/deathmatch)) // there are so so so many explosives in deathmatch and i dont think anyone is going to fish in the *death*match arena
+	if(!istype(parent.loc, /area/deathmatch)) // there are so so so many explosives in deathmatch and i dont think anyone is going to fish in the *death*match arena
 		parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
 
 /datum/component/chasm/UnregisterFromParent()

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -49,7 +49,8 @@
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
 		addtimer(CALLBACK(src, PROC_REF(drop_stuff)), 0)
-	if(!istype(parent.loc, /area/deathmatch)) // there are so so so many explosives in deathmatch and i dont think anyone is going to fish in the *death*match arena
+	var/turf/turf_parent = parent
+	if(!istype(turf_parent.loc, /area/deathmatch)) // there are so so so many explosives in deathmatch and i dont think anyone is going to fish in the *death*match arena
 		parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
 
 /datum/component/chasm/UnregisterFromParent()

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -79,6 +79,8 @@
 /// Handles adding the chasm component to the turf (So stuff falls into it!)
 /turf/open/chasm/proc/apply_components(mapload)
 	AddComponent(/datum/component/chasm, GET_TURF_BELOW(src), mapload)
+	if(istype(loc, /area/deathmatch)) // dynamite fishing was not very thought out
+		qdel(GetComponent(/datum/component/fishing_spot)) // KILL 6 BILLION DEM- LOBSTROSITIES
 
 /turf/open/chasm/can_cross_safely(atom/movable/crossing)
 	return HAS_TRAIT(src, TRAIT_CHASM_STOPPED) || HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -79,8 +79,6 @@
 /// Handles adding the chasm component to the turf (So stuff falls into it!)
 /turf/open/chasm/proc/apply_components(mapload)
 	AddComponent(/datum/component/chasm, GET_TURF_BELOW(src), mapload)
-	if(istype(loc, /area/deathmatch)) // dynamite fishing was not very thought out
-		qdel(GetComponent(/datum/component/fishing_spot)) // KILL 6 BILLION DEM- LOBSTROSITIES
 
 /turf/open/chasm/can_cross_safely(atom/movable/crossing)
 	return HAS_TRAIT(src, TRAIT_CHASM_STOPPED) || HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -643,7 +643,7 @@
 	r_hand = /obj/item/sbeacondrop/bomb
 	l_pocket = /obj/item/grenade/syndieminibomb
 	r_pocket = /obj/item/grenade/syndieminibomb
-	implants = list(/obj/item/implanter/explosive_macro)
+	implants = list(/obj/item/implant/explosive/macro)
 	backpack_contents = list(
 		/obj/item/assembly/signaler = 10,
 	)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -38,6 +38,7 @@
 		loadouts = GLOB.deathmatch_game.loadouts
 	add_player(player, loadouts[1], TRUE)
 	ui_interact(player)
+	addtimer(CALLBACK(src, PROC_REF(lobby_afk_probably)), 5 MINUTES) // being generous here
 
 /datum/deathmatch_lobby/Destroy(force, ...)
 	. = ..()
@@ -168,6 +169,12 @@
 		return
 	announce(span_reallybig("The players have took too long! Game ending!"))
 	end_game()
+
+/datum/deathmatch_lobby/proc/lobby_afk_probably()
+	if (QDELING(src))
+		return
+	announce(span_warning("Lobby ([host]) was closed due to not starting after 5 minutes, being potentially AFK. Please be faster next time."))
+	GLOB.deathmatch_game.remove_lobby(host)
 
 /datum/deathmatch_lobby/proc/end_game()
 	if (!location)
@@ -306,7 +313,7 @@
 	var/max_players = map.max_players
 	for (var/possible_unlucky_loser in players)
 		max_players--
-		if (max_players <= 0)
+		if (max_players < 0)
 			var/loser_mob = players[possible_unlucky_loser]["mob"]
 			remove_ckey_from_play(possible_unlucky_loser)
 			add_observer(loser_mob)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -171,7 +171,7 @@
 	end_game()
 
 /datum/deathmatch_lobby/proc/lobby_afk_probably()
-	if (QDELING(src))
+	if (QDELING(src) || playing)
 		return
 	announce(span_warning("Lobby ([host]) was closed due to not starting after 5 minutes, being potentially AFK. Please be faster next time."))
 	GLOB.deathmatch_game.remove_lobby(host)

--- a/tgui/packages/tgui/interfaces/DeathmatchPanel.tsx
+++ b/tgui/packages/tgui/interfaces/DeathmatchPanel.tsx
@@ -133,17 +133,15 @@ function LobbyDisplay(props) {
       </Table.Cell>
       <Table.Cell collapsing>
         {!lobby.playing ? (
-          <>
-            <Button
-              disabled={isActive}
-              color="good"
-              onClick={() => act('join', { id: lobby.name })}
-              width="100%"
-              textAlign="center"
-            >
-              {playing === lobby.name ? 'View' : 'Join'}
-            </Button>
-          </>
+          <Button
+            disabled={isActive}
+            color="good"
+            onClick={() => act('join', { id: lobby.name })}
+            width="100%"
+            textAlign="center"
+          >
+            {playing === lobby.name ? 'View' : 'Join'}
+          </Button>
         ) : (
           <Button
             disabled={isActive}

--- a/tgui/packages/tgui/interfaces/DeathmatchPanel.tsx
+++ b/tgui/packages/tgui/interfaces/DeathmatchPanel.tsx
@@ -138,14 +138,11 @@ function LobbyDisplay(props) {
               disabled={isActive}
               color="good"
               onClick={() => act('join', { id: lobby.name })}
+              width="100%"
+              textAlign="center"
             >
               {playing === lobby.name ? 'View' : 'Join'}
             </Button>
-            <Button
-              color="caution"
-              icon="eye"
-              onClick={() => act('spectate', { id: lobby.name })}
-            />
           </>
         ) : (
           <Button


### PR DESCRIPTION

## About The Pull Request

you may no longer fish in deathmatch chasms
as a result that means doing literally anything with explosives wont send 9000000 lobstrosities onto the map
fixed cuban pete loadout macrobomb
lobbies will close after 5 minutes of inactivity
changing map will now make a more accurate number of observers

also removed that useless eye button in the lobby list

## Why It's Good For The Game
6 billion lobstroties because of a firecracker sucks
bug bad
afk empty lobbies bad

## Changelog
:cl:
fix: deathmatch - chasms will no longer do anything when blown up, cuban pete loadout macrobomb fixed, AFK lobbies will close after 5 minutes, fixed changing maps incorrectly taking one more observer than it should
/:cl:
