### PR TITLE
Fixes runtime & code for anomaly effects

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -19,15 +19,12 @@
 	var/countdown_colour
 	/// Reference to the countdown effect
 	var/obj/effect/countdown/anomaly/countdown
-
-	/// Do we drop a core when we're neutralized?
-	var/drops_core = TRUE
 	///Do we keep on living forever?
 	var/immortal = FALSE
 	///Chance per second that we will move
 	var/move_chance = ANOMALY_MOVECHANCE
 
-/obj/effect/anomaly/Initialize(mapload, new_lifespan, drops_core = TRUE)
+/obj/effect/anomaly/Initialize(mapload, new_lifespan)
 	. = ..()
 
 	if(!mapload)
@@ -39,7 +36,6 @@
 	if (!impact_area)
 		return INITIALIZE_HINT_QDEL
 
-	src.drops_core = drops_core
 	if(anomaly_core)
 		anomaly_core = new anomaly_core(src)
 		anomaly_core.code = rand(1,100)
@@ -108,18 +104,15 @@
 		)
 	)
 
-	if(drops_core)
-		if(isnull(anomaly_core))
-			stack_trace("An anomaly ([src]) exists that drops a core, yet has no core!")
-		else
-			var/anomaly_type = anomaly_core.type
-			if (SSresearch.is_core_available(anomaly_type))
-				SSresearch.increment_existing_anomaly_cores(anomaly_type)
-				anomaly_core.forceMove(drop_location())
-				anomaly_core = null
-			else // You exceeded the cap sorry
-				visible_message(span_warning("[anomaly_core] loses its lustre as it falls to the ground, there is too little ambient energy to support another core of this type."))
-				new /obj/item/inert_anomaly(drop_location())
+	if(!isnull(anomaly_core))
+		var/anomaly_type = anomaly_core.type
+		if (SSresearch.is_core_available(anomaly_type))
+			SSresearch.increment_existing_anomaly_cores(anomaly_type)
+			anomaly_core.forceMove(drop_location())
+			anomaly_core = null
+		else // You exceeded the cap sorry
+			visible_message(span_warning("[anomaly_core] loses its lustre as it falls to the ground, there is too little ambient energy to support another core of this type."))
+			new /obj/item/inert_anomaly(drop_location())
 
 	// else, anomaly core gets deleted by qdel(src).
 
@@ -137,7 +130,6 @@
 	immortal = TRUE
 	name = (has_core ? "stable " : "hollow ") + name
 	if(!has_core)
-		drops_core = FALSE
 		QDEL_NULL(anomaly_core)
 	if (anchor)
 		move_chance = 0

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -16,7 +16,7 @@
 	/// Range of the anomaly pulse
 	var/range = 2
 
-/obj/effect/anomaly/bioscrambler/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/bioscrambler/Initialize(mapload, new_lifespan)
 	. = ..()
 	pursuit_target = WEAKREF(find_nearest_target())
 

--- a/code/game/objects/effects/anomalies/anomalies_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bluespace.dm
@@ -10,7 +10,7 @@
 	///Distance we can teleport someone passively
 	var/teleport_distance = 4
 
-/obj/effect/anomaly/bluespace/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/bluespace/Initialize(mapload, new_lifespan)
 	. = ..()
 	apply_wibbly_filters(src)
 
@@ -97,7 +97,7 @@
 	teleport_distance = 12
 	anomaly_core = null
 
-/obj/effect/anomaly/bluespace/big/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/bluespace/big/Initialize(mapload, new_lifespan)
 	. = ..()
 
 	transform *= 3

--- a/code/game/objects/effects/anomalies/anomalies_dimensional.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional.dm
@@ -20,7 +20,7 @@
 	/// Maximum teleports it will do before going away permanently
 	var/maximum_teleports = 4
 
-/obj/effect/anomaly/dimensional/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/dimensional/Initialize(mapload, new_lifespan)
 	. = ..()
 	overlays += mutable_appearance('icons/effects/effects.dmi', "dimensional_overlay")
 

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -13,7 +13,7 @@
 	///The actual number of ghosts orbiting the anomaly.
 	var/ghosts_orbiting = 0
 
-/obj/effect/anomaly/ectoplasm/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/ectoplasm/Initialize(mapload, new_lifespan)
 	. = ..()
 
 	AddComponent(/datum/component/deadchat_control/cardinal_movement, _deadchat_mode = ANARCHY_MODE, _inputs = list(), _input_cooldown = 7 SECONDS)

--- a/code/game/objects/effects/anomalies/anomalies_flux.dm
+++ b/code/game/objects/effects/anomalies/anomalies_flux.dm
@@ -7,7 +7,7 @@
 	var/shockdamage = 20
 	var/explosive = FLUX_EXPLOSIVE
 
-/obj/effect/anomaly/flux/Initialize(mapload, new_lifespan, drops_core = TRUE, explosive = FLUX_EXPLOSIVE)
+/obj/effect/anomaly/flux/Initialize(mapload, new_lifespan, explosive = FLUX_EXPLOSIVE)
 	. = ..()
 	src.explosive = explosive
 	var/static/list/loc_connections = list(
@@ -55,7 +55,7 @@
 	explosive = FLUX_NO_EXPLOSION
 
 // We need to override the default arguments here to achieve the desired effect
-/obj/effect/anomaly/flux/minor/Initialize(mapload, new_lifespan, drops_core = FALSE, explosive = FLUX_NO_EXPLOSION)
+/obj/effect/anomaly/flux/minor/Initialize(mapload, new_lifespan, explosive = FLUX_NO_EXPLOSION)
 	return ..()
 
 ///Bigger, meaner, immortal flux anomaly
@@ -71,7 +71,7 @@
 	///the zappy flags
 	var/zap_flags = ZAP_GENERATES_POWER | ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE
 
-/obj/effect/anomaly/flux/big/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/flux/big/Initialize(mapload, new_lifespan)
 	. = ..()
 
 	transform *= 3

--- a/code/game/objects/effects/anomalies/anomalies_flux.dm
+++ b/code/game/objects/effects/anomalies/anomalies_flux.dm
@@ -52,7 +52,7 @@
 
 /// A flux anomaly which doesn't explode or produce a core
 /obj/effect/anomaly/flux/minor
-	explosive = FLUX_NO_EXPLOSION
+	anomaly_core = null
 
 // We need to override the default arguments here to achieve the desired effect
 /obj/effect/anomaly/flux/minor/Initialize(mapload, new_lifespan, explosive = FLUX_NO_EXPLOSION)

--- a/code/game/objects/effects/anomalies/anomalies_gravity.dm
+++ b/code/game/objects/effects/anomalies/anomalies_gravity.dm
@@ -17,7 +17,7 @@
 	///Warp effect holder for displacement filter to "pulse" the anomaly
 	var/atom/movable/warp_effect/warp
 
-/obj/effect/anomaly/grav/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/grav/Initialize(mapload, new_lifespan)
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
@@ -112,7 +112,7 @@
 	anomaly_core = null
 	move_force = MOVE_FORCE_OVERPOWERING
 
-/obj/effect/anomaly/grav/high/big/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/grav/high/big/Initialize(mapload, new_lifespan)
 	. = ..()
 
 	transform *= 3

--- a/code/game/objects/effects/anomalies/anomalies_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomalies_hallucination.dm
@@ -15,7 +15,7 @@
 		span_warning("You are going insane!"),
 	)
 
-/obj/effect/anomaly/hallucination/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/hallucination/Initialize(mapload, new_lifespan)
 	. = ..()
 	apply_wibbly_filters(src)
 	generate_decoys()
@@ -55,11 +55,11 @@
 			new /obj/effect/anomaly/hallucination/decoy(floor)
 
 /obj/effect/anomaly/hallucination/decoy
-	drops_core = FALSE
+	anomaly_core = null
 	///Stores the fake analyzer scan text, so the result is always consistent for each anomaly.
 	var/report_text
 
-/obj/effect/anomaly/hallucination/decoy/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/hallucination/decoy/Initialize(mapload, new_lifespan)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_ILLUSORY_EFFECT, INNATE_TRAIT)
 	report_text = pick(

--- a/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
+++ b/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
@@ -7,7 +7,7 @@
 	var/releasedelay = 10
 	anomaly_core = /obj/item/assembly/signaler/anomaly/pyro
 
-/obj/effect/anomaly/pyro/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/pyro/Initialize(mapload, new_lifespan)
 	. = ..()
 	apply_wibbly_filters(src)
 
@@ -50,7 +50,7 @@
 	releasedelay = 2
 	move_force = MOVE_FORCE_OVERPOWERING
 
-/obj/effect/anomaly/pyro/big/Initialize(mapload, new_lifespan, drops_core)
+/obj/effect/anomaly/pyro/big/Initialize(mapload, new_lifespan)
 	. = ..()
 
 	transform *= 3

--- a/code/modules/antagonists/wizard/grand_ritual/grand_side_effect.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_side_effect.dm
@@ -110,7 +110,7 @@
 			continue
 		can_create[create_path] = can_create[create_path] - 1
 		var/obj/effect/anomaly/target = new create_path(pick(anomaly_positions), /*new_lifespan = */rand(15 SECONDS, 30 SECONDS))
-		target.anomaly_core = null
+		QDEL_NULL(target.anomaly_core)
 		to_create--
 
 #undef MIN_ANOMALIES_CREATED

--- a/code/modules/antagonists/wizard/grand_ritual/grand_side_effect.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_side_effect.dm
@@ -109,7 +109,8 @@
 		if (can_create[create_path] == 0)
 			continue
 		can_create[create_path] = can_create[create_path] - 1
-		new create_path(pick(anomaly_positions), /*new_lifespan = */rand(15 SECONDS, 30 SECONDS), /*drops_core = */FALSE)
+		var/obj/effect/anomaly/target = new create_path(pick(anomaly_positions), /*new_lifespan = */rand(15 SECONDS, 30 SECONDS))
+		target.anomaly_core = null
 		to_create--
 
 #undef MIN_ANOMALIES_CREATED


### PR DESCRIPTION
## About The Pull Request
- Fixes #89046. Even though it set `anomaly_type = null` is still set `drops_core = TRUE` leading to the runtime.
- We now remove `drops_core` var all together. If `anomaly_type = null` it means we don't drop a core and that's inferred so we don't need this var to tell us that again

## Changelog
:cl:
code: removes a redundant var from anomaly effects
fix: Fixes runtimes for some anomaly effects
/:cl:

