### PR TITLE
 Makes Icebox ruins not count towards blob total, as well as preventing them from spawning there.

### DIFF
--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/area/areas_ruins.dmi'
 	icon_state = "ruins"
 	default_gravity = STANDARD_GRAVITY
-	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA
+	area_flags = HIDDEN_AREA | UNIQUE_AREA
 	ambience_index = AMBIENCE_RUINS
 	flags_1 = CAN_BE_DIRTY_1
 	sound_environment = SOUND_ENVIRONMENT_STONEROOM


### PR DESCRIPTION

## About The Pull Request

Makes icebox ruins not count towards blob total, also stops them from spawning there.

## Why It's Good For The Game

I've been seeing a decent bit of blobs spawning on icebox ruins, such as Moffuchi's, the abandoned engineering outpost, Lizard gas, almost every ruin on icebox. The intent of blob isnt to cower off station, ensure likely no one can find you, then branch out onto the station. I understand that wastes blobs exist, but if they do it in the actual wastes, it doesnt count towards their total, and they actually have to branch out into the wastes before they begin. With Z level blobs already fucking over people majorly on icebox if the blob picks the right spot, I'm sure they wont need to be able to spawn in ruins to win. They also cannot spawn in ruins on any other station, so it just seems right to me.
## Changelog
:cl:
fix: Blob's can no longer place their core in ruins on Icebox.
/:cl:
