### PR TITLE
Renames the bar portal from "restaurant portal"

### DIFF
--- a/code/modules/food_and_drinks/restaurant/generic_venues.dm
+++ b/code/modules/food_and_drinks/restaurant/generic_venues.dm
@@ -86,6 +86,7 @@
 	)
 
 /obj/machinery/restaurant_portal/bar
+	name = "bar portal"
 	linked_venue = /datum/venue/bar
 
 /obj/item/holosign_creator/robot_seat/bar


### PR DESCRIPTION

## About The Pull Request

Renames the bar portal (that thing the bartenders can use to summon robots to buy drinks) to "bar portal" rather than "restaurant portal". It had previously shared the name, so the only way to know which was which was to interact with it and see if it turned on.
## Why It's Good For The Game

There was no way to visually tell which was which while playing.
## Changelog
:cl:
fix: The bar and restaurant portals are now distinguishable at a glance.
/:cl:
