### PR TITLE
[NO GBP] Fixes a input stall in the traitor guncase

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -510,7 +510,7 @@
 
 	var/i_dont_even_think_once_about_blowing_stuff_up = tgui_alert(user, "Would you like to activate the evidence disposal bomb now?", "BYE BYE", list("Yes","No"))
 
-	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || currently_exploding || QDELETED(user) || QDELETED(src) || get_dist(user, loc) > 2)
+	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || currently_exploding || QDELETED(user) || QDELETED(src) || user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING))
 		return
 
 	explosion_timer = addtimer(CALLBACK(src, PROC_REF(think_fast_chucklenuts)), 5 SECONDS, (TIMER_UNIQUE|TIMER_OVERRIDE))

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -510,7 +510,7 @@
 
 	var/i_dont_even_think_once_about_blowing_stuff_up = tgui_alert(user, "Would you like to activate the evidence disposal bomb now?", "BYE BYE", list("Yes","No"))
 
-	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || !i_dont_even_think_once_about_blowing_stuff_up || currently_exploding || QDELETED(user) || QDELETED(src) || get_dist(user, loc) > 2)
+	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || currently_exploding || QDELETED(user) || QDELETED(src) || get_dist(user, loc) > 2)
 		return
 
 	explosion_timer = addtimer(CALLBACK(src, PROC_REF(think_fast_chucklenuts)), 5 SECONDS, (TIMER_UNIQUE|TIMER_OVERRIDE))

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -504,9 +504,15 @@
 
 /obj/item/storage/toolbox/guncase/traitor/click_alt_secondary(mob/user)
 	. = ..()
-	var/i_dont_even_think_once_about_blowing_stuff_up = tgui_alert(user, "Would you like to activate the evidence disposal bomb now?", "BYE BYE", list("Yes","No"))
-	if(i_dont_even_think_once_about_blowing_stuff_up == "No")
+	if(currently_exploding)
+		user.balloon_alert(user, "already exploding!")
 		return
+
+	var/i_dont_even_think_once_about_blowing_stuff_up = tgui_alert(user, "Would you like to activate the evidence disposal bomb now?", "BYE BYE", list("Yes","No"))
+
+	if(i_dont_even_think_once_about_blowing_stuff_up != ("Yes") || !i_dont_even_think_once_about_blowing_stuff_up || currently_exploding || QDELETED(user) || QDELETED(src) || get_dist(user, loc) > 2)
+		return
+
 	explosion_timer = addtimer(CALLBACK(src, PROC_REF(think_fast_chucklenuts)), 5 SECONDS, (TIMER_UNIQUE|TIMER_OVERRIDE))
 	to_chat(user, span_warning("You prime [src]'s evidence disposal bomb!"))
 	log_bomber(user, "has activated a", src, "for detonation")

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -510,7 +510,7 @@
 
 	var/i_dont_even_think_once_about_blowing_stuff_up = tgui_alert(user, "Would you like to activate the evidence disposal bomb now?", "BYE BYE", list("Yes","No"))
 
-	if(i_dont_even_think_once_about_blowing_stuff_up != ("Yes") || !i_dont_even_think_once_about_blowing_stuff_up || currently_exploding || QDELETED(user) || QDELETED(src) || get_dist(user, loc) > 2)
+	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || !i_dont_even_think_once_about_blowing_stuff_up || currently_exploding || QDELETED(user) || QDELETED(src) || get_dist(user, loc) > 2)
 		return
 
 	explosion_timer = addtimer(CALLBACK(src, PROC_REF(think_fast_chucklenuts)), 5 SECONDS, (TIMER_UNIQUE|TIMER_OVERRIDE))


### PR DESCRIPTION

## About The Pull Request

What it says on the tin

## Why It's Good For The Game

When I read the new standards documentation and my mistake is the example being used

![image](https://github.com/user-attachments/assets/d07ee775-5fb6-4639-b180-4f11a6fdc78c)

## Changelog
:cl:
fix: The traitor guncase properly checks for condition changes before letting a player activate the time bomb.
/:cl:
