### PR TITLE
Fixes icon spacing in late join ui

### DIFF
--- a/tgui/packages/tgui/interfaces/JobSelection.tsx
+++ b/tgui/packages/tgui/interfaces/JobSelection.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Icon,
   NoticeBox,
+  Section,
   Stack,
   StyleableSection,
 } from 'tgui-core/components';
@@ -39,16 +40,18 @@ type Data = {
   round_duration: string;
 };
 
-export const JobEntry = (data: {
+type JobEntryProps = {
   jobName: string;
   job: Job;
   department: Department;
   onClick: () => void;
-}) => {
-  const jobName = data.jobName;
-  const job = data.job;
-  const department = data.department;
+};
+
+function JobEntry(props: JobEntryProps) {
+  const { jobName, job, department, onClick } = props;
+
   const jobIcon = JOB2ICON[jobName] || null;
+
   return (
     <Button
       fluid
@@ -79,124 +82,137 @@ export const JobEntry = (data: {
         ))
       }
       onClick={() => {
-        !job.unavailable_reason && data.onClick();
+        !job.unavailable_reason && onClick();
       }}
     >
-      <>
-        {jobIcon && <Icon name={jobIcon} />}
-        {job.command ? <b>{jobName}</b> : jobName}
-        <span
-          style={{
-            whiteSpace: 'nowrap',
-            position: 'absolute',
-            right: '0.5em',
-          }}
-        >
-          {job.used_slots} / {job.open_slots}
-        </span>
-      </>
+      <Stack fill>
+        {jobIcon && (
+          <Stack.Item>
+            <Icon name={jobIcon} />
+          </Stack.Item>
+        )}
+        <Stack.Item grow>{job.command ? <b>{jobName}</b> : jobName}</Stack.Item>
+        <Stack.Item>
+          <span
+            style={{
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {job.used_slots} / {job.open_slots}
+          </span>
+        </Stack.Item>
+      </Stack>
     </Button>
   );
+}
+
+type DepartmentEntryProps = {
+  name: string;
+  department: Department;
 };
 
-export const JobSelection = (props) => {
+function DepartmentEntry(props: DepartmentEntryProps) {
+  const { name, department } = props;
+  const { act } = useBackend<Data>();
+
+  return (
+    <Box minWidth="30%">
+      <StyleableSection
+        title={
+          <>
+            {name}
+            <span
+              style={{
+                fontSize: '1rem',
+                whiteSpace: 'nowrap',
+                position: 'absolute',
+                right: '1em',
+                color: Color.fromHex(department.color).darken(60).toString(),
+              }}
+            >
+              {department.open_slots +
+                (department.open_slots === 1 ? ' slot' : ' slots') +
+                ' available'}
+            </span>
+          </>
+        }
+        style={{
+          backgroundColor: department.color,
+          marginBottom: '1em',
+          breakInside: 'avoid-column',
+        }}
+        titleStyle={{
+          'border-bottom-color': Color.fromHex(department.color)
+            .darken(50)
+            .toString(),
+        }}
+        textStyle={{
+          color: Color.fromHex(department.color).darken(80).toString(),
+        }}
+      >
+        <Stack vertical>
+          {Object.entries(department.jobs).map(([name, job]) => (
+            <Stack.Item key={name}>
+              <JobEntry
+                key={name}
+                jobName={name}
+                job={job}
+                department={department}
+                onClick={() => {
+                  act('select_job', { job: name });
+                }}
+              />
+            </Stack.Item>
+          ))}
+        </Stack>
+      </StyleableSection>
+    </Box>
+  );
+}
+
+export function JobSelection(props) {
   const { act, data } = useBackend<Data>();
   if (!data?.departments_static) {
     return null; // Stop TGUI whitescreens with TGUI-dev!
   }
+
   const departments: Record<string, Department> = deepMerge(
     data.departments,
     data.departments_static,
   );
 
+  const { shuttle_status, round_duration } = data;
+
   return (
-    <Window
-      width={1012}
-      height={data.shuttle_status ? 690 : 666 /* Hahahahahaha */}
-    >
-      <Window.Content scrollable>
-        <StyleableSection
-          title={
-            <>
-              {data.shuttle_status && (
-                <NoticeBox info>{data.shuttle_status}</NoticeBox>
-              )}
-              <span style={{ color: 'grey' }}>
-                It is currently {data.round_duration} into the shift.
-              </span>
-              <Button
-                style={{ position: 'absolute', right: '1em' }}
-                onClick={() => act('select_job', { job: 'Random' })}
-                content="Random Job!"
-                tooltip="Roll target random job. You can re-roll or cancel your random job if you don't like it."
-              />
-            </>
+    <Window width={1012} height={shuttle_status ? 690 : 666 /* Hahahahahaha */}>
+      <Window.Content>
+        <Section
+          buttons={
+            <Button
+              onClick={() => act('select_job', { job: 'Random' })}
+              tooltip="Roll target random job. You can re-roll or cancel your random job if you don't like it."
+            >
+              Random Job!
+            </Button>
           }
-          titleStyle={{ minHeight: '3.4em' }}
+          fill
+          scrollable
+          title={
+            <Box m={1}>
+              {shuttle_status && <NoticeBox info>{shuttle_status}</NoticeBox>}
+              <span style={{ color: 'grey' }}>
+                It is currently {round_duration} into the shift.
+              </span>
+            </Box>
+          }
         >
           <Box style={{ columns: '20em' }}>
-            {Object.entries(departments).map((departmentEntry) => {
-              const departmentName = departmentEntry[0];
-              const entry = departmentEntry[1];
-              return (
-                <Box key={departmentName} minWidth="30%">
-                  <StyleableSection
-                    title={
-                      <>
-                        {departmentName}
-                        <span
-                          style={{
-                            fontSize: '1rem',
-                            whiteSpace: 'nowrap',
-                            position: 'absolute',
-                            right: '1em',
-                            color: Color.fromHex(entry.color)
-                              .darken(60)
-                              .toString(),
-                          }}
-                        >
-                          {entry.open_slots +
-                            (entry.open_slots === 1 ? ' slot' : ' slots') +
-                            ' available'}
-                        </span>
-                      </>
-                    }
-                    style={{
-                      backgroundColor: entry.color,
-                      marginBottom: '1em',
-                      breakInside: 'avoid-column',
-                    }}
-                    titleStyle={{
-                      'border-bottom-color': Color.fromHex(entry.color)
-                        .darken(50)
-                        .toString(),
-                    }}
-                    textStyle={{
-                      color: Color.fromHex(entry.color).darken(80).toString(),
-                    }}
-                  >
-                    <Stack vertical>
-                      {Object.entries(entry.jobs).map((job) => (
-                        <Stack.Item key={job[0]}>
-                          <JobEntry
-                            key={job[0]}
-                            jobName={job[0]}
-                            job={job[1]}
-                            department={entry}
-                            onClick={() => {
-                              act('select_job', { job: job[0] });
-                            }}
-                          />
-                        </Stack.Item>
-                      ))}
-                    </Stack>
-                  </StyleableSection>
-                </Box>
-              );
-            })}
+            {Object.entries(departments).map(([name, department]) => (
+              <DepartmentEntry key={name} name={name} department={department} />
+            ))}
           </Box>
-        </StyleableSection>
+        </Section>
       </Window.Content>
     </Window>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/JobSelection.tsx
+++ b/tgui/packages/tgui/interfaces/JobSelection.tsx
@@ -81,6 +81,7 @@ function JobEntry(props: JobEntryProps) {
           job.description
         ))
       }
+      tooltipPosition="top"
       onClick={() => {
         !job.unavailable_reason && onClick();
       }}
@@ -198,12 +199,12 @@ export function JobSelection(props) {
           fill
           scrollable
           title={
-            <Box m={1}>
+            <>
               {shuttle_status && <NoticeBox info>{shuttle_status}</NoticeBox>}
-              <span style={{ color: 'grey' }}>
+              <Box as="span" color="label">
                 It is currently {round_duration} into the shift.
-              </span>
-            </Box>
+              </Box>
+            </>
           }
         >
           <Box style={{ columns: '20em' }}>


### PR DESCRIPTION

## About The Pull Request
An alternate to #89040
![Screenshot 2025-01-12 035024](https://github.com/user-attachments/assets/230e599a-8cae-4dba-8dee-4e9975b7a61e)

Refactors the UI
Adds scrollbar to section rather than window so that the title doesnt disappear
Gives more contrast to the window's main content section
Tooltip now shows closer to the mouse. It was far off in some cases
Functions!
## Why It's Good For The Game
Fixes a ui bug
## Changelog
:cl:
fix: Fixed icon spacing in the late join menu.
/:cl:
