### PR TITLE
Prevent gibspawners from randomly causing failures with mapping nearstation tests

### DIFF
--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -50,10 +50,13 @@
 
 				gib.add_blood_DNA(dna_to_add)
 
+// These might streak off into space and cause annoying flaky failures with mapping nearstation tests
+#ifndef UNIT_TESTS
 				var/list/directions = gibdirections[i]
 				if(isturf(loc))
 					if(directions.len)
 						gib.streak(directions, mapload)
+#endif
 
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION
## About The Pull Request

this stops gibs from being streaked from spawners during unit tests, as there's a chance it might just go into space, causing a mapping nearstation test failure.

there's already a precedent for the "just disable it during unit tests" solution with https://github.com/tgstation/tgstation/pull/87878

## Why It's Good For The Game

flaky tests bad :3

## Changelog

no player-facing changes