### PR TITLE
Add logging to screenshot CI test failure

### DIFF
--- a/tools/screenshot-test-comparison/index.js
+++ b/tools/screenshot-test-comparison/index.js
@@ -64,6 +64,7 @@ for (const filename of fs.readdirSync(artifactsDirectory)) {
 
 		const fullPathCompareScreenshot = path.join(screenshotsDirectory, screenshotName)
 		if (!fs.existsSync(fullPathCompareScreenshot)) {
+			console.error(`${fullPathCompareScreenshot} is missing an existing screenshot to compare against`)
 			fail(screenshotName, fullPathScreenshotName)
 			continue
 		}


### PR DESCRIPTION

## About The Pull Request
This adds an error log message whenever a CI screenshot test is failed due to it not pre-existing. It took me forever to figure out what the problem was while I was scanning through CI test failures and had to look through error logs of other downstreams repos.

## Why It's Good For The Game
N/A

## Changelog
:cl:
code: Add error message logs to screenshot CI test failure when screenshots do not exist.
/:cl:
