### PR TITLE
fixes megafauna not having an attack delay

### DIFF
--- a/code/datums/components/basic_mob_attack_telegraph.dm
+++ b/code/datums/components/basic_mob_attack_telegraph.dm
@@ -14,14 +14,17 @@
 /datum/component/basic_mob_attack_telegraph/Initialize(
 	telegraph_icon = 'icons/mob/telegraphing/telegraph.dmi',
 	telegraph_state = ATTACK_EFFECT_BITE,
+	display_telegraph_overlay = TRUE,
 	telegraph_duration = 0.4 SECONDS,
 	datum/callback/on_began_forecast,
 )
 	. = ..()
-	if (!isbasicmob(parent))
+	if (!isliving(parent))
 		return ELEMENT_INCOMPATIBLE
 
-	target_overlay = mutable_appearance(telegraph_icon, telegraph_state)
+	if(display_telegraph_overlay)
+		target_overlay = mutable_appearance(telegraph_icon, telegraph_state)
+
 	src.telegraph_duration = telegraph_duration
 	src.on_began_forecast = on_began_forecast
 
@@ -58,9 +61,13 @@
 	return COMPONENT_HOSTILE_NO_ATTACK
 
 /// Perform an attack after a delay
-/datum/component/basic_mob_attack_telegraph/proc/delayed_attack(mob/living/basic/source, atom/target)
+/datum/component/basic_mob_attack_telegraph/proc/delayed_attack(mob/living/source, atom/target)
 	current_target = target
-	target.add_overlay(target_overlay)
+
+	if(target_overlay)
+		RegisterSignal(target, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_target_overlays_update))
+		target.update_appearance()
+
 	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(forget_target))
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(target_moved))
 
@@ -73,7 +80,12 @@
 		return
 	ADD_TRAIT(source, TRAIT_BASIC_ATTACK_FORECAST, REF(src))
 	forget_target(target)
-	source.melee_attack(target, ignore_cooldown = TRUE) // We already started the cooldown when we triggered the forecast
+	if(isbasicmob(source))
+		var/mob/living/basic/basic_source = source
+		basic_source.melee_attack(target, ignore_cooldown = TRUE) // We already started the cooldown when we triggered the forecast
+		return
+	var/mob/living/simple_animal/hostile/hostile_source = source
+	hostile_source.AttackingTarget(target)
 
 /// The guy we're trying to attack moved, is he still in range?
 /datum/component/basic_mob_attack_telegraph/proc/target_moved(atom/target)
@@ -86,5 +98,10 @@
 /datum/component/basic_mob_attack_telegraph/proc/forget_target(atom/target)
 	SIGNAL_HANDLER
 	current_target = null
-	target.cut_overlay(target_overlay)
-	UnregisterSignal(target, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
+	target.update_appearance()
+	UnregisterSignal(target, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED, COMSIG_ATOM_UPDATE_OVERLAYS))
+
+/datum/component/basic_mob_attack_telegraph/proc/on_target_overlays_update(atom/parent_atom, list/overlays)
+	SIGNAL_HANDLER
+	if(parent_atom == current_target)
+		overlays += target_overlay

--- a/code/datums/components/basic_mob_attack_telegraph.dm
+++ b/code/datums/components/basic_mob_attack_telegraph.dm
@@ -19,7 +19,7 @@
 	datum/callback/on_began_forecast,
 )
 	. = ..()
-	if (!isliving(parent))
+	if (!isbasicmob(parent) && !ishostile(parent))
 		return ELEMENT_INCOMPATIBLE
 
 	if(display_telegraph_overlay)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -396,10 +396,10 @@
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget(atom/attacked_target)
 	in_melee = TRUE
-	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, target) & COMPONENT_HOSTILE_NO_ATTACK)
+	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, attacked_target) & COMPONENT_HOSTILE_NO_ATTACK)
 		return FALSE //but more importantly return before attack_animal called
-	var/result = target.attack_animal(src)
-	SEND_SIGNAL(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, target, result)
+	var/result = attacked_target.attack_animal(src)
+	SEND_SIGNAL(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, attacked_target, result)
 	return result
 
 /mob/living/simple_animal/hostile/proc/Aggro()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -56,9 +56,18 @@
 	var/list/attack_action_types = list()
 	/// Summoning line, said when summoned via megafauna vents.
 	var/summon_line = "I'll kick your ass!"
+	///any delay before we start attacking something near us
+	var/attack_delay = 0.25 SECONDS
 
 /mob/living/simple_animal/hostile/megafauna/Initialize(mapload)
 	. = ..()
+
+	AddComponent(\
+		/datum/component/basic_mob_attack_telegraph,\
+		display_telegraph_overlay = FALSE,\
+		telegraph_duration = attack_delay,\
+	)
+
 	AddComponent(/datum/component/seethrough_mob)
 	AddElement(/datum/element/simple_flying)
 	if(gps_name && true_spawn)
@@ -122,7 +131,7 @@
 	if(recovery_time >= world.time)
 		return
 	. = ..()
-	if(!.)
+	if(target && !CanAttack(target))
 		LoseTarget()
 		return
 	if(!isliving(target))
@@ -158,8 +167,6 @@
 		span_danger("[src] disembowels [L]!"),
 		span_userdanger("You feast on [L]'s organs, restoring your health!"))
 
-
-
 /mob/living/simple_animal/hostile/megafauna/CanAttack(atom/the_target)
 	. = ..()
 	if (!.)
@@ -168,7 +175,6 @@
 		return TRUE
 	var/mob/living/living_target = the_target
 	return !living_target.has_status_effect(/datum/status_effect/gutted)
-
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)
 	switch (severity)


### PR DESCRIPTION

## About The Pull Request
i opted to fix this by making the `basic_mob_attack_telegraph` compatible with simple animals for the moment, they now have their short attack delay back.

## Why It's Good For The Game
closes #87791 , closes #88984 , 

## Changelog
:cl:
fix: fixes megafauna instantly attacking people adjacent to them
/:cl:
