### PR TITLE
Fixes crafting menu not changing the cursor when hovered over

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -137,6 +137,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "craft"
 	screen_loc = ui_crafting
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/area_creator
 	name = "create new area"


### PR DESCRIPTION

## About The Pull Request

Closes #89206

## Changelog
:cl:
fix: Fixed crafting menu not changing the cursor when hovered over
/:cl:
