### PR TITLE
Supply Consoles restyle & order content preview

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -95,7 +95,7 @@
 	if(!forced && !SSshuttle.initialized) // our quartermaster taught us not to be ashamed of our supply packs
 		SSshuttle.express_consoles += src // specially since they're such a good price and all
 		return // yeah, I see that, your quartermaster gave you good advice
-	 // it gets cheaper when I return it
+	// it gets cheaper when I return it
 	for(var/pack_id in SSshuttle.supply_packs) // mmhm
 		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id] // sometimes, I return it so much, I rip the manifest
 		if(!meme_pack_data[pack.group]) // see, my quartermaster taught me a few things too

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -1,3 +1,4 @@
+#define EXPRESS_EMAG_DISCOUNT 0.72
 #define BEACON_PRINT_COOLDOWN 10 SECONDS
 
 /obj/machinery/computer/cargo/express
@@ -136,6 +137,9 @@
 	data["supplies"] = meme_pack_data
 	return data
 
+/obj/machinery/computer/cargo/express/get_discount()
+	return (obj_flags & EMAGGED) ? EXPRESS_EMAG_DISCOUNT : 1
+
 /obj/machinery/computer/cargo/express/ui_act(action, params, datum/tgui/ui)
 	. = ..()
 	if(.)
@@ -240,4 +244,5 @@
 			update_appearance()
 			return TRUE
 
+#undef EXPRESS_EMAG_DISCOUNT
 #undef BEACON_PRINT_COOLDOWN

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -92,26 +92,17 @@
 
 /obj/machinery/computer/cargo/express/proc/packin_up(forced = FALSE) // oh shit, I'm sorry
 	meme_pack_data = list() // sorry for what?
-	if (!forced && !SSshuttle.initialized) // Subsystem is still sleeping, add ourselves to its buffer and abort
-		SSshuttle.express_consoles += src
-		return
-	for(var/pack in SSshuttle.supply_packs) // our quartermaster taught us not to be ashamed of our supply packs
-		var/datum/supply_pack/P = SSshuttle.supply_packs[pack]  // specially since they're such a good price and all
-		if(!meme_pack_data[P.group]) // yeah, I see that, your quartermaster gave you good advice
-			meme_pack_data[P.group] = list( // it gets cheaper when I return it
-				"name" = P.group, // mmhm
-				"packs" = list()  // sometimes, I return it so much, I rip the manifest
-			) // see, my quartermaster taught me a few things too
-		if((P.hidden) || (P.special)) // like, how not to rip the manifest
-			continue// by using someone else's crate
-		if(P.contraband && !contraband) // will you show me?
-			continue // i'd be right happy to
-		meme_pack_data[P.group]["packs"] += list(list(
-			"name" = P.name,
-			"cost" = P.get_cost() * get_discount(),
-			"id" = pack,
-			"desc" = P.desc || P.name // If there is a description, use it. Otherwise use the pack's name.
-		))
+	if(!forced && !SSshuttle.initialized) // our quartermaster taught us not to be ashamed of our supply packs
+		SSshuttle.express_consoles += src // specially since they're such a good price and all
+		return // yeah, I see that, your quartermaster gave you good advice
+	 // it gets cheaper when I return it
+	for(var/pack_id in SSshuttle.supply_packs) // mmhm
+		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id] // sometimes, I return it so much, I rip the manifest
+		if(!meme_pack_data[pack.group]) // see, my quartermaster taught me a few things too
+			meme_pack_data[pack.group] = list( // like, how not to rip the manifest
+				"name" = pack.group, // by using someone else's crate
+				"packs" = get_packs_data(pack.group, express = TRUE), // will you show me?
+			) // i'd be right happy to
 
 /obj/machinery/computer/cargo/express/ui_data(mob/user)
 	var/canBeacon = beacon && (isturf(beacon.loc) || ismob(beacon.loc))//is the beacon in a valid location?

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -1,4 +1,3 @@
-#define EXPRESS_EMAG_DISCOUNT 0.72
 #define BEACON_PRINT_COOLDOWN 10 SECONDS
 
 /obj/machinery/computer/cargo/express
@@ -137,9 +136,6 @@
 	data["supplies"] = meme_pack_data
 	return data
 
-/obj/machinery/computer/cargo/express/proc/get_discount()
-	return (obj_flags & EMAGGED) ? EXPRESS_EMAG_DISCOUNT : 1
-
 /obj/machinery/computer/cargo/express/ui_act(action, params, datum/tgui/ui)
 	. = ..()
 	if(.)
@@ -244,5 +240,4 @@
 			update_appearance()
 			return TRUE
 
-#undef EXPRESS_EMAG_DISCOUNT
 #undef BEACON_PRINT_COOLDOWN

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -1,3 +1,5 @@
+#define EXPRESS_EMAG_DISCOUNT 0.72
+
 /obj/machinery/computer/cargo
 	name = "supply console"
 	desc = "Used to order supplies, approve requests, and control the shuttle."
@@ -193,7 +195,7 @@
 		var/obj/structure/closet/crate/crate = pack.crate_type
 		packs += list(list(
 			"name" = pack.name,
-			"cost" = pack.get_cost(),
+			"cost" = pack.get_cost() * (express ? get_discount() : 1),
 			"id" = pack_id,
 			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
 			"crate_icon" = crate?.icon,
@@ -217,6 +219,9 @@
 		))
 
 	return contains
+
+/obj/machinery/computer/cargo/proc/get_discount()
+	return (obj_flags & EMAGGED) ? EXPRESS_EMAG_DISCOUNT : 1
 
 /**
  * adds an supply pack to the checkout cart
@@ -486,3 +491,5 @@
 
 	var/datum/signal/status_signal = new(list("command" = command))
 	frequency.post_signal(src, status_signal)
+
+#undef EXPRESS_EMAG_DISCOUNT

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -173,6 +173,11 @@
 
 	return data
 
+/**
+ * returns a list of supply packs for a certain group
+ * * group - the group of packs to return
+ * * express - if this is an express console
+ */
 /obj/machinery/computer/cargo/proc/get_packs_data(group, express = FALSE)
 	var/list/packs = list()
 	for(var/pack_id in SSshuttle.supply_packs)
@@ -206,6 +211,10 @@
 
 	return packs
 
+/**
+ * returns a list of the contents of a supply pack
+ * * pack - the pack to get the contents of
+ */
 /obj/machinery/computer/cargo/proc/get_pack_contains(datum/supply_pack/pack)
 	var/list/contains = list()
 	for(var/obj/item/item as anything in pack.contains)
@@ -218,6 +227,10 @@
 
 	return contains
 
+/**
+ * returns the discount multiplier applied to all supply packs,
+ * the discount is calculated as follows: pack_cost * get_discount()
+ */
 /obj/machinery/computer/cargo/proc/get_discount()
 	return 1
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -95,9 +95,9 @@
 	var/list/data = list()
 	data["department"] = "Cargo" // Hardcoded here, for customization in budgetordering.dm AKA NT IRN
 	data["location"] = SSshuttle.supply.getStatusText()
-	var/datum/bank_account/D = SSeconomy.get_dep_account(cargo_account)
-	if(D)
-		data["points"] = D.account_balance
+	var/datum/bank_account/bank = SSeconomy.get_dep_account(cargo_account)
+	if(bank)
+		data["points"] = bank.account_balance
 	data["grocery"] = SSshuttle.chef_groceries.len
 	data["away"] = SSshuttle.supply.getDockedId() == docking_away
 	data["self_paid"] = self_paid
@@ -206,7 +206,7 @@
 
 	return packs
 
-/obj/machinery/computer/cargo/proc/get_pack_contains(var/datum/supply_pack/pack)
+/obj/machinery/computer/cargo/proc/get_pack_contains(datum/supply_pack/pack)
 	var/list/contains = list()
 	for(var/obj/item/item as anything in pack.contains)
 		contains += list(list(

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -204,8 +204,8 @@
 	for(var/obj/item/item as anything in pack.contains)
 		contains += list(list(
 			"name" = item.name,
-			"icon" = item.icon,
-			"icon_state" = item.icon_state,
+			"icon" = item.greyscale_config ? null : item.icon,
+			"icon_state" = item.greyscale_config ? null : item.icon_state,
 			"amount" = pack.contains[item],
 		))
 	return contains

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -173,14 +173,21 @@
 
 	return data
 
-/obj/machinery/computer/cargo/proc/get_packs_data(group)
+/obj/machinery/computer/cargo/proc/get_packs_data(group, express = FALSE)
 	var/list/packs = list()
 	for(var/pack_id in SSshuttle.supply_packs)
 		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
 		if(pack.group != group)
 			continue
 
-		if((pack.hidden && !(obj_flags & EMAGGED)) || (pack.contraband && !contraband) || (pack.special && !pack.special_enabled) || pack.drop_pod_only)
+		// Express console packs check
+		if(express && (pack.hidden || pack.special))
+			continue
+
+		if((pack.hidden && !(obj_flags & EMAGGED)) || (pack.special && !pack.special_enabled) || pack.drop_pod_only)
+			continue
+
+		if(pack.contraband && !contraband)
 			continue
 
 		var/obj/structure/closet/crate/crate = pack.crate_type
@@ -189,8 +196,8 @@
 			"cost" = pack.get_cost(),
 			"id" = pack_id,
 			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
-			"crate_icon" = crate.icon,
-			"crate_icon_state" = crate.icon_state,
+			"crate_icon" = crate?.icon,
+			"crate_icon_state" = crate?.icon_state,
 			"goody" = pack.goody,
 			"access" = pack.access,
 			"contraband" = pack.contraband,
@@ -206,8 +213,9 @@
 			"name" = item.name,
 			"icon" = item.greyscale_config ? null : item.icon,
 			"icon_state" = item.greyscale_config ? null : item.icon_state,
-			"amount" = pack.contains[item],
+			"amount" = pack.contains[item]
 		))
+
 	return contains
 
 /**

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -1,5 +1,3 @@
-#define EXPRESS_EMAG_DISCOUNT 0.72
-
 /obj/machinery/computer/cargo
 	name = "supply console"
 	desc = "Used to order supplies, approve requests, and control the shuttle."
@@ -195,7 +193,7 @@
 		var/obj/structure/closet/crate/crate = pack.crate_type
 		packs += list(list(
 			"name" = pack.name,
-			"cost" = pack.get_cost() * (express ? get_discount() : 1),
+			"cost" = pack.get_cost() * get_discount(),
 			"id" = pack_id,
 			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
 			"crate_icon" = crate?.icon,
@@ -221,7 +219,7 @@
 	return contains
 
 /obj/machinery/computer/cargo/proc/get_discount()
-	return (obj_flags & EMAGGED) ? EXPRESS_EMAG_DISCOUNT : 1
+	return 1
 
 /**
  * adds an supply pack to the checkout cart
@@ -491,5 +489,3 @@
 
 	var/datum/signal/status_signal = new(list("command" = command))
 	frequency.post_signal(src, status_signal)
-
-#undef EXPRESS_EMAG_DISCOUNT

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -190,14 +190,14 @@
 		if(pack.contraband && !contraband)
 			continue
 
-		var/obj/structure/closet/crate/crate = pack.crate_type
+		var/obj/item/first_item = length(pack.contains) > 0 ? pack.contains[1] : null
 		packs += list(list(
 			"name" = pack.name,
 			"cost" = pack.get_cost() * get_discount(),
 			"id" = pack_id,
 			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
-			"crate_icon" = crate?.icon,
-			"crate_icon_state" = crate?.icon_state,
+			"first_item_icon" = first_item?.icon,
+			"first_item_icon_state" = first_item?.icon_state,
 			"goody" = pack.goody,
 			"access" = pack.access,
 			"contraband" = pack.contraband,

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -184,7 +184,7 @@
 		if(express && (pack.hidden || pack.special))
 			continue
 
-		if((pack.hidden && !(obj_flags & EMAGGED)) || (pack.special && !pack.special_enabled) || pack.drop_pod_only)
+		if(!express && ((pack.hidden && !(obj_flags & EMAGGED)) || (pack.special && !pack.special_enabled) || pack.drop_pod_only))
 			continue
 
 		if(pack.contraband && !contraband)

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
@@ -11,7 +11,6 @@ import {
 import { formatMoney } from 'tgui-core/format';
 
 import { useBackend } from '../../backend';
-import { CargoCartButtons } from './CargoButtons';
 import { CargoData } from './types';
 
 export function CargoCart(props) {
@@ -23,13 +22,13 @@ export function CargoCart(props) {
   return (
     <Stack fill vertical>
       <Stack.Item grow>
-        <Section fill scrollable title="Cart" buttons={<CargoCartButtons />}>
+        <Section fill scrollable>
           <CheckoutItems />
         </Section>
       </Stack.Item>
       {cart.length > 0 && !!can_send && (
-        <Stack.Item>
-          <Section align="right">
+        <Stack.Item m={0}>
+          <Section>
             <Stack fill align="center">
               <Stack.Item grow>
                 {!sendable && <Icon color="blue" name="toolbox" spin />}
@@ -82,25 +81,24 @@ function CheckoutItems(props) {
           <Table.Cell>{entry.object}</Table.Cell>
 
           <Table.Cell width={11}>
-            {can_send && entry.can_be_cancelled ? (
-              <RestrictedInput
-                width={5}
-                minValue={0}
-                maxValue={max_order}
-                value={entry.amount}
-                onEnter={(e, value) =>
-                  act('modify', {
-                    order_name: entry.object,
-                    amount: value,
-                  })
-                }
-              />
-            ) : (
-              <Input width="40px" value={entry.amount} disabled />
-            )}
-
-            {!!can_send && !!entry.can_be_cancelled && (
+            {!!can_send && !!entry.can_be_cancelled ? (
               <>
+                <Button
+                  icon="minus"
+                  onClick={() => act('remove', { order_name: entry.object })}
+                />
+                <RestrictedInput
+                  width={5}
+                  minValue={0}
+                  maxValue={max_order}
+                  value={entry.amount}
+                  onEnter={(e, value) =>
+                    act('modify', {
+                      order_name: entry.object,
+                      amount: value,
+                    })
+                  }
+                />
                 <Button
                   icon="plus"
                   disabled={amount_by_name[entry.object] >= max_order}
@@ -108,11 +106,9 @@ function CheckoutItems(props) {
                     act('add_by_name', { order_name: entry.object })
                   }
                 />
-                <Button
-                  icon="minus"
-                  onClick={() => act('remove', { order_name: entry.object })}
-                />
               </>
+            ) : (
+              <Input width="40px" value={entry.amount} disabled />
             )}
           </Table.Cell>
 

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
@@ -28,10 +28,12 @@ export function CargoCart(props) {
       </Stack.Item>
       {cart.length > 0 && !!can_send && (
         <Stack.Item m={0}>
-          <Section>
+          <Section textAlign="right">
             <Stack fill align="center">
               <Stack.Item grow>
-                {!sendable && <Icon color="blue" name="toolbox" spin />}
+                {!sendable && (
+                  <Icon mr={0.5} size={1.5} color="blue" name="toolbox" spin />
+                )}
               </Stack.Item>
               <Stack.Item>
                 <Button

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -1,21 +1,20 @@
 import { sortBy } from 'common/collections';
 import { Dispatch, useMemo, useState } from 'react';
 import {
+  BlockQuote,
   Button,
   Icon,
+  ImageButton,
+  Modal,
   Section,
   Stack,
   Tabs,
   Tooltip,
-  ImageButton,
-  Modal,
-  BlockQuote,
 } from 'tgui-core/components';
 import { formatMoney } from 'tgui-core/format';
 
-import { SearchBar } from '../common/SearchBar';
 import { useBackend, useSharedState } from '../../backend';
-import { CargoCartButtons } from './CargoButtons';
+import { SearchBar } from '../common/SearchBar';
 import { searchForSupplies } from './helpers';
 import { CargoData, Supply, SupplyCategory } from './types';
 
@@ -24,8 +23,8 @@ type Props = {
 };
 
 export function CargoCatalog(props: Props) {
-  const { express } = props;
   const { data } = useBackend<CargoData>();
+  const { express } = props;
 
   const supplies = Object.values(data.supplies);
   const [showContents, setShowContents] = useState('');
@@ -62,9 +61,9 @@ export function CargoCatalog(props: Props) {
           closeContents={setShowContents}
         />
       )}
-      <Section fill title="Catalog" buttons={!express && <CargoCartButtons />}>
-        <Stack fill>
-          <Stack.Item grow>
+      <Stack fill>
+        <Stack.Item grow mr={-1.33}>
+          <Section fill>
             <CatalogTabs
               activeSupplyName={activeSupplyName}
               categories={supplies}
@@ -72,13 +71,15 @@ export function CargoCatalog(props: Props) {
               setActiveSupplyName={setActiveSupplyName}
               setSearchText={setSearchText}
             />
-          </Stack.Item>
-          <Stack.Divider />
-          <Stack.Item grow={express ? 2 : 3}>
+          </Section>
+        </Stack.Item>
+        <Stack.Divider />
+        <Stack.Item grow={express ? 2 : 3} m={0}>
+          <Section fill scrollable>
             <CatalogList packs={packs} openContents={setShowContents} />
-          </Stack.Item>
-        </Stack>
-      </Section>
+          </Section>
+        </Stack.Item>
+      </Stack>
     </>
   );
 }
@@ -126,7 +127,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
           }}
         />
       </Stack.Item>
-      <Stack.Item grow overflowY="auto" overflowX="hidden">
+      <Stack.Item grow p={1} m={-1} mt={2} overflowY={'auto'}>
         <Tabs vertical>
           <Tabs.Tab
             key="search_results"
@@ -182,7 +183,7 @@ function CatalogList(props: CatalogListProps) {
   const { packs = [], openContents } = props;
 
   return (
-    <Section fill scrollable>
+    <>
       {packs.map((pack) => {
         let color = '';
         const digits = Math.floor(Math.log10(pack.cost) + 1);
@@ -268,7 +269,7 @@ function CatalogList(props: CatalogListProps) {
           </ImageButton>
         );
       })}
-    </Section>
+    </>
   );
 }
 
@@ -285,22 +286,24 @@ function CatalogPackInfo(props: CatalogContentsProps) {
 
   return (
     <Modal p={1} width={'50vw'} height={'50vh'}>
-      <Section
-        fill
-        title={`${name}`}
-        buttons={
-          <Button
-            icon={'close'}
-            color={'bad'}
-            onClick={() => closeContents('')}
-          />
-        }
-      >
-        <Stack fill vertical>
-          <Stack.Item>
+      <Stack fill vertical>
+        <Stack.Item>
+          <Section
+            fill
+            title={`${name}`}
+            buttons={
+              <Button
+                icon={'close'}
+                color={'bad'}
+                onClick={() => closeContents('')}
+              />
+            }
+          >
             <BlockQuote>{pack?.desc || 'No description available.'}</BlockQuote>
-          </Stack.Item>
-          <Stack.Item grow overflowY="auto" overflowX="hidden">
+          </Section>
+        </Stack.Item>
+        <Stack.Item m={0} grow>
+          <Section fill scrollable>
             {(contains?.length ?? 0) ? (
               contains?.map((item) => (
                 <ImageButton
@@ -326,14 +329,14 @@ function CatalogPackInfo(props: CatalogContentsProps) {
                   />
                 </Stack.Item>
                 <Stack.Item mt={2} color={'label'} textAlign={'center'}>
-                  We can't find information about even the approximate contents
-                  of this order.
+                  {`We can't find information about even the approximate contents
+                  of this order.`}
                 </Stack.Item>
               </Stack>
             )}
-          </Stack.Item>
-        </Stack>
-      </Section>
+          </Section>
+        </Stack.Item>
+      </Stack>
     </Modal>
   );
 }

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -3,16 +3,17 @@ import { Dispatch, useMemo, useState } from 'react';
 import {
   Button,
   Icon,
-  Input,
   Section,
   Stack,
   Tabs,
   Tooltip,
   ImageButton,
   Modal,
+  BlockQuote,
 } from 'tgui-core/components';
 import { formatMoney } from 'tgui-core/format';
 
+import { SearchBar } from '../common/SearchBar';
 import { useBackend, useSharedState } from '../../backend';
 import { CargoCartButtons } from './CargoButtons';
 import { searchForSupplies } from './helpers';
@@ -124,32 +125,23 @@ function CatalogTabs(props: CatalogTabsProps) {
   return (
     <Stack fill vertical>
       <Stack.Item>
-        <Stack align="center">
-          <Stack.Item>
-            <Icon name="search" />
-          </Stack.Item>
-          <Stack.Item grow>
-            <Input
-              fluid
-              placeholder="Search..."
-              value={searchText}
-              onInput={(e, value) => {
-                if (value === searchText) {
-                  return;
-                }
+        <SearchBar
+          query={searchText}
+          onSearch={(value) => {
+            if (value === searchText) {
+              return;
+            }
 
-                if (value.length) {
-                  // Start showing results
-                  setActiveSupplyName('search_results');
-                } else if (activeSupplyName === 'search_results') {
-                  // return to normal category
-                  setActiveSupplyName(sorted[0]?.name);
-                }
-                setSearchText(value);
-              }}
-            />
-          </Stack.Item>
-        </Stack>
+            if (value.length) {
+              // Start showing results
+              setActiveSupplyName('search_results');
+            } else if (activeSupplyName === 'search_results') {
+              // return to normal category
+              setActiveSupplyName(sorted[0]?.name);
+            }
+            setSearchText(value);
+          }}
+        />
       </Stack.Item>
       <Stack.Item grow overflowY="auto" overflowX="hidden">
         <Tabs vertical>
@@ -170,10 +162,10 @@ function CatalogTabs(props: CatalogTabsProps) {
                 setSearchText('');
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Stack justify={'space-between'}>
                 <span>{supply.name}</span>
                 <span> {supply.packs.length}</span>
-              </div>
+              </Stack>
             </Tabs.Tab>
           ))}
         </Tabs>
@@ -274,12 +266,10 @@ type CatalogContentsProps = {
 
 function CatalogPackInfo(props: CatalogContentsProps) {
   const { name, packs, closeContents } = props;
-  const [activeTab, setActiveTab] = useState('contents');
-
   const pack = packs.find((pack) => pack.name === name);
 
   return (
-    <Modal p={0} width={'50vw'} height={'50vh'}>
+    <Modal p={1} width={'50vw'} height={'50vh'}>
       <Section
         fill
         title={`${name}`}
@@ -293,39 +283,23 @@ function CatalogPackInfo(props: CatalogContentsProps) {
       >
         <Stack fill vertical>
           <Stack.Item>
-            <Tabs>
-              <Tabs.Tab
-                selected={activeTab === 'contents'}
-                onClick={() => setActiveTab('contents')}
-              >
-                Contents
-              </Tabs.Tab>
-              <Tabs.Tab
-                selected={activeTab === 'description'}
-                onClick={() => setActiveTab('description')}
-              >
-                Description
-              </Tabs.Tab>
-            </Tabs>
+            <BlockQuote>{pack?.desc || 'No description available.'}</BlockQuote>
           </Stack.Item>
-          <Stack.Item grow mt={0} overflowY="auto">
-            {activeTab === 'contents' &&
-              pack?.contains?.map((item) => (
-                <ImageButton
-                  key={item.name}
-                  fluid
-                  dmIcon={item.icon}
-                  dmIconState={item.icon_state}
-                  imageSize={32}
-                >
-                  <Stack fill>
-                    <Stack.Item textAlign="left">{item.name}</Stack.Item>
-                    {!!item.amount && <Stack.Item>x{item.amount}</Stack.Item>}
-                  </Stack>
-                </ImageButton>
-              ))}
-            {activeTab === 'description' &&
-              (pack?.desc || 'No description available.')}
+          <Stack.Item grow overflowY="auto" overflowX="hidden">
+            {pack?.contains?.map((item) => (
+              <ImageButton
+                key={item.name}
+                fluid
+                dmIcon={item.icon}
+                dmIconState={item.icon_state}
+                imageSize={32}
+              >
+                <Stack fill>
+                  <Stack.Item textAlign="left">{item.name}</Stack.Item>
+                  {!!item.amount && <Stack.Item>x{item.amount}</Stack.Item>}
+                </Stack>
+              </ImageButton>
+            ))}
           </Stack.Item>
         </Stack>
       </Section>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -297,8 +297,8 @@ function CatalogPackInfo(props: CatalogContentsProps) {
         </Stack.Item>
         <Stack.Item m={0} grow>
           <Section fill scrollable>
-            {(contains?.length ?? 0) ? (
-              contains?.map((item) => (
+            {contains && contains.length > 0 ? (
+              contains.map((item) => (
                 <ImageButton
                   key={item.name}
                   fluid

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -1,5 +1,5 @@
 import { sortBy } from 'common/collections';
-import { Dispatch, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useMemo, useState } from 'react';
 import {
   BlockQuote,
   Button,
@@ -175,7 +175,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
 
 type CatalogListProps = {
   packs: SupplyCategory['packs'];
-  openContents: Dispatch<string>;
+  openContents: Dispatch<SetStateAction<string>>;
 };
 
 function CatalogList(props: CatalogListProps) {
@@ -273,7 +273,7 @@ function CatalogList(props: CatalogListProps) {
 
 type CatalogContentsProps = {
   name: string;
-  closeContents: Dispatch<string>;
+  closeContents: Dispatch<SetStateAction<string>>;
   packs: SupplyCategory['packs'];
 };
 
@@ -288,7 +288,7 @@ function CatalogPackInfo(props: CatalogContentsProps) {
         <Stack.Item>
           <Section
             fill
-            title={`${name}`}
+            title={name}
             buttons={
               <Button
                 icon={'close'}

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -128,7 +128,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
           }}
         />
       </Stack.Item>
-      <Stack.Item grow p={1} m={-1} mt={1} overflowY={'auto'}>
+      <Stack.Item grow p={1} m={-1} mt={1} overflowY="auto">
         <Tabs vertical>
           <Tabs.Tab
             key="search_results"
@@ -147,7 +147,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
                 setSearchText('');
               }}
             >
-              <Stack justify={'space-between'}>
+              <Stack justify="space-between">
                 <span>{supply.name}</span>
                 <span> {supply.packs.length}</span>
               </Stack>
@@ -162,8 +162,8 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
             color={self_paid ? 'caution' : 'transparent'}
             icon={self_paid ? 'check-square-o' : 'square-o'}
             onClick={() => act('toggleprivate')}
-            tooltip={'Use your own funds to purchase items.'}
-            tooltipPosition={'top'}
+            tooltip="Use your own funds to purchase items."
+            tooltipPosition="top"
           >
             Buy Privately
           </Button>
@@ -243,13 +243,8 @@ function CatalogList(props: CatalogListProps) {
                   </Stack>
                 </Stack.Item>
               )}
-              <Stack.Item align={'center'} width={5.5} mt={-0.75} mb={-0.75}>
-                <Stack
-                  vertical
-                  color={'gold'}
-                  lineHeight={0.75}
-                  fontSize={0.85}
-                >
+              <Stack.Item align="center" width={5.5} mt={-0.75} mb={-0.75}>
+                <Stack vertical color="gold" lineHeight={0.75} fontSize={0.85}>
                   <Stack.Item
                     opacity={privateBuy && 0.75}
                     style={{ textDecoration: privateBuy && 'red line-through' }}
@@ -283,7 +278,7 @@ function CatalogPackInfo(props: CatalogContentsProps) {
   const contains = pack?.contains;
 
   return (
-    <Modal p={1} width={'50vw'} height={'50vh'}>
+    <Modal p={1} width="50vw" height="50vh">
       <Stack fill vertical>
         <Stack.Item>
           <Section
@@ -291,8 +286,8 @@ function CatalogPackInfo(props: CatalogContentsProps) {
             title={name}
             buttons={
               <Button
-                icon={'close'}
-                color={'bad'}
+                icon="close"
+                color="bad"
                 onClick={() => closeContents('')}
               />
             }
@@ -311,7 +306,7 @@ function CatalogPackInfo(props: CatalogContentsProps) {
                   dmIconState={item.icon_state}
                   buttonsAlt={
                     !!item.amount && (
-                      <Stack.Item backgroundColor={'rgba(255, 255, 255, 0.1'}>
+                      <Stack.Item backgroundColor="rgba(255, 255, 255, 0.1">
                         x{item.amount}
                       </Stack.Item>
                     )
@@ -324,15 +319,11 @@ function CatalogPackInfo(props: CatalogContentsProps) {
                 </ImageButton>
               ))
             ) : (
-              <Stack fill vertical align={'center'} justify={'center'}>
+              <Stack fill vertical align="center" justify="center">
                 <Stack.Item>
-                  <Icon
-                    name={'triangle-exclamation'}
-                    size={6}
-                    color={'orange'}
-                  />
+                  <Icon name="triangle-exclamation" size={6} color="orange" />
                 </Stack.Item>
-                <Stack.Item mt={2} color={'label'} textAlign={'center'}>
+                <Stack.Item mt={2} color="label" textAlign="center">
                   {`We can't find information about even the approximate contents
                   of this order.`}
                 </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -189,9 +189,9 @@ function CatalogList(props: CatalogListProps) {
         let color = '';
         const digits = Math.floor(Math.log10(pack.cost) + 1);
         if (self_paid) {
-          color = 'orange';
-        } else if (digits >= 5 && digits <= 6) {
           color = 'yellow';
+        } else if (digits >= 5 && digits <= 6) {
+          color = 'orange';
         } else if (digits > 6) {
           color = 'bad';
         }

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -65,6 +65,7 @@ export function CargoCatalog(props: Props) {
         <Stack.Item grow mr={-1.33}>
           <Section fill>
             <CatalogTabs
+              express={express}
               activeSupplyName={activeSupplyName}
               categories={supplies}
               searchText={searchText}
@@ -127,7 +128,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
           }}
         />
       </Stack.Item>
-      <Stack.Item grow p={1} m={-1} mt={2} overflowY={'auto'}>
+      <Stack.Item grow p={1} m={-1} mt={1} overflowY={'auto'}>
         <Tabs vertical>
           <Tabs.Tab
             key="search_results"

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -309,11 +309,17 @@ function CatalogPackInfo(props: CatalogContentsProps) {
                   fluid
                   dmIcon={item.icon}
                   dmIconState={item.icon_state}
+                  buttonsAlt={
+                    !!item.amount && (
+                      <Stack.Item backgroundColor={'rgba(255, 255, 255, 0.1'}>
+                        x{item.amount}
+                      </Stack.Item>
+                    )
+                  }
                   imageSize={32}
                 >
                   <Stack fill>
                     <Stack.Item textAlign="left">{item.name}</Stack.Item>
-                    {!!item.amount && <Stack.Item>x{item.amount}</Stack.Item>}
                   </Stack>
                 </ImageButton>
               ))

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -209,8 +209,8 @@ function CatalogList(props: CatalogListProps) {
           <ImageButton
             key={pack.id}
             fluid
-            dmIcon={pack.crate_icon}
-            dmIconState={pack.crate_icon_state}
+            dmIcon={pack.first_item_icon}
+            dmIconState={pack.first_item_icon_state}
             imageSize={32}
             color={color}
             disabled={(amount_by_name[pack.name] || 0) >= max_order}

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -17,7 +17,6 @@ import { useBackend, useSharedState } from '../../backend';
 import { SearchBar } from '../common/SearchBar';
 import { searchForSupplies } from './helpers';
 import { CargoData, Supply, SupplyCategory } from './types';
-import { logger } from '../../logging';
 
 type Props = {
   express?: boolean;

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -17,6 +17,7 @@ import { useBackend, useSharedState } from '../../backend';
 import { SearchBar } from '../common/SearchBar';
 import { searchForSupplies } from './helpers';
 import { CargoData, Supply, SupplyCategory } from './types';
+import { logger } from '../../logging';
 
 type Props = {
   express?: boolean;
@@ -197,10 +198,17 @@ function CatalogList(props: CatalogListProps) {
         }
 
         const privateBuy = (self_paid && !pack.goody) || app_cost;
+        const tooltipIcon = (content: string, icon: string, color: string) => (
+          <Stack.Item>
+            <Tooltip content={content}>
+              <Icon color={color} name={icon} />
+            </Tooltip>
+          </Stack.Item>
+        );
 
         return (
           <ImageButton
-            key={pack.name}
+            key={pack.id}
             fluid
             dmIcon={pack.crate_icon}
             dmIconState={pack.crate_icon_state}
@@ -226,21 +234,14 @@ function CatalogList(props: CatalogListProps) {
               </Stack.Item>
               {(!!pack.small_item || !!pack.access || !!pack.contraband) && (
                 <Stack.Item>
-                  {!!pack.small_item && (
-                    <Tooltip content="Small Item">
-                      <Icon color="purple" name="compress-alt" />
-                    </Tooltip>
-                  )}
-                  {!!pack.access && (
-                    <Tooltip content="Restricted">
-                      <Icon color="average" name="lock" />
-                    </Tooltip>
-                  )}
-                  {!!pack.contraband && (
-                    <Tooltip content="Contraband">
-                      <Icon color="bad" name="pastafarianism" />
-                    </Tooltip>
-                  )}
+                  <Stack reverse>
+                    {!!pack.small_item &&
+                      tooltipIcon('Small Item', 'compress-alt', 'purple')}
+                    {!!pack.access &&
+                      tooltipIcon('Restricted', 'lock', 'average')}
+                    {!!pack.contraband &&
+                      tooltipIcon('Contraband', 'pastafarianism', 'bad')}
+                  </Stack>
                 </Stack.Item>
               )}
               <Stack.Item align={'center'} width={5.5} mt={-0.75} mb={-0.75}>
@@ -251,11 +252,8 @@ function CatalogList(props: CatalogListProps) {
                   fontSize={0.85}
                 >
                   <Stack.Item
-                    style={
-                      privateBuy
-                        ? { textDecoration: 'red line-through', opacity: 0.75 }
-                        : undefined
-                    }
+                    opacity={privateBuy && 0.75}
+                    style={{ textDecoration: privateBuy && 'red line-through' }}
                   >
                     {formatMoney(pack.cost)} cr
                   </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoExpress.tsx
@@ -10,9 +10,9 @@ import {
 } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 
-import { useBackend } from '../backend';
-import { Window } from '../layouts';
-import { CargoCatalog } from './Cargo/CargoCatalog';
+import { useBackend } from '../../backend';
+import { Window } from '../../layouts';
+import { CargoCatalog } from './CargoCatalog';
 
 type Data = {
   locked: BooleanLike;

--- a/tgui/packages/tgui/interfaces/Cargo/CargoRequests.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoRequests.tsx
@@ -10,22 +10,7 @@ export function CargoRequests(props) {
   const { requests = [], requestonly, can_send, can_approve_requests } = data;
 
   return (
-    <Section
-      fill
-      scrollable
-      title="Active Requests"
-      buttons={
-        !requestonly && (
-          <Button
-            icon="times"
-            color="transparent"
-            onClick={() => act('denyall')}
-          >
-            Clear
-          </Button>
-        )
-      }
-    >
+    <Section fill scrollable>
       {requests.length === 0 && <NoticeBox success>No Requests</NoticeBox>}
       {requests.length > 0 && (
         <Table>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoStatus.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoStatus.tsx
@@ -30,7 +30,7 @@ export function CargoStatus(props) {
     <Section
       title={department}
       buttons={
-        <Box inline bold verticalAlign={'middle'}>
+        <Box inline bold verticalAlign="middle">
           <AnimatedNumber
             value={points}
             format={(value) => formatMoney(value)}

--- a/tgui/packages/tgui/interfaces/Cargo/CargoStatus.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoStatus.tsx
@@ -30,7 +30,7 @@ export function CargoStatus(props) {
     <Section
       title={department}
       buttons={
-        <Box inline bold>
+        <Box inline bold verticalAlign={'middle'}>
           <AnimatedNumber
             value={points}
             format={(value) => formatMoney(value)}

--- a/tgui/packages/tgui/interfaces/Cargo/index.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/index.tsx
@@ -28,9 +28,7 @@ export function Cargo(props) {
 
 export function CargoContent(props) {
   const { data } = useBackend<CargoData>();
-
   const { cart = [], requests = [], requestonly } = data;
-
   const [tab, setTab] = useSharedState('cargotab', TAB.Catalog);
 
   let amount = 0;
@@ -44,7 +42,7 @@ export function CargoContent(props) {
         <CargoStatus />
       </Stack.Item>
       <Stack.Item>
-        <Tabs fluid>
+        <Tabs fluid textAlign="center">
           <Tabs.Tab
             icon="list"
             selected={tab === TAB.Catalog}
@@ -71,6 +69,7 @@ export function CargoContent(props) {
                 Checkout ({amount})
               </Tabs.Tab>
               <Tabs.Tab
+                style={{ flexGrow: 0 }}
                 icon="question"
                 selected={tab === TAB.Help}
                 onClick={() => setTab(TAB.Help)}

--- a/tgui/packages/tgui/interfaces/Cargo/index.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/index.tsx
@@ -42,7 +42,7 @@ export function CargoContent(props) {
         <CargoStatus />
       </Stack.Item>
       <Stack.Item>
-        <Tabs fluid textAlign="center">
+        <Tabs fluid>
           <Tabs.Tab
             icon="list"
             selected={tab === TAB.Catalog}
@@ -69,7 +69,6 @@ export function CargoContent(props) {
                 Checkout ({amount})
               </Tabs.Tab>
               <Tabs.Tab
-                style={{ flexGrow: 0 }}
                 icon="question"
                 selected={tab === TAB.Help}
                 onClick={() => setTab(TAB.Help)}

--- a/tgui/packages/tgui/interfaces/Cargo/index.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/index.tsx
@@ -1,7 +1,9 @@
-import { Stack, Tabs } from 'tgui-core/components';
+import { Button, Section, Stack, Tabs } from 'tgui-core/components';
+import { toTitleCase } from 'tgui-core/string';
 
 import { useBackend, useSharedState } from '../../backend';
 import { Window } from '../../layouts';
+import { CargoCartButtons } from './CargoButtons';
 import { CargoCart } from './CargoCart';
 import { CargoCatalog } from './CargoCatalog';
 import { CargoHelp } from './CargoHelp';
@@ -11,7 +13,7 @@ import { CargoData } from './types';
 
 enum TAB {
   Catalog = 'catalog',
-  Requests = 'requests',
+  Requests = 'active requests',
   Cart = 'cart',
   Help = 'help',
 }
@@ -27,7 +29,7 @@ export function Cargo(props) {
 }
 
 export function CargoContent(props) {
-  const { data } = useBackend<CargoData>();
+  const { act, data } = useBackend<CargoData>();
   const { cart = [], requests = [], requestonly } = data;
   const [tab, setTab] = useSharedState('cargotab', TAB.Catalog);
 
@@ -42,44 +44,66 @@ export function CargoContent(props) {
         <CargoStatus />
       </Stack.Item>
       <Stack.Item>
-        <Tabs fluid>
-          <Tabs.Tab
-            icon="list"
-            selected={tab === TAB.Catalog}
-            onClick={() => setTab(TAB.Catalog)}
-          >
-            Catalog
-          </Tabs.Tab>
-          <Tabs.Tab
-            icon="envelope"
-            textColor={tab !== TAB.Requests && requests.length > 0 && 'yellow'}
-            selected={tab === TAB.Requests}
-            onClick={() => setTab(TAB.Requests)}
-          >
-            Requests ({requests.length})
-          </Tabs.Tab>
-          {!requestonly && (
+        <Section
+          title={toTitleCase(tab || '')}
+          buttons={
             <>
-              <Tabs.Tab
-                icon="shopping-cart"
-                textColor={tab !== TAB.Cart && amount > 0 && 'yellow'}
-                selected={tab === TAB.Cart}
-                onClick={() => setTab(TAB.Cart)}
-              >
-                Checkout ({amount})
-              </Tabs.Tab>
-              <Tabs.Tab
-                icon="question"
-                selected={tab === TAB.Help}
-                onClick={() => setTab(TAB.Help)}
-              >
-                Help
-              </Tabs.Tab>
+              {tab === TAB.Requests && !requestonly && (
+                <Button
+                  icon="times"
+                  color="transparent"
+                  onClick={() => act('denyall')}
+                >
+                  Clear
+                </Button>
+              )}
+              {(tab === TAB.Catalog || tab === TAB.Cart) && (
+                <CargoCartButtons />
+              )}
             </>
-          )}
-        </Tabs>
+          }
+        >
+          <Tabs fluid m={-1}>
+            <Tabs.Tab
+              icon="list"
+              selected={tab === TAB.Catalog}
+              onClick={() => setTab(TAB.Catalog)}
+            >
+              Catalog
+            </Tabs.Tab>
+            <Tabs.Tab
+              icon="envelope"
+              textColor={
+                tab !== TAB.Requests && requests.length > 0 && 'yellow'
+              }
+              selected={tab === TAB.Requests}
+              onClick={() => setTab(TAB.Requests)}
+            >
+              Requests ({requests.length})
+            </Tabs.Tab>
+            {!requestonly && (
+              <>
+                <Tabs.Tab
+                  icon="shopping-cart"
+                  textColor={tab !== TAB.Cart && amount > 0 && 'yellow'}
+                  selected={tab === TAB.Cart}
+                  onClick={() => setTab(TAB.Cart)}
+                >
+                  Checkout ({amount})
+                </Tabs.Tab>
+                <Tabs.Tab
+                  icon="question"
+                  selected={tab === TAB.Help}
+                  onClick={() => setTab(TAB.Help)}
+                >
+                  Help
+                </Tabs.Tab>
+              </>
+            )}
+          </Tabs>
+        </Section>
       </Stack.Item>
-      <Stack.Item grow mt={0}>
+      <Stack.Item grow m={0}>
         {tab === TAB.Catalog && <CargoCatalog />}
         {tab === TAB.Requests && <CargoRequests />}
         {tab === TAB.Cart && <CargoCart />}

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -31,8 +31,8 @@ export type Supply = {
   access: BooleanLike;
   cost: number;
   desc: string;
-  crate_icon: string;
-  crate_icon_state: string;
+  crate_icon: string | null;
+  crate_icon_state: string | null;
   goody: BooleanLike;
   id: string;
   name: string;

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -31,11 +31,21 @@ export type Supply = {
   access: BooleanLike;
   cost: number;
   desc: string;
+  crate_icon: string;
+  crate_icon_state: string;
   goody: BooleanLike;
   id: string;
   name: string;
   small_item: BooleanLike;
   contraband: BooleanLike;
+  contains: SupplyItem[];
+};
+
+type SupplyItem = {
+  name: string;
+  icon: string;
+  icon_state: string;
+  amount: number;
 };
 
 type CartEntry = {

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -31,8 +31,8 @@ export type Supply = {
   access: BooleanLike;
   cost: number;
   desc: string;
-  crate_icon: string | null;
-  crate_icon_state: string | null;
+  first_item_icon: string | null;
+  first_item_icon_state: string | null;
   goody: BooleanLike;
   id: string;
   name: string;

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -43,8 +43,8 @@ export type Supply = {
 
 type SupplyItem = {
   name: string;
-  icon: string;
-  icon_state: string;
+  icon: string | null;
+  icon_state: string | null;
   amount: number;
 };
 

--- a/tgui/packages/tgui/interfaces/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/CargoExpress.tsx
@@ -10,9 +10,9 @@ import {
 } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 
-import { useBackend } from '../../backend';
-import { Window } from '../../layouts';
-import { CargoCatalog } from './CargoCatalog';
+import { useBackend } from '../backend';
+import { Window } from '../layouts';
+import { CargoCatalog } from './Cargo/CargoCatalog';
 
 type Data = {
   locked: BooleanLike;

--- a/tgui/packages/tgui/interfaces/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/CargoExpress.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   LabeledList,
   Section,
+  Stack,
 } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 
@@ -30,9 +31,17 @@ export function CargoExpress(props) {
 
   return (
     <Window width={600} height={700}>
-      <Window.Content scrollable>
-        <InterfaceLockNoticeBox accessText="a Cargo Technician-level ID card" />
-        {!locked && <CargoExpressContent />}
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <InterfaceLockNoticeBox accessText="a Cargo Technician-level ID card" />
+          </Stack.Item>
+          {!locked && (
+            <Stack.Item grow m={0}>
+              <CargoExpressContent />
+            </Stack.Item>
+          )}
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -52,36 +61,43 @@ function CargoExpressContent(props) {
   } = data;
 
   return (
-    <>
-      <Section
-        title="Cargo Express"
-        buttons={
-          <Box inline bold>
-            <AnimatedNumber value={Math.round(points)} />
-            {' credits'}
-          </Box>
-        }
-      >
-        <LabeledList>
-          <LabeledList.Item label="Landing Location">
-            <Button selected={!using_beacon} onClick={() => act('LZCargo')}>
-              Cargo Bay
-            </Button>
-            <Button
-              selected={using_beacon}
-              disabled={!hasBeacon}
-              onClick={() => act('LZBeacon')}
-            >
-              {beaconzone} ({beaconName})
-            </Button>
-            <Button disabled={!canBuyBeacon} onClick={() => act('printBeacon')}>
-              {printMsg}
-            </Button>
-          </LabeledList.Item>
-          <LabeledList.Item label="Notice">{message}</LabeledList.Item>
-        </LabeledList>
-      </Section>
-      <CargoCatalog express />
-    </>
+    <Stack fill vertical>
+      <Stack.Item>
+        <Section
+          title="Cargo Express"
+          buttons={
+            <Box inline bold>
+              <AnimatedNumber value={Math.round(points)} />
+              {' credits'}
+            </Box>
+          }
+        >
+          <LabeledList>
+            <LabeledList.Item label="Landing Location">
+              <Button selected={!using_beacon} onClick={() => act('LZCargo')}>
+                Cargo Bay
+              </Button>
+              <Button
+                selected={using_beacon}
+                disabled={!hasBeacon}
+                onClick={() => act('LZBeacon')}
+              >
+                {beaconzone} ({beaconName})
+              </Button>
+              <Button
+                disabled={!canBuyBeacon}
+                onClick={() => act('printBeacon')}
+              >
+                {printMsg}
+              </Button>
+            </LabeledList.Item>
+            <LabeledList.Item label="Notice">{message}</LabeledList.Item>
+          </LabeledList>
+        </Section>
+      </Stack.Item>
+      <Stack.Item grow m={0}>
+        <CargoCatalog express />
+      </Stack.Item>
+    </Stack>
   );
 }

--- a/tgui/packages/tgui/interfaces/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/CargoExpress.tsx
@@ -2,11 +2,11 @@ import {
   AnimatedNumber,
   Box,
   Button,
+  Icon,
   LabeledList,
+  NoticeBox,
   Section,
   Stack,
-  NoticeBox,
-  Icon,
 } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 

--- a/tgui/packages/tgui/interfaces/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/CargoExpress.tsx
@@ -5,13 +5,14 @@ import {
   LabeledList,
   Section,
   Stack,
+  NoticeBox,
+  Icon,
 } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 import { CargoCatalog } from './Cargo/CargoCatalog';
-import { InterfaceLockNoticeBox } from './common/InterfaceLockNoticeBox';
 
 type Data = {
   locked: BooleanLike;
@@ -19,29 +20,41 @@ type Data = {
   using_beacon: BooleanLike;
   beaconzone: string;
   beaconName: string;
+  beaconError: BooleanLike;
   canBuyBeacon: BooleanLike;
   hasBeacon: BooleanLike;
+  canBeacon: BooleanLike;
   printMsg: string;
   message: string;
 };
 
 export function CargoExpress(props) {
   const { data } = useBackend<Data>();
-  const { locked } = data;
+  const { beaconError, canBeacon, message, locked } = data;
 
   return (
     <Window width={600} height={700}>
       <Window.Content>
-        <Stack fill vertical>
-          <Stack.Item>
-            <InterfaceLockNoticeBox accessText="a Cargo Technician-level ID card" />
-          </Stack.Item>
-          {!locked && (
+        {locked ? (
+          <Section fill>
+            <Stack fill vertical textAlign={'center'} justify={'center'}>
+              <Stack.Item bold color={'red'}>
+                <Icon mb={3} name={'lock'} size={7.5} />
+                <br />
+                {`Swipe a Cargo Technician-level ID card to unlock this interface.`}
+              </Stack.Item>
+            </Stack>
+          </Section>
+        ) : (
+          <Stack fill vertical>
+            <NoticeBox color={beaconError || !canBeacon ? 'red' : 'blue'}>
+              {message}
+            </NoticeBox>
             <Stack.Item grow m={0}>
               <CargoExpressContent />
             </Stack.Item>
-          )}
-        </Stack>
+          </Stack>
+        )}
       </Window.Content>
     </Window>
   );
@@ -51,7 +64,6 @@ function CargoExpressContent(props) {
   const { act, data } = useBackend<Data>();
   const {
     hasBeacon,
-    message,
     points,
     using_beacon,
     beaconzone,
@@ -66,7 +78,7 @@ function CargoExpressContent(props) {
         <Section
           title="Cargo Express"
           buttons={
-            <Box inline bold>
+            <Box inline bold verticalAlign={'middle'}>
               <AnimatedNumber value={Math.round(points)} />
               {' credits'}
             </Box>
@@ -80,9 +92,10 @@ function CargoExpressContent(props) {
               <Button
                 selected={using_beacon}
                 disabled={!hasBeacon}
+                tooltip={beaconzone}
                 onClick={() => act('LZBeacon')}
               >
-                {beaconzone} ({beaconName})
+                {beaconName}
               </Button>
               <Button
                 disabled={!canBuyBeacon}
@@ -91,7 +104,6 @@ function CargoExpressContent(props) {
                 {printMsg}
               </Button>
             </LabeledList.Item>
-            <LabeledList.Item label="Notice">{message}</LabeledList.Item>
           </LabeledList>
         </Section>
       </Stack.Item>


### PR DESCRIPTION
## About The Pull Request
In a nutshell, everything will be visible in the `Demo` section.
But if you want some details...

- Filling of static_data was divided into procs, for better understanding and possibility to use the same actions in two order consoles
- Added an image of the first item in crate at each order (almost)
- Added the ability to see what is inside an order, the information is not always accurate due to the nature of some orders such as random hats
- Slightly remaked layout, making everything look more cohesive and eliminating the empty space at the bottom of the screen
- When buying anonymously, the original price does not disappear, but is crossed out, and the new price is written below it

## Demo
<details><summary> Screenshots </summary>

Supply Console
| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/6067fc76-de5a-4d32-929a-239074514767) | ![image](https://github.com/user-attachments/assets/81b3ab2a-f6d6-4f7a-8fff-0d5f459bcef9) |

Express Console
| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/934554e5-ec42-422f-b6ce-f66a137bd280) | ![image](https://github.com/user-attachments/assets/0d00c364-eece-4aa4-8f7d-f40ab7b9bb27) |

Other 
| Content preview | Express login | 
| - | - |
| ![image](https://github.com/user-attachments/assets/62b3374e-5f46-4113-9da9-f481aa25739c) | ![image](https://github.com/user-attachments/assets/8468f191-a5da-4de4-86f1-e0aca10256b3) |

</details>

<details><summary> Video </summary>

https://github.com/user-attachments/assets/c7e16206-39f5-413c-9eea-c0284350c4a3

</details>

## Why It's Good For The Game
More convenience plus a bit prettier.
The ability to view the contents of an order, even if some madman didn't describe its contents in the description (those who did this are really crazy)
Section with tabs scrolls on both 515 and 516
And little cleaner data receiving code

## Changelog

:cl:
qol: Supply console got little redesign, and ability to see what can be inside a order.
code: Supply console and express supply console, now use a unified method of acquiring data
/:cl:

