### PR TITLE
Make deluxe donks uncraftable unless learned

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -418,6 +418,7 @@
 	)
 	result = /obj/item/food/donkpocket/deluxe
 	category = CAT_PASTRY
+	crafting_flags = parent_type::crafting_flags | CRAFT_MUST_BE_LEARNED
 
 /datum/crafting_recipe/food/donkpocket/deluxe/nocarb
 	time = 15


### PR DESCRIPTION

## About The Pull Request
Apparently deluxe donk pockets were craftable without getting the SUPER SEKRIT RECIPE from the ruins. Let's fix that
## Why It's Good For The Game
What's the point in the recipe if you don't have to collect it tbh
## Changelog
:cl:
fix: Deluxe Donk Pockets (and their no-carb and vegan variants) are no longer craftable without collecting the recipe.
/:cl:
