### PR TITLE
Fix an icon smoothing runtime caused by shuttles during recursive map loading

### DIFF
--- a/code/modules/shuttle/stationary_port/stationary_port.dm
+++ b/code/modules/shuttle/stationary_port/stationary_port.dm
@@ -23,7 +23,10 @@
 			T.turf_flags |= NO_RUINS
 
 	if(SSshuttle.initialized)
-		INVOKE_ASYNC(SSshuttle, TYPE_PROC_REF(/datum/controller/subsystem/shuttle, setup_shuttles), list(src))
+		return INITIALIZE_HINT_LATELOAD
+
+/obj/docking_port/stationary/LateInitialize()
+	INVOKE_ASYNC(SSshuttle, TYPE_PROC_REF(/datum/controller/subsystem/shuttle, setup_shuttles), list(src))
 
 #ifdef TESTING
 	highlight("#f00")


### PR DESCRIPTION
## About The Pull Request

So, funny thing. The syndie base lazy template loads recursively, as it contains two shuttle docks (infiltrator and steel rain).

But stationary shuttle docks will immediately load their `roundstart_template` _asynchronously_ upon Initialize. This can cause issues - such as the shuttle's atoms being initialized before everything else is, in a weird way. The usual side-effect of this would be runtimes resulting from the shuttle's initialized walls trying to smooth with non-initialized turfs on the template that loaded it.

I simply moved to stationary docking port's async load to LateInitialize. There's prolly a better long-term solution, but this doesn't hurt, and solves the relevant issue.

you know i really hope we don't have _3_ layer map templates anywhere.

## Why It's Good For The Game

less runtime good.

## Changelog
:cl:
fix: Fixed an icon smoothing error caused by shuttles during recursive map loading, i.e the nukie shuttles with their base.
/:cl:
