### PR TITLE
Pyro Slime Objective Test

### DIFF
--- a/code/modules/antagonists/pyro_slime/pyro_slime.dm
+++ b/code/modules/antagonists/pyro_slime/pyro_slime.dm
@@ -15,7 +15,7 @@
 	owner.announce_objectives()
 
 /datum/objective/pyro_slime
-	explanation_text = "Remember ventcrawl! Using alt+click on vents to quickly travel about the station. Consume energy from the living, corpses have no energy, Drag yourself onto them to feed, Then multiply yourself and spread throughout the station. You are weak to fire extinguishers, stealth and surprise will be your aid."
+	explanation_text = "I am fire. I am hunger. The cold is agony. The living pulse with energy; their warmth fuels me. The dead are husks, their embers long faded. Water is death. Fire... fire is freedom."
 
 /datum/objective/pyro_slime/check_completion()
 	return owner.current.stat != DEAD

--- a/code/modules/antagonists/pyro_slime/pyro_slime.dm
+++ b/code/modules/antagonists/pyro_slime/pyro_slime.dm
@@ -15,7 +15,7 @@
 	owner.announce_objectives()
 
 /datum/objective/pyro_slime
-	explanation_text = "All I know fire. I speak in tongues of flame. Why is everyone so cold?"
+	explanation_text = "Remember ventcrawl! Using alt+click on vents to quickly travel about the station. Consume energy from the living, corpses have no energy, Drag yourself onto them to feed, Then multiply yourself and spread throughout the station. You are weak to fire extinguishers, stealth and surprise will be your aid."
 
 /datum/objective/pyro_slime/check_completion()
 	return owner.current.stat != DEAD


### PR DESCRIPTION
## About The Pull Request

Pyro Slime is a fairly common role on TG station but many new players may be unfamiliar to vent crawl or what they need to do, i.e feeding energy, splitting, this gives a little explainer text to it to make it easier.
## Why It's Good For The Game

Regular players will know how to play slime well, this gives new players more of a possible advantage as the role often comes up most rounds as a ghost role.
## Changelog
:cl:
qol: Pyro Slime Objective Text Edit
/:cl:
