### PR TITLE
Minor kiss code refactor/unification

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -472,7 +472,7 @@
 	icon_state = "heart"
 	inhand_icon_state = "nothing"
 	/// The kind of projectile this version of the kiss blower fires
-	var/kiss_type = /obj/projectile/kiss
+	var/kiss_type_override = null
 	/// TRUE if the user was aiming anywhere but the mouth when they offer the kiss, if it's offered
 	var/cheek_kiss
 
@@ -480,11 +480,13 @@
 	return ranged_interact_with_atom(interacting_with, user, modifiers)
 
 /obj/item/hand_item/kisser/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
-		kiss_type = /obj/projectile/kiss/french
+	if(!kiss_type_overide)
+		if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
+			kiss_type_overide = /obj/projectile/kiss/french
+		if(HAS_TRAIT(user, TRAIT_CHEF_KISS))
+			kiss_type_override = /obj/projectile/kiss/chef
 
-	if(HAS_TRAIT(user, TRAIT_CHEF_KISS))
-		kiss_type = /obj/projectile/kiss/chef
+	var/kiss_type = kiss_type_override || /obj/projectile/kiss
 
 	var/obj/projectile/blown_kiss = new kiss_type(get_turf(user))
 	user.visible_message("<b>[user]</b> blows \a [blown_kiss] at [target]!", span_notice("You blow \a [blown_kiss] at [target]!"))
@@ -531,19 +533,19 @@
 	name = "kiss of death"
 	desc = "If looks could kill, they'd be this."
 	color = COLOR_BLACK
-	kiss_type = /obj/projectile/kiss/death
+	kiss_type_override = /obj/projectile/kiss/death
 
 /obj/item/hand_item/kisser/syndie
 	name = "syndie kiss"
 	desc = "oooooo you like syndicate ur a syndiekisser"
 	color = COLOR_SYNDIE_RED
-	kiss_type = /obj/projectile/kiss/syndie
+	kiss_type_override = /obj/projectile/kiss/syndie
 
 /obj/item/hand_item/kisser/ink
 	name = "ink kiss"
 	desc = "Is that a blot of ink in your pocket or are you just happy to see me?"
 	color = COLOR_ALMOST_BLACK
-	kiss_type = /obj/projectile/kiss/ink
+	kiss_type_override = /obj/projectile/kiss/ink
 
 /obj/projectile/kiss
 	name = "kiss"

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -472,7 +472,7 @@
 	icon_state = "heart"
 	inhand_icon_state = "nothing"
 	/// The kind of projectile this version of the kiss blower fires
-	var/kiss_type = null
+	var/kiss_type = /obj/projectile/kiss
 	/// TRUE if the user was aiming anywhere but the mouth when they offer the kiss, if it's offered
 	var/cheek_kiss
 

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -472,7 +472,7 @@
 	icon_state = "heart"
 	inhand_icon_state = "nothing"
 	/// The kind of projectile this version of the kiss blower fires
-	var/kiss_type_override = null
+	var/kiss_type = null
 	/// TRUE if the user was aiming anywhere but the mouth when they offer the kiss, if it's offered
 	var/cheek_kiss
 
@@ -480,14 +480,6 @@
 	return ranged_interact_with_atom(interacting_with, user, modifiers)
 
 /obj/item/hand_item/kisser/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(!kiss_type_overide)
-		if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
-			kiss_type_overide = /obj/projectile/kiss/french
-		if(HAS_TRAIT(user, TRAIT_CHEF_KISS))
-			kiss_type_override = /obj/projectile/kiss/chef
-
-	var/kiss_type = kiss_type_override || /obj/projectile/kiss
-
 	var/obj/projectile/blown_kiss = new kiss_type(get_turf(user))
 	user.visible_message("<b>[user]</b> blows \a [blown_kiss] at [target]!", span_notice("You blow \a [blown_kiss] at [target]!"))
 
@@ -533,19 +525,31 @@
 	name = "kiss of death"
 	desc = "If looks could kill, they'd be this."
 	color = COLOR_BLACK
-	kiss_type_override = /obj/projectile/kiss/death
+	kiss_type = /obj/projectile/kiss/death
 
 /obj/item/hand_item/kisser/syndie
 	name = "syndie kiss"
 	desc = "oooooo you like syndicate ur a syndiekisser"
 	color = COLOR_SYNDIE_RED
-	kiss_type_override = /obj/projectile/kiss/syndie
+	kiss_type = /obj/projectile/kiss/syndie
 
 /obj/item/hand_item/kisser/ink
 	name = "ink kiss"
 	desc = "Is that a blot of ink in your pocket or are you just happy to see me?"
 	color = COLOR_ALMOST_BLACK
-	kiss_type_override = /obj/projectile/kiss/ink
+	kiss_type = /obj/projectile/kiss/ink
+
+/obj/item/hand_item/kisser/french
+	name = "french kiss"
+	desc = "You really should brush your teeth."
+	color = COLOR_GRAY
+	kiss_type = /obj/projectile/kiss/french
+
+/obj/item/hand_item/kisser/chef
+	name = "chef's kiss"
+	desc = "The secret ingridient is love. And opium, but mostly love."
+	color = COLOR_LIGHT_PINK
+	kiss_type = /obj/projectile/kiss/chef
 
 /obj/projectile/kiss
 	name = "kiss"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -256,6 +256,12 @@
 	. = ..()
 	var/kiss_type = /obj/item/hand_item/kisser
 
+	if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
+		kiss_type = /obj/item/hand_item/kisser/french
+
+	if(HAS_TRAIT(user, TRAIT_CHEF_KISS))
+		kiss_type = /obj/item/hand_item/kisser/chef
+
 	if(HAS_TRAIT(user, TRAIT_SYNDIE_KISS))
 		kiss_type = /obj/item/hand_item/kisser/syndie
 
@@ -265,17 +271,17 @@
 	var/datum/action/cooldown/ink_spit/ink_action = locate() in user.actions
 	if(ink_action?.IsAvailable())
 		kiss_type = /obj/item/hand_item/kisser/ink
-		ink_action.StartCooldown()
 	else
 		ink_action = null
 
 	var/obj/item/kiss_blower = new kiss_type(user)
 	if(user.put_in_hands(kiss_blower))
 		to_chat(user, span_notice("You ready your kiss-blowing hand."))
-	else
-		qdel(kiss_blower)
-		to_chat(user, span_warning("You're incapable of blowing a kiss in your current state."))
-		ink_action?.ResetCooldown()
+		ink_action?.StartCooldown()
+		return
+
+	qdel(kiss_blower)
+	to_chat(user, span_warning("You're incapable of blowing a kiss in your current state."))
 
 /datum/emote/living/laugh
 	key = "laugh"


### PR DESCRIPTION

## About The Pull Request

Merged two parts (garlic breath and chef's love/syndie kisses, death's kisses and ink spit) of kiss code, which prevents former from overriding latter. Countering syndicate lipstick by throwing mime berets at its user is pretty funny, but also extremely weird (and makes coders angry at disjointed code)

Closes #89395

## Changelog
:cl:
fix: Chef's love and french kissing no longer can stop laser projectiles of syndiekissers.
code: Unified two parts of kiss code.
/:cl:
