### PR TITLE
Fixes a few bugs with stargazer targeting and attacks

### DIFF
--- a/code/datums/actions/mobs/open_mob_commands.dm
+++ b/code/datums/actions/mobs/open_mob_commands.dm
@@ -23,4 +23,4 @@
 	if(our_mob_resolved)
 		var/datum/component/obeys_commands/command_component = our_mob_resolved.GetComponent(/datum/component/obeys_commands)
 		if(command_component)
-			command_component.display_menu(our_mob_resolved, owner)
+			command_component.display_menu(owner)

--- a/code/datums/ai/basic_mobs/targeting_strategies/dont_target_friends.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/dont_target_friends.dm
@@ -5,7 +5,7 @@
 	/// If we can try to closed turfs or not
 	var/attack_closed_turf = FALSE
 	/// If we want it to attack ALL OBJECTS
-	var/attack_objs = FALSE
+	var/attack_obj = FALSE
 
 ///Returns true or false depending on if the target can be attacked by the mob
 /datum/targeting_strategy/basic/not_friends/can_attack(mob/living/living_mob, atom/target, vision_range)

--- a/code/datums/ai/basic_mobs/targeting_strategies/dont_target_friends.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/dont_target_friends.dm
@@ -4,11 +4,17 @@
 	var/attack_until_past_stat = HARD_CRIT
 	/// If we can try to closed turfs or not
 	var/attack_closed_turf = FALSE
+	/// If we want it to attack ALL OBJECTS
+	var/attack_objs = FALSE
 
 ///Returns true or false depending on if the target can be attacked by the mob
 /datum/targeting_strategy/basic/not_friends/can_attack(mob/living/living_mob, atom/target, vision_range)
 	if(attack_closed_turf && isclosedturf(target))
 		return TRUE
+
+	if(attack_obj && isobj(target))
+		if(!(target.resistance_flags & INDESTRUCTIBLE))
+			return TRUE
 
 	if(target in living_mob.ai_controller.blackboard[BB_FRIENDS_LIST])
 		return FALSE
@@ -21,6 +27,15 @@
 
 /datum/targeting_strategy/basic/not_friends/attack_closed_turfs
 	attack_closed_turf = TRUE
+
+//Allows mobs to target objs. In case you want your mob to target these without going after walls
+/datum/targeting_strategy/basic/not_friends/attack_objs
+	attack_obj = TRUE
+
+//Let us target everything that needs targeting, just like they used to.
+/datum/targeting_strategy/basic/not_friends/attack_everything
+	attack_closed_turf = TRUE
+	attack_obj = TRUE
 
 /// Subtype that allows us to target items while deftly avoiding attacking our allies. Be careful when it comes to targeting items as an AI could get trapped targeting something it can't destroy.
 /datum/targeting_strategy/basic/not_friends/allow_items

--- a/code/datums/components/pet_commands/obeys_commands.dm
+++ b/code/datums/components/pet_commands/obeys_commands.dm
@@ -19,7 +19,7 @@
 	var/radial_relative_to_user
 
 /// The available_commands parameter should be passed as a list of typepaths
-/datum/component/obeys_commands/Initialize(list/command_typepaths = list(), list/radial_menu_offset = list(0, 0), radial_relative_to_user = FALSE)
+/datum/component/obeys_commands/Initialize(list/command_typepaths = list(), list/radial_menu_offset = list(0, 0), radial_menu_lifetime = 7 SECONDS, radial_relative_to_user = FALSE)
 	. = ..()
 	if (!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -30,6 +30,7 @@
 		CRASH("Initialised obedience component with no commands.")
 	src.radial_menu_offset = radial_menu_offset
 	src.radial_relative_to_user = radial_relative_to_user
+	src.radial_menu_lifetime = radial_menu_lifetime
 	for (var/command_path in command_typepaths)
 		var/datum/pet_command/new_command = new command_path(parent)
 		available_commands[new_command.command_name] = new_command

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -242,7 +242,7 @@
 	star_gazer_mob.maxHealth = INFINITY
 	star_gazer_mob.health = INFINITY
 	user.AddComponent(/datum/component/death_linked, star_gazer_mob)
-	star_gazer_mob.AddComponent(/datum/component/obeys_commands, star_gazer_commands, radial_menu_lifetime = 15 SECONDS, radial_relative_to_user = TRUE)
+	star_gazer_mob.AddComponent(/datum/component/obeys_commands, star_gazer_commands, radial_relative_to_user = TRUE)
 	star_gazer_mob.AddComponent(/datum/component/damage_aura, range = 7, burn_damage = 0.5, simple_damage = 0.5, immune_factions = list(FACTION_HERETIC), current_owner = user)
 	star_gazer_mob.befriend(user)
 	var/datum/action/cooldown/open_mob_commands/commands_action = new /datum/action/cooldown/open_mob_commands()

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -242,7 +242,7 @@
 	star_gazer_mob.maxHealth = INFINITY
 	star_gazer_mob.health = INFINITY
 	user.AddComponent(/datum/component/death_linked, star_gazer_mob)
-	star_gazer_mob.AddComponent(/datum/component/obeys_commands, star_gazer_commands, radial_relative_to_user = TRUE)
+	star_gazer_mob.AddComponent(/datum/component/obeys_commands, star_gazer_commands, radial_menu_offset = list(30,0), radial_menu_lifetime = 15 SECONDS, radial_relative_to_user = TRUE)
 	star_gazer_mob.AddComponent(/datum/component/damage_aura, range = 7, burn_damage = 0.5, simple_damage = 0.5, immune_factions = list(FACTION_HERETIC), current_owner = user)
 	star_gazer_mob.befriend(user)
 	var/datum/action/cooldown/open_mob_commands/commands_action = new /datum/action/cooldown/open_mob_commands()

--- a/code/modules/mob/living/basic/heretic/star_gazer.dm
+++ b/code/modules/mob/living/basic/heretic/star_gazer.dm
@@ -79,7 +79,7 @@
 	blackboard = list(
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_TARGET_MINIMUM_STAT = HARD_CRIT,
-		BB_PET_TARGETING_STRATEGY = /datum/targeting_strategy/basic/not_friends/attack_closed_turfs,
+		BB_PET_TARGETING_STRATEGY = /datum/targeting_strategy/basic/not_friends/attack_everything,
 	)
 
 	ai_movement = /datum/ai_movement/basic_avoidance


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #89060 and a few other inconsistencies that I think aren't reported yet. In particular, these are:
- Ordering the Stargazer to attack a window, machinery, and essentially anything that isn't a wall or person will result in refusal. This behavior was different.
- The spell to remotely command the Stargazer doesn't work.
- The shift-hover radial menu is weirdly offset.

I'm still trying to figure out what makes the mob not attack windows unlike before, so I'll set it as a draft until I fix it.

## Why It's Good For The Game

Summoning an elder god bound to your will would be even better if it was actually bound to your will.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Stargazer, a cosmic heretic's ascension, can be properly commanded once more.
code: Basic mob pets can now target objects, or objects and walls by using two new targeting strategies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
