### PR TITLE
Syringe/chem guns no longer do damage.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet/dart
 	name = "dart"
 	icon_state = "cbbolt"
-	damage = 6
+	damage = 0
 	embed_type = null
 	shrapnel_type = null
 	var/inject_flags = null


### PR DESCRIPTION
## About The Pull Request

Removed damage from syringe gun.
## Why It's Good For The Game

Originally wanted to remove the ability for syringes to blow up fuel tanks, but then saw that syringes do more damage then buckshot and scatter blast - this is kinda stupid, that an actual bullet, does less damage then a syringe. Syringes can brake doors, blow up fuel tanks, brake windows even - this probably not the best thing. 

Medics can accidently explode fuel tanks while trying to syringe someone with meds, or traitors can blow themself up with morphine?, space a room accidently (this is extremely unlikely but still) . Chem gun also uses syringe damage and can blow up fuel tanks with literal water balls, very counterintuitive.  

If I am missing  something, and syringe damage has an actual reason, please do write it.
## Changelog
:cl: 
balance: Syringes and chem darts no longer do damage. 
/:cl:
