### PR TITLE
Regenerative Coma it doesn't work anymore if you have TRAIT_NOSOFTCRIT trait.

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -378,7 +378,7 @@
 			return power * 0.9
 		if(SOFT_CRIT)
 			return power * 0.5
-	if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma && !(HAS_TRAIT(M,TRAIT_NOCRITDAMAGE)))
+	if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma && !(HAS_TRAIT(M,TRAIT_NOSOFTCRIT)))
 		to_chat(M, span_warning("You feel yourself slip into a regenerative coma..."))
 		active_coma = TRUE
 		addtimer(CALLBACK(src, PROC_REF(coma), M), 6 SECONDS)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -378,7 +378,7 @@
 			return power * 0.9
 		if(SOFT_CRIT)
 			return power * 0.5
-	if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma)
+	if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma && !(HAS_TRAIT(M,TRAIT_NOCRITDAMAGE)))
 		to_chat(M, span_warning("You feel yourself slip into a regenerative coma..."))
 		active_coma = TRUE
 		addtimer(CALLBACK(src, PROC_REF(coma), M), 6 SECONDS)


### PR DESCRIPTION

## About The Pull Request

This is a small change in the symptom of regenerative coma, which I made so that it would not block other treatment methods in critical condition due to the insane rate at which self-made viruses spread during contact transfer. This results in the almost ubiquity of this symptom, which strongly affects your game, which is very difficult to notice if you are not a doctor. Very often, this symptom spoils the miners' game, which leads to idiotic accidental deaths when you use a luxury pen before a fight and expect that you will be able to fight from a critical condition, but fall asleep in battle due to an accidentally acquired virus. 

(Or to put it briefly, the TRAIT_NOSOFTCRIT trait (for example, penthrite gives it) now blocks falling into a regenerative coma.)
## Why It's Good For The Game
There will be no more stupid, pointless and difficult-to-control lapses into a regenerative coma when you don't need it and you can continue to live without it.

## Changelog
:cl:
add: TRAIT_NOSOFTCRIT now blocks falling into a regenerative coma.
/:cl:
