### PR TITLE
Fixes timestamp logging being timezone sensitive

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -6,10 +6,8 @@
 	var/time_string = time2text(world.timeofday, format)
 	return show_ds ? "[time_string]:[world.timeofday % 10]" : time_string
 
-/proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
-	if(!wtime)
-		wtime = world.time
-	return time2text(wtime - GLOB.timezoneOffset, format)
+/proc/gameTimestamp(format = "hh:mm:ss", wtime=world.time)
+	return time2text(wtime, format)
 
 /proc/station_time(display_only = FALSE, wtime=world.time)
 	return ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/c59bb0eb-74bd-4403-943e-5bc4b56794a7)

![image](https://github.com/user-attachments/assets/13605368-30dd-47e3-87bb-ade13bb5e7fb)

## Changelog
:cl:
fix: fixed timestamps being timezone sensitive
admin: due to this bug some logs may have been timestamped incorrectly
/:cl:
