### PR TITLE
Modularizes the comms agent ruin on icebox

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
@@ -31,12 +31,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/ruin/comms_agent)
-"ce" = (
-/obj/machinery/modular_computer/preset{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "cI" = (
 /obj/structure/water_source/puddle,
 /obj/item/reagent_containers/cup/glass/waterbottle/large/empty{
@@ -163,12 +157,7 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/ruin/comms_agent)
 "kp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
+/turf/open/space/basic,
 /area/ruin/comms_agent)
 "kA" = (
 /obj/effect/turf_decal/siding/wood,
@@ -274,17 +263,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"pl" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/door/airlock/centcom{
-	name = "Syndicate Secure Airlock System";
-	desc = "Truly, a marvel of modern engineering."
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "pV" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -300,29 +278,11 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/wood/parquet,
 /area/ruin/comms_agent)
-"rh" = (
-/obj/structure/chair/office/tactical{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "rA" = (
 /obj/machinery/atmospherics/components/tank/air,
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/plating,
 /area/ruin/comms_agent/maint)
-"rW" = (
-/obj/structure/filingcabinet,
-/obj/item/paperwork,
-/obj/item/paper/monitorkey,
-/obj/item/paper/fluff/ruins/listeningstation/briefing{
-	pixel_x = -2
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "sc" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	pixel_y = 32
@@ -334,13 +294,6 @@
 /obj/structure/flora/rock/pile/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"sJ" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/machinery/computer/camera_advanced/syndie{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "tb" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
@@ -400,20 +353,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/ruin/comms_agent)
-"vB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/pen/survival{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/machinery/button/door{
-	id = "syndie_lpost_icemoon_windows";
-	name = "Window Shutters";
-	req_access = list("syndicate")
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "vK" = (
 /obj/effect/turf_decal/siding/wideplating/light,
 /obj/machinery/computer/arcade/orion_trail,
@@ -449,21 +388,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/ruin/comms_agent)
-"xq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/syndicate/freerange{
-	pixel_x = 31
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/fax{
-	syndicate_network = 1;
-	allow_exotic_faxes = 1;
-	fax_name = "Listening Post";
-	desc = "Bluespace technologies on the application of bureaucracy. This one is send-only";
-	pixel_y = 5
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "xs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -490,12 +414,6 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/iron,
-/area/ruin/comms_agent)
-"yG" = (
-/obj/machinery/computer/message_monitor{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
 /area/ruin/comms_agent)
 "yR" = (
 /obj/structure/table,
@@ -537,13 +455,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"BQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/office/tactical,
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "BZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/north,
@@ -954,17 +865,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/comms_agent)
-"Tn" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin/carbon{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/machinery/newscaster/directional/south,
-/obj/item/pen/edagger,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/tile,
-/area/ruin/comms_agent)
 "Tp" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
@@ -990,14 +890,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
-/area/ruin/comms_agent)
-"UI" = (
-/obj/structure/table/reinforced,
-/obj/item/paper/monitorkey{
-	pixel_x = -15;
-	pixel_y = 7
-	},
-/turf/open/floor/wood/tile,
 /area/ruin/comms_agent)
 "Vo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1029,15 +921,6 @@
 "WR" = (
 /turf/closed/wall,
 /area/ruin/comms_agent)
-"WU" = (
-/obj/structure/sign/warning/explosives/alt/directional/north,
-/obj/machinery/syndicatebomb/self_destruct{
-	anchored = 1
-	},
-/obj/machinery/light/small/red/directional/north,
-/obj/machinery/door/window/brigdoor/left/directional/south,
-/turf/open/floor/circuit/red,
-/area/ruin/comms_agent)
 "Xk" = (
 /obj/effect/mapping_helpers/airlock/access/any/syndicate,
 /obj/machinery/door/airlock/glass,
@@ -1047,20 +930,11 @@
 /turf/open/floor/plating,
 /area/ruin/comms_agent)
 "XU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "syndie_lpost_icemoon_windows"
+/obj/modular_map_root/syndicatebase{
+	key = "commsoffice";
+	config_file = "strings/modular_maps/syndicatebaseice.toml"
 	},
-/turf/open/floor/plating,
-/area/ruin/comms_agent)
-"Yz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
+/turf/open/space/basic,
 /area/ruin/comms_agent)
 "YA" = (
 /turf/open/floor/wood/parquet,
@@ -2431,11 +2305,11 @@ QT
 jB
 Sc
 Jh
-WR
-yG
-sJ
-Tn
-nP
+XU
+kp
+kp
+kp
+kp
 MH
 MH
 MH
@@ -2488,11 +2362,11 @@ kL
 Sc
 Tp
 Gq
-pl
-HX
-rh
-UI
-XU
+kp
+kp
+kp
+kp
+kp
 MH
 MH
 MH
@@ -2545,11 +2419,11 @@ FZ
 zi
 in
 bt
-WR
-xq
-Yz
-ce
-XU
+kp
+kp
+kp
+kp
+kp
 MH
 MH
 sB
@@ -2602,11 +2476,11 @@ Qn
 up
 in
 ag
-WR
-WR
-BQ
-vB
-XU
+kp
+kp
+kp
+kp
+kp
 MH
 MH
 OM
@@ -2659,11 +2533,11 @@ nP
 dP
 tu
 kL
-WR
-WU
 kp
-rW
-XU
+kp
+kp
+kp
+kp
 MH
 MH
 OM
@@ -2716,11 +2590,11 @@ nP
 nP
 nP
 Xk
-WR
-WR
-WR
-nP
-nP
+kp
+kp
+kp
+kp
+kp
 MH
 MH
 OM

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_cheap.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_cheap.dmm
@@ -1,0 +1,170 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/briefing{
+	pixel_x = -2
+	},
+/obj/item/paper/monitorkey,
+/obj/item/paperwork,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"b" = (
+/turf/closed/wall/r_wall,
+/area/ruin/comms_agent)
+"c" = (
+/turf/closed/wall,
+/area/ruin/comms_agent)
+"h" = (
+/obj/modular_map_connector,
+/turf/closed/wall/rust,
+/area/ruin/comms_agent)
+"l" = (
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 1
+	},
+/obj/item/paper/monitorkey,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"n" = (
+/obj/structure/chair/office/tactical,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"q" = (
+/obj/item/radio/intercom/syndicate/freerange{
+	pixel_x = -31
+	},
+/obj/machinery/modular_computer/preset{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"s" = (
+/turf/closed/wall/rust,
+/area/ruin/comms_agent)
+"v" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"w" = (
+/obj/item/kirbyplants/random/fullysynthetic,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"y" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"z" = (
+/obj/structure/table,
+/obj/machinery/fax{
+	syndicate_network = 1;
+	allow_exotic_faxes = 1;
+	fax_name = "Listening Post";
+	desc = "Bluespace technologies on the application of bureaucracy. This one is send-only";
+	pixel_y = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"B" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/centcom{
+	name = "Syndicate Secure Airlock System";
+	desc = "Truly, a marvel of modern engineering."
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"I" = (
+/obj/structure/closet/crate/secure/syndicate,
+/obj/item/storage/backpack/duffelbag/syndie/x4,
+/obj/item/storage/backpack/duffelbag/syndie/x4,
+/obj/item/assembly/signaler,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"P" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"Q" = (
+/obj/machinery/computer/message_monitor{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"T" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"U" = (
+/obj/structure/closet/crate,
+/mob/living/basic/cockroach,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/clothing/syndie,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/maintenance/three,
+/obj/item/pen,
+/obj/item/paper_bin,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+
+(1,1,1) = {"
+h
+w
+q
+P
+c
+"}
+(2,1,1) = {"
+B
+v
+v
+Q
+s
+"}
+(3,1,1) = {"
+c
+a
+n
+l
+s
+"}
+(4,1,1) = {"
+s
+s
+y
+z
+c
+"}
+(5,1,1) = {"
+s
+I
+T
+U
+s
+"}
+(6,1,1) = {"
+c
+s
+c
+s
+b
+"}

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_cheap.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_cheap.dmm
@@ -82,7 +82,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/ruin/comms_agent)
 "I" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_luxury.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_luxury.dmm
@@ -1,0 +1,216 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/r_wall,
+/area/ruin/comms_agent)
+"f" = (
+/obj/machinery/door/window/brigdoor/left/directional/south,
+/obj/machinery/syndicatebomb/self_destruct{
+	anchored = 1
+	},
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/structure/sign/warning/explosives/alt/directional/north,
+/turf/open/floor/mineral/gold,
+/area/ruin/comms_agent)
+"j" = (
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"k" = (
+/obj/structure/table/reinforced/plasmarglass,
+/obj/machinery/light_switch/directional/south,
+/obj/item/paper_bin/carbon{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen/fountain{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/obj/item/paper{
+	pixel_y = 6;
+	default_raw_text = "Your office has been sponsored by yours truly, Donk Corporation!";
+	pixel_x = 15
+	},
+/obj/item/paper/monitorkey{
+	pixel_y = 1;
+	pixel_x = 15
+	},
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"m" = (
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/donk_co/directional/east,
+/turf/open/floor/wood/large,
+/area/ruin/comms_agent)
+"n" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"o" = (
+/obj/structure/table/reinforced/plasmarglass,
+/obj/machinery/button/door{
+	id = "syndie_lpost_icemoon_windows";
+	name = "Window Shutters";
+	req_access = list("syndicate");
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"r" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"u" = (
+/obj/structure/table/reinforced/plasmarglass,
+/obj/machinery/fax{
+	syndicate_network = 1;
+	allow_exotic_faxes = 1;
+	fax_name = "Listening Post";
+	desc = "Bluespace technologies on the application of bureaucracy. This one is send-only"
+	},
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"v" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/ruin/comms_agent)
+"w" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/modular_computer/preset,
+/turf/open/floor/wood/large,
+/area/ruin/comms_agent)
+"x" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/centcom{
+	name = "Syndicate Secure Airlock System";
+	desc = "Truly, a marvel of modern engineering."
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/ruin/comms_agent)
+"C" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"D" = (
+/obj/structure/fireplace,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = -10
+	},
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"J" = (
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/radio/intercom/syndicate/freerange{
+	pixel_x = -31
+	},
+/turf/open/floor/carpet/donk,
+/area/ruin/comms_agent)
+"M" = (
+/obj/structure/filingcabinet,
+/obj/item/paperwork,
+/obj/item/paper/monitorkey,
+/obj/item/paper/fluff/ruins/listeningstation/briefing{
+	pixel_x = -2
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"N" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/ruin/comms_agent)
+"W" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "syndie_lpost_icemoon_windows"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"X" = (
+/obj/modular_map_connector,
+/turf/closed/wall/r_wall,
+/area/ruin/comms_agent)
+
+(1,1,1) = {"
+X
+j
+J
+k
+a
+"}
+(2,1,1) = {"
+x
+n
+C
+o
+W
+"}
+(3,1,1) = {"
+a
+D
+r
+u
+W
+"}
+(4,1,1) = {"
+a
+w
+N
+v
+W
+"}
+(5,1,1) = {"
+a
+f
+m
+M
+W
+"}
+(6,1,1) = {"
+a
+a
+a
+a
+a
+"}

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_luxury.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_luxury.dmm
@@ -126,7 +126,6 @@
 	pixel_y = -10
 	},
 /obj/item/stack/sheet/mineral/wood/fifty,
-/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
 /turf/open/floor/carpet/donk,
 /area/ruin/comms_agent)
 "J" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_standard.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_standard.dmm
@@ -1,0 +1,196 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall,
+/area/ruin/comms_agent)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/syndicate/freerange{
+	pixel_x = 31
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	syndicate_network = 1;
+	allow_exotic_faxes = 1;
+	fax_name = "Listening Post";
+	desc = "Bluespace technologies on the application of bureaucracy. This one is send-only";
+	pixel_y = 5
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"f" = (
+/obj/machinery/modular_computer/preset{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"g" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/carbon{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/item/pen/edagger,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"k" = (
+/obj/modular_map_connector,
+/turf/closed/wall,
+/area/ruin/comms_agent)
+"q" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"u" = (
+/obj/structure/filingcabinet,
+/obj/item/paperwork,
+/obj/item/paper/monitorkey,
+/obj/item/paper/fluff/ruins/listeningstation/briefing{
+	pixel_x = -2
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"v" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/pen/survival{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/machinery/button/door{
+	id = "syndie_lpost_icemoon_windows";
+	name = "Window Shutters";
+	req_access = list("syndicate")
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"w" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"y" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"z" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "syndie_lpost_icemoon_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/comms_agent)
+"C" = (
+/obj/structure/chair/office/tactical{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"G" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/centcom{
+	name = "Syndicate Secure Airlock System";
+	desc = "Truly, a marvel of modern engineering."
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"J" = (
+/obj/structure/sign/warning/explosives/alt/directional/north,
+/obj/machinery/syndicatebomb/self_destruct{
+	anchored = 1
+	},
+/obj/machinery/light/small/red/directional/north,
+/obj/machinery/door/window/brigdoor/left/directional/south,
+/turf/open/floor/circuit/red,
+/area/ruin/comms_agent)
+"L" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"M" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/monitorkey{
+	pixel_x = -15;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"Q" = (
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+"R" = (
+/turf/closed/wall/r_wall,
+/area/ruin/comms_agent)
+"X" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/office/tactical,
+/turf/open/floor/wood/tile,
+/area/ruin/comms_agent)
+
+(1,1,1) = {"
+k
+Q
+y
+g
+R
+"}
+(2,1,1) = {"
+G
+L
+C
+M
+z
+"}
+(3,1,1) = {"
+a
+b
+q
+f
+z
+"}
+(4,1,1) = {"
+a
+a
+X
+v
+z
+"}
+(5,1,1) = {"
+a
+J
+w
+u
+z
+"}
+(6,1,1) = {"
+a
+a
+a
+R
+R
+"}

--- a/strings/modular_maps/syndicatebaseice.toml
+++ b/strings/modular_maps/syndicatebaseice.toml
@@ -1,0 +1,5 @@
+directory = "_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/"
+
+[rooms.commsoffice]
+modules = ["commsoffice_standard.dmm", "commsoffice_cheap.dmm", "commsoffice_luxury.dmm"]
+


### PR DESCRIPTION

## About The Pull Request
Modularizes the comms agent ruin on icebox
only includes the actual comms agent's office part because i am tired ok
<details>
<summary>comms_luxury</summary>
(![image](https://github.com/user-attachments/assets/703d0dab-ba57-4e94-babf-9b09c4b90d86))
</details>

<details>
<summary>comms_cheap</summary>
![image](https://github.com/user-attachments/assets/cf6ad70e-d527-41b5-b90e-b2968794dc18)
</details>

and comms_standard is the previous office that was in the non modularized map
## Why It's Good For The Game
modularized things are unique and good
## Changelog
:cl:
map: modularizes the comms agent ruin on icebox
/:cl:
