### PR TITLE
Makes chasms not spawn things when explosions happen again.

### DIFF
--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -159,7 +159,6 @@
 	radial_name = "Chasm"
 	overlay_state = "portal_chasm"
 	radial_state = "ground_hole"
-	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_NONE
 
 /datum/fish_source/portal/ocean
 	fish_table = list(
@@ -327,6 +326,7 @@
 		/datum/chasm_detritus = 30,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 15
+	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_NONE
 
 /datum/fish_source/chasm/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I thought I had told carlarc to put the `FISH_SOURCE_FLAG_EXPLOSIVE_NONE` flag on the `chasm` subtype and not `portal/chasm`, but perhaps it was just my fault. 

## Why It's Good For The Game
Chasms weren't compatible with explosive fishing before the flag was introduced, so it should work as intended now. Even if they were, most stuff would just drop back into the chasms right away so it's futile.

## Changelog

:cl:
fix: Chasms are once again incompatible with explosive fishing.
/:cl:
