### PR TITLE
Prevents xenobio autoinjectors from being deepfried

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/reagent_containers/cup,
 	/obj/item/reagent_containers/syringe,
 	/obj/item/reagent_containers/hypospray/medipen, //letting medipens become edible opens them to being injected/drained with IV drip & saltshakers
+	/obj/item/slimecrossbeaker/autoinjector, //same as medipen
 )))
 
 /obj/machinery/deepfryer


### PR DESCRIPTION

## About The Pull Request
#82676 Added medipens into deepfryer blacklist as it allowed them to be filled with custom reagents. Xenobio autoinjectors that are made from industrial crossbreeds function very similarly to medipens with few differences. However, they have a different typepath from medipens so they were not included in the original PR. This adds them into the blacklist too.
## Why It's Good For The Game
Xenobio autoinjectors are not ment to be filled with custom reagents, this fixes that.
## Changelog
:cl:
fix: Xenobio autoinjectors, such as mending solution from industrial purple crossbreed, cannot be deepfried and thus filled with custom reagents using saltshaker anymore.
/:cl:
