### PR TITLE
Heretics dream of objects around unused influences

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -243,11 +243,11 @@ GLOBAL_LIST_INIT(dreams, populate_dream_list())
 	for(var/object_type in allowed_typecaches_by_root_type)
 		var/list/filtered_objects = typecache_filter_list(all_objects, allowed_typecaches_by_root_type[object_type])
 		if(filtered_objects.len)
-			var/obj/found_object = pick(filtered_objects)
-			. += initial(found_object.name)
 			if (!something_found)
 				. += "Its waters reflect"
 				something_found = TRUE
+			var/obj/found_object = pick(filtered_objects)
+			. += initial(found_object.name)
 	if(!something_found)
 		. += pick("It's pitch black", "The reflections are vague", "You stroll aimlessly")
 	else

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -21,8 +21,12 @@
 
 /mob/living/carbon/proc/dream()
 	set waitfor = FALSE
+	var/datum/dream/chosen_dream
 
-	var/datum/dream/chosen_dream = pick_weight(GLOB.dreams)
+	if (IS_HERETIC(src) && GLOB.reality_smash_track.smashes.len)
+		chosen_dream = new /datum/dream/heretic(pick(GLOB.reality_smash_track.smashes))
+	else
+		chosen_dream = pick_weight(GLOB.dreams)
 
 	ADD_TRAIT(src, TRAIT_DREAMING, DREAMING_SOURCE)
 	dream_sequence(chosen_dream.GenerateDream(src), chosen_dream)
@@ -182,5 +186,60 @@ GLOBAL_LIST_INIT(dreams, populate_dream_list())
 
 /datum/dream/hear_something/proc/StopSound(mob/living/carbon/dreamer)
 	SEND_SOUND(dreamer, sound(channel=reserved_sound_channel))
+
+/// Heretics can see dreams about random machinery from the perspective of a random unused influence
+/datum/dream/heretic
+	sleep_until_finished = TRUE
+	/// The influence we will be dreaming about
+	var/obj/effect/heretic_influence/influence
+	/// The distance to the objects visible from the influence during the dream
+	var/dream_view_range = 5
+	var/list/obj/what_you_can_see = list(
+		/obj/item,
+		/obj/structure,
+		/obj/machinery,
+	)
+	var/static/list/obj/what_you_cant_see = typecacheof(list(
+		// Underfloor stuff and default wallmounts
+		/obj/item/radio/intercom,
+		/obj/structure/cable,
+		/obj/structure/disposalpipe/segment,
+		/obj/machinery/atmospherics/pipe/smart/manifold4w,
+		/obj/machinery/atmospherics/components/unary/vent_scrubber,
+		/obj/machinery/atmospherics/components/unary/vent_pump,
+		/obj/machinery/duct,
+		/obj/machinery/navbeacon,
+		/obj/machinery/power/terminal,
+		/obj/machinery/power/apc,
+		/obj/machinery/light_switch,
+		/obj/machinery/light,
+		/obj/machinery/camera,
+		/obj/machinery/door/firedoor,
+		/obj/machinery/firealarm,
+		/obj/machinery/airalarm,
+		/obj/structure/window/fulltile,
+		/obj/structure/window/reinforced/fulltile,
+	))
+
+/datum/dream/heretic/New(obj/effect/heretic_influence/found_influence)
+	influence = found_influence
+
+/datum/dream/heretic/GenerateDream(mob/living/carbon/dreamer)
+	. = list()
+	. += "You wander through the forest of Mansus"
+	. += "There is a " + pick("pond", "well", "lake", "puddle", "stream", "spring", "brook", "marsh")
+	. += "In the water reflection you see"
+
+	var/list/all_objects = oview(dream_view_range, influence)
+	var/something_found = FALSE
+	for(var/object_type in what_you_can_see)
+		var/list/allowed_only = typecache_filter_list(all_objects, typecacheof(object_type))
+		var/list/filtered_objects = typecache_filter_list_reverse(allowed_only, what_you_cant_see)
+		var/obj/found_object = pick(filtered_objects)
+		if(found_object)
+			. += initial(found_object.name)
+			something_found = TRUE
+	if(!something_found)
+		. += "nothing"
 
 #undef DREAMING_SOURCE

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -23,7 +23,7 @@
 	set waitfor = FALSE
 	var/datum/dream/chosen_dream
 
-	if (IS_HERETIC(src) && GLOB.reality_smash_track.smashes.len)
+	if (IS_HERETIC(src) && !("mansus_dream_fatigue" in src.mob_mood.mood_events) && GLOB.reality_smash_track.smashes.len)
 		chosen_dream = new /datum/dream/heretic(pick(GLOB.reality_smash_track.smashes))
 	else
 		chosen_dream = pick_weight(GLOB.dreams)
@@ -230,16 +230,23 @@ GLOBAL_LIST_INIT(dreams, populate_dream_list())
 	. += "There is a " + pick("pond", "well", "lake", "puddle", "stream", "spring", "brook", "marsh")
 	. += "In the water reflection you see"
 
+	dreamer.add_mood_event("mansus_dream_fatigue", /datum/mood_event/mansus_dream_fatigue)
+
 	var/list/all_objects = oview(dream_view_range, influence)
 	var/something_found = FALSE
 	for(var/object_type in what_you_can_see)
 		var/list/allowed_only = typecache_filter_list(all_objects, typecacheof(object_type))
 		var/list/filtered_objects = typecache_filter_list_reverse(allowed_only, what_you_cant_see)
-		var/obj/found_object = pick(filtered_objects)
-		if(found_object)
+		if(filtered_objects.len)
+			var/obj/found_object = pick(filtered_objects)
 			. += initial(found_object.name)
 			something_found = TRUE
 	if(!something_found)
 		. += "nothing"
+
+/datum/mood_event/mansus_dream_fatigue
+	description = "I must recover before I can dream of the Mansus again."
+	mood_change = -2
+	timeout = 5 MINUTES
 
 #undef DREAMING_SOURCE

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -44,7 +44,7 @@ As a Geneticist, T goes to A, and G goes to C.
 As a Ghost, you can both start and join capture the flag games through the minigames menu, or by clicking on one of the team spawners, which can be found under the "Misc" section of the orbit menu.
 As a Ghost, you can double click on just about anything to follow it. Or just warp around!
 As a Ghost, you can see the inside of a container on the ground by clicking on it.
-As a Heretic, you can locate influences by dreaming about random objects around it when you sleep.
+As a Heretic, you can locate an influence by dreaming about random objects around it when you sleep.
 As a Heretic, the Path of Ash focuses on stealth and disorientation, but as you progress, sheds this playstyle in favor of a more aggressive, fiery finale.
 As a Heretic, the Path of Moon will literally drive people around you crazy - perhaps crazy enough to become your allies should you succeed.
 As a Heretic, the Path of Lock is an Assistant's best friend, and can open many pathways. Including ones beyond the veil...

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -44,7 +44,7 @@ As a Geneticist, T goes to A, and G goes to C.
 As a Ghost, you can both start and join capture the flag games through the minigames menu, or by clicking on one of the team spawners, which can be found under the "Misc" section of the orbit menu.
 As a Ghost, you can double click on just about anything to follow it. Or just warp around!
 As a Ghost, you can see the inside of a container on the ground by clicking on it.
-As a Heretic, you can locate influences by dreaming about the objects around it when you sleep.
+As a Heretic, you can locate influences by dreaming about random objects around it when you sleep.
 As a Heretic, the Path of Ash focuses on stealth and disorientation, but as you progress, sheds this playstyle in favor of a more aggressive, fiery finale.
 As a Heretic, the Path of Moon will literally drive people around you crazy - perhaps crazy enough to become your allies should you succeed.
 As a Heretic, the Path of Lock is an Assistant's best friend, and can open many pathways. Including ones beyond the veil...

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -44,6 +44,7 @@ As a Geneticist, T goes to A, and G goes to C.
 As a Ghost, you can both start and join capture the flag games through the minigames menu, or by clicking on one of the team spawners, which can be found under the "Misc" section of the orbit menu.
 As a Ghost, you can double click on just about anything to follow it. Or just warp around!
 As a Ghost, you can see the inside of a container on the ground by clicking on it.
+As a Heretic, you can locate influences by dreaming about the objects around it when you sleep.
 As a Heretic, the Path of Ash focuses on stealth and disorientation, but as you progress, sheds this playstyle in favor of a more aggressive, fiery finale.
 As a Heretic, the Path of Moon will literally drive people around you crazy - perhaps crazy enough to become your allies should you succeed.
 As a Heretic, the Path of Lock is an Assistant's best friend, and can open many pathways. Including ones beyond the veil...

--- a/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
@@ -159,7 +159,8 @@ const GuideSection = () => {
           &nbsp;around the station invisible to the normal eye and&nbsp;
           <b>right click</b> on them to harvest them for&nbsp;
           <span style={hereticBlue}>knowledge points</span>. Tapping them makes
-          them visible to all after a short time.
+          them visible to all after a short time. Dreaming of Mansus may help to
+          find them.
         </Stack.Item>
         <Stack.Item>
           - Use your&nbsp;


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/5fee2111-289b-46c6-82f8-096fcfadc50f)

![image](https://github.com/user-attachments/assets/1402896d-4d39-4168-a105-7d28bd199999)

![image](https://github.com/user-attachments/assets/20a7a1fd-3f63-4657-9834-0f568f241490)

Heretics can now traverse Mansus in their dreams to see into the real world through the perspective of unused essences, if any.

They get a mood debuff for five minutes while doing so, and dream regularly until recovered.

## Why It's Good For The Game

Essences sometimes spawn in closed locations (like vault, telecomms, toilet room) and stay untapped till the end of the round.

This change should promote a more covert way of gaining a roundstart knowledge boost for heretics.

They may dream of completely random and useless objects, but it will still help them to know that there is still an unused essence somewhere.

## Changelog

:cl:
add: Heretics can now get clues about objects around unused influences in their dreams, with a 5 minute cooldown
/:cl:

