### PR TITLE
COMSIG_ELEMENT_DETACH documentation spellcheck

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_datum.dm
+++ b/code/__DEFINES/dcs/signals/signals_datum.dm
@@ -26,7 +26,7 @@
 
 /// fires on the target datum when an element is attached to it (/datum/element)
 #define COMSIG_ELEMENT_ATTACH "element_attach"
-/// fires on the target datum when an element is attached to it  (/datum/element)
+/// fires on the target datum when an element is detached from it (/datum/element)
 #define COMSIG_ELEMENT_DETACH "element_detach"
 
 // Merger datum signals


### PR DESCRIPTION

## About The Pull Request

The documentation for `COMSIG_ELEMENT_DETACH` mentioned `(...) when an element is attached to it  (/datum/element)` which is both wrong given it's the detach signal, and contains a double space at the end.
We just change it to `detached from` and remove the double space:
`is attached to it  (/datum/element)` > `is detached from it (/datum/element)`
## Why It's Good For The Game

Spellcheck 👍 
