### PR TITLE
Fixes broken instances of overflowY for 516

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -26,7 +26,6 @@
 
 /obj/item/modular_computer/laptop/examine(mob/user)
 	. = ..()
-	to_chat(world, "load in 516 please :D")
 	if(screen_on)
 		. += span_notice("Alt-click to close it.")
 

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -26,6 +26,7 @@
 
 /obj/item/modular_computer/laptop/examine(mob/user)
 	. = ..()
+	to_chat(world, "load in 516 please :D")
 	if(screen_on)
 		. += span_notice("Alt-click to close it.")
 

--- a/tgui/packages/tgui/interfaces/OreSilo.tsx
+++ b/tgui/packages/tgui/interfaces/OreSilo.tsx
@@ -210,13 +210,13 @@ const LogsList = (props: LogsListProps) => {
   const { logs } = props;
 
   return logs.length > 0 ? (
-    <Box pr={1} height="100%" overflowY="scroll">
+    <Section fill scrollable pr={1} height="100%">
       <VirtualList>
         {logs.map((log, index) => (
           <LogEntry key={index} log={log} />
         ))}
       </VirtualList>
-    </Box>
+    </Section>
   ) : (
     <NoticeBox>No log entries currently present!</NoticeBox>
   );

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -255,7 +255,7 @@ export const PersonalCrafting = (props) => {
   const CATEGORY_ICONS =
     mode === MODE.cooking ? CATEGORY_ICONS_COOKING : CATEGORY_ICONS_CRAFTING;
   return (
-    <Window width={700} height={400}>
+    <Window width={700} height={720}>
       <Window.Content>
         <Stack fill>
           <Stack.Item width={'200px'}>

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -259,242 +259,250 @@ export const PersonalCrafting = (props) => {
       <Window.Content>
         <Stack fill>
           <Stack.Item width={'200px'}>
-            <Stack fill vertical justify={'space-between'}>
-              <Stack.Item>
-                <Input
-                  autoFocus
-                  placeholder={
-                    'Search in ' +
-                    data.recipes.length +
-                    (mode === MODE.cooking ? ' recipes...' : ' designs...')
-                  }
-                  value={searchText}
-                  onInput={(e, value) => {
-                    setPages(1);
-                    setSearchText(value);
-                  }}
-                  fluid
-                />
-              </Stack.Item>
-              <Stack.Item>
-                <Tabs fluid textAlign="center">
-                  <Tabs.Tab
-                    selected={tabMode === TABS.category}
-                    onClick={() => {
-                      if (tabMode === TABS.category) {
-                        return;
-                      }
-                      setTabMode(TABS.category);
+            <Section fill>
+              <Stack fill vertical justify={'space-between'}>
+                <Stack.Item>
+                  <Input
+                    autoFocus
+                    expensive
+                    placeholder={
+                      'Search in ' +
+                      data.recipes.length +
+                      (mode === MODE.cooking ? ' recipes...' : ' designs...')
+                    }
+                    value={searchText}
+                    onInput={(e, value) => {
                       setPages(1);
-                      setCategory(
-                        Object.keys(craftability).length
-                          ? 'Can Make'
-                          : data.categories[0],
-                      );
+                      setSearchText(value);
                     }}
-                  >
-                    Category
-                  </Tabs.Tab>
-                  {mode === MODE.cooking && (
+                    fluid
+                  />
+                </Stack.Item>
+                <Stack.Item>
+                  <Tabs fluid textAlign="center">
                     <Tabs.Tab
-                      selected={tabMode === TABS.foodtype}
+                      selected={tabMode === TABS.category}
                       onClick={() => {
-                        if (tabMode === TABS.foodtype) {
+                        if (tabMode === TABS.category) {
                           return;
                         }
-                        setTabMode(TABS.foodtype);
+                        setTabMode(TABS.category);
                         setPages(1);
-                        setFoodType(
+                        setCategory(
                           Object.keys(craftability).length
                             ? 'Can Make'
-                            : data.foodtypes[0],
+                            : data.categories[0],
                         );
                       }}
                     >
-                      Type
+                      Category
                     </Tabs.Tab>
-                  )}
-                  <Tabs.Tab
-                    selected={tabMode === TABS.material}
-                    onClick={() => {
-                      if (tabMode === TABS.material) {
-                        return;
-                      }
-                      setTabMode(TABS.material);
-                      setPages(1);
-                      setMaterial(material_occurences[0].atom_id);
-                    }}
-                  >
-                    {mode === MODE.cooking ? 'Ingredient' : 'Material'}
-                  </Tabs.Tab>
-                </Tabs>
-              </Stack.Item>
-              <Box height={'100%'} p={1} style={{ overflowY: 'auto' }}>
-                <Tabs vertical>
-                  {tabMode === TABS.foodtype &&
-                    mode === MODE.cooking &&
-                    foodtypes.map((foodtype) => (
+                    {mode === MODE.cooking && (
                       <Tabs.Tab
-                        key={foodtype}
-                        selected={
-                          activeType === foodtype && searchText.length === 0
-                        }
-                        onClick={(e) => {
-                          setFoodType(foodtype);
-                          setPages(1);
-                          if (content) {
-                            content.scrollTop = 0;
-                          }
-                          if (searchText.length > 0) {
-                            setSearchText('');
-                          }
-                        }}
-                      >
-                        <FoodtypeContent
-                          type={foodtype}
-                          diet={diet}
-                          craftableCount={Object.keys(craftability).length}
-                        />
-                      </Tabs.Tab>
-                    ))}
-                  {tabMode === TABS.material &&
-                    material_occurences.map((material) => (
-                      <Tabs.Tab
-                        key={material.atom_id}
-                        selected={
-                          activeMaterial === material.atom_id &&
-                          searchText.length === 0
-                        }
-                        onClick={(e) => {
-                          setMaterial(material.atom_id);
-                          setPages(1);
-                          if (content) {
-                            content.scrollTop = 0;
-                          }
-                          if (searchText.length > 0) {
-                            setSearchText('');
-                          }
-                        }}
-                      >
-                        <MaterialContent
-                          atom_id={material.atom_id}
-                          occurences={material.occurences}
-                        />
-                      </Tabs.Tab>
-                    ))}
-                  {tabMode === TABS.category &&
-                    categories.map((category) => (
-                      <Tabs.Tab
-                        key={category}
-                        selected={
-                          activeCategory === category && searchText.length === 0
-                        }
-                        onClick={(e) => {
-                          setCategory(category);
-                          setPages(1);
-                          if (content) {
-                            content.scrollTop = 0;
-                          }
-                          if (searchText.length > 0) {
-                            setSearchText('');
-                          }
-                        }}
-                      >
-                        <Stack>
-                          <Stack.Item width="14px" textAlign="center">
-                            <Icon
-                              color={
-                                category === 'Blood Cult' ? 'red' : 'default'
-                              }
-                              name={CATEGORY_ICONS[category] || 'circle'}
-                            />
-                          </Stack.Item>
-                          <Stack.Item
-                            grow
-                            color={
-                              category === 'Blood Cult' ? 'red' : 'default'
-                            }
-                          >
-                            {category}
-                          </Stack.Item>
-                          {category === 'Can Make' && (
-                            <Stack.Item>
-                              {Object.keys(craftability).length}
-                            </Stack.Item>
-                          )}
-                        </Stack>
-                      </Tabs.Tab>
-                    ))}
-                </Tabs>
-              </Box>
-              <Stack.Item>
-                <Divider />
-                <Button.Checkbox
-                  fluid
-                  content="Can make only"
-                  checked={display_craftable_only}
-                  onClick={() => {
-                    act('toggle_recipes');
-                  }}
-                />
-                <Button.Checkbox
-                  fluid
-                  content="Compact list"
-                  checked={display_compact}
-                  onClick={() => act('toggle_compact')}
-                />
-              </Stack.Item>
-              {!forced_mode && (
-                <Stack.Item>
-                  <Stack textAlign="center">
-                    <Stack.Item grow>
-                      <Button.Checkbox
-                        fluid
-                        lineHeight={2}
-                        content="Craft"
-                        checked={mode === MODE.crafting}
-                        icon="hammer"
-                        style={{
-                          border:
-                            '2px solid ' +
-                            (mode === MODE.crafting ? '#20b142' : '#333'),
-                        }}
+                        selected={tabMode === TABS.foodtype}
                         onClick={() => {
-                          if (mode === MODE.crafting) {
+                          if (tabMode === TABS.foodtype) {
                             return;
                           }
-                          setTabMode(TABS.category);
-                          setCategory(DEFAULT_CAT_CRAFTING);
-                          act('toggle_mode');
+                          setTabMode(TABS.foodtype);
+                          setPages(1);
+                          setFoodType(
+                            Object.keys(craftability).length
+                              ? 'Can Make'
+                              : data.foodtypes[0],
+                          );
                         }}
-                      />
-                    </Stack.Item>
-                    <Stack.Item grow>
-                      <Button.Checkbox
-                        fluid
-                        lineHeight={2}
-                        content="Cook"
-                        checked={mode === MODE.cooking}
-                        icon="utensils"
-                        style={{
-                          border:
-                            '2px solid ' +
-                            (mode === MODE.cooking ? '#20b142' : '#333'),
-                        }}
-                        onClick={() => {
-                          if (mode === MODE.cooking) {
-                            return;
-                          }
-                          setTabMode(TABS.category);
-                          setCategory(DEFAULT_CAT_COOKING);
-                          act('toggle_mode');
-                        }}
-                      />
-                    </Stack.Item>
-                  </Stack>
+                      >
+                        Type
+                      </Tabs.Tab>
+                    )}
+                    <Tabs.Tab
+                      selected={tabMode === TABS.material}
+                      onClick={() => {
+                        if (tabMode === TABS.material) {
+                          return;
+                        }
+                        setTabMode(TABS.material);
+                        setPages(1);
+                        setMaterial(material_occurences[0].atom_id);
+                      }}
+                    >
+                      {mode === MODE.cooking ? 'Ingredient' : 'Material'}
+                    </Tabs.Tab>
+                  </Tabs>
                 </Stack.Item>
-              )}
-            </Stack>
+                <Stack.Item grow m={-1} style={{ overflowY: 'auto' }}>
+                  <Box height={'100%'} p={1}>
+                    <Tabs vertical>
+                      {tabMode === TABS.foodtype &&
+                        mode === MODE.cooking &&
+                        foodtypes.map((foodtype) => (
+                          <Tabs.Tab
+                            key={foodtype}
+                            selected={
+                              activeType === foodtype && searchText.length === 0
+                            }
+                            onClick={(e) => {
+                              setFoodType(foodtype);
+                              setPages(1);
+                              if (content) {
+                                content.scrollTop = 0;
+                              }
+                              if (searchText.length > 0) {
+                                setSearchText('');
+                              }
+                            }}
+                          >
+                            <FoodtypeContent
+                              type={foodtype}
+                              diet={diet}
+                              craftableCount={Object.keys(craftability).length}
+                            />
+                          </Tabs.Tab>
+                        ))}
+                      {tabMode === TABS.material &&
+                        material_occurences.map((material) => (
+                          <Tabs.Tab
+                            key={material.atom_id}
+                            selected={
+                              activeMaterial === material.atom_id &&
+                              searchText.length === 0
+                            }
+                            onClick={(e) => {
+                              setMaterial(material.atom_id);
+                              setPages(1);
+                              if (content) {
+                                content.scrollTop = 0;
+                              }
+                              if (searchText.length > 0) {
+                                setSearchText('');
+                              }
+                            }}
+                          >
+                            <MaterialContent
+                              atom_id={material.atom_id}
+                              occurences={material.occurences}
+                            />
+                          </Tabs.Tab>
+                        ))}
+                      {tabMode === TABS.category &&
+                        categories.map((category) => (
+                          <Tabs.Tab
+                            key={category}
+                            selected={
+                              activeCategory === category &&
+                              searchText.length === 0
+                            }
+                            onClick={(e) => {
+                              setCategory(category);
+                              setPages(1);
+                              if (content) {
+                                content.scrollTop = 0;
+                              }
+                              if (searchText.length > 0) {
+                                setSearchText('');
+                              }
+                            }}
+                          >
+                            <Stack>
+                              <Stack.Item width="14px" textAlign="center">
+                                <Icon
+                                  color={
+                                    category === 'Blood Cult'
+                                      ? 'red'
+                                      : 'default'
+                                  }
+                                  name={CATEGORY_ICONS[category] || 'circle'}
+                                />
+                              </Stack.Item>
+                              <Stack.Item
+                                grow
+                                color={
+                                  category === 'Blood Cult' ? 'red' : 'default'
+                                }
+                              >
+                                {category}
+                              </Stack.Item>
+                              {category === 'Can Make' && (
+                                <Stack.Item>
+                                  {Object.keys(craftability).length}
+                                </Stack.Item>
+                              )}
+                            </Stack>
+                          </Tabs.Tab>
+                        ))}
+                    </Tabs>
+                  </Box>
+                </Stack.Item>
+                <Stack.Item>
+                  <Divider />
+                  <Button.Checkbox
+                    fluid
+                    content="Can make only"
+                    checked={display_craftable_only}
+                    onClick={() => {
+                      act('toggle_recipes');
+                    }}
+                  />
+                  <Button.Checkbox
+                    fluid
+                    content="Compact list"
+                    checked={display_compact}
+                    onClick={() => act('toggle_compact')}
+                  />
+                </Stack.Item>
+                {!forced_mode && (
+                  <Stack.Item>
+                    <Stack textAlign="center">
+                      <Stack.Item grow>
+                        <Button.Checkbox
+                          fluid
+                          lineHeight={2}
+                          content="Craft"
+                          checked={mode === MODE.crafting}
+                          icon="hammer"
+                          style={{
+                            border:
+                              '2px solid ' +
+                              (mode === MODE.crafting ? '#20b142' : '#333'),
+                          }}
+                          onClick={() => {
+                            if (mode === MODE.crafting) {
+                              return;
+                            }
+                            setTabMode(TABS.category);
+                            setCategory(DEFAULT_CAT_CRAFTING);
+                            act('toggle_mode');
+                          }}
+                        />
+                      </Stack.Item>
+                      <Stack.Item grow>
+                        <Button.Checkbox
+                          fluid
+                          lineHeight={2}
+                          content="Cook"
+                          checked={mode === MODE.cooking}
+                          icon="utensils"
+                          style={{
+                            border:
+                              '2px solid ' +
+                              (mode === MODE.cooking ? '#20b142' : '#333'),
+                          }}
+                          onClick={() => {
+                            if (mode === MODE.cooking) {
+                              return;
+                            }
+                            setTabMode(TABS.category);
+                            setCategory(DEFAULT_CAT_COOKING);
+                            act('toggle_mode');
+                          }}
+                        />
+                      </Stack.Item>
+                    </Stack>
+                  </Stack.Item>
+                )}
+              </Stack>
+            </Section>
           </Stack.Item>
           <Stack.Item grow my={-1}>
             <Box

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -255,253 +255,246 @@ export const PersonalCrafting = (props) => {
   const CATEGORY_ICONS =
     mode === MODE.cooking ? CATEGORY_ICONS_COOKING : CATEGORY_ICONS_CRAFTING;
   return (
-    <Window width={700} height={720}>
+    <Window width={700} height={400}>
       <Window.Content>
         <Stack fill>
           <Stack.Item width={'200px'}>
-            <Section fill>
-              <Stack fill vertical justify={'space-between'}>
-                <Stack.Item>
-                  <Input
-                    autoFocus
-                    placeholder={
-                      'Search in ' +
-                      data.recipes.length +
-                      (mode === MODE.cooking ? ' recipes...' : ' designs...')
-                    }
-                    value={searchText}
-                    onInput={(e, value) => {
+            <Stack fill vertical justify={'space-between'}>
+              <Stack.Item>
+                <Input
+                  autoFocus
+                  placeholder={
+                    'Search in ' +
+                    data.recipes.length +
+                    (mode === MODE.cooking ? ' recipes...' : ' designs...')
+                  }
+                  value={searchText}
+                  onInput={(e, value) => {
+                    setPages(1);
+                    setSearchText(value);
+                  }}
+                  fluid
+                />
+              </Stack.Item>
+              <Stack.Item>
+                <Tabs fluid textAlign="center">
+                  <Tabs.Tab
+                    selected={tabMode === TABS.category}
+                    onClick={() => {
+                      if (tabMode === TABS.category) {
+                        return;
+                      }
+                      setTabMode(TABS.category);
                       setPages(1);
-                      setSearchText(value);
+                      setCategory(
+                        Object.keys(craftability).length
+                          ? 'Can Make'
+                          : data.categories[0],
+                      );
                     }}
-                    fluid
-                  />
-                </Stack.Item>
-                <Stack.Item>
-                  <Tabs fluid textAlign="center">
+                  >
+                    Category
+                  </Tabs.Tab>
+                  {mode === MODE.cooking && (
                     <Tabs.Tab
-                      selected={tabMode === TABS.category}
+                      selected={tabMode === TABS.foodtype}
                       onClick={() => {
-                        if (tabMode === TABS.category) {
+                        if (tabMode === TABS.foodtype) {
                           return;
                         }
-                        setTabMode(TABS.category);
+                        setTabMode(TABS.foodtype);
                         setPages(1);
-                        setCategory(
+                        setFoodType(
                           Object.keys(craftability).length
                             ? 'Can Make'
-                            : data.categories[0],
+                            : data.foodtypes[0],
                         );
                       }}
                     >
-                      Category
+                      Type
                     </Tabs.Tab>
-                    {mode === MODE.cooking && (
+                  )}
+                  <Tabs.Tab
+                    selected={tabMode === TABS.material}
+                    onClick={() => {
+                      if (tabMode === TABS.material) {
+                        return;
+                      }
+                      setTabMode(TABS.material);
+                      setPages(1);
+                      setMaterial(material_occurences[0].atom_id);
+                    }}
+                  >
+                    {mode === MODE.cooking ? 'Ingredient' : 'Material'}
+                  </Tabs.Tab>
+                </Tabs>
+              </Stack.Item>
+              <Box height={'100%'} p={1} style={{ overflowY: 'auto' }}>
+                <Tabs vertical>
+                  {tabMode === TABS.foodtype &&
+                    mode === MODE.cooking &&
+                    foodtypes.map((foodtype) => (
                       <Tabs.Tab
-                        selected={tabMode === TABS.foodtype}
-                        onClick={() => {
-                          if (tabMode === TABS.foodtype) {
-                            return;
-                          }
-                          setTabMode(TABS.foodtype);
+                        key={foodtype}
+                        selected={
+                          activeType === foodtype && searchText.length === 0
+                        }
+                        onClick={(e) => {
+                          setFoodType(foodtype);
                           setPages(1);
-                          setFoodType(
-                            Object.keys(craftability).length
-                              ? 'Can Make'
-                              : data.foodtypes[0],
-                          );
+                          if (content) {
+                            content.scrollTop = 0;
+                          }
+                          if (searchText.length > 0) {
+                            setSearchText('');
+                          }
                         }}
                       >
-                        Type
+                        <FoodtypeContent
+                          type={foodtype}
+                          diet={diet}
+                          craftableCount={Object.keys(craftability).length}
+                        />
                       </Tabs.Tab>
-                    )}
-                    <Tabs.Tab
-                      selected={tabMode === TABS.material}
-                      onClick={() => {
-                        if (tabMode === TABS.material) {
-                          return;
+                    ))}
+                  {tabMode === TABS.material &&
+                    material_occurences.map((material) => (
+                      <Tabs.Tab
+                        key={material.atom_id}
+                        selected={
+                          activeMaterial === material.atom_id &&
+                          searchText.length === 0
                         }
-                        setTabMode(TABS.material);
-                        setPages(1);
-                        setMaterial(material_occurences[0].atom_id);
-                      }}
-                    >
-                      {mode === MODE.cooking ? 'Ingredient' : 'Material'}
-                    </Tabs.Tab>
-                  </Tabs>
-                </Stack.Item>
-                <Stack.Item grow m={-1}>
-                  <Box height={'100%'} p={1} style={{ overflowY: 'auto' }}>
-                    <Tabs vertical>
-                      {tabMode === TABS.foodtype &&
-                        mode === MODE.cooking &&
-                        foodtypes.map((foodtype) => (
-                          <Tabs.Tab
-                            key={foodtype}
-                            selected={
-                              activeType === foodtype && searchText.length === 0
-                            }
-                            onClick={(e) => {
-                              setFoodType(foodtype);
-                              setPages(1);
-                              if (content) {
-                                content.scrollTop = 0;
+                        onClick={(e) => {
+                          setMaterial(material.atom_id);
+                          setPages(1);
+                          if (content) {
+                            content.scrollTop = 0;
+                          }
+                          if (searchText.length > 0) {
+                            setSearchText('');
+                          }
+                        }}
+                      >
+                        <MaterialContent
+                          atom_id={material.atom_id}
+                          occurences={material.occurences}
+                        />
+                      </Tabs.Tab>
+                    ))}
+                  {tabMode === TABS.category &&
+                    categories.map((category) => (
+                      <Tabs.Tab
+                        key={category}
+                        selected={
+                          activeCategory === category && searchText.length === 0
+                        }
+                        onClick={(e) => {
+                          setCategory(category);
+                          setPages(1);
+                          if (content) {
+                            content.scrollTop = 0;
+                          }
+                          if (searchText.length > 0) {
+                            setSearchText('');
+                          }
+                        }}
+                      >
+                        <Stack>
+                          <Stack.Item width="14px" textAlign="center">
+                            <Icon
+                              color={
+                                category === 'Blood Cult' ? 'red' : 'default'
                               }
-                              if (searchText.length > 0) {
-                                setSearchText('');
-                              }
-                            }}
-                          >
-                            <FoodtypeContent
-                              type={foodtype}
-                              diet={diet}
-                              craftableCount={Object.keys(craftability).length}
+                              name={CATEGORY_ICONS[category] || 'circle'}
                             />
-                          </Tabs.Tab>
-                        ))}
-                      {tabMode === TABS.material &&
-                        material_occurences.map((material) => (
-                          <Tabs.Tab
-                            key={material.atom_id}
-                            selected={
-                              activeMaterial === material.atom_id &&
-                              searchText.length === 0
+                          </Stack.Item>
+                          <Stack.Item
+                            grow
+                            color={
+                              category === 'Blood Cult' ? 'red' : 'default'
                             }
-                            onClick={(e) => {
-                              setMaterial(material.atom_id);
-                              setPages(1);
-                              if (content) {
-                                content.scrollTop = 0;
-                              }
-                              if (searchText.length > 0) {
-                                setSearchText('');
-                              }
-                            }}
                           >
-                            <MaterialContent
-                              atom_id={material.atom_id}
-                              occurences={material.occurences}
-                            />
-                          </Tabs.Tab>
-                        ))}
-                      {tabMode === TABS.category &&
-                        categories.map((category) => (
-                          <Tabs.Tab
-                            key={category}
-                            selected={
-                              activeCategory === category &&
-                              searchText.length === 0
-                            }
-                            onClick={(e) => {
-                              setCategory(category);
-                              setPages(1);
-                              if (content) {
-                                content.scrollTop = 0;
-                              }
-                              if (searchText.length > 0) {
-                                setSearchText('');
-                              }
-                            }}
-                          >
-                            <Stack>
-                              <Stack.Item width="14px" textAlign="center">
-                                <Icon
-                                  color={
-                                    category === 'Blood Cult'
-                                      ? 'red'
-                                      : 'default'
-                                  }
-                                  name={CATEGORY_ICONS[category] || 'circle'}
-                                />
-                              </Stack.Item>
-                              <Stack.Item
-                                grow
-                                color={
-                                  category === 'Blood Cult' ? 'red' : 'default'
-                                }
-                              >
-                                {category}
-                              </Stack.Item>
-                              {category === 'Can Make' && (
-                                <Stack.Item>
-                                  {Object.keys(craftability).length}
-                                </Stack.Item>
-                              )}
-                            </Stack>
-                          </Tabs.Tab>
-                        ))}
-                    </Tabs>
-                  </Box>
-                </Stack.Item>
+                            {category}
+                          </Stack.Item>
+                          {category === 'Can Make' && (
+                            <Stack.Item>
+                              {Object.keys(craftability).length}
+                            </Stack.Item>
+                          )}
+                        </Stack>
+                      </Tabs.Tab>
+                    ))}
+                </Tabs>
+              </Box>
+              <Stack.Item>
+                <Divider />
+                <Button.Checkbox
+                  fluid
+                  content="Can make only"
+                  checked={display_craftable_only}
+                  onClick={() => {
+                    act('toggle_recipes');
+                  }}
+                />
+                <Button.Checkbox
+                  fluid
+                  content="Compact list"
+                  checked={display_compact}
+                  onClick={() => act('toggle_compact')}
+                />
+              </Stack.Item>
+              {!forced_mode && (
                 <Stack.Item>
-                  <Divider />
-                  <Button.Checkbox
-                    fluid
-                    content="Can make only"
-                    checked={display_craftable_only}
-                    onClick={() => {
-                      act('toggle_recipes');
-                    }}
-                  />
-                  <Button.Checkbox
-                    fluid
-                    content="Compact list"
-                    checked={display_compact}
-                    onClick={() => act('toggle_compact')}
-                  />
+                  <Stack textAlign="center">
+                    <Stack.Item grow>
+                      <Button.Checkbox
+                        fluid
+                        lineHeight={2}
+                        content="Craft"
+                        checked={mode === MODE.crafting}
+                        icon="hammer"
+                        style={{
+                          border:
+                            '2px solid ' +
+                            (mode === MODE.crafting ? '#20b142' : '#333'),
+                        }}
+                        onClick={() => {
+                          if (mode === MODE.crafting) {
+                            return;
+                          }
+                          setTabMode(TABS.category);
+                          setCategory(DEFAULT_CAT_CRAFTING);
+                          act('toggle_mode');
+                        }}
+                      />
+                    </Stack.Item>
+                    <Stack.Item grow>
+                      <Button.Checkbox
+                        fluid
+                        lineHeight={2}
+                        content="Cook"
+                        checked={mode === MODE.cooking}
+                        icon="utensils"
+                        style={{
+                          border:
+                            '2px solid ' +
+                            (mode === MODE.cooking ? '#20b142' : '#333'),
+                        }}
+                        onClick={() => {
+                          if (mode === MODE.cooking) {
+                            return;
+                          }
+                          setTabMode(TABS.category);
+                          setCategory(DEFAULT_CAT_COOKING);
+                          act('toggle_mode');
+                        }}
+                      />
+                    </Stack.Item>
+                  </Stack>
                 </Stack.Item>
-                {!forced_mode && (
-                  <Stack.Item>
-                    <Stack textAlign="center">
-                      <Stack.Item grow>
-                        <Button.Checkbox
-                          fluid
-                          lineHeight={2}
-                          content="Craft"
-                          checked={mode === MODE.crafting}
-                          icon="hammer"
-                          style={{
-                            border:
-                              '2px solid ' +
-                              (mode === MODE.crafting ? '#20b142' : '#333'),
-                          }}
-                          onClick={() => {
-                            if (mode === MODE.crafting) {
-                              return;
-                            }
-                            setTabMode(TABS.category);
-                            setCategory(DEFAULT_CAT_CRAFTING);
-                            act('toggle_mode');
-                          }}
-                        />
-                      </Stack.Item>
-                      <Stack.Item grow>
-                        <Button.Checkbox
-                          fluid
-                          lineHeight={2}
-                          content="Cook"
-                          checked={mode === MODE.cooking}
-                          icon="utensils"
-                          style={{
-                            border:
-                              '2px solid ' +
-                              (mode === MODE.cooking ? '#20b142' : '#333'),
-                          }}
-                          onClick={() => {
-                            if (mode === MODE.cooking) {
-                              return;
-                            }
-                            setTabMode(TABS.category);
-                            setCategory(DEFAULT_CAT_COOKING);
-                            act('toggle_mode');
-                          }}
-                        />
-                      </Stack.Item>
-                    </Stack>
-                  </Stack.Item>
-                )}
-              </Stack>
-            </Section>
+              )}
+            </Stack>
           </Stack.Item>
           <Stack.Item grow my={-1}>
             <Box

--- a/tgui/packages/tgui/interfaces/TelecommsMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/TelecommsMonitor.tsx
@@ -161,6 +161,7 @@ const MachineList = (props: MachineListProps) => {
 
   return (
     <Section
+      scrollable
       fill
       title={title}
       buttons={
@@ -179,7 +180,7 @@ const MachineList = (props: MachineListProps) => {
       {sortedMachines.length > 0 ? (
         <Stack fill vertical>
           <Stack.Item grow>
-            <Stack fill vertical overflowY="scroll">
+            <Stack fill vertical>
               {sortedMachines.map((machine, index) => (
                 <Stack.Item key={index}>
                   <Button

--- a/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
@@ -105,19 +105,20 @@ export const GenericUplink = (props: GenericUplinkProps) => {
         </Stack>
       </Stack.Item>
       <Stack.Item grow={1}>
-        <Box height="100%" pr={1} mr={-1} style={{ overflowY: 'auto' }}>
-          {items.length === 0 && (
+        <Box height="100%" pr={1} mr={-1}>
+          {(items.length === 0 && (
             <NoticeBox>
               {searchText.length === 0
                 ? 'No items in this category.'
                 : 'No results found.'}
             </NoticeBox>
+          )) || (
+            <ItemList
+              compactMode={searchText.length > 0 || compactMode}
+              items={items}
+              handleBuy={handleBuy}
+            />
           )}
-          <ItemList
-            compactMode={searchText.length > 0 || compactMode}
-            items={items}
-            handleBuy={handleBuy}
-          />
         </Box>
       </Stack.Item>
     </Stack>
@@ -148,85 +149,87 @@ const ItemList = (props: ItemListProps) => {
     <Icon m={compactMode ? '10px' : '26px'} name="spinner" spin />
   );
   return (
-    <Stack vertical mt={compactMode ? -0.5 : -1}>
-      {items.map((item, index) => (
-        <Stack.Item key={index} mt={compactMode ? 0.5 : 1}>
-          <Section key={item.name} fitted={compactMode ? true : false}>
-            <Stack>
-              <Stack.Item>
-                <Box
-                  width={compactMode ? '32px' : '64px'}
-                  height={compactMode ? '32px' : '64px'}
-                  position="relative"
-                  m={compactMode ? '2px' : 0}
-                  mr={1}
-                >
-                  <DmIcon
-                    position="absolute"
-                    bottom="0"
-                    fallback={fallback}
-                    icon={item.icon}
-                    icon_state={item.icon_state}
+    <Section fill scrollable>
+      <Stack vertical mt={compactMode ? -0.5 : -1}>
+        {items.map((item, index) => (
+          <Stack.Item key={index} mt={compactMode ? 0.5 : 1}>
+            <Section key={item.name} fitted={compactMode ? true : false}>
+              <Stack>
+                <Stack.Item>
+                  <Box
                     width={compactMode ? '32px' : '64px'}
-                  />
-                </Box>
-              </Stack.Item>
-              <Stack.Item grow={1}>
-                {compactMode ? (
-                  <Stack>
-                    <Stack.Item
-                      bold
-                      grow={1}
-                      lineHeight="36px"
-                      style={{
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap',
-                        textOverflow: 'ellipsis',
-                      }}
-                    >
-                      {item.name}
-                    </Stack.Item>
-                    <Stack.Item>
-                      <Tooltip content={item.desc}>
-                        <Icon name="info-circle" lineHeight="36px" />
-                      </Tooltip>
-                    </Stack.Item>
-                    <Stack.Item>
-                      <Button
-                        m="8px"
-                        disabled={item.disabled}
-                        onClick={(e) => handleBuy(item)}
-                      >
-                        {item.cost}
-                      </Button>
-                    </Stack.Item>
-                  </Stack>
-                ) : (
-                  <Section
-                    title={item.name}
-                    buttons={
-                      <Button
-                        disabled={item.disabled}
-                        onClick={(e) => handleBuy(item)}
-                      >
-                        {item.cost}
-                      </Button>
-                    }
+                    height={compactMode ? '32px' : '64px'}
+                    position="relative"
+                    m={compactMode ? '2px' : 0}
+                    mr={1}
                   >
-                    <Box
-                      style={{
-                        opacity: '0.75',
-                      }}
+                    <DmIcon
+                      position="absolute"
+                      bottom="0"
+                      fallback={fallback}
+                      icon={item.icon}
+                      icon_state={item.icon_state}
+                      width={compactMode ? '32px' : '64px'}
+                    />
+                  </Box>
+                </Stack.Item>
+                <Stack.Item grow={1}>
+                  {compactMode ? (
+                    <Stack>
+                      <Stack.Item
+                        bold
+                        grow={1}
+                        lineHeight="36px"
+                        style={{
+                          overflow: 'hidden',
+                          whiteSpace: 'nowrap',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {item.name}
+                      </Stack.Item>
+                      <Stack.Item>
+                        <Tooltip content={item.desc}>
+                          <Icon name="info-circle" lineHeight="36px" />
+                        </Tooltip>
+                      </Stack.Item>
+                      <Stack.Item>
+                        <Button
+                          m="8px"
+                          disabled={item.disabled}
+                          onClick={(e) => handleBuy(item)}
+                        >
+                          {item.cost}
+                        </Button>
+                      </Stack.Item>
+                    </Stack>
+                  ) : (
+                    <Section
+                      title={item.name}
+                      buttons={
+                        <Button
+                          disabled={item.disabled}
+                          onClick={(e) => handleBuy(item)}
+                        >
+                          {item.cost}
+                        </Button>
+                      }
                     >
-                      {item.desc}
-                    </Box>
-                  </Section>
-                )}
-              </Stack.Item>
-            </Stack>
-          </Section>
-        </Stack.Item>
-      ))}
-    </Stack>
+                      <Box
+                        style={{
+                          opacity: '0.75',
+                        }}
+                      >
+                        {item.desc}
+                      </Box>
+                    </Section>
+                  )}
+                </Stack.Item>
+              </Stack>
+            </Section>
+          </Stack.Item>
+        ))}
+      </Stack>
+    </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
@@ -46,7 +46,7 @@ export const GenericUplink = (props: GenericUplinkProps) => {
         <Stack vertical fill>
           <Stack.Item>
             <Stack>
-              <Stack.Item grow={1}>
+              <Stack.Item grow>
                 <Button
                   bold
                   fluid
@@ -83,7 +83,7 @@ export const GenericUplink = (props: GenericUplinkProps) => {
               fluid
             />
           </Stack.Item>
-          <Stack.Item grow={1}>
+          <Stack.Item grow>
             <Tabs vertical fill>
               {categories.map((category) => (
                 <Tabs.Tab
@@ -104,15 +104,15 @@ export const GenericUplink = (props: GenericUplinkProps) => {
           </Stack.Item>
         </Stack>
       </Stack.Item>
-      <Stack.Item grow={1}>
+      <Stack.Item grow>
         <Box height="100%" pr={1} mr={-1}>
-          {(items.length === 0 && (
+          {items.length === 0 ? (
             <NoticeBox>
               {searchText.length === 0
                 ? 'No items in this category.'
                 : 'No results found.'}
             </NoticeBox>
-          )) || (
+          ) : (
             <ItemList
               compactMode={searchText.length > 0 || compactMode}
               items={items}
@@ -173,12 +173,12 @@ const ItemList = (props: ItemListProps) => {
                     />
                   </Box>
                 </Stack.Item>
-                <Stack.Item grow={1}>
+                <Stack.Item grow>
                   {compactMode ? (
                     <Stack>
                       <Stack.Item
                         bold
-                        grow={1}
+                        grow
                         lineHeight="36px"
                         style={{
                           overflow: 'hidden',


### PR DESCRIPTION
## About The Pull Request

After updating to 516, I tried messing around with some stuff, and found the Uplink didn't have a scrollbar. Looking into it, I noticed 515 still had it, so I looked at what was giving it the scrollbar in the first place, ``overflowY``, and (with the great help of Aylong) found it was a problem with the individual UIs using it.
Therefore, I went through all instances of it to make sure they work, here's all UIs that broke, and what I did.

- Oresilo: Replaced with ``scrollable``, also made it a Section instead of a Box.
- PersonalCrafting: Uses it twice, first one works as intended, second one doesn't. Updated to work & changed the UI a bit. Video demonstration below
- TelecommsMonitor: Replaced with ``scrollable``.
- GenericUplink: Replaced with ``scrollable``, no longer uses auto, so it's always 'scrollable' even if it's on compact mode.

I changed the Crafting UI so the buttons at the bottom left don't get cropped out anymore, making good use of our scrollable element.
Before:
https://github.com/user-attachments/assets/de074634-4bb9-4013-ac65-869b05fce2cc

After:
https://github.com/user-attachments/assets/e20a7377-69d2-41d1-a042-f79194dcc6f7

Though this doesn't really do anything, I did test this on 515 just to be 100% sure nothing breaks.

## Why It's Good For The Game

Scrolling works in these few instances on 516 now, few less things to deal with later.
I think it's better to use scrollable where ``overflowY`` is not needed because it's what we use more so it's easier to spot when it breaks in the future.

## Changelog

:cl:
fix: Fixed the ability to scroll for Ore silo's logging, personal crafting's material section, telecomms monitors, and traitor uplinks for clients on 516.
/:cl: