### PR TITLE
Fixes all luminescent fluid giving unnaturally red eyes on overdose, instead of just the red one

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3240,7 +3240,7 @@
 	// The glow *is* unnatural, so...
 	metabolized_traits = list(TRAIT_MINOR_NIGHT_VISION, TRAIT_UNNATURAL_RED_GLOWY_EYES)
 
-/datum/reagent/luminescent_fluid/overdose_start(mob/living/affected_mob)
+/datum/reagent/luminescent_fluid/red/overdose_start(mob/living/affected_mob)
 	. = ..()
 	if (!ishuman(affected_mob))
 		return


### PR DESCRIPTION

## About The Pull Request

While reading the code to answer a technical question I noticed that luminescent fluid had its `overdose_start(...)` proc defined twice:
https://github.com/tgstation/tgstation/blob/91981e151c75f3e971951612f161e81f9898f5b8/code/modules/reagents/chemistry/reagents/other_reagents.dm#L3227-L3235
https://github.com/tgstation/tgstation/blob/91981e151c75f3e971951612f161e81f9898f5b8/code/modules/reagents/chemistry/reagents/other_reagents.dm#L3237-L3247
...The latter of which permanently applying the unnaturally red eyes trait.
Given the proc is defined twice, and the latter comes immediately after the red subtype that gives the same trait on metabolize, it looks like it was intended to be for the red subtype only.

This fixes that.
## Why It's Good For The Game

Fixes jank.
## Changelog
:cl:
fix: Only red glowstick fluid gives permanent unnaturally red eyes on overdose.
/:cl:
