### PR TITLE
adds ignored faction to pellet cloud transferred variables

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -108,9 +108,9 @@
 
 	// things like mouth executions and gunpoints can multiply the damage and wounds of projectiles, so this makes sure those effects are applied to each pellet instead of just one
 	var/original_damage = shell.loaded_projectile.damage
-	var/original_wb = shell.loaded_projectile.wound_bonus
-	var/original_bwb = shell.loaded_projectile.bare_wound_bonus
-	var/original_if = shell.loaded_projectile.ignored_factions
+	var/original_wounds_bonus = shell.loaded_projectile.wound_bonus
+	var/original_bare_wounds_bonus = shell.loaded_projectile.bare_wound_bonus
+	var/original_ignored_faction = shell.loaded_projectile.ignored_factions
 
 	for(var/i in 1 to num_pellets)
 		shell.ready_proj(target, user, SUPPRESSED_VERY, zone_override, fired_from)

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -110,6 +110,7 @@
 	var/original_damage = shell.loaded_projectile.damage
 	var/original_wb = shell.loaded_projectile.wound_bonus
 	var/original_bwb = shell.loaded_projectile.bare_wound_bonus
+	var/original_if = shell.loaded_projectile.ignored_factions
 
 	for(var/i in 1 to num_pellets)
 		shell.ready_proj(target, user, SUPPRESSED_VERY, zone_override, fired_from)
@@ -124,6 +125,7 @@
 		shell.loaded_projectile.damage = original_damage
 		shell.loaded_projectile.wound_bonus = original_wb
 		shell.loaded_projectile.bare_wound_bonus = original_bwb
+		shell.loaded_projectile.ignored_factions = original_if
 		pellets += shell.loaded_projectile
 		var/turf/current_loc = get_turf(fired_from)
 		if (!istype(target_loc) || !istype(current_loc) || !(shell.loaded_projectile))

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -123,9 +123,9 @@
 		RegisterSignal(shell.loaded_projectile, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(pellet_hit))
 		RegisterSignals(shell.loaded_projectile, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_QDELETING), PROC_REF(pellet_range))
 		shell.loaded_projectile.damage = original_damage
-		shell.loaded_projectile.wound_bonus = original_wb
-		shell.loaded_projectile.bare_wound_bonus = original_bwb
-		shell.loaded_projectile.ignored_factions = original_if
+		shell.loaded_projectile.wound_bonus = original_wounds_bonus
+		shell.loaded_projectile.bare_wound_bonus = original_bare_wounds_bonus
+		shell.loaded_projectile.ignored_factions = original_ignored_faction
 		pellets += shell.loaded_projectile
 		var/turf/current_loc = get_turf(fired_from)
 		if (!istype(target_loc) || !istype(current_loc) || !(shell.loaded_projectile))


### PR DESCRIPTION
## About The Pull Request

does what it says on the title. 
Adds ignored faction to pellet cloud component, allowing shotguns to make use of the ignore faction variable for goofy things like shotgun magic, funny TDM rounds, or turrets
Honestly more for downstream effort.

## Why It's Good For The Game
1. I dont see too much on why not. 
2. Its a variable that gets used very rarely, and when used is preferable that it works.
3. pellet cloud is already capable of, funnily enough, handling homing if you set up a shotgun shell to set_homing_target in the way the Abielle smartgun bullets are. (though, it ends up becoming a wad of pellets instead of some fancy fan that coalesces into the target)

## Changelog
:cl:
fix: adds Ignored Factions to pellet cloud component variable transfer
/:cl:
