### PR TITLE
Fixes incorrect power consumption on reagent grinders

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -453,7 +453,7 @@
 			total_weight += item_weight
 
 	//use power according to the total weight of items grinded
-	use_energy((active_power_usage * (duration / 1 SECONDS)) * (total_weight / maximum_weight))
+	use_energy((active_power_usage * (duration / (1 SECONDS))) * (total_weight / maximum_weight))
 
 	addtimer(CALLBACK(src, PROC_REF(stop_operating)), duration)
 
@@ -513,6 +513,6 @@
 	beaker.reagents.convert_reagent(/datum/reagent/consumable/cream, /datum/reagent/consumable/whipped_cream)
 
 	//power consumed based on the ratio of total reagents mixed
-	use_energy((active_power_usage * (duration / 1 SECONDS)) * (beaker.reagents.total_volume / beaker.reagents.maximum_volume))
+	use_energy((active_power_usage * (duration / (1 SECONDS))) * (beaker.reagents.total_volume / beaker.reagents.maximum_volume))
 
 	operating = FALSE


### PR DESCRIPTION

## About The Pull Request

Only place where I found this. SECONDS is *10, so this instead multiplied the value by 10 rather than divided it

## Changelog
:cl:
fix: Fixed incorrect power consumption on reagent grinders
/:cl:
