### PR TITLE
Grillable foods grill in hot air

### DIFF
--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -210,3 +210,5 @@
 	var/speed_modifier = LERP(0.5, 1, temp_scale)
 
 	on_grill(parent, atom_parent.loc, seconds_per_tick * speed_modifier)
+
+#undef IDEAL_GRILLING_TEMPERATURE

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -14,6 +14,10 @@
 	var/who_placed_us
 	/// Reagents that should be added to the result
 	var/list/added_reagents
+	/// Open turf we were last placed on, to check temperature
+	var/turf/open/listening_turf
+	/// Are we grilling right now?
+	var/is_grilling = FALSE
 
 /datum/component/grillable/Initialize(cook_result, required_cook_time, positive_result, use_large_steam_sprite, list/added_reagents)
 	. = ..()
@@ -32,14 +36,20 @@
 	RegisterSignal(parent, COMSIG_ITEM_GRILL_TURNED_OFF, PROC_REF(on_grill_turned_off))
 	RegisterSignal(parent, COMSIG_ITEM_GRILL_PROCESS, PROC_REF(on_grill))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_location_changed))
+	on_location_changed(parent)
 
 /datum/component/grillable/UnregisterFromParent()
+	if (listening_turf)
+		UnregisterSignal(listening_turf, COMSIG_TURF_EXPOSE)
+
 	UnregisterSignal(parent, list(
 		COMSIG_ATOM_EXAMINE,
 		COMSIG_ITEM_GRILL_TURNED_ON,
 		COMSIG_ITEM_GRILL_TURNED_OFF,
 		COMSIG_ITEM_GRILL_PROCESS,
 		COMSIG_ITEM_GRILL_PLACED,
+		COMSIG_MOVABLE_MOVED
 	))
 
 // Inherit the new values passed to the component
@@ -55,6 +65,32 @@
 	if(use_large_steam_sprite)
 		src.use_large_steam_sprite = use_large_steam_sprite
 
+/datum/component/grillable/Destroy(force)
+	. = ..()
+	STOP_PROCESSING(SSmachines, src)
+	listening_turf = null
+
+/// Signal proc for [COMSIG_MOVABLE_MOVED], our location has changed and we should register for temperature information
+/datum/component/grillable/proc/on_location_changed(atom/source)
+	SIGNAL_HANDLER
+
+	if (is_grilling)
+		on_grill_turned_off(source)
+		STOP_PROCESSING(SSmachines, src)
+
+	if (listening_turf)
+		UnregisterSignal(listening_turf, COMSIG_TURF_EXPOSE)
+
+	if (isnull(source))
+		return
+
+	var/turf/open/current_turf = source.loc
+	if (!isopenturf(current_turf))
+		return
+	listening_turf = current_turf
+	RegisterSignal(current_turf, COMSIG_TURF_EXPOSE, PROC_REF(on_turf_atmos_changed))
+	on_turf_atmos_changed(current_turf, current_turf.air, current_turf.air?.temperature || 0)
+
 /// Signal proc for [COMSIG_ITEM_GRILL_PLACED], item is placed on the grill.
 /datum/component/grillable/proc/on_grill_placed(datum/source, mob/griller)
 	SIGNAL_HANDLER
@@ -62,12 +98,11 @@
 	if(griller && griller.mind)
 		who_placed_us = REF(griller.mind)
 
-	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
-
 /// Signal proc for [COMSIG_ITEM_GRILL_TURNED_ON], starts the grilling process.
 /datum/component/grillable/proc/on_grill_turned_on(datum/source)
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(add_grilled_item_overlay))
 
+	is_grilling = TRUE
 	var/atom/atom_parent = parent
 	atom_parent.update_appearance()
 
@@ -75,6 +110,7 @@
 /datum/component/grillable/proc/on_grill_turned_off(datum/source)
 	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS)
 
+	is_grilling = FALSE
 	var/atom/atom_parent = parent
 	atom_parent.update_appearance()
 
@@ -138,15 +174,27 @@
 	else
 		examine_list += span_danger("[parent] should probably not be put on the grill.")
 
-///Ran when an object moves from the grill
-/datum/component/grillable/proc/on_moved(atom/source, atom/OldLoc, Dir, Forced)
-	SIGNAL_HANDLER
-
-	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS)
-	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
-	source.update_appearance()
-
 /datum/component/grillable/proc/add_grilled_item_overlay(datum/source, list/overlays)
 	SIGNAL_HANDLER
 
 	overlays += mutable_appearance('icons/effects/steam.dmi', "[use_large_steam_sprite ? "steam_triple" : "steam_single"]", ABOVE_OBJ_LAYER)
+
+/// Signal proc for [COMSIG_TURF_EXPOSE], atmosphere might be hot enough for grilling.
+/datum/component/grillable/proc/on_turf_atmos_changed(turf/open/source, datum/gas_mixture/air, exposed_temperature)
+	SIGNAL_HANDLER
+
+	if (!is_grilling)
+		if (exposed_temperature < FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+			return
+		on_grill_turned_on(source)
+		START_PROCESSING(SSmachines, src)
+	else
+		if (exposed_temperature >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+			return
+		on_grill_turned_off(source)
+		STOP_PROCESSING(SSmachines, src)
+
+// Grill while exposed to hot air
+/datum/component/grillable/process(seconds_per_tick)
+	var/atom/atom_parent = parent
+	on_grill(parent, atom_parent.loc, seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request

This PR makes is so that if the air is hot enough to trigger a fire door to close, grillable foods left out in the open will grill themselves.
I picked the minimum grilling temperature essentially at random because I don't know what heat units are or should be, but the define `FIRE_MINIMUM_TEMPERATURE_TO_EXIST` sounded about right.

IMPORTANT NOTE: **All foods are grillable by default** and become "burned mess" after about 30 seconds.
If this seems like too much of a grief vector (a significant fire in the kitchen may cause all food to grill itself into oblivion) I can make this optional rather than a default-enabled thing on all food. IDK whether or not this matters, because all food is also flammable.

Food will only grill based on air temperature if it is set out on an open tile (including while on a table), not while in your hands or backpack or pockets or a closet or inside an oven or (oddly enough) while on a grill.

## Why It's Good For The Game

it increases my emulsion if eggs can fry on a hot sidewalk

## Changelog

:cl:
add: Eggs (and all other edible food) left in a hot place will fry.
/:cl:
