### PR TITLE
removes an errant percent while recharging the BR-38

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -58,7 +58,7 @@
 		return
 	if(istype(charging, /obj/item/gun/ballistic/automatic/battle_rifle))
 		var/obj/item/gun/ballistic/automatic/battle_rifle/recalibrating_gun = charging
-		. += span_notice("- \The [charging]'s system degradation is at stage [recalibrating_gun.degradation_stage] of [recalibrating_gun.degradation_stage_max]%</b>.")
+		. += span_notice("- \The [charging]'s system degradation is at stage [recalibrating_gun.degradation_stage] of [recalibrating_gun.degradation_stage_max]</b>.")
 		. += span_notice("- \The [charging]'s degradation buffer is at <b>[PERCENT(recalibrating_gun.shots_before_degradation/recalibrating_gun.max_shots_before_degradation)]%</b>.")
 		return
 	. += span_notice("- \The [charging] is not reporting a power level.")


### PR DESCRIPTION
## About The Pull Request
The max system degradation level readout on the recharger while using the BR-38 no longer has an errant percent in the readout.

## Why It's Good For The Game
It bugged me. Also I guess that if this wasn't fixed it could imply that the degradation states are percentage based when they're not.

## Changelog

:cl:
spellcheck: Removed an errant typo on the recharger's readout while recharging the BR-38.
/:cl:
