### PR TITLE
Fix flaky Ethereal test

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -15,12 +15,17 @@
 	var/poll_role = "split personality"
 
 /datum/brain_trauma/severe/split_personality/on_gain()
-	var/mob/living/M = owner
-	if(M.stat == DEAD || !M.client) //No use assigning people to a corpse or braindead
+	var/mob/living/brain_owner = owner
+	if(brain_owner.stat == DEAD || !GET_CLIENT(brain_owner)) //No use assigning people to a corpse or braindead
 		qdel(src)
 		return
 	..()
 	make_backseats()
+
+#ifdef UNIT_TESTS
+	return // There's no ghosts in the unit test
+#endif
+
 	get_ghost()
 
 /datum/brain_trauma/severe/split_personality/proc/make_backseats()

--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -228,13 +228,13 @@
 
 	playsound(get_turf(regenerating), 'sound/mobs/humanoids/ethereal/ethereal_revive.ogg', 100)
 	to_chat(regenerating, span_notice("You burst out of the crystal with vigour... </span><span class='userdanger'>But at a cost."))
+	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 
 	if(prob(10)) //10% chance for a severe trauma
 		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_ABSOLUTE)
 	else
 		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ABSOLUTE)
 
-	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	// revive calls fully heal -> deletes the crystal.
 	// this qdeleted check is just for sanity.
 	if(!QDELETED(src))

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -5,8 +5,6 @@
 	var/mob/living/carbon/human/victim = allocate(/mob/living/carbon/human/consistent)
 	var/obj/item/organ/heart/ethereal/respawn_heart = new()
 	respawn_heart.Insert(victim, special = TRUE, movement_flags = DELETE_IF_REPLACED) // Pretend this guy is an ethereal
-
-	victim.mind_initialize()
 	victim.mock_client = new()
 
 	victim.death()

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -6,6 +6,9 @@
 	var/obj/item/organ/heart/ethereal/respawn_heart = new()
 	respawn_heart.Insert(victim, special = TRUE, movement_flags = DELETE_IF_REPLACED) // Pretend this guy is an ethereal
 
+	victim.mind_initialize()
+	victim.mock_client = new()
+
 	victim.death()
 	TEST_ASSERT_NOTNULL(respawn_heart.crystalize_timer_id, "Ethereal heart didn't respond to host death.")
 	victim.revive()


### PR DESCRIPTION
## About The Pull Request

Fixes #89050
One of the possible results of applying a severe brain trauma is Split Personality, which fails to apply if you are either Clientless or Dead, both of which are true during unit tests.

We now apply the brain trauma _after_ you revive (fixing it in the real case), and give the test ethereal a mock client (fixing it in the fake case... I think?).
Of course then, after that, it looks for a ghost. Predictably there are also no ghost candidates during unit testing. I couldn't think of any solution to this other than a unit testing ifdef that skips ghost polling, so I did that.

## Changelog

:cl
fix: It's once again possible (but very unlikely) for a reviving ethereal to develop a split personality.
/:cl:
