### PR TITLE
Magazine Miscellany (and a very small tidbit of gun examine QoL)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -219,7 +219,7 @@
 /obj/item/ammo_box/update_desc(updates)
 	. = ..()
 	var/shells_left = LAZYLEN(stored_ammo)
-	desc = "[initial(desc)] There [(shells_left == 1) ? "is" : "are"] [shells_left] [casing_phrasing]\s left!"
+	desc = "[initial(desc)]<br>There [(shells_left == 1) ? "is" : "are"] <b>[shells_left]</b> [casing_phrasing]\s left!"
 
 /obj/item/ammo_box/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -1,9 +1,14 @@
+#define FIRE_BULLETS " Loaded with rounds which ignite targets and leave flaming trails, but inflict less damage."
+#define HP_BULLETS " Loaded with hollow-point rounds which are effective against unarmored targets, but suffer greatly against armor."
+#define AP_BULLETS " Loaded with armor-piercing rounds which are effective against armored targets, but less effective against unarmored targets."
+
 // Makarov (9mm) //
 
 /obj/item/ammo_box/magazine/m9mm
 	name = "pistol magazine (9mm)"
 	icon_state = "9x19p"
 	base_icon_state = "9x19p"
+	desc = "A 9mm handgun magazine, suitable for the Makarov pistol."
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = CALIBER_9MM
 	max_ammo = 12
@@ -14,27 +19,28 @@
 	name = "pistol magazine (9mm incendiary)"
 	icon_state = "9x19pI"
 	base_icon_state = "9x19pI"
-	desc = "A gun magazine. Loaded with rounds which ignite the target."
+	desc = parent_type::desc + FIRE_BULLETS
 	ammo_type = /obj/item/ammo_casing/c9mm/fire
 
 /obj/item/ammo_box/magazine/m9mm/hp
 	name = "pistol magazine (9mm HP)"
 	icon_state = "9x19pH"
 	base_icon_state = "9x19pH"
-	desc= "A gun magazine. Loaded with hollow-point rounds, extremely effective against unarmored targets, but nearly useless against protective clothing."
+	desc = parent_type::desc + HP_BULLETS
 	ammo_type = /obj/item/ammo_casing/c9mm/hp
 
 /obj/item/ammo_box/magazine/m9mm/ap
 	name = "pistol magazine (9mm AP)"
 	icon_state = "9x19pA"
 	base_icon_state = "9x19pA"
-	desc= "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets."
+	desc = parent_type::desc + AP_BULLETS
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
 
 // Stechkin APS (9mm) //
 
 /obj/item/ammo_box/magazine/m9mm_aps
 	name = "stechkin pistol magazine (9mm)"
+	desc = "A 9mm handgun magazine, suitable for the Stechkin APS machine pistol."
 	icon_state = "9mmaps-15"
 	base_icon_state = "9mmaps"
 	ammo_type = /obj/item/ammo_casing/c9mm
@@ -47,21 +53,24 @@
 
 /obj/item/ammo_box/magazine/m9mm_aps/fire
 	name = "stechkin pistol magazine (9mm incendiary)"
+	desc = parent_type::desc + FIRE_BULLETS
 	ammo_type = /obj/item/ammo_casing/c9mm/fire
 
 /obj/item/ammo_box/magazine/m9mm_aps/hp
 	name = "stechkin pistol magazine (9mm HP)"
+	desc = parent_type::desc + HP_BULLETS
 	ammo_type = /obj/item/ammo_casing/c9mm/hp
 
 /obj/item/ammo_box/magazine/m9mm_aps/ap
 	name = "stechkin pistol magazine (9mm AP)"
+	desc = parent_type::desc + AP_BULLETS
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
 
 // Ansem (10mm) //
 
 /obj/item/ammo_box/magazine/m10mm
 	name = "pistol magazine (10mm)"
-	desc = "A gun magazine."
+	desc = "A 10mm handgun magazine, suitable for the Ansem pistol."
 	icon_state = "9x19p"
 	base_icon_state = "9x19p"
 	ammo_type = /obj/item/ammo_casing/c10mm
@@ -74,27 +83,28 @@
 	name = "pistol magazine (10mm incendiary)"
 	icon_state = "9x19pI"
 	base_icon_state = "9x19pI"
-	desc = "A 10mm pistol magazine. Loaded with rounds which ignite the target."
+	desc = parent_type::desc + FIRE_BULLETS
 	ammo_type = /obj/item/ammo_casing/c10mm/fire
 
 /obj/item/ammo_box/magazine/m10mm/hp
 	name = "pistol magazine (10mm HP)"
 	icon_state = "9x19pH"
 	base_icon_state = "9x19pH"
-	desc= "A 10mm pistol magazine. Loaded with hollow-point rounds, extremely effective against unarmored targets, but nearly useless against protective clothing."
+	desc = parent_type::desc + HP_BULLETS
 	ammo_type = /obj/item/ammo_casing/c10mm/hp
 
 /obj/item/ammo_box/magazine/m10mm/ap
 	name = "pistol magazine (10mm AP)"
 	icon_state = "9x19pA"
 	base_icon_state = "9x19pA"
-	desc= "A 10mm pistol magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets."
+	desc = parent_type::desc + AP_BULLETS
 	ammo_type = /obj/item/ammo_casing/c10mm/ap
 
 // Regal Condor (10mm) //
 
 /obj/item/ammo_box/magazine/r10mm
 	name = "regal condor magazine (10mm Reaper)"
+	desc = "A very expensive 10mm handgun magazine, suitable for the Regal Condor. Loaded with \"reaper\" rounds, which are dangerously effective against everything."
 	icon_state = "r10mm-8"
 	base_icon_state = "r10mm"
 	ammo_type = /obj/item/ammo_casing/c10mm/reaper
@@ -107,6 +117,7 @@
 
 /obj/item/ammo_box/magazine/m45
 	name = "handgun magazine (.45)"
+	desc = "A .45 handgun magazine, suitable for the M1911."
 	icon_state = "45-8"
 	base_icon_state = "45"
 	ammo_type = /obj/item/ammo_casing/c45
@@ -118,9 +129,14 @@
 // Desert Eagle (.50 AE) //
 
 /obj/item/ammo_box/magazine/m50
-	name = "handgun magazine (.50ae)"
+	name = "handgun magazine (.50 AE)"
+	desc = "A .50 AE handgun magazine, suitable for the Desert Eagle."
 	icon_state = "50ae"
 	ammo_type = /obj/item/ammo_casing/a50ae
 	caliber = CALIBER_50AE
 	max_ammo = 7
 	multiple_sprites = AMMO_BOX_PER_BULLET
+
+#undef FIRE_BULLETS
+#undef HP_BULLETS
+#undef AP_BULLETS

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -1,6 +1,6 @@
-#define FIRE_BULLETS " Loaded with rounds which ignite targets and leave flaming trails, but inflict less damage."
-#define HP_BULLETS " Loaded with hollow-point rounds which are effective against unarmored targets, but suffer greatly against armor."
-#define AP_BULLETS " Loaded with armor-piercing rounds which are effective against armored targets, but less effective against unarmored targets."
+#define FIRE_BULLETS " Carries rounds which ignite targets and leave flaming trails, but inflict less damage."
+#define HP_BULLETS " Carries hollow-point rounds which are effective against unarmored targets, but suffer greatly against armor."
+#define AP_BULLETS " Carries armor-piercing rounds which are effective against armored targets, but less effective against unarmored targets."
 
 // Makarov (9mm) //
 

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -1,14 +1,10 @@
-/obj/item/ammo_box/magazine/m10mm/rifle
+/obj/item/ammo_box/magazine/sr10mm
 	name = "rifle magazine (10mm)"
 	desc = "A well-worn magazine fitted for the surplus rifle."
-	icon_state = "75-full"
-	base_icon_state = "75"
+	icon_state = "75"
 	ammo_type = /obj/item/ammo_casing/c10mm
 	max_ammo = 10
-
-/obj/item/ammo_box/magazine/m10mm/rifle/update_icon_state()
-	. = ..()
-	icon_state = "[base_icon_state]-[LAZYLEN(stored_ammo) ? "full" : "empty"]"
+	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/ammo_box/magazine/m223
 	name = "toploader magazine (.223)"

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -574,7 +574,7 @@
 /obj/item/gun/ballistic/examine(mob/user)
 	. = ..()
 	var/count_chambered = !(bolt_type == BOLT_TYPE_NO_BOLT || bolt_type == BOLT_TYPE_OPEN)
-	. += "It has [get_ammo(count_chambered)] round\s remaining."
+	. += "It has <b>[get_ammo(count_chambered)]</b> round\s remaining."
 
 	if (!chambered && !hidden_chambered)
 		. += "It does not seem to have a round chambered."

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -326,7 +326,7 @@
 	icon_state = "surplus"
 	worn_icon_state = null
 	weapon_weight = WEAPON_HEAVY
-	accepted_magazine_type = /obj/item/ammo_box/magazine/m10mm/rifle
+	accepted_magazine_type = /obj/item/ammo_box/magazine/sr10mm
 	fire_delay = 30
 	burst_size = 1
 	can_unsuppress = TRUE

--- a/tools/UpdatePaths/Scripts/88889_surplusriflemags.txt
+++ b/tools/UpdatePaths/Scripts/88889_surplusriflemags.txt
@@ -1,0 +1,3 @@
+#comment Repaths the 10mm surplus rifle's magazines from m10mm/rifle to sr10mm, so it doesn't show up as an Ansem magazine subtype.
+
+/obj/item/ammo_box/magazine/m10mm/rifle : /obj/item/ammo_box/magazine/sr10mm{@OLD}


### PR DESCRIPTION
## About The Pull Request
- Makarov magazines no longer have a placeholder description from the base type.
- Standardized pistol magazines' descriptions and extended descriptions for ammo types.
- Repathed the gangs-era surplus rifle's magazines (these still exist? wow) from m10mm/rifle to /sr10mm so they no longer fit in Ansems.
- Ammo counts from examined guns are now bolded to be slightly easier to notice at a glance.
- Magazines now show ammo count on a new line.
![image](https://github.com/user-attachments/assets/8a30a631-24fb-4d23-b2ca-895bfe24cbc3)


## Why It's Good For The Game
Makarov description being an obvious placeholder bugged me and then things got out of scope.
The bold ammo count thing is really small but it might come in handy for someone? Possibly?

## Changelog
Surplus rifle changes not mentioned in changelog because it's unobtainable in-game and also just really bad as a gun in general.
:cl:
qol: Examining a gun or magazine now shows the ammo capacity in bold.
spellcheck: Standardized pistol magazine descriptions, fixing Makarov magazines having a placeholder description.
/:cl:
