### PR TITLE
Optimize Nyctophobia quirk to not process while certain traits present

### DIFF
--- a/code/datums/quirks/negative_quirks/nyctophobia.dm
+++ b/code/datums/quirks/negative_quirks/nyctophobia.dm
@@ -6,6 +6,7 @@
 	medical_record_text = "Patient demonstrates a fear of the dark. (Seriously?)"
 	hardcore_value = 5
 	mail_goodies = list(/obj/effect/spawner/random/engineering/flashlight)
+	no_process_traits = list(TRAIT_MIND_TEMPORARILY_GONE, TRAIT_FEARLESS, TRAIT_KNOCKEDOUT)
 
 /datum/quirk/nyctophobia/add(client/client_source)
 	RegisterSignal(quirk_holder, COMSIG_MOVABLE_MOVED, PROC_REF(on_holder_moved))


### PR DESCRIPTION

## About The Pull Request
While I was code diving I noticed that another negative processing quirk had a small optimization that stops the quirk from processing if it had certain traits present:

https://github.com/tgstation/tgstation/blob/57e0bd510f5c8784e001d8ad44da1ddcfddeaee8/code/datums/quirks/negative_quirks/claustrophobia.dm#L1-L11

The list for `no_process_traits` can be applied to Nyctophobia since both of them are technically phobias.

## Why It's Good For The Game
Faster code.

## Changelog
:cl:
code: Optimize Nyctophobia quirk to not process while certain traits present
/:cl:
