### PR TITLE
Fixes MOD holster having required slots which prevent it from working without basically fully deploying anyway

### DIFF
--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -112,7 +112,6 @@
 	incompatible_modules = list(/obj/item/mod/module/holster)
 	cooldown_time = 0.5 SECONDS
 	allow_flags = MODULE_ALLOW_INACTIVE
-	required_slots = list(ITEM_SLOT_OCLOTHING|ITEM_SLOT_GLOVES|ITEM_SLOT_FEET)
 	/// Gun we have holstered.
 	var/obj/item/gun/holstered
 


### PR DESCRIPTION

## About The Pull Request

Originally, this module could be activated while the core was inactive. Now, it doesn't because it needs you to deploy the vast majority of your modsuit even while inactive. Kind of lame.

This corrects that so you can still deploy your firearm without the suit being more or less deployed.

## Why It's Good For The Game

Looks like a copy-paste job to me. Or not understanding what this module was. Hard to say.

## Changelog
:cl:
fix: Allows MOD holsters to once again activate while the modsuit is inactive and undeployed.
/:cl:
