### PR TITLE
[no gbp] some wawa fixes

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -18430,7 +18430,8 @@
 /area/station/security/lockers)
 "gAD" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "gAQ" = (
@@ -51779,7 +51780,8 @@
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "skj" = (
@@ -174367,9 +174369,9 @@ nhf
 guk
 jxa
 jxa
-xfK
-mHf
 rHF
+mHf
+xfK
 jxa
 kri
 uWt

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -11364,8 +11364,8 @@
 	pixel_y = 6
 	},
 /obj/item/circuitboard/mecha/ripley/main{
-	pixel_x = -10;
-	pixel_y = -6
+	pixel_x = -9;
+	pixel_y = -10
 	},
 /obj/item/circuitboard/mecha/ripley/peripherals{
 	pixel_x = -4;
@@ -12408,17 +12408,17 @@
 "esX" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 4;
-	pixel_y = 5
+	pixel_x = 0;
+	pixel_y = 7
 	},
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = -8;
-	pixel_y = 9
+	pixel_x = 0;
+	pixel_y = 4
 	},
 /obj/item/stock_parts/power_store/cell/high,
 /obj/machinery/cell_charger,
 /obj/item/borg/upgrade/rename{
-	pixel_x = 3;
+	pixel_x = 4;
 	pixel_y = 18
 	},
 /turf/open/floor/iron/dark/textured,

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -11363,6 +11363,14 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/circuitboard/mecha/ripley/main{
+	pixel_x = -10;
+	pixel_y = -6
+	},
+/obj/item/circuitboard/mecha/ripley/peripherals{
+	pixel_x = -4;
+	pixel_y = -7
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "dZy" = (
@@ -34480,6 +34488,8 @@
 	},
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
@@ -58351,6 +58361,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
+"uxA" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "uxH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -105231,7 +105245,7 @@ raz
 cPt
 toV
 ebU
-irJ
+uxA
 cPt
 cPt
 dmE

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -58361,10 +58361,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
-"uxA" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
 "uxH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -105245,7 +105241,7 @@ raz
 cPt
 toV
 ebU
-uxA
+irJ
 cPt
 cPt
 dmE

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2992,6 +2992,12 @@
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bay" = (
@@ -4179,20 +4185,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"bxQ" = (
-/obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "byb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -6357,6 +6349,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cnT" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "cnZ" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/side{
@@ -10047,6 +10049,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "dBX" = (
@@ -10143,6 +10146,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"dDb" = (
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "dDc" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron,
@@ -12946,6 +12959,12 @@
 /area/station/engineering/supermatter/room)
 "eCb" = (
 /obj/machinery/vending/hydronutrients,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "eCd" = (
@@ -13370,6 +13389,12 @@
 "eJB" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "eJE" = (
@@ -14575,6 +14600,16 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"fle" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "flm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18639,10 +18674,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"gEk" = (
-/obj/effect/spawner/random/trash/mopbucket,
-/turf/open/misc/asteroid,
-/area/station/maintenance/central/greater)
 "gEm" = (
 /obj/structure/railing{
 	dir = 4
@@ -22091,7 +22122,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "hPp" = (
@@ -23357,6 +23390,10 @@
 /obj/item/camera,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"imU" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "imZ" = (
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/closed/wall/r_wall,
@@ -28796,10 +28833,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"kiE" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "kiK" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance/two,
@@ -31355,9 +31388,9 @@
 /area/station/medical/treatment_center)
 "kZS" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("hydroponics");
+	name = "Hydroponics Desk"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -34376,6 +34409,11 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/atmos/upper)
+"mhD" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/contraband/narcotics,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "mhF" = (
 /obj/effect/spawner/random/decoration/material,
 /obj/effect/spawner/random/decoration/material,
@@ -36430,20 +36468,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
-"mRw" = (
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "mRA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -37655,6 +37679,7 @@
 /area/station/command/bridge)
 "nlZ" = (
 /obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/trash/mopbucket,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
 "nmc" = (
@@ -40694,6 +40719,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"oxh" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/girder/displaced,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "oxB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41438,12 +41468,6 @@
 /obj/item/lightreplacer,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"oKI" = (
-/obj/effect/spawner/random/structure/chair_maintenance{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "oKM" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/disposalpipe/segment{
@@ -41885,13 +41909,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
-"oTa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "oTe" = (
 /turf/closed/wall/rust,
 /area/station/asteroid)
@@ -51175,6 +51192,7 @@
 	dir = 8
 	},
 /obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rZE" = (
@@ -51292,7 +51310,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "sbn" = (
-/obj/effect/spawner/random/trash/mess,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
@@ -54660,9 +54681,9 @@
 /area/station/hallway/primary/central)
 "tkR" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
+/obj/machinery/door/window/left/directional/north{
+	req_access = list("hydroponics");
+	name = "Hydroponics Desk"
 	},
 /obj/structure/desk_bell,
 /obj/machinery/door/firedoor,
@@ -55771,6 +55792,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tEp" = (
@@ -56925,20 +56947,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"tYg" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "tYs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -58055,6 +58063,9 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "urz" = (
@@ -61736,6 +61747,16 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
+"vKR" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "vKV" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
@@ -159491,7 +159512,7 @@ gYW
 pny
 eht
 vFg
-wjI
+oxh
 hCs
 tEn
 reU
@@ -159748,7 +159769,7 @@ gYW
 gYW
 gYW
 sbn
-wjI
+oxh
 hCs
 wxv
 mnP
@@ -160004,8 +160025,8 @@ tXp
 gYW
 qUr
 gYW
-kIB
 xiM
+hCs
 hCs
 aZK
 oqs
@@ -160261,10 +160282,10 @@ mne
 gYW
 cjp
 gYW
-gYW
-oTa
+wjI
 hCs
-tYg
+vKR
+kSO
 jVF
 cAg
 cAg
@@ -160516,12 +160537,12 @@ bCm
 gYW
 fne
 gYW
-wAv
 kIB
 pEO
 wjI
 hCs
-bxQ
+cnT
+kSO
 rRd
 gbS
 gbS
@@ -160775,8 +160796,8 @@ wAv
 gYW
 gYW
 gYW
-gYW
 jIU
+hCs
 hCs
 gUu
 ban
@@ -161032,10 +161053,10 @@ wAv
 wAv
 mpZ
 wAv
-wAv
 wjI
 hCs
-mRw
+dDb
+kSO
 oqs
 gbS
 gbS
@@ -161285,13 +161306,13 @@ fne
 dTe
 tAa
 gYW
-oKI
+kIB
 gYW
 gYW
 gYW
-kiE
 wjI
-azV
+hCs
+fle
 kSO
 abo
 abo
@@ -161546,8 +161567,8 @@ gYW
 gYW
 uSe
 cjp
-wAv
-wAv
+wjI
+hCs
 hCs
 urx
 rRd
@@ -161803,9 +161824,9 @@ vxX
 gYW
 uSe
 cjp
-mMN
-wAv
-hCs
+wjI
+wjI
+azV
 hPk
 mnP
 xFT
@@ -163088,8 +163109,8 @@ vxX
 vxX
 vxX
 gYW
-gYW
-gYW
+imU
+mhD
 dTe
 wAv
 apQ
@@ -163344,8 +163365,8 @@ gMk
 uet
 vxX
 vxX
-vxX
-tAa
+gYW
+gYW
 gYW
 dTe
 dTe
@@ -163603,7 +163624,7 @@ gMk
 vxX
 vxX
 tAa
-gEk
+aWJ
 dTe
 dTe
 roB


### PR DESCRIPTION
## About The Pull Request

the west doors of this room can be opened if you have sci access or maint access
supposedly xenobiologists kept somehow getting stuck here

![image](https://github.com/user-attachments/assets/9aa805b2-de0f-44ab-bfc7-f2441f0fd035)

bci machine is accessible

![image](https://github.com/user-attachments/assets/4dc52513-d458-4845-b853-53ed6985becd)

robotics gets the ripley boards and has 150 iron (most maps) instead of 50

![image](https://github.com/user-attachments/assets/d97ffa58-2030-45e6-848f-b0ade7401111)

botany gets 4 more trays

![image](https://github.com/user-attachments/assets/833e64cd-588b-44d5-8d38-55a482493745)


## Why It's Good For The Game

getting stuck somehow is bad
robotics is now on par with the rest of the stations
botany is also now on par kinda

## Changelog
:cl:
fix: on wawastation, fixed the placement of the BCI machine, the maint room south of sci break room can be opened by scientists, robotics gets the ripley boards and 150 iron instead of 50 iron, botany gets 4 more trays
/:cl:
