### PR TITLE
ink kisses now delete the spawned projectile

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -660,6 +660,8 @@
 	. = ..()
 	var/obj/projectile/ink_spit/ink_spit =  new (target)
 	ink_spit.on_hit(target)
+	if(!QDELETED(ink_spit)) // in case it somehow remains around
+		qdel(ink_spit)
 
 // Based on energy gun characteristics
 /obj/projectile/kiss/syndie


### PR DESCRIPTION

## About The Pull Request

If you ink kissed a obj there would be a floating ink spit as it did not delete the projectile. This is now fixed

## Why It's Good For The Game

bugg

## Changelog

:cl:
fix: ink kisses now delete the spawned projectile
/:cl:

