### PR TITLE
Magilitis may not roll as a random chemical. Also adds Magilitis Minus, a weaker version that CAN roll as a random chemical.

### DIFF
--- a/code/datums/status_effects/debuffs/genetic_damage.dm
+++ b/code/datums/status_effects/debuffs/genetic_damage.dm
@@ -34,7 +34,7 @@
 /datum/status_effect/genetic_damage/tick(seconds_between_ticks)
 	if(ismonkey(owner) && total_damage >= GORILLA_MUTATION_MINIMUM_DAMAGE && SPT_PROB(GORILLA_MUTATION_CHANCE_PER_SECOND, seconds_between_ticks))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.gorillize(genetics_gorilla = TRUE)
+		carbon_owner.gorillize(/mob/living/basic/gorilla/genetics)
 		qdel(src)
 		return
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -448,6 +448,13 @@
 	for(var/i in 1 to 5)
 		new /obj/item/grenade/smokebomb(src)
 
+/obj/item/storage/box/syndie_kit/magillitis
+
+/obj/item/storage/box/syndie_kit/magillitis/PopulateContents()
+	new /obj/item/reagent_containers/hypospray/medipen/magillitis(src)
+	new /obj/item/reagent_containers/cup/bottle/magillitis_weak(src)
+	new /obj/item/reagent_containers/syringe(src)
+
 /obj/item/storage/box/syndie_kit/mail_counterfeit
 	name = "mail counterfeit kit"
 	desc = "A GLA Postal Service branded box. It's emblazoned with the motto: *Nothing stops the mail*."

--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -196,9 +196,11 @@
 	. = ..()
 	qdel(GetComponent(/datum/component/amputating_limbs))
 
-/mob/living/basic/gorilla/genetics/nostunlock
+/mob/living/basic/gorilla/genetics/magilitisminus
 	name = "Gorilla"
 	desc = "You might think this is a normal gorilla, but upon closer inspection theyre rather skinny. Theyre still an actual gorilla though so they might punch your guts out."
 	gentle_throw_punch = TRUE
+	initial_size = 1
+	speed = 0
 
 #undef GORILLA_HANDS_LAYER

--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla.dm
@@ -52,6 +52,8 @@
 		/obj/item/food/salad/jungle,
 		/obj/item/food/sundae,
 	)
+	/// does our punch stunlock people via throws
+	var/gentle_throw_punch = FALSE
 
 /mob/living/basic/gorilla/Initialize(mapload)
 	. = ..()
@@ -104,7 +106,7 @@
 		target.Paralyze(2 SECONDS)
 		visible_message(span_danger("[src] knocks [target] down!"))
 	else
-		target.throw_at(get_edge_target_turf(target, dir), range = rand(1, 2), speed = 7, thrower = src)
+		target.throw_at(get_edge_target_turf(target, dir), range = rand(1, 2), speed = 7, thrower = src, gentle = gentle_throw_punch)
 
 /mob/living/basic/gorilla/gib(drop_bitflags = DROP_BRAIN)
 	if(!(drop_bitflags & DROP_BRAIN))
@@ -193,5 +195,10 @@
 /mob/living/basic/gorilla/genetics/Initialize(mapload)
 	. = ..()
 	qdel(GetComponent(/datum/component/amputating_limbs))
+
+/mob/living/basic/gorilla/genetics/nostunlock
+	name = "Gorilla"
+	desc = "You might think this is a normal gorilla, but upon closer inspection theyre rather skinny. Theyre still an actual gorilla though so they might punch your guts out."
+	gentle_throw_punch = TRUE
 
 #undef GORILLA_HANDS_LAYER

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -311,8 +311,8 @@
 	qdel(src)
 	return new_crab
 
-/mob/living/carbon/proc/gorillize(genetics_gorilla = FALSE)
-	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
+/mob/living/carbon/proc/gorillize(gorilla_type = /mob/living/basic/gorilla)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM) || !ispath(gorilla_type, /mob/living/basic/gorilla))
 		return
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	Paralyze(1, ignore_canstun = TRUE)
@@ -327,7 +327,6 @@
 	regenerate_icons()
 	icon = null
 	SetInvisibility(INVISIBILITY_MAXIMUM)
-	var/gorilla_type = genetics_gorilla ? /mob/living/basic/gorilla/genetics : /mob/living/basic/gorilla
 	var/mob/living/basic/gorilla/new_gorilla = new gorilla_type(get_turf(src))
 	new_gorilla.set_combat_mode(TRUE)
 	if(mind)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2446,7 +2446,7 @@
 	name = "Magillitis-"
 	description = "A variant of the experimental serum that turns you into a gorilla. This one unfortunately just barely improves your muscle mass so youre basically just a skinny gorilla."
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
-	gorilla_type = /mob/living/basic/gorilla/genetics/nostunlock
+	gorilla_type = /mob/living/basic/gorilla/genetics/magilitisminus
 
 /datum/reagent/growthserum
 	name = "Growth Serum"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2431,15 +2431,22 @@
 
 /datum/reagent/magillitis
 	name = "Magillitis"
-	description = "An experimental serum which causes rapid muscular growth in Hominidae. Side-affects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."
+	description = "An experimental serum which causes rapid muscular growth in Hominidae. Side-effects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."
 	color = "#00f041"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
+	var/gorilla_type = /mob/living/basic/gorilla
 
 /datum/reagent/magillitis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if((ishuman(affected_mob)) && current_cycle > 10)
-		var/mob/living/basic/gorilla/new_gorilla = affected_mob.gorillize()
+		var/mob/living/basic/gorilla/new_gorilla = affected_mob.gorillize(gorilla_type)
 		new_gorilla.AddComponent(/datum/component/regenerator, regeneration_delay = 12 SECONDS, brute_per_second = 1.5, outline_colour = COLOR_PALE_GREEN)
+
+/datum/reagent/magillitis/weak
+	name = "Magillitis-"
+	description = "A variant of the experimental serum that turns you into a gorilla. This one unfortunately just barely improves your muscle mass so youre basically just a skinny gorilla."
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	gorilla_type = /mob/living/basic/gorilla/genetics/nostunlock
 
 /datum/reagent/growthserum
 	name = "Growth Serum"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2443,7 +2443,7 @@
 		new_gorilla.AddComponent(/datum/component/regenerator, regeneration_delay = 12 SECONDS, brute_per_second = 1.5, outline_colour = COLOR_PALE_GREEN)
 
 /datum/reagent/magillitis/weak
-	name = "Magillitis-"
+	name = "Magillitis Minus"
 	description = "A variant of the experimental serum that turns you into a gorilla. This one unfortunately just barely improves your muscle mass so youre basically just a skinny gorilla."
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 	gorilla_type = /mob/living/basic/gorilla/genetics/magilitisminus

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -165,6 +165,11 @@
 	desc = "A small bottle. Contains a serum known only as 'magillitis'."
 	list_reagents = list(/datum/reagent/magillitis = 5)
 
+/obj/item/reagent_containers/cup/bottle/magillitis_weak
+	name = "magillitis- bottle"
+	desc = "A small bottle. Contains a variant of the serum known only as 'magillitis-'."
+	list_reagents = list(/datum/reagent/magillitis/weak = 5)
+
 /obj/item/reagent_containers/cup/bottle/venom
 	name = "venom bottle"
 	desc = "A small bottle. Contains Venom."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -306,7 +306,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/magillitis
 	name = "experimental autoinjector"
-	desc = "A custom-frame needle injector with a small single-use reservoir, containing an experimental serum. Unlike the more common medipen frame, it cannot pierce through protective armor or space suits, nor can the chemical inside be extracted."
+	desc = "A custom-frame needle injector with a small single-use reservoir, containing an experimental serum. Unlike the more common medipen frame, it cannot pierce through protective armor or space suits, nor can the chemical inside be extracted. This experimental serum is highly complex and cannot be reproduced normally."
 	icon_state = "gorillapen"
 	inhand_icon_state = "gorillapen"
 	base_icon_state = "gorillapen"

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -166,10 +166,11 @@
 
 /datum/uplink_item/role_restricted/magillitis_serum
 	name = "Magillitis Serum Autoinjector"
-	desc = "A single-use autoinjector which contains an experimental serum that causes rapid muscular growth in Hominidae. \
+	desc = "A box with an single-use autoinjector which contains an experimental serum that causes rapid muscular growth in Hominidae. \
 			Side-affects may include hypertrichosis, violent outbursts, and an unending affinity for bananas. \
-			Now also contains regenerative chemicals to keep users healthy as they exercise their newfound muscles."
-	item = /obj/item/reagent_containers/hypospray/medipen/magillitis
+			Now also contains regenerative chemicals to keep users healthy as they exercise their newfound muscles. \
+			Also contains a weaker variant of the serum, that does not make gorillas as powerful, but may be synthesized."
+	item = /obj/item/storage/box/syndie_kit/magillitis
 	cost = 15
 	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR)
 


### PR DESCRIPTION
## About The Pull Request

Magilitis may no longer be reproduced by the odyseuss syringe gun, and roll in the random chem pool
Added a variant named "Magilitis-" that can however.
BUT: It creates weaker gorillas. It creates a tiny bit faster genetics gorillas without stunning throws. Still launches people backward

The uplink item for magilitis is now a kit containing the same autoinjector and 5 units of magilitis-
Price unchanged
Essentially lets you make 2 gorillas but one is strong and the other is not. If you feel fancy you can load magilitis- into the odyseuss
![image](https://github.com/user-attachments/assets/0621e92b-7644-479e-a426-8b2c906d84ac)


magilitis- gorilla

https://github.com/user-attachments/assets/6e039d5b-2390-47be-a688-7528a5d09afc



## Why It's Good For The Game

all it takes is an odyseuss or one botanist to turn everyone into massive hulking 200kg gorillas that can rip your heart out in seconds unless youre stun immune and exceptionally well armored or just well armed
that kinda sucks because there being 9 million stunlock monsters onstation sucks for anyone that is not a gorilla or stun immune

fixes that problem by just making said 9 million stunlock monsters just 9 million normal monsters

## Changelog
:cl:
balance: Magilitis may not show up in the random chem pool. Added a variant of said chemical that may however, but creates weaker apes. The magilitis uplink item is now a kit that contains both.
/:cl:
