### PR TITLE
Fixes more scrollables for 516

### DIFF
--- a/tgui/packages/tgui/interfaces/Autolathe.tsx
+++ b/tgui/packages/tgui/interfaces/Autolathe.tsx
@@ -53,7 +53,7 @@ export const Autolathe = (props) => {
 
   return (
     <Window title="Autolathe" width={670} height={600}>
-      <Window.Content scrollable>
+      <Window.Content>
         <Stack vertical fill>
           <Stack.Item>
             <Section title="Total Materials">

--- a/tgui/packages/tgui/interfaces/ExosuitFabricator.tsx
+++ b/tgui/packages/tgui/interfaces/ExosuitFabricator.tsx
@@ -242,8 +242,8 @@ const Queue = (props: QueueProps) => {
             />
           </Section>
         </Stack.Item>
-        <Stack.Item grow>
-          <Section fill style={{ overflow: 'auto' }}>
+        <Stack.Item grow style={{ overflowY: 'auto', overflowX: 'hidden' }}>
+          <Section fill>
             <QueueList
               availableMaterials={availableMaterials}
               SHEET_MATERIAL_AMOUNT={SHEET_MATERIAL_AMOUNT}

--- a/tgui/packages/tgui/interfaces/Fabrication/DesignBrowser.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/DesignBrowser.tsx
@@ -214,8 +214,8 @@ export const DesignBrowser = <T extends Design = Design>(
             <Stack.Item>
               <Section title="Categories" fitted />
             </Stack.Item>
-            <Stack.Item grow>
-              <Section fill style={{ overflow: 'auto' }}>
+            <Stack.Item grow style={{ overflowY: 'auto', overflowX: 'hidden' }}>
+              <Section fill>
                 <div className="FabricatorTabs">
                   <div
                     className={classes([
@@ -275,8 +275,8 @@ export const DesignBrowser = <T extends Design = Design>(
                 />
               </Section>
             </Stack.Item>
-            <Stack.Item grow>
-              <Section fill style={{ overflow: 'auto' }}>
+            <Stack.Item grow style={{ overflowY: 'auto', overflowX: 'hidden' }}>
+              <Section fill>
                 {searchText.length > 0 ? (
                   <VirtualList>
                     {sortBy(


### PR DESCRIPTION
## About The Pull Request

I was looking at https://github.com/tgstation/tgstation/pull/89312 (Ghommie merged it while I was looking at it lol, this would've been a comment otherwise) and noticed a few problems:

1. There's other instances of ``style={{ overflow: 'auto' }}`` in the code, I checked them and they don't work, this fixed one instance of the 3 that exists.
2. Autolathes have 2 scrollbars, one for the whole UI and one for the item list (3 actually, one on the left for the sections)

This fixes all instances, and uses overflowY instead of scrollable so it isn't there permanently.
Also removes the unnecessary scrollbar to Autolathes.

## Why It's Good For The Game

Fixes more UIs for 516 and removes unnecessary and annoying scrollbar from autolathes.

## Changelog

:cl:
fix: Autolathes no longer have a scrollbar that sends you off the screen.
fix: Exosuit fabricators' queue list & Techfab/Autolathe's left side (with the sections of printables) now have a scrollbar when the full list doesn't fit on the UI for 516 users. Techfab/Autolathe also now does this for the list of items too, instead of always having one.
/:cl: