### PR TITLE
Fixes SiliConnect not being able to download logs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -194,6 +194,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 
 	return NONE
 
+// This has to go at the very end of interaction so we don't block every interaction with ID-like items
 /mob/living/silicon/robot/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
 	if(. || !tool.GetID())

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -145,19 +145,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		balloon_alert(user, "no radio found!")
 		return ITEM_INTERACT_BLOCKING
 
-	if(tool.GetID())
-		if(opened)
-			balloon_alert(user, "close the chassis cover first!")
-			return ITEM_INTERACT_BLOCKING
-		if(!allowed(user))
-			balloon_alert(user, "access denied!")
-			return ITEM_INTERACT_BLOCKING
-		locked = !locked
-		update_icons()
-		balloon_alert(user, "chassis cover lock [emagged ? "glitches" : "toggled"]")
-		logevent("[emagged ? "ChÃ¥vÃis" : "Chassis"] cover lock has been [locked ? "engaged" : "released"]")
-		return ITEM_INTERACT_SUCCESS
-
 	if(istype(tool, /obj/item/borg/upgrade))
 		if(!opened)
 			balloon_alert(user, "chassis cover is closed!")
@@ -206,6 +193,22 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return modularInterface.computer_disk_act(user, tool)
 
 	return NONE
+
+/mob/living/silicon/robot/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(. || !tool.GetID())
+		return
+	if(opened)
+		balloon_alert(user, "close the chassis cover first!")
+		return ITEM_INTERACT_BLOCKING
+	if(!allowed(user))
+		balloon_alert(user, "access denied!")
+		return ITEM_INTERACT_BLOCKING
+	locked = !locked
+	update_icons()
+	balloon_alert(user, "chassis cover lock [emagged ? "glitches" : "toggled"]")
+	logevent("[emagged ? "ChÃ¥vÃis" : "Chassis"] cover lock has been [locked ? "engaged" : "released"]")
+	return ITEM_INTERACT_SUCCESS
 
 #define LOW_DAMAGE_UPPER_BOUND 1/3
 #define MODERATE_DAMAGE_UPPER_BOUND 2/3

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -193,12 +193,12 @@
 	physical = null
 	return ..()
 
-/obj/item/modular_computer/pre_attack_secondary(atom/A, mob/living/user, params)
-	if(active_program?.tap(A, user, params))
-		user.do_attack_animation(A) //Emulate this animation since we kill the attack in three lines
+/obj/item/modular_computer/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	if(active_program?.tap(interacting_with, user, modifiers))
+		user.do_attack_animation(interacting_with) //Emulate this animation since we kill the attack in three lines
 		playsound(loc, 'sound/items/weapons/tap.ogg', get_clamped_volume(), TRUE, -1) //Likewise for the tap sound
 		addtimer(CALLBACK(src, PROC_REF(play_ping)), 0.5 SECONDS, TIMER_UNIQUE) //Slightly delayed ping to indicate success
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return ITEM_INTERACT_SUCCESS
 	return ..()
 
 // shameless copy of newscaster photo saving

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -124,7 +124,7 @@
  *user is the person making the attack action
  *params is anything the pre_attack() proc had in the same-named variable.
 */
-/datum/computer_file/program/proc/tap(atom/tapped_atom, mob/living/user, params)
+/datum/computer_file/program/proc/tap(atom/tapped_atom, mob/living/user)
 	return FALSE
 
 ///Makes sure a program can run on this hardware (for apps limited to tablets/computers/laptops)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -122,9 +122,9 @@
  *Arguments:
  *A is the atom being tapped
  *user is the person making the attack action
- *params is anything the pre_attack() proc had in the same-named variable.
+ *modifiers is anything the pre_attack() proc had in the same-named variable.
 */
-/datum/computer_file/program/proc/tap(atom/tapped_atom, mob/living/user)
+/datum/computer_file/program/proc/tap(atom/tapped_atom, mob/living/user, list/modifiers)
 	return FALSE
 
 ///Makes sure a program can run on this hardware (for apps limited to tablets/computers/laptops)

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -28,12 +28,12 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /// Keep this in sync with its tool based counterpart [/obj/proc/analyzer_act] and [/atom/proc/tool_act]
-/datum/computer_file/program/atmosscan/tap(atom/A, mob/living/user, params)
+/datum/computer_file/program/atmosscan/tap(atom/tapped_atom, mob/living/user, list/modifiers)
 	if(atmozphere_mode != ATMOZPHERE_SCAN_CLICK)
 		return FALSE
-	if(!atmos_scan(user=user, target=A, silent=FALSE))
+	if(!atmos_scan(user, tapped_atom))
 		return FALSE
-	on_analyze(source=computer, target=A)
+	on_analyze(computer, tapped_atom)
 	return TRUE
 
 /// Updates our gasmix data if on click mode.

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -26,8 +26,8 @@
 	DL_progress = 0
 	return ..()
 
-/datum/computer_file/program/borg_monitor/tap(atom/A, mob/living/user, params)
-	var/mob/living/silicon/robot/borgo = A
+/datum/computer_file/program/borg_monitor/tap(atom/tapped_atom, mob/living/user, list/modifiers)
+	var/mob/living/silicon/robot/borgo = tapped_atom
 	if(!istype(borgo) || !borgo.modularInterface)
 		return FALSE
 	DL_source = borgo
@@ -39,6 +39,7 @@
 		username = "user [stored_card.registered_name]"
 	to_chat(borgo, span_userdanger("Request received from [username] for the system log file. Upload in progress."))//Damning evidence may be contained, so warn the borg
 	borgo.logevent("File request by [username]: /var/logs/syslog")
+	borgo.balloon_alert(user, "downloading logs")
 	return TRUE
 
 /datum/computer_file/program/borg_monitor/process_tick(seconds_per_tick)

--- a/code/modules/modular_computers/file_system/programs/coupon.dm
+++ b/code/modules/modular_computers/file_system/programs/coupon.dm
@@ -88,7 +88,7 @@
  * Normally, modular PCs can be print paper already, but I find this additional step
  * to be less lazy and fitting to the "I gotta go print it before it expires" aspect of it.
  */
-/datum/computer_file/program/coupon/tap(atom/tapped_atom, mob/living/user, params)
+/datum/computer_file/program/coupon/tap(atom/tapped_atom, mob/living/user, list/modifiers)
 	if(!istype(tapped_atom, /obj/machinery/photocopier))
 		return FALSE
 	var/obj/item/card/id/user_id = computer.computer_id_slot

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -35,7 +35,7 @@
 		QDEL_NULL(internal_picture)
 	return ..()
 
-/datum/computer_file/program/maintenance/camera/tap(atom/tapped_atom, mob/living/user, params)
+/datum/computer_file/program/maintenance/camera/tap(atom/tapped_atom, mob/living/user, list/modifiers)
 	. = ..()
 	if(internal_picture)
 		QDEL_NULL(internal_picture)

--- a/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
@@ -10,7 +10,7 @@
 	/// Information from the last scanned person, to display on the app.
 	var/last_record = ""
 
-/datum/computer_file/program/maintenance/phys_scanner/tap(atom/tapped_atom, mob/living/user, params)
+/datum/computer_file/program/maintenance/phys_scanner/tap(atom/tapped_atom, mob/living/user, list/modifiers)
 	. = ..()
 
 	if(!iscarbon(tapped_atom))


### PR DESCRIPTION

## About The Pull Request

Closes #89329
Also added a balloon_alert

## Changelog
:cl:
qol: SiliConnect now informs you that you're successfully downloading logs
fix: Fixes SiliConnect not being able to download logs
/:cl:
