### PR TITLE
Adds a barbot seat projector to Wawa's bar

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -31873,12 +31873,16 @@
 "ljU" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/table,
-/obj/item/clothing/head/hats/tophat,
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_x = -4;
 	pixel_y = 7
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/holosign_creator/robot_seat/bar{
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/obj/item/clothing/head/hats/tophat,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "ljZ" = (


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/6cdf66c6-eb47-4060-bb81-6670e469b3ce)

## Why It's Good For The Game

Map parity, you'd expect to be able to do your job roundstart.

## Changelog
:cl:
fix: Added a barboat seat projector to Wawa's bar
/:cl:
