### PR TITLE
Removes tgs3 references

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 GPLv3.txt
 LICENSE
 README.md
-TGS3.json
 .github
 .gitignore
 .gitattributes

--- a/.github/guides/STANDARDS.md
+++ b/.github/guides/STANDARDS.md
@@ -74,8 +74,6 @@ var/path_type = "/obj/item/baseball_bat"
 
 * Changes to the `/config` tree must be made in a way that allows for updating server deployments while preserving previous behaviour. This is due to the fact that the config tree is to be considered owned by the user and not necessarily updated alongside the remainder of the code. The code to preserve previous behaviour may be removed at some point in the future given the OK by maintainers.
 
-* The dlls section of tgs3.json is not designed for dlls that are purely `call()()`ed since those handles are closed between world reboots. Only put in dlls that may have to exist between world reboots.
-
 ## Structural
 ### No duplicated code (Don't repeat yourself)
 Copying code from one place to another may be suitable for small, short-time projects, but /tg/station is a long-term project and highly discourages this.

--- a/TGS3.json
+++ b/TGS3.json
@@ -1,9 +1,0 @@
-{
-    "documentation": "/tg/station server 3 configuration file",
-    "synchronize_paths": [],
-    "static_directories": [
-      "config",
-      "data"
-    ],
-    "dlls": []
-  }

--- a/code/__DEFINES/tgs.config.dm
+++ b/code/__DEFINES/tgs.config.dm
@@ -1,5 +1,4 @@
 #define TGS_EXTERNAL_CONFIGURATION
-#define TGS_V3_API
 #define TGS_DEFINE_AND_SET_GLOBAL(Name, Value) GLOBAL_VAR_INIT(##Name, ##Value); GLOBAL_PROTECT(##Name)
 #define TGS_READ_GLOBAL(Name) GLOB.##Name
 #define TGS_WRITE_GLOBAL(Name, Value) GLOB.##Name = ##Value

--- a/tools/tgs_scripts/PreCompile.bat
+++ b/tools/tgs_scripts/PreCompile.bat
@@ -1,15 +1,6 @@
 @echo off
 cd /D "%~dp0"
 set TG_BOOTSTRAP_CACHE=%cd%
-IF NOT %1 == "" (
-	rem TGS4+: we are passed the game directory on the command line
-	cd %1
-) ELSE IF EXIST "..\Game\B\tgstation.dmb" (
-	rem TGS3: Game/B/tgstation.dmb exists, so build in Game/A
-	cd ..\Game\A
-) ELSE (
-	rem TGS3: Otherwise build in Game/B
-	cd ..\Game\B
-)
+cd %1
 set CBT_BUILD_MODE=TGS
 tools\build\build


### PR DESCRIPTION

## About The Pull Request
Woo yea we are free woo yea tgs6!!!!

Only remainder is this in precompile.bat and I dont get enough about tgs to know if I can only delete the else or the elif too
```
IF NOT %1 == "" (
	rem TGS4+: we are passed the game directory on the command line
	cd %1
) ELSE IF EXIST "..\Game\B\tgstation.dmb" (
	rem TGS3: Game/B/tgstation.dmb exists, so build in Game/A
	cd ..\Game\A
) ELSE (
	rem TGS3: Otherwise build in Game/B
	cd ..\Game\B
)
```

## Changelog
:cl:
code: deleted all remaining code referencing TGS3
/:cl:
