### PR TITLE
Fixes a barricade balloon runtime

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -90,7 +90,7 @@
 	balloon_alert(user, "deconstructing barricade...")
 	if(!tool.use_tool(src, user, 2 SECONDS, volume=50))
 		return
-	balloon_alert(user, "barricade deconstructed")
+	loc.balloon_alert(user, "barricade deconstructed")
 	tool.play_tool_sound(src)
 	new /obj/item/stack/sheet/mineral/wood(get_turf(src), drop_amount)
 	qdel(src)


### PR DESCRIPTION

## About The Pull Request

balloon_alert is async and thus should not be called on objects that are about to qdelete

## Changelog
:cl:
fix: Fixed a missing "barricade deconstructed" balloon alert when crowbaring a barricade
/:cl:
