### PR TITLE
Fixes CI's limp (another hard del)

### DIFF
--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -55,7 +55,8 @@
 	right = carbon_owner.get_bodypart(BODY_ZONE_R_LEG)
 	update_limp()
 	RegisterSignal(carbon_owner, COMSIG_MOVABLE_MOVED, PROC_REF(check_step))
-	RegisterSignals(carbon_owner, list(COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB), PROC_REF(update_limp))
+	RegisterSignal(carbon_owner, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(on_limb_removed))
+	RegisterSignals(carbon_owner, list(COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB), PROC_REF(update_limp))
 	return TRUE
 
 /datum/status_effect/limp/on_remove()
@@ -87,6 +88,17 @@
 		if(prob(limp_chance_right * determined_mod))
 			owner.client.move_delay += slowdown_right * determined_mod
 		next_leg = left
+
+/// We need to make sure that we properly clear these refs if one of the owner's limbs gets deleted
+/datum/status_effect/limp/proc/on_limb_removed(datum/source, obj/item/bodypart/limb_lost, special, dismembered)
+	SIGNAL_HANDLER
+
+	if(limb_lost == left)
+		left = null
+	if(limb_lost == right)
+		right = null
+
+	update_limp()
 
 /datum/status_effect/limp/proc/update_limp()
 	SIGNAL_HANDLER

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -122,13 +122,13 @@
 		for(var/thing in left.wounds)
 			var/datum/wound/wound = thing
 			slowdown_left += wound.limp_slowdown
-			limp_chance_left = max(limp_chance_left, W.limp_chance)
+			limp_chance_left = max(limp_chance_left, wound.limp_chance)
 
 	if(right)
 		for(var/thing in right.wounds)
 			var/datum/wound/wound = thing
 			slowdown_right += wound.limp_slowdown
-			limp_chance_right = max(limp_chance_right, W.limp_chance)
+			limp_chance_right = max(limp_chance_right, wound.limp_chance)
 
 	// this handles losing your leg with the limp and the other one being in good shape as well
 	if(!slowdown_left && !slowdown_right)

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -53,7 +53,7 @@
 	var/mob/living/carbon/carbon_owner = owner
 	left = carbon_owner.get_bodypart(BODY_ZONE_L_LEG)
 	right = carbon_owner.get_bodypart(BODY_ZONE_R_LEG)
-	update_limp()
+	update_limp(src)
 	RegisterSignal(carbon_owner, COMSIG_MOVABLE_MOVED, PROC_REF(check_step))
 	RegisterSignal(carbon_owner, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(on_limb_removed))
 	RegisterSignals(carbon_owner, list(COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB), PROC_REF(update_limp))
@@ -98,17 +98,18 @@
 	if(limb_lost == right)
 		right = null
 
-	update_limp()
+	update_limp() // calling this with no arg so we know it's coming from here and not a signal
 
-/datum/status_effect/limp/proc/update_limp()
+/datum/status_effect/limp/proc/update_limp(datum/source)
 	SIGNAL_HANDLER
 
-	var/mob/living/carbon/C = owner
-	left = C.get_bodypart(BODY_ZONE_L_LEG)
-	right = C.get_bodypart(BODY_ZONE_R_LEG)
+	var/mob/living/carbon/carbon_mob = owner
+	if(source) // if we don't have a source, that means we are calling it from on_limb_removed. In that case we do not want to reassign these to the about-to-be-removed limbs (which can cause hanging refs)
+		left = carbon_mob.get_bodypart(BODY_ZONE_L_LEG)
+		right = carbon_mob.get_bodypart(BODY_ZONE_R_LEG)
 
 	if(!left && !right)
-		C.remove_status_effect(src)
+		carbon_mob.remove_status_effect(src)
 		return
 
 	slowdown_left = 0
@@ -119,19 +120,19 @@
 	// technically you can have multiple wounds causing limps on the same limb, even if practically only bone wounds cause it in normal gameplay
 	if(left)
 		for(var/thing in left.wounds)
-			var/datum/wound/W = thing
-			slowdown_left += W.limp_slowdown
+			var/datum/wound/wound = thing
+			slowdown_left += wound.limp_slowdown
 			limp_chance_left = max(limp_chance_left, W.limp_chance)
 
 	if(right)
 		for(var/thing in right.wounds)
-			var/datum/wound/W = thing
-			slowdown_right += W.limp_slowdown
+			var/datum/wound/wound = thing
+			slowdown_right += wound.limp_slowdown
 			limp_chance_right = max(limp_chance_right, W.limp_chance)
 
 	// this handles losing your leg with the limp and the other one being in good shape as well
 	if(!slowdown_left && !slowdown_right)
-		C.remove_status_effect(src)
+		carbon_mob.remove_status_effect(src)
 		return
 
 /////////////////////////


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/88645
Fixes https://github.com/tgstation/tgstation/issues/88567
Fixes https://github.com/NovaSector/NovaSector/issues/4757
Fixes https://github.com/NovaSector/NovaSector/issues/4624

The limp effect was holding refs to a mobs legs. This should hopefully clear that up. `COMSIG_CARBON_REMOVE_LIMB` gets called during the qdel chain for limbs so it should fix it. Also, that signal should probably be renamed to `COMSIG_CARBON_PRE_REMOVE_LIMB` because that limb ain't removed yet at the time of its sending which is why it's a not enough to just rely on `update_limp()` to clear the refs there.

![image](https://github.com/user-attachments/assets/e7b6bd33-691f-4e30-9b4f-16301368ef8b)

## Changelog

N/A