### PR TITLE
Adds the resin mister module to the (single?) roundstart atmos MODsuit

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -82,6 +82,7 @@
 		/obj/item/mod/module/t_ray,
 		/obj/item/mod/module/quick_carry,
 		/obj/item/mod/module/headprotector,
+		/obj/item/mod/module/mister/atmos,
 	)
 	default_pins = list(
 		/obj/item/mod/module/magboot,

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -86,6 +86,7 @@
 	)
 	default_pins = list(
 		/obj/item/mod/module/magboot,
+		/obj/item/mod/module/mister/atmos,
 		/obj/item/mod/module/flashlight,
 	)
 


### PR DESCRIPTION

![obraz](https://github.com/user-attachments/assets/21c80f72-21bc-4375-b030-10aa166ca7c0)
![obraz](https://github.com/user-attachments/assets/d7495ea2-80c7-4804-98d6-91fdd436483b)
![obraz](https://github.com/user-attachments/assets/94e77fb7-a240-4223-aaa6-d57d2ba63ed0)


_They don't know I don't have enough GBP to feed my kids & make it through winter..._ 😔
Can I pass this off as QoL?
## About The Pull Request
So you see, the suit locker DOES contain a resin mister... the backpack one... the one that's in every other locker... and goes in the same slot as the MODsuit...
![obraz](https://github.com/user-attachments/assets/983adce0-5cda-4dee-b537-15d3ca312ff3)
It's like a spit in the face, isn't it?
## Why It's Good For The Game
I feel it's exasperating how neglected this was.
Sure, the original resin mister isn't that commonly used because it takes up the backslot.
Neither is the MODsuit, because it has little to offer and slows you down.

But first someone kept that resin backpack in the same suit storage instead of giving it the module...
And then a quick carry module was added instead & it's seemingly the only thing that differentiates it from the engineering MODsuit!
Why?
## Changelog
:cl:
qol: Added the resin mister module to the roundstart atmos MODsuit.
/:cl:
