### PR TITLE
Smol cleanup of `autopsy/success`

### DIFF
--- a/code/modules/surgery/autopsy.dm
+++ b/code/modules/surgery/autopsy.dm
@@ -44,7 +44,7 @@
 	)
 	display_pain(target, "You feel a burning sensation in your chest!")
 
-/datum/surgery_step/autopsy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/autopsy_scanner/tool, datum/surgery/surgery, default_display_results = FALSE)
+/datum/surgery_step/autopsy/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/autopsy_scanner/tool, datum/surgery/surgery, default_display_results = FALSE)
 	ADD_TRAIT(target, TRAIT_DISSECTED, AUTOPSY_TRAIT)
 	ADD_TRAIT(target, TRAIT_SURGICALLY_ANALYZED, AUTOPSY_TRAIT)
 	tool.scan_cadaver(user, target)

--- a/code/modules/surgery/autopsy.dm
+++ b/code/modules/surgery/autopsy.dm
@@ -46,7 +46,7 @@
 
 /datum/surgery_step/autopsy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/autopsy_scanner/tool, datum/surgery/surgery, default_display_results = FALSE)
 	ADD_TRAIT(target, TRAIT_DISSECTED, AUTOPSY_TRAIT)
-	if(!HAS_TRAIT(src, TRAIT_SURGICALLY_ANALYZED))
+	if(!HAS_TRAIT(target, TRAIT_SURGICALLY_ANALYZED))
 		ADD_TRAIT(target, TRAIT_SURGICALLY_ANALYZED, AUTOPSY_TRAIT)
 	tool.scan_cadaver(user, target)
 	var/obj/machinery/computer/operating/operating_computer = surgery.locate_operating_computer(get_turf(target))

--- a/code/modules/surgery/autopsy.dm
+++ b/code/modules/surgery/autopsy.dm
@@ -51,9 +51,8 @@
 	var/obj/machinery/computer/operating/operating_computer = surgery.locate_operating_computer(get_turf(target))
 	if (!isnull(operating_computer))
 		SEND_SIGNAL(operating_computer, COMSIG_OPERATING_COMPUTER_AUTOPSY_COMPLETE, target)
-	if(HAS_MIND_TRAIT(user, TRAIT_MORBID) && ishuman(user))
-		var/mob/living/carbon/human/morbid_weirdo = user
-		morbid_weirdo.add_mood_event("morbid_dissection_success", /datum/mood_event/morbid_dissection_success)
+	if(HAS_MIND_TRAIT(user, TRAIT_MORBID))
+		user.add_mood_event("morbid_dissection_success", /datum/mood_event/morbid_dissection_success)
 	return ..()
 
 /datum/surgery_step/autopsy/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/autopsy.dm
+++ b/code/modules/surgery/autopsy.dm
@@ -46,8 +46,7 @@
 
 /datum/surgery_step/autopsy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/autopsy_scanner/tool, datum/surgery/surgery, default_display_results = FALSE)
 	ADD_TRAIT(target, TRAIT_DISSECTED, AUTOPSY_TRAIT)
-	if(!HAS_TRAIT(target, TRAIT_SURGICALLY_ANALYZED))
-		ADD_TRAIT(target, TRAIT_SURGICALLY_ANALYZED, AUTOPSY_TRAIT)
+	ADD_TRAIT(target, TRAIT_SURGICALLY_ANALYZED, AUTOPSY_TRAIT)
 	tool.scan_cadaver(user, target)
 	var/obj/machinery/computer/operating/operating_computer = surgery.locate_operating_computer(get_turf(target))
 	if (!isnull(operating_computer))


### PR DESCRIPTION
## About The Pull Request

I saw `HAS_TRAIT(src, TRAIT_SURGICALLY_ANALYZED)` and wanted to fix it

1. `HAS_TRAIT(src, TRAIT_SURGICALLY_ANALYZED)` is incorrect, because `src` is the surgery step, meaning this will never fail. No I will not make it `add_traits()`
2. This line is not necessary anyways, even if I did correct it - adding the trait to a mob which already has the trait is fine. (There does not exist any other source of `TRAIT_SURGICALLY_ANALYZED`, and even if there was, I can't imagine why we would not also apply our own) 
3. `mood` is mob level, no need to `ishuman` it. Though we need to cast `user` to /living, which it probably should be anyways

## Changelog

Not player facing