### PR TITLE
Fixes crusher damage tracking not fully working

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -31,7 +31,7 @@
 	SIGNAL_HANDLER
 
 	if(istype(attacking_item, /obj/item/kinetic_crusher))
-		total_damage += (-1 * damage_dealt)
+		total_damage += damage_dealt
 
 /datum/status_effect/syphon_mark
 	id = "syphon_mark"


### PR DESCRIPTION

## About The Pull Request

Closes #87550
Partially handles #73887 (not the trophy damage part)

damage_dealt is positive here, dealing damage with direct crusher swings sent it into negatives

## Changelog
:cl:
fix: Fixed crusher trophies dropping rarer than intended, or sometimes not dropping at all
/:cl:
