### PR TITLE
Makes parasitic eggs show up on advanced medical scanners

### DIFF
--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -5,6 +5,7 @@
 	visual = TRUE
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_PARASITE_EGG
+	organ_flags = parent_type::organ_flags | ORGAN_HAZARDOUS
 
 /obj/item/organ/body_egg/on_find(mob/living/finder)
 	..()


### PR DESCRIPTION
## About The Pull Request

For some reason they didn't before. This will make xeno embryos, headslugs, etc show up as a 'Harmful Foreign Body' when using an advanced medical scanner.

## Why It's Good For The Game

I could have sworn these showed at some point.

## Changelog

:cl:
qol: alien eggs (xeno embryos, headslugs, etc) will now show up on the advanced medical scanner
/:cl:
