### PR TITLE
Improvements to the Syndicate Lavaland base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1596,6 +1596,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3328,8 +3328,6 @@
 /obj/item/ammo_box/magazine/m9mm,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Jr" = (
@@ -4144,8 +4142,6 @@
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Vb" = (
@@ -4523,8 +4519,6 @@
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Zw" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3329,6 +3329,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Jr" = (
@@ -4144,6 +4145,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Vb" = (
@@ -4522,6 +4524,7 @@
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Zw" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2169,6 +2169,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
+"sB" = (
+/obj/structure/sign/warning/secure_area,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/cargo)
 "sH" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen"
@@ -3322,8 +3326,8 @@
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/machinery/airalarm/directional/north,
-/obj/item/crowbar/red,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Jr" = (
@@ -3654,6 +3658,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
+"Oj" = (
+/obj/structure/sign/warning/secure_area,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/arrivals)
 "Oq" = (
 /obj/effect/spawner/random/vending/colavend{
 	hacked = 1
@@ -4133,8 +4141,8 @@
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/machinery/airalarm/directional/north,
-/obj/item/crowbar/red,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Vb" = (
@@ -4512,7 +4520,7 @@
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/crowbar/red,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_lava_base/dormitories)
 "Zw" = (
@@ -5331,7 +5339,7 @@ Vb
 mT
 mT
 mT
-oF
+Oj
 ab
 ab
 ab
@@ -6654,7 +6662,7 @@ ab
 ab
 ab
 ab
-fx
+sB
 gh
 fx
 si

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -667,6 +667,9 @@
 /area/ruin/syndicate_lava_base/chemistry)
 "fx" = (
 /obj/structure/sign/warning/secure_area,
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
+	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/syndicate_lava_base/cargo)
 "fA" = (
@@ -1866,6 +1869,9 @@
 /area/ruin/syndicate_lava_base/arrivals)
 "oF" = (
 /obj/structure/sign/warning/secure_area,
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
+	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/syndicate_lava_base/arrivals)
 "oH" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_1.dmm
@@ -135,6 +135,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/telecomms)
+"R" = (
+/obj/structure/filingcabinet/medical,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/telecomms)
 "U" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -216,7 +220,7 @@ f
 (6,1,1) = {"
 a
 e
-c
+R
 Z
 m
 C

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_3.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_3.dmm
@@ -41,6 +41,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/closet/cardboard,
+/obj/item/modular_computer/pda/chameleon/broken{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/telecomms)
 "m" = (
@@ -63,7 +67,7 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/telecomms)
 "q" = (
-/obj/structure/girder,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/syndicate_lava_base/telecomms)
 "r" = (
@@ -75,16 +79,12 @@
 /area/ruin/syndicate_lava_base/telecomms)
 "t" = (
 /obj/structure/sign/poster/contraband/syndiemoth/directional/west,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom";
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/phone{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/obj/item/paper/monitorkey{
+	pixel_x = 5
 	},
 /turf/open/floor/iron/grimy,
 /area/ruin/syndicate_lava_base/telecomms)
@@ -99,6 +99,7 @@
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_fredrickleft"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/telecomms)
 "y" = (
@@ -112,16 +113,21 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/syndicate_lava_base/telecomms)
 "z" = (
-/obj/item/modular_computer/pda/chameleon/broken{
-	pixel_x = 5;
-	pixel_y = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/food/cherrycupcake{
 	pixel_x = -7;
 	pixel_y = 13
 	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Syndicate Radio Intercom";
+	pixel_y = 5
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/phone{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/syndicate_lava_base/telecomms)
 "A" = (
@@ -189,6 +195,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/filingcabinet/security,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/telecomms)
 "K" = (
@@ -199,6 +206,7 @@
 "O" = (
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/filingcabinet/medical,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/telecomms)
 "P" = (

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -309,6 +309,8 @@
 	shoes = /obj/item/clothing/shoes/combat
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_hand = /obj/item/gun/ballistic/rifle/sniper_rifle
+	belt = /obj/item/storage/belt/utility/full
+	glasses = /obj/item/clothing/glasses/welding/up
 
 	implants = list(/obj/item/implant/weapons_auth)
 
@@ -320,6 +322,8 @@
 	suit = /obj/item/clothing/suit/armor/vest
 	mask = /obj/item/clothing/mask/chameleon/gps
 	r_hand = /obj/item/melee/energy/sword/saber
+	belt = /obj/item/storage/belt/utility/full
+	glasses = /obj/item/clothing/glasses/welding/up
 
 /datum/outfit/lavaland_syndicate/comms/icemoon
 	name = "Icemoon Syndicate Comms Agent"

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -112,7 +112,7 @@
 	name = "Lava powered RTG"
 	desc = "This device only works when exposed to the toxic fumes of Lavaland"
 	circuit = null
-	power_gen = 1500
+	power_gen = 20000
 	anchored = TRUE
 	resistance_flags = LAVA_PROOF
 


### PR DESCRIPTION

## About The Pull Request

Makes the Lavaland Syndicate base more sustainable without its crew.
Now, two more turrets guard previously unchecked access points, so miners have to put some effort in something other than crossing the lava.
On top of that, RTGs now generate 20kW of power, same as abductor and debug ones, removing the need for the turbine to be set up every time.
Finally, the Syndicate agents inside now get a full mechanical toolbox in their rooms, so they can break out if a miner managed to enter the base and wall off their rooms.

On top of all that, a message monitoring console has been added to the only telecomms random room that didn't have it, and its atmosphere has been sealed off from outside (which it wasn't for some reason).
Finally, a single defibrillator has been added to the medbay

## Why It's Good For The Game

The base, despite being a decent ghost spawn, would be borderline unrecoverable if it didn't get crew early in the shift.
Power-wise, the RTG output was insufficient, and APCs would start losing power, until the entire base was practically non-functional. Setting the turbine at this point was also marginally harder than before, which made getting out of the powerless state unnecessarily hard.

Talking about the turbine, it's a deathtrap if the crew doesn't know what they're doing. It not being necessary anymore would help the operator stay alive and be able to do whatever they joined to do.

And now, even if you do die, you can be revived by your comrades with the new defibrillator available in the base's medbay.

On the topic of defenses, it was rather easy for a miner with an RCD or a lava boat to cross the lake, take all the loot with minimal effort, and wall the agents inside. This is now slightly harder due to the additional turrets.
On top of that, if a miner does manage to break in and take everything, a simple wall won't lock the operatives in anymore, since they now have tools to break out.

Finally, the changes to the telecomms random rooms seek to let the comms agents do roughly the same things, most importantly, mess with the PDA messages.

## Changelog

:cl:
map: The Syndicate Lavaland base has been generally improved, with more defenses and comms equipment.
/:cl:

