### PR TITLE
UI data improvements for plumbing reaction chamber

### DIFF
--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -214,10 +214,6 @@
 
 /obj/machinery/plumbing/reaction_chamber/chem/handle_reagents(seconds_per_tick)
 	if(reagents.ph < acidic_limit || reagents.ph > alkaline_limit)
-		//no power
-		if(!is_operational)
-			return
-
 		//nothing to react with
 		var/num_of_reagents = length(reagents.reagent_list)
 		if(!num_of_reagents)

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -94,8 +94,6 @@
 	var/list/reagents_data = list()
 	for(var/datum/reagent/required_reagent as anything in required_reagents) //make a list where the key is text, because that looks alot better in the ui than a typepath
 		var/list/reagent_data = list()
-		if(catalysts[required_reagent])
-			continue
 		reagent_data["name"] = initial(required_reagent.name)
 		reagent_data["volume"] = required_reagents[required_reagent]
 		reagents_data += list(reagent_data)
@@ -131,45 +129,48 @@
 			if(!input_reagent)
 				return FALSE
 
+			if(catalysts[input_reagent])
+				return FALSE
+
+			var/input_amount = text2num(params["amount"])
+			if(!input_amount)
+				return FALSE
+
 			if(!required_reagents[input_reagent])
-				var/input_amount = text2num(params["amount"])
-				if(input_amount)
-					required_reagents[input_reagent] = input_amount
-					return TRUE
-			return FALSE
+				required_reagents[input_reagent] = input_amount
+				return TRUE
 
 		if("remove")
 			var/reagent = get_chem_id(params["chem"])
 			if(reagent)
 				required_reagents.Remove(reagent)
 				return TRUE
-			return FALSE
 
 		if("temperature")
 			var/target = text2num(params["target"])
 			if(!isnull(target))
 				target_temperature = clamp(target, 0, 1000)
 				return TRUE
-			return FALSE
 
 		if("catalyst")
 			var/reagent = get_chem_id(params["chem"])
-
 			if(!reagent)
 				return FALSE
 
-			if(reagent && !catalysts[reagent])
+			if(!catalysts[reagent])
 				catalysts[reagent] = required_reagents[reagent]
+				required_reagents -= reagent
 				return TRUE
-			else
-				return FALSE
 
 		if("catremove")
 			var/reagent = get_chem_id(params["chem"])
-			if(reagent)
+			if(!reagent)
+				return FALSE
+
+			if(catalysts[reagent])
+				required_reagents[reagent] = catalysts[reagent]
 				catalysts -= reagent
 				return TRUE
-			return FALSE
 
 	var/result = handle_ui_act(action, params, ui, state)
 	if(isnull(result))
@@ -214,7 +215,7 @@
 /obj/machinery/plumbing/reaction_chamber/chem/handle_reagents(seconds_per_tick)
 	if(reagents.ph < acidic_limit || reagents.ph > alkaline_limit)
 		//no power
-		if(machine_stat & NOPOWER)
+		if(!is_operational)
 			return
 
 		//nothing to react with

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -23,9 +23,6 @@
 	///towards which temperature do we build (except during draining)?
 	var/target_temperature = 300
 
-/obj/machinery/plumbing/reaction_chamber/Destroy()
-	return ..()
-
 /obj/machinery/plumbing/reaction_chamber/Initialize(mapload, bolt, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/reaction_chamber, bolt, layer)


### PR DESCRIPTION
## About The Pull Request
- Catalysts would be stored in both `required_reagents` & `catalysts` lists so it would occupy memory twice. This ensures they are stored in their own respective lists thus saving memory
- Removes redundant `return FALSE` statements inside `ui_act()`. The parent return value is already `FALSE` so we can just allow that to return instead of explicitly specifying it when a certain condition fails

## Changelog
:cl:
code: improved ui data code for plumbing reaction chamber
/:cl:

