### PR TITLE
Fixes shuttles leaving replaced floors behind

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -609,7 +609,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	CRASH("Bad op: area/drop_location() called")
 
 /// A hook so areas can modify the incoming args of ChangeTurf
-/area/proc/PlaceOnTopReact(list/new_baseturfs, turf/added_layer, flags)
+/area/proc/place_on_top_react(list/new_baseturfs, turf/added_layer, flags)
 	return flags
 
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -608,8 +608,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/drop_location()
 	CRASH("Bad op: area/drop_location() called")
 
-/// A hook so areas can modify the incoming args (of what??)
-/area/proc/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
+/// A hook so areas can modify the incoming args of ChangeTurf
+/area/proc/PlaceOnTopReact(list/new_baseturfs, turf/added_layer, flags)
 	return flags
 
 

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -17,11 +17,11 @@
 	sound_environment = SOUND_ENVIRONMENT_ROOM
 
 
-/area/shuttle/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
+/area/shuttle/PlaceOnTopReact(list/new_baseturfs, turf/added_layer, flags)
 	. = ..()
-	if(length(new_baseturfs) > 1 || fake_turf_type)
-		return // More complicated larger changes indicate this isn't a player
-	if(ispath(new_baseturfs[1], /turf/open/floor/plating))
+	if(ispath(added_layer, /turf/open/floor/plating))
+		new_baseturfs.Add(/turf/baseturf_skipover/shuttle)
+	else if(ispath(new_baseturfs[1], /turf/open/floor/plating))
 		new_baseturfs.Insert(1, /turf/baseturf_skipover/shuttle)
 
 ////////////////////////////Multi-area shuttles////////////////////////////

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -17,7 +17,7 @@
 	sound_environment = SOUND_ENVIRONMENT_ROOM
 
 
-/area/shuttle/PlaceOnTopReact(list/new_baseturfs, turf/added_layer, flags)
+/area/shuttle/place_on_top_react(list/new_baseturfs, turf/added_layer, flags)
 	. = ..()
 	if(ispath(added_layer, /turf/open/floor/plating))
 		new_baseturfs.Add(/turf/baseturf_skipover/shuttle)

--- a/code/game/turfs/baseturfs.dm
+++ b/code/game/turfs/baseturfs.dm
@@ -34,6 +34,8 @@
 	new_baseturfs.Add(baseturfs)
 	if(isopenturf(src))
 		new_baseturfs.Add(type)
+	var/area/our_area = get_area(src)
+	flags = our_area.PlaceOnTopReact(new_baseturfs, added_layer, flags)
 
 	return ChangeTurf(added_layer, new_baseturfs, flags)
 

--- a/code/game/turfs/baseturfs.dm
+++ b/code/game/turfs/baseturfs.dm
@@ -35,14 +35,14 @@
 	if(isopenturf(src))
 		new_baseturfs.Add(type)
 	var/area/our_area = get_area(src)
-	flags = our_area.PlaceOnTopReact(new_baseturfs, added_layer, flags)
+	flags = our_area.place_on_top_react(new_baseturfs, added_layer, flags)
 
 	return ChangeTurf(added_layer, new_baseturfs, flags)
 
 /// Places a turf on top - for map loading
 /turf/proc/load_on_top(turf/added_layer, flags)
 	var/area/our_area = get_area(src)
-	flags = our_area.PlaceOnTopReact(list(baseturfs), added_layer, flags)
+	flags = our_area.place_on_top_react(list(baseturfs), added_layer, flags)
 
 	if(flags & CHANGETURF_SKIP) // We haven't been initialized
 		if(flags_1 & INITIALIZED_1)


### PR DESCRIPTION
## About The Pull Request

The splitting of the `PlaceOnTop` proc in #79702 removed the call to `PlaceOnTopReact` that shuttle areas use to place shuttle baseturf skipovers under any plating placed on them. This is the underlying cause of repaired shuttle tiles getting left behind when the shuttle moves.

This PR was originally part of #88493, but has been atomized out because if that PR ever gets merged, it's going to be many weeks before it does.

## Why It's Good For The Game

Fixes #81099 

## Changelog


:cl:
fix: Replaced floor tiles on shuttles no longer get left behind when the shuttle moves.
/:cl:
