### PR TITLE
Fixes sign language action signal registering bugs

### DIFF
--- a/code/datums/actions/mobs/sign_language.dm
+++ b/code/datums/actions/mobs/sign_language.dm
@@ -24,13 +24,14 @@
 	if(!owner)
 		return
 
+	RegisterSignal(grant_to, SIGNAL_REMOVETRAIT(TRAIT_MUTE), PROC_REF(on_unmuted))
+	RegisterSignal(grant_to, SIGNAL_ADDTRAIT(TRAIT_MUTE), PROC_REF(on_muted))
+
 	if (HAS_TRAIT(grant_to, TRAIT_MUTE))
-		RegisterSignal(grant_to, SIGNAL_REMOVETRAIT(TRAIT_MUTE), PROC_REF(on_unmuted))
 		// Convenience. Mute Carbons can only speak with sign language.
 		if (!active)
 			Activate()
 	else
-		RegisterSignal(grant_to, SIGNAL_ADDTRAIT(TRAIT_MUTE), PROC_REF(on_muted))
 		// Convenience. Only display action if the Carbon isn't mute.
 		show_action()
 
@@ -77,7 +78,6 @@
 /datum/action/innate/sign_language/proc/on_muted()
 	SIGNAL_HANDLER
 
-	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_MUTE), PROC_REF(on_unmuted))
 	hide_action()
 	// Enable sign language if the Carbon knows it and just gained TRAIT_MUTE
 	if (!HAS_TRAIT(owner, TRAIT_SIGN_LANG))


### PR DESCRIPTION

## About The Pull Request

I noticed a double signal registering error in the runtime logs today, so I looked into it.
Apparently this is because the sign language action registers `on_muted()` on `SIGNAL_ADDTRAIT(TRAIT_MUTE)`, which then whenever it is called tries to register `on_unmuted()` on `SIGNAL_REMOVETRAIT(TRAIT_MUTE)`, leading to a runtime error being thrown.

But, as a side, it seems that due to how it registers signals, there's a second bug:
When someone who is already mute gets sign language, it only registers `on_unmuted()` on `SIGNAL_REMOVETRAIT(TRAIT_MUTE)`... which then shows the action again, but never registers for `SIGNAL_ADDTRAIT(TRAIT_MUTE)`, and thus never hides it again.

We solve both of these by just making it register for both `SIGNAL_ADDTRAIT(TRAIT_MUTE)` and `SIGNAL_REMOVETRAIT(TRAIT_MUTE)` when given the action, rather than doing a whole bunch of unnecessary signal juggling.
## Why It's Good For The Game

Less jank, less over-complication, less cluttering of the runtime logs.
## Changelog
:cl:
fix: Sign language no longer throws a runtime error when repeatedly muted and unmuted.
fix: Sign language no longer fails to hide the action when you get it while mute, stop being mute, and start being mute again.
/:cl:
