### PR TITLE
You can no longer get stuck in stacked lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1218,13 +1218,14 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		return
 	if(!opened && ((shove_flags & SHOVE_KNOCKDOWN_BLOCKED) || !(shove_flags & SHOVE_BLOCKED)))
 		return
-	if(opened)
+	if (!toggle())
+		return
+	if(!opened) // Reversed because we should've toggled already
 		if (target.loc != loc)
 			return
 		target.forceMove(src)
 	else
 		target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
-	toggle()
 	update_icon()
 	target.visible_message(span_danger("[shover.name] shoves [target.name] into [src]!"),
 		span_userdanger("You're shoved into [src] by [shover.name]!"),


### PR DESCRIPTION

## About The Pull Request

Stacking two lockers ontop of eachother and shoving someone into them will result in them getting stuck in an open locker, with no way to get out.

## Changelog
:cl:
fix: You can no longer get stuck in stacked lockers
/:cl:
