### PR TITLE
Fix calibre define text

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -37,7 +37,7 @@
 /// The caliber used by the the M-90gl Carbine, and NT-ARG 'Boarder'.
 #define CALIBER_A223 "a223"
 /// The caliber used by bolt action rifles.
-#define CALIBER_STRILKA310 ".310_strilka"
+#define CALIBER_STRILKA310 ".310 strilka"
 /// The caliber used by shotguns.
 #define CALIBER_SHOTGUN "shotgun"
 /// The caliber used by grenade launchers.

--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -49,7 +49,7 @@
 /// The caliber used by most energy guns.
 #define CALIBER_ENERGY "energy"
 /// The acliber used by foam force and donksoft toy guns.
-#define CALIBER_FOAM "foam_force"
+#define CALIBER_FOAM "foam force"
 /// The caliber used by the bow and arrow.
 #define CALIBER_ARROW "arrow"
 /// The caliber used by the harpoon gun.


### PR DESCRIPTION
## About The Pull Request

Fixes bug inadvertently reported by forum screenshot.
Two defined ammo calibre strings had underscores in them, however this are occasionally printed to users and thus can and should just use spaces.

## Changelog

:cl:
spellcheck: Foam Force's brand management team require us to remove an erroneous underscore which was in violation of their logo usage terms and conditions.
/:cl:
