### PR TITLE
Xenomorphs transfer non-standard organs (including the absence of such organs) on evolution.

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -24,6 +24,16 @@
 		/obj/item/bodypart/leg/left/alien,
 	)
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	)
+
 GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	/datum/strippable_item/hand/left,
 	/datum/strippable_item/hand/right,
@@ -35,10 +45,6 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	. = ..()
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW, 0.5, -11)
 	AddElement(/datum/element/strippable, GLOB.strippable_alien_humanoid_items)
-
-/mob/living/carbon/alien/adult/create_internal_organs()
-	organs += new /obj/item/organ/stomach/alien()
-	return ..()
 
 /mob/living/carbon/alien/adult/cuff_resist(obj/item/I)
 	playsound(src, 'sound/mobs/non-humanoids/hiss/hiss5.ogg', 40, TRUE, TRUE)  //Alien roars when starting to break free

--- a/code/modules/mob/living/carbon/alien/adult/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/adult/caste/drone.dm
@@ -5,14 +5,21 @@
 	health = 125
 	icon_state = "aliend"
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+	)
+
 /mob/living/carbon/alien/adult/drone/Initialize(mapload)
 	GRANT_ACTION(/datum/action/cooldown/alien/evolve_to_praetorian)
-	return ..()
-
-/mob/living/carbon/alien/adult/drone/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large
-	organs += new /obj/item/organ/alien/resinspinner
-	organs += new /obj/item/organ/alien/acid
 	return ..()
 
 /datum/action/cooldown/alien/evolve_to_praetorian

--- a/code/modules/mob/living/carbon/alien/adult/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/adult/caste/hunter.dm
@@ -5,13 +5,21 @@
 	health = 125
 	icon_state = "alienh"
 	alien_speed = -0.3
+
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small,
+	)
+
 	var/atom/movable/screen/leap_icon = null
 	///How fast does our pounce move us?
 	var/pounce_speed = 2
-
-/mob/living/carbon/alien/adult/hunter/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small
-	..()
 
 //Hunter verbs
 

--- a/code/modules/mob/living/carbon/alien/adult/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/adult/caste/praetorian.dm
@@ -6,6 +6,20 @@
 	icon_state = "alienp"
 	alien_speed = 0.5
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin,
+	)
+
 /mob/living/carbon/alien/adult/royal/praetorian/Initialize(mapload)
 	real_name = name
 
@@ -16,13 +30,6 @@
 
 	grant_actions_by_list(innate_actions)
 
-	return ..()
-
-/mob/living/carbon/alien/adult/royal/praetorian/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large
-	organs += new /obj/item/organ/alien/resinspinner
-	organs += new /obj/item/organ/alien/acid
-	organs += new /obj/item/organ/alien/neurotoxin
 	return ..()
 
 /datum/action/cooldown/alien/evolve_to_queen

--- a/code/modules/mob/living/carbon/alien/adult/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/adult/caste/sentinel.dm
@@ -6,12 +6,19 @@
 	icon_state = "aliens"
 	alien_speed = 0.2
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin,
+	)
+
 /mob/living/carbon/alien/adult/sentinel/Initialize(mapload)
 	GRANT_ACTION(/datum/action/cooldown/mob_cooldown/sneak/alien)
 	return ..()
-
-/mob/living/carbon/alien/adult/sentinel/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	organs += new /obj/item/organ/alien/acid
-	organs += new /obj/item/organ/alien/neurotoxin
-	..()

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -43,6 +43,21 @@
 	melee_damage_upper = 50
 	alien_speed = 2
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large/queen,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin,
+		ORGAN_SLOT_XENO_EGGSAC = /obj/item/organ/alien/eggsac,
+	)
+
 /mob/living/carbon/alien/adult/royal/queen/Initialize(mapload)
 	var/static/list/innate_actions = list(
 		/datum/action/cooldown/alien/promote,
@@ -50,14 +65,6 @@
 	)
 	grant_actions_by_list(innate_actions)
 
-	return ..()
-
-/mob/living/carbon/alien/adult/royal/queen/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large/queen
-	organs += new /obj/item/organ/alien/resinspinner
-	organs += new /obj/item/organ/alien/acid
-	organs += new /obj/item/organ/alien/neurotoxin
-	organs += new /obj/item/organ/alien/eggsac
 	return ..()
 
 /mob/living/carbon/alien/adult/royal/queen/set_name()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -33,6 +33,15 @@
 		/obj/item/queen_promotion,
 	))
 
+	var/list/default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+	)
+
 /mob/living/carbon/alien/Initialize(mapload)
 	add_verb(src, /mob/living/proc/mob_sleep)
 	add_verb(src, /mob/living/proc/toggle_resting)
@@ -52,14 +61,11 @@
 		span_alien("Your claws lack the dexterity to hold %TARGET."), \
 		CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_has_trait), src, TRAIT_ADVANCEDTOOLUSER))
 
-/mob/living/carbon/alien/create_internal_organs()
-	organs += new /obj/item/organ/brain/alien
-	organs += new /obj/item/organ/alien/hivenode
-	organs += new /obj/item/organ/tongue/alien
-	organs += new /obj/item/organ/eyes/alien
-	organs += new /obj/item/organ/liver/alien
-	organs += new /obj/item/organ/ears
-	..()
+/mob/living/carbon/alien/proc/create_internal_organs()
+	for(var/slot in default_organ_types_by_slot)
+		var/organ_type = default_organ_types_by_slot[slot]
+		var/obj/item/organ/organ = new organ_type()
+		organ.Insert(src, special = TRUE)
 
 /mob/living/carbon/alien/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) // beepsky won't hunt aliums
 	return -10
@@ -144,6 +150,24 @@ Des: Removes all infected images from the alien.
 	if(mind)
 		mind.name = new_xeno.real_name
 		mind.transfer_to(new_xeno)
+
+	for(var/slot in (organs_slot | default_organ_types_by_slot))
+		var/obj/item/organ/old_organ = get_organ_slot(slot)
+		var/obj/item/organ/new_organ = new_xeno.get_organ_slot(slot)
+		if(old_organ)
+			// Transfer any organs that differ from their intended original type
+			// Also transfer brains regardless - if we somehow put skillchips or traumas into xeno brains, those should carry over
+			if(istype(old_organ, /obj/item/organ/brain) || (old_organ.type != default_organ_types_by_slot[slot]))
+				if(new_organ)
+					new_organ.Remove(new_xeno, special = TRUE, movement_flags = NO_ID_TRANSFER)
+					qdel(new_organ)
+				old_organ.Remove(src, special = TRUE, movement_flags = NO_ID_TRANSFER)
+				old_organ.Insert(new_xeno, special = TRUE, movement_flags = NO_ID_TRANSFER)
+		else
+			// If we don't have an organ in a slot that should have one in both the old and new xeno, remove the organ from that slot in the new xeno
+			if(default_organ_types_by_slot[slot] && new_xeno.default_organ_types_by_slot[slot] && new_organ)
+				new_organ.Remove(new_xeno, special = TRUE)
+				qdel(new_organ)
 
 	var/obj/item/organ/stomach/alien/melting_pot = get_organ_slot(ORGAN_SLOT_STOMACH)
 	var/obj/item/organ/stomach/alien/frying_pan = new_xeno.get_organ_slot(ORGAN_SLOT_STOMACH)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -24,6 +24,16 @@
 		/obj/item/bodypart/head/larva,
 	)
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small/tiny,
+	)
+
 	var/amount_grown = 0
 	var/max_grown = 100
 	var/time_of_birth
@@ -38,10 +48,6 @@
 	grant_actions_by_list(innate_actions)
 
 	return ..()
-
-/mob/living/carbon/alien/larva/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small/tiny
-	..()
 
 //This needs to be fixed
 // This comment is 12 years old I hope it's fixed by now

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1096,10 +1096,6 @@
 		final_modification += bodypart.speed_modifier
 	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/bodypart, update = TRUE, multiplicative_slowdown = final_modification)
 
-/mob/living/carbon/proc/create_internal_organs()
-	for(var/obj/item/organ/internal_organ in organs)
-		internal_organ.Insert(src)
-
 /proc/cmp_organ_slot_asc(slot_a, slot_b)
 	return GLOB.organ_process_order.Find(slot_a) - GLOB.organ_process_order.Find(slot_b)
 


### PR DESCRIPTION
## About The Pull Request

When a xenomorph evolves, any organs transplanted into it (that aren't the default type for that slot) get transferred to the new caste it evolves into. Additionally, If a xenomorph is missing an organ in a slot it should have one in, the caste it evolves into will also have the organ for that slot missing.

Brains also always get transferred, regardless of whether they are xeno brains, so as to preserve skillchips and traumas.

## Why It's Good For The Game

Improves the mechanical consistency of surgically altered xenos.

## Changelog

:cl:
qol: Xenomorphs that have had their organs removed, or replaced with organs they shouldn't normally have, keep those organs (or lack thereof) when evolving.
fix: Xenomorphs that somehow get skillchips or brain traumas will keep them when evolving.
/:cl:
