### PR TITLE
Changed job post-equip order to fix station trait issues

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -135,9 +135,6 @@
 	/// If set, look for a policy with this instead of the job title
 	var/policy_override
 
-	/// Pref from which we should fetch an alternate name for this job
-	var/alternate_name_pref
-
 /datum/job/New()
 	. = ..()
 	var/new_spawn_positions = CHECK_MAP_JOB_CHANGE(title, "spawn_positions")
@@ -163,9 +160,6 @@
 
 	var/mob/living/carbon/human/spawned_human = spawned
 	var/list/roundstart_experience
-
-	if (alternate_name_pref)
-		spawned_human.apply_pref_name(alternate_name_pref, player_client)
 
 	if(!config) //Needed for robots.
 		roundstart_experience = minimal_skills

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -37,14 +37,7 @@
 	job_flags = STATION_JOB_FLAGS
 
 	job_tone = "honk"
-
-
-/datum/job/clown/after_spawn(mob/living/spawned, client/player_client)
-	. = ..()
-	if(!ishuman(spawned))
-		return
-	spawned.apply_pref_name(/datum/preference/name/clown, player_client)
-
+	alternate_name_pref = /datum/preference/name/clown
 
 /datum/outfit/job/clown
 	name = "Clown"

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -37,7 +37,11 @@
 	job_flags = STATION_JOB_FLAGS
 
 	job_tone = "honk"
-	alternate_name_pref = /datum/preference/name/clown
+
+/datum/job/clown/after_spawn(mob/living/spawned, client/player_client)
+	if (ishuman(spawned))
+		spawned.apply_pref_name(/datum/preference/name/clown, player_client)
+	return ..()
 
 /datum/outfit/job/clown
 	name = "Clown"

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -35,14 +35,7 @@
 	voice_of_god_silence_power = 3
 
 	job_tone = "silence"
-
-
-/datum/job/mime/after_spawn(mob/living/spawned, client/player_client)
-	. = ..()
-	if(!ishuman(spawned))
-		return
-	spawned.apply_pref_name(/datum/preference/name/mime, player_client)
-
+	alternate_name_pref = /datum/preference/name/mime
 
 /datum/outfit/job/mime
 	name = "Mime"

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -35,7 +35,11 @@
 	voice_of_god_silence_power = 3
 
 	job_tone = "silence"
-	alternate_name_pref = /datum/preference/name/mime
+
+/datum/job/mime/after_spawn(mob/living/spawned, client/player_client)
+	if (ishuman(spawned))
+		spawned.apply_pref_name(/datum/preference/name/mime, player_client)
+	return ..()
 
 /datum/outfit/job/mime
 	name = "Mime"


### PR DESCRIPTION
## About The Pull Request

Closes #88692
A bit of a tricky one, this fixes station traits using incorrect names for jobs. Moved name changing to run before the parent proc, and also moved comsig after job traits so that it truely runs after job spawning, not in the middle of the process (in case something removed or changes job-related traits)

## Changelog
:cl:
fix: Station traits no longer use clown and mime's human names (they're not human)
/:cl:
