### PR TITLE
Little Stat Panel fix for Byond 516

### DIFF
--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -150,6 +150,7 @@ img {
 }
 
 .grid-item:hover .grid-item-text {
+	height: 100%;
 	overflow: visible;
 	white-space: normal;
 	background-color: #ececec;


### PR DESCRIPTION
## About The Pull Request
On the 516, when hovering over the cropped text, the transposed text does not expand the background
It's a small fix for that.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/7fb94a56-5796-4652-92ba-a8ba6a0f9824) | ![image](https://github.com/user-attachments/assets/f7f17185-7d1d-4db7-8602-65c639faebb5) |
