### PR TITLE
Add spaceacillin pills to survival boxes

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -12,6 +12,8 @@
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
 	/// What medipen should be present in this box?
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
+	/// What medical pill should be present in this box?
+	var/pill_type = /obj/item/reagent_containers/pill/antiviral
 	/// Are we crafted?
 	var/crafted = FALSE
 
@@ -35,6 +37,9 @@
 
 	if(!isnull(medipen_type))
 		new medipen_type(src)
+
+	if(!isnull(pill_type))
+		new pill_type(src)
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -142,6 +142,13 @@
 	list_reagents = list(/datum/reagent/medicine/mannitol = 15)
 	rename_with_volume = TRUE
 
+/obj/item/reagent_containers/pill/antiviral
+	name = "spaceacillin pill"
+	desc = "Used to suppress the symptoms of disease."
+	icon_state = "pill1"
+	list_reagents = list(/datum/reagent/medicine/spaceacillin = 6)
+	rename_with_volume = TRUE
+
 /obj/item/reagent_containers/pill/sansufentanyl
 	name = "sansufentanyl pill"
 	desc = "Used to treat Hereditary Manifold Sickness. Temporary side effects include - nausea, dizziness, impaired motor coordination."


### PR DESCRIPTION

## About The Pull Request
Takes the "add spaceacillin pills to survival boxes" part from #89062
It's a 6u spaceacillin pill, which should last for ~5 minutes.
## Why It's Good For The Game
Compare the player's possible early response to catching a virus to other environmental hazards:
Plasma flood ->find a fire closet, grab an oxygen tank and firesuit
Depressurized atmosphere -> get internals from your survival box, get out of the depressurized zone
Catch a virus -> ???
This change gives players an option, an early response to mitigate the virus's effects.
## Changelog
:cl: hyperjll, zoomachina
add: survival boxes now contain a spaceacillin pill
/:cl:
