### PR TITLE
Makes some admin panels use browser

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -171,10 +171,8 @@
 
 /obj/machinery/pipedispenser/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
-	if(default_unfasten_wrench(user, tool, time = 4 SECONDS))
-		user << browse(null, "window=pipedispenser")
-
-	return TRUE
+	default_unfasten_wrench(user, tool, time = 4 SECONDS)
+	return ITEM_INTERACT_SUCCESS
 
 
 /obj/machinery/pipedispenser/disposal

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -267,15 +267,12 @@
 				if(!electronics)
 					to_chat(usr, span_warning("The assembly is missing electronics!"))
 					return
-				user << browse(null, "window=windoor_access")
 				user.visible_message(span_notice("[user] pries the windoor into the frame."),
 					span_notice("You start prying the windoor into the frame..."))
 
 				if(W.use_tool(src, user, 40, volume=100) && electronics)
 					set_density(TRUE) //Shouldn't matter but just incase
-
 					to_chat(user, span_notice("You finish the windoor."))
-
 					finish_door()
 
 			else

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -181,4 +181,6 @@
 	dat += build_antag_listing()
 
 	dat += "</body></html>"
-	usr << browse(dat.Join(), "window=roundstatus;size=500x500")
+	var/datum/browser/browser = new(usr, "roundstatus", "Round Status", 500, 500)
+	browser.set_content(dat.Join())
+	browser.open()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -537,7 +537,9 @@ ADMIN_VERB(del_log, R_DEBUG, "Display del() Log", "Display del's log of everythi
 
 	dellog += "</ol>"
 
-	user << browse(dellog.Join(), "window=dellog")
+	var/datum/browser/browser = new(usr, "dellog", "Del Log", 00, 400)
+	browser.set_content(dellog.Join())
+	browser.open()
 
 ADMIN_VERB(display_overlay_log, R_DEBUG, "Display Overlay Log", "Display SSoverlays log of everything that's passed through it.", ADMIN_CATEGORY_DEBUG)
 	render_stats(SSoverlays.stats, user)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -56,7 +56,9 @@ ADMIN_VERB(radio_report, R_DEBUG, "Radio Report", "Shows a report of all radio d
 				else
 					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device]<br>"
 
-	user << browse(output,"window=radioreport")
+	var/datum/browser/browser = new(user, "radioreport", "Radio Logs", 400, 440)
+	browser.set_content(output)
+	browser.open()
 	BLACKBOX_LOG_ADMIN_VERB("Show Radio Report")
 
 ADMIN_VERB(reload_admins, R_NONE, "Reload Admins", "Reloads all admins from the database.", ADMIN_CATEGORY_MAIN)

--- a/code/modules/admin/verbs/list_exposer.dm
+++ b/code/modules/admin/verbs/list_exposer.dm
@@ -25,7 +25,10 @@
 	var/data = "<b>Showing last [length(GLOB.lawchanges)] law changes.</b><hr>"
 	for(var/entry in GLOB.lawchanges)
 		data += "[entry]<BR>"
-	usr << browse(data, "window=lawchanges;size=800x500")
+
+	var/datum/browser/browser = new(usr, "lawchanges", "Law Changes", 800, 500)
+	browser.set_content(data)
+	browser.open()
 
 /datum/admins/proc/list_dna()
 	var/data = "<b>Showing DNA from blood.</b><hr>"
@@ -35,7 +38,10 @@
 		if(subject.ckey)
 			data += "<tr><td>[subject]</td><td>[subject.dna.unique_enzymes]</td><td>[subject.dna.blood_type]</td></tr>"
 	data += "</table>"
-	usr << browse(data, "window=DNA;size=440x410")
+
+	var/datum/browser/browser = new(usr, "DNA", "DNA Log", 440, 410)
+	browser.set_content(data)
+	browser.open()
 
 /datum/admins/proc/list_fingerprints() //kid named fingerprints
 	var/data = "<b>Showing Fingerprints.</b><hr>"
@@ -45,7 +51,10 @@
 		if(subject.ckey)
 			data += "<tr><td>[subject]</td><td>[md5(subject.dna.unique_identity)]</td></tr>"
 	data += "</table>"
-	usr << browse(data, "window=fingerprints;size=440x410")
+
+	var/datum/browser/browser = new(usr, "fingerprints", "Fingerprint Log", 440, 410)
+	browser.set_content(data)
+	browser.open()
 
 /datum/admins/proc/show_manifest()
 	if(!SSticker.HasRoundStarted())

--- a/code/modules/transport/admin.dm
+++ b/code/modules/transport/admin.dm
@@ -8,6 +8,8 @@ ADMIN_VERB(reset_tram, R_DEBUG|R_ADMIN, "Reset Tram", "Reset a tram controller o
 
 	var/datum/transport_controller/linear/tram/broken_controller
 	var/selected_transport_id = tgui_input_list(user, "Which tram?", "Off the rails", debug_tram_list)
+	if(isnull(selected_transport_id))
+		return
 	var/reset_type = tgui_input_list(user, "How hard of a reset?", "How bad is it screwed up", list("Clear Tram Contents", "Controller", "Controller and Contents", "Delete Datum", "Cancel"))
 
 	if(isnull(reset_type) || reset_type == "Cancel")


### PR DESCRIPTION
## About The Pull Request

del() log, radio log, check antagonists, law/dna/fingerprint logs all use browser instead, which means darkmode, wahoo

![image](https://github.com/user-attachments/assets/efd968cf-9182-4e65-a4f0-2edb3431827a)
![image](https://github.com/user-attachments/assets/2bfd6ad2-42f0-4e42-8ad7-63821b31f021)
![image](https://github.com/user-attachments/assets/4a8f13e4-8e81-43cc-b00c-aecf033c9947)

The only difference now is that they are in darkmode, really.
Also removed browse calls to pipe dispensers (the machine) and windoor assembly, as they both use TGUI now so these don't do anything.
Lastly, adds an early return to the tram admin tool if you don't select a tram, cause I found it annoying.

## Why It's Good For The Game

Try to use old admin tools, get flashbanged

## Changelog

:cl:
admin: Check antagonists & del/law/dna/fingerprint/radio log panels use browsers which means they have darkmode. Also the tram panel will cancel out if you click cancel.
/:cl: