### PR TITLE
[NO GBP] fix my whoopsies from the void cloak fix pr

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -696,7 +696,7 @@
 	if(item_flags & DROPDEL && !QDELETED(src))
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
-	UnregisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_EXAMINE_SKIP), SIGNAL_REMOVETRAIT(TRAIT_EXAMINE_SKIP)))
+	UnregisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_NO_WORN_ICON), SIGNAL_REMOVETRAIT(TRAIT_NO_WORN_ICON)))
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	if(!silent)
 		playsound(src, drop_sound, DROP_SOUND_VOLUME, vary = sound_vary, ignore_walls = FALSE)
@@ -761,7 +761,7 @@
 		give_item_action(action, user, slot)
 
 	item_flags |= IN_INVENTORY
-	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_EXAMINE_SKIP), SIGNAL_REMOVETRAIT(TRAIT_EXAMINE_SKIP)), PROC_REF(update_slot_icon), override = TRUE)
+	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_NO_WORN_ICON), SIGNAL_REMOVETRAIT(TRAIT_NO_WORN_ICON)), PROC_REF(update_slot_icon), override = TRUE)
 	if(!initial)
 		if(equip_sound && (slot_flags & slot))
 			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE)

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -111,11 +111,11 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/hide_item(datum/source, obj/item/item, slot)
 	SIGNAL_HANDLER
 	if(slot & ITEM_SLOT_SUITSTORE)
-		item.add_traits(list(TRAIT_NO_STRIP, TRAIT_NO_WORN_ICON), REF(src)) // i'd use examine hide but its a flag and yeah
+		item.add_traits(list(TRAIT_NO_STRIP, TRAIT_NO_WORN_ICON, TRAIT_EXAMINE_SKIP), REF(src))
 
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/show_item(datum/source, obj/item/item, slot)
 	SIGNAL_HANDLER
-	item.remove_traits(list(TRAIT_NO_STRIP, TRAIT_NO_WORN_ICON), REF(src))
+	item.remove_traits(list(TRAIT_NO_STRIP, TRAIT_NO_WORN_ICON, TRAIT_EXAMINE_SKIP), REF(src))
 
 /obj/item/clothing/suit/hooded/cultrobes/void/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

thanks @MrMelbert for pointing out the mistake in my sleep deprived code - I accidentally registered `SIGNAL_ADDTRAIT(TRAIT_EXAMINE_SKIP), SIGNAL_REMOVETRAIT(TRAIT_EXAMINE_SKIP)` instead of `SIGNAL_ADDTRAIT(TRAIT_NO_WORN_ICON), SIGNAL_REMOVETRAIT(TRAIT_NO_WORN_ICON)`

also, I accidentally left this in:

```
item.add_traits(list(TRAIT_NO_STRIP, TRAIT_NO_WORN_ICON), REF(src)) // i'd use examine hide but its a flag and yeah
```

after making `TRAIT_EXAMINE_SKIP` a trait, so I added that.

## Why It's Good For The Game

this should work properly

## Changelog

:cl:
fix: Fixed some mistakes I made while fixing the void cloak.
/:cl: