### PR TITLE
Fixes `atom_storage` breaking pockets when moving its item to hand

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -856,15 +856,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 	if(ishuman(user))
 		var/mob/living/carbon/human/hum = user
-		if(hum.l_store == parent && !hum.get_active_held_item())
-			INVOKE_ASYNC(hum, TYPE_PROC_REF(/mob, put_in_hands), parent)
-			hum.l_store = null
+		if(hum.l_store == parent || hum.r_store == parent)
 			return
-		if(hum.r_store == parent && !hum.get_active_held_item())
-			INVOKE_ASYNC(hum, TYPE_PROC_REF(/mob, put_in_hands), parent)
-			hum.r_store = null
-			return
-
 	if(parent.loc == user)
 		INVOKE_ASYNC(src, PROC_REF(open_storage), user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION
## About The Pull Request
- Fixes #89101

As said in Tin `atom_storage` would move items from pocket to hand manually without updating the inventory correctly. This is not required because `/obj/item/attack_hand` already moves an item from anywhere to hand in the correct way so we don't have to do anything except not block it from doing its job

## Changelog
:cl:
fix: pockets update their icons correctly when removing items that have storage (e.g. box of bandages) from them
/:cl:

