### PR TITLE
Patches some random potential hrefs 

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -347,7 +347,7 @@
 
 			var/selection = params["selection"]
 			for(var/path in card_trims)
-				if(!(card_trims[path] == selection))
+				if(card_trims[path] != selection)
 					continue
 
 				if(SSid_access.apply_trim_to_card(stored_id_card, path, copy_access = FALSE))

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -188,7 +188,10 @@
 			var/ref = params["ref"]
 			playsound(src, SFX_TERMINAL_TYPE, 50, FALSE)
 			var/obj/machinery/power/apc/remote_target = locate(ref) in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc)
+			if(!remote_target || !check_apc(remote_target))
+				return
 			connect_apc(remote_target, user)
+			return TRUE
 		if("check-logs")
 			log_activity("Checked Logs")
 		if("check-apcs")
@@ -198,13 +201,19 @@
 			var/type = params["type"]
 			var/value = params["value"]
 			var/obj/machinery/power/apc/target = locate(ref) in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc)
-			if(!target)
+			if(!target || !check_apc(target))
 				return
 
 			value = target.setsubsystem(text2num(value))
 			switch(type) // Sanity check
-				if("equipment", "lighting", "environ")
-					target.vars[type] = value
+				if("equipment")
+					target.equipment = value
+				if("lighting")
+					target.lighting = value
+				if("environ")
+					target.environ = value
+				if(null)
+					return
 				else
 					message_admins("Warning: possible href exploit by [key_name(user)] - attempted to set [html_encode(type)] on [target] to [html_encode(value)]")
 					user.log_message("possibly trying to href exploit - attempted to set [html_encode(type)] on [target] to [html_encode(value)]", LOG_ADMIN)
@@ -227,9 +236,12 @@
 		if("breaker")
 			var/ref = params["ref"]
 			var/obj/machinery/power/apc/breaker_target = locate(ref) in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc)
+			if(!breaker_target || !check_apc(breaker_target))
+				return
 			breaker_target.toggle_breaker(user)
 			var/setTo = breaker_target.operating ? "On" : "Off"
 			log_activity("Turned APC [breaker_target.area.name]'s breaker [setTo]")
+			return TRUE
 
 /obj/machinery/computer/apc_control/ui_close(mob/user)
 	. = ..()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -429,11 +429,13 @@
 		if("set_pos")
 			var/new_x = text2num(params["x"])
 			var/new_y = text2num(params["y"])
+			// sanitizes our ranges for us
 			our_pad.set_offset(new_x, new_y)
 			. = TRUE
 		if("move_pos")
 			var/plus_x = text2num(params["x"])
 			var/plus_y = text2num(params["y"])
+			// sanitizes our ranges for us
 			our_pad.set_offset(
 				x = our_pad.x_offset + plus_x,
 				y = our_pad.y_offset + plus_y
@@ -441,7 +443,7 @@
 			. = TRUE
 		if("rename")
 			. = TRUE
-			var/new_name = params["name"]
+			var/new_name = reject_bad_name(params["name"], allow_numbers = TRUE, max_length = MAX_NAME_LEN, cap_after_symbols = FALSE)
 			if(!new_name)
 				return
 			our_pad.display_name = new_name

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -166,7 +166,12 @@
 
 		if("make_limb")
 			var/design_id = params["design_id"]
-			if(!stored_research.researched_designs.Find(design_id) && !stored_research.hacked_designs.Find(design_id) && !imported_designs.Find(design_id))
+			var/temp_category = params["active_tab"]
+			if(!stored_research.researched_designs[design_id] && !stored_research.hacked_designs[design_id] && !imported_designs[design_id])
+				return
+			if(!(obj_flags & EMAGGED) && stored_research.hacked_designs.Find(design_id))
+				return
+			if(!(temp_category in categories))
 				return
 			being_built = SSresearch.techweb_design_by_id(design_id)
 			// All the reagents we're using to make our organ.
@@ -187,9 +192,6 @@
 			use_energy(power)
 			flick("limbgrower_fill", src)
 			icon_state = "limbgrower_idleon"
-			var/temp_category = params["active_tab"]
-			if( ! (temp_category in categories) )
-				return FALSE //seriously come on
 			selected_category = temp_category
 			addtimer(CALLBACK(src, PROC_REF(build_item), consumed_reagents_list), production_speed * production_coefficient)
 			return TRUE

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -284,7 +284,7 @@
 		if ("set_radius")
 			if (active)
 				return
-			var/change_radius = max(1,(text2num(params["new_radius"])))
+			var/change_radius = clamp(text2num(params["new_radius"]), 1, max_radius)
 			if(change_radius >= 10)
 				radius = round(change_radius)//if its over 10 we don't allow decimals
 				return

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -39,7 +39,7 @@
 	///Base false positive/negative chance
 	var/base_false_beep = 5
 	///List of species that can be scanned by the gate. Supports adding more species' IDs during in-game.
-	var/list/available_species = list(
+	var/static/list/available_species = list(
 		SPECIES_HUMAN,
 		SPECIES_LIZARD,
 		SPECIES_FLYPERSON,
@@ -50,6 +50,31 @@
 		SPECIES_PODPERSON,
 		SPECIES_GOLEM,
 		SPECIES_ZOMBIE,
+	)
+	/// All scan modes available to the scanner
+	var/static/list/all_modes = list(
+		SCANGATE_NONE,
+		SCANGATE_MINDSHIELD,
+		SCANGATE_DISEASE,
+		SCANGATE_GUNS,
+		SCANGATE_WANTED,
+		SCANGATE_SPECIES,
+		SCANGATE_NUTRITION,
+	)
+	/// All disease severity thresholds available to the scanner
+	var/static/list/all_disease_thresholds = list(
+		DISEASE_SEVERITY_POSITIVE,
+		DISEASE_SEVERITY_NONTHREAT,
+		DISEASE_SEVERITY_MINOR,
+		DISEASE_SEVERITY_MEDIUM,
+		DISEASE_SEVERITY_HARMFUL,
+		DISEASE_SEVERITY_DANGEROUS,
+		DISEASE_SEVERITY_BIOHAZARD,
+	)
+	/// All nutrition levels available to the scanner
+	var/static/list/nutrition_modes = list(
+		"Starving",
+		"Obese",
 	)
 	/// Overlay object we're using for scanlines
 	var/obj/effect/overlay/scanline = null
@@ -292,6 +317,8 @@
 	switch(action)
 		if("set_mode")
 			var/new_mode = params["new_mode"]
+			if(!new_mode || !(new_mode in all_modes))
+				return
 			scangate_mode = new_mode
 			. = TRUE
 		if("toggle_reverse")
@@ -303,26 +330,25 @@
 			. = TRUE
 		if("set_disease_threshold")
 			var/new_threshold = params["new_threshold"]
+			if(!new_threshold || !(new_threshold in all_disease_thresholds))
+				return
 			disease_threshold = new_threshold
 			. = TRUE
 		if("set_target_species")
 			var/new_specie_id = params["new_species_id"]
-			if(!(new_specie_id in available_species))
+			if(!new_specie_id || !(new_specie_id in available_species))
 				return
 			detect_species_id = new_specie_id
 			. = TRUE
 		if("set_target_nutrition")
 			var/new_nutrition = params["new_nutrition"]
-			var/nutrition_list = list(
-				"Starving",
-				"Obese"
-			)
-			if(new_nutrition && (new_nutrition in nutrition_list))
-				switch(new_nutrition)
-					if("Starving")
-						detect_nutrition = NUTRITION_LEVEL_STARVING
-					if("Obese")
-						detect_nutrition = NUTRITION_LEVEL_FAT
+			if(!new_nutrition || !(new_nutrition in nutrition_modes))
+				return
+			switch(new_nutrition)
+				if("Starving")
+					detect_nutrition = NUTRITION_LEVEL_STARVING
+				if("Obese")
+					detect_nutrition = NUTRITION_LEVEL_FAT
 			. = TRUE
 
 /obj/machinery/scanner_gate/preset_guns

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -306,16 +306,24 @@
 	switch(action)
 		//Lists of decals and designs
 		if("select decal")
-			var/selected_decal = params["decal"]
-			var/selected_dir = text2num(params["dir"])
-			stored_decal = selected_decal
-			stored_dir = selected_dir
+			. = TRUE
+			for(var/decal_set in decal_list)
+				if(decal_set[2] == params["decal"])
+					stored_decal = params["decal"]
+					break
+			for(var/dir_set in dir_list)
+				if(dir_set[2] == text2num(params["dir"]))
+					stored_dir = text2num(params["dir"])
+					break
+
 		if("select color")
-			var/selected_color = params["color"]
-			stored_color = selected_color
+			. = TRUE
+			stored_color = params["color"]
+
 		if("pick custom color")
 			if(supports_custom_color)
 				pick_painting_tool_color(usr, stored_custom_color)
+
 	update_decal_path()
 	. = TRUE
 


### PR DESCRIPTION
## About The Pull Request

I don't think any of these are particularly dangerous, but I figured they should be patched in case they become potentially dangerous.

Most notable one I think is that the limb grower didn't verify that it was emagged when printing emag designs - so you could freely print synthetic armblades without an emag.

Scanner gate also had an exploit vector via `examine`. 

APC controller didn't verify the APC you are accessing was one actually visible to the console, hard to exploit.

Decal painter didn't verify the selected decals was one of the options. Not sure if it could be used to make decals of any object, better safe than sorry. 

