### PR TITLE
Fixes PAIs not being able to send messages or turn the GPS off

### DIFF
--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 ///Toggles the tracking for the gps
 /datum/component/gps/item/proc/toggletracking(mob/user)
-	if(!user.can_perform_action(parent))
+	if(!user.can_perform_action(parent, ALLOW_RESTING | ALLOW_PAI))
 		return //user not valid to use gps
 	if(emped)
 		to_chat(user, span_warning("It's busted!"))

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -575,7 +575,7 @@
 	var/mob/sender
 	if(ismob(source))
 		sender = source
-		if(!sender.can_perform_action(computer, ALLOW_RESTING))
+		if(!sender.can_perform_action(computer, ALLOW_RESTING | ALLOW_PAI))
 			return FALSE
 
 	if(!COOLDOWN_FINISHED(src, last_text))
@@ -730,7 +730,7 @@
 
 	if(QDELETED(src))
 		return
-	if(!usr.can_perform_action(computer, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
+	if(!usr.can_perform_action(computer, FORBID_TELEKINESIS_REACH | ALLOW_RESTING | ALLOW_PAI))
 		return
 
 	// send an activation message and open the messenger


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4826

Since https://github.com/tgstation/tgstation/pull/88651 PAIs have been blanket barred from being able to pass any `can_perform_action()` check.

From the pr:

![image](https://github.com/user-attachments/assets/67842da5-7208-4c43-b71f-4ba5c0c2f7af)

## Why It's Good For The Game

As it turns out there are a few things that it makes sense for them to be able to interact with. Now you can again!

## Changelog

:cl:
fix: fixed PAIs not being able to send or reply to messages using their digital messenger app.
fix: fixed PAIs not being able to turn off the GPS tracking using their gpa app.
/:cl: