### PR TITLE
Increases the base force of standard toolboxes by exactly one. 

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -7,8 +7,8 @@
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	obj_flags = CONDUCTS_ELECTRICITY
-	force = 12
-	throwforce = 12
+	force = 13
+	throwforce = 13
 	throw_speed = 2
 	throw_range = 7
 	demolition_mod = 1.25
@@ -198,13 +198,15 @@
 	has_latches = FALSE
 	force = 19
 	throwforce = 22
+	var/base_force = 20
+	var/base_throwforce = 23
 
 /obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
 	var/power = 0
 	for (var/obj/item/stack/telecrystal/stored_crystals in get_all_contents())
 		power += (stored_crystals.amount / 2)
-	force = 19 + power
-	throwforce = 22 + power
+	force = base_force + power
+	throwforce = base_throwforce + power
 
 /obj/item/storage/toolbox/mechanical/old/clean/attack(mob/target, mob/living/user)
 	calc_damage()

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -198,15 +198,13 @@
 	has_latches = FALSE
 	force = 19
 	throwforce = 22
-	var/base_force = 20
-	var/base_throwforce = 23
 
 /obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
 	var/power = 0
 	for (var/obj/item/stack/telecrystal/stored_crystals in get_all_contents())
 		power += (stored_crystals.amount / 2)
-	force = base_force + power
-	throwforce = base_throwforce + power
+	force = initial(force) + power
+	throwforce = initial(throwforce) + power
 
 /obj/item/storage/toolbox/mechanical/old/clean/attack(mob/target, mob/living/user)
 	calc_damage()


### PR DESCRIPTION

## About The Pull Request

Increases the base force of toolboxes by exactly 1.

Cleans up some magic numbers in ancient toolbox force calculations. 

## Why It's Good For The Game

So, you may be asking yourself. "Anne, why?"

The answer is very simple. It's just the right amount of force necessary to send a space carp packing in terror by bonking them on the head once.

There really isn't much deeper justification. I just thought it would be funny to see an assistant lob a toolbox at a carp and it teleports away in fear.

**Does this mean that the assistant is now able to take down their fellow space in all but one less strike, going from 9 strikes against a healthy spaceman to 8?** 

Yes.

**Does it matter?**

No. 

It takes the same amount of hits before and after for our spaceman to start to slow down. While it amounts to one less hit overall, the threshold is pretty razor thin and white room math is not necessarily indicative of actual play results. Most people may not even notice the difference because whether it is 8 or 9 hits, that is still a lot of attacks before bringing someone down. And that is assuming that the person has exactly zero armor of any kind. 

## Changelog
:cl:
balance: The force of most standard varieties of toolboxes has increased from 12 to 13 force.
code: Removed some magic numbers from the calculations for ancient toolboxes damage scaling.
/:cl:
