### PR TITLE
Changed bitters bottle transfer amounts

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -624,6 +624,8 @@
 	volume = 30
 	list_reagents = list(/datum/reagent/consumable/ethanol/bitters = 30)
 	drink_type = ALCOHOL
+	//allows for single unit dispensing
+	possible_transfer_amounts = list(1, 2, 3, 4, 5) 
 
 /obj/item/reagent_containers/cup/glass/bottle/curacao
 	name = "Beekhof Blauw Curaçao"

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -626,6 +626,7 @@
 	drink_type = ALCOHOL
 	//allows for single unit dispensing
 	possible_transfer_amounts = list(1, 2, 3, 4, 5) 
+	amount_per_transfer_from_this = 5
 
 /obj/item/reagent_containers/cup/glass/bottle/curacao
 	name = "Beekhof Blauw Curaçao"


### PR DESCRIPTION

## About The Pull Request

Andromeda Bitters bottle now only dispenses in 1~5u increments, limiting throughput but allowing for higher precision.

## Why It's Good For The Game
TL;DR: Bitters are usually called for in limited amounts in drinks and as a result are usually stored in dasher bottles. This pr makes it so the Andromeda bitters bottle now acts like a dasher bottle.

Currently, there are a few recipes for drinks in the game which require for very low ratios of bitters to the rest of the drink (eg the Cinderella), calling for ratios which require fewer than 5u per 50u of total drink. While this is pretty accurate to the kind of ratios you'd expect for these sorts of drinks in real life, they are kind of a pain to make currently due the smallest dispensable amount from the bitters bottle being 5u, meaning that you either have to use a dropper or intentionally add more bitters than the reaction needs, then take out the excess via the chemmaster. This is annoying and in my opinion somewhat detracts from the bartender aesthetic of effortlessly building your drinks either in a shaker or in the glass.

To fix this issue, the andromeda bitters bottle will now have it's dispense amounts set to 1-5. This more realistically reflects how dasher bottles dispense very small amounts at a time, and makes creating the aforementioned drinks much easier. 

It should be noted that the bottle can no longer dispense in some of the higher amounts it previously could (10, 25, etc.) This is intentional, and I think that if someone ever ends up adding a drink that's mostly composed of bitters like a trinidad sour, giving them the authentic experience of needing to shake your bitters bottle for a slightly annoying amount of time is funny.

## Changelog
:cl:
qol: Andromeda Bitters bottle now only dispenses in 1-5u increments
/:cl:
