### PR TITLE
Implements /Exited() for clipboards

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -26,13 +26,11 @@
 	/// Is the pen integrated?
 	var/integrated_pen = FALSE
 	/**
-	 * Weakref of the topmost piece of paper
-	 *
+	 * Topmost piece of paper
 	 * This is used for the paper displayed on the clipboard's icon
 	 * and it is the one attacked, when attacking the clipboard.
-	 * (As you can't organise contents directly in BYOND)
 	 */
-	var/datum/weakref/toppaper_ref
+	var/obj/item/paper/top_paper
 
 /obj/item/clipboard/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins putting [user.p_their()] head into the clip of \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -50,9 +48,8 @@
 	. = ..()
 	if(!integrated_pen && pen)
 		. += span_notice("Alt-click to remove [pen].")
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-	if(toppaper)
-		. += span_notice("Right-click to remove [toppaper].")
+	if(top_paper)
+		. += span_notice("Right-click to remove [top_paper].")
 
 /// Take out the topmost paper
 /obj/item/clipboard/proc/remove_paper(obj/item/paper/paper, mob/user)
@@ -69,26 +66,16 @@
 
 /obj/item/clipboard/Exited(atom/movable/gone, direction)
 	. = ..()
-
 	if (gone == pen)
 		pen = null
 		update_icon()
 		return
 
-	if (!istype(gone, /obj/item/paper))
+	if (gone != top_paper)
 		return
 
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-	if (gone != toppaper)
-		return
-
-	UnregisterSignal(toppaper, COMSIG_ATOM_UPDATED_ICON)
-	toppaper_ref = null
-	var/obj/item/paper/newtop = locate(/obj/item/paper) in src
-	if(newtop)
-		toppaper_ref = WEAKREF(newtop)
-	else
-		toppaper_ref = null
+	UnregisterSignal(top_paper, COMSIG_ATOM_UPDATED_ICON)
+	top_paper = locate(/obj/item/paper) in src
 	update_icon()
 
 /obj/item/clipboard/click_alt(mob/user)
@@ -112,32 +99,29 @@
 	. += "clipboard_over"
 
 /obj/item/clipboard/proc/get_paper_overlay()
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-	if(isnull(toppaper))
+	if(isnull(top_paper))
 		return
 
-	var/mutable_appearance/paper_overlay = mutable_appearance(icon, toppaper.icon_state, offset_spokesman = src, appearance_flags = KEEP_APART)
-	paper_overlay = toppaper.color_atom_overlay(paper_overlay)
-	paper_overlay.overlays += toppaper.overlays
+	var/mutable_appearance/paper_overlay = mutable_appearance(icon, top_paper.icon_state, offset_spokesman = src, appearance_flags = KEEP_APART)
+	paper_overlay = top_paper.color_atom_overlay(paper_overlay)
+	paper_overlay.overlays += top_paper.overlays
 	return paper_overlay
 
 /obj/item/clipboard/attack_hand(mob/user, list/modifiers)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-		remove_paper(toppaper, user)
+		remove_paper(top_paper, user)
 		return TRUE
 	. = ..()
 
 /obj/item/clipboard/attackby(obj/item/weapon, mob/user, params)
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
 	if(istype(weapon, /obj/item/paper))
 		//Add paper into the clipboard
 		if(!user.transferItemToLoc(weapon, src))
 			return
-		if(toppaper)
-			UnregisterSignal(toppaper, COMSIG_ATOM_UPDATED_ICON)
+		if(top_paper)
+			UnregisterSignal(top_paper, COMSIG_ATOM_UPDATED_ICON)
 		RegisterSignal(weapon, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_top_paper_change))
-		toppaper_ref = WEAKREF(weapon)
+		top_paper = weapon
 		to_chat(user, span_notice("You clip [weapon] onto [src]."))
 	else if(istype(weapon, /obj/item/pen) && !pen)
 		//Add a pen into the clipboard, attack (write) if there is already one
@@ -145,8 +129,8 @@
 			return
 		pen = weapon
 		to_chat(usr, span_notice("You slot [weapon] into [src]."))
-	else if(toppaper)
-		toppaper.attackby(user.get_active_held_item(), user)
+	else if(top_paper)
+		top_paper.attackby(user.get_active_held_item(), user)
 	update_appearance()
 
 /obj/item/clipboard/attack_self(mob/user)
@@ -166,14 +150,13 @@
 	data["pen"] = "[pen]"
 	data["integrated_pen"] = integrated_pen
 
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-	data["top_paper"] = "[toppaper]"
-	data["top_paper_ref"] = "[REF(toppaper)]"
+	data["top_paper"] = "[top_paper]"
+	data["top_paper_ref"] = "[REF(top_paper)]"
 
 	data["paper"] = list()
 	data["paper_ref"] = list()
 	for(var/obj/item/paper/paper in src)
-		if(paper == toppaper)
+		if(paper == top_paper)
 			continue
 		data["paper"] += "[paper]"
 		data["paper_ref"] += "[REF(paper)]"
@@ -214,7 +197,7 @@
 		if("move_top_paper")
 			var/obj/item/paper/paper = locate(params["ref"]) in src
 			if(istype(paper))
-				toppaper_ref = WEAKREF(paper)
+				top_paper = paper
 				to_chat(usr, span_notice("You move [paper] to the top."))
 				update_icon()
 				. = TRUE

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -61,22 +61,34 @@
 	paper.forceMove(user.loc)
 	user.put_in_hands(paper)
 	to_chat(user, span_notice("You remove [paper] from [src]."))
-	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
-	if(paper == toppaper)
-		UnregisterSignal(toppaper, COMSIG_ATOM_UPDATED_ICON)
-		toppaper_ref = null
-		var/obj/item/paper/newtop = locate(/obj/item/paper) in src
-		if(newtop && (newtop != paper))
-			toppaper_ref = WEAKREF(newtop)
-		else
-			toppaper_ref = null
-	update_icon()
 
 /obj/item/clipboard/proc/remove_pen(mob/user)
 	pen.forceMove(user.loc)
 	user.put_in_hands(pen)
 	to_chat(user, span_notice("You remove [pen] from [src]."))
-	pen = null
+
+/obj/item/clipboard/Exited(atom/movable/gone, direction)
+	. = ..()
+
+	if (gone == pen)
+		pen = null
+		update_icon()
+		return
+
+	if (!istype(gone, /obj/item/paper))
+		return
+
+	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
+	if (gone != toppaper)
+		return
+
+	UnregisterSignal(toppaper, COMSIG_ATOM_UPDATED_ICON)
+	toppaper_ref = null
+	var/obj/item/paper/newtop = locate(/obj/item/paper) in src
+	if(newtop)
+		toppaper_ref = WEAKREF(newtop)
+	else
+		toppaper_ref = null
 	update_icon()
 
 /obj/item/clipboard/click_alt(mob/user)


### PR DESCRIPTION

## About The Pull Request

Moved visual updates upon pen/paper removal into /Exited(), thanks to Ephe for the idea

## Why It's Good For The Game

Makes sure that we don't hang onto references if our pen/paper gets removed via less-than-normal methods, like instant recall

## Changelog
:cl:
fix: Clipboards should no longer retain pens that got removed via Instant Recall
/:cl:
