### PR TITLE
Smoke puff on long exhale fix

### DIFF
--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -454,7 +454,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!isturf(smoker.loc))
 		return
 
-	var/obj/effect/abstract/particle_holder/big_smoke = new(smoker.loc, /particles/smoke/cig/big)
+	var/obj/effect/abstract/particle_holder/big_smoke = new(smoker, /particles/smoke/cig/big)
 	update_particle_position(big_smoke, smoker.dir)
 	QDEL_IN(big_smoke, big_smoke.particles.lifespan)
 

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -454,6 +454,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!isturf(smoker.loc))
 		return
 
+	// This should be smoker.loc but it inexplicably doesn't work 
 	var/obj/effect/abstract/particle_holder/big_smoke = new(smoker, /particles/smoke/cig/big)
 	update_particle_position(big_smoke, smoker.dir)
 	QDEL_IN(big_smoke, big_smoke.particles.lifespan)


### PR DESCRIPTION
## About The Pull Request

Semi-fixes smoke puff on long exhale (when you take the cig out of your mouth). The smoke cloud is fixed on your character, but it's better than no cloud at all.

Fixes https://github.com/tgstation/tgstation/issues/87804

https://github.com/user-attachments/assets/e973d126-186d-4034-80ce-4b4e5dc965cf

## Why It's Good For The Game

mmm yummy cigarettes

## Changelog

:cl:
fix: smoke puff on long exhale now displays properly
/:cl: