### PR TITLE
Fixes Cryogelidia trapping you in stasis hell even though the cube broke

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -86,8 +86,6 @@
 * Will be removed when the required reagent is removed too
 * is processed on the dead.
 */
-/atom/movable/screen/alert/status_effect/freon/cryostylane
-	desc = "You're frozen inside of a protective ice cube! While inside, you can't do anything, but are immune to harm! You will be free when the chem runs out."
 
 /datum/reagent/inverse/cryostylane
 	name = "Cryogelidia"
@@ -97,27 +95,21 @@
 	ph = 14
 	chemical_flags = REAGENT_DEAD_PROCESS | REAGENT_IGNORE_STASIS | REAGENT_DONOTSPLIT
 	metabolization_rate = 1 * REM
-	///The cube we're stasis'd in
-	var/obj/structure/ice_stasis/cube
-	var/atom/movable/screen/alert/status_effect/freon/cryostylane_alert
 
-/datum/reagent/inverse/cryostylane/on_mob_add(mob/living/carbon/affected_mob, amount)
+/datum/reagent/inverse/cryostylane/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE)
 	. = ..()
-	if(HAS_TRAIT(affected_mob, TRAIT_RESISTCOLD))
+	if(HAS_TRAIT(exposed_mob, TRAIT_RESISTCOLD))
 		holder.remove_reagent(type, volume)
 		return
-	cube = new /obj/structure/ice_stasis(get_turf(affected_mob))
-	cube.color = COLOR_CYAN
-	cube.set_anchored(TRUE)
-	affected_mob.forceMove(cube)
-	affected_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
-	cryostylane_alert = affected_mob.throw_alert("cryostylane_alert", /atom/movable/screen/alert/status_effect/freon/cryostylane)
-	cryostylane_alert.attached_effect = src //so the alert can reference us, if it needs to
+	exposed_mob.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
+	exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
 
 /datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	if(!cube || affected_mob.loc != cube)
-		metabolization_rate += 0.01
+	if(!affected_mob.has_status_effect(/datum/status_effect/frozenstasis/irresistable))
+		holder.remove_reagent(type, volume) // remove it all if we were broken out
+		return
+	metabolization_rate += 0.01 //speed up our metabolism over time. Chop chop.
 
 /datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	if(current_cycle >= 60)
@@ -125,12 +117,7 @@
 		return
 	return ..()
 
-/datum/reagent/inverse/cryostylane/on_mob_delete(mob/living/carbon/affected_mob, amount)
+/datum/reagent/inverse/cryostylane/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
-	QDEL_NULL(cube)
-	if(!iscarbon(affected_mob))
-		return
-
-	var/mob/living/carbon/carbon_mob = affected_mob
-	carbon_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
-	carbon_mob.clear_alert("cryostylane_alert")
+	affected_mob.remove_status_effect(/datum/status_effect/frozenstasis/irresistable)
+	affected_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -101,8 +101,10 @@
 	if(HAS_TRAIT(exposed_mob, TRAIT_RESISTCOLD))
 		holder.remove_reagent(type, volume)
 		return
+
 	exposed_mob.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
-	exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
+	if(!exposed_mob.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT))
+		exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
 
 /datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -98,10 +98,14 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = STATUS_EFFECT_PERMANENT //Will remove self when block breaks.
 	alert_type = /atom/movable/screen/alert/status_effect/freon/stasis
+	/// The cube we will place our mob into.
 	var/obj/structure/ice_stasis/cube
+	/// Whether or not this version of the status effect can be resisted out of.
+	var/resistable = TRUE
 
 /datum/status_effect/frozenstasis/on_apply()
-	RegisterSignal(owner, COMSIG_LIVING_RESIST, PROC_REF(breakCube))
+	if(resistable)
+		RegisterSignal(owner, COMSIG_LIVING_RESIST, PROC_REF(breakCube))
 	cube = new /obj/structure/ice_stasis(get_turf(owner))
 	owner.forceMove(cube)
 	ADD_TRAIT(owner, TRAIT_GODMODE, TRAIT_STATUS_EFFECT(id))
@@ -120,7 +124,11 @@
 	if(cube)
 		qdel(cube)
 	REMOVE_TRAIT(owner, TRAIT_GODMODE, TRAIT_STATUS_EFFECT(id))
-	UnregisterSignal(owner, COMSIG_LIVING_RESIST)
+	if(resistable)
+		UnregisterSignal(owner, COMSIG_LIVING_RESIST)
+
+/datum/status_effect/frozenstasis/irresistable
+	resistable = FALSE
 
 /datum/status_effect/slime_clone
 	id = "slime_cloned"


### PR DESCRIPTION
## About The Pull Request

Rather than mimic the effects of the chilled extract's cube, we actually use the status effect to accomplish that goal, except it does not give you the option to resist out of the cube. On exposure, our mob is cubed along with being put into stasis. 

If the status effect is removed (because someone broke the cube), we purge the chem from our system.

When we are no longer metabolizing the chemical, we also remove the cube and the stasis effect.

## Why It's Good For The Game

Someone asked me to fix it, and I'm obliging. Hopefully this comparable to prior behavior. I make no promises. but it appears to be working as expected.

## Changelog
:cl:
fix: Cryogelidia can no longer put you into stasis longer than the lifespan of the cube prison it kept you in.
/:cl:
