### PR TITLE
Fix airlock authentication card not getting stored in containers

### DIFF
--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -176,6 +176,12 @@
 	. = ..()
 	type_whitelist = list(typesof(/obj/machinery/door/airlock), typesof(/obj/machinery/door/window/), typesof(/obj/machinery/door/firedoor)) //list of all acceptable typepaths that this device can affect
 
+/obj/item/card/emag/doorjack/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	// only for doorjacks since regular emags still need to be able to break locks on storage items
+	if(interacting_with.atom_storage)
+		return NONE
+	. = ..()
+
 /obj/item/card/emag/doorjack/proc/use_charge(mob/user)
 	charges --
 	to_chat(user, span_notice("You use [src]. It now has [charges] charge[charges == 1 ? "" : "s"] remaining."))


### PR DESCRIPTION

## About The Pull Request
Trying to insert an airlock auth card into a bag or container would not work due to a message saying the target must be an airlock. It's now fixed and should insert into a container regardless if on help or harm intent.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix airlock authentication card not getting stored in containers
/:cl:
