### PR TITLE
Fix Odysseus medibeam line of sight check always failing

### DIFF
--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -83,7 +83,7 @@
 
 	last_check = world.time
 
-	var/obj/cur_loc = loc;
+	var/cur_loc = loc;
 	if(mounted) // los_check will fail as the parent loc of the medbeam's own loc would be the mech in this instance.
 		cur_loc = loc.loc
 

--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -83,7 +83,11 @@
 
 	last_check = world.time
 
-	if(!los_check(loc, current_target, mid_check = CALLBACK(src, PROC_REF(mid_los_check))))
+	var/obj/cur_loc = loc;
+	if(mounted) // los_check will fail as the parent loc of the medbeam's own loc would be the mech in this instance.
+		cur_loc = loc.loc
+
+	if(!los_check(cur_loc, current_target, mid_check = CALLBACK(src, PROC_REF(mid_los_check))))
 		QDEL_NULL(current_beam)//this will give the target lost message
 		return
 


### PR DESCRIPTION

## About the Pull Request

Closes #88803
Make the line of sight check start from the odysseus rather than the mech part, allowing it to function normally.
## Changelog

:cl:
fix: The Odysseus medibeam now no longer always fails its own line of sight check
/:cl:

