### PR TITLE
Wound-related traits now balance out

### DIFF
--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -57,18 +57,20 @@
 		return
 
 	// note that these are fed into an exponent, so these are magnified
-	if(HAS_TRAIT(owner, TRAIT_EASILY_WOUNDED))
+	var/easily_wounded = HAS_TRAIT(owner, TRAIT_EASILY_WOUNDED)
+	var/hardly_wounded = HAS_TRAIT(owner, TRAIT_HARDLY_WOUNDED)
+	if(easily_wounded && !hardly_wounded)
 		damage *= 1.5
 	else
 		damage = min(damage, WOUND_MAX_CONSIDERED_DAMAGE)
 
-	if(HAS_TRAIT(owner,TRAIT_HARDLY_WOUNDED))
+	if(hardly_wounded && !easily_wounded)
 		damage *= 0.85
 
-	if(HAS_TRAIT(owner, TRAIT_EASYDISMEMBER))
+	if(HAS_TRAIT(owner, TRAIT_EASYDISMEMBER) && !HAS_TRAIT(owner, TRAIT_NODISMEMBER))
 		damage *= 1.1
 
-	if(HAS_TRAIT(owner, TRAIT_EASYBLEED) && ((woundtype == WOUND_PIERCE) || (woundtype == WOUND_SLASH)))
+	if(HAS_TRAIT(owner, TRAIT_EASYBLEED) && !HAS_TRAIT(owner, TRAIT_NOBLOOD) && ((woundtype == WOUND_PIERCE) || (woundtype == WOUND_SLASH)))
 		damage *= 1.5
 
 	var/base_roll = rand(1, round(damage ** WOUND_DAMAGE_EXPONENT))


### PR DESCRIPTION
## About The Pull Request

Ports my downstream PR, https://github.com/Monkestation/Monkestation2.0/pull/2229

This makes it so traits that affect wound multipliers now 1:1 balance out - having both `TRAIT_EASILY_WOUNDED` and `TRAIT_HARDLY_WOUNDED` will just act like you have neither, same with `TRAIT_EASYDISMEMBER` + `TRAIT_NODISMEMBER`, and `TRAIT_EASYBLEED` + `TRAIT_NOBLOOD` (which I think is a niche case that might never happen anyways, but it doesn't hurt to account for it)

## Why It's Good For The Game

It kinda just makes logical sense, honestly.

## Changelog
:cl:
balance: Simultaneously having traits that both make you easier and harder to wound will now act like you have neither, resulting in you taking the normal amount of wound damage.
/:cl:
