### PR TITLE
Mawed crucible no longer tries to refill when it can't

### DIFF
--- a/code/modules/antagonists/heretic/structures/mawed_crucible.dm
+++ b/code/modules/antagonists/heretic/structures/mawed_crucible.dm
@@ -28,6 +28,8 @@
 	if(COOLDOWN_TIMELEFT(src, refill_cooldown))
 		return
 	COOLDOWN_START(src, refill_cooldown, 30 SECONDS)
+	if(current_mass >= max_mass)
+		return
 	current_mass++
 	playsound(src, 'sound/items/eatfood.ogg', 100, TRUE)
 	update_appearance(UPDATE_ICON_STATE)

--- a/code/modules/antagonists/heretic/structures/mawed_crucible.dm
+++ b/code/modules/antagonists/heretic/structures/mawed_crucible.dm
@@ -27,9 +27,9 @@
 /obj/structure/destructible/eldritch_crucible/process(seconds_per_tick)
 	if(COOLDOWN_TIMELEFT(src, refill_cooldown))
 		return
-	COOLDOWN_START(src, refill_cooldown, 30 SECONDS)
 	if(current_mass >= max_mass)
 		return
+	COOLDOWN_START(src, refill_cooldown, 30 SECONDS)
 	current_mass++
 	playsound(src, 'sound/items/eatfood.ogg', 100, TRUE)
 	update_appearance(UPDATE_ICON_STATE)


### PR DESCRIPTION
## About The Pull Request

It seems like mawed crucible was gaining charges above the allowed maximum, and they were used fully when a potion is made, so it was pointless.

This resulted in the crucible spamming the loud eating noise every 30 seconds even when it has 3/3 charges, and if you want it to shut up, you could only break it down. And you couldn't use rusty grasp to do this quickly.

## Why It's Good For The Game

Bug fixes are good.

## Changelog

:cl:
fix: Mawed crucible doesn't try to gain charges when they're at maximum
/:cl:

