### PR TITLE
Fix premium & contraband "hidden" discounts

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1444,7 +1444,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 			vend_ready = TRUE
 			return
 
-		if(!proceed_payment(card_used, living_user, item_record, price_to_use))
+		if(!proceed_payment(card_used, living_user, item_record, price_to_use, params["discountless"]))
 			vend_ready = TRUE
 			return
 
@@ -1506,13 +1506,14 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
  * mob_paying - the mob that is trying to purchase the item.
  * product_to_vend - the product record of the item we're trying to vend.
  * price_to_use - price of the item we're trying to vend.
+ * discountless - whether or not to apply discounts
  */
-/obj/machinery/vending/proc/proceed_payment(obj/item/card/id/paying_id_card, mob/living/mob_paying, datum/data/vending_product/product_to_vend, price_to_use)
+/obj/machinery/vending/proc/proceed_payment(obj/item/card/id/paying_id_card, mob/living/mob_paying, datum/data/vending_product/product_to_vend, price_to_use, discountless)
 	if(QDELETED(paying_id_card)) //not available(null) or somehow is getting destroyed
 		speak("You do not possess an ID to purchase [product_to_vend.name].")
 		return FALSE
 	var/datum/bank_account/account = paying_id_card.registered_account
-	if(account.account_job && account.account_job.paycheck_department == payment_department)
+	if(account.account_job && account.account_job.paycheck_department == payment_department && !discountless)
 		price_to_use = max(round(price_to_use * DEPARTMENT_DISCOUNT), 1) //No longer free, but signifigantly cheaper.
 	if(LAZYLEN(product_to_vend.returned_products))
 		price_to_use = 0 //returned items are free

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -304,6 +304,7 @@ const Product = (props) => {
           })
         : act('vend', {
             ref: product.ref,
+            discountless: !!product.premium,
           });
     },
   };


### PR DESCRIPTION

## About The Pull Request
Fixes #89186
Fixes probably an old bug. Discount premium and contraband products in vending machines, was only controlled on the UI side the whole time. That is, a person with enough money to make the buy button active could buy a premium/contraband product at a discount. I'm sure it wasn't intended that way.

I'm not sure if this is the best fix, but it's the single cheapest and easiest one I've found
All because premium and contraband goods, exist only on the interface side, and in the corresponding list of any vendor

## Why It's Good For The Game
Bugs bad

## Changelog

:cl:
fix: Premium and contraband products in vending machines, now really has no discount
/:cl:
