### PR TITLE
Fix a few wall mounted issues on icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -37547,7 +37547,6 @@
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -39663,7 +39662,6 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/radio/intercom/directional/north,
 /obj/item/radio/intercom/directional/north,
 /obj/item/newspaper,
 /obj/machinery/camera/directional/north{
@@ -54950,7 +54948,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash/grime,
 /obj/effect/decal/cleanable/generic,
-/obj/structure/sign/departments/maint/directional/west,
 /obj/structure/sign/departments/maint/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/lesser)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -61372,7 +61372,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_y = 37
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "rHz" = (


### PR DESCRIPTION
## About The Pull Request

Remove a few instances of duplicated wall mounted items and moves the light switch in engineering shared storage because it's covered by the APC.

## Why It's Good For The Game

Gotta click the light switch

## Changelog

:cl:
map: fixed the lightswitch in Ice Box shared engineering storage being covered by the APC.
/:cl:
