### PR TITLE
cult slurring/stuttering is removed before the april fools punch line upon conversion

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -306,6 +306,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 	// We're not guaranteed to be a human but we'll cast here since we use it in a few branches
 	var/mob/living/carbon/human/human_convertee = convertee
 
+	if(istype(human_convertee)) //remove the slurring/stuttering before the april fools punch line reference
+		human_convertee.uncuff()
+		human_convertee.remove_status_effect(/datum/status_effect/speech/slurring/cult)
+		human_convertee.remove_status_effect(/datum/status_effect/speech/stutter)
+
 	if(check_holidays(APRIL_FOOLS) && prob(10))
 		convertee.Paralyze(10 SECONDS)
 		if(istype(human_convertee))
@@ -325,10 +330,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 	to_chat(convertee, span_cult_bold_italic("Assist your new compatriots in their dark dealings. \
 		Your goal is theirs, and theirs is yours. You serve the Geometer above all else. Bring it back."))
 
-	if(istype(human_convertee))
-		human_convertee.uncuff()
-		human_convertee.remove_status_effect(/datum/status_effect/speech/slurring/cult)
-		human_convertee.remove_status_effect(/datum/status_effect/speech/stutter)
 	if(isshade(convertee))
 		convertee.icon_state = "shade_cult"
 		convertee.name = convertee.real_name

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -306,8 +306,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 	// We're not guaranteed to be a human but we'll cast here since we use it in a few branches
 	var/mob/living/carbon/human/human_convertee = convertee
 
-	if(istype(human_convertee)) //remove the slurring/stuttering before the april fools punch line reference
+	if(istype(human_convertee)) //remove the slurring/stuttering/silence before the april fools punch line reference
 		human_convertee.uncuff()
+		human_convertee.remove_status_effect(/datum/status_effect/silenced)
 		human_convertee.remove_status_effect(/datum/status_effect/speech/slurring/cult)
 		human_convertee.remove_status_effect(/datum/status_effect/speech/stutter)
 


### PR DESCRIPTION
## About The Pull Request
Critical fix to the game, less than two months away from the most wonderful time of the year (on both directions).

## Why It's Good For The Game
See above.

## Changelog

:cl:
fix: cult slurring/stuttering now removed before the april fools punch line upon conversion, thus untarnishing the Rick and Morty reference.
/:cl:
