### PR TITLE
Change layer manifold and smart pipe volumes to be consistent with other pipes

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -38,6 +38,9 @@
 #define TRINARY 3
 #define QUATERNARY 4
 
+// The volume per direction of atmos pipes.
+#define UNARY_PIPE_VOLUME 35
+
 //TANKS
 /// The volume of the standard handheld gas tanks on the station.
 #define TANK_STANDARD_VOLUME 70

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -8,7 +8,7 @@
 	pipe_flags = PIPING_ALL_LAYER | PIPING_DEFAULT_LAYER_ONLY | PIPING_CARDINAL_AUTONORMALIZE | PIPING_BRIDGE
 	piping_layer = PIPING_LAYER_DEFAULT
 	device_type = 0
-	volume = 260
+	volume = 200
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "manifoldlayer"
 	paintable = TRUE

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -24,7 +24,8 @@
 
 /obj/machinery/atmospherics/pipe/New()
 	add_atom_colour(pipe_color, FIXED_COLOUR_PRIORITY)
-	volume = 35 * device_type
+	if (!volume) // Pipes can have specific volumes or have it determined by their device_type.
+		volume = UNARY_PIPE_VOLUME * device_type
 	. = ..()
 
 /obj/machinery/atmospherics/pipe/setup_hiding()

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -71,9 +71,8 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 /obj/machinery/atmospherics/pipe/smart/set_init_directions(init_dir)
 	if(init_dir)
 		initialize_directions = init_dir
-		var/i
 		var/j = 1
-		for (i = 0, i < 4, i++)
+		for (var/i in 1 to 4)
 			if (init_dir & j)
 				volume += UNARY_PIPE_VOLUME
 			j << 1

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -20,12 +20,19 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 
 	//find all directions this pipe is connected with other nodes
 	connections = NONE
+	var/new_volume = 0
 	for(var/i in 1 to device_type)
 		if(!nodes[i])
 			continue
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/connected_dir = get_dir(src, node)
 		connections |= connected_dir
+		new_volume += UNARY_PIPE_VOLUME
+	new_volume = max(new_volume, UNARY_PIPE_VOLUME * 2)
+
+	if(parent && parent.air && parent.air.volume)
+		parent.air.volume = parent.air.volume + new_volume - volume // Update associate pipenet with new volume.
+	volume = new_volume
 
 	//set the correct direction for this node in case of binary directions
 	switch(connections)
@@ -64,8 +71,16 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 /obj/machinery/atmospherics/pipe/smart/set_init_directions(init_dir)
 	if(init_dir)
 		initialize_directions = init_dir
+		var/i
+		var/j = 1
+		for (i = 0, i < 4, i++)
+			if (init_dir & j)
+				volume += UNARY_PIPE_VOLUME
+			j << 1
+		volume = max(volume, UNARY_PIPE_VOLUME * 2) // Minimum 2 directions
 	else
 		initialize_directions = ALL_CARDINALS
+		volume = UNARY_PIPE_VOLUME * 4
 
 //mapping helpers
 /obj/machinery/atmospherics/pipe/smart/simple


### PR DESCRIPTION
## About The Pull Request

Fixes #64109 and Fixes #73127, making the following changes:

- Added a define for the volume of a unary pipe and replaced mentions of 35.
- Added a check to /pipe/New() to allow pipes to specify their volume.
- Changed the specified volume of layer manifolds to 200, consistent with the value stated on the wiki.
- Changed the volume of smart pipes from a fixed 140 (since they are always considered quaternary) to be calculated based on the number of connected nodes, same as before smart pipes were introduced. Volume is calculated on creation or when the icon updates, and the associated pipenet volume is updated accordingly.

## Why It's Good For The Game

Non-quaternary pipes were larger than intended and manifolds had zero volume due to how volume was calculated based on device_type. These changes improve the consistency of pipe volumes. Also closes #64109 and #73127.

## Changelog
:cl:
fix: Layer manifold and pipe volumes are now consistent with other pipes
/:cl:
