### PR TITLE
Fix the chat reliability subsystem

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -135,13 +135,14 @@ export const chatMiddleware = (store) => {
             requesting < sequence;
             requesting++
           ) {
-            requested_sequences.push(requesting);
+            sequences_requested.push(requesting);
             Byond.sendMessage('chat/resend', requesting);
           }
         }
       }
 
       chatRenderer.processBatch([payload_obj.content]);
+      sequences.push(sequence);
       return;
     }
     if (type === loadChat.type) {


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/Monkestation/Monkestation2.0/pull/5160, fixes https://github.com/tgstation/tgstation/issues/54692

turns out the code was using the wrong var name (`requested_sequences` instead of `sequences_requested`), and `sequences` was never being pushed to in the first place. whoops - thanks to @Kashargul in coderbus for pointing out the var name mixup, which led to this fix.

while i'm not 100% sure how to test this, the very unscientific test of "asking people on discord if they've experienced dropped chat messages in the past few days" makes me think it works

## Why It's Good For The Game

fixing an annoying-ass bug is good

## Changelog
:cl:
fix: Random messages should no longer be dropped and not appear in chat.
/:cl:
