### PR TITLE
Fixes runtime spam from `end_reaction`

### DIFF
--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -209,7 +209,9 @@
 
 	var/reaction_message = null
 
-	if (!HAS_TRAIT(my_atom, TRAIT_SILENT_REACTIONS))
+	if (isnull(my_atom))
+		stack_trace("A reagent datum with no atom is being forced to end its reactions, this is likely a bug.")
+	else if (!HAS_TRAIT(my_atom, TRAIT_SILENT_REACTIONS))
 		reaction_message = equilibrium.reaction.mix_message
 		if(equilibrium.reaction.mix_sound)
 			playsound(get_turf(my_atom), equilibrium.reaction.mix_sound, 80, TRUE)

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -209,9 +209,7 @@
 
 	var/reaction_message = null
 
-	if (isnull(my_atom))
-		stack_trace("A reagent datum with no atom is being forced to end its reactions, this is likely a bug.")
-	else if (!HAS_TRAIT(my_atom, TRAIT_SILENT_REACTIONS))
+	if (!isnull(my_atom) && !HAS_TRAIT(my_atom, TRAIT_SILENT_REACTIONS))
 		reaction_message = equilibrium.reaction.mix_message
 		if(equilibrium.reaction.mix_sound)
 			playsound(get_turf(my_atom), equilibrium.reaction.mix_sound, 80, TRUE)


### PR DESCRIPTION
## About The Pull Request

It seems as if in some contexts, a reagent holder will end up with no associated atom, but with ongoing chemical reactions

It will attempt to stop these reactions, either naturally or by being forced to (from the aforementioned event of disassociating with its atom), but this will runtime due to this has trait check.

I actually have a feeling this proc was originally intended to be pure but uhh I dunno for sure

I'm not *100%* sure if this is the correct fix or if it's silencing a runtime. Originally I was gonna add a stack trace but I decided against it - If any reviewer would prefer that I'll re-add it

