### PR TITLE
[NO GBP] Blinking no longer stacks lizard overlays

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -186,7 +186,8 @@
 
 /datum/emote/living/carbon/human/blink/run_emote(mob/living/carbon/human/user, params, type_override, intentional)
 	. = ..()
-	user.update_body_parts_head_only() // Refreshing instantly makes the user blink
+	// Set to update_body until update_body_parts_head_only is fixed
+	user.update_body() // Refreshing instantly makes the user blink
 
 /datum/emote/living/carbon/human/blink_r
 	key = "blink_r"
@@ -203,8 +204,9 @@
 
 /datum/emote/living/carbon/human/blink_r/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
+	// Set to update_body until update_body_parts_head_only is fixed
 	for (var/i in 1 to 3)
-		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon/human, update_body_parts_head_only)), i * 0.3 SECONDS)
+		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, update_body)), i * 0.3 SECONDS)
 
 ///Snowflake emotes only for le epic chimp
 /datum/emote/living/carbon/human/monkey


### PR DESCRIPTION

## About The Pull Request

update_body_parts_head_only is broken and doesn't clean overlays, resulting in lizard blinking stacking their frills and snouts infinitely, breaking the overlay cap and turning them into error sprites. This is pretty bad for perf as update_body is somewhat expensive, but this is a hotfix as lizards who emote right now turn "invisible" as they become walking error sprites

## Changelog
:cl:
fix: Lizards no longer turn into error sprites when blinking
/:cl:
