### PR TITLE
516: Fixes tgui character limit on MAX_LENGTH = INFINITY tgui inputs by setting it to the length of 12.5 bee movie scripts

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -104,6 +104,7 @@
 #define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=byond://?src=[REF(alice)];follow=[REF(bob)];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(F)</a>"
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
+#define CAPLESS_MESSAGE_LEN 1e5 // 100,000. This is primarily for admin tgui inputs.
 #define MAX_MESSAGE_LEN 1024
 #define MAX_NAME_LEN 42
 #define MAX_BROADCAST_LEN 512

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -104,7 +104,7 @@
 #define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=byond://?src=[REF(alice)];follow=[REF(bob)];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(F)</a>"
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
-#define CAPLESS_MESSAGE_LEN 1e5 // 100,000. This is primarily for admin tgui inputs.
+#define CAPLESS_MESSAGE_LEN 1e6 // 1,000,000. This is primarily for admin tgui inputs.
 #define MAX_MESSAGE_LEN 1024
 #define MAX_NAME_LEN 42
 #define MAX_BROADCAST_LEN 512

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -15,7 +15,7 @@
  * * encode - Toggling this determines if input is filtered via html_encode. Setting this to FALSE gives raw input.
  * * timeout - The timeout of the textbox, after which the modal will close and qdel itself. Set to zero for no timeout.
  */
-/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = INFINITY, multiline = FALSE, encode = TRUE, timeout = 0, ui_state = GLOB.always_state)
+/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = CAPLESS_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0, ui_state = GLOB.always_state)
 	if (!user)
 		user = usr
 	if (!istype(user))


### PR DESCRIPTION
## About The Pull Request

In 516, tgui inputs that have ```max_length = INFINITY``` break with the scientific notation and is capping you at 1 character. I made a new ```#define CAPLESS_MESSAGE_LEN 1e6``` which is 1,000,000 characters which should be close enough. 

![image](https://github.com/user-attachments/assets/5103c01d-9a9c-47b2-8ad8-763b5b6a7706)

fixes: #89331
## Why It's Good For The Game

Admins should be able to function in 516 too.

## Changelog

:cl:
fix: For 516 compatibility, admin side tgui inputs now cap at 1,000,000 characters, or roughly 12.5 bee movie scripts, instead of 1 character.
/:cl:

