### PR TITLE
Fixes camera consoles crashing client on 516

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -200,7 +200,7 @@
 /// TOOD: Remove this entirely when 516 is stable
 /datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
 	if(viewing_hud.master_groups[key])
-		stack_trace("Hey brother, our key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob]. Ya fucked up, why are there dupes")
+		stack_trace("[key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob]!")
 		return
 	relay_loc = "1,1"
 	rebuild_plane_masters()

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -196,19 +196,16 @@
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
 
-/// This is janky as hell but since something changed with CENTER positioning after build 1614 we have to switch to the bandaid LEFT,TOP positioning
-/// using LEFT,TOP *at* or *before* 1614 will result in another broken offset for cameras
-#define MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS 1614
-
+/// Note do not use return ..() because it will cause client crush when screen gets deleted
+/// TOOD: Remove this entirely when 516 is stable
 /datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
-	// If we're about to display this group to a mob who's client is more recent than the last known version with working CENTER, then we need to remake the relays
-	// with the correct screen_loc using the relay override
-	if(viewing_hud.mymob?.client?.byond_build > MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS)
-		relay_loc = "LEFT,TOP"
-		rebuild_plane_masters()
-	return ..()
-
-#undef MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS
+	if(viewing_hud.master_groups[key])
+		stack_trace("Hey brother, our key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob]. Ya fucked up, why are there dupes")
+		return
+	relay_loc = "1,1"
+	rebuild_plane_masters()
+	set_hud(viewing_hud)
+	show_hud()
 
 /datum/plane_master_group/popup/build_planes_offset(datum/hud/source, new_offset, use_scale = TRUE)
 	return ..(source, new_offset, FALSE)


### PR DESCRIPTION
## About The Pull Request
Closes: https://github.com/tgstation/tgstation/issues/89330
Replaced old hacky workaround https://github.com/tgstation/tgstation/pull/80818 with brand new hacky workaround.
## Why It's Good For The Game
It is
## Changelog
:cl:
fix: fixed camera consoles, spyglasses etc. client crash on 516
/:cl:
