### PR TITLE
[NO GBP] Fixes a flaw in Overwatch Agent bodycam distribution

### DIFF
--- a/code/modules/antagonists/nukeop/datums/operative_support.dm
+++ b/code/modules/antagonists/nukeop/datums/operative_support.dm
@@ -14,6 +14,9 @@
 	..()
 	for(var/datum/mind/teammate_mind in nuke_team.members)
 		var/mob/living/our_teammate = teammate_mind.current
+		if(!our_teammate) // If an agent is purchased after the death of an agent -- when they no longer have a body, we skip that mind because they're invalid.
+			continue
+
 		our_teammate.AddComponent( \
 			/datum/component/simple_bodycam, \
 			camera_name = "operative bodycam", \

--- a/code/modules/antagonists/nukeop/datums/operative_support.dm
+++ b/code/modules/antagonists/nukeop/datums/operative_support.dm
@@ -14,7 +14,7 @@
 	..()
 	for(var/datum/mind/teammate_mind in nuke_team.members)
 		var/mob/living/our_teammate = teammate_mind.current
-		if(!our_teammate) // If an agent is purchased after the death of an agent -- when they no longer have a body, we skip that mind because they're invalid.
+		if(!istype(our_teammate)) // If an agent is purchased after the death of an agent -- when they no longer have a body, we skip that mind because they're invalid.
 			continue
 
 		our_teammate.AddComponent( \


### PR DESCRIPTION
## About The Pull Request

This patches the (assumed) cause of a bug that causes the Overwatch Nukie agent bodycam distribution to runtime and fail. This occurs when a nukie has already died or been transferred to a new body before the agent is summoned.

The logic hooks through the list of nukie minds and picks out the current body of the user to implant cameras in. If they're dead, or occupying a ghost/other being, they're not a living mob and are incompatible with the following logic, causing a runtime and halting further camera distribution.

After watching this bug unfold live, seeing the runtime log, and having designed the original feature, I can say with a high degree of certainty that this will prevent this from happening again.
## Why It's Good For The Game

This feature should work and it is my job to make sure it does that.
## Changelog
:cl: Rhials
fix: Overwatch agent bodycameras (SHOULD) properly install if an agent has already died.
/:cl:
