### PR TITLE
Radio examine qol

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -1,3 +1,6 @@
+// Just a generic span with class
+#define span_class(class, str) ("<span class='[class]'>" + str + "</span>")
+
 // Sorted alphabetically
 #define span_abductor(str) ("<span class='abductor'>" + str + "</span>")
 #define span_admin(str) ("<span class='admin'>" + str + "</span>")

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -57,16 +57,15 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	if(special_channels & RADIO_SPECIAL_BINARY)
 		available_channels += "<li><b>[span_binarysay(MODE_TOKEN_BINARY)] for [span_binarysay(capitalize(MODE_BINARY))]</b></li>"
 
-	if(length(channels))
-		for(var/i in 1 to length(channels))
-			var/channel_name = channels[i]
-			var/channel_token = GLOB.channel_tokens[channel_name]
-			var/channel_span_class = get_radio_span(GLOB.radiochannels[channel_name])
+	for(var/i in 1 to length(channels))
+		var/channel_name = channels[i]
+		var/channel_token = GLOB.channel_tokens[channel_name]
+		var/channel_span_class = get_radio_span(GLOB.radiochannels[channel_name])
 
-			if(i == 1)
-				available_channels += "<li><b>[span_class(channel_span_class, MODE_TOKEN_DEPARTMENT)]</b> or <b>[span_class(channel_span_class, channel_token)]</b> for <b>[span_class(channel_span_class, channel_name)]</b></li>"
-			else
-				available_channels += "<li><b>[span_class(channel_span_class, channel_token)]</b> for <b>[span_class(channel_span_class, channel_name)]</b></li>"
+		if(i == 1)
+			available_channels += "<li><b>[span_class(channel_span_class, MODE_TOKEN_DEPARTMENT)]</b> or <b>[span_class(channel_span_class, channel_token)]</b> for <b>[span_class(channel_span_class, channel_name)]</b></li>"
+		else
+			available_channels += "<li><b>[span_class(channel_span_class, channel_token)]</b> for <b>[span_class(channel_span_class, channel_name)]</b></li>"
 
 	. += span_notice("A small screen on the headset displays the following available frequencies:")
 	. += span_notice("<ul style='display:inline-block; margin: 0; list-style: square;'>[available_channels.Join()]</ul>")

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -47,23 +47,32 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/examine(mob/user)
 	. = ..()
 
-	if(item_flags & IN_INVENTORY && loc == user)
-		// construction of frequency description
-		var/list/avail_chans = list("Use [RADIO_KEY_COMMON] for the currently tuned frequency")
-		if(special_channels & RADIO_SPECIAL_BINARY)
-			avail_chans += "use [MODE_TOKEN_BINARY] for [MODE_BINARY]"
-		if(length(channels))
-			for(var/i in 1 to length(channels))
-				if(i == 1)
-					avail_chans += "use [MODE_TOKEN_DEPARTMENT] or [GLOB.channel_tokens[channels[i]]] for [LOWER_TEXT(channels[i])]"
-				else
-					avail_chans += "use [GLOB.channel_tokens[channels[i]]] for [LOWER_TEXT(channels[i])]"
-		. += span_notice("A small screen on the headset displays the following available frequencies:\n[english_list(avail_chans)].")
-
-		if(command)
-			. += span_info("Alt-click to toggle the high-volume mode.")
-	else
+	if(!(item_flags & IN_INVENTORY) || loc != user)
 		. += span_notice("A small screen on the headset flashes, it's too small to read without holding or wearing the headset.")
+		return
+
+	// construction of frequency description
+	var/list/available_channels = list()
+	available_channels += "<li><b>[span_radio(RADIO_KEY_COMMON)]</b> for the currently tuned frequency</li>"
+	if(special_channels & RADIO_SPECIAL_BINARY)
+		available_channels += "<li><b>[span_binarysay(MODE_TOKEN_BINARY)] for [span_binarysay(capitalize(MODE_BINARY))]</b></li>"
+
+	if(length(channels))
+		for(var/i in 1 to length(channels))
+			var/channel_name = channels[i]
+			var/channel_token = GLOB.channel_tokens[channel_name]
+			var/channel_span_class = get_radio_span(GLOB.radiochannels[channel_name])
+
+			if(i == 1)
+				available_channels += "<li><b>[span_class(channel_span_class, MODE_TOKEN_DEPARTMENT)]</b> or <b>[span_class(channel_span_class, channel_token)]</b> for <b>[span_class(channel_span_class, channel_name)]</b></li>"
+			else
+				available_channels += "<li><b>[span_class(channel_span_class, channel_token)]</b> for <b>[span_class(channel_span_class, channel_name)]</b></li>"
+
+	. += span_notice("A small screen on the headset displays the following available frequencies:")
+	. += span_notice("<ul style='display:inline-block; margin: 0; list-style: square;'>[available_channels.Join()]</ul>")
+
+	if(command)
+		. += span_info("<b>Alt-click</b> to toggle the high-volume mode.")
 
 /obj/item/radio/headset/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -528,7 +528,7 @@
 /obj/item/radio/examine(mob/user)
 	. = ..()
 	if (frequency && in_range(src, user))
-		. += span_notice("It is set to broadcast over the [frequency/10] frequency.")
+		. += span_notice("It is set to broadcast over the [span_radio("[frequency/10]")] frequency.")
 	if (unscrewed)
 		. += span_notice("It can be attached and modified.")
 	else


### PR DESCRIPTION
## About The Pull Request

Add `span_class` macro to use instead of <span class='class'> (now only used for changes I made to radio examine).
Make radio channel tokens info from headset examine more readable by color coding and displaying it in list format. 
Currently set broadcast frequence is also color coded and bold.

## Why It's Good For The Game

It's now easier to understand headset examine info :D

<details>
<summary>
Before
</summary>

![image](https://github.com/user-attachments/assets/6b5d7533-6b8e-47b9-9cd2-7c7a92552ca2)
![image](https://github.com/user-attachments/assets/7fcbde2b-0817-4db6-aca8-d15c17d708be)
</details>

<details>
<summary>
After
</summary>

![image](https://github.com/user-attachments/assets/6e9a7156-9c76-4843-8a45-7fce752a7b27)
![image](https://github.com/user-attachments/assets/50e5fb70-eb18-4fc5-803a-070774c73ccf)
</details>

## Changelog

:cl:
qol: tokens and channel names in radio headset examine are now color coded and display in list format
qol: broadcast frequency in examine is also color coded
code: add new `span_class` macro
/:cl: