### PR TITLE
Update wawastation.dmm

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -26548,6 +26548,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/holosign_creator/robot_seat/bar,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "jwK" = (


### PR DESCRIPTION
## About The Pull Request

Adds a bar seating incicator placer to Wawa's bar at (097, 091, 1)

## Why It's Good For The Game

Lacking the seating placer for Wawa's bar is Quite Bad(TM) for mainaining consistency between the other stations' equipment. Providing a seating placer would be Quite Good(TM) for providing bartenders means to do their job without requiring crew members to indulge in alcoholism, and to line the pockets of NT's service department

## Changelog

:cl:

fix: NanoTrasen's bartending liscence has been reinstated for sale of alcohol to robots on Wawa class stations

/:cl: