### PR TITLE
The Big Bess ripley now uses the correct sprite while piloted by an AI.

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -259,10 +259,11 @@
 GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 
 /obj/vehicle/sealed/mecha/ripley/cargo
-	desc = "An ailing, old, repurposed cargo hauler. Most of its equipment wires are frayed or missing and its frame is rusted."
 	name = "\improper APLU \"Big Bess\""
+	desc = "An ailing, old, repurposed cargo hauler. Most of its equipment wires are frayed or missing and its frame is rusted."
 	icon_state = "hauler"
 	base_icon_state = "hauler"
+	silicon_icon_state = "hauler-empty"
 	max_integrity = 100 //Has half the health of a normal RIPLEY mech, so it's harder to use as a weapon.
 
 /obj/vehicle/sealed/mecha/ripley/cargo/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/89038

I don't know what they meant by moving across z-levels. This straight up just didn't use the correct sprite while piloted by a silicon, period.

## Why It's Good For The Game

Bugs suck!

## Changelog
:cl:
fix: The Big Bess cargo hauler no longer magically becomes (visually) a standard Ripley exosuit.
/:cl:
