### PR TITLE
Fix all decap'd heads looking brainless

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -87,7 +87,6 @@
 
 	SEND_SIGNAL(owner, COMSIG_CARBON_REMOVE_LIMB, src, special, dismembered)
 	SEND_SIGNAL(src, COMSIG_BODYPART_REMOVED, owner, special, dismembered)
-	update_limb(dropping_limb = TRUE)
 	bodypart_flags &= ~BODYPART_IMPLANTED //limb is out and about, it can't really be considered an implant
 	owner.remove_bodypart(src, special)
 
@@ -96,6 +95,7 @@
 		LAZYREMOVE(owner.all_scars, scar)
 
 	var/mob/living/carbon/phantom_owner = update_owner(null) // so we can still refer to the guy who lost their limb after said limb forgets 'em
+	update_limb(dropping_limb = TRUE)
 
 	for(var/datum/wound/wound as anything in wounds)
 		wound.remove_wound(TRUE)


### PR DESCRIPTION
## About The Pull Request

Order of operations thing (I think) 

- `drop_limb`
- `update_limb`
- It correctly updates the limb `show_debrained = FALSE`
- Remove from limb
- `death`
- `update_body_parts`
- `update_limb`
- Now the head is still associated with the mob, but the organs are gone, so technically, we have no brain
- It updates the limb `show_debrained = TRUE`
- `update_owner(null)`
- Head is only NOW disassociated with the mob after we've wrongly assumed the mob has no brain
- `update_icon_dropped` (with the incorrect values) 

Moving to after we have been disassociated with the owner entirely seems to fix it, might have knock on effects though. Didn't seem to in (short) testing but yeah

Maybe fixes #87971

## Changelog

:cl: Melbert
fix: Heads with brains no longer look debrained
/:cl:
