### PR TITLE
Firing a burst fire gun as a Pacifist no longer permanently breaks the weapon

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -416,7 +416,8 @@
 		if(HAS_TRAIT(user, TRAIT_PACIFISM)) // If the user has the pacifist trait, then they won't be able to fire [src] if the round chambered inside of [src] is lethal.
 			if(chambered.harmful) // Is the bullet chambered harmful?
 				to_chat(user, span_warning("[src] is lethally chambered! You don't want to risk harming anyone..."))
-				return
+				firing_burst = FALSE
+				return FALSE
 		var/sprd
 		if(randomspread)
 			sprd = round((rand(0, 1) - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (random_spread))


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/88904

## Why It's Good For The Game

Bugs are really not cool. It's funny that a pacifist can somehow render a gun permanently unusable, it's...not exactly good.

## Changelog
:cl:
fix: Burst fire weapons cannot be permanently broken by pacifists attempting to fire them.
/:cl:
