### PR TITLE
Gets rid of mobile hollow bioscramblers spawning in the anomaly research ruin.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -71,7 +71,7 @@
 /turf/open/floor/grass,
 /area/misc/anomaly_research)
 "dr" = (
-/obj/effect/spawner/random/environmentally_safe_anomaly,
+/obj/effect/spawner/random/environmentally_safe_anomaly/bioscramblerless,
 /turf/open/lava/plasma/ice_moon,
 /area/misc/anomaly_research)
 "ds" = (
@@ -90,7 +90,7 @@
 /area/misc/anomaly_research)
 "dD" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/spawner/random/environmentally_safe_anomaly,
+/obj/effect/spawner/random/environmentally_safe_anomaly/bioscramblerless,
 /turf/open/lava/plasma/ice_moon,
 /area/misc/anomaly_research)
 "eq" = (
@@ -602,7 +602,7 @@
 /turf/open/floor/iron/white,
 /area/misc/anomaly_research)
 "qM" = (
-/obj/effect/spawner/random/environmentally_safe_anomaly,
+/obj/effect/spawner/random/environmentally_safe_anomaly/bioscramblerless,
 /obj/effect/turf_decal/trimline/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -683,7 +683,7 @@
 /area/misc/anomaly_research)
 "sX" = (
 /obj/machinery/light/small/built/directional/north,
-/obj/effect/spawner/random/environmentally_safe_anomaly,
+/obj/effect/spawner/random/environmentally_safe_anomaly/bioscramblerless,
 /obj/item/reagent_containers/cup/bottle/wittel,
 /obj/effect/spawner/random/trash/grime,
 /obj/effect/decal/cleanable/dirt,
@@ -1855,7 +1855,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/misc/anomaly_research)
 "ZL" = (
-/obj/effect/spawner/random/environmentally_safe_anomaly,
+/obj/effect/spawner/random/environmentally_safe_anomaly/bioscramblerless,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,

--- a/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
@@ -6,7 +6,7 @@
 		/obj/effect/anomaly/pyro/big,
 		/obj/effect/anomaly/flux/big,
 		/obj/effect/anomaly/bluespace/big,
-		/obj/effect/anomaly/grav/high/big
+		/obj/effect/anomaly/grav/high/big,
 	)
 
 ///Spawns a stable anomally that doesnt drop cores and doesn't destroy or alter the environment
@@ -17,7 +17,7 @@
 		/obj/effect/anomaly/flux,
 		/obj/effect/anomaly/bluespace,
 		/obj/effect/anomaly/hallucination,
-		/obj/effect/anomaly/bioscrambler/docile
+		/obj/effect/anomaly/bioscrambler/docile,
 	)
 
 	///Do we anchor the anomaly? Set to true if you don't want anomalies drifting away (like if theyre in space or something)
@@ -28,6 +28,14 @@
 
 	var/obj/effect/anomaly/anomaly = .
 	anomaly.stabilize(anchor = anchor_anomaly, has_core = FALSE)
+
+/obj/effect/spawner/random/environmentally_safe_anomaly/bioscramblerless
+	name = "safe anomaly spawner without bioscramblers"
+	loot = list(
+		/obj/effect/anomaly/flux,
+		/obj/effect/anomaly/bluespace,
+		/obj/effect/anomaly/hallucination,
+	)
 
 /obj/effect/spawner/random/environmentally_safe_anomaly/immobile
 	name = "stationary safe anomaly spawner"


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Mobile anomalies still spawn in and around the ruin, but never bioscramblers.

## Why It's Good For The Game

A) These fucking things cannot be disabled by conventional means. It needs anomaly research.

B) They drift through space away from the ruin literally every single time the ruin spawns. They are meant to be an environmental hazard for the ruin, not for the entire playing space because a remote ruin spawned.

C) Because they are not blocked by walls, they will keep drifting until eventually arriving on the station, where they will stay there. Typically occupying a space perpetually until a scientist comes and fixes the problem with their anomaly neutralizer.

The only reason this happened was because of bioscramblers being reworked into the state they are now. I don't imagine the original creator intended for the ruin to create problems for the wider round like this.

## Changelog
:cl:
del: Mobile hollow bioscramblers no longer spawn from the anomaly research ruin, sparing everyone from the inevitable unannounced arrival of a permanent hollow bioscrambler aboard the station. You maybe still encounter immobile bioscramblers in the ruin, however.
/:cl:
