### PR TITLE
fix: floortile gloves fishing

### DIFF
--- a/code/modules/clothing/gloves/combat.dm
+++ b/code/modules/clothing/gloves/combat.dm
@@ -35,6 +35,6 @@
 	icon_state = "ftc_gloves"
 	inhand_icon_state = "greyscale_gloves"
 
-/obj/item/clothing/gloves/combat/floortiletile/Initialize(mapload)
+/obj/item/clothing/gloves/combat/floortile/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/adjust_fishing_difficulty, -5) //tacticool


### PR DESCRIPTION
replaces /obj/item/clothing/gloves/combat/floortiletile/Initialize(mapload) with
/obj/item/clothing/gloves/combat/floortile/Initialize(mapload)