### PR TITLE
Adds a TGUI warning for the bottle of mayhem

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -249,7 +249,9 @@
 	icon_state = "vial"
 
 /obj/item/mayhem/attack_self(mob/user)
-	if(tgui_alert(user, "Breaking the bottle will cause nearby crewmembers to go into a murderous frenzy. Be sure you know what you are doing","Break the bottle?",list("Break it!","DON'T")) != "Break it!")
+	if(tgui_alert(user, "Breaking the bottle will cause nearby crewmembers to go into a murderous frenzy. Be sure you know what you are doing...","Break the bottle?",list("Break it!","DON'T")) != "Break it!")
+		return
+	if(QDELETED(src) || !user.is_holding(src) || user.incapacitated)
 		return
 	for(var/mob/living/carbon/human/target in range(7,user))
 		target.apply_status_effect(/datum/status_effect/mayhem)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -249,17 +249,15 @@
 	icon_state = "vial"
 
 /obj/item/mayhem/attack_self(mob/user)
-	var/safety_mayhem = tgui_alert(user, "Doing this will drive nearby crewmembers into a murderous frenzy. Be sure you know what you're doing.", "Break the bottle?", list("Proceed", "Abort"))
-		if(safety_mayhem = "Abort" || QDELETED(parent) || QDELETED(real_location) || QDELETED(user) || !user.can_perform_action(parent, NEED_DEXTERITY) )
-			return
-		else
-			for(var/mob/living/carbon/human/target in range(7,user))
-				target.apply_status_effect(/datum/status_effect/mayhem)
-			to_chat(user, span_notice("You shatter the bottle!"))
-			playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
-			message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
-			user.log_message("activated a bottle of mayhem", LOG_ATTACK)
-			qdel(src)
+	if(tgui_alert(user, "Breaking the bottle will cause nearby crewmembers to go into a murderous frenzy. Be sure you know what you are doing","Break the bottle?",list("Break it!","DON'T")) != "Break it!")
+		return
+	for(var/mob/living/carbon/human/target in range(7,user))
+		target.apply_status_effect(/datum/status_effect/mayhem)
+	to_chat(user, span_notice("You shatter the bottle!"))
+	playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
+	message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
+	user.log_message("activated a bottle of mayhem", LOG_ATTACK)
+	qdel(src)
 
 /obj/item/clothing/suit/hooded/hostile_environment
 	name = "H.E.C.K. suit"

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -249,6 +249,14 @@
 	icon_state = "vial"
 
 /obj/item/mayhem/attack_self(mob/user)
+        var/safety = tgui_alert(user, "Doing this will drive nearby crewmembers into a murderous frenzy. Be sure you know what you're doing.", "Break the bottle?", list("Proceed", "Abort"))
+	if(safety != "Proceed" \
+		|| QDELETED(parent) \
+		|| QDELETED(real_location) \
+		|| QDELETED(user) \
+		|| !user.can_perform_action(parent, NEED_DEXTERITY) 
+	)
+		return
 	for(var/mob/living/carbon/human/target in range(7,user))
 		target.apply_status_effect(/datum/status_effect/mayhem)
 	to_chat(user, span_notice("You shatter the bottle!"))

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -257,13 +257,14 @@
 		|| !user.can_perform_action(parent, NEED_DEXTERITY) 
 	)
 		return
-	for(var/mob/living/carbon/human/target in range(7,user))
-		target.apply_status_effect(/datum/status_effect/mayhem)
-	to_chat(user, span_notice("You shatter the bottle!"))
-	playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
-	message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
-	user.log_message("activated a bottle of mayhem", LOG_ATTACK)
-	qdel(src)
+        else
+	     for(var/mob/living/carbon/human/target in range(7,user))
+		    target.apply_status_effect(/datum/status_effect/mayhem)
+	     to_chat(user, span_notice("You shatter the bottle!"))
+	     playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
+	     message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
+	     user.log_message("activated a bottle of mayhem", LOG_ATTACK)
+	     qdel(src)
 
 /obj/item/clothing/suit/hooded/hostile_environment
 	name = "H.E.C.K. suit"

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -249,17 +249,17 @@
 	icon_state = "vial"
 
 /obj/item/mayhem/attack_self(mob/user)
-        var/safety = tgui_alert(user, "Doing this will drive nearby crewmembers into a murderous frenzy. Be sure you know what you're doing.", "Break the bottle?", list("Proceed", "Abort"))
-	    	if(safety != "Proceed" || QDELETED(parent) || QDELETED(real_location) || QDELETED(user) || !user.can_perform_action(parent, NEED_DEXTERITY))
+	var/safety_mayhem = tgui_alert(user, "Doing this will drive nearby crewmembers into a murderous frenzy. Be sure you know what you're doing.", "Break the bottle?", list("Proceed", "Abort"))
+		if(safety_mayhem = "Abort" || QDELETED(parent) || QDELETED(real_location) || QDELETED(user) || !user.can_perform_action(parent, NEED_DEXTERITY) )
 			return
-        	else
-	    		for(var/mob/living/carbon/human/target in range(7,user))
-					target.apply_status_effect(/datum/status_effect/mayhem)
-	    		to_chat(user, span_notice("You shatter the bottle!"))
-	    		playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
-	    		message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
-	    		user.log_message("activated a bottle of mayhem", LOG_ATTACK)
-	    		qdel(src)
+		else
+			for(var/mob/living/carbon/human/target in range(7,user))
+				target.apply_status_effect(/datum/status_effect/mayhem)
+			to_chat(user, span_notice("You shatter the bottle!"))
+			playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
+			message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
+			user.log_message("activated a bottle of mayhem", LOG_ATTACK)
+			qdel(src)
 
 /obj/item/clothing/suit/hooded/hostile_environment
 	name = "H.E.C.K. suit"

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -250,21 +250,16 @@
 
 /obj/item/mayhem/attack_self(mob/user)
         var/safety = tgui_alert(user, "Doing this will drive nearby crewmembers into a murderous frenzy. Be sure you know what you're doing.", "Break the bottle?", list("Proceed", "Abort"))
-	if(safety != "Proceed" \
-		|| QDELETED(parent) \
-		|| QDELETED(real_location) \
-		|| QDELETED(user) \
-		|| !user.can_perform_action(parent, NEED_DEXTERITY) 
-	)
-		return
-        else
-	     for(var/mob/living/carbon/human/target in range(7,user))
-		    target.apply_status_effect(/datum/status_effect/mayhem)
-	     to_chat(user, span_notice("You shatter the bottle!"))
-	     playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
-	     message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
-	     user.log_message("activated a bottle of mayhem", LOG_ATTACK)
-	     qdel(src)
+	    	if(safety != "Proceed" || QDELETED(parent) || QDELETED(real_location) || QDELETED(user) || !user.can_perform_action(parent, NEED_DEXTERITY))
+			return
+        	else
+	    		for(var/mob/living/carbon/human/target in range(7,user))
+					target.apply_status_effect(/datum/status_effect/mayhem)
+	    		to_chat(user, span_notice("You shatter the bottle!"))
+	    		playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
+	    		message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] has activated a bottle of mayhem!"))
+	    		user.log_message("activated a bottle of mayhem", LOG_ATTACK)
+	    		qdel(src)
 
 /obj/item/clothing/suit/hooded/hostile_environment
 	name = "H.E.C.K. suit"


### PR DESCRIPTION
## About The Pull Request

Adds a TGUI warning for the bottle of mayhem if you try to break it so that you know what you are about to do 
## Why It's Good For The Game

Having a confirmation warning allows the player to know what the mayhem in a bottle will do (drives people into a killing frenzy) and give them one more chance before actually breaking the bottle, especially for nonantags who may not know what it actually does.
## Changelog
:cl:
qol: Gives a confirmation box describing the mayhem in a bottle's effect when a player tries to break the bottle. Player must confirm before bottle takes effect.
/:cl: