### PR TITLE
Restores Northstar's shuttles to the codebase

### DIFF
--- a/_maps/shuttles/arrival_northstar.dmm
+++ b/_maps/shuttles/arrival_northstar.dmm
@@ -1,0 +1,278 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/arrival)
+"c" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"d" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Arrivals shuttle";
+	name = "Arrival Shuttle Requests Console"
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/medkit/regular{
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"g" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst/right{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"j" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"k" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/medkit/o2,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"n" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"q" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"r" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"s" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"t" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/arrival)
+"u" = (
+/obj/effect/turf_decal/trimline/red/corner,
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/shuttle/arrival)
+"v" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"w" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst/left{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"y" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"z" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"A" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/shuttle/arrival)
+"C" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/shuttle/arrival)
+"D" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 4
+	},
+/obj/docking_port/mobile/arrivals{
+	name = "northstar arrivals shuttle"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"E" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"F" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/red/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/arrival)
+"H" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"J" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 1
+	},
+/obj/machinery/light/red/directional/south,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"L" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"M" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"N" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/arrival)
+"P" = (
+/obj/effect/turf_decal/trimline/red/warning,
+/turf/open/floor/pod,
+/area/shuttle/arrival)
+"V" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/arrival)
+"W" = (
+/obj/effect/turf_decal/trimline/red/corner,
+/turf/open/floor/pod/dark,
+/area/shuttle/arrival)
+"Z" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+
+(1,1,1) = {"
+a
+t
+Z
+Z
+t
+a
+"}
+(2,1,1) = {"
+t
+t
+v
+q
+t
+t
+"}
+(3,1,1) = {"
+t
+k
+W
+E
+s
+t
+"}
+(4,1,1) = {"
+t
+F
+P
+b
+z
+t
+"}
+(5,1,1) = {"
+t
+N
+P
+b
+n
+Z
+"}
+(6,1,1) = {"
+t
+d
+u
+A
+C
+c
+"}
+(7,1,1) = {"
+t
+N
+P
+b
+n
+Z
+"}
+(8,1,1) = {"
+t
+V
+P
+b
+J
+t
+"}
+(9,1,1) = {"
+t
+j
+y
+r
+M
+t
+"}
+(10,1,1) = {"
+t
+L
+L
+L
+L
+t
+"}
+(11,1,1) = {"
+t
+g
+D
+H
+w
+t
+"}

--- a/_maps/shuttles/cargo_northstar.dmm
+++ b/_maps/shuttles/cargo_northstar.dmm
@@ -1,0 +1,295 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst/right,
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"c" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"d" = (
+/obj/machinery/button/door/directional/east{
+	id = "QMLoaddoor";
+	name = "Loading Doors";
+	pixel_y = -8
+	},
+/obj/machinery/button/door/directional/east{
+	id = "QMLoaddoor2";
+	name = "Loading Doors";
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad"
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"f" = (
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "QMLoad"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"g" = (
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor2";
+	name = "Supply Dock Loading Door"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"h" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/shuttle/supply)
+"i" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/supply)
+"j" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"k" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"n" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"o" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst/left,
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"q" = (
+/obj/machinery/power/shuttle_engine/heater{
+	icon_state = "router"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"s" = (
+/turf/template_noop,
+/area/template_noop)
+"u" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"v" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"w" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plating,
+/area/shuttle/supply)
+"x" = (
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"B" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"C" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"D" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"G" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light/red/directional/west,
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"I" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"K" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "Supply Dock Loading Door"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"M" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
+"N" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"O" = (
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Supply Shuttle Airlock"
+	},
+/obj/docking_port/mobile/supply,
+/turf/open/floor/catwalk_floor/iron,
+/area/shuttle/supply)
+"Q" = (
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "QMLoad"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/supply)
+"V" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"Y" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+"Z" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/light/red/directional/west,
+/turf/open/floor/iron/smooth,
+/area/shuttle/supply)
+
+(1,1,1) = {"
+h
+h
+i
+i
+i
+i
+i
+i
+i
+i
+s
+"}
+(2,1,1) = {"
+h
+f
+Q
+G
+v
+v
+Z
+C
+x
+I
+o
+"}
+(3,1,1) = {"
+w
+c
+j
+Y
+k
+N
+k
+n
+D
+q
+u
+"}
+(4,1,1) = {"
+w
+c
+j
+Y
+N
+k
+N
+n
+M
+q
+u
+"}
+(5,1,1) = {"
+h
+c
+j
+d
+B
+B
+B
+V
+x
+I
+b
+"}
+(6,1,1) = {"
+h
+g
+K
+h
+O
+w
+w
+h
+h
+i
+s
+"}

--- a/_maps/shuttles/mining_common_northstar.dmm
+++ b/_maps/shuttles/mining_common_northstar.dmm
@@ -1,0 +1,163 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"d" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"e" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"k" = (
+/obj/effect/turf_decal/caution/stand_clear/red{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"l" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plating,
+/area/shuttle/mining)
+"q" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"r" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/plasma_effects/directional/south,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"t" = (
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"v" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/mining)
+"z" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/trimline/brown,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/light/small/red/directional/south,
+/turf/open/floor/pod/dark,
+/area/shuttle/mining)
+"A" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"C" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Public Mining Shuttle"
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/docking_port/mobile{
+	dir = 4;
+	name = "lavaland shuttle";
+	port_direction = 8;
+	shuttle_id = "mining_common"
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"D" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"E" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/mining)
+"G" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/trimline/brown,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/mining)
+"J" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"P" = (
+/obj/machinery/computer/shuttle/mining/common,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"T" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"U" = (
+/obj/structure/table/reinforced,
+/obj/item/radio,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+
+(1,1,1) = {"
+v
+l
+l
+C
+l
+v
+a
+"}
+(2,1,1) = {"
+l
+P
+T
+k
+z
+v
+v
+"}
+(3,1,1) = {"
+l
+D
+J
+t
+G
+e
+q
+"}
+(4,1,1) = {"
+v
+U
+A
+d
+r
+v
+v
+"}
+(5,1,1) = {"
+v
+l
+l
+E
+l
+v
+a
+"}

--- a/_maps/shuttles/mining_northstar.dmm
+++ b/_maps/shuttles/mining_northstar.dmm
@@ -1,0 +1,271 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/door/airlock/survival_pod{
+	name = "Mining Shuttle"
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	name = "mining shuttle";
+	port_direction = 8;
+	shuttle_id = "mining"
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"c" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/structure/sign/warning/xeno_mining/directional/north,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"d" = (
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/structure/closet/crate/internals,
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown,
+/obj/machinery/light/small/red/directional/south,
+/turf/open/floor/pod/dark,
+/area/shuttle/mining)
+"j" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/end{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"l" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 5
+	},
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"m" = (
+/obj/effect/turf_decal/caution/stand_clear/red{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"s" = (
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"z" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown,
+/turf/open/floor/pod/dark,
+/area/shuttle/mining)
+"A" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/mining)
+"D" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/end,
+/obj/machinery/light/small/red/directional/south,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"F" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/crowbar/red,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"G" = (
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"I" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/mining)
+"K" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+"P" = (
+/turf/template_noop,
+/area/template_noop)
+"R" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plating,
+/area/shuttle/mining)
+"S" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating,
+/area/shuttle/mining)
+"W" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown,
+/obj/structure/ore_box,
+/turf/open/floor/pod/dark,
+/area/shuttle/mining)
+"X" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/mining)
+"Z" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/mining)
+
+(1,1,1) = {"
+P
+I
+R
+a
+R
+I
+P
+"}
+(2,1,1) = {"
+I
+I
+c
+m
+d
+I
+I
+"}
+(3,1,1) = {"
+R
+s
+j
+G
+W
+S
+A
+"}
+(4,1,1) = {"
+R
+F
+K
+G
+z
+S
+A
+"}
+(5,1,1) = {"
+I
+I
+l
+Z
+D
+I
+I
+"}
+(6,1,1) = {"
+P
+I
+R
+X
+R
+I
+P
+"}

--- a/code/datums/shuttles/arrival.dm
+++ b/code/datums/shuttles/arrival.dm
@@ -26,6 +26,10 @@
 	suffix = "pubby"
 	name = "arrival shuttle (Pubby)"
 
+/datum/map_template/shuttle/arrival/northstar
+	suffix = "northstar"
+	name = "arrival shuttle (North Star)"
+
 /datum/map_template/shuttle/arrival/nebula
 	suffix = "nebula"
 	name = "arrival shuttle (Nebula)"

--- a/code/datums/shuttles/cargo.dm
+++ b/code/datums/shuttles/cargo.dm
@@ -27,6 +27,10 @@
 	suffix = "delta"
 	name = "cargo ferry (Delta)"
 
+/datum/map_template/shuttle/cargo/northstar
+	suffix = "northstar"
+	name = "cargo ferry (North Star)"
+
 /datum/map_template/shuttle/cargo/nebula
 	suffix = "nebula"
 	name = "supply shuttle (Nebula)"

--- a/code/datums/shuttles/mining.dm
+++ b/code/datums/shuttles/mining.dm
@@ -44,6 +44,10 @@
 	suffix = "large"
 	name = "mining shuttle (Large)"
 
+/datum/map_template/shuttle/mining/northstar
+	suffix = "northstar"
+	name = "mining shuttle (North Star)"
+
 /datum/map_template/shuttle/mining/nebula
 	suffix = "nebula"
 	name = "mining shuttle (Nebula)"
@@ -60,3 +64,7 @@
 /datum/map_template/shuttle/mining_common/kilo
 	suffix = "kilo"
 	name = "lavaland shuttle (Kilo)"
+
+/datum/map_template/shuttle/mining_common/northstar
+	suffix = "northstar"
+	name = "lavaland shuttle (North Star)"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -135,6 +135,10 @@
 	roundstart_template = /datum/map_template/shuttle/mining/kilo
 	height = 10
 
+/obj/docking_port/stationary/mining_home/northstar
+	roundstart_template = /datum/map_template/shuttle/mining/northstar
+	height = 6
+
 /obj/docking_port/stationary/mining_home/nebula
 	roundstart_template = /datum/map_template/shuttle/mining/nebula
 	height = 10
@@ -146,6 +150,9 @@
 
 /obj/docking_port/stationary/mining_home/common/kilo
 	roundstart_template = /datum/map_template/shuttle/mining_common/kilo
+
+/obj/docking_port/stationary/mining_home/common/northstar
+	roundstart_template = /datum/map_template/shuttle/mining_common/northstar
 
 /obj/structure/closet/crate/miningcar
 	name = "mine cart"


### PR DESCRIPTION
## About The Pull Request
Puts Northstar's shuttles and docks back into the code. This allows for Northstar to be loaded by admins.

## Why It's Good For The Game

Per Maurukas, shuttles should stay in the code.

![image](https://github.com/user-attachments/assets/87b80dbc-e8e1-43e4-a776-d5c0e4b460a7)

![image](https://github.com/user-attachments/assets/e4a9f03d-be12-49b5-8d1b-ad7ceeadb10f)

## Changelog

Nothing player facing.