### PR TITLE
Fix some list input issues

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
@@ -59,7 +59,9 @@ export const ListInputModal = (props: ListInputModalProps) => {
   // User presses a letter key and searchbar is visible
   const onFocusSearch = () => {
     setSearchBarVisible(false);
-    setSearchBarVisible(true);
+    setTimeout(() => {
+      setSearchBarVisible(true);
+    }, 1);
   };
   // User presses a letter key with no searchbar visible
   const onLetterSearch = (key: number) => {
@@ -181,6 +183,7 @@ const ListDisplay = (props) => {
           <Button
             color="transparent"
             fluid
+            id={index}
             key={index}
             onClick={() => onClick(index)}
             onDoubleClick={(event) => {


### PR DESCRIPTION

## About The Pull Request
The scrollIntoView function uses the ID of the elements, not a single button had its id set any more since the react change, so the elements were not scrolled into view when the arrow keys were used for navigation.

Setting the search bar to false and true without a timeout in between will not refocus it, preventing the user from navigating back with any letter key after focussing the list once.

## Why It's Good For The Game
## Changelog
:cl:
fix: list input scrolls into view again when using the array keys for navigation
fix: Using letter keys while focussing the list focusses the search bar again
/:cl:
