### PR TITLE
Fixes some fuel pool/hotspot CI failures/hard del

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -132,6 +132,8 @@
 	if(!isnull(starting_temperature))
 		temperature = starting_temperature
 	perform_exposure()
+	if(QDELETED(src)) // It is actually possible for this hotspot to become qdeleted in perform_exposure() if another hotspot gets created (for example in fire_act() of fuel pools)
+		return // In this case, we want to just leave and let the new hotspot take over.
 	setDir(pick(GLOB.cardinals))
 	air_update_turf(FALSE, FALSE)
 	var/static/list/loc_connections = list(
@@ -348,7 +350,8 @@
 	SSair.hotspots -= src
 	var/turf/open/T = loc
 	if(istype(T) && T.active_hotspot == src)
-		our_hot_group.remove_from_group(src)
+		if(our_hot_group)
+			our_hot_group.remove_from_group(src)
 		our_hot_group = null
 		T.set_active_hotspot(null)
 	return ..()
@@ -405,6 +408,8 @@
 		return
 
 /datum/hot_group/proc/add_to_group(obj/effect/hotspot/target)
+	if(QDELETED(target))
+		return
 	spot_list += target
 	target.our_hot_group = src
 	var/turf/open/target_turf = target.loc

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -349,10 +349,10 @@
 /obj/effect/hotspot/Destroy()
 	SSair.hotspots -= src
 	var/turf/open/T = loc
-	if(istype(T) && T.active_hotspot == src)
-		if(our_hot_group)
-			our_hot_group.remove_from_group(src)
+	if(our_hot_group)
+		our_hot_group.remove_from_group(src)
 		our_hot_group = null
+	if(istype(T) && T.active_hotspot == src)
 		T.set_active_hotspot(null)
 	return ..()
 
@@ -401,8 +401,9 @@
 /datum/hot_group/proc/remove_from_group(obj/effect/hotspot/target)
 	spot_list -= target
 	var/turf/open/target_turf = target.loc
-	x_coord -= target_turf.x
-	y_coord -= target_turf.y
+	if(target_turf)
+		x_coord -= target_turf.x
+		y_coord -= target_turf.y
 	if(!length(spot_list))
 		qdel(src)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4798
Fixes https://github.com/tgstation/tgstation/issues/87974

Fixes the race condition that lead to both of the above.

Basically what is going on with this, is a second hotspot can potentially be created (through say, `fire_act()` of a fuel pool).

This causes `set_active_hotspot()` to be called before the first one is finished initializing, which results in the first hot spot becoming qdeleted midway through its initialization and causing issues. 

<details><summary>More in-depth explanation</summary>

Hotspot A gets initialized->perform_exposure() is called -> turf's `active_hotspot` is set to hotspot A -> fire_act() creates a second hotspot-Hotspot B

Hotspot B gets initialized now and goes through the same process above, notably qdeleting the previous `active_hotspot`, which is Hotspot A.

Then we return to Hotspot A's `initialize()` where it's now been qdeleted, causing all of these issues.

</details>

Should be fixed now that this special case has been considered.

## Why It's Good For The Game

Less spurious CI failures

## Changelog

Nothing player facing
