### PR TITLE
Fix runtimes with `REMOVE_TRAITS_IN`

### DIFF
--- a/code/__DEFINES/traits/_traits.dm
+++ b/code/__DEFINES/traits/_traits.dm
@@ -97,7 +97,9 @@
 		}; \
 		if (_L) { \
 			for (var/_T in _L) { \
-				_L[_T] -= _S;\
+				if (_L[_T]) { \
+					_L[_T] -= _S \
+				};\
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T)); \

--- a/code/__DEFINES/traits/_traits.dm
+++ b/code/__DEFINES/traits/_traits.dm
@@ -100,7 +100,7 @@
 		if (_L) { \
 			for (var/_T in _L) { \
 				if (_L[_T]) { \
-					_L[_T] -= _S \
+					_L[_T] -= _S; \
 				}; \
 				if (!length(_L[_T])) { \
 					_L -= _T; \

--- a/code/__DEFINES/traits/_traits.dm
+++ b/code/__DEFINES/traits/_traits.dm
@@ -74,7 +74,9 @@
 		var/list/_S = sources; \
 		if (_L) { \
 			for (var/_T in _L) { \
-				_L[_T] &= _S;\
+				if (_L[_T]) { \
+					_L[_T] &= _S; \
+				}; \
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T), _T); \
@@ -99,7 +101,7 @@
 			for (var/_T in _L) { \
 				if (_L[_T]) { \
 					_L[_T] -= _S \
-				};\
+				}; \
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T)); \


### PR DESCRIPTION

## About The Pull Request

ok so `REMOVE_TRAITS_IN` would sometimes run with like `type mismatch: null -= /list (/list)`

credit to @RikuTheKiller for actually figuring this out and fixing it, here's their explaination on what caused the issue:
> okay so
> its due to linked traits
> like knocked out which adds other traits
> when knocked out is removed, it sends a removed signal
> but sending that signal modifies the list mid for loop
> so now when it tries to index it on the next iteration with a trait key thats already gone
> it returns null, and tries to remove a list from a null
> and it runtimes

## Why It's Good For The Game

`REMOVE_TRAITS_IN` is a handy macro, and it'd be nice if it reliably worked

## Changelog

no user-facing changes