### PR TITLE
Slightly optimizes `apply_height_filters`

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -310,22 +310,24 @@
  * * priority - Priority used when sorting the filter.
  * * params - Parameters of the filter.
  */
-/datum/proc/add_filter(name, priority, list/params)
+/datum/proc/add_filter(name, priority, list/params, update = TRUE)
 	LAZYINITLIST(filter_data)
 	var/list/copied_parameters = params.Copy()
 	copied_parameters["priority"] = priority
 	filter_data[name] = copied_parameters
-	update_filters()
+	if(update)
+		update_filters()
 
 ///A version of add_filter that takes a list of filters to add rather than being individual, to limit calls to update_filters().
-/datum/proc/add_filters(list/list/filters)
+/datum/proc/add_filters(list/list/filters, update = TRUE)
 	LAZYINITLIST(filter_data)
 	for(var/list/individual_filter as anything in filters)
 		var/list/params = individual_filter["params"]
 		var/list/copied_parameters = params.Copy()
 		copied_parameters["priority"] = individual_filter["priority"]
 		filter_data[individual_filter["name"]] = copied_parameters
-	update_filters()
+	if(update)
+		update_filters()
 
 /// Reapplies all the filters.
 /datum/proc/update_filters()
@@ -350,8 +352,9 @@
  * * name - Filter name
  * * new_params - New parameters of the filter
  * * overwrite - TRUE means we replace the parameter list completely. FALSE means we only replace the things on new_params.
+ * * update - TRUE means we automatically call update_filters() afterwards. This should be FALSE if you're going to be doing other filter changes next.
  */
-/datum/proc/modify_filter(name, list/new_params, overwrite = FALSE)
+/datum/proc/modify_filter(name, list/new_params, overwrite = FALSE, update = TRUE)
 	var/filter = get_filter(name)
 	if(!filter)
 		return
@@ -360,7 +363,8 @@
 	else
 		for(var/thing in new_params)
 			filter_data[name][thing] = new_params[thing]
-	update_filters()
+	if(update)
+		update_filters()
 
 /** Update a filter's parameter and animate this change. If the filter doesn't exist we won't do anything.
  * Basically a [datum/proc/modify_filter] call but with animations. Unmodified filter parameters are kept.
@@ -382,12 +386,13 @@
 	modify_filter(name, new_params)
 
 /// Updates the priority of the passed filter key
-/datum/proc/change_filter_priority(name, new_priority)
+/datum/proc/change_filter_priority(name, new_priority, update = TRUE)
 	if(!filter_data || !filter_data[name])
 		return
 
 	filter_data[name]["priority"] = new_priority
-	update_filters()
+	if(update)
+		update_filters()
 
 /// Returns the filter associated with the passed key
 /datum/proc/get_filter(name)
@@ -402,7 +407,7 @@
 	return filter_data?.Find(name)
 
 /// Removes the passed filter, or multiple filters, if supplied with a list.
-/datum/proc/remove_filter(name_or_names)
+/datum/proc/remove_filter(name_or_names, update = TRUE)
 	if(!filter_data)
 		return
 
@@ -414,7 +419,7 @@
 			filter_data -= name
 			. = TRUE
 
-	if(.)
+	if(. && update)
 		update_filters()
 	return .
 

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1000,7 +1000,7 @@ generate/load female uniform sprites matching all previously decided variables
 		"Monkey_Legs",
 		"Monkey_Gnome_Cut_Torso",
 		"Monkey_Gnome_Cut_Legs",
-	), update = FALSE)
+	), update = FALSE) // note: the add_filter(s) calls after this will call update_filters on their own. so by not calling it here, we avoid calling it twice.
 
 	switch(get_mob_height())
 		// Don't set this one directly, use TRAIT_DWARF

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -989,7 +989,7 @@ generate/load female uniform sprites matching all previously decided variables
 	var/static/icon/lenghten_torso_mask = icon('icons/effects/cut.dmi', "Cut3")
 	var/static/icon/lenghten_legs_mask = icon('icons/effects/cut.dmi', "Cut4")
 
-	appearance.remove_filter(list(
+	var/should_update = appearance.remove_filter(list(
 		"Cut_Torso",
 		"Cut_Legs",
 		"Lenghten_Legs",
@@ -1000,7 +1000,7 @@ generate/load female uniform sprites matching all previously decided variables
 		"Monkey_Legs",
 		"Monkey_Gnome_Cut_Torso",
 		"Monkey_Gnome_Cut_Legs",
-	))
+	), update = FALSE)
 
 	switch(get_mob_height())
 		// Don't set this one directly, use TRAIT_DWARF
@@ -1101,6 +1101,10 @@ generate/load female uniform sprites matching all previously decided variables
 					"params" = displacement_map_filter(lenghten_legs_mask, x = 0, y = 0, size = 2),
 				),
 			))
+		else
+			// as we don't add any filters - we need to make sure to run update_filters ourselves, as we didn't update during our previous remove_filter, and any other case would've ran it at the end of add_filter(s)
+			if(should_update)
+				appearance.update_filters()
 
 	// Kinda gross but because many humans overlays do not use KEEP_TOGETHER we need to manually propogate the filter
 	// Otherwise overlays, such as worn overlays on icons, won't have the filter "applied", and the effect kinda breaks


### PR DESCRIPTION
## About The Pull Request

This slightly optimizes `/mob/living/carbon/human/proc/apply_height_filters` by ensuring `update_filters` only gets called once, rather than twice.

This adds an `update` var to the add/remove_filter(s) procs, which when false (they're true by default), they won't automatically call update_filters at the end

basically, same principle as only running `updatehealth` at the end of multiple damage adjustment procs.

## Why It's Good For The Game

`update_filters` is an incredibly intensive proc, that can cause `apply_height_filters` to be where tick usage goes to die in certain scenarios. this should help mitigate that somewhat, albeit it certainly won't solve the issue.

## Changelog

No user-facing changes, merely some slight performance improvements.