### PR TITLE
Allow pAIs to withdraw their candidacy

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -70,6 +70,13 @@ SUBSYSTEM_DEF(pai)
 			candidate.savefile_load(user)
 			ui.send_full_update()
 			return TRUE
+		if("withdraw")
+			if(!candidate.ready)
+				to_chat(user, span_warning("You need to submit an application before you can withdraw one."))
+				return FALSE
+			candidate.ready = FALSE
+			to_chat(user, span_notice("Your pAI candidacy has been withdrawn."))
+			return TRUE
 	return FALSE
 
 /**

--- a/tgui/packages/tgui/interfaces/PaiSubmit.tsx
+++ b/tgui/packages/tgui/interfaces/PaiSubmit.tsx
@@ -145,6 +145,14 @@ const ButtonsDisplay = (props) => {
             SUBMIT
           </Button>
         </Stack.Item>
+        <Stack.Item>
+          <Button
+            onClick={() => act('withdraw')}
+            tooltip="Withdraws your pAI candidacy, if any."
+          >
+            WITHDRAW
+          </Button>
+        </Stack.Item>
       </Stack>
     </Section>
   );


### PR DESCRIPTION
## About The Pull Request
This PR adds a "withdraw" button to the pAI candidacy menu, which immediately (or near-immediately, given there's a small delay between tgui refreshes) removes your information from the pAI device's candidate download screen.

(The below video was recorded on a local instance of Monkestation, but I've verified that it works exactly the same on tgstation proper too.)

https://github.com/user-attachments/assets/8508f17f-db61-4ae9-bdc8-b4214489b8b6

## Why It's Good For The Game
Being able to withdraw your candidacy means that, should you need to go AFK or otherwise leave the game for an extended period of time, your candidate details won't clog up the candidate download screen. Plus, you won't frustrate players who download a pAI, only to find that they're AFK.

## Changelog

:cl:MichiRecRoom
qol: pAIs can now withdraw their candidacy at any time. 
/:cl: