### PR TITLE
Fixes HFR moderator overflow runtime.

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -25,7 +25,7 @@
 		fusion_process(seconds_per_tick)
 		// Note that we process damage/healing even if the fusion process aborts.
 		// Running out of fuel won't save you if your moderator and coolant are exploding on their own.
-		check_spill()
+		process_moderator_overflow()
 		process_damageheal(seconds_per_tick)
 		check_alert()
 	if (start_power)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -569,18 +569,27 @@
  * HFR cracking related procs
  */
 
+/**
+ * Checks for any hypertorus part that is cracked and returns it if found, otherwise returns null.
+ */
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_cracked_parts()
 	for(var/obj/machinery/atmospherics/components/unary/hypertorus/part in machine_parts)
 		if(part.cracked)
-			return TRUE
-	return FALSE
+			return part
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/create_crack()
+/**
+ * Causes a random hypertorus part in machine_parts to become cracked and update their appearance.
+ * Returns the hypertorus part.
+ */
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/create_crack() as /obj/machinery/atmospherics/components/unary/hypertorus
 	var/obj/machinery/atmospherics/components/unary/hypertorus/part = pick(machine_parts)
 	part.cracked = TRUE
 	part.update_appearance()
 	return part
 
+/**
+ * Takes a ratio portion of target_mix and moves it to the origin's location's air.
+ */
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/spill_gases(obj/origin, datum/gas_mixture/target_mix, ratio)
 	var/datum/gas_mixture/remove_mixture = target_mix.remove_ratio(ratio)
 	var/turf/origin_turf = origin.loc
@@ -588,8 +597,12 @@
 		return
 	origin_turf.assume_air(remove_mixture)
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_spill(seconds_per_tick)
+/**
+ * Processes leaking from moderator hypercriticality.
+ */
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/process_moderator_overflow(seconds_per_tick)
 	var/obj/machinery/atmospherics/components/unary/hypertorus/cracked_part = check_cracked_parts()
+	// Processing of a preexisting crack if any.
 	if (cracked_part)
 		// We have an existing crack
 		var/leak_rate
@@ -607,6 +620,7 @@
 		spill_gases(cracked_part, moderator_internal, ratio = 1 - (1 - leak_rate) ** seconds_per_tick)
 		return
 
+	// No crack. Check for conditions to cause a leak and create a crack if possible.
 	if (moderator_internal.total_moles() < HYPERTORUS_HYPERCRITICAL_MOLES)
 		return
 	cracked_part = create_crack()


### PR DESCRIPTION

## About The Pull Request
Fixes a runtime when the HFR moderator overflows. This should also let the HFR continue leaking its moderator contents after a crack is created. I didn't test this but it's quite simple really.
## Why It's Good For The Game
Closes #70617
## Changelog
:cl:
fix: Fixes HFR moderator leaking not leaking properly when a part is cracked.
/:cl:
