### PR TITLE
Cancelling stray admin configured syndicate cargo-pods actually works, also adds missing uplinks to customization

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -161,7 +161,14 @@
 	var/pack_telecrystals = tgui_input_number(usr, "Please input crate's value in telecrystals.", "Set Telecrystals.", 30)
 	if(isnull(pack_telecrystals))
 		return ADMIN_CANCEL_EVENT
-	var/list/possible_uplinks = list("Traitor" = UPLINK_TRAITORS, "Nuke Op" = UPLINK_NUKE_OPS, "Clown Op" = UPLINK_CLOWN_OPS)
+	var/list/possible_uplinks = list(
+		"Traitor" = UPLINK_TRAITORS,
+		"Nuke Op" = UPLINK_NUKE_OPS,
+		"Clown Op" = UPLINK_CLOWN_OPS,
+		"Lone Op" = UPLINK_LONE_OP,
+		"Infiltrator" = UPLINK_INFILTRATORS,
+		"Spy" = UPLINK_SPY
+		)
 	var/uplink_type = tgui_input_list(usr, "Choose uplink to draw items from.", "Choose uplink type.", possible_uplinks)
 	var/selection
 	if(!isnull(uplink_type))

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -149,7 +149,7 @@
 	var/admin_selected_pack = tgui_alert(usr,"Customize Pod contents?", "Pod Contents", list("Yes", "No", "Cancel"))
 	switch(admin_selected_pack)
 		if("Yes")
-			override_contents()
+			return override_contents()
 		if("No")
 			pack_type_override = null
 		else


### PR DESCRIPTION
## About The Pull Request

Must have missed this in initial tests. Cancelling the stray syndicate cargo pod event while modifying the telecrystal value or uplink type did not cancel it. Now it does.

Bonus - Uplinks that have been introduced since customization was added have been added
## Why It's Good For The Game

I may have accidently dropped a syndicate cargo pod on a station today and I'd prefer to do it intentionally.
## Changelog
:cl:
fix: Admin fired stray syndicate cargo pods will not rebel against admin whims and launch themselves when cancelled.
admin: Admins have new categories to fill syndicate cargo pods with.
/:cl:
