### PR TITLE
Fix shuttle parallax

### DIFF
--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -115,6 +115,8 @@ All ShuttleMove procs go here
 	if(rotation)
 		shuttleRotate(rotation)
 
+	update_parallax_contents()
+
 	return TRUE
 
 /atom/movable/proc/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
@@ -239,7 +241,7 @@ All ShuttleMove procs go here
 	. = ..()
 	if(pipe_vision_img)
 		pipe_vision_img.loc = loc
-		
+
 	var/missing_nodes = FALSE
 	for(var/i in 1 to device_type)
 		if(nodes[i])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes shuttle parallax that was broken as a result of the [PR](https://github.com/tgstation/tgstation/pull/82644).
The problem was that Move would only update after walking and such. The update was forcing Parallax to update when a mob is standing still.

**BEFORE FIX**

https://github.com/user-attachments/assets/f015435e-16d4-44d4-97e5-03d242ddda4c

**AFTER FIX**

https://github.com/user-attachments/assets/22d4e256-54b9-4d8c-93ee-2312f2cabe39

## Why It's Good For The Game
Full immersive gameplay comeback.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed shuttle parallax when a mob is standing still.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
