### PR TITLE
Add mousetraps cargo crate to service category

### DIFF
--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -307,3 +307,10 @@
 	)
 	crate_name = "bowmaking starter kit crate"
 	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/service/mousetraps
+	name = "Pest-B-Gon Mousetraps"
+	desc = "Three boxes of handy little spring-loaded traps for catching pesty rodents. Keep out of reach of children!"
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/box/mousetraps = 3)
+	crate_name = "mousetraps crate"


### PR DESCRIPTION

## About The Pull Request
Low cost cargo crate that is filled with 3 boxes of mousetraps. It's apart of the service category.

## Why It's Good For The Game
Threatening the rat king with using all the station budget to stop his army should be achievable. Ordering cats was very disappointing. 

## Changelog
:cl:
add: Rat kings across the station tremble in fear since mousetraps have been added to the cargo crate via service category.
/:cl:
