### PR TITLE
Fix annoying runtime in station trait

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -183,9 +183,10 @@ SUBSYSTEM_DEF(economy)
 				continue
 			if(!moneybags || moneybags.account_balance < current_acc.account_balance)
 				moneybags = current_acc
-		earning_report += "Our GMM Spotlight would like to alert you that <b>[moneybags.account_holder]</b> is your station's most affulent crewmate! They've hit it big with [moneybags.account_balance] credits saved. "
-		update_alerts = TRUE
-		inflict_moneybags(moneybags)
+		if (moneybags)
+			earning_report += "Our GMM Spotlight would like to alert you that <b>[moneybags.account_holder]</b> is your station's most affulent crewmate! They've hit it big with [moneybags.account_balance] credits saved. "
+			update_alerts = TRUE
+			inflict_moneybags(moneybags)
 	earning_report += "That's all from the <i>Nanotrasen Economist Division</i>."
 	GLOB.news_network.submit_article(earning_report, "Station Earnings Report", "Station Announcements", null, update_alert = update_alerts)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

For some reason I was getting this station trait a lot while testing and it would runtime on my usual setup where I spawn myself in from observer, because there were no bank accounts in existence.
This won't have any particular impact on a real round because you are probably not getting a real round with no bank accounts.

## Changelog

Not player facing