### PR TITLE
Fixes broken shadows on 516

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -51,14 +51,14 @@
 	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
 #endif
 
-	if(viewing_hud.mymob?.client?.byond_version > 515)
-		relay_loc = "1,1"
-		rebuild_plane_masters()
-
 	set_hud(viewing_hud)
 	our_hud.master_groups[key] = src
 	show_hud()
 	build_planes_offset(our_hud, active_offset)
+
+	if(viewing_hud.mymob?.client?.byond_version > 515)
+		relay_loc = "1,1"
+		rebuild_hud()
 
 /// Well, refresh our group, mostly useful for plane specific updates
 /datum/plane_master_group/proc/refresh_hud()
@@ -70,6 +70,7 @@
 	hide_hud()
 	rebuild_plane_masters()
 	show_hud()
+	our_hud.update_parallax_pref()
 	build_planes_offset(our_hud, active_offset)
 
 /// Regenerate our plane masters, this is useful if we don't have a mob but still want to rebuild. Such in the case of changing the screen_loc of relays

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -58,7 +58,7 @@
 
 	if(viewing_hud.mymob?.client?.byond_version > 515)
 		relay_loc = "1,1"
-		rebuild_hud()
+		rebuild_plane_masters()
 
 /// Well, refresh our group, mostly useful for plane specific updates
 /datum/plane_master_group/proc/refresh_hud()

--- a/code/modules/admin/verbs/plane_debugger.dm
+++ b/code/modules/admin/verbs/plane_debugger.dm
@@ -341,7 +341,7 @@
 	var/list/our_planes = group.plane_masters
 
 	switch(action)
-		if("refresh")
+		if("rebuild")
 			group.rebuild_hud()
 		if("reset_mob")
 			set_target(null)

--- a/tgui/packages/tgui/interfaces/PlaneMasterDebug.tsx
+++ b/tgui/packages/tgui/interfaces/PlaneMasterDebug.tsx
@@ -651,7 +651,7 @@ const DrawAbovePlane = (props) => {
           <MobResetButton />
           <ToggleMirror />
           <VVButton />
-          <RefreshButton />
+          <RebuildButton />
         </>
       )}
       {!!enable_group_view && <GroupDropdown />}
@@ -695,7 +695,7 @@ const PlaneWindow = (props) => {
           <MobResetButton no_position />
           <ToggleMirror no_position />
           <VVButton no_position />
-          <RefreshButton no_position />
+          <RebuildButton no_position />
         </>
       }
     >
@@ -896,7 +896,7 @@ const GroupDropdown = (props) => {
   );
 };
 
-const RefreshButton = (props) => {
+const RebuildButton = (props) => {
   const { act } = useBackend();
   const { no_position } = props;
 
@@ -906,8 +906,8 @@ const RefreshButton = (props) => {
       right={no_position ? '' : '6px'}
       position={no_position ? '' : 'absolute'}
       icon="recycle"
-      onClick={() => act('refresh')}
-      tooltip="Refreshes ALL plane masters. Kinda laggy, but useful"
+      onClick={() => act('Rebuild')}
+      tooltip="Rebuilds ALL plane masters. Kinda laggy, but useful"
     />
   );
 };


### PR DESCRIPTION

## About The Pull Request
Bandaid fix of broken shadows on 516. 
Renamed refresh button to rebuild for consistency in plane debugger (Edit/Dubug-Planes).
Rebuild now also reapplies parallax, so it will not be turned off after rebuild.  
Closes #89230 
## Why It's Good For The Game
faster 516 adoption
## Changelog
:cl:
fix: fixed shadows on 516
/:cl:
