### PR TITLE
Examining walls no longer allows you to see items mounted on its other side

### DIFF
--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -41,7 +41,8 @@
  */
 /datum/component/wall_mounted/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
-	examine_list += span_notice("\The [hanging_wall_turf] is currently supporting [span_bold("[parent]")]. Deconstruction or excessive damage would cause it to [span_bold("fall to the ground")].")
+	if (parent in view(user.client?.view || world.view, user))
+		examine_list += span_notice("\The [hanging_wall_turf] is currently supporting [span_bold("[parent]")]. Deconstruction or excessive damage would cause it to [span_bold("fall to the ground")].")
 
 /**
  * When the type of turf changes, if it is changing into a floor we should drop our contents


### PR DESCRIPTION

## About The Pull Request

Closes #89413

## Changelog
:cl:
fix: Examining walls no longer allows you to see items mounted on its other side
/:cl:
