### PR TITLE
Shock Therapy: Puts the Taser back on Security Officers replacing the disabler, returning us to 2012.

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	id_trim = /datum/id_trim/job/security_officer
 	uniform = /obj/item/clothing/under/rank/security/officer
 	suit = /obj/item/clothing/suit/armor/vest/alt/sec
-	suit_store = /obj/item/gun/energy/disabler
+	suit_store = /obj/item/gun/energy/taser
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
 		)
@@ -233,7 +233,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	chameleon_extras = list(
 		/obj/item/clothing/glasses/hud/security/sunglasses,
 		/obj/item/clothing/head/helmet,
-		/obj/item/gun/energy/disabler,
+		/obj/item/gun/energy/taser,
 		)
 		//The helmet is necessary because /obj/item/clothing/head/helmet/sec is overwritten in the chameleon list by the standard helmet, which has the same name and icon state
 	implants = list(/obj/item/implant/mindshield)


### PR DESCRIPTION
## About The Pull Request

Puts the Taser back on Security Officers replacing the disabler, returning us to 2012.

## Why It's Good For The Game

I don't think a single taser in a fancy table in the armory is gonna be enough to get real good data on how good/bad the new Taser is post-redesign, so let's go about it in the most drastic way possible to gather a *lot* more data, and give all Secoffs the taser out the gate when they spawn. Plus, it lets us 2012 boomers reminisce about the good old days. If it's good, we can merge it, and disablers can be the new armory-alternative.

## Changelog

:cl:
balance: Security v. Nanotrasen has finally been decided by the Spinward Supreme Court in favor of the Security Department, and Tasers have been re-issued to all Nanotrasen Security Officers.
/:cl:
