### PR TITLE
Fixes another fishy CI runtime

### DIFF
--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -63,7 +63,8 @@
 /obj/item/fish/starfish/chrystarfish/set_status(new_status, silent)
 	. = ..()
 	if(new_status == FISH_DEAD)
-		new fillet_type(get_turf(src))
+		if(fillet_type)
+			new fillet_type(get_turf(src))
 		playsound(src, SFX_SHATTER, 50)
 		qdel(src)
 

--- a/code/modules/fishing/fish_mount.dm
+++ b/code/modules/fishing/fish_mount.dm
@@ -74,7 +74,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/fish_mount/proc/add_first_fish()
-	var/obj/item/fish/fish_path = pick(subtypesof(/obj/item/fish) - typesof(/obj/item/fish/holo))
+	var/obj/item/fish/fish_path = pick(subtypesof(/obj/item/fish) - list(typesof(/obj/item/fish/holo) + list(/obj/item/fish/starfish/chrystarfish))) // chrystarfish immediately shatters when placed
 	if(fish_path.fish_id_redirect_path)
 		fish_path = fish_path.fish_id_redirect_path
 	var/fluff_name = pick("John Trasen III", "a nameless intern", "Pun Pun", AQUARIUM_COMPANY, "Unknown", "Central Command")


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/07e97f86-fc15-4d0b-8b36-ffa100525efc)

Fish trophies from persistence are meant to be dusted and thus drop no fillet. So we always need to be checking that we actually have a `fillet_type` before attempting to create one. Just fixes one spot that wasn't doing that.

## Why It's Good For The Game

Annoying CI failures for no reason begone.

## Changelog

:cl: 
fix: due to a number of complaints of fish explosions, chrystarfish will no longer be chosen as the random starting fish for the  fish mount.
/:cl: