### PR TITLE
Fixes evidence bag not reverting to tiny size after dumping its contents out

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -62,9 +62,7 @@
 	SIGNAL_HANDLER
 
 	if(!atom_storage.get_total_weight())
-		return
-
-	update_weight_class(WEIGHT_CLASS_TINY)
+		update_weight_class(WEIGHT_CLASS_TINY)
 
 /obj/item/evidencebag/attack_self(mob/user)
 	if(!atom_storage.get_total_weight())


### PR DESCRIPTION

## About The Pull Request

Closes #89217

## Changelog
:cl:
fix: Fixed evidence bag not reverting to tiny size after dumping its contents out
/:cl:
