### PR TITLE
Fixes DB admin ranks being 16 bits wide instead of 24

### DIFF
--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -18,7 +18,7 @@ Version 5.29, 4 February 2024, by Tiviplus
 Fixed admin rank table flags being capped at 16 in the DB instead of 24 (byond max)
 
 ```sql
-ALTER TABLE 'admin_ranks'
+ALTER TABLE `admin_ranks`
 	MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
 	MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
 	MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;

--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -19,9 +19,9 @@ Fixed admin rank table flags being capped at 16 in the DB instead of 24 (byond m
 
 ```sql
 ALTER TABLE 'admin_ranks'
-MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
-MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
-MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;
+	MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
+	MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
+	MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;
 ```
 -----------------------------------------------------
 Version 5.28, 1 November 2024, by Ghommie

--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -5,14 +5,24 @@ Make sure to also update `DB_MAJOR_VERSION` and `DB_MINOR_VERSION`, which can be
 The latest database version is 5.28; The query to update the schema revision table is:
 
 ```sql
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 28);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 29);
 ```
 or
 
 ```sql
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 28);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 29);
 ```
 In any query remember to add a prefix to the table names if you use one.
+-----------------------------------------------------
+Version 5.29, 4 February 2024, by Tiviplus
+Fixed admin rank table flags being capped at 16 in the DB instead of 24 (byond max)
+
+```sql
+ALTER TABLE 'admin_ranks'
+MODIFY COLUMN `flags` mediumint(5) unsigned NOT NULL,
+MODIFY COLUMN `exclude_flags` mediumint(5) unsigned NOT NULL,
+MODIFY COLUMN `can_edit_flags` mediumint(5) unsigned NOT NULL;
+```
 -----------------------------------------------------
 Version 5.28, 1 November 2024, by Ghommie
 Added `fish_progress` as the first 'progress' subtype of 'datum/award/scores'

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -53,9 +53,9 @@ DROP TABLE IF EXISTS `admin_ranks`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_ranks` (
   `rank` varchar(32) NOT NULL,
-  `flags` smallint(5) unsigned NOT NULL,
-  `exclude_flags` smallint(5) unsigned NOT NULL,
-  `can_edit_flags` smallint(5) unsigned NOT NULL,
+  `flags` mediumint(5) unsigned NOT NULL,
+  `exclude_flags` mediumint(5) unsigned NOT NULL,
+  `can_edit_flags` mediumint(5) unsigned NOT NULL,
   PRIMARY KEY (`rank`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -53,9 +53,9 @@ DROP TABLE IF EXISTS `SS13_admin_ranks`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `SS13_admin_ranks` (
   `rank` varchar(32) NOT NULL,
-  `flags` smallint(5) unsigned NOT NULL,
-  `exclude_flags` smallint(5) unsigned NOT NULL,
-  `can_edit_flags` smallint(5) unsigned NOT NULL,
+  `flags` mediumint(5) unsigned NOT NULL,
+  `exclude_flags` mediumint(5) unsigned NOT NULL,
+  `can_edit_flags` mediumint(5) unsigned NOT NULL,
   PRIMARY KEY (`rank`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 28
+#define DB_MINOR_VERSION 29
 
 
 //! ## Timing subsystem


### PR DESCRIPTION
## About The Pull Request
smallint is 2 bytes, increased it to mediumint which is 3 bytes
Issue has not cropped up yet as theres only 15 flags right now, but there can be up to 24 in dm side soooo

```
DEBUG-SQL: MySqlError { ERROR 1264 (22003): Out of range value for column 'flags' at row 1 } | Query used: INSERT INTO admin_ranks
 - (rank, flags, exclude_flags, can_edit_flags)
```


my mysql is broken so I havent tested the update query but how bad can it be :clueless:
## Changelog
:cl:
server: An issue where more than 16 admin flags could not exist in the DB has been corrected
/:cl:
