### PR TITLE
fixed the space dragon overlay assuming the base color

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -170,11 +170,7 @@
 	else if (HAS_TRAIT(src, TRAIT_WING_BUFFET))
 		overlay_state = "overlay_gust"
 
-	var/mutable_appearance/overlay = mutable_appearance(icon, "[icon_living]_[overlay_state]")
-	overlay.appearance_flags = RESET_COLOR
-	// the overlay should inherit the atom color only if the dragon is dyed by colorful reagent or something
-	if(!cached_color_filter)
-		overlay.appearance_flags |= KEEP_APART
+	var/mutable_appearance/overlay = mutable_appearance(icon, "[icon_living]_[overlay_state]", appearance_flags = RESET_COLOR|KEEP_APART)
 	. += overlay
 
 /mob/living/basic/space_dragon/melee_attack(obj/vehicle/sealed/mecha/target, list/modifiers, ignore_cooldown)

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -172,6 +172,9 @@
 
 	var/mutable_appearance/overlay = mutable_appearance(icon, "[icon_living]_[overlay_state]")
 	overlay.appearance_flags = RESET_COLOR
+	// the overlay should inherit the atom color only if the dragon is dyed by colorful reagent or something
+	if(!cached_color_filter)
+		overlay.appearance_flags |= KEEP_APART
 	. += overlay
 
 /mob/living/basic/space_dragon/melee_attack(obj/vehicle/sealed/mecha/target, list/modifiers, ignore_cooldown)


### PR DESCRIPTION
## About The Pull Request
For some reason the unit test screenshot was unaffected but the overlay of the space dragon shouldn't inherit the color (unless the dragon is hit with colorful reagent or w/e) of the atom. This is most noticeably on the space shark form which has an underside that should be white, which is learly not happening right now.

## Why It's Good For The Game
Fixing a small issue I have noticed while watching moocows videos on conveyor belts shenanigan.

## Changelog

:cl:
fix: Space dragons' eyes, teeths and claws (and shark form's underside) are once again of a different color than the rest of the body.
/:cl:
