### PR TITLE
Fixes wawa's xenobio reagent grinders being inaccessible

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -46930,9 +46930,7 @@
 	dir = 1
 	},
 /obj/item/stack/sheet/mineral/plasma,
-/obj/machinery/reagentgrinder{
-	pixel_y = 4
-	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "qGN" = (
@@ -48819,9 +48817,7 @@
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/machinery/reagentgrinder{
-	pixel_y = 4
-	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "rms" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -46926,13 +46926,13 @@
 /area/station/medical/exam_room)
 "qGD" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "qGN" = (
@@ -48817,11 +48817,11 @@
 /area/station/engineering/atmos/upper)
 "rmi" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "rms" = (


### PR DESCRIPTION

## About The Pull Request

They get offset by tables already
Closes #88550
Closes #87096

## Changelog
:cl:
fix: Fixed wawa's xenobio reagent grinders being inaccessible
/:cl:
