### PR TITLE
Reduces the self-purge effect from Haloperidol

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1420,6 +1420,9 @@
 	if (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) >= 10 SECONDS)
 		affected_mob.adjust_hallucinations(-10 SECONDS * REM * seconds_per_tick)
 
+	if(affected_mob.getStaminaLoss() >= 100)
+		affected_mob.reagents.remove_reagent(type, 0.16 * REM * seconds_per_tick)
+
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))
 		need_mob_update += affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1, 50, affected_organ_flags)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1421,7 +1421,7 @@
 		affected_mob.adjust_hallucinations(-10 SECONDS * REM * seconds_per_tick)
 
 	if(affected_mob.getStaminaLoss() >= 100)
-		affected_mob.reagents.remove_reagent(type, 0.16 * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(type, metabolization_rate * REM * seconds_per_tick)
 
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1420,9 +1420,6 @@
 	if (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) >= 10 SECONDS)
 		affected_mob.adjust_hallucinations(-10 SECONDS * REM * seconds_per_tick)
 
-	if(affected_mob.getStaminaLoss() >= 100)
-		affected_mob.reagents.remove_reagent(type, 2 * REM * seconds_per_tick)
-
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))
 		need_mob_update += affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1, 50, affected_organ_flags)


### PR DESCRIPTION
## About The Pull Request

This reverts my first ever PR which made Haloperidol purge itself while players were in stamina crit. This change was initially made because this chem (believe it or not, it's not the only chem that was capable of this) could stack in exceedingly high amounts and keep players in stamina crit for MINUTES on end. It REALLY wasn't fun for those who got subjected to it during my experimentation with it.

However, after the PR (https://github.com/tgstation/tgstation/pull/83445) which went under my radar (this was made nearly 2 months after my first pr). Getting permanently stamina crit is no longer possible, especially via chems. So the Haloperidol self-purge (being the band-aid it was) is no longer necessary.

No, I'm not doing this because i want to buff haloperidol. With or without the self-purge, ya'll really need to learn what calomel is.


EDIT: Maintainer assigned to this is unhappy and won't let this be merged without compromise.
Title changed from "Removes the self-purge effect from Haloperidol"
And the self-purge is instead now reduced to double it's existing metabolization speed, rather than 2 units it's effectively: 0.16 + 0.16 (while stam crit)

## Why It's Good For The Game

Removes some unnecessary band-aid code. (While maintaining balance?)

## Changelog

:cl:
balance: Haloperidol's self-purge is drastically reduced while the host is stamina crit, as a result of permanent stamina crit no longer being a thing to worry about.
/:cl:
