### PR TITLE
Temporary bodies return players to minds without bodies

### DIFF
--- a/code/datums/components/temporary_body.dm
+++ b/code/datums/components/temporary_body.dm
@@ -14,11 +14,12 @@
 	var/delete_on_death = FALSE
 
 /datum/component/temporary_body/Initialize(datum/mind/old_mind, mob/living/old_body, delete_on_death = FALSE)
-	if(!isliving(parent) || !isliving(old_body))
+	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
-	ADD_TRAIT(old_body, TRAIT_MIND_TEMPORARILY_GONE, REF(src))
 	src.old_mind_ref = WEAKREF(old_mind)
-	src.old_body_ref = WEAKREF(old_body)
+	if(istype(old_body))
+		ADD_TRAIT(old_body, TRAIT_MIND_TEMPORARILY_GONE, REF(src))
+		src.old_body_ref = WEAKREF(old_body)
 	src.delete_on_death = delete_on_death
 
 /datum/component/temporary_body/RegisterWithParent()
@@ -40,7 +41,7 @@
 	var/datum/mind/old_mind = old_mind_ref?.resolve()
 	var/mob/living/old_body = old_body_ref?.resolve()
 
-	if(!old_mind || !old_body)
+	if(!old_mind)
 		return
 
 	var/mob/living/living_parent = parent
@@ -50,12 +51,13 @@
 	if(!ghost)
 		CRASH("[src] belonging to [parent] was completely unable to find a ghost to put back into a body!")
 	ghost.mind = old_mind
-	if(old_body.stat != DEAD)
+	if(old_body?.stat != DEAD)
 		old_mind.transfer_to(old_body, force_key_move = TRUE)
 	else
 		old_mind.set_current(old_body)
 
-	REMOVE_TRAIT(old_body, TRAIT_MIND_TEMPORARILY_GONE, REF(src))
+	if(old_body)
+		REMOVE_TRAIT(old_body, TRAIT_MIND_TEMPORARILY_GONE, REF(src))
 
 	old_mind = null
 	old_body = null

--- a/code/datums/components/temporary_body.dm
+++ b/code/datums/components/temporary_body.dm
@@ -39,7 +39,7 @@
 /datum/component/temporary_body/proc/on_parent_destroy()
 	SIGNAL_HANDLER
 	var/datum/mind/old_mind = old_mind_ref?.resolve()
-	var/mob/living/old_body = old_body_ref?.resolve()
+	var/mob/living/old_body = old_body_ref?.resolve() || old_mind.current
 
 	if(!old_mind)
 		return

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1027,7 +1027,7 @@ GLOBAL_VAR_INIT(narsie_summon_count, 0)
 		visible_message(span_warning("A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo":""]man."))
 		to_chat(user, span_cult_italic("Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely..."))
 		var/obj/structure/emergency_shield/cult/weak/N = new(T)
-		if(ghost_to_spawn.mind && ghost_to_spawn.mind.current)
+		if(ghost_to_spawn.mind && ghost_to_spawn.mind)
 			new_human.AddComponent( \
 				/datum/component/temporary_body, \
 				old_mind = ghost_to_spawn.mind, \

--- a/code/modules/basketball/controller.dm
+++ b/code/modules/basketball/controller.dm
@@ -192,6 +192,12 @@ GLOBAL_VAR(basketball_game)
 		var/client/player_client = GLOB.directory[player_key]
 		if(player_client)
 			player_client.prefs.safe_transfer_prefs_to(baller, is_antag = TRUE)
+		if(player_client.mob.mind)
+			baller.AddComponent( \
+				/datum/component/temporary_body, \
+				old_mind = player_client.mob.mind, \
+				old_body = player_client.mob.mind.current, \
+			)
 		baller.key = player_key
 
 		SEND_SOUND(baller, sound('sound/items/whistle/whistle.ogg', volume=30))

--- a/code/modules/bitrunning/server/threats.dm
+++ b/code/modules/bitrunning/server/threats.dm
@@ -113,7 +113,7 @@
 	var/datum/mind/ghost_mind = ghost.mind
 	new_mob.key = ghost.key
 
-	if(ghost_mind?.current)
+	if(ghost_mind)
 		new_mob.AddComponent(/datum/component/temporary_body, ghost_mind, ghost_mind.current, TRUE)
 
 	var/datum/mind/antag_mind = new_mob.mind

--- a/code/modules/bitrunning/spawners.dm
+++ b/code/modules/bitrunning/spawners.dm
@@ -9,7 +9,7 @@
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/special(mob/living/spawned_mob, mob/mob_possessor)
 	var/datum/mind/ghost_mind = mob_possessor.mind
-	if(ghost_mind?.current) // Preserves any previous bodies before making the switch
+	if(ghost_mind) // Preserves any previous bodies before making the switch
 		spawned_mob.AddComponent(/datum/component/temporary_body, ghost_mind, ghost_mind.current, TRUE)
 
 	..()

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -153,7 +153,7 @@
 		player_mob.set_species(/datum/species/human)
 
 	var/datum/mind/new_member_mind = new_team_member.mob.mind
-	if(new_member_mind?.current)
+	if(new_member_mind)
 		player_mob.AddComponent( \
 			/datum/component/temporary_body, \
 			old_mind = new_member_mind, \

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -141,7 +141,7 @@
 	new_player.dna.update_dna_identity()
 	new_player.updateappearance(icon_update = TRUE, mutcolor_update = TRUE, mutations_overlay_update = TRUE)
 	new_player.add_traits(list(TRAIT_CANNOT_CRYSTALIZE, TRAIT_PERMANENTLY_MORTAL, TRAIT_TEMPORARY_BODY), INNATE_TRAIT)
-	if(!isnull(observer.mind) && observer.mind?.current)
+	if(observer.mind)
 		new_player.AddComponent( \
 			/datum/component/temporary_body, \
 			old_mind = observer.mind, \

--- a/code/modules/mafia/roles/roles.dm
+++ b/code/modules/mafia/roles/roles.dm
@@ -116,7 +116,7 @@
  * Adds the playing_mafia trait so people examining them will know why they're currently lacking a soul.
  */
 /datum/mafia_role/proc/put_player_in_body(client/player)
-	if(player.mob.mind && player.mob.mind.current)
+	if(player.mob.mind)
 		body.AddComponent( \
 			/datum/component/temporary_body, \
 			old_mind = player.mob.mind, \


### PR DESCRIPTION
## About The Pull Request

There are a couple of cases where ghost roles that give the temporary body component prevent you from returning to the round when they really shouldn't. The particular cases are:
- You entered a temporary body while you had no body, but could be recovered via means such as podcloning
- You enter a temporary body, and while in that body, your original body is permanently removed while your mind could be recovered via means such as podcloning
- Basketball

This PR addresses those cases by allowing the temporary body component to operate with a null `old_body`, and allowing the temporary body component to be given to ghosts whose minds don't have bodies.


## Why It's Good For The Game

Erroneous DNRs caused by code oversights are probably very undesirable to the playerbase.

## Changelog

:cl:
fix: Joining a minigame or taking certain ghost roles, while you have a mind without a body, will no longer DNR you, just in case you can be resurrected by some means.
fix: If your old body is permanently destroyed while you are playing a minigame or as certain ghost roles, you will still return to your character's original mind, just in case you can be resurrected by some means.
fix: The basketball minigame now gives its players and referee temporary bodies.
/:cl:
