### PR TITLE
Fixed wrong area/wall in Icemoon Underground - Round 3

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -104068,7 +104068,7 @@ thA
 iDt
 psb
 rxz
-gFX
+wDU
 wDU
 aNw
 qmt


### PR DESCRIPTION

## About The Pull Request

![StrongDMM_u12oSaxu6Q](https://github.com/user-attachments/assets/72df4f86-f0fb-4254-99c8-85b23701ac91)

(No funny screenshot of me malding in-game this time)

## Changelog
:cl:
fix: Fixed wrong area/wall in Icemoon Underground
/:cl:
