### PR TITLE
Charge up Tram's TCOMMS SMES

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -36872,13 +36872,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/right)
-"lVh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "lVi" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science)
@@ -57397,10 +57390,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "tms" = (
-/obj/machinery/power/smes{
-	charge = 5e+06
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/full,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tmz" = (
@@ -153688,8 +153679,8 @@ dDm
 uoO
 uoO
 fss
-lVh
-lVh
+fss
+fss
 nYr
 rEq
 bSS


### PR DESCRIPTION
## About The Pull Request

Replaces the SMES in Tram's TCOMMS room at (105, 080, 1) for a fully charged variant

## Why It's Good For The Game

Currently without touching the station's main SMESes that supply the powernet, the SMES in Tram's TCOMMS room remains powered for about 3 minutes with another 1 minute on the APC before it shuts down equipment power. 4 minutes to attend to the powernet while setting up the SM is Quite Bad(TM). Replacing the 8% charge SMES for a full variant increases the time to depower to over 30 minutes, giving the station plenty of time to communicate and force entry into engineering as the rest of the station runs out of power around them to rig the engine themselves, which would be Quite Good(TM).

## Changelog

:cl:
fix: NanoTrasen telecomms technicians operating on Tram class stations have been reminded not to charge their power tools directly from their TCOMMS SMES
/:cl: