### PR TITLE
Improves mind lockbox handling

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -31,23 +31,26 @@
 		return ..()
 
 	if(can_unlock(user, card))
-		if(atom_storage.locked)
-			atom_storage.locked = STORAGE_NOT_LOCKED
-		else
-			atom_storage.locked = STORAGE_FULLY_LOCKED
-			atom_storage.close_all()
-		balloon_alert(user, atom_storage.locked ? "locked" : "unlocked")
-		update_appearance()
+		toggle_locked(user)
 		return ITEM_INTERACT_SUCCESS
 
 	return ITEM_INTERACT_BLOCKING
 
-/obj/item/storage/lockbox/proc/can_unlock(mob/living/user, obj/item/card/id/id_card)
+/obj/item/storage/lockbox/proc/can_unlock(mob/living/user, obj/item/card/id/id_card, silent = FALSE)
 	if(check_access(id_card))
 		return TRUE
-
-	balloon_alert(user, "access denied!")
+	if(!silent)
+		balloon_alert(user, "access denied!")
 	return FALSE
+
+/obj/item/storage/lockbox/proc/toggle_locked(mob/living/user)
+	if(atom_storage.locked)
+		atom_storage.locked = STORAGE_NOT_LOCKED
+	else
+		atom_storage.locked = STORAGE_FULLY_LOCKED
+		atom_storage.close_all()
+	balloon_alert(user, atom_storage.locked ? "locked" : "unlocked")
+	update_appearance()
 
 /obj/item/storage/lockbox/update_icon_state()
 	. = ..()
@@ -248,11 +251,11 @@
 	ADD_TRAIT(src, TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NO_MANIFEST_CONTENTS_ERROR, TRAIT_GENERIC)
 
-/obj/item/storage/lockbox/order/can_unlock(mob/living/user, obj/item/card/id/id_card)
+/obj/item/storage/lockbox/order/can_unlock(mob/living/user, obj/item/card/id/id_card, silent = FALSE)
 	if(id_card.registered_account == buyer_account)
 		return TRUE
-
-	balloon_alert(user, "incorrect bank account!")
+	if(!silent)
+		balloon_alert(user, "incorrect bank account!")
 	return FALSE
 
 ///screentips for lockboxes

--- a/code/modules/lost_crew/lost_crew_manager.dm
+++ b/code/modules/lost_crew/lost_crew_manager.dm
@@ -140,7 +140,7 @@ GLOBAL_DATUM_INIT(lost_crew_manager, /datum/lost_crew_manager, new)
 	if (atom_storage.locked && can_unlock(user))
 		toggle_locked(user)
 		return
-	. = ..()
+	return ..()
 
 /obj/item/storage/lockbox/mind/can_unlock(mob/living/user, obj/item/card/id/id_card, silent = FALSE)
 	if (user.mind == mind)

--- a/code/modules/lost_crew/lost_crew_manager.dm
+++ b/code/modules/lost_crew/lost_crew_manager.dm
@@ -128,10 +128,37 @@ GLOBAL_DATUM_INIT(lost_crew_manager, /datum/lost_crew_manager, new)
 	/// The mind needed to unlock the box
 	var/datum/mind/mind
 
+/obj/item/storage/lockbox/mind/attack_hand(mob/user, list/modifiers)
+	if (!(src in user.held_items))
+		return ..()
+	if(atom_storage.locked && can_unlock(user, silent = TRUE))
+		toggle_locked(user)
+		return
+	return ..()
+
 /obj/item/storage/lockbox/mind/attack_self(mob/user, modifiers)
+	if (atom_storage.locked && can_unlock(user))
+		toggle_locked(user)
+		return
 	. = ..()
 
-	if(user.mind == mind)
-		atom_storage.locked = STORAGE_NOT_LOCKED
-		balloon_alert(user, atom_storage.locked ? "locked" : "unlocked")
-		update_appearance()
+/obj/item/storage/lockbox/mind/can_unlock(mob/living/user, obj/item/card/id/id_card, silent = FALSE)
+	if (user.mind == mind)
+		return TRUE
+	if (!silent)
+		balloon_alert(user, "access denied!")
+	return FALSE
+
+/obj/item/storage/lockbox/mind/toggle_locked(mob/living/user)
+	if(!atom_storage.locked)
+		return
+
+	atom_storage.locked = STORAGE_NOT_LOCKED
+	balloon_alert(user, "unlocked")
+	update_appearance()
+
+/obj/item/storage/lockbox/mind/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	if(broken || user.mind != mind)
+		return NONE
+	context[SCREENTIP_CONTEXT_LMB] = "Use in-hand to unlock"
+	return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION

## About The Pull Request

Mind lockboxes have received a tooltip about their in-hand use, but also can be unlocked by trying to open them normally (clicking on one while holding it in your offhand). Should reduce the player confusion around these significantly.

Closes #88999

## Why It's Good For The Game
More intuitive handling of objects is always nice

## Changelog
:cl:
qol: Improved mind lockbox handling
/:cl:
