### PR TITLE
Aquarium component: fixes admiring, fixes panel context, improves context

### DIFF
--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -592,7 +592,7 @@
 			context[SCREENTIP_CONTEXT_LMB] = open_panel ? "Adjust settings" : "Admire"
 		if(isitem)
 			context[SCREENTIP_CONTEXT_RMB] = "Admire"
-		context[SCREENTIP_CONTEXT_ALT_LMB] = "[open_panel ? "Open" : "Close"] settings panel"
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "[!open_panel ? "Open" : "Close"] settings panel"
 		return CONTEXTUAL_SCREENTIP_SET
 	if(istype(held_item, /obj/item/plunger))
 		context[SCREENTIP_CONTEXT_LMB] = "Empty feed storage"

--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -114,6 +114,7 @@
 
 	if(isitem(movable))
 		RegisterSignal(movable, COMSIG_ITEM_ATTACK_SELF, PROC_REF(interact))
+		RegisterSignal(movable, COMSIG_ITEM_ATTACK_SELF_SECONDARY, PROC_REF(secondary_interact))
 		RegisterSignals(movable, list(COMSIG_ATOM_ATTACK_ROBOT_SECONDARY, COMSIG_ATOM_ATTACK_HAND_SECONDARY), PROC_REF(on_secondary_attack_hand))
 	else
 		RegisterSignal(movable, COMSIG_ATOM_UI_INTERACT, PROC_REF(interact))
@@ -453,15 +454,20 @@
 
 /datum/component/aquarium/proc/interact(atom/movable/source, mob/user)
 	SIGNAL_HANDLER
-
 	if(HAS_TRAIT(source, TRAIT_AQUARIUM_PANEL_OPEN))
 		INVOKE_ASYNC(src, PROC_REF(ui_interact), user)
-	else if(!isitem(source))
-		INVOKE_ASYNC(src, PROC_REF(admire), user)
+		return
+	INVOKE_ASYNC(src, PROC_REF(admire), source, user)
+
+/datum/component/aquarium/proc/secondary_interact(atom/movable/source, mob/user)
+	SIGNAL_HANDLER
+	if(HAS_TRAIT(source, TRAIT_AQUARIUM_PANEL_OPEN))
+		return
+	INVOKE_ASYNC(src, PROC_REF(admire), source, user)
 
 /datum/component/aquarium/proc/on_secondary_attack_hand(obj/item/source, mob/living/user)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(admire), user)
+	INVOKE_ASYNC(src, PROC_REF(admire), source, user)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/component/aquarium/ui_interact(mob/user, datum/tgui/ui)
@@ -579,9 +585,10 @@
 /datum/component/aquarium/proc/on_requesting_context_from_item(atom/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER
 	var/open_panel = HAS_TRAIT(source, TRAIT_AQUARIUM_PANEL_OPEN)
-	if(!held_item)
+	var/is_held_item = (held_item == source)
+	if(!held_item || is_held_item)
 		var/isitem = isitem(source)
-		if(!isitem || open_panel)
+		if(!isitem || is_held_item)
 			context[SCREENTIP_CONTEXT_LMB] = open_panel ? "Adjust settings" : "Admire"
 		if(isitem)
 			context[SCREENTIP_CONTEXT_RMB] = "Admire"


### PR DESCRIPTION

## About The Pull Request

Admiring was broken, and looking into it, it's because it didn't actually pass the user as `user` and instead as `source`, which is supposed to be the aquarium movable.
Changing this fixes our issue.

Then I noticed admiring was kind of jank for fish tanks (item)- you could right click to admire it, but only if it's not in-hand.
At the same time, you could left click admire aquariums when the panel is closed, but you _can't_ left click admire fish tanks even when they're in hand.
So in this pr we actually let you admire fish tanks when in your active hand, both left click and right click, left click only working if the panel is closed.

Similarly, the tooltips for such would only get displayed when your hand were to be empty, so this makes it also account for the held item being the fish tank.

I also noticed the open/close panel tooltip was inverted, so I inverted it to be the right way around.
## Why It's Good For The Game

Nice if it works.
Nice if it doesn't feel incredibly jank.
Nice if the tooltips display more.
## Changelog
:cl:
fix: Aquarium/fish tank admiring works again.
fix: Inverted aquarium/fish tank panel opening tooltip to be the right way.
qol: You can actually admire an in-hand fish tank by clicking on it.
qol: Aquarium/fish tank admiring tooltips are more consistent.
/:cl:
