### PR TITLE
Quirks begin processing again

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -33,9 +33,9 @@
 	/// The base weight for the each quirk's mail goodies list to be selected is 5
 	/// then the item selected is determined by pick(selected_quirk.mail_goodies)
 	var/list/mail_goodies
-	/// The minimum stat where this quirk can process (if it has QUIRK_PROCESSES)
+	/// max process stat below which this quirk can process (if it has QUIRK_PROCESSES) and above which it stops.
 	/// If null, then it will process regardless of stat.
-	var/minimum_process_stat = HARD_CRIT
+	var/maximum_process_stat = null
 	/// A list of additional signals to register with update_process()
 	var/list/process_update_signals
 	/// A list of traits that should stop this quirk from processing.
@@ -90,7 +90,7 @@
 	add(client_source)
 
 	if(quirk_flags & QUIRK_PROCESSES)
-		if(!isnull(minimum_process_stat))
+		if(!isnull(maximum_process_stat))
 			RegisterSignal(quirk_holder, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_changed))
 		if(process_update_signals)
 			RegisterSignals(quirk_holder, process_update_signals, PROC_REF(update_process))
@@ -175,7 +175,7 @@
 		return FALSE
 	if(!(quirk_flags & QUIRK_PROCESSES))
 		return FALSE
-	if(!isnull(minimum_process_stat) && quirk_holder.stat <= minimum_process_stat)
+	if(!isnull(maximum_process_stat) && quirk_holder.stat >= maximum_process_stat)
 		return FALSE
 	for(var/trait in no_process_traits)
 		if(HAS_TRAIT(quirk_holder, trait))

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -33,7 +33,7 @@
 	/// The base weight for the each quirk's mail goodies list to be selected is 5
 	/// then the item selected is determined by pick(selected_quirk.mail_goodies)
 	var/list/mail_goodies
-	/// max process stat below which this quirk can process (if it has QUIRK_PROCESSES) and above which it stops.
+	/// max stat below which this quirk can process (if it has QUIRK_PROCESSES) and above which it stops.
 	/// If null, then it will process regardless of stat.
 	var/maximum_process_stat = HARD_CRIT
 	/// A list of additional signals to register with update_process()

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -35,7 +35,7 @@
 	var/list/mail_goodies
 	/// max process stat below which this quirk can process (if it has QUIRK_PROCESSES) and above which it stops.
 	/// If null, then it will process regardless of stat.
-	var/maximum_process_stat = null
+	var/maximum_process_stat = HARD_CRIT
 	/// A list of additional signals to register with update_process()
 	var/list/process_update_signals
 	/// A list of traits that should stop this quirk from processing.

--- a/code/datums/quirks/negative_quirks/claustrophobia.dm
+++ b/code/datums/quirks/negative_quirks/claustrophobia.dm
@@ -7,7 +7,7 @@
 	hardcore_value = 5
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
 	mail_goodies = list(/obj/item/reagent_containers/syringe/convermol) // to help breathing
-	minimum_process_stat = CONSCIOUS
+	maximum_process_stat = CONSCIOUS
 	no_process_traits = list(TRAIT_MIND_TEMPORARILY_GONE, TRAIT_FEARLESS, TRAIT_KNOCKEDOUT)
 
 /datum/quirk/claustrophobia/remove()

--- a/code/datums/quirks/negative_quirks/claustrophobia.dm
+++ b/code/datums/quirks/negative_quirks/claustrophobia.dm
@@ -7,7 +7,7 @@
 	hardcore_value = 5
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
 	mail_goodies = list(/obj/item/reagent_containers/syringe/convermol) // to help breathing
-	maximum_process_stat = CONSCIOUS
+	maximum_process_stat = SOFT_CRIT
 	no_process_traits = list(TRAIT_MIND_TEMPORARILY_GONE, TRAIT_FEARLESS, TRAIT_KNOCKEDOUT)
 
 /datum/quirk/claustrophobia/remove()


### PR DESCRIPTION
## About The Pull Request
- Fixes #89263
- Fixes #89262

A mob's `stat` integer value increases the more messed up they become
https://github.com/tgstation/tgstation/blob/5ec828cc4dfa83549afd6504dc9300d6dcdd190e/code/__DEFINES/stat.dm#L6-L10

So when our `minimum_process_stat` is actually the 2nd highest integer value there is
https://github.com/tgstation/tgstation/blob/5ec828cc4dfa83549afd6504dc9300d6dcdd190e/code/datums/quirks/_quirk.dm#L38

The quirk never processes because we aren't dead yet i.e our stat is below hard crit for a majority of normal game play.
![Screenshot (459)](https://github.com/user-attachments/assets/dc3d319c-0520-4965-9e71-75ebeb4d3f92)

So let's reverse our thinking. 

## Changelog
:cl:
fix: quirks work again
/:cl: