### PR TITLE
Fix BYOND cache not being handled properly in CI

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -1,0 +1,51 @@
+# This is a reusable workflow to restore BYOND from a cache, or to install it otherwise.
+name: Restore or Install BYOND
+description: Attempts to restore a specified BYOND version from cache; if it can't, it installs it.
+
+inputs:
+  major:
+    description: "The major BYOND version to install. Defaults to the BYOND_MAJOR specified in `dependencies.sh`."
+    required: false
+    type: string
+  minor:
+    description: "The minor BYOND version to install. Defaults to the BYOND_MINOR specified in `dependencies.sh`."
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Configure BYOND version from inputs
+      if: ${{ inputs.major }}
+      shell: bash
+      run: |
+        echo "BYOND_MAJOR=${{ inputs.major }}" >> $GITHUB_ENV
+        echo "BYOND_MINOR=${{ inputs.minor }}" >> $GITHUB_ENV
+    - name: Configure BYOND version from dependencies.sh
+      if: ${{ !inputs.major }}
+      shell: bash
+      run: |
+        source dependencies.sh
+        echo "BYOND_MAJOR=$BYOND_MAJOR" >> $GITHUB_ENV
+        echo "BYOND_MINOR=$BYOND_MINOR" >> $GITHUB_ENV
+
+    # The use of `actions/cache/restore` and `actions/cache/save` here is deliberate, as we want to
+    # save the BYOND install to a cache as early as possible. If we used just `actions/cache`, it
+    # would only attempt to save the cache at the end of a job. This ensures that if a workflow run
+    # is cancelled, we already have a cache to restore from.
+    - name: Restore BYOND cache
+      id: restore_byond_cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/BYOND
+        key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
+    - name: Install BYOND
+      if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
+      shell: bash
+      run: bash tools/ci/install_byond.sh
+    - name: Save BYOND cache
+      if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
+      uses: actions/cache/save@v4
+      with:
+        path: ~/BYOND
+        key: ${{ steps.restore_byond_cache.outputs.cache-primary-key }}

--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -21,12 +21,9 @@ jobs:
     - name: Checkout
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       uses: actions/checkout@v4
-    - name: Restore BYOND cache
+    - name: Install BYOND
       if: steps.secrets_set.outputs.SECRETS_ENABLED
-      uses: actions/cache@v4
-      with:
-        path: ~/BYOND
-        key: ${{ runner.os }}-byond-${{ hashFiles('dependencies.sh') }}
+      uses: ./.github/actions/restore_or_install_byond
     - name: Install rust-g
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       run: |
@@ -34,7 +31,6 @@ jobs:
     - name: Compile and generate Autowiki files
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       run: |
-        bash tools/ci/install_byond.sh
         source $HOME/BYOND/byond/bin/byondsetup
         tools/build/build --ci autowiki
     - name: Run Autowiki

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Mandatory Empty Step
         run: exit 0
 
+  setup_caches:
+    name: Setup commonly-used caches
+    needs: start_gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up BYOND cache
+        uses: ./.github/actions/restore_or_install_byond
+
   run_linters:
     name: Run Linters
     needs: start_gate
@@ -143,20 +152,16 @@ jobs:
 
   compile_all_maps:
     name: Compile Maps
-    needs: collect_data
+    needs: [ collect_data, setup_caches ]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4
-      - name: Restore BYOND cache
-        uses: actions/cache@v4
-        with:
-          path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ hashFiles('dependencies.sh') }}
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
       - name: Compile All Maps
         run: |
-          bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
       - name: Check client Compatibility
@@ -197,7 +202,7 @@ jobs:
 
   run_all_tests:
     name: Integration Tests
-    needs: collect_data
+    needs: [ collect_data, setup_caches ]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -27,15 +27,6 @@ jobs:
       - name: Mandatory Empty Step
         run: exit 0
 
-  setup_byond_cache:
-    name: Setup BYOND cache
-    needs: start_gate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up BYOND cache
-        uses: ./.github/actions/restore_or_install_byond
-
   run_linters:
     name: Run Linters
     needs: start_gate
@@ -152,7 +143,7 @@ jobs:
 
   compile_all_maps:
     name: Compile Maps
-    needs: [ collect_data, setup_byond_cache ]
+    needs: collect_data
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
@@ -171,7 +162,7 @@ jobs:
           max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}
 
   collect_data:
-    name: Collect data for other tasks
+    name: Collect data and setup caches for other tasks
     needs: start_gate
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -199,10 +190,12 @@ jobs:
         #the regex here does not filter out non-numbers because error messages about no input are less helpful then error messages about bad input (which includes the bad input)
         run: |
           echo "max_required_byond_client=$(grep -Ev '^[[:blank:]]{0,}#{1,}|^[[:blank:]]{0,}$' .github/max_required_byond_client.txt | tail -n1)" >> $GITHUB_OUTPUT
+      - name: Set up BYOND cache
+        uses: ./.github/actions/restore_or_install_byond
 
   run_all_tests:
     name: Integration Tests
-    needs: [ collect_data, setup_byond_cache ]
+    needs: collect_data
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Mandatory Empty Step
         run: exit 0
 
-  setup_caches:
-    name: Setup commonly-used caches
+  setup_byond_cache:
+    name: Setup BYOND cache
     needs: start_gate
     runs-on: ubuntu-latest
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   compile_all_maps:
     name: Compile Maps
-    needs: [ collect_data, setup_caches ]
+    needs: [ collect_data, setup_byond_cache ]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
@@ -202,7 +202,7 @@ jobs:
 
   run_all_tests:
     name: Integration Tests
-    needs: [ collect_data, setup_caches ]
+    needs: [ collect_data, setup_byond_cache ]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -31,11 +31,6 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - name: Restore BYOND cache
-        uses: actions/cache@v4
-        with:
-          path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ hashFiles('dependencies.sh') }}
       - name: Setup database
         run: |
           sudo systemctl start mysql
@@ -49,15 +44,14 @@ jobs:
       - name: Install dreamluau
         run: |
           bash tools/ci/install_dreamluau.sh
-      - name: Configure version
-        run: |
-          echo "BYOND_MAJOR=${{ inputs.major }}" >> $GITHUB_ENV
-          echo "BYOND_MINOR=${{ inputs.minor }}" >> $GITHUB_ENV
-        if: ${{ inputs.major }}
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
+        with:
+          major: ${{ inputs.major }}
+          minor: ${{ inputs.minor }}
       - name: Compile Tests
         id: compile_tests
         run: |
-          bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DANSICOLORS -Werror -ITG0001 -I"loop_checks"
       - name: Run Tests


### PR DESCRIPTION
## About The Pull Request
We currently cache the BYOND install in CI, to reduce the number of times we download BYOND from BYOND's website.

However, an error in how this is handled causes alternate-version tests and integration tests to use the same cache key - despite using different BYOND versions. This causes BYOND to be downloaded many times over, as different jobs detect the wrong BYOND version and re-download it individually.

This PR solves this by implementing the following:
* There is now one cache per BYOND version
* The cache for the primary BYOND version (specified in `dependencies.sh`) is setup *before* any integration testing is performed, to ensure that we aren't downloading BYOND `maps.len` number of times.
* The caches for alternate BYOND versions are set up as soon as they're installed, to ensure that if a workflow is cancelled, we're still using a copy of BYOND from the cache.

Additionally, to handle setting up and restoring the BYOND cache, I've set up a new action inside the `.github` folder: `restore_or_install_byond`. This action is given a BYOND version (defaulting to the version specified in `dependencies.sh` if none is specified), and takes the following steps:
1. It attempts to restore the cache relating to that BYOND version. If it succeeds, the action ends, and the BYOND install is now available for use.
2. If restoration fails, it installs BYOND as normal, then saves the install to a cache. Again, the BYOND install is now available for use.

----

P.S. Since CI is slow on this repo, and I needed to test that this worked before submitting a PR, I've set workflows to run on my fork of the repo, so you can see it in action here: <https://github.com/LikeLakers2/tgstation/actions/workflows/ci_suite.yml> 