### PR TITLE
[NO GBP] Fix-up a line I missed during refactoring in my `icon_exists` optimization PR

### DIFF
--- a/code/__HELPERS/lighting.dm
+++ b/code/__HELPERS/lighting.dm
@@ -9,7 +9,7 @@
 
 	//Test to make sure emissives with broken or missing icon states are created
 	if(PERFORM_ALL_TESTS(focus_only/invalid_emissives))
-		if(icon_state && !icon_exists(icon, icon_state)) //Scream set to False so we can have a custom stack_trace
+		if(icon_state && !icon_exists(icon, icon_state))
 			stack_trace("An emissive appearance was added with non-existant icon_state \"[icon_state]\" in [icon]!")
 
 	return appearance

--- a/code/modules/asset_cache/assets/vending.dm
+++ b/code/modules/asset_cache/assets/vending.dm
@@ -30,10 +30,9 @@
 			continue
 
 		if (PERFORM_ALL_TESTS(focus_only/invalid_vending_machine_icon_states))
-			var/icon_states_list = icon_states(icon_file)
-			if (!(icon_state in icon_states_list))
+			if (!icon_exists(icon_file, icon_state))
 				var/icon_states_string
-				for (var/an_icon_state in icon_states_list)
+				for (var/an_icon_state in icon_states(icon_file))
 					if (!icon_states_string)
 						icon_states_string = "[json_encode(an_icon_state)]([text_ref(an_icon_state)])"
 					else


### PR DESCRIPTION
## About The Pull Request
While porting https://github.com/tgstation/tgstation/pull/89357 over to monkestation, I found that I missed refactoring a couple lines in `code\modules\asset_cache\assets\vending.dm`. This PR fixes that.

The changed code is all behind `if (PERFORM_ALL_TESTS(focus_only/invalid_vending_machine_icon_states))`. This means the changed code will only be executed if unit tests are enabled *and* `invalid_vending_machine_icon_states` is a test that will be run.

Despite that, I feel this code may be marginally faster, as the use of `icon_states()` is now behind `!icon_exists()`.

## Why It's Good For The Game
Gotta go ever so slightly faster.