### PR TITLE
Fixes some stuff with toggle_fullscreen

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1194,7 +1194,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	if (fullscreen)
 		// ATTN!! ONCE 515.1631 IS REQUIRED REPLACE WITH winset(src, "mainwindow", "menu=;is-fullscreen=true") (and remember to replace the other call of course)
-		// this means no double maximise calls to make sure window fits, and supresses, titlebar, can-resize and is-maximized
+		// this means no double maximise calls to make sure window fits, and supresses titlebar, can-resize and is-maximized here making those redundant
 		// both implementations are functionally "windowed borderless"
 		winset(src, "mainwindow", "on-size=;titlebar=false;can-resize=false;menu=;is-maximized=false")
 		winset(src, "mainwindow", "is-maximized=true")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1193,18 +1193,14 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	fullscreen = !fullscreen
 
 	if (fullscreen)
-		winset(mob, "mainwindow", "on-size=")
-		winset(mob, "mainwindow", "titlebar=false")
-		winset(mob, "mainwindow", "can-resize=false")
-		winset(mob, "mainwindow", "menu=")
-		winset(mob, "mainwindow", "is-maximized=false")
-		winset(mob, "mainwindow", "is-maximized=true")
+		// ATTN!! ONCE 515.1631 IS REQUIRED REPLACE WITH winset(src, "mainwindow", "menu=;is-fullscreen=true") (and remember to replace the other call of course)
+		// this means no double maximise calls to make sure window fits, and supresses, titlebar, can-resize and is-maximized
+		// both implementations are functionally "windowed borderless"
+		winset(src, "mainwindow", "on-size=;titlebar=false;can-resize=false;menu=;is-maximized=false")
+		winset(src, "mainwindow", "is-maximized=true")
 	else
-		winset(mob, "mainwindow", "menu=menu")
-		winset(mob, "mainwindow", "titlebar=true")
-		winset(mob, "mainwindow", "can-resize=true")
-		winset(mob, "mainwindow", "is-maximized=false")
-		winset(mob, "mainwindow", "on-size=attempt_auto_fit_viewport")
+		winset(src, "mainwindow", "menu=menu;titlebar=true;can-resize=true;is-maximized=true;on-size=attempt_auto_fit_viewport")
+
 	attempt_auto_fit_viewport()
 
 /client/verb/toggle_status_bar()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1193,9 +1193,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	fullscreen = !fullscreen
 
 	if (fullscreen)
-		// ATTN!! ONCE 515.1631 IS REQUIRED REPLACE WITH winset(src, "mainwindow", "menu=;is-fullscreen=true") (and remember to replace the other call of course)
-		// this means no double maximise calls to make sure window fits, and supresses titlebar, can-resize and is-maximized here making those redundant
-		// both implementations are functionally "windowed borderless"
+#if (MIN_COMPILER_VERSION > 515 || MIN_COMPILER_BUILD > 1630)
+	#warn ATTN!! ONCE 515.1631 IS REQUIRED REPLACE WITH winset(src, "mainwindow", "menu=;is-fullscreen=true"). This means no double maximise calls to make sure window fits, and supresses titlebar, can-resize and is-maximized here making those redundant both implementations are functionally "windowed borderless"
+#endif
 		winset(src, "mainwindow", "on-size=;titlebar=false;can-resize=false;menu=;is-maximized=false")
 		winset(src, "mainwindow", "is-maximized=true")
 	else

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1210,9 +1210,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	show_status_bar = !show_status_bar
 
 	if (show_status_bar)
-		winset(mob, "mapwindow.status_bar", "is-visible=true")
+		winset(src, "mapwindow.status_bar", "is-visible=true")
 	else
-		winset(mob, "mapwindow.status_bar", "is-visible=false")
+		winset(src, "mapwindow.status_bar", "is-visible=false")
 
 /// Clears the client's screen, aside from ones that opt out
 /client/proc/clear_screen()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1193,18 +1193,18 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	fullscreen = !fullscreen
 
 	if (fullscreen)
-		winset(usr, "mainwindow", "on-size=")
-		winset(usr, "mainwindow", "titlebar=false")
-		winset(usr, "mainwindow", "can-resize=false")
-		winset(usr, "mainwindow", "menu=")
-		winset(usr, "mainwindow", "is-maximized=false")
-		winset(usr, "mainwindow", "is-maximized=true")
+		winset(mob, "mainwindow", "on-size=")
+		winset(mob, "mainwindow", "titlebar=false")
+		winset(mob, "mainwindow", "can-resize=false")
+		winset(mob, "mainwindow", "menu=")
+		winset(mob, "mainwindow", "is-maximized=false")
+		winset(mob, "mainwindow", "is-maximized=true")
 	else
-		winset(usr, "mainwindow", "menu=menu")
-		winset(usr, "mainwindow", "titlebar=true")
-		winset(usr, "mainwindow", "can-resize=true")
-		winset(usr, "mainwindow", "is-maximized=false")
-		winset(usr, "mainwindow", "on-size=attempt_auto_fit_viewport")
+		winset(mob, "mainwindow", "menu=menu")
+		winset(mob, "mainwindow", "titlebar=true")
+		winset(mob, "mainwindow", "can-resize=true")
+		winset(mob, "mainwindow", "is-maximized=false")
+		winset(mob, "mainwindow", "on-size=attempt_auto_fit_viewport")
 	attempt_auto_fit_viewport()
 
 /client/verb/toggle_status_bar()
@@ -1214,9 +1214,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	show_status_bar = !show_status_bar
 
 	if (show_status_bar)
-		winset(usr, "mapwindow.status_bar", "is-visible=true")
+		winset(mob, "mapwindow.status_bar", "is-visible=true")
 	else
-		winset(usr, "mapwindow.status_bar", "is-visible=false")
+		winset(mob, "mapwindow.status_bar", "is-visible=false")
 
 /// Clears the client's screen, aside from ones that opt out
 /client/proc/clear_screen()


### PR DESCRIPTION

## About The Pull Request
toggle_fullscreen:
collapsed 11 winsets into 3
is-maximised now is true for both sets, to ensure that the screen doesnt sometimes go tiny when this is being toggled (was reported on tgmc) (and yes this doesnt impact resizing)
now uses src instead of fickle usr
added a comment for a better implementation once its possible

toggle_status_bar
now uses src instead of fickle usr

p.s when will someone add prefs for this lmao
## Changelog
:cl:
fix: fixed a case that could make untoggling fullscreen make your window small
code: Cleaned up some fullscreen and status bar toggle code to function better
/:cl:
