### PR TITLE
AIs can now examine.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -9,7 +9,7 @@
 ///from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_SHIFT "shift_click"
 //	#define COMSIG_MOB_CANCEL_CLICKON (1<<0) //shared with other forms of click, this is so you're aware it exists here too.
-	#define COMPONENT_ALLOW_EXAMINATE (2<<0) //! Allows the user to examinate regardless of client.eye.
+	#define COMPONENT_ALLOW_EXAMINATE (1<<1) //! Allows the user to examinate regardless of client.eye.
 ///from base of atom/ShiftClick()
 #define COMSIG_SHIFT_CLICKED_ON "shift_clicked_on"
 ///from base of atom/CtrlClickOn(): (/mob)

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -8,7 +8,8 @@
 #define COMSIG_CLICK "atom_click"
 ///from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_SHIFT "shift_click"
-	#define COMPONENT_ALLOW_EXAMINATE (1<<0) //! Allows the user to examinate regardless of client.eye.
+//	#define COMSIG_MOB_CANCEL_CLICKON (1<<0) //shared with other forms of click, this is so you're aware it exists here too.
+	#define COMPONENT_ALLOW_EXAMINATE (2<<0) //! Allows the user to examinate regardless of client.eye.
 ///from base of atom/ShiftClick()
 #define COMSIG_SHIFT_CLICKED_ON "shift_clicked_on"
 ///from base of atom/CtrlClickOn(): (/mob)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -115,7 +115,9 @@
 	target.AICtrlShiftClick(src)
 
 /mob/living/silicon/ai/ShiftClickOn(atom/target)
-	target.AIShiftClick(src)
+	if(target.AIShiftClick(src))
+		return
+	return ..()
 
 /mob/living/silicon/ai/CtrlClickOn(atom/target)
 	target.AICtrlClick(src)
@@ -154,7 +156,7 @@
 	return
 
 /atom/proc/AIShiftClick(mob/living/silicon/ai/user)
-	return
+	return FALSE
 
 /atom/proc/AICtrlShiftClick(mob/living/silicon/ai/user)
 	return
@@ -179,10 +181,11 @@
 
 /obj/machinery/door/airlock/AIShiftClick(mob/living/silicon/ai/user)  // Opens and closes doors!
 	if(obj_flags & EMAGGED)
-		return
+		return FALSE
 
 	user_toggle_open(user)
 	add_hiddenprint(user)
+	return TRUE
 
 /obj/machinery/door/airlock/AICtrlShiftClick(mob/living/silicon/ai/user)  // Sets/Unsets Emergency Access Override
 	if(obj_flags & EMAGGED)
@@ -222,10 +225,10 @@
 /// Toggle APC lighting settings
 /obj/machinery/power/apc/AIShiftClick(mob/living/silicon/ai/user)
 	if(!can_use(user, loud = TRUE))
-		return
+		return FALSE
 
 	if(!is_operational || failure_timer)
-		return
+		return FALSE
 
 	lighting = lighting ? APC_CHANNEL_OFF : APC_CHANNEL_ON
 	if (user)
@@ -235,6 +238,7 @@
 		user.log_message("turned [enabled_or_disabled] the [src] lighting settings", LOG_GAME)
 	update_appearance()
 	update()
+	return TRUE
 
 /// Toggle APC equipment settings
 /obj/machinery/power/apc/ai_click_alt(mob/living/silicon/ai/user)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -339,10 +339,10 @@
 
 /atom/proc/ShiftClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_SHIFT_CLICKED_ON, user)
-	var/flags = SEND_SIGNAL(user, COMSIG_CLICK_SHIFT, src)
-	if(flags & COMSIG_MOB_CANCEL_CLICKON)
+	var/shiftclick_flags = SEND_SIGNAL(user, COMSIG_CLICK_SHIFT, src)
+	if(shiftclick_flags & COMSIG_MOB_CANCEL_CLICKON)
 		return
-	if(user.client && (user.client.eye == user || user.client.eye == user.loc || flags & COMPONENT_ALLOW_EXAMINATE))
+	if(user.client && (user.client.eye == user || user.client.eye == user.loc || shiftclick_flags & COMPONENT_ALLOW_EXAMINATE))
 		user.examinate(src)
 
 /mob/proc/TurfAdjacent(turf/tile)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -128,6 +128,12 @@
 		return
 	update_ai_detect_hud()
 
+///Called when the AI shiftclicks on something to examinate it.
+/mob/eye/camera/ai/proc/examinate_check(mob/user, atom/source)
+	SIGNAL_HANDLER
+	if(user.client.eye == src)
+		return COMPONENT_ALLOW_EXAMINATE
+
 /*----------------------------------------------------*/
 
 /atom/proc/move_camera_by_click()
@@ -199,6 +205,7 @@
 	eyeobj.ai = src
 	eyeobj.name = "[name] (AI Eye)"
 	eyeobj.setLoc(loc, TRUE)
+	eyeobj.RegisterSignal(src, COMSIG_CLICK_SHIFT, TYPE_PROC_REF(/mob/eye/camera/ai, examinate_check))
 	set_eyeobj_visible(TRUE)
 
 /mob/living/silicon/ai/proc/set_eyeobj_visible(state = TRUE)


### PR DESCRIPTION
## About The Pull Request

AIs can now examine things that don't have a specific shiftclick interaction, which is solely APCs and airlocks.
Also fixes Dullahans not being able to examine through their head, because that's a thing I found accidentally.

## Why It's Good For The Game

AIs only being able to examine things near its core has always been very annoying, and you're currently able to examine things through security cameras anyways so it's not like we're consistent on how much details the cameras are able to see. This at least makes it a consistent "yes, you can examine through cameras".
AIs also don't really have enough ShiftClick interactions to block all of examine just for their existence.

## Changelog

:cl:
balance: AIs can now examine through their eye.
fix: Dullahans can also examine through their head again.
/:cl:
