### PR TITLE
Fixes a fishy CI failure caused by a hard delete

### DIFF
--- a/code/modules/fishing/fish_mount.dm
+++ b/code/modules/fishing/fish_mount.dm
@@ -108,6 +108,11 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/fish_mount/proc/add_fish(obj/item/fish/fish, from_persistence = FALSE, catcher)
+	if(QDELETED(src)) // don't ever try to add a fish to one of these that's already been deleted - and get rid of the one that was created
+		qdel(fish)
+		return
+	if(QDELETED(fish)) // no adding deleted fishies either
+		return
 	if(mounted_fish)
 		mounted_fish.forceMove(loc)
 	fish.forceMove(src)

--- a/code/modules/fishing/fish_mount.dm
+++ b/code/modules/fishing/fish_mount.dm
@@ -78,7 +78,7 @@
 	if(fish_path.fish_id_redirect_path)
 		fish_path = fish_path.fish_id_redirect_path
 	var/fluff_name = pick("John Trasen III", "a nameless intern", "Pun Pun", AQUARIUM_COMPANY, "Unknown", "Central Command")
-	add_fish(new fish_path(src), from_persistence = TRUE, catcher = fluff_name)
+	add_fish(new fish_path(loc), from_persistence = TRUE, catcher = fluff_name)
 	mounted_fish.randomize_size_and_weight()
 	mounted_fish.set_status(FISH_DEAD)
 	SSpersistence.save_trophy_fish(src)


### PR DESCRIPTION
## About The Pull Request

Likely caused by a race condition with a `load_trophy_fish()` occurring after the item is deleted somehow. I erred on the side of caution and just made sure we can never get any fish being added to the trophy after its deletion.

![image](https://github.com/user-attachments/assets/1968ee5a-78e8-428e-9421-2416860962bc)

## Why It's Good For The Game

Too many spurious CI failures lately

## Changelog

N/A