### PR TITLE
Improvised explosives and pneumatic cannons recipes use the base pipe objects

### DIFF
--- a/code/datums/components/crafting/chemistry.dm
+++ b/code/datums/components/crafting/chemistry.dm
@@ -6,7 +6,7 @@
 		/datum/reagent/fuel = 20,
 		/obj/item/stack/cable_coil = 15,
 		/obj/item/assembly/timer = 1,
-		/obj/item/pipe/quaternary/pipe = 1,
+		/obj/item/pipe = 1,
 	)
 	time = 6 SECONDS
 	category = CAT_CHEMISTRY

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -154,7 +154,7 @@
 	reqs = list(
 		/obj/item/stack/sheet/iron = 4,
 		/obj/item/stack/package_wrap = 8,
-		/obj/item/pipe/quaternary = 2,
+		/obj/item/pipe = 2,
 	)
 	time = 5 SECONDS
 	category = CAT_WEAPON_RANGED


### PR DESCRIPTION

## About The Pull Request

Previously, IEDs could only be crafted with smart pipe fittings and their descendants. This caused an issue: pipes pre-existing on the ground and pipes created by RPDs could not be used for crafting this recipe, despite looking and acting identical, because they dropped the quaternary pipe object parent type. This PR makes the crafting recipe use the base pipe item, making it consistent with every other item that uses pipes for crafting, such as improvised jetpacks, and various pipe based guns.

This PR also updates the improvised pneumatic device to also use the base pipe item (it used the quaternary parent item, so it did not display any visible bugs).

While this adds the ability to craft IEDs using vents and other pipes, this has always been the case with the aforementioned other recipes.

## Why It's Good For The Game

If a crafting recipe is asking for a pipe object, it should probably allow you to use the pipe object that looks and acts identical. Consistency among recipes.

Closes #82295

## Changelog

:cl:
fix: IEDs can now also be crafted using pipes you have ripped up from the ground.
/:cl:

