### PR TITLE
Fix typo in path for cavesound3.ogg

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(ambience)
 		'sound/items/tools/crowbar.ogg',
 		'sound/items/deconstruct.ogg',
 		'sound/ambience/misc/source_holehit3.ogg',
-		'sound/ambience//misc/cavesound3.ogg',
+		'sound/ambience/misc/cavesound3.ogg',
 	)
 
 /area/station/maintenance/play_ambience(mob/M, sound/override_sound, volume)


### PR DESCRIPTION

## About The Pull Request

Fixed a file path.
## Why It's Good For The Game

It fixes a bug.
## Changelog
:cl:
fix: Typo in path for cavesound3.ogg
/:cl:
