### PR TITLE
Makes integrated circuit nodes more colorful

### DIFF
--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -123,6 +123,8 @@
 #define CIRCUIT_FLAG_REFUSE_MODULE (1<<5)
 /// This circuit component cannot be inserted into the same circuit multiple times. Only use this for major headaches.
 #define CIRCUIT_NO_DUPLICATES (1<<6)
+/// This circuit component is currently disabled via configs
+#define CIRCUIT_FLAG_DISABLED (1<<7)
 
 // Datatype flags
 /// The datatype supports manual inputs

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -33,6 +33,11 @@
 
 	var/list/options_map
 
+/obj/item/circuit_component/soundemitter/Initialize(mapload)
+	if(CONFIG_GET(flag/disallow_circuit_sounds))
+		circuit_flags |= CIRCUIT_FLAG_DISABLED
+	. = ..()
+
 /obj/item/circuit_component/soundemitter/get_ui_notices()
 	. = ..()
 	. += create_ui_notice("Sound Cooldown: [DisplayTimeText(sound_cooldown)]", "orange", "stopwatch")
@@ -79,10 +84,7 @@
 
 /obj/item/circuit_component/soundemitter/input_received(datum/port/input/port)
 	if(CONFIG_GET(flag/disallow_circuit_sounds))
-		ui_color = "red"
 		return
-	else
-		ui_color = initial(ui_color)
 
 	if(!parent.shell)
 		return

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -35,7 +35,7 @@
 
 /obj/item/circuit_component/soundemitter/Initialize(mapload)
 	if(CONFIG_GET(flag/disallow_circuit_sounds))
-		circuit_flags |= CIRCUIT_FLAG_DISABLED
+		update_ui_alerts(new_flag=CIRCUIT_FLAG_DISABLED)
 	. = ..()
 
 /obj/item/circuit_component/soundemitter/get_ui_notices()
@@ -43,6 +43,9 @@
 	. += create_ui_notice("Sound Cooldown: [DisplayTimeText(sound_cooldown)]", "orange", "stopwatch")
 	if(CONFIG_GET(flag/disallow_circuit_sounds))
 		. += create_ui_notice("Non-functional", "red", "exclamation")
+		update_ui_alerts(new_flag=CIRCUIT_FLAG_DISABLED)
+	else
+		update_ui_alerts(remove_flag=CIRCUIT_FLAG_DISABLED)
 
 
 /obj/item/circuit_component/soundemitter/populate_ports()
@@ -84,7 +87,11 @@
 
 /obj/item/circuit_component/soundemitter/input_received(datum/port/input/port)
 	if(CONFIG_GET(flag/disallow_circuit_sounds))
+		// Without constantly checking the config 24/7 or sending a signal to every circuit, best we can do to update existing emitters is this.
+		update_ui_alerts(new_flag=CIRCUIT_FLAG_DISABLED)
 		return
+	else
+		update_ui_alerts(remove_flag=CIRCUIT_FLAG_DISABLED)
 
 	if(!parent.shell)
 		return

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -65,8 +65,8 @@
 	var/ui_buttons = null
 
 	/// The "important" UI tooltips of this circuit component. Used for important things like instant & disabled circuits, they're drawn next to the default tooltip icon.
-	/// An assoc list with the format "alert_icon" = "alert_name".
-	var/ui_alerts = null
+	/// An assoc list with the format ui_alerts["alert_icon"] = "alert_name".
+	var/ui_alerts = list()
 
 /// Called when the option ports should be set up
 /obj/item/circuit_component/proc/populate_options()
@@ -90,14 +90,7 @@
 		trigger_input = add_input_port("Trigger", PORT_TYPE_SIGNAL, order = 2)
 	if((circuit_flags & CIRCUIT_FLAG_OUTPUT_SIGNAL) && !trigger_output)
 		trigger_output = add_output_port("Triggered", PORT_TYPE_SIGNAL, order = 2)
-	if(circuit_flags & CIRCUIT_FLAG_INSTANT)
-		if(!length(ui_alerts))
-			ui_alerts = list()
-		ui_alerts += list("tachometer-alt" = "Instant")
-	if(circuit_flags & CIRCUIT_FLAG_DISABLED)
-		if(!length(ui_alerts))
-			ui_alerts = list()
-		ui_alerts += list("exclamation" = "Non-functional")
+	update_ui_alerts()
 
 /obj/item/circuit_component/Destroy()
 	if(parent)
@@ -122,6 +115,21 @@
 	. = ..()
 	if(circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
 		. += span_notice("It's incompatible with module components.")
+
+/// updates the ui alerts in the given component. new_flag adds flags, remove_flag removes them
+/obj/item/circuit_component/proc/update_ui_alerts(new_flag, remove_flag)
+	if(new_flag)
+		circuit_flags |= new_flag
+	if(remove_flag)
+		circuit_flags &= ~remove_flag
+	if(circuit_flags & CIRCUIT_FLAG_INSTANT)
+		ui_alerts["tachometer-alt"] = "Instant"
+	else
+		ui_alerts -= "tachometer-alt"
+	if(circuit_flags & CIRCUIT_FLAG_DISABLED)
+		ui_alerts["exclamation"] = "Non-functional"
+	else
+		ui_alerts -= "exclamation"
 
 /**
  * Called when a shell is registered from the component/the component is added to a circuit.

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -64,6 +64,10 @@
 	/// The UI buttons of this circuit component. An assoc list that has this format: "button_icon" = "action_name"
 	var/ui_buttons = null
 
+	/// The "important" UI tooltips of this circuit component. Used for important things like instant & disabled circuits, they're drawn next to the default tooltip icon.
+	/// An assoc list with the format "alert_icon" = "alert_name".
+	var/ui_alerts = null
+
 /// Called when the option ports should be set up
 /obj/item/circuit_component/proc/populate_options()
 	return
@@ -87,7 +91,13 @@
 	if((circuit_flags & CIRCUIT_FLAG_OUTPUT_SIGNAL) && !trigger_output)
 		trigger_output = add_output_port("Triggered", PORT_TYPE_SIGNAL, order = 2)
 	if(circuit_flags & CIRCUIT_FLAG_INSTANT)
-		ui_color = "orange"
+		if(!length(ui_alerts))
+			ui_alerts = list()
+		ui_alerts += list("tachometer-alt" = "Instant")
+	if(circuit_flags & CIRCUIT_FLAG_DISABLED)
+		if(!length(ui_alerts))
+			ui_alerts = list()
+		ui_alerts += list("exclamation" = "Non-functional")
 
 /obj/item/circuit_component/Destroy()
 	if(parent)

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -380,6 +380,8 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 		component_data["y"] = component.rel_y
 		component_data["removable"] = component.removable
 		component_data["color"] = component.ui_color
+		component_data["category"] = component.category
+		component_data["ui_alerts"] = component.ui_alerts
 		component_data["ui_buttons"] = component.ui_buttons
 		.["components"] += list(component_data)
 

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
@@ -1,5 +1,6 @@
 import { Component, createRef } from 'react';
 import { Box, Button, Stack } from 'tgui-core/components';
+import { classes } from 'tgui-core/react';
 
 import { noop } from './constants';
 import { Port } from './Port';
@@ -43,20 +44,33 @@ export class DisplayComponent extends Component {
       <Box {...rest}>
         <div ref={this.ref}>
           <Box
-            backgroundColor={component.color || 'blue'}
             py={1}
             px={1}
-            className="ObjectComponent__Titlebar"
+            className={classes([
+              'ObjectComponent__Titlebar',
+              `ObjectComponent__Category__${component.category}`,
+            ])}
           >
             <Stack>
               <Stack.Item grow={1} unselectable="on">
                 {component.name}
               </Stack.Item>
+              {!!component.ui_alerts &&
+                Object.keys(component.ui_alerts).map((icon) => (
+                  <Stack.Item key={icon}>
+                    <Button
+                      icon={icon}
+                      className={`ObjectComponent__Category__${category}`}
+                      compact
+                      tooltip={component.ui_alerts[icon]}
+                    />
+                  </Stack.Item>
+                ))}
               <Stack.Item>
                 <Button
-                  color="transparent"
                   icon="info"
                   compact
+                  className={`ObjectComponent__Category__${category}`}
                   tooltip={component.description}
                   tooltipPosition="top"
                 />

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
@@ -48,7 +48,7 @@ export class DisplayComponent extends Component {
             px={1}
             className={classes([
               'ObjectComponent__Titlebar',
-              `ObjectComponent__Category__${component.category || "Unassigned"}`,
+              `ObjectComponent__Category__${component.category || 'Unassigned'}`,
             ])}
           >
             <Stack>
@@ -60,7 +60,7 @@ export class DisplayComponent extends Component {
                   <Stack.Item key={icon}>
                     <Button
                       icon={icon}
-                      className={`ObjectComponent__Category__${component.category || "Unassigned"}`}
+                      className={`ObjectComponent__Category__${component.category || 'Unassigned'}`}
                       compact
                       tooltip={component.ui_alerts[icon]}
                     />
@@ -70,7 +70,7 @@ export class DisplayComponent extends Component {
                 <Button
                   icon="info"
                   compact
-                  className={`ObjectComponent__Category__${component.category || "Unassigned"}`}
+                  className={`ObjectComponent__Category__${component.category || 'Unassigned'}`}
                   tooltip={component.description}
                   tooltipPosition="top"
                 />

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
@@ -40,7 +40,7 @@ export class DisplayComponent extends Component {
 
   render() {
     const { component, fixedSize, ...rest } = this.props;
-    const cat_or_unassigned = component.category || 'Unassigned';
+    const categoryClass = `ObjectComponent__Category__${component.category || 'Unassigned'}`;
     return (
       <Box {...rest}>
         <div ref={this.ref}>
@@ -49,7 +49,7 @@ export class DisplayComponent extends Component {
             px={1}
             className={classes([
               'ObjectComponent__Titlebar',
-              `ObjectComponent__Category__${cat_or_unassigned}`,
+              categoryClass,
             ])}
           >
             <Stack>
@@ -61,7 +61,7 @@ export class DisplayComponent extends Component {
                   <Stack.Item key={icon}>
                     <Button
                       icon={icon}
-                      className={`ObjectComponent__Category__${cat_or_unassigned}`}
+                      className={categoryClass}
                       compact
                       tooltip={component.ui_alerts[icon]}
                     />
@@ -71,7 +71,7 @@ export class DisplayComponent extends Component {
                 <Button
                   icon="info"
                   compact
-                  className={`ObjectComponent__Category__${cat_or_unassigned}`}
+                  className={categoryClass}
                   tooltip={component.description}
                   tooltipPosition="top"
                 />

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
@@ -40,6 +40,7 @@ export class DisplayComponent extends Component {
 
   render() {
     const { component, fixedSize, ...rest } = this.props;
+    const cat_or_unassigned = component.category || 'Unassigned';
     return (
       <Box {...rest}>
         <div ref={this.ref}>
@@ -48,7 +49,7 @@ export class DisplayComponent extends Component {
             px={1}
             className={classes([
               'ObjectComponent__Titlebar',
-              `ObjectComponent__Category__${component.category || 'Unassigned'}`,
+              `ObjectComponent__Category__${cat_or_unassigned}`,
             ])}
           >
             <Stack>
@@ -60,7 +61,7 @@ export class DisplayComponent extends Component {
                   <Stack.Item key={icon}>
                     <Button
                       icon={icon}
-                      className={`ObjectComponent__Category__${component.category || 'Unassigned'}`}
+                      className={`ObjectComponent__Category__${cat_or_unassigned}`}
                       compact
                       tooltip={component.ui_alerts[icon]}
                     />
@@ -70,7 +71,7 @@ export class DisplayComponent extends Component {
                 <Button
                   icon="info"
                   compact
-                  className={`ObjectComponent__Category__${component.category || 'Unassigned'}`}
+                  className={`ObjectComponent__Category__${cat_or_unassigned}`}
                   tooltip={component.description}
                   tooltipPosition="top"
                 />

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
@@ -48,7 +48,7 @@ export class DisplayComponent extends Component {
             px={1}
             className={classes([
               'ObjectComponent__Titlebar',
-              `ObjectComponent__Category__${component.category}`,
+              `ObjectComponent__Category__${component.category || "Unassigned"}`,
             ])}
           >
             <Stack>
@@ -60,7 +60,7 @@ export class DisplayComponent extends Component {
                   <Stack.Item key={icon}>
                     <Button
                       icon={icon}
-                      className={`ObjectComponent__Category__${category}`}
+                      className={`ObjectComponent__Category__${component.category || "Unassigned"}`}
                       compact
                       tooltip={component.ui_alerts[icon]}
                     />
@@ -70,7 +70,7 @@ export class DisplayComponent extends Component {
                 <Button
                   icon="info"
                   compact
-                  className={`ObjectComponent__Category__${category}`}
+                  className={`ObjectComponent__Category__${component.category || "Unassigned"}`}
                   tooltip={component.description}
                   tooltipPosition="top"
                 />

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/DisplayComponent.jsx
@@ -47,10 +47,7 @@ export class DisplayComponent extends Component {
           <Box
             py={1}
             px={1}
-            className={classes([
-              'ObjectComponent__Titlebar',
-              categoryClass,
-            ])}
+            className={classes(['ObjectComponent__Titlebar', categoryClass])}
           >
             <Stack>
               <Stack.Item grow={1} unselectable="on">

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/ObjectComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/ObjectComponent.jsx
@@ -95,7 +95,7 @@ export class ObjectComponent extends Component {
       x,
       y,
       index,
-      category = 'Uncategorized',
+      category = 'Unassigned',
       removable,
       ui_alerts,
       ui_buttons,

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/ObjectComponent.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/ObjectComponent.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import { Box, Button, Stack } from 'tgui-core/components';
-import { shallowDiffers } from 'tgui-core/react';
+import { classes, shallowDiffers } from 'tgui-core/react';
 
 import { ABSOLUTE_Y_OFFSET, noop } from './constants';
 import { Port } from './Port';
@@ -95,8 +95,9 @@ export class ObjectComponent extends Component {
       x,
       y,
       index,
-      color = 'blue',
+      category = 'Uncategorized',
       removable,
+      ui_alerts,
       ui_buttons,
       locations,
       onPortUpdated = noop,
@@ -136,10 +137,12 @@ export class ObjectComponent extends Component {
         {...rest}
       >
         <Box
-          backgroundColor={color}
           py={1}
           px={1}
-          className="ObjectComponent__Titlebar"
+          className={classes([
+            'ObjectComponent__Titlebar',
+            `ObjectComponent__Category__${category}`,
+          ])}
         >
           <Stack>
             <Stack.Item grow={1} unselectable="on">
@@ -150,8 +153,8 @@ export class ObjectComponent extends Component {
                 <Stack.Item key={icon}>
                   <Button
                     icon={icon}
-                    color="transparent"
                     compact
+                    className={`ObjectComponent__Category__${category}`}
                     onClick={() =>
                       act('perform_action', {
                         component_id: index,
@@ -161,11 +164,22 @@ export class ObjectComponent extends Component {
                   />
                 </Stack.Item>
               ))}
+            {!!ui_alerts &&
+              Object.keys(ui_alerts).map((icon) => (
+                <Stack.Item key={icon}>
+                  <Button
+                    className={`ObjectComponent__Category__${category}`}
+                    icon={icon}
+                    compact
+                    tooltip={ui_alerts[icon]}
+                  />
+                </Stack.Item>
+              ))}
             <Stack.Item>
               <Button
-                color="transparent"
                 icon="info"
                 compact
+                className={`ObjectComponent__Category__${category}`}
                 onClick={(e) =>
                   act('set_examined_component', {
                     component_id: index,
@@ -178,9 +192,9 @@ export class ObjectComponent extends Component {
             {!!removable && (
               <Stack.Item>
                 <Button
-                  color="transparent"
                   icon="times"
                   compact
+                  className={`ObjectComponent__Category__${category}`}
                   onClick={() =>
                     act('detach_component', { component_id: index })
                   }

--- a/tgui/packages/tgui/styles/interfaces/IntegratedCircuit.scss
+++ b/tgui/packages/tgui/styles/interfaces/IntegratedCircuit.scss
@@ -70,3 +70,65 @@ $border-radius: base.$border-radius !default;
   border: base.em(1px) solid rgba($border-color, 0.75);
   border-radius: $border-radius;
 }
+
+$category-colors: (
+  'Utility': (
+    bg: hsl(136, 82%, 30%),
+    contrast: white,
+  ),
+  'Entity': (
+    bg: hsl(288, 60%, 49%),
+    contrast: white,
+  ),
+  'Sensor': (
+    bg: hsl(337, 67%, 66%),
+    contrast: white,
+  ),
+  'Math': (
+    bg: hsl(113, 76%, 51%),
+    contrast: black,
+  ),
+  'Unassigned': (
+    bg: hsl(208, 65%, 47%),
+    contrast: white,
+  ),
+  'String': (
+    bg: hsl(24, 89%, 50%),
+    contrast: white,
+  ),
+  'List': (
+    bg: hsl(0, 0%, 67%),
+    contrast: black,
+  ),
+  'Action': (
+    bg: hsl(178, 73%, 51%),
+    contrast: black,
+  ),
+  'ID': (
+    bg: hsl(52, 97%, 52%),
+    contrast: black,
+  ),
+  'NTNet': (
+    bg: hsl(239, 64%, 44%),
+    contrast: white,
+  ),
+  'Abstract': (
+    bg: hsl(208, 65%, 47%),
+    contrast: white,
+  ),
+  'Admin': (
+    bg: hsl(0, 72%, 50%),
+    contrast: white,
+  ),
+  'BCI': (
+    bg: hsl(240, 1%, 13%),
+    contrast: white,
+  ),
+);
+
+@each $category-name, $values in $category-colors {
+  .ObjectComponent__Category__#{$category-name} {
+    background-color: map-get($values, bg);
+    color: map-get($values, contrast);
+  }
+}

--- a/tgui/packages/tgui/styles/interfaces/IntegratedCircuit.scss
+++ b/tgui/packages/tgui/styles/interfaces/IntegratedCircuit.scss
@@ -73,7 +73,7 @@ $border-radius: base.$border-radius !default;
 
 $category-colors: (
   'Utility': (
-    bg: hsl(136, 82%, 30%),
+    bg: hsl(136, 77%, 23%),
     contrast: white,
   ),
   'Entity': (
@@ -85,7 +85,7 @@ $category-colors: (
     contrast: white,
   ),
   'Math': (
-    bg: hsl(113, 76%, 51%),
+    bg: hsl(113, 65%, 47%),
     contrast: black,
   ),
   'Unassigned': (
@@ -93,7 +93,7 @@ $category-colors: (
     contrast: white,
   ),
   'String': (
-    bg: hsl(24, 89%, 50%),
+    bg: hsl(24, 84%, 48%),
     contrast: white,
   ),
   'List': (
@@ -101,11 +101,11 @@ $category-colors: (
     contrast: black,
   ),
   'Action': (
-    bg: hsl(178, 73%, 51%),
+    bg: hsl(178, 59%, 45%),
     contrast: black,
   ),
   'ID': (
-    bg: hsl(52, 97%, 52%),
+    bg: hsl(52, 75%, 48%),
     contrast: black,
   ),
   'NTNet': (
@@ -121,7 +121,7 @@ $category-colors: (
     contrast: white,
   ),
   'BCI': (
-    bg: hsl(240, 1%, 13%),
+    bg: black,
     contrast: white,
   ),
 );


### PR DESCRIPTION
## About The Pull Request
Makes it so nodes in an integrated circuit are colored depending on their category in the component menu.

Before:
![1212121212121212](https://github.com/user-attachments/assets/aec4602f-c837-415f-8f42-0dcfb9e0e4aa)

After:
![452345235345](https://github.com/user-attachments/assets/2a28f471-f0c1-4fda-9727-41db18894cb1)

All categories (BCI has been changed to solid black since this for contrast purposes)
![e](https://private-user-images.githubusercontent.com/66052067/410190943-b66d26b0-29b5-4b3f-8e65-35e6a44b74d1.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mzg3OTU0OTIsIm5iZiI6MTczODc5NTE5MiwicGF0aCI6Ii82NjA1MjA2Ny80MTAxOTA5NDMtYjY2ZDI2YjAtMjliNS00YjNmLThlNjUtMzVlNmE0NGI3NGQxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAyMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMjA1VDIyMzk1MlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWI5MzMxOWUyMzUxMmRkZTQwMThkOTNiNTk3OTEyOTExNWY4NjNkODE0YWJjZjE0MTQwYzM2YTZjYjY0ZGQ4ZDEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.uRa_SkIjdhzEbedzzLI1hDzOK-vpgC2ZNoQtvxo4ijE)

If I was some sort of tgui magician I'd try to implement a way to add comment fields, but since I'm nowhere near that, I figured this was the least I could do.

## Why It's Good For The Game
This makes it far easier to read integrated circuits and remember what they do. While there's still inherently some amount of confusion due to the nature of how node-based programming visually works, hopefully having it so nodes aren't all the same color helps a bit.
## Changelog
:cl: Wallem
qol: Integrated Circuit nodes are now colored depending on their type.
/:cl:
