### PR TITLE
Fix hand teleporter random dangerous location

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -234,7 +234,7 @@
 				continue //putting them at the edge is dumb
 			if(dangerous_turf.y > world.maxy - PORTAL_DANGEROUS_EDGE_LIMIT || dangerous_turf.y < PORTAL_DANGEROUS_EDGE_LIMIT)
 				continue
-			if(!check_teleport_valid(src, teleport_location))
+			if(!check_teleport_valid(src, dangerous_turf))
 				continue
 			dangerous_turfs += dangerous_turf
 


### PR DESCRIPTION
## About The Pull Request

Fixes #89199
Loop was checking if `teleport_location` was a valid teleport destination, however at time of dangerous teleport loop that value contains a string, we only set it after the loop. We check the iterated turf instead.

## Changelog

:cl:
fix: You can once again teleport dangerously with the hand teleporter
/:cl:
