### PR TITLE
Fixes quirks page not updating on changing tabs

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -313,7 +313,11 @@ export function QuirksPage(props) {
     data.character_preferences.non_contextual.random_body !==
       RandomSetting.Disabled || randomToggleEnabled;
 
-  const [selectedQuirks, setSelectedQuirks] = useState(data.selected_quirks);
+  const selectedQuirks = data.selected_quirks;
+  function setSelectedQuirks(selected_quirks) {
+    data.selected_quirks = selected_quirks;
+  }
+
   const [searchQuery, setSearchQuery] = useState('');
   const server_data = useServerPrefs();
   if (!server_data) return;


### PR DESCRIPTION
## About The Pull Request

I believe this is an overlooked victim of the past react refactors that got rid of `UseLocalState`. `UseState` is not enough here because as soon as the tab is swapped, the state is lost. We should instead just be writing directly to the `PreferencesMenuData` which maintains its state across all the tabs.

## Why It's Good For The Game

Having to close the entire prefs window to get your quirks to display properly was kind of annoying.

<details><summary>Before (resets to the initial quirks list upon tabbing back)</summary>

![BUgwBGAFoo](https://github.com/user-attachments/assets/1bbacdfb-023b-42d9-a0d9-ed0fcc47023f)

</details>

<details><summary>After (now your changes are accurately reflected)</summary>

![5wnPrrlxic](https://github.com/user-attachments/assets/14790f8c-eb8e-45fe-95d9-f6af3b7a28dc)

</details>

## Changelog

:cl:
fix: changes made in quirks menu will now reflect properly upon tabbing away and then back again to the quirks tab, without having to close the entire preferences menu
/:cl:
