### PR TITLE
Fix big smoke on cigarette exhale (and tram smashing apparently) 

### DIFF
--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -19,6 +19,10 @@
 	if(!loc)
 		stack_trace("particle holder was created with no loc!")
 		return INITIALIZE_HINT_QDEL
+
+	if(PLANE_TO_TRUE(loc.plane) == FLOOR_PLANE)
+		vis_flags &= ~VIS_INHERIT_PLANE // don't yoink the floor plane. we'll just sit on game plane, it's fine
+
 	// We nullspace ourselves because some objects use their contents (e.g. storage) and some items may drop everything in their contents on deconstruct.
 	parent = loc
 	loc = null

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -386,7 +386,7 @@
 				if(QDELING(victim_structure))
 					continue
 				if(!is_type_in_typecache(victim_structure, transport_controller_datum.ignored_smashthroughs))
-					if((PLANE_TO_TRUE(victim_structure.plane) == FLOOR_PLANE && victim_structure.layer > TRAM_RAIL_LAYER) || (victim_structure.plane == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
+					if((PLANE_TO_TRUE(victim_structure.plane) == FLOOR_PLANE && victim_structure.layer > TRAM_RAIL_LAYER) || (PLANE_TO_TRUE(victim_structure.plane) == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
 						if(victim_structure.anchored && initial(victim_structure.anchored) == TRUE)
 							visible_message(span_danger("[src] smashes through [victim_structure]!"))
 							victim_structure.deconstruct(FALSE)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -386,7 +386,7 @@
 				if(QDELING(victim_structure))
 					continue
 				if(!is_type_in_typecache(victim_structure, transport_controller_datum.ignored_smashthroughs))
-					if((victim_structure.plane == FLOOR_PLANE && victim_structure.layer > TRAM_RAIL_LAYER) || (victim_structure.plane == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
+					if((PLANE_TO_TRUE(victim_structure.plane) == FLOOR_PLANE && victim_structure.layer > TRAM_RAIL_LAYER) || (victim_structure.plane == GAME_PLANE && victim_structure.layer > LOW_OBJ_LAYER) )
 						if(victim_structure.anchored && initial(victim_structure.anchored) == TRUE)
 							visible_message(span_danger("[src] smashes through [victim_structure]!"))
 							victim_structure.deconstruct(FALSE)


### PR DESCRIPTION
## About The Pull Request

Two errors from floor plane conversion

Closes #87804
Closes #88939  (This is a more correct fix) 

- Particle holders inherited plane but did not inherit layer, meaning their plane was `FLOOR_PLANE` but their layer was only like `4`, which made it layer far far under everything. 
   - Fixes this by removing `VIS_INHERIT_PLANE` on particle holders on the floor plane. This keeps it on game plane, which is (I think) what you would want 99 times out of 100 when working on particles attached to turfs?

- While searching through the code I noticed this bit of tram code has a similar pitfall, it's not checking for the real floor plane. So I just made it check true plane

## Changelog

:cl: Melbert
fix: Big smoke puff from cigarettes happen
fix: Tram now smashes certain objects it should be smashing again
/:cl:
