### PR TITLE
Unit Test failures now output a job summary, making it easier to see what the failures are.

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -61,6 +61,7 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DANSICOLORS -Werror -ITG0001 -I"loop_checks"
       - name: Run Tests
+        id: run_tests
         run: |
           source $HOME/BYOND/byond/bin/byondsetup
           bash tools/ci/run_server.sh ${{ inputs.map }}
@@ -71,6 +72,29 @@ jobs:
           name: test_artifacts_${{ inputs.map }}_${{ inputs.major }}_${{ inputs.minor }}
           path: data/screenshots_new/
           retention-days: 1
+      - name: On test fail, write a step summary
+        if: always() && steps.run_tests.outcome == 'failure'
+        run: |
+          # Get a JSON array of failed unit tests
+          FAILED_UNIT_TESTS=$(jq 'to_entries | map(.value | select(.status == 1))' data/unit_tests.json)
+
+          FAIL_COUNT=$(echo $FAILED_UNIT_TESTS | jq 'length')
+
+          echo "# Test failures" >> $GITHUB_STEP_SUMMARY
+          echo "$FAIL_COUNT tests failed." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          for i in $( seq $FAIL_COUNT ); do
+            CURRENT_FAIL=$(echo $FAILED_UNIT_TESTS | jq --arg i $i '.[($i | tonumber) - 1]')
+
+            TEST=$(echo $CURRENT_FAIL | jq --raw-output '.name')
+
+            echo "### $TEST" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo $CURRENT_FAIL | jq --raw-output '.message' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          done
       - name: Check client Compatibility
         if: always() && steps.compile_tests.outcome == 'success'
         uses: tgstation/byond-client-compatibility-check@v3

--- a/tools/ci/run_server.sh
+++ b/tools/ci/run_server.sh
@@ -22,5 +22,6 @@ cd ..
 
 mkdir -p data/screenshots_new
 cp -r ci_test/data/screenshots_new data/screenshots_new
+cp ci_test/data/unit_tests.json data/unit_tests.json
 
 cat ci_test/data/logs/ci/clean_run.lk


### PR DESCRIPTION
This change was requested by Absolucy, of catgirl fame.

## About The Pull Request
The CI is very useful for figuring out if you made any errors with your changes. Among other things, it runs unit tests on a variety of maps and BYOND versions, making sure everything still works as expected.

Unfortunately, figuring out the specific errors you got in CI is a bit of a pain. You could scroll through the individual logs - but the logs are so long, it'd take forever.

You could also use the annotations section, but that's gets filled with generic error messages:

![image](https://github.com/user-attachments/assets/0c01374d-65fd-4586-8bea-e71725e3ffe5)

This PR helps on this matter, by adding [a job summary](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary) whenever a failure is detected. Here's an example where I intentionally generated fails:

![image](https://github.com/user-attachments/assets/6f0fd948-125f-4685-9230-20fa48b2b357)

(If you want to see how it looks on your own screen, have a look: <https://github.com/LikeLakers2/tgstation/actions/runs/13026959405>)

As it is set up currently, each integration test job will generate its own summary; each summary contains one section per failed test; each section will contain the associated failure message(s) in a code block.

This system is pretty basic currently (for example, breaking something across all maps will cause many job summaries to be generated), but it's a step up from what we had previously. Ideally, I'll come back to this later, and improve on the job summary output - for example, by merging identical errors across maps, and having the failures generated as a singular job summary.

## Why It's Good For The Game
Having all the failures summarized in one place, without generic failure messages splattered in-between, can make it easier to diagnose issues detected by CI.