### PR TITLE
Fixes Undeleted SQL Query in Tutorial Code

### DIFF
--- a/code/controllers/subsystem/tutorials.dm
+++ b/code/controllers/subsystem/tutorials.dm
@@ -92,6 +92,7 @@ SUBSYSTEM_DEF(tutorials)
 	)
 
 	if (!select_tutorials_for_ckey.Execute())
+		qdel(select_tutorials_for_ckey)
 		return
 
 	while (select_tutorials_for_ckey.NextRow())


### PR DESCRIPTION

## About The Pull Request

Surprisingly never came up until now, anyways this needs to deleted in case the `Execute()` fails because undeleted SQL queries are bad (iirc)
## Why It's Good For The Game

No more random errors
## Changelog
Unneeded
