### PR TITLE
Space carp speech includes fish puns

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -120,6 +120,10 @@
 	ai_controller.set_blackboard_key(BB_CARP_RIFT, teleport)
 	ai_controller.set_blackboard_key(BB_OBSTACLE_TARGETING_WHITELIST, allowed_obstacle_targets)
 
+/mob/living/basic/carp/Destroy()
+	QDEL_NULL(teleport)
+	return ..()
+
 /// Tell the elements and the blackboard what food we want to eat
 /mob/living/basic/carp/proc/setup_eating()
 	AddElement(/datum/element/basic_eating, food_types = desired_food)

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -104,6 +104,7 @@
 		AddElement(/datum/element/ai_flee_while_injured)
 	setup_eating()
 
+	AddComponent(/datum/component/speechmod, replacements = strings("crustacean_replacement.json", "crustacean"))
 	AddComponent(/datum/component/aggro_emote, emote_list = string_list(list("gnashes")))
 	AddComponent(/datum/component/regenerator, outline_colour = regenerate_colour)
 	AddComponent(/datum/component/profound_fisher)


### PR DESCRIPTION
## About The Pull Request

This PR adds the fish pun speech filter to space carp.
This was originally added and implemented for crabs and lobsters but it seems like it should be fine on space fish as well.

Space Dragons don't have this because Dragons are more refined than the riff-raff and take classes on proper diction.

## Why It's Good For The Game

For some reason space carp can speak common if they are sapient.
Most sapient space carp come from space dragon rifts so it's useful for them to be able to speak to each other and coordinate.
I think it's kind of weird that they can talk to the crew to be honest, but it's probably more fun that they can. That said, if they are going to be able to communicate with the crew then they should have to talk like a fish.

## Changelog

:cl:
add: Space Carp now have a more distinctive accent when speaking Common.
/:cl: