### PR TITLE
TM: Make EVA public access

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -66539,15 +66539,13 @@
 /area/station/service/library/abandoned)
 "qGJ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "qGL" = (
@@ -80869,9 +80867,6 @@
 /area/station/medical/abandoned)
 "ukd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage"
-	},
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/stripes/line,
@@ -80880,6 +80875,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "ukj" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29113,13 +29113,11 @@
 /area/station/commons/toilet/restrooms)
 "knj" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "knt" = (
@@ -44134,13 +44132,11 @@
 /area/station/maintenance/port/aft)
 "pIm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "pIs" = (


### PR DESCRIPTION

## About The Pull Request
I want to see how shifts will change with EVA being public access

## Why It's Good For The Game
I don't think it will make much difference other than making lowpop rounds slightly more convenient.


## Changelog
:cl:
map: I found the keys for EVA! It's unlocked now.
/:cl:
