### PR TITLE
Silicons can toggle open state of shutters and blast doors by clicking them

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -481,8 +481,12 @@
 	src.animation = animation
 	update_appearance()
 
-/// Public proc that simply handles opening the door. Returns TRUE if the door was opened, FALSE otherwise.
-/// Use argument "forced" in conjunction with try_to_force_door_open if you want/need additional checks depending on how sorely you need the door opened.
+/**
+ * Public proc that simply handles opening the door. Returns TRUE if the door was opened, FALSE otherwise.
+ *
+ * Arguments:
+ * * forced - Use in conjunction with try_to_force_door_open if you want/need additional checks depending on how sorely you need the door opened.
+ */
 /obj/machinery/door/proc/open(forced = DEFAULT_DOOR_CHECKS)
 	if(!density)
 		return TRUE

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -52,6 +52,14 @@
 		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)
 			. += span_notice("The <i>wires</i> have been removed and it's ready to be <b>sliced apart</b>.")
 
+/obj/machinery/door/poddoor/attack_ai(mob/user)
+	. = ..()
+	open(FALSE) // silicons can't open something remotely if it is unpowered
+
+/obj/machinery/door/poddoor/attack_robot(mob/user)
+	. = ..()
+	return attack_ai()
+
 /obj/machinery/door/poddoor/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(isnull(held_item))

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -54,7 +54,7 @@
 
 /obj/machinery/door/poddoor/attack_ai(mob/user)
 	. = ..()
-	open(FALSE) // silicons can't open something remotely if it is unpowered
+	try_to_activate_door(user, TRUE)
 
 /obj/machinery/door/poddoor/attack_robot(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
title 
## Why It's Good For The Game
- since they can do it to airlocks, why not shutters and blast doors?
- more possibilities for silicons to kill people
## Changelog
:cl: grungussuss
add: Silicons can now remotely close or open shutters and blast doors by clicking on them.
/:cl:
