### PR TITLE
Cap perceived food quality, fix examine index out of bounds runtime when perceived food quality is too high

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -584,7 +584,6 @@ Behavior that's still missing from this component that original food items had t
 	if(food_quality == 0)
 		return // meh
 
-	food_quality = min(food_quality, FOOD_QUALITY_TOP)
 	var/atom/owner = parent
 	var/timeout_mod = owner.reagents.get_average_purity(/datum/reagent/consumable) * 2 // mood event duration is 100% at average purity of 50%
 	var/datum/mood_event/event = GLOB.food_quality_events[food_quality]
@@ -640,7 +639,7 @@ Behavior that's still missing from this component that original food items had t
 		food_quality += DISLIKED_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_disliked_foodtypes())
 		food_quality += LIKED_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_liked_foodtypes())
 
-	return food_quality
+	return min(food_quality, FOOD_QUALITY_TOP)
 
 /// Get the number of matching food types in provided bitfields
 /datum/component/edible/proc/count_matching_foodtypes(bitfield_one, bitfield_two)


### PR DESCRIPTION

## About The Pull Request

When going through runtime logs earlier, I noticed the edible component's examine logic would have an index out of bounds runtime whenever a lizard were to observe a piece of stinging flatbread.
This seems to be because its `examine(...)` proc would call `get_perceived_food_quality(...)`, getting an `8`, and then use the resulting value as an index for `GLOB.food_quality_description`, while the highest value for such is `FOOD_QUALITY_TOP = 7`.

Trying to find similar issues I noticed `checkLiked(...)` would cap it to `min(food_quality, FOOD_QUALITY_TOP)` before running anything that cared about it.
So in this pr we just move that `min(food_quality, FOOD_QUALITY_TOP)` call into `get_perceived_food_quality(...)` right before it returns, catching all our potential out of bounds issues.

This fixes our issues.
## Why It's Good For The Game

Fixes jank.
## Changelog
:cl:
fix: Examining edible items with too high of a perceived food quality no longer runtimes and actually displays a food quality message.
/:cl:
