### PR TITLE
Unregister noticeable AI controller when it unpossesses mob

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_ai_controller.dm
+++ b/code/__DEFINES/dcs/signals/signals_ai_controller.dm
@@ -1,6 +1,8 @@
 
 ///sent from ai controllers when they possess a pawn: (datum/ai_controller/source_controller)
 #define COMSIG_AI_CONTROLLER_POSSESSED_PAWN "ai_controller_possessed_pawn"
+///sent from ai controllers when they stop possessing a pawn: (datum/ai_controller/source_controller)
+#define COMSIG_AI_CONTROLLER_UNPOSSESSED_PAWN "ai_controller_unpossessed_pawn"
 ///sent from ai controllers when they pick behaviors: (list/datum/ai_behavior/old_behaviors, list/datum/ai_behavior/new_behaviors)
 #define COMSIG_AI_CONTROLLER_PICKED_BEHAVIORS "ai_controller_picked_behaviors"
 ///sent from ai controllers when a behavior is inserted into the queue: (list/new_arguments)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -294,6 +294,7 @@ multiple modular subtrees with behaviors
 	if(isnull(pawn))
 		return // instantiated without an applicable pawn, fine
 
+	SEND_SIGNAL(src, COMSIG_AI_CONTROLLER_UNPOSSESSED_PAWN)
 	set_ai_status(AI_STATUS_OFF)
 	UnregisterSignal(pawn, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_MOB_LOGIN, COMSIG_MOB_LOGOUT, COMSIG_MOB_STATCHANGE, COMSIG_QDELETING))
 	clear_able_to_run()

--- a/code/datums/elements/ai_control_examine.dm
+++ b/code/datums/elements/ai_control_examine.dm
@@ -18,10 +18,11 @@
 	var/datum/ai_controller/target_controller = target
 	src.noticable_organ_examines = noticable_organ_examines
 	RegisterSignal(target_controller, COMSIG_AI_CONTROLLER_POSSESSED_PAWN, PROC_REF(on_ai_controller_possessed_pawn))
+	RegisterSignal(target_controller, COMSIG_AI_CONTROLLER_UNPOSSESSED_PAWN, PROC_REF(on_ai_controller_unpossessed_pawn))
 
 /datum/element/ai_control_examine/Detach(datum/ai_controller/target_controller)
 	. = ..()
-	UnregisterSignal(target_controller, COMSIG_AI_CONTROLLER_POSSESSED_PAWN)
+	UnregisterSignal(target_controller, list(COMSIG_AI_CONTROLLER_POSSESSED_PAWN, COMSIG_AI_CONTROLLER_UNPOSSESSED_PAWN))
 	if(target_controller.pawn && ishuman(target_controller.pawn))
 		UnregisterSignal(target_controller.pawn, COMSIG_ORGAN_IMPLANTED)
 
@@ -50,3 +51,24 @@
 	var/examine_text = noticable_organ_examines[organ_slot]
 	var/body_zone = organ_slot != ORGAN_SLOT_BRAIN ? noticable_organ.zone : null
 	noticable_organ.AddElement(/datum/element/noticable_organ/ai_control, examine_text, body_zone)
+
+/// Signal when the ai controller stops possessing a pawn, either it's deleted or it got moved to another pawn for some reason
+/datum/element/ai_control_examine/proc/on_ai_controller_unpossessed_pawn(datum/ai_controller/source_controller)
+	SIGNAL_HANDLER
+	if(!ishuman(source_controller.pawn))
+		return
+
+	var/mob/living/carbon/human/human_pawn = source_controller.pawn
+
+	for(var/organ_slot_key in noticable_organ_examines)
+		var/obj/item/organ/found = human_pawn.get_organ_slot(organ_slot_key)
+		if(!found)
+			continue
+		make_organ_uninteresting(organ_slot_key, found, human_pawn)
+
+	UnregisterSignal(human_pawn, COMSIG_ORGAN_IMPLANTED)
+
+/datum/element/ai_control_examine/proc/make_organ_uninteresting(organ_slot, obj/item/organ/noticable_organ, mob/living/carbon/human/human_pawn)
+	var/examine_text = noticable_organ_examines[organ_slot]
+	var/body_zone = organ_slot != ORGAN_SLOT_BRAIN ? noticable_organ.zone : null
+	noticable_organ.RemoveElement(/datum/element/noticable_organ/ai_control, examine_text, body_zone)

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -18,12 +18,6 @@
 	SSmobs.cubemonkeys -= src
 	return ..()
 
-/mob/living/carbon/human/species/monkey/proc/make_angry()
-	if(!isnull(ai_controller))
-		QDEL_NULL(ai_controller)
-
-	new /datum/ai_controller/monkey/angry(src)
-
 /mob/living/carbon/human/species/monkey/angry
 	ai_controller = /datum/ai_controller/monkey/angry
 

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -18,6 +18,12 @@
 	SSmobs.cubemonkeys -= src
 	return ..()
 
+/mob/living/carbon/human/species/monkey/proc/make_angry()
+	if(!isnull(ai_controller))
+		QDEL_NULL(ai_controller)
+
+	new /datum/ai_controller/monkey/angry(src)
+
 /mob/living/carbon/human/species/monkey/angry
 	ai_controller = /datum/ai_controller/monkey/angry
 


### PR DESCRIPTION
## About The Pull Request

Fixes #89161
Basically this element just didn't clean up after itself.
If the AI controller it is assigned to is destroyed or reassigned, it will uncreate any elements it had assigned to any organs on the pawn too.

## Changelog

not player facing as far as I know