### PR TITLE
Allows admins to filter observable mobs by ckey

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -59,6 +59,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 /datum/orbit_menu/ui_static_data(mob/user)
 	var/list/new_mob_pois = SSpoints_of_interest.get_mob_pois(CALLBACK(src, PROC_REF(validate_mob_poi)), append_dead_role = FALSE)
 	var/list/new_other_pois = SSpoints_of_interest.get_other_pois()
+	var/is_admin = user?.client?.holder
 
 	var/list/alive = list()
 	var/list/antagonists = list()
@@ -101,10 +102,13 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		serialized["client"] = !!mob_poi.client
 		serialized["name"] = mob_poi.real_name
 
+		if (is_admin)
+			serialized["ckey"] = mob_poi.ckey
+
 		if(isliving(mob_poi))
 			serialized += get_living_data(mob_poi)
 
-		var/list/antag_data = get_antag_data(mob_poi.mind, user?.client?.holder)
+		var/list/antag_data = get_antag_data(mob_poi.mind, is_admin)
 		if(length(antag_data))
 			serialized += antag_data
 			antagonists += list(serialized)

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitCollapsible.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitCollapsible.tsx
@@ -4,7 +4,7 @@ import { Collapsible, Flex, Tooltip } from 'tgui-core/components';
 import { OrbitContext } from '.';
 import { VIEWMODE } from './constants';
 import {
-  isJobOrNameMatch,
+  isJobCkeyOrNameMatch,
   sortByDepartment,
   sortByDisplayName,
 } from './helpers';
@@ -29,7 +29,7 @@ export function OrbitCollapsible(props: Props) {
     useContext(OrbitContext);
 
   const filteredSection = section.filter((observable) =>
-    isJobOrNameMatch(observable, searchQuery),
+    isJobCkeyOrNameMatch(observable, searchQuery),
   );
 
   if (viewMode === VIEWMODE.Department) {

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitSearchBar.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitSearchBar.tsx
@@ -4,7 +4,7 @@ import { Button, Icon, Input, Section, Stack } from 'tgui-core/components';
 import { useBackend } from '../../backend';
 import { OrbitContext } from '.';
 import { VIEWMODE } from './constants';
-import { isJobOrNameMatch, sortByOrbiters } from './helpers';
+import { isJobCkeyOrNameMatch, sortByOrbiters } from './helpers';
 import { OrbitData } from './types';
 
 /** Search bar for the orbit ui. Has a few buttons to switch between view modes and auto-observe */
@@ -37,7 +37,7 @@ export function OrbitSearchBar(props) {
       data.npcs,
     ]
       .flat()
-      .filter((observable) => isJobOrNameMatch(observable, searchQuery))
+      .filter((observable) => isJobCkeyOrNameMatch(observable, searchQuery))
       .sort(sortByOrbiters)[0];
 
     if (mostRelevant !== undefined) {

--- a/tgui/packages/tgui/interfaces/Orbit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/helpers.ts
@@ -120,18 +120,19 @@ export function getDisplayColor(
 }
 
 /** Checks if a full name or job title matches the search. */
-export function isJobOrNameMatch(
+export function isJobCkeyOrNameMatch(
   observable: Observable,
   searchQuery: string,
 ): boolean {
   if (!searchQuery) return true;
 
-  const { full_name, job, name } = observable;
+  const { full_name, job, name, ckey } = observable;
 
   return (
     full_name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     job?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
+    ckey?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     false
   );
 }

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -36,6 +36,7 @@ export type Observable = {
   mind_job: string;
   name: string;
   orbiters: number;
+  ckey: string;
 }>;
 
 type Critical = {


### PR DESCRIPTION

## About The Pull Request

Adds ckey sorting akin to how you can look someone up by their name or job in the observer menu, only available for admins.

## Why It's Good For The Game

Wine said it would be mad useful, no reason not to - they can already observe people by ckey via the ``Who`` verb, this just adds a cleaner way to do so.

## Changelog
:cl:
admin: Admins can now filter observable mobs by ckey
/:cl:
