### PR TITLE
Fixes bluespace fishing rod issues.

### DIFF
--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -126,7 +126,6 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	RegisterSignal(comp, COMSIG_QDELETING, PROC_REF(on_spot_gone))
 	register_reward_signals(comp.fish_source)
 	RegisterSignal(fish_source, COMSIG_FISHING_SOURCE_INTERRUPT_CHALLENGE, PROC_REF(interrupt_challenge))
-	fish_source.RegisterSignal(user, COMSIG_MOB_COMPLETE_FISHING, TYPE_PROC_REF(/datum/fish_source, on_challenge_completed))
 	background = comp.fish_source.background
 	if(comp.fish_source.wait_time_range)
 		wait_time_range = comp.fish_source.wait_time_range
@@ -194,9 +193,11 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 			COMSIG_FISHING_CHALLENGE_ROLL_REWARD,
 			COMSIG_FISHING_CHALLENGE_GET_DIFFICULTY,
 		))
+		fish_source.UnregisterSignal(user, COMSIG_MOB_COMPLETE_FISHING)
 	fish_source = new_fish_source
 	fish_source.RegisterSignal(src, COMSIG_FISHING_CHALLENGE_ROLL_REWARD, TYPE_PROC_REF(/datum/fish_source, roll_reward_minigame))
 	fish_source.RegisterSignal(src, COMSIG_FISHING_CHALLENGE_GET_DIFFICULTY, TYPE_PROC_REF(/datum/fish_source, calculate_difficulty_minigame))
+	fish_source.RegisterSignal(user, COMSIG_MOB_COMPLETE_FISHING, TYPE_PROC_REF(/datum/fish_source, on_challenge_completed))
 
 /datum/fishing_challenge/proc/send_alert(message)
 	location?.balloon_alert(user, message)

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -188,13 +188,13 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
  * Proc responsible for registering the signals for difficulty and possible reward.
  * Call this if you want to override the fish source from which we roll rewards (preferably before the minigame phase).
  */
-/datum/fishing_challenge/proc/register_reward_signals(datum/fish_source/fish_source)
+/datum/fishing_challenge/proc/register_reward_signals(datum/fish_source/new_fish_source)
 	if(fish_source)
 		fish_source.UnregisterSignal(src, list(
 			COMSIG_FISHING_CHALLENGE_ROLL_REWARD,
 			COMSIG_FISHING_CHALLENGE_GET_DIFFICULTY,
 		))
-	src.fish_source = fish_source
+	fish_source = new_fish_source
 	fish_source.RegisterSignal(src, COMSIG_FISHING_CHALLENGE_ROLL_REWARD, TYPE_PROC_REF(/datum/fish_source, roll_reward_minigame))
 	fish_source.RegisterSignal(src, COMSIG_FISHING_CHALLENGE_GET_DIFFICULTY, TYPE_PROC_REF(/datum/fish_source, calculate_difficulty_minigame))
 

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -184,7 +184,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	return ..()
 
 /**
- * Proc responsible for registering the signals for difficulty and possible reward.
+ * Proc responsible for registering the signals for difficulty, possible reward, and challenge completion.
  * Call this if you want to override the fish source from which we roll rewards (preferably before the minigame phase).
  */
 /datum/fishing_challenge/proc/register_reward_signals(datum/fish_source/new_fish_source)


### PR DESCRIPTION

## About The Pull Request

I was notified of the bluespace fishing rod not working by someone, and after some querying and looking into it, noticed it's a set of two specific bugs:
1. The `register_reward_signals(...)` proc that is used to swap fishing sources doesn't actually properly deregister the old fishing source. This would case it to have both sources registered at the point of rolling a reward, and run into issues determining the reward/difficulty.
https://github.com/tgstation/tgstation/blob/91981e151c75f3e971951612f161e81f9898f5b8/code/modules/fishing/fishing_minigame.dm#L187-L199
We fix this by making the parameter have a unique name instead of doing `src.fish_source = fish_source` fuckery, also avoiding future confusion.
2. We were registering `COMSIG_MOB_COMPLETE_FISHING` and thus `on_challenge_completed(...)` on the initial fishing source, but not updating it. This would cause the completion and reward spawning checks to be run using the old fishing source rather than our bluespace one, making several of them dysfunctional as they assume their source is being used for spawning rewards.
https://github.com/tgstation/tgstation/blob/91981e151c75f3e971951612f161e81f9898f5b8/code/modules/fishing/fishing_minigame.dm#L129
We fix this by including it in `register_reward_signals(...)`, similarly also deregistering the old source in that proc. I feel this proc's fine given it's along the same lines as the other signals, so there's no need to make a separate proc entirely.

This fixes our issues.
I spent a decent chunk of time rerolling bluespace fish sources to test this.
## Why It's Good For The Game

Jank begone.
I love my random organs from bluespace fishing rod rolling surgery actually working.
## Changelog
:cl:
fix: Fixed bluespace fishing rods having a lower chance to work than intended by pulling from both the old AND random source.
fix: Bluespace fishing rods actually use the random source instead of the original source for dispensing the reward. Fixes them not working on open organ manipulation surgeries, and several random sources not working properly.
/:cl:
