### PR TITLE
virtual pets now auto-follow you on release

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -436,6 +436,10 @@
 #define COMSIG_COMPUTER_RECEIVED_MESSAGE "computer_received_message"
 ///from /datum/computer_file/program/virtual_pet/proc/handle_level_up
 #define COMSIG_VIRTUAL_PET_LEVEL_UP "virtual_pet_level_up"
+///from /datum/computer_file/program/virtual_pet/proc/release_pet
+#define COMSIG_VIRTUAL_PET_SUMMONED "virtual_pet_summoned"
+///from /datum/computer_file/program/virtual_pet/proc/recall_pet
+#define COMSIG_VIRTUAL_PET_RECALLED "virtual_pet_recalled"
 
 // /obj/vehicle/sealed/mecha signals
 

--- a/code/modules/mob/living/basic/pets/orbie/orbie_ai.dm
+++ b/code/modules/mob/living/basic/pets/orbie/orbie_ai.dm
@@ -105,6 +105,14 @@
 /datum/pet_command/follow/orbie
 	follow_behavior = /datum/ai_behavior/pet_follow_friend/orbie
 
+/datum/pet_command/follow/orbie/New(mob/living/parent)
+	. = ..()
+	RegisterSignal(parent, COMSIG_VIRTUAL_PET_SUMMONED, PROC_REF(on_summon))
+
+/datum/pet_command/follow/orbie/proc/on_summon(datum/source, mob/living/friend)
+	SIGNAL_HANDLER
+	set_command_active(source, friend)
+
 /datum/ai_behavior/pet_follow_friend/orbie
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_MOVE_AND_PERFORM | AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 

--- a/code/modules/modular_computers/file_system/programs/virtual_pet.dm
+++ b/code/modules/modular_computers/file_system/programs/virtual_pet.dm
@@ -486,7 +486,7 @@ GLOBAL_LIST_EMPTY(virtual_pets_list)
 			if(pet.loc == computer)
 				release_pet(ui.user)
 			else
-				recall_pet()
+				recall_pet(ui.user)
 			COOLDOWN_START(src, summon_cooldown, 10 SECONDS)
 
 		if("apply_customization")
@@ -585,9 +585,10 @@ GLOBAL_LIST_EMPTY(virtual_pets_list)
 	var/obj/item/food/virtual_chocolate/chocolate = new(get_turf(computer))
 	chocolate.AddElement(/datum/element/temporary_atom, life_time = 30 SECONDS) //we cant maintain its existence for too long!
 
-/datum/computer_file/program/virtual_pet/proc/recall_pet()
+/datum/computer_file/program/virtual_pet/proc/recall_pet(mob/living/friend)
 	animate(pet, transform = matrix().Scale(0.3, 0.3), time = 1.5 SECONDS)
 	addtimer(CALLBACK(pet, TYPE_PROC_REF(/atom/movable, forceMove), computer), 1.5 SECONDS)
+	SEND_SIGNAL(pet, COMSIG_VIRTUAL_PET_RECALLED, friend)
 
 /datum/computer_file/program/virtual_pet/proc/release_pet(mob/living/our_user)
 	var/turf/drop_zone
@@ -602,6 +603,7 @@ GLOBAL_LIST_EMPTY(virtual_pets_list)
 	animate(pet, transform = matrix(), time = 1.5 SECONDS)
 	pet.forceMove(final_turf)
 	playsound(computer.loc, 'sound/mobs/non-humanoids/orbie/orbie_send_out.ogg', 20)
+	SEND_SIGNAL(pet, COMSIG_VIRTUAL_PET_SUMMONED, our_user)
 	new /obj/effect/temp_visual/guardian/phase(pet.loc)
 
 #undef PET_MAX_LEVEL


### PR DESCRIPTION

## About The Pull Request
when you summon a virtual pet's hologram, itll automatically follow you on release rather than u having to give it the command

## Why It's Good For The Game
adds some minor convenience to the minigame. 

## Changelog
:cl:
qol: virtual pet holograms now automatically follow you when released rather than having to give it the command post summon
/:cl:
