### PR TITLE
Makes the Syndie Lipstick's uplink desc more descriptive

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -31,7 +31,9 @@
 
 /datum/uplink_item/stealthy_weapons/slipstick
 	name = "Syndie Lipstick"
-	desc = "Stylish way to kiss to death, isn't it syndiekisser?"
+	desc = "A highly advanced container of lipstick, we'll save you the trouble of explaining how it works here: \
+		After applying the lipstick to yourself, any kisses you blow will turn into laser kisses! (Use the kiss emote to fire laser kisses.) \
+		You may blow an unlimited amount of laser kisses! Stylish way to kiss to death, isn't it syndiekisser?"
 	item = /obj/item/lipstick/syndie
 	cost = 6
 


### PR DESCRIPTION
## About The Pull Request

Hi, i did something similar to this in: https://github.com/tgstation/tgstation/pull/87157
This uplink listing didn't tell people what it does or how it's used, and that's no good.

## Why It's Good For The Game

People should know what these things do BEFORE they buy them, nor should they have to boot up the wiki to find out.

## Changelog

:cl:
qol: The Syndie Lipstick's desc in the uplink now actually tells the potential buyer what it does (and how to use it)
/:cl:
