### PR TITLE
The tesla cannon self recharges

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -368,6 +368,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/tesla_cannon)
 	shaded_charge = TRUE
 	weapon_weight = WEAPON_HEAVY
+	selfcharge = TRUE
 
 /obj/item/gun/energy/tesla_cannon/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
makes the tesla cannon self recharge at the same rate as the captain's antique laser gun
## Why It's Good For The Game
for requiring an anomaly core, this weapon sure is weak, this should make it a bit stronger so it's worth using an anomaly core for.
## Changelog
:cl: grungussuss
balance: the tesla cannon now self recharges
/:cl:
