### PR TITLE
Upgrade the listening post's intercom

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -214,13 +214,16 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "lk" = (
-/obj/item/radio/intercom/directional/east{
-	freerange = 1
-	},
 /obj/machinery/computer/camera_advanced{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Syndicate Radio Intercom";
+	pixel_x = 27
+	},
+/obj/item/paper/fluff/jobs/engineering/frequencies,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "lu" = (
@@ -400,9 +403,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "xp" = (
-/obj/structure/table/reinforced,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "xP" = (


### PR DESCRIPTION
## About The Pull Request

Replaces the intercom at (018, 014) with a wide-band version. Additionally replaces the reinforced table at (018, 017) with a standard table to match the rest of the structures, and adds a paper with radio frequencies on them at (018, 015)

## Why It's Good For The Game

The current intercom is restricted to the small band of frequencies around common, as with normal station radios. Despite the radio operator having access to departmental radio frequencies, they have no means to spread disinformation on them, unlike their Lavaland counterpart, which is Quite Bad(TM). Expanding the radio frequencies enables more options for sabotage, which is Quite Good(TM). The reference paper with radio frequencies is also Quite Good(TM) for assisting operators who don't have the channels memorised and saves them from searching the wiki. The table also sucks, that is all on that matter.

## Changelog

:cl:
fix: Syndicate Sabotage Operatives have improvised an improved radio for their listening post, at the cost of a table
/:cl: