### PR TITLE
ProcArgumentGlobal pragma as error from warning

### DIFF
--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -23,6 +23,7 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
+#pragma ProcArgumentGlobal error
 
 //3000-3999
 #pragma EmptyBlock error


### PR DESCRIPTION
## About The Pull Request
Makes OD2211 as an error since it fixes a byond bug that nobody should be using
```
New Pragma: OD2211 - ProcArgumentGlobal
A new pragma has been added for detecting this BYOND bug: https://www.byond.com/forum/post/2830750
When a proc argument begins with /var/ instead of var/, it creates a global variable instead of an argument.
/datum/proc/foo(/var/bar = 5)
    return

/proc/main()
    world.log << global.bar // This prints 5 in BYOND

Since this is obviously nonsense, elevating this pragma to an error is strongly encouraged. I have only found it in one SS13 codebase so far.
```
