### PR TITLE
uses the nt frequency define for loaded modlinks instead of just "NT"

### DIFF
--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -317,7 +317,7 @@
 	on_user_set_dir_generic(mod_link, newdir || SOUTH)
 
 /obj/item/clothing/neck/link_scryer/loaded
-	starting_frequency = "NT"
+	starting_frequency = MODLINK_FREQ_NANOTRASEN
 
 /obj/item/clothing/neck/link_scryer/loaded/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

see title
## Why It's Good For The Game

if the frequency is ever changed from NT by default for any reason, pre-loaded scryers wont be able to call normal modsuits because they dont use the define without this
## Changelog
:cl:
code: modlink scryers use the nt frequency define rather than just plain text doing it themselves
/:cl:
