### PR TITLE
Fix some inverted teleport validation checks

### DIFF
--- a/code/datums/components/dejavu.dm
+++ b/code/datums/components/dejavu.dm
@@ -81,7 +81,7 @@
 
 	//comes after healing so new limbs comically drop to the floor
 	if(starting_turf)
-		if(check_teleport_valid(parent, starting_turf))
+		if(!check_teleport_valid(parent, starting_turf))
 			to_chat(parent, span_warning("For some reason, your head aches and fills with mental fog when you try to think of where you were... It feels like you're now going against some dull, unstoppable universal force."))
 		else
 			var/atom/movable/master = parent

--- a/code/game/objects/items/implants/security/implant_beacon.dm
+++ b/code/game/objects/items/implants/security/implant_beacon.dm
@@ -25,7 +25,7 @@
 	var/list/info_shown = ..()
 
 	var/area/destination_area = get_area(imp_in)
-	if(isnull(destination_area) || check_teleport_valid(imp_in, usr))
+	if(isnull(destination_area) || !check_teleport_valid(imp_in, usr))
 		info_shown["Status"] = "Implant carrier teleport signal cannot be reached!"
 	else
 		var/turf/turf_to_check = get_turf(imp_in)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -285,7 +285,7 @@
 ///Is, for some reason, separate from the teleport target's check in try_create_portal_to()
 /obj/item/hand_tele/proc/can_teleport_notifies(mob/user)
 	var/turf/current_location = get_turf(user)
-	if (!current_location || check_teleport_valid(src, current_location) || is_away_level(current_location.z) || !isturf(user.loc))
+	if (!current_location || !check_teleport_valid(src, current_location) || is_away_level(current_location.z) || !isturf(user.loc))
 		to_chat(user, span_notice("[src] is malfunctioning."))
 		return FALSE
 

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -159,7 +159,7 @@
 
 /obj/item/mod/module/timeline_jumper/used()
 	var/area/noteleport_check = get_area(mod.wearer)
-	if(noteleport_check && check_teleport_valid(mod.wearer, get_turf(mod.wearer)))
+	if(noteleport_check && !check_teleport_valid(mod.wearer, get_turf(mod.wearer)))
 		to_chat(mod.wearer, span_danger("Some dull, universal force is between you and the [phased_mob ? "current timeline" : "stream between timelines"]."))
 		return FALSE
 	return ..()

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -432,7 +432,7 @@
 	if(phase_state)
 		flick(phase_state, src)
 	var/turf/destination_turf = get_step(loc, movement_dir)
-	if(check_teleport_valid(src, destination_turf) || SSmapping.level_trait(destination_turf.z, ZTRAIT_NOPHASE))
+	if(!check_teleport_valid(src, destination_turf) || SSmapping.level_trait(destination_turf.z, ZTRAIT_NOPHASE))
 		return FALSE
 	return TRUE
 

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -14,7 +14,7 @@
 	var/teleport_range = 7
 
 /obj/item/mecha_parts/mecha_equipment/teleporter/action(mob/source, atom/target, list/modifiers)
-	if(!action_checks(target) || check_teleport_valid(source, target, TELEPORT_CHANNEL_BLUESPACE))
+	if(!action_checks(target) || !check_teleport_valid(source, target, TELEPORT_CHANNEL_BLUESPACE))
 		return
 	var/turf/T = get_turf(target)
 	if(T && (loc.z == T.z) && (get_dist(loc, T) <= teleport_range))
@@ -35,7 +35,7 @@
 
 
 /obj/item/mecha_parts/mecha_equipment/wormhole_generator/action(mob/source, atom/target, list/modifiers)
-	if(!action_checks(target) || check_teleport_valid(source, target, TELEPORT_CHANNEL_WORMHOLE))
+	if(!action_checks(target) || !check_teleport_valid(source, target, TELEPORT_CHANNEL_WORMHOLE))
 		return
 	var/area/targetarea = pick(get_areas_in_range(100, chassis))
 	if(!targetarea)//Literally middle of nowhere how did you even get here


### PR DESCRIPTION
## About The Pull Request

A bunch of places in code were recently updated to use a helper proc for validating teleportation.
Unfortunately a lot of them also got the return value inverted, and would only let you teleport to illegal locations. Most notably this effected the hand teleporter, but also several other items.

Fixes #88966 

what is a "dull universal force" supposed to be anyway

## Changelog

:cl:
fix: The hand teleporter (and several other items) will now allow you to teleport to and from valid locations and forbid you from teleporting to or from places you can't teleport to or from, instead of the other way around.
/:cl:
