### PR TITLE
Fix regen mesh

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -225,9 +225,9 @@
 
 /// Checks if the wound is in a state that ointment or flesh will help
 /datum/wound/burn/flesh/proc/can_be_ointmented_or_meshed()
-	if(infestation > 0 || sanitization < infestation)
+	if(infestation > 0 && sanitization < infestation)
 		return TRUE
-	if(flesh_damage > 0 || flesh_healing <= flesh_damage)
+	if(flesh_damage > 0 && flesh_healing <= flesh_damage)
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -270,7 +270,7 @@
 				if(!brute_to_heal && stop_bleeding) // no brute, no bleeding
 					carbon_patient.balloon_alert(user, "[affecting.plaintext_zone] is not bleeding or bruised!")
 				else if(!burn_to_heal && (flesh_regeneration || sanitization) && any_burn_wound) // no burns, existing burn wounds are treated
-					carbon_patient.balloon_alert(user, "[affecting.plaintext_zone] has been fully treated!")
+					carbon_patient.balloon_alert(user, "[affecting.plaintext_zone] is fully treated, give it time!")
 				else if(!affecting.brute_dam && !affecting.burn_dam) // not hurt at all
 					carbon_patient.balloon_alert(user, "[affecting.plaintext_zone] is not hurt!")
 				else // probably hurt in some way but we are not the right item for this


### PR DESCRIPTION
## About The Pull Request

Fixes #89007

The conditionals were messed up - Burn wound sanitation / flesh healing heals the wound over time so it's not like these would reasonably drop to zero while meshing them. 

## Changelog

:cl: Melbert
fix: Regen meshes stop when they've done all they can again
/:cl:


