### PR TITLE
[NO GBP] Fixes incorrect ignore_throwspeed_threshold on sticky tape

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -23,7 +23,7 @@
 /datum/embedding/sticky_tape
 	pain_mult = 0
 	jostle_pain_mult = 0
-	ignore_throwspeed_threshold = 0
+	ignore_throwspeed_threshold = TRUE
 	immune_traits = null
 
 /obj/item/stack/sticky_tape/attack_hand(mob/user, list/modifiers)


### PR DESCRIPTION

## About The Pull Request

Closes #88894
No one took it for 3 days, gotta fix it.

## Changelog
:cl:
fix: Sticky tape should be sticky again.
/:cl:
