### PR TITLE
Fix supply pod beacon renaming

### DIFF
--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -104,16 +104,16 @@
 	unlink_console()
 	return CLICK_ACTION_SUCCESS
 
-/obj/item/supplypod_beacon/attackby(obj/item/attacking_item, mob/user)
-	. = ..()
-	if(IS_WRITING_UTENSIL(attacking_item))
-		var/new_beacon_name = tgui_input_text(user, "What would you like the tag to be?", "Beacon Tag", max_length = MAX_NAME_LEN)
-		if(isnull(new_beacon_name))
-			return
+/obj/item/supplypod_beacon/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!IS_WRITING_UTENSIL(tool))
+		return NONE
 
-		if(!user.can_perform_action(src) || !user.can_write(attacking_item))
-			return ..()
+	var/new_beacon_name = tgui_input_text(user, "What would you like the tag to be?", "Beacon Tag", max_length = MAX_NAME_LEN)
+	if(isnull(new_beacon_name))
+		return ITEM_INTERACT_BLOCKING
 
-		name = "[initial(name)] ([new_beacon_name])"
-		return
-	return ..()
+	if(!user.can_perform_action(src) || !user.can_write(tool))
+		return ITEM_INTERACT_BLOCKING
+
+	name = "[initial(name)] ([new_beacon_name])"
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -104,12 +104,16 @@
 	unlink_console()
 	return CLICK_ACTION_SUCCESS
 
-/obj/item/supplypod_beacon/attackby(obj/item/W, mob/user)
-	if(IS_WRITING_UTENSIL(W)) //give a tag that is visible from the linked express console
-		return ..()
-	var/new_beacon_name = tgui_input_text(user, "What would you like the tag to be?", "Beacon Tag", max_length = MAX_NAME_LEN)
-	if(isnull(new_beacon_name))
+/obj/item/supplypod_beacon/attackby(obj/item/attacking_item, mob/user)
+	. = ..()
+	if(IS_WRITING_UTENSIL(attacking_item))
+		var/new_beacon_name = tgui_input_text(user, "What would you like the tag to be?", "Beacon Tag", max_length = MAX_NAME_LEN)
+		if(isnull(new_beacon_name))
+			return
+
+		if(!user.can_perform_action(src) || !user.can_write(attacking_item))
+			return ..()
+
+		name = "[initial(name)] ([new_beacon_name])"
 		return
-	if(!user.can_perform_action(src))
-		return
-	name += " ([tag])"
+	return ..()


### PR DESCRIPTION
## About The Pull Request
Fixes supply pod beacon renaming and allow to any writing tool do it.
I ran into this bug when trying to break beacon. Instead of hitting it I started renaming it, it was funny

## Why It's Good For The Game
No more `Supply Pod Beacon #1 () () () ()`
<details><summary> xdd </summary>

![image](https://github.com/user-attachments/assets/94676622-c054-42e0-820e-7282fd86fea4)

</details>


## Changelog

:cl:
fix: You can rename supply pod beacon with a any writing tool.
/:cl:

