### PR TITLE
Fixes fishing auto reel moving fixed objects

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -106,9 +106,9 @@
 
 /obj/item/fishing_line/auto_reel/proc/on_hooked_item(obj/item/fishing_rod/source, atom/movable/target, mob/living/user)
 	SIGNAL_HANDLER
+
 	if(!istype(target) || target.anchored || target.move_resist >= MOVE_FORCE_STRONG)
 		return
-	var/atom/movable/movable_target = target
 	var/please_be_gentle = FALSE
 	var/atom/destination
 	var/datum/callback/throw_callback

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -112,16 +112,16 @@
 	var/please_be_gentle = FALSE
 	var/atom/destination
 	var/datum/callback/throw_callback
-	if(isliving(movable_target) || !isitem(movable_target))
+	if(isliving(target) || !isitem(target))
 		destination = get_step_towards(user, target)
 		please_be_gentle = TRUE
 	else
 		destination = user
-		throw_callback = CALLBACK(src, PROC_REF(clear_hitby_signal), movable_target)
-		RegisterSignal(movable_target, COMSIG_MOVABLE_PRE_IMPACT, PROC_REF(catch_it_chucklenut))
+		throw_callback = CALLBACK(src, PROC_REF(clear_hitby_signal), target)
+		RegisterSignal(target, COMSIG_MOVABLE_PRE_IMPACT, PROC_REF(catch_it_chucklenut))
 
-	if(!movable_target.safe_throw_at(destination, source.cast_range, 2, callback = throw_callback, gentle = please_be_gentle))
-		UnregisterSignal(movable_target, COMSIG_MOVABLE_PRE_IMPACT)
+	if(!target.safe_throw_at(destination, source.cast_range, 2, callback = throw_callback, gentle = please_be_gentle))
+		UnregisterSignal(target, COMSIG_MOVABLE_PRE_IMPACT)
 	else
 		playsound(src, 'sound/items/weapons/batonextend.ogg', 50, TRUE)
 

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -104,9 +104,9 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(rod, COMSIG_FISHING_ROD_HOOKED_ITEM)
 
-/obj/item/fishing_line/auto_reel/proc/on_hooked_item(obj/item/fishing_rod/source, atom/target, mob/living/user)
+/obj/item/fishing_line/auto_reel/proc/on_hooked_item(obj/item/fishing_rod/source, atom/movable/target, mob/living/user)
 	SIGNAL_HANDLER
-	if(!ismovable(target))
+	if(!istype(target) || target.anchored || target.move_resist >= MOVE_FORCE_STRONG)
 		return
 	var/atom/movable/movable_target = target
 	var/please_be_gentle = FALSE
@@ -127,6 +127,7 @@
 
 /obj/item/fishing_line/auto_reel/proc/catch_it_chucklenut(obj/item/source, atom/hit_atom, datum/thrownthing/throwingdatum)
 	SIGNAL_HANDLER
+
 	var/mob/living/user = throwingdatum.initial_target.resolve()
 	if(QDELETED(user) || hit_atom != user)
 		return NONE


### PR DESCRIPTION
## About The Pull Request
- Fixes #89103

It still latches onto the intercom but the auto reel function won't work on it so you have to break the line manually

## Changelog
:cl:
fix: fishing rod auto reel won't rip of intercoms or other anchored/immovable objects
/:cl:

