### PR TITLE
Swaps box/material for a bag

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -2283,6 +2283,10 @@
 /obj/item/disk/tech_disk/debug,
 /turf/open/floor/iron,
 /area/station/science)
+"OZ" = (
+/obj/item/storage/bag/sheetsnatcher/debug,
+/turf/open/floor/iron,
+/area/station/science)
 "Pc" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -6441,7 +6445,7 @@ Pv
 Xp
 ah
 NZ
-bD
+OZ
 XC
 co
 bA

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -12,7 +12,7 @@
  * Plant Bag
  * Sheet Snatcher
  * Book Bag
- *      Biowaste Bag
+ * Biowaste Bag
  *
  * -Sayu
  */
@@ -319,6 +319,63 @@
 	name = "sheet snatcher 9000"
 	desc = ""
 	capacity = 500//Borgs get more because >specialization
+
+
+// -----------------------------
+//    Sheet Snatcher (Debug)
+// -----------------------------
+
+/obj/item/storage/bag/sheetsnatcher/debug
+	name = "sheet snatcher EXTREME EDITION"
+	desc = "A Nanotrasen storage system designed which has been given post-market alterations to hold any type of sheet. Comes pre-populated with "
+	color = "#ff3737" // I'm too lazy to make a unique sprite
+	capacity = 5000 // Hopefully enough to fit anything you need
+	w_class = WEIGHT_CLASS_TINY
+
+// Copy-pasted from the former /obj/item/storage/box/material, w/ small additions like rods, cardboard, plastic.
+// "Only 20 uranium 'cause of radiation"
+/obj/item/storage/bag/sheetsnatcher/debug/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/stack/sheet/iron/fifty=1,
+		/obj/item/stack/sheet/glass/fifty=1,
+		/obj/item/stack/sheet/rglass/fifty=1,
+		/obj/item/stack/sheet/plasmaglass/fifty=1,
+		/obj/item/stack/sheet/titaniumglass/fifty=1,
+		/obj/item/stack/sheet/plastitaniumglass/fifty=1,
+		/obj/item/stack/sheet/plasteel/fifty=1,
+		/obj/item/stack/sheet/mineral/titanium/fifty=1,
+		/obj/item/stack/sheet/mineral/gold=50,
+		/obj/item/stack/sheet/mineral/silver=50,
+		/obj/item/stack/sheet/mineral/plasma=50,
+		/obj/item/stack/sheet/mineral/uranium=20,
+		/obj/item/stack/sheet/mineral/diamond=50,
+		/obj/item/stack/sheet/bluespace_crystal=50,
+		/obj/item/stack/sheet/mineral/bananium=50,
+		/obj/item/stack/sheet/mineral/wood/fifty=1,
+		/obj/item/stack/sheet/plastic/fifty=1,
+		/obj/item/stack/sheet/runed_metal/fifty=1,
+		/obj/item/stack/rods/fifty=1,
+		/obj/item/stack/sheet/mineral/plastitanium=50,
+		/obj/item/stack/sheet/mineral/abductor=50,
+		/obj/item/stack/sheet/cardboard/fifty=1,
+		)
+	//This needs to be done here and not in Initialize() because the stacks get merged and fall out when their weight updates if this is set after PopulateContents()
+	atom_storage.allow_big_nesting = TRUE
+	atom_storage.max_slots = 99
+	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
+	atom_storage.max_total_storage = capacity
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/bag/sheetsnatcher/debug/Initialize(mapload)
+	. = ..()
+	// Overrides so it can hold all possible sheets
+	atom_storage.set_holdable(
+		can_hold_list = list(
+			/obj/item/stack/sheet,
+			/obj/item/stack/sheet/mineral/sandstone,
+			/obj/item/stack/sheet/mineral/wood,
+		)
+	)
 
 // -----------------------------
 //           Book bag

--- a/code/game/objects/items/storage/boxes/engineering_boxes.dm
+++ b/code/game/objects/items/storage/boxes/engineering_boxes.dm
@@ -18,43 +18,6 @@
 	for(var/i in 1 to 7)
 		new/obj/item/grenade/chem_grenade/smart_metal_foam(src)
 
-/obj/item/storage/box/material
-	name = "box of materials"
-	illustration = "implant"
-
-/obj/item/storage/box/material/Initialize(mapload)
-	. = ..()
-	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC //This needs to be set here too because the parent type overrides it again
-
-/obj/item/storage/box/material/PopulateContents() //less uranium because radioactive
-	var/static/items_inside = list(
-		/obj/item/stack/sheet/iron/fifty=1,
-		/obj/item/stack/sheet/glass/fifty=1,
-		/obj/item/stack/sheet/rglass=50,
-		/obj/item/stack/sheet/plasmaglass=50,
-		/obj/item/stack/sheet/titaniumglass=50,
-		/obj/item/stack/sheet/plastitaniumglass=50,
-		/obj/item/stack/sheet/plasteel=50,
-		/obj/item/stack/sheet/mineral/plastitanium=50,
-		/obj/item/stack/sheet/mineral/titanium=50,
-		/obj/item/stack/sheet/mineral/gold=50,
-		/obj/item/stack/sheet/mineral/silver=50,
-		/obj/item/stack/sheet/mineral/plasma=50,
-		/obj/item/stack/sheet/mineral/uranium=20,
-		/obj/item/stack/sheet/mineral/diamond=50,
-		/obj/item/stack/sheet/bluespace_crystal=50,
-		/obj/item/stack/sheet/mineral/bananium=50,
-		/obj/item/stack/sheet/mineral/wood=50,
-		/obj/item/stack/sheet/plastic/fifty=1,
-		/obj/item/stack/sheet/runed_metal/fifty=1,
-		)
-	//This needs to be done here and not in Initialize() because the stacks get merged and fall out when their weight updates if this is set after PopulateContents()
-	atom_storage.allow_big_nesting = TRUE
-	atom_storage.max_slots = 99
-	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
-	atom_storage.max_total_storage = 99
-	generate_items_inside(items_inside,src)
-
 /obj/item/storage/box/debugtools
 	name = "box of debug tools"
 	icon_state = "syndiebox"
@@ -79,7 +42,7 @@
 		/obj/item/stack/spacecash/c1000=50,
 		/obj/item/storage/box/beakers/bluespace=1,
 		/obj/item/storage/box/beakers/variety=1,
-		/obj/item/storage/box/material=1,
+		/obj/item/storage/bag/sheetsnatcher/debug=1,
 		/obj/item/uplink/debug=1,
 		/obj/item/uplink/nuclear/debug=1,
 		/obj/item/clothing/ears/earmuffs/debug = 1,


### PR DESCRIPTION

## About The Pull Request
Removes `box/material`, and instead turns it into `bag/debug`. Replaces the box in the debug toolkit box, and places a bag in the little science room of runtimestation.
## Why It's Good For The Game
Manually putting sheets into runtimestation's ore silo--or having to spawn in a sheet snatcher to do it for me--is really annoying, Now instead we can just pick up the bag and shove it in and be done with it.
## Changelog
Not player facing
