### PR TITLE
Fixing issues with non-human mobs that can fish

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_fish.dm
+++ b/code/__DEFINES/dcs/signals/signals_fish.dm
@@ -60,9 +60,6 @@
 /// Sent to the fisherman when the reward is dispensed: (reward)
 #define COMSIG_FISH_SOURCE_REWARD_DISPENSED "fish_source_reward_dispensed"
 
-/// Called when you try to use fishing rod on anything
-#define COMSIG_PRE_FISHING "pre_fishing"
-
 /// Called when an ai-controlled mob interacts with the fishing spot
 #define COMSIG_NPC_FISHING "npc_fishing"
 	#define NPC_FISHING_SPOT 1

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -50,8 +50,7 @@
 	if(!mapload)
 		addtimer(CALLBACK(src, PROC_REF(drop_stuff)), 0)
 	var/turf/turf_parent = parent
-	if(!istype(turf_parent.loc, /area/deathmatch)) // there are so so so many explosives in deathmatch and i dont think anyone is going to fish in the *death*match arena
-		parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
+	parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
 
 /datum/component/chasm/UnregisterFromParent()
 	storage = null

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -49,7 +49,6 @@
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
 		addtimer(CALLBACK(src, PROC_REF(drop_stuff)), 0)
-	var/turf/turf_parent = parent
 	parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
 
 /datum/component/chasm/UnregisterFromParent()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -795,7 +795,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
  * doing hackier code, because we've hundreds of turfs like lava, water etc every round,
  */
 /turf/proc/add_lazy_fishing(fish_source_path)
-	RegisterSignal(src, COMSIG_PRE_FISHING, PROC_REF(add_fishing_spot_comp))
+	RegisterSignal(src, COMSIG_FISHING_ROD_CAST, PROC_REF(add_fishing_spot_comp))
 	RegisterSignal(src, COMSIG_NPC_FISHING, PROC_REF(on_npc_fishing))
 	RegisterSignal(src, COMSIG_FISH_RELEASED_INTO, PROC_REF(on_fish_release_into))
 	RegisterSignal(src, COMSIG_TURF_CHANGE, PROC_REF(remove_lazy_fishing))
@@ -805,7 +805,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/remove_lazy_fishing()
 	SIGNAL_HANDLER
 	UnregisterSignal(src, list(
-		COMSIG_PRE_FISHING,
+		COMSIG_FISHING_ROD_CAST,
 		COMSIG_NPC_FISHING,
 		COMSIG_FISH_RELEASED_INTO,
 		COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL),
@@ -814,10 +814,11 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	REMOVE_TRAIT(src, TRAIT_FISHING_SPOT, INNATE_TRAIT)
 	fish_source = null
 
-/turf/proc/add_fishing_spot_comp(datum/source)
+/turf/proc/add_fishing_spot_comp(datum/source, obj/item/fishing_rod/rod, mob/user)
 	SIGNAL_HANDLER
-	source.AddComponent(/datum/component/fishing_spot, fish_source)
+	var/datum/component/fishing_spot/spot = source.AddComponent(/datum/component/fishing_spot, fish_source)
 	remove_lazy_fishing()
+	return spot.handle_cast(arglist(args))
 
 /turf/proc/on_npc_fishing(datum/source, list/fish_spot_container)
 	SIGNAL_HANDLER

--- a/code/modules/fishing/fish/types/station.dm
+++ b/code/modules/fishing/fish/types/station.dm
@@ -215,8 +215,10 @@
 		if(FISH_BERNARD)
 			sprite_width = 4
 			sprite_height = 6
+			base_icon_state = "bernardfish"
 		if(FISH_MATTHEW)
 			sprite_width = 6
+			base_icon_state = "matthewfish"
 	update_appearance()
 
 #define PERSISTENCE_FISH_FRITTERISH_VARIANT "fritterish_variant"

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -292,6 +292,8 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 
 /datum/fishing_challenge/proc/no_longer_fishing(datum/source)
 	SIGNAL_HANDLER
+	if(completed) //we already won/lost
+		return
 	user.balloon_alert(user, "interrupted!")
 	interrupt()
 
@@ -893,6 +895,14 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 		RegisterSignal(spot, COMSIG_MOVABLE_MOVED, PROC_REF(follow_movable))
 	SET_BASE_PIXEL(spot.pixel_x, spot.pixel_y)
 	SET_BASE_VISUAL_PIXEL(spot.pixel_w, spot.pixel_z)
+	// early return for spots with a plane lower than this. the floor plane is topdown and we don't want to inherit their layers.
+	if(spot.plane < plane)
+		return
+	if(spot.plane > plane) //We want this to render above the fishing spot.
+		var/turf/turf = get_turf(spot)
+		SET_PLANE_EXPLICIT(src, PLANE_TO_TRUE(spot.plane), turf)
+	if(spot.layer > layer) //Ditto. New stuff renders above old stuff if the layer is the same iirc (with some caveats).
+		layer = spot.layer
 
 /obj/effect/fishing_float/proc/follow_movable(atom/movable/source)
 	SIGNAL_HANDLER

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -438,7 +438,7 @@
 	// especially for entities with the profound fisher component, which should only work on
 	// proper fishing spots.
 	if(user.CanReach(target, src))
-		hook_hit(targer, user)
+		hook_hit(target, user)
 		return
 	casting = TRUE
 	var/obj/projectile/fishing_cast/cast_projectile = new(get_turf(src))

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -410,7 +410,6 @@
 		reel(user)
 		return ITEM_INTERACT_BLOCKING
 
-	SEND_SIGNAL(interacting_with, COMSIG_PRE_FISHING)
 	cast_line(interacting_with, user)
 	return ITEM_INTERACT_SUCCESS
 
@@ -433,6 +432,14 @@
 		return
 	if(!COOLDOWN_FINISHED(src, casting_cd))
 		return
+	COOLDOWN_START(src, casting_cd, 1 SECONDS)
+	// skip firing a projectile if the target is adjacent and can be reached (no order windows in the way),
+	// otherwise it may end up hitting other things on its turf, which is problematic
+	// especially for entities with the profound fisher component, which should only work on
+	// proper fishing spots.
+	if(user.CanReach(target, src))
+		hook_hit(targer, user)
+		return
 	casting = TRUE
 	var/obj/projectile/fishing_cast/cast_projectile = new(get_turf(src))
 	cast_projectile.range = get_cast_range(user)
@@ -444,7 +451,6 @@
 	cast_projectile.impacted = list(WEAKREF(user) = TRUE)
 	cast_projectile.aim_projectile(target, user)
 	cast_projectile.fire()
-	COOLDOWN_START(src, casting_cd, 1 SECONDS)
 
 /// Called by hook projectile when hitting things
 /obj/item/fishing_rod/proc/hook_hit(atom/atom_hit_by_hook_projectile, mob/user)

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -326,7 +326,6 @@
 	// pretend like this mob has a mind. they should be fished up first
 	no_brain.mind_initialize()
 
-	SEND_SIGNAL(the_hole, COMSIG_PRE_FISHING) // we need to do this for the fishing spot component to be attached
 	var/datum/component/fishing_spot/the_hole_fishing_spot = the_hole.GetComponent(/datum/component/fishing_spot)
 	var/datum/fish_source/fishing_source = the_hole_fishing_spot.fish_source
 	var/obj/item/fishing_hook/rescue/the_hook = allocate(/obj/item/fishing_hook/rescue, run_loc_floor_top_right)


### PR DESCRIPTION
## About The Pull Request
This PR fixes an issue that has been reported about the profound fisher trait, because even then, a projectile is fired that may hit things other than the intended target, making it impossible for the mob to continue fishing if the abstract fishing rod hooks on something else. To fix this we just need to skip the projectile stuff and go straight to the `hook_hit` call ~~also allowing someone to fish on oneself (eg. through the fishing spot generated by the organ manip surgery)~~.

Also dealt with a few other issues like a "interrupted!" balloon alert being sent after the minigame is already completed, fritterish icons, layering of the float, a bad signal and a redundant check meant to stop explosions from spawning fishing loot from chasms (because someone forgot to add the relative flag).

## Why It's Good For The Game
This should fix #88974 and other stuff as well

## Changelog

:cl:
fix: Trying to fish on an adjacent spot won't end up hitting other things on the same turf (provided you actually click the fishing spot and not other things).
fix: Fixing the icon state for the "fritterish" fish variants.
/:cl:
