### PR TITLE
Fixes dropdown names in prefs [No gbp]

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
@@ -30,19 +30,16 @@ export function FeatureDropdownInput(props: DropdownInputProps) {
 
   const [dropdownOptions, setDropdownOptions] = useState<DropdownOptions>([]);
 
-  let displayNames: Record<string, string> = {};
-
   function populateOptions() {
     if (!serverData) return;
 
     const { choices = [] } = serverData;
-    displayNames = serverData.display_names as Record<string, string>;
 
     let newOptions: DropdownOptions = [];
 
     for (const choice of choices) {
-      let displayText: ReactNode = displayNames
-        ? displayNames[choice]
+      let displayText: ReactNode = serverData.display_names
+        ? serverData.display_names[choice]
         : capitalizeFirst(choice);
 
       newOptions.push({
@@ -60,10 +57,7 @@ export function FeatureDropdownInput(props: DropdownInputProps) {
     }
   }, [serverData]);
 
-  let displayText = value;
-  if (displayNames) {
-    displayText = displayNames[value];
-  }
+  const displayText = serverData?.display_names?.[value] || String(value);
 
   return (
     <Dropdown
@@ -81,21 +75,17 @@ export function FeatureDropdownInput(props: DropdownInputProps) {
 export function FeatureIconnedDropdownInput(props: IconnedDropdownInputProps) {
   const { serverData, handleSetValue, value } = props;
 
-  // Skeletons so we can load
-  let displayNames: Record<string, string> = {};
-
   const [dropdownOptions, setDropdownOptions] = useState<DropdownOptions>([]);
 
   function populateOptions() {
     if (!serverData) return;
     const { icons = {}, choices = [] } = serverData;
-    displayNames = serverData.display_names as Record<string, string>;
 
     let newOptions: DropdownOptions = [];
 
     for (const choice of choices) {
-      let displayText: ReactNode = displayNames
-        ? displayNames[choice]
+      let displayText: ReactNode = serverData.display_names?.[choice]
+        ? serverData.display_names?.[choice]
         : capitalizeFirst(choice);
 
       if (serverData.icons?.[choice]) {
@@ -127,10 +117,7 @@ export function FeatureIconnedDropdownInput(props: IconnedDropdownInputProps) {
     }
   }, [serverData]);
 
-  let displayText = capitalizeFirst(value || '');
-  if (displayNames) {
-    displayText = displayNames[value];
-  }
+  const displayText = serverData?.display_names?.[value] || value;
 
   return (
     <Dropdown

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
@@ -117,7 +117,7 @@ export function FeatureIconnedDropdownInput(props: IconnedDropdownInputProps) {
     }
   }, [serverData]);
 
-  const displayText = serverData?.display_names?.[value] || value;
+  const displayText = serverData?.display_names?.[value] || String(value);
 
   return (
     <Dropdown


### PR DESCRIPTION

## About The Pull Request
Troubleshooting an issue with @vinylspiders revealed this component wasn't working properly for us either.

displayNames doesn't like being assigned in a useEffect so it never really has a value. I've fixed it, it's working, it's also more idiomatic react
## Why It's Good For The Game
This should fix prefs showing up as "male" "female" instead of being properly converted via display names
## Changelog
:cl:
fix: Character pref dropdowns should have their display names fixed
/:cl:
