### PR TITLE
[NO GBP] Fixes items not embedding

### DIFF
--- a/code/datums/embedding.dm
+++ b/code/datums/embedding.dm
@@ -274,6 +274,7 @@
 /// Avoid calling this directly as this doesn't move the object from its owner's contents
 /// Returns TRUE if the item got deleted due to DROPDEL flag
 /datum/embedding/proc/stop_embedding()
+	STOP_PROCESSING(SSprocessing, src)
 	if (owner_limb)
 		UnregisterSignal(owner_limb, COMSIG_BODYPART_REMOVED)
 		owner_limb._unembed_object(parent)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -843,6 +843,7 @@
 	do_drop_animation(master_storage.parent)
 
 /obj/item/pre_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	get_embed() // Ensure that embedding is lazyloaded before we impact the target, if we can have it
 	var/impact_flags = ..()
 	if(w_class < WEIGHT_CLASS_BULKY)
 		impact_flags |= COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH


### PR DESCRIPTION

## About The Pull Request

Partially handles #88892
I tested with stingbangs, not throwing stars. Yeah.
This does NOT solve the main issue of #88892 with jagged rods, as that would require rewriting how projectile_drop and caseless elements function

## Changelog
:cl:
fix: Fixed items not embedding
/:cl:
