### PR TITLE
Fix jumpsuit sensors context not applying when jumpsuit is held, allow changing sensors when jumpsuit is in active hand

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -69,7 +69,7 @@
 
 	var/changed = FALSE
 
-	if(isnull(held_item) && has_sensor == HAS_SENSORS)
+	if((isnull(held_item) || held_item == src) && has_sensor == HAS_SENSORS)
 		context[SCREENTIP_CONTEXT_RMB] = "Toggle suit sensors"
 		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Set suit sensors to tracking"
 		changed = TRUE

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -122,6 +122,14 @@
 	toggle()
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+/obj/item/clothing/under/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+
+	toggle()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/clothing/under/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	. = ..()
 	if(damaged_state == CLOTHING_SHREDDED && has_sensor > NO_SENSORS)


### PR DESCRIPTION

## About The Pull Request

I noticed that jumpsuit maxing sensors context tips wouldn't actually show when it's in your active hand, even though it does work.
Soooo in this pr we simply make it also display when it's the current held item.

Additionally, we add a `attack_self_secondary(...)` override so the right-click sensors menu actually works when the jumpsuit is in your active hand.

This fixes our issues.
## Why It's Good For The Game

It's kinda awkward when it doesn't give you the ctrl-click to max sensors context when the jumpsuit is in your active hand, even though it DOES work.
Needing to drop the jumpsuit or swap to the other hand to change sensors is kinda awkward.
## Changelog
:cl:
fix: Jumpsuit sensors context tips actually show when you are holding the jumpsuit.
qol: You may right click to change jumpsuit sensors when it's in your active hand, instead of having to swap to an empty hand or drop it to do so.
/:cl:
