### PR TITLE
Fixes rave visor deleting its music player on deactivation (and spamming runtimes)

### DIFF
--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -125,7 +125,6 @@
 		return
 
 	music_player.unlisten_all()
-	QDEL_NULL(music_player)
 	if(deleting)
 		return
 	SEND_SOUND(mod.wearer, sound('sound/machines/terminal/terminal_off.ogg', volume = 50, channel = CHANNEL_JUKEBOX))


### PR DESCRIPTION

## About The Pull Request

So the rave visor was deleting its music player on deactivation, even though it only gets created on init.
All we do here is stop it from deleting its music player on deactivation, as I believe that's not actually necessary.
This fixes our issue.
It still deletes the music player on destroy.
## Why It's Good For The Game

This is bad:
![image](https://github.com/user-attachments/assets/e382ae21-40a4-4006-8f2a-cf56666c7120)
## Changelog
:cl:
fix: Rave visor music actually works after the first deactivation.
/:cl:
