### PR TITLE
Medbot emag spark overlay fix [NO GBP]

### DIFF
--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -249,7 +249,8 @@
 	medical_mode_flags &= ~MEDBOT_DECLARE_CRIT
 	balloon_alert(user, "reagent synthesis circuits shorted")
 	audible_message(span_danger("[src] buzzes oddly!"))
-	flick("medbot_spark", src)
+	var/mutable_appearance/spark = mutable_appearance(icon, "[base_icon_state]_spark")
+	flick_overlay_view(spark, 1 SECONDS)
 	playsound(src, SFX_SPARKS, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return TRUE
 

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -249,8 +249,7 @@
 	medical_mode_flags &= ~MEDBOT_DECLARE_CRIT
 	balloon_alert(user, "reagent synthesis circuits shorted")
 	audible_message(span_danger("[src] buzzes oddly!"))
-	var/mutable_appearance/spark = mutable_appearance(icon, "[base_icon_state]_spark")
-	flick_overlay_view(spark, 1 SECONDS)
+	flick_overlay_view(mutable_appearance(icon, "[base_icon_state]_spark"), 1 SECONDS)
 	playsound(src, SFX_SPARKS, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/user-attachments/assets/38218bb2-d38c-4698-afff-db75dde0597c

I've used flick() which flicked the medbot icon itself instead of adding a spark overlay on top of it. 

## Why It's Good For The Game

Fix

## Changelog

:cl:
fix: Fixed medbot emag VFX
/:cl:
