### PR TITLE
Add currently playing song name to jukebox examine text

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -26,6 +26,11 @@
 	QDEL_NULL(music_player)
 	return ..()
 
+/obj/machinery/jukebox/examine(mob/user)
+	. = ..()
+	if(music_player.active_song_sound)
+		. += "Now playing: [music_player.selection.song_name]"
+
 /obj/machinery/jukebox/no_access
 	req_access = null
 


### PR DESCRIPTION
## About The Pull Request

Add a line to the jukebox's examine text with the name of the song if there's currently one playing

## Why It's Good For The Game

Sometimes you wanna know what song this is without having to go up and open the UI

## Changelog

:cl:
qol: you can now examine the jukebox to see what song is currently playing
/:cl:
