### PR TITLE
removes outdated word usage in traumas.json

### DIFF
--- a/strings/traumas.json
+++ b/strings/traumas.json
@@ -61,7 +61,7 @@
 		"THe saiyans screwed",
 		"TURBIN IS BEST ENGIENE",
 		"u just did the world a little bit more sad place for someone",
-		"ur a fuckeing autist!",
+		"ur a fuckeing IDOT!",
 		"waaaaaagh!!!",
 		"wearnig siNGUARLTY is.... FINE haHAAA",
 		"WHERES THE SLIP REWRITE WHERE THR FUCK ID IT?",


### PR DESCRIPTION
## About The Pull Request

Removes a word some people consider a slur that brain traumas force you to say. 

## Why It's Good For The Game

Whether or not someone personally considers it one, you at least shouldn't be forced to say it against your will.

## Changelog
:cl:

spellcheck: removed the word "autist" from a forced say effect.

/:cl:
