### PR TITLE
Fixes an armrest related hard del

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -92,8 +92,6 @@
 	return mutable_appearance(icon, "[icon_state]_armrest")
 
 /obj/structure/chair/proc/update_armrest()
-	if(isnull(armrest))
-		return
 	armrest = color_atom_overlay(armrest)
 	update_appearance()
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -92,6 +92,8 @@
 	return mutable_appearance(icon, "[icon_state]_armrest")
 
 /obj/structure/chair/proc/update_armrest()
+	if(isnull(armrest))
+		return
 	armrest = color_atom_overlay(armrest)
 	update_appearance()
 

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1373,6 +1373,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_atoms_ontop)
 
 /obj/effect/mapping_helpers/mob_buckler/Initialize(mapload)
 	. = ..()
+	if(!mapload)
+		log_mapping("[src] spawned outside of mapload!")
+		return INITIALIZE_HINT_QDEL
+
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/mapping_helpers/mob_buckler/LateInitialize()
 	var/atom/movable/buckle_to
 	var/list/mobs = list()
 	for(var/atom/movable/possible_buckle as anything in loc)
@@ -1385,12 +1392,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_atoms_ontop)
 
 	if(isnull(buckle_to))
 		log_mapping("[type] at [x] [y] [z] did not find anything to buckle to")
-		return INITIALIZE_HINT_QDEL
+		qdel(src)
+		return
 
 	for(var/mob/living/mob as anything in mobs)
 		buckle_to.buckle_mob(mob, force = force_buckle)
 
-	return INITIALIZE_HINT_QDEL
+	qdel(src)
 
 ///Basic mob flag helpers for things like deleting on death.
 /obj/effect/mapping_helpers/basic_mob_flags


### PR DESCRIPTION
## About The Pull Request

Another spurious CI runtime that keeps coming up all the time and is annoying me. I believe it's occurring due to the chair not being initialized before a `mob_buckler` mapping helper tries to buckle mobs to it. 

So I moved their code to lateload to hopefully ensure that doesn't happen, as well as an additional safety measure in the armchair code itself.

edit: confirmed that this does indeed fix it, as I have it merged downstream preemptively due to it being such a blocking nuisance

![image](https://github.com/user-attachments/assets/508e3f58-08ee-4e54-98a2-8a655ce85530)

Caused by 

## Why It's Good For The Game

Less CI failures

## Changelog

N/A
