### PR TITLE
Convert weather duration to use time defines

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -14,8 +14,8 @@
 	var/desc = "Heavy gusts of wind blanket the area, periodically knocking down anyone caught in the open."
 	/// The message displayed in chat to foreshadow the weather's beginning
 	var/telegraph_message = span_warning("The wind begins to pick up.")
-	/// In deciseconds, how long from the beginning of the telegraph until the weather begins
-	var/telegraph_duration = 300
+	/// How long from the beginning of the telegraph until the weather begins
+	var/telegraph_duration = 30 SECONDS
 	/// The sound file played to everyone on an affected z-level
 	var/telegraph_sound
 	/// The overlay applied to all tiles on the z-level
@@ -23,12 +23,12 @@
 
 	/// Displayed in chat once the weather begins in earnest
 	var/weather_message = span_userdanger("The wind begins to blow ferociously!")
-	/// In deciseconds, how long the weather lasts once it begins
-	var/weather_duration = 1200
+	/// How long the weather lasts once it begins
+	var/weather_duration = 2 MINUTES
 	/// See above - this is the lowest possible duration
-	var/weather_duration_lower = 1200
+	var/weather_duration_lower = 2 MINUTES
 	/// See above - this is the highest possible duration
-	var/weather_duration_upper = 1500
+	var/weather_duration_upper = 2.5 MINUTES
 	/// Looping sound while weather is occuring
 	var/weather_sound
 	/// Area overlay while the weather is occuring
@@ -38,8 +38,8 @@
 
 	/// Displayed once the weather is over
 	var/end_message = span_danger("The wind relents its assault.")
-	/// In deciseconds, how long the "wind-down" graphic will appear before vanishing entirely
-	var/end_duration = 300
+	/// How long the "wind-down" graphic will appear before vanishing entirely
+	var/end_duration = 30 SECONDS
 	/// Sound that plays while weather is ending
 	var/end_sound
 	/// Area overlay while weather is ending

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -4,16 +4,16 @@
 	desc = "An intense atmospheric storm lifts ash off of the planet's surface and billows it down across the area, dealing intense fire damage to the unprotected."
 
 	telegraph_message = span_boldwarning("An eerie moan rises on the wind. Sheets of burning ash blacken the horizon. Seek shelter.")
-	telegraph_duration = 300
+	telegraph_duration = 30 SECONDS
 	telegraph_overlay = "light_ash"
 
 	weather_message = span_userdanger("<i>Smoldering clouds of scorching ash billow down around you! Get inside!</i>")
-	weather_duration_lower = 600
-	weather_duration_upper = 1200
+	weather_duration_lower = 1 MINUTES
+	weather_duration_upper = 2 MINUTES
 	weather_overlay = "ash_storm"
 
 	end_message = span_bolddanger("The shrieking wind whips away the last of the ash and falls to its usual murmur. It should be safe to go outside now.")
-	end_duration = 300
+	end_duration = 30 SECONDS
 	end_overlay = "light_ash"
 
 	area_type = /area

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -4,15 +4,15 @@
 	desc = "The ground turns into surprisingly cool lava, lightly damaging anything on the floor."
 
 	telegraph_message = span_warning("You feel the ground beneath you getting hot. Waves of heat distort the air.")
-	telegraph_duration = 150
+	telegraph_duration = 15 SECONDS
 
 	weather_message = span_userdanger("The floor is lava! Get on top of something!")
-	weather_duration_lower = 300
-	weather_duration_upper = 600
+	weather_duration_lower = 30 SECONDS
+	weather_duration_upper = 1 MINUTES
 	weather_overlay = "lava"
 
 	end_message = span_danger("The ground cools and returns to its usual form.")
-	end_duration = 0
+	end_duration = 0 SECONDS
 
 	area_type = /area
 	protected_areas = list(/area/space)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -3,17 +3,17 @@
 	name = "radiation storm"
 	desc = "A cloud of intense radiation passes through the area dealing rad damage to those who are unprotected."
 
-	telegraph_duration = 400
+	telegraph_duration = 40 SECONDS
 	telegraph_message = span_danger("The air begins to grow warm.")
 
 	weather_message = span_userdanger("<i>You feel waves of heat wash over you! Find shelter!</i>")
 	weather_overlay = "ash_storm"
-	weather_duration_lower = 600
-	weather_duration_upper = 1500
+	weather_duration_lower = 1 MINUTES
+	weather_duration_upper = 2.5 MINUTES
 	weather_color = "green"
 	weather_sound = 'sound/announcer/alarm/bloblarm.ogg'
 
-	end_duration = 100
+	end_duration = 10 SECONDS
 	end_message = span_notice("The air seems to be cooling off again.")
 
 	area_type = /area

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -4,16 +4,16 @@
 	probability = 90
 
 	telegraph_message = span_warning("Drifting particles of snow begin to dust the surrounding area..")
-	telegraph_duration = 300
+	telegraph_duration = 30 SECONDS
 	telegraph_overlay = "light_snow"
 
 	weather_message = span_userdanger("<i>Harsh winds pick up as dense snow begins to fall from the sky! Seek shelter!</i>")
 	weather_overlay = "snow_storm"
-	weather_duration_lower = 600
-	weather_duration_upper = 1500
+	weather_duration_lower = 1 MINUTES
+	weather_duration_upper = 2.5 MINUTES
 	use_glow = FALSE
 
-	end_duration = 100
+	end_duration = 10 SECONDS
 	end_message = span_bolddanger("The snowfall dies down, it should be safe to go outside again.")
 
 	area_type = /area

--- a/code/datums/weather/weather_types/void_storm.dm
+++ b/code/datums/weather/weather_types/void_storm.dm
@@ -8,8 +8,8 @@
 	weather_message = span_hypnophrase("You feel the air around you getting colder... and void's sweet embrace...")
 	weather_overlay = "light_snow"
 	weather_color = COLOR_BLACK
-	weather_duration_lower = 60 SECONDS
-	weather_duration_upper = 120 SECONDS
+	weather_duration_lower = 1 MINUTES
+	weather_duration_upper = 2 MINUTES
 
 	use_glow = FALSE
 


### PR DESCRIPTION

## About The Pull Request
This converts many of the deciseconds numbers into using the proper time defines `SECONDS` and `MINUTES`.

## Why It's Good For The Game
Cleaner code.

## Changelog
:cl:
code: Convert weather duration to use time defines
/:cl:
