### PR TITLE
Fixes prettier file associations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
 	"git.branchProtection": ["master"],
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",
-	"[javascript][typescript][typescriptreact][javascriptreact][html][scss][css][json][jsonc][markdown]": {
+	"[javascript][typescript][typescriptreact][javascriptreact][html][scss][css][json][jsonc][markdown][yaml]": {
 		"editor.rulers": [80],
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 		"editor.formatOnSave": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,27 +18,7 @@
 	"git.branchProtection": ["master"],
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",
-	"[javascript]": {
-		"editor.rulers": [80],
-		"editor.defaultFormatter": "esbenp.prettier-vscode",
-		"editor.formatOnSave": true
-	},
-	"[javascriptreact]": {
-		"editor.rulers": [80],
-		"editor.defaultFormatter": "esbenp.prettier-vscode",
-		"editor.formatOnSave": true
-	},
-	"[typescript]": {
-		"editor.rulers": [80],
-		"editor.defaultFormatter": "esbenp.prettier-vscode",
-		"editor.formatOnSave": true
-	},
-	"[typescriptreact]": {
-		"editor.rulers": [80],
-		"editor.defaultFormatter": "esbenp.prettier-vscode",
-		"editor.formatOnSave": true
-	},
-	"[scss]": {
+	"[javascript][typescript][typescriptreact][javascriptreact][html][scss][css][json][jsonc][markdown]": {
 		"editor.rulers": [80],
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 		"editor.formatOnSave": true


### PR DESCRIPTION
## About The Pull Request
Small change that not only saves a few lines from our current config but also enforces prettier on other file types (INSIDE tgui).

VS Code is kind of confusing in re: formatter settings and which setting takes precedence. I've learned that adding this just fixes weirdness with user-set formatters. This overrides local configuration, which we are trying to do anyway with .editorconfig.

Based on [this informative tweet](https://x.com/colinhacks/status/1841934672647094599) by colinhacks, creator of zod
## Why It's Good For The Game
More PRs can pass linters on CI
## Changelog

N/A