### PR TITLE
Converts pixel_x offsets on fish to pixel_w

### DIFF
--- a/code/modules/fishing/fish/types/anadromous.dm
+++ b/code/modules/fishing/fish/types/anadromous.dm
@@ -39,8 +39,8 @@
 	icon = 'icons/obj/aquarium/wide.dmi'
 	icon_state = "pike"
 	inhand_icon_state = "pike"
-	base_pixel_x = -16
-	pixel_x = -16
+	base_pixel_w = -16
+	pixel_w = -16
 	stable_population = 4
 	sprite_width = 10
 	sprite_height = 3

--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -127,8 +127,8 @@
 	pickup_sound = SFX_FISH_PICKUP
 	sound_vary = TRUE
 
-	base_pixel_x = -16
-	pixel_x = -16
+	base_pixel_w = -16
+	pixel_w = -16
 	sprite_width = 13
 	sprite_height = 9
 

--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -5,8 +5,8 @@
 	desc = "A monster of exposed muscles and innards, wrapped in a fish-like skeleton. You don't remember ever seeing it on the catalog."
 	icon = 'icons/obj/aquarium/wide.dmi'
 	icon_state = "mastodon"
-	base_pixel_x = -16
-	pixel_x = -16
+	base_pixel_w = -16
+	pixel_w = -16
 	sprite_width = 12
 	sprite_height = 7
 	fish_flags = parent_type::fish_flags & ~FISH_FLAG_SHOW_IN_CATALOG

--- a/code/modules/fishing/fish/types/saltwater.dm
+++ b/code/modules/fishing/fish/types/saltwater.dm
@@ -158,8 +158,8 @@
 	wound_bonus = 10
 	bare_wound_bonus = 20
 	armour_penetration = 75
-	base_pixel_x = -18
-	pixel_x = -18
+	base_pixel_w = -18
+	pixel_w = -18
 	sprite_width = 13
 	sprite_height = 6
 	stable_population = 3

--- a/code/modules/fishing/fish/types/station.dm
+++ b/code/modules/fishing/fish/types/station.dm
@@ -255,8 +255,8 @@
 	desc = "A <u>deliciously</u> extremophile alien fish. This one is so big, you could write legends about it."
 	icon = 'icons/obj/aquarium/wide.dmi'
 	icon_state = "nessiefish"
-	base_pixel_x = -16
-	pixel_x = -16
+	base_pixel_w = -16
+	pixel_w = -16
 	sprite_width = 12
 	sprite_height = 4
 	average_size = 150

--- a/code/modules/fishing/fish/types/syndicate.dm
+++ b/code/modules/fishing/fish/types/syndicate.dm
@@ -95,8 +95,8 @@
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5
-	base_pixel_x = -16
-	pixel_x = -16
+	base_pixel_w = -16
+	pixel_w = -16
 	sprite_width = 8
 	sprite_height = 5
 	stable_population = 3


### PR DESCRIPTION

## About The Pull Request

Fixes large fishes going behind wallmounts like here
![image](https://github.com/user-attachments/assets/22f1f192-2c09-491a-948a-16c01b4467ec)

## Changelog
:cl:
fix: Large fish should not render behind their wall mounts now
/:cl:
