### PR TITLE
Updates the same-tile-item ban map lint to clarify it means the same tile and not adjacent tiles

### DIFF
--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -365,7 +365,7 @@ class Rules:
                 if not banned_neighbor.matches(identified, neighbor):
                     continue
 
-                failures.append(fail_content(identified, f"Typepath {identified.path} has a banned neighbor{when_text}: {neighbor.path}"))
+                failures.append(fail_content(identified, f"Typepath {identified.path} has a banned path on the same tile{when_text}: {neighbor.path}"))
 
         for required_neighbor in self.required_neighbors:
             found = False


### PR DESCRIPTION
this lint confused the hell out of me so I fixed it to be more clear