### PR TITLE
Scales high-energy SM anomaly spawn with damage

### DIFF
--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -140,9 +140,9 @@
 		supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
 	if(prob(5))
 		supermatter_anomaly_gen(src, HALLUCINATION_ANOMALY, rand(5, 10))
-	if(internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || prob(1))
+	if(internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || (damage > danger_point && prob(1)))
 		supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 10))
-	if((internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (prob(0.3) && internal_energy > POWER_PENALTY_THRESHOLD))
+	if((internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (damage > danger_point && prob(0.3) && internal_energy > POWER_PENALTY_THRESHOLD))
 		supermatter_anomaly_gen(src, PYRO_ANOMALY, rand(5, 10))
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_pull(turf/center, pull_range = 3)

--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -140,9 +140,9 @@
 		supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
 	if(prob(5))
 		supermatter_anomaly_gen(src, HALLUCINATION_ANOMALY, rand(5, 10))
-	if(internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || (damage > danger_point && prob(1)))
+	if(internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || (damage > explosion_point * 0.2 && prob(1)))
 		supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 10))
-	if((internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (damage > danger_point && prob(0.3) && internal_energy > POWER_PENALTY_THRESHOLD))
+	if((internal_energy > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (damage > explosion_point * 0.4 && prob(0.3) && internal_energy > POWER_PENALTY_THRESHOLD))
 		supermatter_anomaly_gen(src, PYRO_ANOMALY, rand(5, 10))
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_pull(turf/center, pull_range = 3)


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/a0e74023-ff9f-49a8-887e-7acd3e1b97a8)

Makes CO2 setup on high energy stable. When energy is in 5-7k range then the anomalies spawn is scaled with damage instead of spawning all 4 anomaly types at 100% health.

### Before:

When SM energy is 5-7k, it spawns hallucination, flux, grav, pyro anomalies

### After:

When SM energy is 5-7k:
- And health is above 80%: it spawns hallucination and flux anomalies
- And health is below 80%:  it spawns hallucination, flux and grav anomalies
- And health is below 60%:  it spawns hallucination, flux, grav and pyro anomalies

## Why It's Good For The Game

It's a bit challenging to setup SM on high energy without delamming it.

But even if you have 100% integrity, above 5000 energy it starts spawning grav anomalies that wreck the room and pyrocastic ones that cause fires.

This PR makes the blue SM a bit more maintainable - if you keep it within the margins, it will only spawn flux and hallucination anomalies. However if you go above 7000 energy or the SM takes damage, it spawns all anomalies as before.

Blue SM is the best.

## Changelog

:cl:
balance: SM anomaly spawn now scales with integrity when energy is in 5-7k range
/:cl:

