### PR TITLE
Fix emotion mask reskinning

### DIFF
--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -8,6 +8,8 @@
 	strip_delay = 40
 	equip_delay_other = 40
 	visor_vars_to_toggle = NONE
+	unique_reskin_changes_base_icon_state = TRUE
+
 	var/adjusted_flags = null
 	///Did we install a filtering cloth?
 	var/has_filter = FALSE
@@ -52,7 +54,7 @@
 
 /obj/item/clothing/mask/update_icon_state()
 	. = ..()
-	icon_state = "[initial(icon_state)][up ? "_up" : ""]"
+	icon_state = "[base_icon_state || initial(icon_state)][up ? "_up" : ""]"
 
 /**
  * Proc called in lungs.dm to act if wearing a mask with filters, used to reduce the filters durability, return a changed gas mixture depending on the filter status

--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -2,6 +2,7 @@
 	name = "emotion mask"
 	desc = "Express your happiness or hide your sorrows with this cultured cutout."
 	icon_state = "joy"
+	base_icon_state = "joy"
 	clothing_flags = MASKINTERNALS
 	flags_inv = HIDESNOUT
 	obj_flags = parent_type::obj_flags | INFINITE_RESKIN

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -8,6 +8,7 @@
 	pickup_sound = 'sound/items/handling/gun/gun_pick_up.ogg'
 	drop_sound = 'sound/items/handling/gun/gun_drop.ogg'
 	sound_vary = TRUE
+	unique_reskin_changes_base_icon_state = TRUE
 
 	///sound when inserting magazine
 	var/load_sound = 'sound/items/weapons/gun/general/magazine_insert_full.ogg'
@@ -201,11 +202,8 @@
 		update_appearance()
 
 /obj/item/gun/ballistic/update_icon_state()
-	if(current_skin)
-		icon_state = "[unique_reskin[current_skin]][sawn_off ? "_sawn" : ""]"
-	else
-		icon_state = "[base_icon_state || initial(icon_state)][sawn_off ? "_sawn" : ""]"
-	return ..()
+	. = ..()
+	icon_state = "[base_icon_state || initial(icon_state)][sawn_off ? "_sawn" : ""]"
 
 /obj/item/gun/ballistic/update_overlays()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -110,6 +110,7 @@
 	desc = "A classic, if not outdated, lethal firearm. Uses .38 Special rounds."
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	icon_state = "c38"
+	base_icon_state = "c38"
 	fire_sound = 'sound/items/weapons/gun/revolver/shot.ogg'
 
 /obj/item/gun/ballistic/revolver/c38/detective

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -267,6 +267,7 @@
 	name = "double-barreled shotgun"
 	desc = "A true classic."
 	icon_state = "dshotgun"
+	base_icon_state = "dshotgun"
 	inhand_icon_state = "shotgun_db"
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM


### PR DESCRIPTION

## About The Pull Request

Sooooo I recently noticed emotion masks wouldn't actually change their skin upon reskinning, even though the reskinning went through successfully.
Looking into it, I found it's because in a recent pr we added an `update_appearance()` call to the reskinning procs, while masks reset their `icon_state` during that line of calls:
https://github.com/tgstation/tgstation/blob/80d3d8a230bba7cb41fba11c7bd75831935c8698/code/modules/clothing/masks/_masks.dm#L53-L55
Meaning, the emotion mask would never actually reskin properly.

So in this pr we instead make this `update_icon_state()` proc prioritise `base_icon_state`, and make reskinnable masks use `unique_reskin_changes_base_icon_state = TRUE`.
We also change a similar odd implementation of this in `/obj/item/gun/ballistic/update_icon_state()`:
https://github.com/tgstation/tgstation/blob/80d3d8a230bba7cb41fba11c7bd75831935c8698/code/modules/projectiles/guns/ballistic.dm#L203-L208
To just use `unique_reskin_changes_base_icon_state = TRUE` instead of awkward usage of `unique_reskin[current_skin]` on an otherwise duplicated line.

This fixes our issues.
## Why It's Good For The Game

Good if stuff works
## Changelog
:cl:
fix: Emotion mask reskinning works properly
/:cl:
