### PR TITLE
show admins classified reports

### DIFF
--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -151,7 +151,10 @@ ADMIN_VERB(create_command_report, R_ADMIN, "Create Command Report", "Create a co
 	change_command_name(original_command_name)
 
 	log_admin("[key_name(ui_user)] has created a command report: \"[command_report_content]\", sent from \"[command_name]\" with the sound \"[played_sound]\".")
+
 	message_admins("[key_name_admin(ui_user)] has created a command report, sent from \"[command_name]\" with the sound \"[played_sound]\"")
+	if(!announce_contents)
+		message_admins("The message was: [command_report_content]")
 
 
 #undef DEFAULT_ANNOUNCEMENT_SOUND


### PR DESCRIPTION

## About The Pull Request

Lets other admins see what you sent in a classified command report.
![image](https://github.com/user-attachments/assets/0029ed80-5a72-4f79-8374-0f00de3acac0)


## Why It's Good For The Game

Admins can see this anyway and I've previously wanted to look this up to see what another admin is doing.

## Changelog
:cl:
admin: All admins will now see what is in a classified command report
:cl:
