### PR TITLE
Ethereal wine charge gain adjusted to fit the new hunger drain stats.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -2655,7 +2655,7 @@
 	var/mob/living/carbon/exposed_carbon = exposed_mob
 	var/obj/item/organ/stomach/ethereal/stomach = exposed_carbon.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(istype(stomach))
-		stomach.adjust_charge(reac_volume * ETHEREAL_DISCHARGE_RATE)
+		stomach.adjust_charge(reac_volume * 5 * ETHEREAL_DISCHARGE_RATE)
 
 /datum/reagent/consumable/ethanol/telepole
 	name = "Telepole"
@@ -2675,7 +2675,7 @@
 	var/mob/living/carbon/exposed_carbon = exposed_mob
 	var/obj/item/organ/stomach/ethereal/stomach = exposed_carbon.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(istype(stomach))
-		stomach.adjust_charge(reac_volume * 8 * ETHEREAL_DISCHARGE_RATE)
+		stomach.adjust_charge(reac_volume * 10 * ETHEREAL_DISCHARGE_RATE)
 
 /datum/reagent/consumable/ethanol/pod_tesla
 	name = "Pod Tesla"


### PR DESCRIPTION
## About The Pull Request

Due to pr #88960 (a very good pr that I fully support) making ethereal hunger not jank, a side affect was that they become hungry a bit faster than prior. Because of this, voltaic wine, which was balanced around the old drain rate, only manages to outpace the hunger drain if you absolutely chug it constantly, and even though its very weak alcohol,  trying to get full off it will probably end in a trip to medical as it stands. (Source: I had to go to medbay two rounds ago because I drank three bottles of it.) This PR just makes it actually able to drink it and gain net charge, without needing to get toxin medicine from being really drunk.  
## Why It's Good For The Game

Ethereals being able to literally live off booze if they want is funny, and given they can eat from omnipresent APCs or Lightbulbs, it's not like this drastically impacts the balance of their access to food.

## Changelog
:cl:
qol: Ethereals can now live off wine again.
/:cl:
