### PR TITLE
fix sass warning

### DIFF
--- a/tgui/packages/tgui/styles/layouts/NtosWindow.scss
+++ b/tgui/packages/tgui/styles/layouts/NtosWindow.scss
@@ -12,7 +12,7 @@
   right: 0;
   height: 2em;
   line-height: 1.928em;
-  background-color: hsla(0, 0, 0, 0.5);
+  background-color: hsla(0, 0%, 0%, 0.5);
   font-family: Consolas, monospace;
   font-size: base.em(14px);
   user-select: none;


### PR DESCRIPTION
No player facing changes, simply fixes an error during the hsl conversion which led to sass warnings as the % was missing.