### PR TITLE
Relative Config $imports

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -177,7 +177,7 @@
 		// look at just the relative directory referenced
 		for(var/entry in separate_levels - actual_filename)
 			if(entry == ".." && length(parsed_folder_bits))
-				parsed_folder_bits.Cut(1, length(parsed_folder_bits) - 1)
+				parsed_folder_bits.Cut(length(parsed_folder_bits), 0)
 			else
 				parsed_folder_bits += entry
 		if(length(parsed_folder_bits))

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -165,8 +165,7 @@
 	if(IsAdminAdvancedProcCall())
 		return
 
-	var/static/regex/folder_splitting = regex("\[\\/\]")
-	var/list/separate_levels = splittext(filename, folder_splitting)
+	var/list/separate_levels = splittext(filename, "/")
 	// allows for inheriting our folder from the thing that included us
 	var/subfolder = ""
 	// do we have an actual directory or is this just one file

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -165,6 +165,26 @@
 	if(IsAdminAdvancedProcCall())
 		return
 
+	var/static/regex/folder_splitting = regex("\[\\/\]")
+	var/list/separate_levels = splittext(filename, folder_splitting)
+	// allows for inheriting our folder from the thing that included us
+	var/subfolder = ""
+	// do we have an actual directory or is this just one file
+	if(length(separate_levels) > 1)
+		var/actual_filename = separate_levels[length(separate_levels)]
+		// We need to sanitize out .. to ensure filename_to_test doesn't accidentially an infinte loop here
+		// Need filename in absolute form
+		var/list/parsed_folder_bits = list()
+		// look at just the relative directory referenced
+		for(var/entry in separate_levels - actual_filename)
+			if(entry == ".." && length(parsed_folder_bits))
+				parsed_folder_bits.Cut(1, length(parsed_folder_bits) - 1)
+			else
+				parsed_folder_bits += entry
+		if(length(parsed_folder_bits))
+			subfolder = "[parsed_folder_bits.Join("/")]/"
+		filename = "[subfolder][actual_filename]"
+
 	var/filename_to_test = world.system_type == MS_WINDOWS ? LOWER_TEXT(filename) : filename
 	if(filename_to_test in stack)
 		log_config_error("Warning: Config recursion detected ([english_list(stack)]), breaking!")
@@ -204,7 +224,7 @@
 			if(!value)
 				log_config_error("Warning: Invalid $include directive: [value]")
 			else
-				LoadEntries(value, stack)
+				LoadEntries("[subfolder][value]", stack)
 				++.
 			continue
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you import a config file inside a subdirectory, the config loader will now look IN that subdirectory, instead of exiting out to the parent folder.

As a consequence, adds support for ".." to our deduplication system to avoid infinite loops due to headmin brain.

## Why It's Good For The Game

jannies are on some shit wanna make their lives a bit nicer

Note: I am testing on windows and also have only a loose grasp of how linux works, might fuck up in that environment idk

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: the config loader now supports relatively pathed imports (importing a file inside a subfolder now acts as if you were IN that subfolder)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
