### PR TITLE
Fix cyborg flash / Makes cyborgs use item interaction

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -1,13 +1,25 @@
 #define MAXIMUM_EMP_WIRES 3
 
-/proc/is_wire_tool(obj/item/I)
-	if(!I)
-		return
-
-	if(I.tool_behaviour == TOOL_WIRECUTTER || I.tool_behaviour == TOOL_MULTITOOL)
+/**
+ * Is the passed item a tool that would interact with wires?
+ *
+ * Arguments:
+ * * tool - The item to check.
+ * * check_secured - If TRUE, and the item ends up being an assembly,
+ * we will only return TRUE if the assembly is not secured.
+ * "Secured" is used to indicate an assembly that may have a use outside of wire interactions,
+ * so we don't want to falsely identify it as a wire tool in some contexts.
+ */
+/proc/is_wire_tool(obj/item/tool, check_secured = FALSE)
+	if(!istype(tool))
+		return FALSE
+	if(tool.tool_behaviour == TOOL_WIRECUTTER || tool.tool_behaviour == TOOL_MULTITOOL)
 		return TRUE
-	if(isassembly(I))
-		return TRUE
+	if(isassembly(tool))
+		var/obj/item/assembly/assembly = tool
+		if(!check_secured || !assembly.secured)
+			return TRUE
+	return FALSE
 
 /atom/proc/attempt_wire_interaction(mob/user)
 	if(!wires)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -123,10 +123,13 @@
 		// Check both our's and their's assembly flags to see if either should not duplicate
 		// If so, and we match types, don't create a holder - block it
 		if(((new_assembly.assembly_flags|assembly_flags) & ASSEMBLY_NO_DUPLICATES) && istype(new_assembly, type))
-			balloon_alert(user, "can't attach another of that!")
+			balloon_alert(user, "can't attach another [new_assembly.name]!")
 			return
-		if(new_assembly.secured || secured)
-			balloon_alert(user, "both devices not attachable!")
+		if(new_assembly.secured)
+			balloon_alert(user, "[new_assembly.name] is not attachable!")
+			return
+		if(secured)
+			balloon_alert(user, "[name] is not attachable!")
 			return
 
 		holder = new /obj/item/assembly_holder(drop_location())

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -126,7 +126,7 @@
 			balloon_alert(user, "can't attach another of that!")
 			return
 		if(new_assembly.secured || secured)
-			balloon_alert(user, "both devices not assembly_behavior!")
+			balloon_alert(user, "both devices not attachable!")
 			return
 
 		holder = new /obj/item/assembly_holder(drop_location())

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			return ITEM_INTERACT_SUCCESS
 		return ITEM_INTERACT_BLOCKING
 
-	if(istype(tool, /obj/item/ai_module) && opened)
+	if(istype(tool, /obj/item/ai_module))
 		if(!opened)
 			balloon_alert(user, "chassis cover is closed!")
 			return ITEM_INTERACT_BLOCKING

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -87,17 +87,17 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(stat == DEAD)
 			balloon_alert(user, "it's dead!")
 			return ITEM_INTERACT_BLOCKING
-		var/obj/item/defibrillator/tool = W
-		if(!(tool.slot_flags & ITEM_SLOT_BACK)) //belt defibs need not apply
+		var/obj/item/defibrillator/defib = tool
+		if(!(defib.slot_flags & ITEM_SLOT_BACK)) //belt defibs need not apply
 			balloon_alert(user, "doesn't fit!")
 			return ITEM_INTERACT_BLOCKING
-		if(tool.cell)
+		if(defib.get_cell())
 			balloon_alert(user, "remove [tool]'s cell first!")
 			return ITEM_INTERACT_BLOCKING
 		if(locate(/obj/item/borg/upgrade/defib) in src)
 			balloon_alert(user, "already has a defibrillator!")
 			return ITEM_INTERACT_BLOCKING
-		var/obj/item/borg/upgrade/defib/backpack/defib_upgrade = new(null, D)
+		var/obj/item/borg/upgrade/defib/backpack/defib_upgrade = new(null, defib)
 		if(apply_upgrade(defib_upgrade, user))
 			balloon_alert(user, "defibrillator installed")
 			return ITEM_INTERACT_SUCCESS
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			balloon_alert(user, "chassis cover is closed!")
 			return ITEM_INTERACT_BLOCKING
 		if(wiresexposed)
-			balloon_alert(user, "close the wire cover first!")
+			balloon_alert(user, "unexpose the wires first!")
 			return ITEM_INTERACT_BLOCKING
 		if(!cell)
 			balloon_alert(user, "install a power cell first!")
@@ -139,7 +139,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		balloon_alert(user, "no radio found!")
 		return ITEM_INTERACT_BLOCKING
 
-	if(tool.GetId())
+	if(tool.GetID())
 		if(opened)
 			balloon_alert(user, "close the chassis cover first!")
 			return ITEM_INTERACT_BLOCKING
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(upgrade.locked)
 			balloon_alert(user, "upgrade locked!")
 			return ITEM_INTERACT_BLOCKING
-		if(user.apply_upgrade(upgrade, user))
+		if(apply_upgrade(upgrade, user))
 			balloon_alert(user, "upgrade installed")
 			return ITEM_INTERACT_SUCCESS
 		return ITEM_INTERACT_BLOCKING

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -926,6 +926,8 @@
 	if(inserted_disk)
 		user.put_in_hands(inserted_disk)
 		balloon_alert(user, "disks swapped")
+	else
+		balloon_alert(user, "disk inserted")
 	inserted_disk = disk
 	playsound(src, 'sound/machines/card_slide.ogg', 50)
 	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION
## About The Pull Request

Fixes #89272

- Adds an argument to `is_wire_tool` to fail if the item is secured, which assemblies are by default. (They must be screwdriver'd to attach to things) 

Makes cyborg use item interaction

- Cleaner, non-deprecated attack chain. 
- Also changes to chats to balloon alerts.

## Changelog

:cl: Melbert
qol: Using items on cyborgs now use balloon alerts instead of chat messages.
fix: You can flash cyborgs again
refactor: Refactored item interaction on cyborgs. 
/:cl:
