### PR TITLE
Fixes persisting brimbeams

### DIFF
--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimbeam.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimbeam.dm
@@ -86,7 +86,8 @@
 /datum/action/cooldown/mob_cooldown/brimbeam/proc/extinguish_laser()
 	if(!length(beam_parts))
 		return FALSE
-	owner.move_resist = initial(owner.move_resist)
+	if (owner)
+		owner.move_resist = initial(owner.move_resist)
 	for(var/obj/effect/brimbeam/beam in beam_parts)
 		beam.disperse()
 	beam_parts = list()


### PR DESCRIPTION
## About The Pull Request

If a brimdemon gets destroyed instantly, their beams would persist because of a runtime here as owner in actions can be null.

Fixes https://github.com/tgstation/tgstation/issues/81994

## Changelog
:cl:
fix: Fixed an issue with persisting brimbeams
/:cl:
