### PR TITLE
Wiki books opens a page in-game again

### DIFF
--- a/code/game/objects/items/wiki_manuals.dm
+++ b/code/game/objects/items/wiki_manuals.dm
@@ -1,5 +1,31 @@
 // Wiki books that are linked to the configured wiki link.
 
+/// The size of the window that the wiki books open in.
+#define BOOK_WINDOW_BROWSE_SIZE "970x710"
+/// This macro will resolve to code that will open up the associated wiki page in the window.
+#define WIKI_PAGE_IFRAME(wikiurl, link_identifier) {"
+	<html>
+	<head>
+	<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+	<style>
+		iframe {
+			display: none;
+		}
+	</style>
+	</head>
+	<body>
+	<script type="text/javascript">
+		function pageloaded(myframe) {
+			document.getElementById("loading").style.display = "none";
+			myframe.style.display = "inline";
+	}
+	</script>
+	<p id='loading'>You start skimming through the manual...</p>
+	<iframe width='100%' height='97%' onload="pageloaded(this)" src="[##wikiurl]/[##link_identifier]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+	</body>
+	</html>
+	"}
+
 // A book that links to the wiki
 /obj/item/book/manual/wiki
 	starting_content = "Nanotrasen presently does not have any resources on this topic. If you would like to know more, contact your local Central Command representative." // safety
@@ -12,9 +38,12 @@
 		user.balloon_alert(user, "this book is empty!")
 		return
 	credit_book_to_reader(user)
-	if(tgui_alert(user, "This book's page will open in your browser. Are you sure?", "Open The Wiki", list("Yes", "No")) != "Yes")
-		return
-	usr << link("[wiki_url]/[page_link]")
+	if(user.client.byond_version < 516) //Remove this once 516 is stable
+		if(tgui_alert(user, "This book's page will open in your browser. Are you sure?", "Open The Wiki", list("Yes", "No")) != "Yes")
+			return
+		DIRECT_OUTPUT(user, link("[wiki_url]/[page_link]"))
+	else
+		DIRECT_OUTPUT(user, browse(WIKI_PAGE_IFRAME(wiki_url, page_link), "window=manual;size=[BOOK_WINDOW_BROWSE_SIZE]")) // if you change this GUARANTEE that it works.
 
 /obj/item/book/manual/wiki/chemistry
 	name = "Chemistry Textbook"
@@ -198,3 +227,6 @@
 	starting_author = "Nanotrasen Edu-tainment Division"
 	starting_title = "Tactical Game Cards - Player's Handbook"
 	page_link = "Tactical_Game_Cards"
+
+#undef BOOK_WINDOW_BROWSE_SIZE
+#undef WIKI_PAGE_IFRAME


### PR DESCRIPTION
## About The Pull Request

Wiki is currently down but this should work once it's back.
If you're on 516 or above it will open the page in-game, if you're still on 515 then it'll do the old behavior from the PR linked in the why it's good for the game section.

## Why It's Good For The Game

In https://github.com/tgstation/tgstation/pull/86891 this was removed "Until 516 with webview2 releases", well it's here now so we're fvckin back

## Changelog

:cl:
qol: The wiki books for users on 516 no longer opens the page on an external website on your browser.
/:cl: