### PR TITLE
Uses game icons in the latejoin menu

### DIFF
--- a/code/modules/bitrunning/job.dm
+++ b/code/modules/bitrunning/job.dm
@@ -10,6 +10,7 @@
 	config_tag = "BITRUNNER"
 	outfit = /datum/outfit/job/bitrunner
 	plasmaman_outfit = /datum/outfit/plasmaman/bitrunner
+	sechud_icon_state = SECHUD_BITRUNNER
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_CAR
 	display_order = JOB_DISPLAY_ORDER_BITRUNNER

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -135,6 +135,9 @@
 	/// If set, look for a policy with this instead of the job title
 	var/policy_override
 
+	/// Default sec hud icon state for this job
+	var/sechud_icon_state = SECHUD_UNKNOWN
+
 /datum/job/New()
 	. = ..()
 	var/new_spawn_positions = CHECK_MAP_JOB_CHANGE(title, "spawn_positions")

--- a/code/modules/jobs/job_types/assistant/assistant.dm
+++ b/code/modules/jobs/job_types/assistant/assistant.dm
@@ -13,6 +13,7 @@ Assistant
 	exp_granted_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/assistant
 	plasmaman_outfit = /datum/outfit/plasmaman
+	sechud_icon_state = SECHUD_ASSISTANT
 	paycheck = PAYCHECK_LOWER // Get a job. Job reassignment changes your paycheck now. Get over it.
 
 	paycheck_department = ACCOUNT_CIV

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -13,6 +13,7 @@
 
 	outfit = /datum/outfit/job/atmos
 	plasmaman_outfit = /datum/outfit/plasmaman/atmospherics
+	sechud_icon_state = SECHUD_ATMOSPHERIC_TECHNICIAN
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_ENG

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -11,6 +11,7 @@
 
 	outfit = /datum/outfit/job/bartender
 	plasmaman_outfit = /datum/outfit/plasmaman/bar
+	sechud_icon_state = SECHUD_BARTENDER
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -11,6 +11,7 @@
 
 	outfit = /datum/outfit/job/botanist
 	plasmaman_outfit = /datum/outfit/plasmaman/botany
+	sechud_icon_state = SECHUD_BOTANIST
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -19,6 +19,7 @@
 
 	outfit = /datum/outfit/job/captain
 	plasmaman_outfit = /datum/outfit/plasmaman/captain
+	sechud_icon_state = SECHUD_CAPTAIN
 
 	paycheck = PAYCHECK_COMMAND
 	paycheck_department = ACCOUNT_SEC

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -13,6 +13,7 @@
 
 	outfit = /datum/outfit/job/cargo_tech
 	plasmaman_outfit = /datum/outfit/plasmaman/cargo
+	sechud_icon_state = SECHUD_CARGO_TECHNICIAN
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_CAR

--- a/code/modules/jobs/job_types/chaplain/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/chaplain
 	plasmaman_outfit = /datum/outfit/plasmaman/chaplain
+	sechud_icon_state = SECHUD_CHAPLAIN
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -14,6 +14,7 @@
 
 	outfit = /datum/outfit/job/chemist
 	plasmaman_outfit = /datum/outfit/plasmaman/chemist
+	sechud_icon_state = SECHUD_CHEMIST
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_MED

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -19,6 +19,7 @@
 
 	outfit = /datum/outfit/job/ce
 	plasmaman_outfit = /datum/outfit/plasmaman/chief_engineer
+	sechud_icon_state = SECHUD_CHIEF_ENGINEER
 	departments_list = list(
 		/datum/job_department/engineering,
 		/datum/job_department/command,

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -19,6 +19,7 @@
 
 	outfit = /datum/outfit/job/cmo
 	plasmaman_outfit = /datum/outfit/plasmaman/chief_medical_officer
+	sechud_icon_state = SECHUD_CHIEF_MEDICAL_OFFICER
 	departments_list = list(
 		/datum/job_department/medical,
 		/datum/job_department/command,

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -11,6 +11,7 @@
 
 	outfit = /datum/outfit/job/clown
 	plasmaman_outfit = /datum/outfit/plasmaman/clown
+	sechud_icon_state = SECHUD_CLOWN
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -8,10 +8,12 @@
 	supervisors = SUPERVISOR_HOP
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "COOK"
-	var/cooks = 0 //Counts cooks amount
+	/// Total cooks in the kitchen
+	var/cooks = 0
 
 	outfit = /datum/outfit/job/cook
 	plasmaman_outfit = /datum/outfit/plasmaman/chef
+	sechud_icon_state = SECHUD_COOK
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/coroner
 	plasmaman_outfit = /datum/outfit/plasmaman/coroner
+	sechud_icon_state = SECHUD_CORONER
 
 	mind_traits = list(TRAIT_MORBID)
 	liver_traits = list(TRAIT_CORONER_METABOLISM)

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/curator
 	plasmaman_outfit = /datum/outfit/plasmaman/curator
+	sechud_icon_state = SECHUD_CURATOR
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -16,6 +16,7 @@
 
 	outfit = /datum/outfit/job/detective
 	plasmaman_outfit = /datum/outfit/plasmaman/detective
+	sechud_icon_state = SECHUD_DETECTIVE
 	departments_list = list(
 		/datum/job_department/security,
 		)

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -13,6 +13,7 @@
 
 	outfit = /datum/outfit/job/geneticist
 	plasmaman_outfit = /datum/outfit/plasmaman/genetics
+	sechud_icon_state = SECHUD_GENETICIST
 	departments_list = list(
 		/datum/job_department/science,
 		)

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -19,6 +19,7 @@
 
 	outfit = /datum/outfit/job/hop
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_personnel
+	sechud_icon_state = SECHUD_HEAD_OF_PERSONNEL
 	departments_list = list(
 		/datum/job_department/service,
 		/datum/job_department/command,

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -19,6 +19,7 @@
 
 	outfit = /datum/outfit/job/hos
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_security
+	sechud_icon_state = SECHUD_HEAD_OF_SECURITY
 	departments_list = list(
 		/datum/job_department/security,
 		/datum/job_department/command,

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -11,6 +11,7 @@
 
 	outfit = /datum/outfit/job/janitor
 	plasmaman_outfit = /datum/outfit/plasmaman/janitor
+	sechud_icon_state = SECHUD_JANITOR
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/lawyer
 	plasmaman_outfit = /datum/outfit/plasmaman/bar
+	sechud_icon_state = SECHUD_LAWYER
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/doctor
 	plasmaman_outfit = /datum/outfit/plasmaman/medical
+	sechud_icon_state = SECHUD_MEDICAL_DOCTOR
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_MED

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -11,6 +11,7 @@
 
 	outfit = /datum/outfit/job/mime
 	plasmaman_outfit = /datum/outfit/plasmaman/mime
+	sechud_icon_state = SECHUD_MIME
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/paramedic
 	plasmaman_outfit = /datum/outfit/plasmaman/paramedic
+	sechud_icon_state = SECHUD_PARAMEDIC
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_MED

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/prisoner
 	plasmaman_outfit = /datum/outfit/plasmaman/prisoner
+	sechud_icon_state = SECHUD_PRISONER
 
 	display_order = JOB_DISPLAY_ORDER_PRISONER
 	department_for_prefs = /datum/job_department/security

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/psychologist
 	plasmaman_outfit = /datum/outfit/plasmaman/psychologist
+	sechud_icon_state = SECHUD_PSYCHOLOGIST
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -16,6 +16,7 @@
 
 	outfit = /datum/outfit/job/quartermaster
 	plasmaman_outfit = /datum/outfit/plasmaman/cargo
+	sechud_icon_state = SECHUD_QUARTERMASTER
 
 	paycheck = PAYCHECK_COMMAND
 	paycheck_department = ACCOUNT_CAR

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -20,6 +20,7 @@
 
 	outfit = /datum/outfit/job/rd
 	plasmaman_outfit = /datum/outfit/plasmaman/research_director
+	sechud_icon_state = SECHUD_RESEARCH_DIRECTOR
 	departments_list = list(
 		/datum/job_department/science,
 		/datum/job_department/command,

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -14,6 +14,7 @@
 
 	outfit = /datum/outfit/job/roboticist
 	plasmaman_outfit = /datum/outfit/plasmaman/robotics
+	sechud_icon_state = SECHUD_ROBOTICIST
 	departments_list = list(
 		/datum/job_department/science,
 		)

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -13,6 +13,7 @@
 
 	outfit = /datum/outfit/job/scientist
 	plasmaman_outfit = /datum/outfit/plasmaman/science
+	sechud_icon_state = SECHUD_SCIENTIST
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SCI

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -16,6 +16,7 @@
 
 	outfit = /datum/outfit/job/security
 	plasmaman_outfit = /datum/outfit/plasmaman/security
+	sechud_icon_state = SECHUD_SECURITY_OFFICER
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SEC

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/miner
 	plasmaman_outfit = /datum/outfit/plasmaman/mining
+	sechud_icon_state = SECHUD_SHAFT_MINER
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_CAR

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -14,6 +14,7 @@
 
 	outfit = /datum/outfit/job/engineer
 	plasmaman_outfit = /datum/outfit/plasmaman/engineering
+	sechud_icon_state = SECHUD_STATION_ENGINEER
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_ENG

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -17,6 +17,7 @@
 
 	outfit = /datum/outfit/job/warden
 	plasmaman_outfit = /datum/outfit/plasmaman/warden
+	sechud_icon_state = SECHUD_WARDEN
 
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SEC

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -114,9 +114,16 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 			if((job_datum.job_flags & JOB_HIDE_WHEN_EMPTY) && owner.IsJobUnavailable(job_datum.title, latejoin = TRUE) != JOB_AVAILABLE)
 				continue
 
+			var/job_icon
+			if(department.department_name == DEPARTMENT_SILICON)
+				job_icon = "borg" // assigns the icon in JS
+			else
+				job_icon = job_datum.sechud_icon_state
+
 			var/list/job_data = list(
 				"command" = !!(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND),
 				"description" = job_datum.description,
+				"icon" = job_icon,
 			)
 
 			department_jobs[job_datum.title] = job_data

--- a/tgui/packages/tgui/constants.test.ts
+++ b/tgui/packages/tgui/constants.test.ts
@@ -3,7 +3,7 @@ import {
   getGasFromId,
   getGasFromPath,
   getGasLabel,
-} from './constants';
+} from './constants/gases';
 
 describe('gas helper functions', () => {
   it('should get the proper gas label', () => {

--- a/tgui/packages/tgui/constants/colors.ts
+++ b/tgui/packages/tgui/constants/colors.ts
@@ -1,0 +1,52 @@
+// All game related colors are stored here
+export const COLORS = {
+  // Department colors
+  department: {
+    captain: '#c06616',
+    security: '#e74c3c',
+    medbay: '#3498db',
+    science: '#9b59b6',
+    engineering: '#f1c40f',
+    cargo: '#f39c12',
+    service: '#7cc46a',
+    centcom: '#00c100',
+    other: '#c38312',
+  },
+  // Damage type colors
+  damageType: {
+    oxy: '#3498db',
+    toxin: '#2ecc71',
+    burn: '#e67e22',
+    brute: '#e74c3c',
+  },
+  // reagent / chemistry related colours
+  reagent: {
+    acidicbuffer: '#fbc314',
+    basicbuffer: '#3853a4',
+  },
+} as const;
+
+// Colors defined in CSS
+export const CSS_COLORS = [
+  'average',
+  'bad',
+  'black',
+  'blue',
+  'brown',
+  'good',
+  'green',
+  'grey',
+  'label',
+  'olive',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'teal',
+  'transparent',
+  'violet',
+  'white',
+  'yellow',
+] as const;
+
+export type CssColor = (typeof CSS_COLORS)[number];

--- a/tgui/packages/tgui/constants/gases.test.ts
+++ b/tgui/packages/tgui/constants/gases.test.ts
@@ -3,7 +3,7 @@ import {
   getGasFromId,
   getGasFromPath,
   getGasLabel,
-} from './constants/gases';
+} from './gases';
 
 describe('gas helper functions', () => {
   it('should get the proper gas label', () => {

--- a/tgui/packages/tgui/constants/gases.ts
+++ b/tgui/packages/tgui/constants/gases.ts
@@ -1,9 +1,3 @@
-/**
- * @file
- * @copyright 2020 Aleksej Komarov
- * @license MIT
- */
-
 type Gas = {
   id: string;
   path: string;
@@ -12,145 +6,7 @@ type Gas = {
   color: string;
 };
 
-// UI states, which are mirrored from the BYOND code.
-export const UI_INTERACTIVE = 2;
-export const UI_UPDATE = 1;
-export const UI_DISABLED = 0;
-export const UI_CLOSE = -1;
-
-// All game related colors are stored here
-export const COLORS = {
-  // Department colors
-  department: {
-    captain: '#c06616',
-    security: '#e74c3c',
-    medbay: '#3498db',
-    science: '#9b59b6',
-    engineering: '#f1c40f',
-    cargo: '#f39c12',
-    service: '#7cc46a',
-    centcom: '#00c100',
-    other: '#c38312',
-  },
-  // Damage type colors
-  damageType: {
-    oxy: '#3498db',
-    toxin: '#2ecc71',
-    burn: '#e67e22',
-    brute: '#e74c3c',
-  },
-  // reagent / chemistry related colours
-  reagent: {
-    acidicbuffer: '#fbc314',
-    basicbuffer: '#3853a4',
-  },
-} as const;
-
-// Colors defined in CSS
-export const CSS_COLORS = [
-  'average',
-  'bad',
-  'black',
-  'blue',
-  'brown',
-  'good',
-  'green',
-  'grey',
-  'label',
-  'olive',
-  'orange',
-  'pink',
-  'purple',
-  'red',
-  'teal',
-  'transparent',
-  'violet',
-  'white',
-  'yellow',
-] as const;
-
-export type CssColor = (typeof CSS_COLORS)[number];
-
-/* IF YOU CHANGE THIS KEEP IT IN SYNC WITH CHAT CSS */
-export const RADIO_CHANNELS = [
-  {
-    name: 'Syndicate',
-    freq: 1213,
-    color: '#8f4a4b',
-  },
-  {
-    name: 'Red Team',
-    freq: 1215,
-    color: '#ff4444',
-  },
-  {
-    name: 'Blue Team',
-    freq: 1217,
-    color: '#3434fd',
-  },
-  {
-    name: 'Green Team',
-    freq: 1219,
-    color: '#34fd34',
-  },
-  {
-    name: 'Yellow Team',
-    freq: 1221,
-    color: '#fdfd34',
-  },
-  {
-    name: 'CentCom',
-    freq: 1337,
-    color: '#2681a5',
-  },
-  {
-    name: 'Supply',
-    freq: 1347,
-    color: '#b88646',
-  },
-  {
-    name: 'Service',
-    freq: 1349,
-    color: '#6ca729',
-  },
-  {
-    name: 'Science',
-    freq: 1351,
-    color: '#c68cfa',
-  },
-  {
-    name: 'Command',
-    freq: 1353,
-    color: '#fcdf03',
-  },
-  {
-    name: 'Medical',
-    freq: 1355,
-    color: '#57b8f0',
-  },
-  {
-    name: 'Engineering',
-    freq: 1357,
-    color: '#f37746',
-  },
-  {
-    name: 'Security',
-    freq: 1359,
-    color: '#dd3535',
-  },
-  {
-    name: 'AI Private',
-    freq: 1447,
-    color: '#d65d95',
-  },
-  {
-    name: 'Common',
-    freq: 1459,
-    color: '#1ecc43',
-  },
-] as const;
-
-const GASES = [
+const gases = [
   {
     id: 'o2',
     path: '/datum/gas/oxygen',
@@ -301,55 +157,55 @@ const GASES = [
 ] as const;
 
 // Returns gas label based on gasId
-export const getGasLabel = (gasId: string, fallbackValue?: string) => {
+export function getGasLabel(gasId: string, fallbackValue?: string) {
   if (!gasId) return fallbackValue || 'None';
 
   const gasSearchString = gasId.toLowerCase();
 
-  for (let idx = 0; idx < GASES.length; idx++) {
-    if (GASES[idx].id === gasSearchString) {
-      return GASES[idx].label;
+  for (let idx = 0; idx < gases.length; idx++) {
+    if (gases[idx].id === gasSearchString) {
+      return gases[idx].label;
     }
   }
 
   return fallbackValue || 'None';
-};
+}
 
 // Returns gas color based on gasId
-export const getGasColor = (gasId: string) => {
+export function getGasColor(gasId: string) {
   if (!gasId) return 'black';
 
   const gasSearchString = gasId.toLowerCase();
 
-  for (let idx = 0; idx < GASES.length; idx++) {
-    if (GASES[idx].id === gasSearchString) {
-      return GASES[idx].color;
+  for (let idx = 0; idx < gases.length; idx++) {
+    if (gases[idx].id === gasSearchString) {
+      return gases[idx].color;
     }
   }
 
   return 'black';
-};
+}
 
 // Returns gas object based on gasId
-export const getGasFromId = (gasId: string): Gas | undefined => {
+export function getGasFromId(gasId: string): Gas | undefined {
   if (!gasId) return;
 
   const gasSearchString = gasId.toLowerCase();
 
-  for (let idx = 0; idx < GASES.length; idx++) {
-    if (GASES[idx].id === gasSearchString) {
-      return GASES[idx];
+  for (let idx = 0; idx < gases.length; idx++) {
+    if (gases[idx].id === gasSearchString) {
+      return gases[idx];
     }
   }
-};
+}
 
 // Returns gas object based on gasPath
-export const getGasFromPath = (gasPath: string): Gas | undefined => {
+export function getGasFromPath(gasPath: string): Gas | undefined {
   if (!gasPath) return;
 
-  for (let idx = 0; idx < GASES.length; idx++) {
-    if (GASES[idx].path === gasPath) {
-      return GASES[idx];
+  for (let idx = 0; idx < gases.length; idx++) {
+    if (gases[idx].path === gasPath) {
+      return gases[idx];
     }
   }
-};
+}

--- a/tgui/packages/tgui/constants/icons.ts
+++ b/tgui/packages/tgui/constants/icons.ts
@@ -1,0 +1,14 @@
+export type IconSettings = {
+  dmi: string;
+  transform: string;
+};
+
+export const HUD_ICON: IconSettings = {
+  dmi: 'icons/mob/huds/hud.dmi',
+  transform: 'scale(2.3) translateX(9px) translateY(1px)',
+};
+
+export const ANTAG_ICON: IconSettings = {
+  dmi: 'icons/mob/huds/antag_hud.dmi',
+  transform: 'scale(1.8) translateX(-16px) translateY(7px)',
+};

--- a/tgui/packages/tgui/constants/radio.ts
+++ b/tgui/packages/tgui/constants/radio.ts
@@ -1,0 +1,78 @@
+/* IF YOU CHANGE THIS KEEP IT IN SYNC WITH CHAT CSS */
+export const RADIO_CHANNELS = [
+  {
+    name: 'Syndicate',
+    freq: 1213,
+    color: '#8f4a4b',
+  },
+  {
+    name: 'Red Team',
+    freq: 1215,
+    color: '#ff4444',
+  },
+  {
+    name: 'Blue Team',
+    freq: 1217,
+    color: '#3434fd',
+  },
+  {
+    name: 'Green Team',
+    freq: 1219,
+    color: '#34fd34',
+  },
+  {
+    name: 'Yellow Team',
+    freq: 1221,
+    color: '#fdfd34',
+  },
+  {
+    name: 'CentCom',
+    freq: 1337,
+    color: '#2681a5',
+  },
+  {
+    name: 'Supply',
+    freq: 1347,
+    color: '#b88646',
+  },
+  {
+    name: 'Service',
+    freq: 1349,
+    color: '#6ca729',
+  },
+  {
+    name: 'Science',
+    freq: 1351,
+    color: '#c68cfa',
+  },
+  {
+    name: 'Command',
+    freq: 1353,
+    color: '#fcdf03',
+  },
+  {
+    name: 'Medical',
+    freq: 1355,
+    color: '#57b8f0',
+  },
+  {
+    name: 'Engineering',
+    freq: 1357,
+    color: '#f37746',
+  },
+  {
+    name: 'Security',
+    freq: 1359,
+    color: '#dd3535',
+  },
+  {
+    name: 'AI Private',
+    freq: 1447,
+    color: '#d65d95',
+  },
+  {
+    name: 'Common',
+    freq: 1459,
+    color: '#1ecc43',
+  },
+] as const;

--- a/tgui/packages/tgui/constants/ui_states.ts
+++ b/tgui/packages/tgui/constants/ui_states.ts
@@ -1,0 +1,5 @@
+// UI states, which are mirrored from the BYOND code.
+export const UI_INTERACTIVE = 2;
+export const UI_UPDATE = 1;
+export const UI_DISABLED = 0;
+export const UI_CLOSE = -1;

--- a/tgui/packages/tgui/interfaces/AtmosFilter.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosFilter.tsx
@@ -7,7 +7,7 @@ import {
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasLabel } from '../constants';
+import { getGasLabel } from '../constants/gases';
 import { Window } from '../layouts';
 
 type Data = {

--- a/tgui/packages/tgui/interfaces/BluespaceSender.tsx
+++ b/tgui/packages/tgui/interfaces/BluespaceSender.tsx
@@ -13,7 +13,7 @@ import { toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasColor } from '../constants';
+import { getGasColor } from '../constants/gases';
 import { Window } from '../layouts';
 
 type Data = {

--- a/tgui/packages/tgui/interfaces/BluespaceVendor.tsx
+++ b/tgui/packages/tgui/interfaces/BluespaceVendor.tsx
@@ -11,7 +11,7 @@ import { toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasColor } from '../constants';
+import { getGasColor } from '../constants/gases';
 import { Window } from '../layouts';
 
 type Data = {

--- a/tgui/packages/tgui/interfaces/BotAnnouncement.tsx
+++ b/tgui/packages/tgui/interfaces/BotAnnouncement.tsx
@@ -12,7 +12,7 @@ import {
 import { createSearch } from 'tgui-core/string';
 
 import { useBackend } from '../backend';
-import { RADIO_CHANNELS } from '../constants';
+import { RADIO_CHANNELS } from '../constants/radio';
 import { Window } from '../layouts';
 
 type ButtonData = {

--- a/tgui/packages/tgui/interfaces/ChemFilter.tsx
+++ b/tgui/packages/tgui/interfaces/ChemFilter.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react';
 import { Button, Section, Stack } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
-import { CssColor } from '../constants';
+import { CssColor } from '../constants/colors';
 import { Window } from '../layouts';
 
 type Data = {

--- a/tgui/packages/tgui/interfaces/ChemHeater.tsx
+++ b/tgui/packages/tgui/interfaces/ChemHeater.tsx
@@ -14,7 +14,7 @@ import { round, toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { COLORS } from '../constants';
+import { COLORS } from '../constants/colors';
 import { Window } from '../layouts';
 import { Beaker, BeakerSectionDisplay } from './common/BeakerDisplay';
 

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -4,7 +4,7 @@ import { BooleanLike } from 'tgui-core/react';
 import { createSearch } from 'tgui-core/string';
 
 import { useBackend } from '../backend';
-import { COLORS } from '../constants';
+import { COLORS } from '../constants/colors';
 import { Window } from '../layouts';
 
 const HEALTH_COLOR_BY_LEVEL = [

--- a/tgui/packages/tgui/interfaces/Crystallizer.tsx
+++ b/tgui/packages/tgui/interfaces/Crystallizer.tsx
@@ -10,7 +10,7 @@ import { toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasColor } from '../constants';
+import { getGasColor } from '../constants/gases';
 import { Window } from '../layouts';
 
 type Data = {

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.tsx
@@ -1,6 +1,5 @@
 import { filter, sortBy } from 'common/collections';
 import { useBackend } from 'tgui/backend';
-import { getGasColor, getGasLabel } from 'tgui/constants';
 import {
   Box,
   Button,
@@ -11,6 +10,7 @@ import {
 } from 'tgui-core/components';
 import { toFixed } from 'tgui-core/math';
 
+import { getGasColor, getGasLabel } from '../../constants/gases';
 import { HypertorusFuel, HypertorusGas } from '.';
 import { HelpDummy, HoverHelp } from './helpers';
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from 'tgui/backend';
-import { getGasColor, getGasLabel } from 'tgui/constants';
+import { getGasColor, getGasLabel } from 'tgui/constants/gases';
 import { Box, Button, Icon, Table, Tooltip } from 'tgui-core/components';
 
 import { HypertorusData } from '.';

--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -1,26 +1,12 @@
 import { DmIcon, Icon } from 'tgui-core/components';
 
+import { ANTAG_ICON, HUD_ICON, IconSettings } from '../../constants/icons';
 import { JOB2ICON } from '../common/JobToIcon';
 import { Antagonist, Observable } from './types';
 
 type Props = {
   item: Observable | Antagonist;
   realNameDisplay: boolean;
-};
-
-type IconSettings = {
-  dmi: string;
-  transform: string;
-};
-
-const normalIcon: IconSettings = {
-  dmi: 'icons/mob/huds/hud.dmi',
-  transform: 'scale(2.3) translateX(9px) translateY(1px)',
-};
-
-const antagIcon: IconSettings = {
-  dmi: 'icons/mob/huds/antag_hud.dmi',
-  transform: 'scale(1.8) translateX(-16px) translateY(7px)',
 };
 
 export function JobIcon(props: Props) {
@@ -33,11 +19,11 @@ export function JobIcon(props: Props) {
 
   let iconSettings: IconSettings;
   if ('antag' in item && !realNameDisplay) {
-    iconSettings = antagIcon;
+    iconSettings = ANTAG_ICON;
     usedJob = item.antag;
     usedIcon = item.antag_icon;
   } else {
-    iconSettings = normalIcon;
+    iconSettings = HUD_ICON;
   }
 
   return (

--- a/tgui/packages/tgui/interfaces/PipeScrubber.tsx
+++ b/tgui/packages/tgui/interfaces/PipeScrubber.tsx
@@ -12,7 +12,7 @@ import { toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasLabel } from '../constants';
+import { getGasLabel } from '../constants/gases';
 import { Window } from '../layouts';
 
 type Data = {

--- a/tgui/packages/tgui/interfaces/PortableScrubber.tsx
+++ b/tgui/packages/tgui/interfaces/PortableScrubber.tsx
@@ -2,7 +2,7 @@ import { Button, Section } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasLabel } from '../constants';
+import { getGasLabel } from '../constants/gases';
 import { Window } from '../layouts';
 import { PortableBasicInfo } from './common/PortableAtmos';
 

--- a/tgui/packages/tgui/interfaces/Radio.jsx
+++ b/tgui/packages/tgui/interfaces/Radio.jsx
@@ -9,7 +9,7 @@ import {
 import { toFixed } from 'tgui-core/math';
 
 import { useBackend } from '../backend';
-import { RADIO_CHANNELS } from '../constants';
+import { RADIO_CHANNELS } from '../constants/radio';
 import { Window } from '../layouts';
 
 export const Radio = (props) => {

--- a/tgui/packages/tgui/interfaces/Supermatter.tsx
+++ b/tgui/packages/tgui/interfaces/Supermatter.tsx
@@ -12,7 +12,7 @@ import { toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
-import { getGasFromPath } from '../constants';
+import { getGasFromPath } from '../constants/gases';
 import { Window } from '../layouts';
 
 const logScale = (value) => Math.log2(16 + Math.max(0, value)) - 4;

--- a/tgui/packages/tgui/interfaces/Telecomms.jsx
+++ b/tgui/packages/tgui/interfaces/Telecomms.jsx
@@ -11,7 +11,7 @@ import {
 } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
-import { RADIO_CHANNELS } from '../constants';
+import { RADIO_CHANNELS } from '../constants/radio';
 import { Window } from '../layouts';
 
 export const Telecomms = (props) => {

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
@@ -8,7 +8,7 @@ import { BooleanLike } from 'tgui-core/react';
 import { decodeHtmlEntities } from 'tgui-core/string';
 
 import { useBackend } from '../../backend';
-import { getGasLabel } from '../../constants';
+import { getGasLabel } from '../../constants/gases';
 
 export type VentProps = {
   refID: string;

--- a/tgui/packages/tgui/interfaces/common/Connections.tsx
+++ b/tgui/packages/tgui/interfaces/common/Connections.tsx
@@ -1,6 +1,6 @@
 import { classes } from 'tgui-core/react';
 
-import { CSS_COLORS } from '../../constants';
+import { CSS_COLORS } from '../../constants/colors';
 
 const SVG_CURVE_INTENSITY = 64;
 


### PR DESCRIPTION
## About The Pull Request
I thought it was a little inconsistent to have fontawesome icons in the latejoin menu && it had some spacing issues (see before and after)

While doing this I made two tangential changes which I can revert if it's too much:
- Moved tgui constants into their own folder
- Added default sechud job icons to the job datum (I found it obtuse to have to grab the id trim just for this)
- Prevents the latejoin menu from scrolling away from section title

<details>
<summary>before & after</summary>

before
![Screenshot 2025-01-11 193714](https://github.com/user-attachments/assets/7766518a-d35a-45dc-ab71-4c1288a7a598)

after
![Screenshot 2025-01-11 223217](https://github.com/user-attachments/assets/f80d9f2a-814c-4f07-bb7f-9aaf3229e9d1)

</details>

## Why It's Good For The Game
Better looking UI, more consistent, some code cleanup
## Changelog
:cl:
fix: Fixed icon spacing on the latejoin menu, which now uses in game icons
/:cl:
