### PR TITLE
[NO GBP] *Properly* rebuild plane masters after client login if switching between 515 and 516

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -106,6 +106,10 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	// and avoid needing to make changes to all idk 300 consumers if we want to change the appearance
 	var/list/asset_refs_for_reuse = list()
 
+	/// The BYOND version of the client that was last logged into this mob.
+	/// Currently used to rebuild all plane master groups when going between 515<->516.
+	var/last_byond_version
+
 /datum/hud/New(mob/owner)
 	mymob = owner
 
@@ -153,13 +157,17 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 /datum/hud/proc/client_refresh(datum/source)
 	SIGNAL_HANDLER
 	var/client/client = mymob.canon_client
-	if(client.rebuild_plane_masters)
-		var/new_relay_loc = (client.byond_version > 515) ? "1,1" : "CENTER"
+	var/new_byond_version = client.byond_version
+#if MIN_COMPILER_VERSION > 515
+	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
+#endif
+	if(!isnull(last_byond_version) && new_byond_version != last_byond_version)
+		var/new_relay_loc = (new_byond_version > 515) ? "1,1" : "CENTER"
 		for(var/group_key as anything in master_groups)
 			var/datum/plane_master_group/group = master_groups[group_key]
 			group.relay_loc = new_relay_loc
-			group.rebuild_plane_masters()
-		client.rebuild_plane_masters = FALSE
+			group.rebuild_hud()
+	last_byond_version = new_byond_version
 	RegisterSignal(client, COMSIG_CLIENT_SET_EYE, PROC_REF(on_eye_change))
 	on_eye_change(null, null, client.eye)
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -269,7 +269,3 @@
 
 	///Which ambient sound this client is currently being provided.
 	var/current_ambient_sound
-
-	/// Does this client's mob need to rebuild its plane masters after login?
-	/// This is currently only used so a client can switch between 515 and 516 without breaking their rendering.
-	var/rebuild_plane_masters = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -332,16 +332,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(GLOB.player_details[ckey])
 		reconnecting = TRUE
 		player_details = GLOB.player_details[ckey]
-		var/old_version = player_details.byond_version
 		player_details.byond_version = byond_version
 		player_details.byond_build = byond_build
-
-#if MIN_COMPILER_VERSION > 516
-	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
-#endif
-		if(old_version != byond_version)
-			rebuild_plane_masters = TRUE
-
 	else
 		player_details = new(ckey)
 		player_details.byond_version = byond_version


### PR DESCRIPTION
## About The Pull Request

so i discovered this downstream, but forgot to pr upstream til now, the proper way to rebuild planemasters is `rebuild_hud`, not directly calling `rebuild_plane_masters`

## Why It's Good For The Game

whoopsie breaking graphics is bad

## Changelog
:cl:
fix: Fixed graphics getting screwed up when reconnecting with BYOND 515 after playing on BYOND 516.
/:cl:
