### PR TITLE
Fix normal crafted medbots being invisible

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -446,8 +446,7 @@
 
 /// Gets what skin (icon_state) this medkit uses for a medbot
 /obj/item/storage/medkit/proc/get_medbot_skin()
-	// The skin var is nullsafe so returning nothing is A-OK
-	return
+	return "generic"
 
 /*
  * Pill Bottles


### PR DESCRIPTION

## About The Pull Request
the comment lies, the skin var is no longer null safe
medibots crafted with a non-special medkit would give it a null skin, which is no longer supported after they were reskinned
## Why It's Good For The Game
👻 
## Changelog
:cl:
fix: crafted medibots are more consistently corporeal
/:cl:
