### PR TITLE
Fixes not being able to adjust pda ringtones in-game

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -148,7 +148,7 @@
 	if(SEND_SIGNAL(computer, COMSIG_TABLET_CHANGE_ID, user, new_ringtone) & COMPONENT_STOP_RINGTONE_CHANGE)
 		return FALSE
 
-	ringtone = ringtone
+	ringtone = new_ringtone
 	return TRUE
 
 /datum/computer_file/program/messenger/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION

## About The Pull Request
x = x is silly
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: PDA ringtones can be changed in-game
/:cl:
