### PR TITLE
Removed the mounted machine gun from the meta central domain

### DIFF
--- a/_maps/virtual_domains/meta_central.dmm
+++ b/_maps/virtual_domains/meta_central.dmm
@@ -1339,13 +1339,6 @@
 /obj/item/pickaxe/rusted,
 /turf/open/floor/iron,
 /area/virtual_domain)
-"lx" = (
-/obj/structure/barricade/sandbags,
-/obj/machinery/deployable_turret{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/virtual_domain)
 "lC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -7784,7 +7777,7 @@ LG
 uS
 hd
 Ol
-lx
+wN
 vU
 hp
 lu


### PR DESCRIPTION

## About The Pull Request

See title, ding dong the machine gun is gone.

## Why It's Good For The Game

It turned out to be a bad idea to put a mounted MG right next to a hostile player spawn in a low difficulty domain. Removing it should make the pirate spawn less capable of wiping the entire bitrunning squad before they clear the first pack of mobs.

## Changelog
:cl:
map: Removed a mounted machine gun from the Meta Central bitrunning domain, expect 85% less instant wipes.
/:cl:
