### PR TITLE
Fix fishing gloves runtime 

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -363,7 +363,7 @@
 	. = max(cast_range, 1)
 	if(!user && !isliving(loc))
 		return
-	user = loc
+	user = !user ? loc : user
 	if(!user.is_holding(src) || !user.mind)
 		return
 	. += round(user.mind.get_skill_level(/datum/skill/fishing) * 0.3)

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -361,10 +361,8 @@
 
 /obj/item/fishing_rod/proc/get_cast_range(mob/living/user)
 	. = max(cast_range, 1)
-	if(!user && !isliving(loc))
-		return
-	user = !user ? loc : user
-	if(!user.is_holding(src) || !user.mind)
+	user = user || loc
+	if (!isliving(user) || !user.mind || !user.is_holding(src))
 		return
 	. += round(user.mind.get_skill_level(/datum/skill/fishing) * 0.3)
 	return max(., 1)


### PR DESCRIPTION

## About The Pull Request
Fixes #89080
`get_cast_range(mob/living/user)` wants to know who's using the fishing rod, in order to apply range bonuses.
However, it wrongly assumed that fishing rod's `loc` is always the user, as long as either `loc` is living or `user` (its argument) is not null.
With athletic fishing gloves, this is a problem because the `fishing rod` is technically inside the gloves.
## Why It's Good For The Game
It's not
## Changelog
Not player facing, I believe
