### PR TITLE
Makes autoshotguns less hacky by leveraging guncode

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -53,9 +53,9 @@
 
 // Automatic Shotguns//
 
-/obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user)
-	..()
-	rack()
+/obj/item/gun/ballistic/shotgun/automatic
+	semi_auto = TRUE
+	casing_ejector = TRUE
 
 /obj/item/gun/ballistic/shotgun/automatic/combat
 	name = "combat shotgun"
@@ -86,7 +86,6 @@
 	inhand_y_dimension = 32
 	worn_icon_state = "cshotgun"
 	w_class = WEIGHT_CLASS_HUGE
-	semi_auto = TRUE
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
 	/// If defined, the secondary tube is this type, if you want different shell loads


### PR DESCRIPTION
## About The Pull Request
automatic subtype shotguns e.g. the combat shotgun no longer use a hacky "pump after every live shot" to handle chambering a new shell and instead are just flagged as semi-automatic with casing ejection to recreate the same functionality without hacky bolt-racking calls

## Why It's Good For The Game
i got curious about how combat shotguns handled shotgun pumping and realized this was kinda hacky

## Changelog

:cl:
code: Semi-automatic shotguns (e.g. combat shotguns) no longer magically pump themselves in lieu of just properly ejecting spent casings.
/:cl: