### PR TITLE
Hydrogen Peroxide and Eldritch Essence rust turfs

### DIFF
--- a/code/modules/antagonists/heretic/items/eldritch_flask.dm
+++ b/code/modules/antagonists/heretic/items/eldritch_flask.dm
@@ -1,5 +1,5 @@
 // An unholy water flask, but for heretics.
-// Heals heretics, hearms non-heretics. Pretty much identical.
+// Heals heretics, harms non-heretics. Pretty much identical.
 /obj/item/reagent_containers/cup/beaker/eldritch
 	name = "flask of eldritch essence"
 	desc = "Toxic to the closed minded, yet refreshing to those with knowledge of the beyond."

--- a/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
@@ -14,7 +14,7 @@
 /datum/heretic_knowledge/essence
 	name = "Priest's Ritual"
 	desc = "Allows you to transmute a tank of water and a glass shard into a Flask of Eldritch Essence. \
-		Eldritch water can be consumed for potent healing, or given to heathens for deadly poisoning."
+		Eldritch Essence can be consumed for potent healing, or given to heathens for deadly poisoning."
 	gain_text = "This is an old recipe. The Owl whispered it to me. \
 		Created by the Priest - the Liquid that both was and is not."
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -521,7 +521,7 @@
 	. = ..()
 	if (reac_volume < 5)
 		return
-	if (!isplatingturf(exposed_turf) && !(exposed_turf.type == /turf/closed/wall || exposed_turf.type == /turf/closed/wall/r_wall))
+	if (!isplatingturf(exposed_turf) && exposed_turf.type != /turf/closed/wall)
 		return
 	if (!HAS_TRAIT(exposed_turf, TRAIT_RUSTY))
 		exposed_turf.AddElement(/datum/element/rust)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -517,12 +517,14 @@
  * Water reaction to turf
  */
 
-/datum/reagent/hydrogen_peroxide/expose_turf(turf/open/exposed_turf, reac_volume)
+/datum/reagent/hydrogen_peroxide/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
-	if(!istype(exposed_turf))
+	if (reac_volume < 5)
 		return
-	if(reac_volume >= 5)
-		exposed_turf.MakeSlippery(TURF_WET_WATER, 10 SECONDS, min(reac_volume*1.5 SECONDS, 60 SECONDS))
+	if (!isplatingturf(exposed_turf) && !(exposed_turf.type == /turf/closed/wall || exposed_turf.type == /turf/closed/wall/r_wall))
+		return
+	if (!HAS_TRAIT(exposed_turf, TRAIT_RUSTY))
+		exposed_turf.AddElement(/datum/element/rust)
 /*
  * Water reaction to a mob
  */
@@ -2898,6 +2900,11 @@
 		need_mob_update += drinker.adjustBruteLoss(2 * REM * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
+
+/datum/reagent/eldritch/expose_turf(turf/exposed_turf, reac_volume)
+	. = ..()
+	if ((reac_volume >= 5 || isplatingturf(exposed_turf)) && !HAS_TRAIT(exposed_turf, TRAIT_RUSTY))
+		exposed_turf.rust_turf()
 
 /datum/reagent/universal_indicator
 	name = "Universal Indicator"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -519,7 +519,7 @@
 
 /datum/reagent/hydrogen_peroxide/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
-	if (reac_volume < 5)
+	if (reac_volume < 1.5)
 		return
 	if (!isplatingturf(exposed_turf) && exposed_turf.type != /turf/closed/wall)
 		return
@@ -2903,7 +2903,7 @@
 
 /datum/reagent/eldritch/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
-	if ((reac_volume >= 5 || isplatingturf(exposed_turf)) && !HAS_TRAIT(exposed_turf, TRAIT_RUSTY))
+	if ((reac_volume >= 1.5 || isplatingturf(exposed_turf)) && !HAS_TRAIT(exposed_turf, TRAIT_RUSTY))
 		exposed_turf.rust_turf()
 
 /datum/reagent/universal_indicator


### PR DESCRIPTION
## About The Pull Request

Hydrogen Peroxide can rust plating and normal (non-reinforced) walls when 1.5+ units are splashed. Eldritch Essence can heretically rust all turfs when 1.5+ units are splashed, and rust plating regardless of amount. (Same rust as the one that's created by aggressive spread). You cannot rust already rusted turfs with the latter since that would break down all walls in the area. 1.667 is the amount that sprayers spread per turf, so you can effectively rust areas with those (but not with high-range smoke machines)

Also some spellchecks, yeah.

## Why It's Good For The Game

I think its a neat interaction which makes sense that could allow for some neat gimmicks (as there's no way to rust turfs as of now to my knowledge)

## Changelog
:cl:
add: Hydrogen Peroxide and Eldritch Essence now can rust turfs, with latter producing heretic instead of normal rust.
spellcheck: Fixed a misspelled comment and a reference to non-existent Eldritch water (as opposed to Eldritch Essence)
/:cl:
