### PR TITLE
[no gbp] fixes turtles rerolling strange seed chems

### DIFF
--- a/code/modules/mob/living/basic/turtle/turtle.dm
+++ b/code/modules/mob/living/basic/turtle/turtle.dm
@@ -49,6 +49,10 @@
 	var/developed_path
 	///our last east/west direction
 	var/last_direction = WEST
+	///seeds our stomach cannot process into fruit, we will spit these seeds out after a short time instead
+	var/static/list/indigestible_seeds = typecacheof(list(
+		/obj/item/seeds/random,
+	))
 
 /mob/living/basic/turtle/Initialize(mapload)
 	. = ..()
@@ -224,7 +228,7 @@
 
 /mob/living/basic/turtle/proc/post_eat(datum/source, obj/item/seeds/potential_food)
 	SIGNAL_HANDLER
-	if(istype(potential_food, /obj/item/seeds/random))
+	if(is_type_in_typecache(potential_food, indigestible_seeds))
 		potential_food.forceMove(src)
 		addtimer(CALLBACK(src, PROC_REF(process_food), potential_food), 20 SECONDS)
 		return COMSIG_MOB_TERMINATE_EAT

--- a/code/modules/mob/living/basic/turtle/turtle.dm
+++ b/code/modules/mob/living/basic/turtle/turtle.dm
@@ -64,6 +64,7 @@
 	AddElement(/datum/element/basic_eating, food_types = eatable_food)
 	AddComponent(/datum/component/happiness)
 	RegisterSignal(src, COMSIG_MOB_PRE_EAT, PROC_REF(pre_eat_food))
+	RegisterSignal(src, COMSIG_MOB_ATE, PROC_REF(post_eat))
 	update_appearance()
 	create_reagents(150, REAGENT_HOLDER_ALIVE)
 	add_verb(src, /mob/living/proc/toggle_resting)
@@ -218,14 +219,30 @@
 
 	if(!istype(potential_food))
 		return NONE
-	if(ispath(potential_food.product, /obj/item/food/grown))
-		addtimer(CALLBACK(src, PROC_REF(process_food), potential_food.product), 30 SECONDS)
+
+	return ispath(potential_food.product, /obj/item/food/grown) ? NONE : COMSIG_MOB_CANCEL_EAT
+
+/mob/living/basic/turtle/proc/post_eat(datum/source, obj/item/seeds/potential_food)
+	SIGNAL_HANDLER
+	if(istype(potential_food, /obj/item/seeds/random))
+		potential_food.forceMove(src)
+		addtimer(CALLBACK(src, PROC_REF(process_food), potential_food), 20 SECONDS)
+		return COMSIG_MOB_TERMINATE_EAT
+
+	addtimer(CALLBACK(src, PROC_REF(process_food), potential_food.product), 30 SECONDS)
 	return NONE
 
-/mob/living/basic/turtle/proc/process_food(food_path)
+/mob/living/basic/turtle/proc/process_food(potential_food)
 	if(QDELETED(src) || stat != CONSCIOUS)
 		return
-	new food_path(drop_location())
+
+	if(ispath(potential_food))
+		new potential_food(drop_location())
+
+	else if((!isnull(potential_food)) && (potential_food in contents))
+		var/atom/movable/movable_food = potential_food
+		movable_food.forceMove(drop_location())
+
 	balloon_alert_to_viewers("spits out some food")
 
 /mob/living/basic/turtle/death(gibbed)


### PR DESCRIPTION

## About The Pull Request
fixes turtles rerolling strange seed chems, this was an oversight i didnt intend for. turtles will now spit the seed out after processing it as is.

## Why It's Good For The Game
this bypassed the legitimate way to roll for chems, which made it very easy to get crazy chems in a very short amount of time

## Changelog
:cl:
fix: fixes turtles rerolling strange seed chems
/:cl:
