### PR TITLE
Fixes fake nuclear disks escaping the digital world.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -27,9 +27,9 @@
 /obj/item/disk/nuclear/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/bed_tuckable, mapload, 6, -6, 0)
-	AddComponent(/datum/component/stationloving, !fake)
 
 	if(!fake)
+		AddComponent(/datum/component/stationloving, !fake)
 		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
 		SSpoints_of_interest.make_point_of_interest(src)
 	else


### PR DESCRIPTION
## About The Pull Request

Fake and Obviously Fake Nuke Disks no longer have the stationloving component, so they will no longer escape bitrunning domains. I only tested this by flying around into space with all the types before and after but the principle is identical.

## Why It's Good For The Game
Fixes #88856

## Changelog
:cl:
fix: Fake Nuclear Disks and Obviously Fake Nuclear Disks no longer teleport when changing Z-level outside of station.
/:cl: