### PR TITLE
Fix the "Debug Controller" verb

### DIFF
--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -61,9 +61,7 @@ ADMIN_VERB(debug_controller, R_DEBUG, "Debug Controller", "Debug the various per
 
 	for (var/var_key in global.vars)
 		var/datum/controller/controller = global.vars[var_key]
-		if(!istype(controller))
-			continue
-		if (istype(controller, /datum/controller/subsystem))
+		if(!istype(controller) || istype(controller, /datum/controller/subsystem))
 			continue
 		controllers[controller.name] = controller //we use an associated list to ensure clients can't hold references to controllers
 		controller_choices += controller.name

--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -59,11 +59,14 @@ ADMIN_VERB(debug_controller, R_DEBUG, "Debug Controller", "Debug the various per
 	var/list/controllers = list()
 	var/list/controller_choices = list()
 
-	for (var/datum/controller/controller in world)
+	for (var/var_key in global.vars)
+		var/datum/controller/controller = global.vars[var_key]
+		if(!istype(controller))
+			continue
 		if (istype(controller, /datum/controller/subsystem))
 			continue
-		controllers["[controller] (controller.type)"] = controller //we use an associated list to ensure clients can't hold references to controllers
-		controller_choices += "[controller] (controller.type)"
+		controllers[controller.name] = controller //we use an associated list to ensure clients can't hold references to controllers
+		controller_choices += controller.name
 
 	var/datum/controller/controller_string = input("Select controller to debug", "Debug Controller") as null|anything in controller_choices
 	var/datum/controller/controller = controllers[controller_string]


### PR DESCRIPTION
## About The Pull Request
The "Debug Controller" verb wasn't doing anything. You'd click on it, and nothing would happen.

Turns out, it was searching for controllers in the wrong place - controllers are considered globals, not part of `/world`.

This PR fixes that. Now you get this fancy box instead of nothing:

![image](https://github.com/user-attachments/assets/af4d76d2-0ad4-4549-8606-8b423762c700)

(As an aside - choosing the Global Variables controller causes several seconds of lag, due to the mass amount of data that needs to be rendered. Perhaps a new verb should be added specifically for going through Global Variables?)


## Why It's Good For The Game
Enables coders to debug the various controllers with less need for debug printing statements.

## Why It's Terrible For The Game
Enables admins with debug permission to abuse the live server even harder.

## Changelog
No player-facing changes. This regards a verb that should only be used during debugging (i.e. locally).