### PR TITLE
Phobia regex should not be a global expression 

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -584,6 +584,6 @@ GLOBAL_LIST_INIT(phobia_species, list(
 	for(var/word in words)
 		words_match += "[REGEX_QUOTE(word)]|"
 	words_match = copytext(words_match, 1, -1)
-	return regex("(\\b|\\A)([words_match])('?s*)(\\b|\\|)", "ig")
+	return regex("(\\b|\\A)([words_match])('?s*)(\\b|\\|)", "i")
 
 #undef PHOBIA_FILE


### PR DESCRIPTION
## About The Pull Request
While developing a new quirk that used the phobia system, I noticed that I was able to bypass the phobia regex.

Looking further into it, I found that the phobia regex is marked as a global expression with the `g`. Quoting the DM Reference on the `g` flag:
> Global: In Find() subsequent calls will start where this left off, and in Replace() all matches are replaced.

This clearly isn't the behavior we want for handling text in phobias! Thus, this PR removes the `g` flag from phobia regexes.

## Why It's Good For The Game
Bug fixes give me good coder points. :D

## Changelog
:cl:MichiRecRoom
fix: Word phobias should always apply now, rather than occasionally being missed.
/:cl:

