### PR TITLE
Bumps tgui core version

### DIFF
--- a/tgui/packages/tgui-bench/package.json
+++ b/tgui/packages/tgui-bench/package.json
@@ -12,6 +12,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.5.4"
+    "tgui-core": "^1.5.7"
   }
 }

--- a/tgui/packages/tgui-bench/package.json
+++ b/tgui/packages/tgui-bench/package.json
@@ -12,6 +12,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.5.7"
+    "tgui-core": "^1.7.1"
   }
 }

--- a/tgui/packages/tgui-bench/package.json
+++ b/tgui/packages/tgui-bench/package.json
@@ -12,6 +12,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.7.1"
+    "tgui-core": "^1.7.2"
   }
 }

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -10,9 +10,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.5.4",
+    "tgui-core": "^1.5.7",
     "tgui-dev-server": "workspace:*",
-    "tgui-polyfill": "workspace:*",
-    "tgui-styles": "^0.0.10"
+    "tgui-polyfill": "workspace:*"
   }
 }

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -10,7 +10,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.5.7",
+    "tgui-core": "^1.7.1",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -10,7 +10,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.7.1",
+    "tgui-core": "^1.7.2",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/packages/tgui-panel/styles/main.scss
+++ b/tgui/packages/tgui-panel/styles/main.scss
@@ -6,7 +6,7 @@
 @use 'sass:meta';
 @use 'sass:color';
 // Components
-@use 'pkg:tgui-styles';
+@use 'pkg:tgui-core/styles';
 
 @use '~tgui/styles/colors.scss';
 @use '~tgui/styles/base.scss' with (

--- a/tgui/packages/tgui-panel/styles/main.scss
+++ b/tgui/packages/tgui-panel/styles/main.scss
@@ -6,7 +6,7 @@
 @use 'sass:meta';
 @use 'sass:color';
 // Components
-@use 'pkg:tgui-core/styles';
+@use '~tgui-core/styles';
 
 @use '~tgui/styles/colors.scss';
 @use '~tgui/styles/base.scss' with (

--- a/tgui/packages/tgui-panel/styles/themes/light.scss
+++ b/tgui/packages/tgui-panel/styles/themes/light.scss
@@ -32,7 +32,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tabs',
+    'pkg:tgui-core/styles/components/Tabs',
     $with: (
       'text-color': rgba(0, 0, 0, 0.5),
       'color-default': rgba(0, 0, 0, 1),
@@ -41,12 +41,12 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Section',
+    'pkg:tgui-core/styles/components/Section',
     $with: ('background-color': hsl(0, 0%, 100%))
   );
 
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(0, 0%, 73.3%),
       'color-disabled': hsl(0, 0%, 21.2%),
@@ -57,17 +57,17 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: (
       'border-color': colors.fg(colors.$label),
       'background-color': hsl(0, 0%, 90.2%)
     )
   );
-  @include meta.load-css('pkg:tgui-styles/components/NumberInput');
-  @include meta.load-css('pkg:tgui-styles/components/TextArea');
-  @include meta.load-css('pkg:tgui-styles/components/Knob');
-  @include meta.load-css('pkg:tgui-styles/components/Slider');
-  @include meta.load-css('pkg:tgui-styles/components/ProgressBar');
+  @include meta.load-css('pkg:tgui-core/styles/components/NumberInput');
+  @include meta.load-css('pkg:tgui-core/styles/components/TextArea');
+  @include meta.load-css('pkg:tgui-core/styles/components/Knob');
+  @include meta.load-css('pkg:tgui-core/styles/components/Slider');
+  @include meta.load-css('pkg:tgui-core/styles/components/ProgressBar');
 
   // Components specific to tgui-panel
   @include meta.load-css(

--- a/tgui/packages/tgui-panel/styles/themes/light.scss
+++ b/tgui/packages/tgui-panel/styles/themes/light.scss
@@ -32,7 +32,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tabs',
+    '~tgui-core/styles/components/Tabs',
     $with: (
       'text-color': rgba(0, 0, 0, 0.5),
       'color-default': rgba(0, 0, 0, 1),
@@ -41,12 +41,12 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Section',
+    '~tgui-core/styles/components/Section',
     $with: ('background-color': hsl(0, 0%, 100%))
   );
 
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(0, 0%, 73.3%),
       'color-disabled': hsl(0, 0%, 21.2%),
@@ -57,17 +57,17 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: (
       'border-color': colors.fg(colors.$label),
       'background-color': hsl(0, 0%, 90.2%)
     )
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/NumberInput');
-  @include meta.load-css('pkg:tgui-core/styles/components/TextArea');
-  @include meta.load-css('pkg:tgui-core/styles/components/Knob');
-  @include meta.load-css('pkg:tgui-core/styles/components/Slider');
-  @include meta.load-css('pkg:tgui-core/styles/components/ProgressBar');
+  @include meta.load-css('~tgui-core/styles/components/NumberInput');
+  @include meta.load-css('~tgui-core/styles/components/TextArea');
+  @include meta.load-css('~tgui-core/styles/components/Knob');
+  @include meta.load-css('~tgui-core/styles/components/Slider');
+  @include meta.load-css('~tgui-core/styles/components/ProgressBar');
 
   // Components specific to tgui-panel
   @include meta.load-css(

--- a/tgui/packages/tgui-say/package.json
+++ b/tgui/packages/tgui-say/package.json
@@ -9,7 +9,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.7.1",
+    "tgui-core": "^1.7.2",
     "tgui-polyfill": "workspace:*"
   }
 }

--- a/tgui/packages/tgui-say/package.json
+++ b/tgui/packages/tgui-say/package.json
@@ -9,7 +9,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.5.7",
+    "tgui-core": "^1.7.1",
     "tgui-polyfill": "workspace:*"
   }
 }

--- a/tgui/packages/tgui-say/package.json
+++ b/tgui/packages/tgui-say/package.json
@@ -9,8 +9,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tgui": "workspace:*",
-    "tgui-core": "^1.5.4",
-    "tgui-polyfill": "workspace:*",
-    "tgui-styles": "^0.0.10"
+    "tgui-core": "^1.5.7",
+    "tgui-polyfill": "workspace:*"
   }
 }

--- a/tgui/packages/tgui-say/styles/main.scss
+++ b/tgui/packages/tgui-say/styles/main.scss
@@ -7,7 +7,7 @@
 // Atomic styles
 @include meta.load-css('~tgui/styles/atomic/text.scss');
 // External styles
-@include meta.load-css('pkg:tgui-styles/components/TextArea');
+@include meta.load-css('pkg:tgui-core/styles/components/TextArea');
 // Local styles
 @include meta.load-css('./button.scss');
 @include meta.load-css('./content.scss');

--- a/tgui/packages/tgui-say/styles/main.scss
+++ b/tgui/packages/tgui-say/styles/main.scss
@@ -7,7 +7,7 @@
 // Atomic styles
 @include meta.load-css('~tgui/styles/atomic/text.scss');
 // External styles
-@include meta.load-css('pkg:tgui-core/styles/components/TextArea');
+@include meta.load-css('~tgui-core/styles/components/TextArea');
 // Local styles
 @include meta.load-css('./button.scss');
 @include meta.load-css('./content.scss');

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -18,7 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-popper": "^2.3.0",
-    "tgui-core": "^1.5.7",
+    "tgui-core": "^1.7.1",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -18,7 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-popper": "^2.3.0",
-    "tgui-core": "^1.7.1",
+    "tgui-core": "^1.7.2",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -18,9 +18,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-popper": "^2.3.0",
-    "tgui-core": "^1.5.4",
+    "tgui-core": "^1.5.7",
     "tgui-dev-server": "workspace:*",
-    "tgui-polyfill": "workspace:*",
-    "tgui-styles": "^0.0.10"
+    "tgui-polyfill": "workspace:*"
   }
 }

--- a/tgui/packages/tgui/styles/interfaces/Fabricator.scss
+++ b/tgui/packages/tgui/styles/interfaces/Fabricator.scss
@@ -3,8 +3,8 @@
 @use '../base.scss';
 @use '../colors.scss';
 @use '../functions.scss' as *;
-@use 'pkg:tgui-core/styles/components/Button' as button;
-@use 'pkg:tgui-core/styles/components/Tabs' as tabs;
+@use '~tgui-core/styles/components/Button' as button;
+@use '~tgui-core/styles/components/Tabs' as tabs;
 
 .Fabricator__Recipe {
   padding: 0.25em 0;

--- a/tgui/packages/tgui/styles/interfaces/Fabricator.scss
+++ b/tgui/packages/tgui/styles/interfaces/Fabricator.scss
@@ -3,8 +3,8 @@
 @use '../base.scss';
 @use '../colors.scss';
 @use '../functions.scss' as *;
-@use 'pkg:tgui-styles/components/Button' as button;
-@use 'pkg:tgui-styles/components/Tabs' as tabs;
+@use 'pkg:tgui-core/styles/components/Button' as button;
+@use 'pkg:tgui-core/styles/components/Tabs' as tabs;
 
 .Fabricator__Recipe {
   padding: 0.25em 0;

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -5,7 +5,7 @@
 
 @use 'sass:meta';
 @use 'base';
-@use 'pkg:tgui-styles';
+@use 'pkg:tgui-core/styles';
 
 // Core styles
 @include meta.load-css('./reset.scss');

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -5,7 +5,7 @@
 
 @use 'sass:meta';
 @use 'base';
-@use 'pkg:tgui-core/styles';
+@use '~tgui-core/styles';
 
 // Core styles
 @include meta.load-css('./reset.scss');

--- a/tgui/packages/tgui/styles/themes/abductor.scss
+++ b/tgui/packages/tgui/styles/themes/abductor.scss
@@ -23,7 +23,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(0, 0%, 21%),
@@ -33,24 +33,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': hsl(227, 29%, 27%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NoticeBox',
+    '~tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(340, 67%, 41%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NumberInput',
+    '~tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(227, 29%, 27%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(340, 67%, 41%))
   );
 

--- a/tgui/packages/tgui/styles/themes/abductor.scss
+++ b/tgui/packages/tgui/styles/themes/abductor.scss
@@ -23,7 +23,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(0, 0%, 21%),
@@ -33,24 +33,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': hsl(227, 29%, 27%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NoticeBox',
+    'pkg:tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(340, 67%, 41%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NumberInput',
+    'pkg:tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(227, 29%, 27%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(340, 67%, 41%))
   );
 

--- a/tgui/packages/tgui/styles/themes/cardtable.scss
+++ b/tgui/packages/tgui/styles/themes/cardtable.scss
@@ -24,7 +24,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(145.26, 73.64%, 25.29%),
       'color-disabled': hsl(0, 0%, 21.18%),
@@ -34,14 +34,14 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NumberInput',
+    '~tgui-core/styles/components/NumberInput',
     $with: ('border-color': #fff)
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': rgba(0, 0, 0, 0.5))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/cardtable.scss
+++ b/tgui/packages/tgui/styles/themes/cardtable.scss
@@ -24,7 +24,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(145.26, 73.64%, 25.29%),
       'color-disabled': hsl(0, 0%, 21.18%),
@@ -34,14 +34,14 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NumberInput',
+    'pkg:tgui-core/styles/components/NumberInput',
     $with: ('border-color': #fff)
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': rgba(0, 0, 0, 0.5))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/hackerman.scss
+++ b/tgui/packages/tgui/styles/themes/hackerman.scss
@@ -22,7 +22,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(120, 17.78%, 35.29%),
@@ -30,7 +30,7 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tabs',
+    '~tgui-core/styles/components/Tabs',
     $with: (
       'color-default': colors.$primary,
       'tab-color-selected': hsla(120, 100%, 50%, 0.25),
@@ -38,11 +38,11 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': colors.$primary)
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Modal');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/hackerman.scss
+++ b/tgui/packages/tgui/styles/themes/hackerman.scss
@@ -22,7 +22,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(120, 17.78%, 35.29%),
@@ -30,7 +30,7 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tabs',
+    'pkg:tgui-core/styles/components/Tabs',
     $with: (
       'color-default': colors.$primary,
       'tab-color-selected': hsla(120, 100%, 50%, 0.25),
@@ -38,11 +38,11 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': colors.$primary)
   );
-  @include meta.load-css('pkg:tgui-styles/components/Modal');
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/malfunction.scss
+++ b/tgui/packages/tgui/styles/themes/malfunction.scss
@@ -22,7 +22,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(0, 0%, 21%),
@@ -32,24 +32,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': hsl(0, 99%, 29%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NoticeBox',
+    '~tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(204, 54%, 23%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NumberInput',
+    '~tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(0, 99%, 29%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(204, 54%, 29%))
   );
 

--- a/tgui/packages/tgui/styles/themes/malfunction.scss
+++ b/tgui/packages/tgui/styles/themes/malfunction.scss
@@ -22,7 +22,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(0, 0%, 21%),
@@ -32,24 +32,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': hsl(0, 99%, 29%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NoticeBox',
+    'pkg:tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(204, 54%, 23%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NumberInput',
+    'pkg:tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(0, 99%, 29%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(204, 54%, 29%))
   );
 

--- a/tgui/packages/tgui/styles/themes/neutral.scss
+++ b/tgui/packages/tgui/styles/themes/neutral.scss
@@ -21,20 +21,20 @@ $neutral: hsl(42.12, 100%, 50%);
 .theme-neutral {
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': color.scale($neutral, $lightness: -30%),
       'color-transparent-text': color.scale($neutral, $lightness: 30%)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $neutral,
       'background-color': rgba(0, 0, 0, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/neutral.scss
+++ b/tgui/packages/tgui/styles/themes/neutral.scss
@@ -21,20 +21,20 @@ $neutral: hsl(42.12, 100%, 50%);
 .theme-neutral {
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': color.scale($neutral, $lightness: -30%),
       'color-transparent-text': color.scale($neutral, $lightness: 30%)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $neutral,
       'background-color': rgba(0, 0, 0, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/ntOS95.scss
+++ b/tgui/packages/tgui/styles/themes/ntOS95.scss
@@ -29,7 +29,7 @@ $scrollbar-color-multiplier: 1;
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(52.3, 40.3%, 84.9%),
       'color-disabled': hsl(0, 0%, 43.9%),
@@ -39,16 +39,16 @@ $scrollbar-color-multiplier: 1;
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': rgba(0, 0, 0, 0.5))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Section',
+    'pkg:tgui-core/styles/components/Section',
     $with: ('background-color': rgba(0, 0, 0, 0.4))
   );
 
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(61.5, 70.2%, 77.6%))
   );
   // Layouts

--- a/tgui/packages/tgui/styles/themes/ntOS95.scss
+++ b/tgui/packages/tgui/styles/themes/ntOS95.scss
@@ -29,7 +29,7 @@ $scrollbar-color-multiplier: 1;
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(52.3, 40.3%, 84.9%),
       'color-disabled': hsl(0, 0%, 43.9%),
@@ -39,16 +39,16 @@ $scrollbar-color-multiplier: 1;
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': rgba(0, 0, 0, 0.5))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Section',
+    '~tgui-core/styles/components/Section',
     $with: ('background-color': rgba(0, 0, 0, 0.4))
   );
 
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(61.5, 70.2%, 77.6%))
   );
   // Layouts

--- a/tgui/packages/tgui/styles/themes/ntos.scss
+++ b/tgui/packages/tgui/styles/themes/ntos.scss
@@ -19,20 +19,20 @@ $nanotrasen: hsl(213, 30%, 32%);
 .theme-ntos {
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': $nanotrasen,
       'color-transparent-text': rgba(227, 240, 255, 0.75)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $nanotrasen,
       'background-color': rgba(0, 0, 0, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/ntos.scss
+++ b/tgui/packages/tgui/styles/themes/ntos.scss
@@ -19,20 +19,20 @@ $nanotrasen: hsl(213, 30%, 32%);
 .theme-ntos {
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': $nanotrasen,
       'color-transparent-text': rgba(227, 240, 255, 0.75)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $nanotrasen,
       'background-color': rgba(0, 0, 0, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/ntos_cat.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_cat.scss
@@ -38,7 +38,7 @@ $scrollbar-color-multiplier: 0.5;
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(300, 91%, 52%),
       'color-transparent-text': hsla(210, 100%, 94%, 0.75),
@@ -48,15 +48,15 @@ $scrollbar-color-multiplier: 0.5;
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('color-default-fill': hsla(350, 100%, 76.5%, 0.75))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Section',
+    'pkg:tgui-core/styles/components/Section',
     $with: ('background-color': hsla(24, 56%, 31%, 0.75))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsla(36, 100%, 50%, 0.75))
   );
 

--- a/tgui/packages/tgui/styles/themes/ntos_cat.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_cat.scss
@@ -38,7 +38,7 @@ $scrollbar-color-multiplier: 0.5;
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(300, 91%, 52%),
       'color-transparent-text': hsla(210, 100%, 94%, 0.75),
@@ -48,15 +48,15 @@ $scrollbar-color-multiplier: 0.5;
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('color-default-fill': hsla(350, 100%, 76.5%, 0.75))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Section',
+    '~tgui-core/styles/components/Section',
     $with: ('background-color': hsla(24, 56%, 31%, 0.75))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsla(36, 100%, 50%, 0.75))
   );
 

--- a/tgui/packages/tgui/styles/themes/ntos_darkmode.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_darkmode.scss
@@ -19,20 +19,20 @@ $nanotrasen: hsl(0, 0%, 17.25%);
 .theme-ntos_darkmode {
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': $nanotrasen,
       'color-transparent-text': rgba(227, 240, 255, 0.75)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $nanotrasen,
       'background-color': rgba(0, 0, 0, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/ntos_darkmode.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_darkmode.scss
@@ -19,20 +19,20 @@ $nanotrasen: hsl(0, 0%, 17.25%);
 .theme-ntos_darkmode {
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': $nanotrasen,
       'color-transparent-text': rgba(227, 240, 255, 0.75)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $nanotrasen,
       'background-color': rgba(0, 0, 0, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/ntos_lightmode.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_lightmode.scss
@@ -20,22 +20,22 @@ $nanotrasen: hsl(0, 0%, 100%);
   @include meta.load-css('../atomic/color.scss', $with: ());
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: ('color-default': $nanotrasen)
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $nanotrasen,
       'background-color': hsla(0, 0%, 0%, 0.5)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Section',
+    'pkg:tgui-core/styles/components/Section',
     $with: ('background-color': hsla(0, 0%, 47%, 0.4))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 0%, 100%))
   );
 

--- a/tgui/packages/tgui/styles/themes/ntos_lightmode.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_lightmode.scss
@@ -20,22 +20,22 @@ $nanotrasen: hsl(0, 0%, 100%);
   @include meta.load-css('../atomic/color.scss', $with: ());
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: ('color-default': $nanotrasen)
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': $nanotrasen,
       'background-color': hsla(0, 0%, 0%, 0.5)
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Section',
+    '~tgui-core/styles/components/Section',
     $with: ('background-color': hsla(0, 0%, 47%, 0.4))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 0%, 100%))
   );
 

--- a/tgui/packages/tgui/styles/themes/ntos_spooky.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_spooky.scss
@@ -18,7 +18,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(345, 96%, 25%),
       'color-disabled': hsl(0, 0%, 21%),
@@ -28,27 +28,27 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Dimmer',
+    '~tgui-core/styles/components/Dimmer',
     $with: ('background-dimness': 0.45)
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': hsl(15, 14%, 26%))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
+  @include meta.load-css('~tgui-core/styles/components/Modal');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NoticeBox',
+    '~tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(0, 90%, 23%))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/NumberInput');
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
-  @include meta.load-css('pkg:tgui-core/styles/components/Table');
+  @include meta.load-css('~tgui-core/styles/components/NumberInput');
+  @include meta.load-css('~tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Table');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 0%, 0%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': hsla(0, 100%, 37%, 0.75),
       'background-color': hsla(0, 97%, 7%, 0.5)

--- a/tgui/packages/tgui/styles/themes/ntos_spooky.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_spooky.scss
@@ -18,7 +18,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(345, 96%, 25%),
       'color-disabled': hsl(0, 0%, 21%),
@@ -28,27 +28,27 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Dimmer',
+    'pkg:tgui-core/styles/components/Dimmer',
     $with: ('background-dimness': 0.45)
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': hsl(15, 14%, 26%))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Modal');
+  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
   @include meta.load-css(
-    'pkg:tgui-styles/components/NoticeBox',
+    'pkg:tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(0, 90%, 23%))
   );
-  @include meta.load-css('pkg:tgui-styles/components/NumberInput');
-  @include meta.load-css('pkg:tgui-styles/components/Section');
-  @include meta.load-css('pkg:tgui-styles/components/Table');
+  @include meta.load-css('pkg:tgui-core/styles/components/NumberInput');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Table');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 0%, 0%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: (
       'color-default-fill': hsla(0, 100%, 37%, 0.75),
       'background-color': hsla(0, 97%, 7%, 0.5)

--- a/tgui/packages/tgui/styles/themes/ntos_synth.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_synth.scss
@@ -32,7 +32,7 @@ $purple: hsl(248, 47%, 37%);
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': $cyan,
       'color-transparent-text': hsla(210, 100%, 94%, 0.75),
@@ -42,15 +42,15 @@ $purple: hsl(248, 47%, 37%);
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('color-default-fill': hsla(300, 91%, 52%, 0.75))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Section',
+    'pkg:tgui-core/styles/components/Section',
     $with: ('background-color': hsla(0, 0%, 0%, 0.3))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsla(36, 100%, 50%, 0.75))
   );
 

--- a/tgui/packages/tgui/styles/themes/ntos_synth.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_synth.scss
@@ -32,7 +32,7 @@ $purple: hsl(248, 47%, 37%);
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': $cyan,
       'color-transparent-text': hsla(210, 100%, 94%, 0.75),
@@ -42,15 +42,15 @@ $purple: hsl(248, 47%, 37%);
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('color-default-fill': hsla(300, 91%, 52%, 0.75))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Section',
+    '~tgui-core/styles/components/Section',
     $with: ('background-color': hsla(0, 0%, 0%, 0.3))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsla(36, 100%, 50%, 0.75))
   );
 

--- a/tgui/packages/tgui/styles/themes/ntos_terminal.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_terminal.scss
@@ -24,7 +24,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': rgba(0, 0, 0, 0),
       'color-disabled': hsl(120, 18%, 35%),
@@ -32,18 +32,18 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': colors.$primary)
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: (
       'background-color': hsla(0, 0%, 0%, 0.5),
       'color-default-fill': hsla(146, 82%, 53%, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Modal');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/ntos_terminal.scss
+++ b/tgui/packages/tgui/styles/themes/ntos_terminal.scss
@@ -24,7 +24,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': rgba(0, 0, 0, 0),
       'color-disabled': hsl(120, 18%, 35%),
@@ -32,18 +32,18 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': colors.$primary)
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: (
       'background-color': hsla(0, 0%, 0%, 0.5),
       'color-default-fill': hsla(146, 82%, 53%, 0.5)
     )
   );
-  @include meta.load-css('pkg:tgui-styles/components/Modal');
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/paper.scss
+++ b/tgui/packages/tgui/styles/themes/paper.scss
@@ -30,13 +30,13 @@ $font-size: 24px;
   @include meta.load-css('../atomic/color.scss');
 
   // Components
-  @include meta.load-css('pkg:tgui-styles/components/Tabs');
+  @include meta.load-css('pkg:tgui-core/styles/components/Tabs');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Section',
+    'pkg:tgui-core/styles/components/Section',
     $with: ('background-color': hsla(0, 0%, 0%, 0.1))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(50, 50%, 90%),
       'color-disabled': hsl(0, 0%, 21%),

--- a/tgui/packages/tgui/styles/themes/paper.scss
+++ b/tgui/packages/tgui/styles/themes/paper.scss
@@ -30,13 +30,13 @@ $font-size: 24px;
   @include meta.load-css('../atomic/color.scss');
 
   // Components
-  @include meta.load-css('pkg:tgui-core/styles/components/Tabs');
+  @include meta.load-css('~tgui-core/styles/components/Tabs');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Section',
+    '~tgui-core/styles/components/Section',
     $with: ('background-color': hsla(0, 0%, 0%, 0.1))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(50, 50%, 90%),
       'color-disabled': hsl(0, 0%, 21%),

--- a/tgui/packages/tgui/styles/themes/retro.scss
+++ b/tgui/packages/tgui/styles/themes/retro.scss
@@ -25,7 +25,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(48, 38%, 84%),
       'color-disabled': hsl(60, 6%, 28%),
@@ -35,10 +35,10 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/retro.scss
+++ b/tgui/packages/tgui/styles/themes/retro.scss
@@ -25,7 +25,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(48, 38%, 84%),
       'color-disabled': hsl(60, 6%, 28%),
@@ -35,10 +35,10 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');

--- a/tgui/packages/tgui/styles/themes/spookyconsole.scss
+++ b/tgui/packages/tgui/styles/themes/spookyconsole.scss
@@ -28,7 +28,7 @@ $updated-bg-map: map.set($updated-bg-map, 'bad', colors.$bad);
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(345, 96%, 25%),
       'color-disabled': hsl(0, 0%, 21%),
@@ -39,23 +39,23 @@ $updated-bg-map: map.set($updated-bg-map, 'bad', colors.$bad);
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Dimmer',
+    '~tgui-core/styles/components/Dimmer',
     $with: ('background-dimness': 0.45)
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': hsl(15, 14%, 26%))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
+  @include meta.load-css('~tgui-core/styles/components/Modal');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NoticeBox',
+    '~tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(0, 90%, 23%))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/NumberInput');
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
-  @include meta.load-css('pkg:tgui-core/styles/components/Table');
+  @include meta.load-css('~tgui-core/styles/components/NumberInput');
+  @include meta.load-css('~tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Table');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 0%, 0%))
   );
 

--- a/tgui/packages/tgui/styles/themes/spookyconsole.scss
+++ b/tgui/packages/tgui/styles/themes/spookyconsole.scss
@@ -28,7 +28,7 @@ $updated-bg-map: map.set($updated-bg-map, 'bad', colors.$bad);
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': hsl(345, 96%, 25%),
       'color-disabled': hsl(0, 0%, 21%),
@@ -39,23 +39,23 @@ $updated-bg-map: map.set($updated-bg-map, 'bad', colors.$bad);
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Dimmer',
+    'pkg:tgui-core/styles/components/Dimmer',
     $with: ('background-dimness': 0.45)
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': hsl(15, 14%, 26%))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Modal');
+  @include meta.load-css('pkg:tgui-core/styles/components/Modal');
   @include meta.load-css(
-    'pkg:tgui-styles/components/NoticeBox',
+    'pkg:tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(0, 90%, 23%))
   );
-  @include meta.load-css('pkg:tgui-styles/components/NumberInput');
-  @include meta.load-css('pkg:tgui-styles/components/Section');
-  @include meta.load-css('pkg:tgui-styles/components/Table');
+  @include meta.load-css('pkg:tgui-core/styles/components/NumberInput');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Table');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 0%, 0%))
   );
 

--- a/tgui/packages/tgui/styles/themes/syndicate.scss
+++ b/tgui/packages/tgui/styles/themes/syndicate.scss
@@ -22,7 +22,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(0, 0%, 21%),
@@ -32,24 +32,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': hsl(120, 60%, 70%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NoticeBox',
+    'pkg:tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(0, 98%, 28%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NumberInput',
+    'pkg:tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(120, 60%, 70%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 96%, 14%))
   );
 

--- a/tgui/packages/tgui/styles/themes/syndicate.scss
+++ b/tgui/packages/tgui/styles/themes/syndicate.scss
@@ -22,7 +22,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(0, 0%, 21%),
@@ -32,24 +32,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': hsl(120, 60%, 70%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NoticeBox',
+    '~tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(0, 98%, 28%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NumberInput',
+    '~tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(120, 60%, 70%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(0, 96%, 14%))
   );
 

--- a/tgui/packages/tgui/styles/themes/wizard.scss
+++ b/tgui/packages/tgui/styles/themes/wizard.scss
@@ -23,7 +23,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Button',
+    '~tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(204, 97%, 21%),
@@ -33,24 +33,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Input',
+    '~tgui-core/styles/components/Input',
     $with: ('border-color': hsl(227, 25%, 34%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NoticeBox',
+    '~tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(340, 58%, 41%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/NumberInput',
+    '~tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(227, 25%, 34%))
   );
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/ProgressBar',
+    '~tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-core/styles/components/Section');
+  @include meta.load-css('~tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-core/styles/components/Tooltip',
+    '~tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(134, 61%, 42%))
   );
 

--- a/tgui/packages/tgui/styles/themes/wizard.scss
+++ b/tgui/packages/tgui/styles/themes/wizard.scss
@@ -23,7 +23,7 @@
 
   // Components
   @include meta.load-css(
-    'pkg:tgui-styles/components/Button',
+    'pkg:tgui-core/styles/components/Button',
     $with: (
       'color-default': colors.$primary,
       'color-disabled': hsl(204, 97%, 21%),
@@ -33,24 +33,24 @@
     )
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/Input',
+    'pkg:tgui-core/styles/components/Input',
     $with: ('border-color': hsl(227, 25%, 34%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NoticeBox',
+    'pkg:tgui-core/styles/components/NoticeBox',
     $with: ('background-color': hsl(340, 58%, 41%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/NumberInput',
+    'pkg:tgui-core/styles/components/NumberInput',
     $with: ('border-color': hsl(227, 25%, 34%))
   );
   @include meta.load-css(
-    'pkg:tgui-styles/components/ProgressBar',
+    'pkg:tgui-core/styles/components/ProgressBar',
     $with: ('background-color': hsla(0, 0%, 0%, 0.5))
   );
-  @include meta.load-css('pkg:tgui-styles/components/Section');
+  @include meta.load-css('pkg:tgui-core/styles/components/Section');
   @include meta.load-css(
-    'pkg:tgui-styles/components/Tooltip',
+    'pkg:tgui-core/styles/components/Tooltip',
     $with: ('background-color': hsl(134, 61%, 42%))
   );
 

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -18723,17 +18723,17 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.7.1"
+    tgui-core: "npm:^1.7.2"
   languageName: unknown
   linkType: soft
 
-"tgui-core@npm:^1.7.1":
-  version: 1.7.1
-  resolution: "tgui-core@npm:1.7.1"
+"tgui-core@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "tgui-core@npm:1.7.2"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/d9475f6b6702b15617abdf3a15d7d30527182214b0f9d28d1a357dd79e474a5b64a000d072e0a52f1b3d578b3c73383e50327bdff19728318b9240ba931c01b6
+  checksum: 10c0/401102042d4d0ede4f8658160124cd523c4ffc44492e0f7d0500d25e0b8a085be2b6f829c89b81eb706c369af16d6d57375704337d7bcc813480caa749c258d4
   languageName: node
   linkType: hard
 
@@ -18761,7 +18761,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.7.1"
+    tgui-core: "npm:^1.7.2"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown
@@ -18788,7 +18788,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.7.1"
+    tgui-core: "npm:^1.7.2"
     tgui-polyfill: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -18850,7 +18850,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-popper: "npm:^2.3.0"
-    tgui-core: "npm:^1.7.1"
+    tgui-core: "npm:^1.7.2"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -18723,17 +18723,17 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.5.7"
+    tgui-core: "npm:^1.7.1"
   languageName: unknown
   linkType: soft
 
-"tgui-core@npm:^1.5.7":
-  version: 1.5.7
-  resolution: "tgui-core@npm:1.5.7"
+"tgui-core@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "tgui-core@npm:1.7.1"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/2037c4e4c23c5f8f5f576c1936e1559edc75511938df3b554b459542159545a66a0649cd4b8bf89ec2993aedcc7ea5665836a1d7d98ddc715c9c74f02da42042
+  checksum: 10c0/d9475f6b6702b15617abdf3a15d7d30527182214b0f9d28d1a357dd79e474a5b64a000d072e0a52f1b3d578b3c73383e50327bdff19728318b9240ba931c01b6
   languageName: node
   linkType: hard
 
@@ -18761,7 +18761,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.5.7"
+    tgui-core: "npm:^1.7.1"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown
@@ -18788,7 +18788,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.5.7"
+    tgui-core: "npm:^1.7.1"
     tgui-polyfill: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -18850,7 +18850,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-popper: "npm:^2.3.0"
-    tgui-core: "npm:^1.5.7"
+    tgui-core: "npm:^1.7.1"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -18723,17 +18723,17 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.5.4"
+    tgui-core: "npm:^1.5.7"
   languageName: unknown
   linkType: soft
 
-"tgui-core@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "tgui-core@npm:1.5.4"
+"tgui-core@npm:^1.5.7":
+  version: 1.5.7
+  resolution: "tgui-core@npm:1.5.7"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/c9959690ff905ddf57b241918cfe889bf840efc70271a7e35832f2a5a2854506ad0e9086a02f16a1a2bd02196a311afb0516b0af3769ca1992072fe7d85c2f1b
+  checksum: 10c0/2037c4e4c23c5f8f5f576c1936e1559edc75511938df3b554b459542159545a66a0649cd4b8bf89ec2993aedcc7ea5665836a1d7d98ddc715c9c74f02da42042
   languageName: node
   linkType: hard
 
@@ -18761,10 +18761,9 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.5.4"
+    tgui-core: "npm:^1.5.7"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
-    tgui-styles: "npm:^0.0.10"
   languageName: unknown
   linkType: soft
 
@@ -18789,18 +18788,10 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tgui: "workspace:*"
-    tgui-core: "npm:^1.5.4"
+    tgui-core: "npm:^1.5.7"
     tgui-polyfill: "workspace:*"
-    tgui-styles: "npm:^0.0.10"
   languageName: unknown
   linkType: soft
-
-"tgui-styles@npm:^0.0.10":
-  version: 0.0.10
-  resolution: "tgui-styles@npm:0.0.10"
-  checksum: 10c0/90d3c9d891680289e79fd1f44dcf15a0cc956345e0337b2f89a64ceb1c5192da217dd8ac64566731471684b6bb6d3b4fc92ff6a072f9d8138e71d423c94821a6
-  languageName: node
-  linkType: hard
 
 "tgui-workspace@workspace:.":
   version: 0.0.0-use.local
@@ -18859,10 +18850,9 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-popper: "npm:^2.3.0"
-    tgui-core: "npm:^1.5.4"
+    tgui-core: "npm:^1.5.7"
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
-    tgui-styles: "npm:^0.0.10"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## About The Pull Request
New version brings expanded documentation right from the component reference, now for nested components as well
![Screenshot 2025-01-04 150456](https://github.com/user-attachments/assets/988a09e0-e9b9-42ba-b5d9-acde1b863279)

ImageButton has had some upgrades via @AyIong 

Since tgui-styles was deprecated in favor of just directly exporting styles, we can now remove that package
## Why It's Good For The Game
Dev exp and better UIs
## Changelog
N/A