### PR TITLE
SaturnX no longer destroys player's retinas

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -695,6 +695,7 @@
 	var/list/col_filter_empty = list(1,0,0,0, 0,0,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,0)
 
 	game_plane_master_controller.add_filter("saturnx_filter", 10, color_matrix_filter(col_filter_twothird, FILTER_COLOR_HCY))
+	game_plane_master_controller.add_filter("saturnx_blur", 1, list("type" = "radial_blur", "size" = 0))
 
 	for(var/filter in game_plane_master_controller.get_filters("saturnx_filter"))
 		animate(filter, loop = -1, color = col_filter_full, time = 4 SECONDS, easing = CIRCULAR_EASING|EASE_IN, flags = ANIMATION_PARALLEL)
@@ -705,11 +706,9 @@
 		animate(color = col_filter_half, time = 24 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
 		animate(color = col_filter_twothird, time = 12 SECONDS, easing = LINEAR_EASING)
 
-	game_plane_master_controller.add_filter("saturnx_blur", 1, list("type" = "radial_blur", "size" = 0))
-
 	for(var/filter in game_plane_master_controller.get_filters("saturnx_blur"))
-		animate(filter, loop = -1, size = 0.04, time = 2 SECONDS, easing = ELASTIC_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
-		animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
+		animate(filter, loop = -1, size = 0.02, time = 2 SECONDS, easing = SINE_EASING, flags = ANIMATION_PARALLEL)
+		animate(size = 0, time = 6 SECONDS, easing = SINE_EASING)
 
 ///This proc turns the living mob passed as the arg "invisible_man"s invisible by giving him the invisible man trait and updating his body, this changes the sprite of all his organic limbs to a 1 alpha version.
 /datum/reagent/drug/saturnx/proc/turn_man_invisible(mob/living/carbon/invisible_man, requires_liver = TRUE)


### PR DESCRIPTION

## About The Pull Request

This PR reduces the strength of SaturnX's radial blur effect, and makes it use sine easing instead of extremely jumpy elastic easing.

Before:

https://github.com/user-attachments/assets/3f617916-d6d6-4d03-97f8-8a999d568303

After:

https://github.com/user-attachments/assets/b7333f24-7663-4fb8-89e3-e0c5f3232e7b

## Why It's Good For The Game

Invisibility may be strong, but it also requires you to drop all of your items, including held ones, to truely be invisible. This filter is too much of a downside/visual effect and needs to be tuned down, as its strong enough to make you dizzy just from looking at it.

## Changelog
:cl:
balance: Significatly tuned down SaturnX's visual filter's strength
/:cl:
