### PR TITLE
Overdose thresholds now positively scale with high purity

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -194,7 +194,8 @@ Primarily used in reagents/reaction_agents
 
 /// Called when this reagent is first added to a mob
 /datum/reagent/proc/on_mob_add(mob/living/affected_mob, amount)
-	overdose_threshold /= max(normalise_creation_purity(), 1) //Maybe??? Seems like it would help pure chems be even better but, if I normalised this to 1, then everything would take a 25% reduction
+	// Scale the overdose threshold of the chem by the difference between the default and creation purity.
+	overdose_threshold += (src.creation_purity - initial(purity)) * overdose_threshold	
 	if(added_traits)
 		affected_mob.add_traits(added_traits, "base:[type]")
 


### PR DESCRIPTION
## About The Pull Request

OD thresholds are scaled by purity when ingested. The current scaling penalises high purity, which appears to have been a mistake, see #64028. This PR changes the scaling to favour higher purities and penalise lower ones.

## Why It's Good For The Game

Properly synthesised chems, will match or exceed the listed OD threshold. Fixes #64028.

## Changelog

:cl:
balance: Overdose thresholds now positively scale with high purity
/:cl:
