### PR TITLE
Fix unscrollable lathe UI on 516

### DIFF
--- a/tgui/packages/tgui/interfaces/Fabrication/DesignBrowser.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/DesignBrowser.tsx
@@ -276,7 +276,7 @@ export const DesignBrowser = <T extends Design = Design>(
               </Section>
             </Stack.Item>
             <Stack.Item grow>
-              <Section fill style={{ overflow: 'auto' }}>
+              <Section fill scrollable>
                 {searchText.length > 0 ? (
                   <VirtualList>
                     {sortBy(


### PR DESCRIPTION

## About The Pull Request

The UI for lathes is broken in 516 ATM, the scrollbar doesn't scroll below the lowest visible item, and the materials under the items aren't visible either.
I tested this on 515 as well and it didn't seem to break anything or change behavior that I could tell.
## Why It's Good For The Game
It's good when things work
![image](https://github.com/user-attachments/assets/220170e2-f579-4373-9e0b-498ce8188c10)
## Changelog
:cl:
fix: Lathes interfaces are no longer unscrollable on 516
/:cl:
