### PR TITLE
Use `STATUS_EFFECT_PRIORITY` for fire handler status effects

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -5,6 +5,7 @@
 	status_type = STATUS_EFFECT_REFRESH //Custom code
 	on_remove_on_mob_delete = TRUE
 	tick_interval = 2 SECONDS
+	processing_speed = STATUS_EFFECT_PRIORITY
 	/// Current amount of stacks we have
 	var/stacks
 	/// Maximum of stacks that we could possibly get


### PR DESCRIPTION

## About The Pull Request

This sets the processing subsystem for `/datum/status_effect/fire_handler` to use `STATUS_EFFECT_PRIORITY` (`SSpriority_effects`)

## Why It's Good For The Game

I'd say being on fire is classified under "certain status effects that'd fuck the player over from lasting much longer due to server load"

## Changelog
:cl:
fix: Being on fire or wet should no longer last much longer than intended while the server is under load.
/:cl:
