### PR TITLE
removes symptom weights by reverting #83456

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -266,7 +266,6 @@
 		properties["severity"] = round((properties["severity"] / 2), 1)
 		properties["severity"] *= (symptoms.len / VIRUS_SYMPTOM_LIMIT) //fewer symptoms, less severity
 		properties["severity"] = round(clamp(properties["severity"], 1, 7), 1)
-	properties["capacity"] = get_symptom_weights()
 
 // Assign the properties that are in the list.
 /datum/disease/advance/proc/assign_properties()
@@ -342,7 +341,7 @@
 // Will generate a random cure, the more resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/generate_cure()
 	if(properties?.len)
-		var/res = clamp(properties["resistance"] - (symptoms.len * 0.5), 1, advance_cures.len)
+		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
 		if(res == oldres)
 			return
 		cures = list(pick(advance_cures[res]))
@@ -405,7 +404,7 @@
 /datum/disease/advance/proc/AddSymptom(datum/symptom/S)
 	if(HasSymptom(S))
 		return
-	while(get_symptom_weights() + S.weight > VIRUS_SYMPTOM_LIMIT)
+	if(symptoms.len >= VIRUS_SYMPTOM_LIMIT)
 		RemoveSymptom(pick(symptoms))
 	symptoms += S
 	S.OnAdd(src)
@@ -421,12 +420,6 @@
 		S.neutered = TRUE
 		S.name += " (neutered)"
 		S.OnRemove(src)
-
-/// How much of the symptom capacity is currently being used?
-/datum/disease/advance/proc/get_symptom_weights()
-	. = 0
-	for(var/datum/symptom/symptom as anything in symptoms)
-		. += symptom.weight
 
 /*
 

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -10,7 +10,6 @@
 	name = "Cough"
 	desc = "The virus irritates the throat of the host, causing occasional coughing. Each cough will try to infect bystanders who are within 1 tile of the host with the virus."
 	illness = "Jest Infection"
-	weight = 2
 	stealth = -1
 	resistance = 3
 	stage_speed = 1

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -10,7 +10,6 @@
 	name = "Sneezing"
 	desc = "The virus causes irritation of the nasal cavity, making the host sneeze occasionally. Sneezes from this symptom will spread the virus in a 4 meter cone in front of the host."
 	illness = "Bard Flu"
-	weight = 2
 	stealth = -2
 	resistance = 3
 	stage_speed = 0

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -39,8 +39,6 @@
 	var/naturally_occuring = TRUE
 	///If the symptom requires an organ for the effects to function, robotic organs are immune to disease unless inorganic biology symptom is present
 	var/required_organ
-	/// How much space does this symptom use?
-	var/weight = 1
 
 /datum/symptom/New()
 	var/list/S = SSdisease.list_symptoms
@@ -108,7 +106,6 @@
 	var/list/data = list()
 	data["name"] = name
 	data["desc"] = desc
-	data["weight"] = weight
 	data["stealth"] = stealth
 	data["resistance"] = resistance
 	data["stage_speed"] = stage_speed

--- a/tgui/packages/tgui/interfaces/Pandemic/Symptom.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Symptom.tsx
@@ -70,7 +70,7 @@ const Thresholds = (props) => {
 /** Displays the numerical trait modifiers for a virus symptom */
 const Traits = (props) => {
   const {
-    symptom: { level, weight, resistance, stage_speed, stealth, transmission },
+    symptom: { level, resistance, stage_speed, stealth, transmission },
   } = props;
 
   return (
@@ -79,11 +79,6 @@ const Traits = (props) => {
         <Tooltip content="Rarity of the symptom.">
           <LabeledList.Item color={getColor(level)} label="Level">
             {level}
-          </LabeledList.Item>
-        </Tooltip>
-        <Tooltip content="The space the symptom takes.">
-          <LabeledList.Item color={getColor(weight)} label="Weight">
-            {weight}
           </LabeledList.Item>
         </Tooltip>
         <Tooltip content="Decides the cure complexity.">


### PR DESCRIPTION
## About The Pull Request
Reverts PR #83456 which added the weight system as well as applying it to two symptoms, sneezing, and coughing.
## Why It's Good For The Game
   The weight system was originally added to in the hopes a general nerf to dangerous diseases. This also had the side effect of reducing a decent amount of potential from good diseases by a fair bit as well. The PR I am reverting was merged during a time where the Virology job was just removed and people were throwing nerfs at it left and right to see what would stick.

  A minor nerf to Virology from #83459 and #83423  however has already solved most of the issues regarding dangerous diseases by allowing people with low resistance diseases to self-cure themselves automatically as well as reducing the overall stage speed by a fair bit allowing for a lot more time to make up a cure and respond in a timely manner. While the latter made airborne spreading methods overall less effective. This was ultimately done at a point where several other nerfs or changes regarding advanced diseases were made with the purpose of nerfing the Virology section of the game even further to a ridiculous degree such as #83458 and #83454. As a side effect, this also closes #86952.

   It doesn't help that the PR didn't make a token effort in making the change known in a way ingame to anyone working on Virology. Thus making it seem as if the symptom cap was reduced to 5 for most cases for unknown reasons causing a lot of frustration where even reaching to other people in a well populated server wouldn't know why the symptom cap would only allow 5 symptoms.
## Changelog
:cl:
del: Removed the weighting of viro symptoms
/:cl:
