### PR TITLE
Makes blood trails a subtype of blood, fixes blood rites jank

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -88,15 +88,19 @@
 	dryname = "dried tracks"
 	drydesc = "Some old bloody tracks left by wheels. Machines are evil, perhaps."
 
-/obj/effect/decal/cleanable/trail_holder //not a child of blood on purpose
+/obj/effect/decal/cleanable/blood/trail_holder
 	name = "blood"
-	icon = 'icons/effects/blood.dmi'
 	desc = "Your instincts say you shouldn't be following these."
+	icon = 'icons/effects/blood.dmi'
+	icon_state = null
+	random_icon_states = null
 	beauty = -50
 	var/list/existing_dirs = list()
 
-/obj/effect/decal/cleanable/trail_holder/can_bloodcrawl_in()
-	return TRUE
+/obj/effect/decal/cleanable/blood/trail_holder/replace_decal(obj/effect/decal/cleanable/blood/trail_holder/blood_decal)
+	if(blood_state != blood_decal.blood_state)
+		return FALSE
+	return ..()
 
 // normal version of the above trail holder object for use in less convoluted things
 /obj/effect/decal/cleanable/blood/trails

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -750,7 +750,7 @@
 /obj/item/melee/blood_magic/manipulator/cast_spell(mob/living/target, mob/living/carbon/user)
 	if((isconstruct(target) || isshade(target)) && !heal_construct(target, user))
 		return
-	if(istype(target, /obj/effect/decal/cleanable/blood) || istype(target, /obj/effect/decal/cleanable/trail_holder) || isturf(target))
+	if(istype(target, /obj/effect/decal/cleanable/blood) || isturf(target))
 		blood_draw(target, user)
 	if(ishuman(target))
 		var/mob/living/carbon/human/human_bloodbag = target
@@ -882,19 +882,13 @@
 		return
 	for(var/obj/effect/decal/cleanable/blood/blood_around_us in range(our_turf,2))
 		if(blood_around_us.blood_state != BLOOD_STATE_HUMAN)
-			break
+			continue
 		if(blood_around_us.bloodiness == 100) // Bonus for "pristine" bloodpools, also to prevent cheese with footprint spam
 			blood_to_gain += 30
 		else
 			blood_to_gain += max((blood_around_us.bloodiness**2)/800,1)
 		new /obj/effect/temp_visual/cult/turf/floor(get_turf(blood_around_us))
 		qdel(blood_around_us)
-	for(var/obj/effect/decal/cleanable/trail_holder/trail_around_us in range(our_turf, 2))
-		if(trail_around_us.blood_state != BLOOD_STATE_HUMAN)
-			break
-		blood_to_gain += 5 //These don't get bloodiness, so we'll just increase this by a fixed value
-		new /obj/effect/temp_visual/cult/turf/floor(get_turf(trail_around_us))
-		qdel(trail_around_us)
 
 	if(!blood_to_gain)
 		return

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -95,7 +95,6 @@
 	var/static/list/cleanable_blood = typecacheof(list(
 		/obj/effect/decal/cleanable/xenoblood,
 		/obj/effect/decal/cleanable/blood,
-		/obj/effect/decal/cleanable/trail_holder,
 	))
 	///pests we hunt
 	var/static/list/huntable_pests = typecacheof(list(

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -91,6 +91,9 @@
 	else
 		return pick (list("xttrails_1", "xttrails2"))
 
+/mob/living/carbon/alien/get_trail_blood()
+	return BLOOD_STATE_XENO
+
 /*----------------------------------------
 Proc: AddInfectionImages()
 Des: Gives the client of the alien an image on each infected mob.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1056,14 +1056,13 @@
 	if(!has_gravity() || !isturf(start) || !blood_volume)
 		return
 
-	var/blood_exists = locate(/obj/effect/decal/cleanable/trail_holder) in start
-
 	var/trail_type = getTrail()
-	if(!trail_type)
+	var/trail_blood_type = get_trail_blood()
+	if(!trail_type || !trail_blood_type)
 		return
 
 	var/brute_ratio = round(getBruteLoss() / maxHealth, 0.1)
-	if(blood_volume < max(BLOOD_VOLUME_NORMAL*(1 - brute_ratio * 0.25), 0))//don't leave trail if blood volume below a threshold
+	if(blood_volume < max(BLOOD_VOLUME_NORMAL * (1 - brute_ratio * 0.25), 0))//don't leave trail if blood volume below a threshold
 		return
 
 	var/bleed_amount = bleedDragAmount()
@@ -1075,16 +1074,39 @@
 			newdir = NORTH
 		else if(newdir == (EAST|WEST))
 			newdir = EAST
+
 	if((newdir in GLOB.cardinals) && (prob(50)))
 		newdir = REVERSE_DIR(get_dir(target_turf, start))
-	if(!blood_exists)
-		new /obj/effect/decal/cleanable/trail_holder(start, get_static_viruses())
 
-	for(var/obj/effect/decal/cleanable/trail_holder/TH in start)
-		if((!(newdir in TH.existing_dirs) || trail_type == "trails_1" || trail_type == "trails_2") && TH.existing_dirs.len <= 16) //maximum amount of overlays is 16 (all light & heavy directions filled)
-			TH.existing_dirs += newdir
-			TH.add_overlay(image('icons/effects/blood.dmi', trail_type, dir = newdir))
-			TH.transfer_mob_blood_dna(src)
+	var/found_trail = FALSE
+	for(var/obj/effect/decal/cleanable/blood/trail_holder/trail in start)
+		if (trail.blood_state != trail_blood_type)
+			continue
+
+		// Don't make double trails, even if they're of a different type
+		if(newdir in trail.existing_dirs)
+			found_trail = TRUE
+			break
+
+		trail.existing_dirs += newdir
+		trail.add_overlay(image('icons/effects/blood.dmi', trail_type, dir = newdir))
+		trail.transfer_mob_blood_dna(src)
+		trail.bloodiness = min(trail.bloodiness + bleed_amount, BLOOD_POOL_MAX)
+		found_trail = TRUE
+		break
+
+	if (found_trail)
+		return
+
+	var/obj/effect/decal/cleanable/blood/trail_holder/trail = new(start, get_static_viruses())
+	trail.blood_state = trail_blood_type
+	trail.existing_dirs += newdir
+	trail.add_overlay(image('icons/effects/blood.dmi', trail_type, dir = newdir))
+	trail.transfer_mob_blood_dna(src)
+	trail.bloodiness = min(bleed_amount, BLOOD_POOL_MAX)
+
+/mob/living/proc/get_trail_blood()
+	return BLOOD_STATE_HUMAN
 
 /mob/living/carbon/human/makeTrail(turf/T)
 	if(HAS_TRAIT(src, TRAIT_NOBLOOD) || !is_bleeding() || HAS_TRAIT(src, TRAIT_NOBLOOD))


### PR DESCRIPTION

## About The Pull Request

Closes #85599 by A) replacing a break statement with continue, and B) converting blood trails to be a subtype of blood pools, properly filled with blood. This should also allow them to interact with bloody soles component, making those who step into them leave bloody footprints.

## Changelog
:cl:
fix: Cult blood rites should not longer create "empty" blood or be unable to suck up more than one blood pool at a time.
code: Blood trails are now considered a subtype of blood pools
/:cl:
