### PR TITLE
Syndicate headsets are now properly protected against disruptor waves

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -355,7 +355,7 @@ effective or pretty fucking useless.
 	user.balloon_alert(user, "disruptor wave released!")
 	to_chat(user, span_notice("You release a disruptor wave, disabling all nearby radio devices."))
 	for (var/atom/potential_owner in view(7, user))
-		disable_radios_on(potential_owner)
+		disable_radios_on(potential_owner, ignore_syndie = TRUE)
 	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
 
 /obj/item/jammer/attack_self_secondary(mob/user, modifiers)
@@ -385,8 +385,10 @@ effective or pretty fucking useless.
 
 	return ITEM_INTERACT_SUCCESS
 
-/obj/item/jammer/proc/disable_radios_on(atom/target)
+/obj/item/jammer/proc/disable_radios_on(atom/target, ignore_syndie = FALSE)
 	for (var/obj/item/radio/radio in target.get_all_contents() + target)
+		if(ignore_syndie && (radio.special_channels & RADIO_SPECIAL_SYNDIE))
+			continue
 		radio.set_broadcasting(FALSE)
 
 /obj/item/jammer/Destroy()

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -360,7 +360,7 @@ effective or pretty fucking useless.
 
 /obj/item/jammer/attack_self_secondary(mob/user, modifiers)
 	. = ..()
-	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+	if(.)
 		return
 	to_chat(user, span_notice("You [active ? "deactivate" : "activate"] [src]."))
 	user.balloon_alert(user, "[active ? "deactivated" : "activated"] the jammer")

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -360,6 +360,8 @@ effective or pretty fucking useless.
 
 /obj/item/jammer/attack_self_secondary(mob/user, modifiers)
 	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
 	to_chat(user, span_notice("You [active ? "deactivate" : "activate"] [src]."))
 	user.balloon_alert(user, "[active ? "deactivated" : "activated"] the jammer")
 	active = !active
@@ -368,6 +370,7 @@ effective or pretty fucking useless.
 	else
 		GLOB.active_jammers -= src
 	update_appearance()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/jammer/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Syndicate encryption keys previously provided protection against the passive effect of radio jammers.

However, https://github.com/tgstation/tgstation/pull/87149 added the ability for them to actively _disable_ headsets either in-view, or on a specific target. Neither of these check for the syndicate encryption key.

This makes it so the aoe disruptor wave will ignore headsets with the syndie key, while the targeted disruption will still disable syndie headsets.

@SmArtKar said this was an oversight, so I'm marking it as a fix.

## Why It's Good For The Game

fixing an oversight

## Changelog
:cl:
fix: Syndicate encryption keys properly protect against AoE radio jamming again.
/:cl:
