### PR TITLE
make roundstart stairs only destructible by medium explosions and above

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -65,7 +65,7 @@
 	return ..()
 
 /obj/structure/stairs/ex_act(severity, target) //makes roundstart stairs only destructible by anything bigger than a light explosion
-	if(resistance_flags & INDESTRUCTIBLE)
+	if(!(resistance_flags & INDESTRUCTIBLE))
 		return ..()
 	if(QDELETED(src) || severity <= EXPLODE_LIGHT)
 		return TRUE

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -8,6 +8,7 @@
 
 /obj/structure/stairs
 	name = "stairs"
+	desc = "A set of stairs. Cool!"
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
 	anchored = TRUE
@@ -16,6 +17,8 @@
 	var/force_open_above = FALSE // replaces the turf above this stair obj with /turf/open/openspace
 	var/terminator_mode = STAIR_TERMINATOR_AUTOMATIC
 	var/turf/listeningTo
+	/// were we made indestructible by mapload
+	var/indestructible_by_mapload = FALSE
 
 /obj/structure/stairs/north
 	dir = NORTH
@@ -52,12 +55,25 @@
 
 	AddElement(/datum/element/connect_loc, loc_connections)
 
+	if(mapload)
+		indestructible_by_mapload = TRUE
+		resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+		desc += " These seem to be reinforced against any sort of damage.. except for a bomb.."
+
 	return ..()
 
 /obj/structure/stairs/Destroy()
 	listeningTo = null
 	GLOB.stairs -= src
 	return ..()
+
+/obj/structure/stairs/ex_act(severity, target) //makes roundstart stairs only destructible by anything bigger than a light explosion
+	if(!indestructible_by_mapload)
+		return ..()
+	if(QDELETED(src) || severity <= EXPLODE_LIGHT)
+		return TRUE
+	atom_destruction(BOMB)
+	return TRUE
 
 /obj/structure/stairs/Move() //Look this should never happen but...
 	. = ..()

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -17,8 +17,6 @@
 	var/force_open_above = FALSE // replaces the turf above this stair obj with /turf/open/openspace
 	var/terminator_mode = STAIR_TERMINATOR_AUTOMATIC
 	var/turf/listeningTo
-	/// were we made indestructible by mapload
-	var/indestructible_by_mapload = FALSE
 
 /obj/structure/stairs/north
 	dir = NORTH
@@ -56,7 +54,6 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 	if(mapload)
-		indestructible_by_mapload = TRUE
 		resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 		desc += " These seem to be reinforced against any sort of damage.. except for a bomb.."
 
@@ -68,7 +65,7 @@
 	return ..()
 
 /obj/structure/stairs/ex_act(severity, target) //makes roundstart stairs only destructible by anything bigger than a light explosion
-	if(!indestructible_by_mapload)
+	if(resistance_flags & INDESTRUCTIBLE)
 		return ..()
 	if(QDELETED(src) || severity <= EXPLODE_LIGHT)
 		return TRUE


### PR DESCRIPTION

## About The Pull Request

make roundstart stairs only destructible by medium explosions and above

tldr this means blobs cant destroy it
fires cant destroy it
whatever else cant destroy it

bombs can though

## Why It's Good For The Game
stairs much like ladders are critical to connect z levels together and them breaking so easy sucks
resolves that by not making them as easy to break

also the blob strat to just spawn in icebox perma and immediately eat the stairs fucking sucks
doesnt fix it but makes it less powerful

none of this applies for non roundstart ones by the way we dont want people to make indestructible stuff

## Changelog
:cl:
balance: make roundstart stairs only destructible by medium explosions and above
/:cl:
