### PR TITLE
Moves the compact combat shotgun back into the warden's locker

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -325,10 +325,10 @@
 	return add_item_to_steal(src, /obj/item/gun/energy/e_gun/hos)
 
 /datum/objective_item/steal/compactshotty
-	name = "the head of security's personal compact shotgun"
+	name = "the warden's personal compact shotgun"
 	targetitem = /obj/item/gun/ballistic/shotgun/automatic/combat/compact
-	excludefromjob = list(JOB_HEAD_OF_SECURITY)
-	item_owner = list(JOB_HEAD_OF_SECURITY)
+	excludefromjob = list(JOB_WARDEN)
+	item_owner = list(JOB_WARDEN)
 	exists_on_map = TRUE
 	difficulty = 4
 	steal_hint = "A miniaturized combat shotgun. May be found in Head of Security's locker or strapped to their back."

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -94,6 +94,12 @@
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/door_remote/head_of_security(src)
+
+
+/obj/structure/closet/secure_closet/warden/populate_contents_immediate()
+	. = ..()
+
+	// Traitor steal objective
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 
 /obj/structure/closet/secure_closet/security

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -77,7 +77,6 @@
 	// Traitor steal objectives
 	new /obj/item/gun/energy/e_gun/hos(src)
 	new /obj/item/pinpointer/nuke(src)
-	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"
@@ -95,6 +94,7 @@
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/door_remote/head_of_security(src)
+	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Also updates the theft objective appropriately.

## Why It's Good For The Game

@MrMelbert asked me to do this, and I'm happy to oblige.

Firstly, the HoS has a signature gun as it is. His X-01 Multiphase. Having another weapon in the form of the shotgun kind of steps on the toes of that weapon's presence, and clutters his arsenal somewhat. The HoS, as is, has the means of gearing for alternative equipment if needed, but let's keep it somewhat slim for weapons.

Secondly; it feels more appropriate as a riot suppression weapon. And the warden puts down riots and brig invasions. He is the CQB guy after all, he should have a shotgun. It's a bit of an identity thing and a functionality thing. Of course, he could just get a riot shotgun (so can the HOS in this instance), but I think having a special one does have impact from a purely aesthetics point of view, gives more of a feeling of 'ownership' over the shotgun (which matters for the sake of whether people are determined as overgearing or not), as well as telegraphing what should be his combat strategy for him more clearly.

No, there is no option where they both have shotguns. Don't bother asking.

## Changelog
:cl:
balance: The compact combat shotgun is now found in the warden's locker.
/:cl:
