### PR TITLE
Moves Birdshot's tech storage to be between bridge and engineering, changes up bridge/morgue

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1110,14 +1110,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"awO" = (
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "awQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -5810,7 +5802,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/rust,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "ciT" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/east,
@@ -6413,6 +6405,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/girder,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ctH" = (
@@ -7885,7 +7878,6 @@
 	name = "Abandoned Brewery"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "cTK" = (
@@ -8319,7 +8311,7 @@
 "cZW" = (
 /obj/structure/closet/crate/grave,
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "dah" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -11943,10 +11935,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
-"enq" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "enE" = (
 /obj/item/cultivator/rake,
 /obj/structure/cable,
@@ -12711,7 +12699,7 @@
 "eBT" = (
 /obj/item/shovel,
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "eCf" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -29338,7 +29326,7 @@
 	dir = 10
 	},
 /turf/open/floor/grass,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "jOS" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/small/directional/south,
@@ -31175,6 +31163,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -34904,7 +34895,7 @@
 "lCS" = (
 /obj/structure/closet/crate/grave/fresh,
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "lCT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
@@ -34963,7 +34954,7 @@
 /obj/structure/flora/bush/jungle,
 /obj/structure/marker_beacon/yellow,
 /turf/open/floor/grass,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "lEa" = (
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central/fore)
@@ -46121,7 +46112,7 @@
 	dir = 4
 	},
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "pAl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/white{
@@ -47964,14 +47955,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"qcQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "qcX" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -57666,10 +57649,9 @@
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
 /turf/open/floor/plating,
-/area/station/medical/morgue)
+/area/station/maintenance/department/science/xenobiology)
 "tnb" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
@@ -59573,7 +59555,7 @@
 "tRn" = (
 /obj/structure/closet/crate/grave/filled,
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "tRw" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -60792,7 +60774,7 @@
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "ukI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -61501,10 +61483,6 @@
 /obj/structure/trap/stun,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"uya" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/department/science/xenobiology)
 "uyA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -61646,10 +61624,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"uBy" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/space/basic,
-/area/space)
 "uBE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/light/no_nightlight/directional/north,
@@ -62499,7 +62473,7 @@
 /area/station/maintenance/central/lesser)
 "uOH" = (
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "uPf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -66488,10 +66462,6 @@
 /obj/item/reagent_containers/cup/bowl,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"vXn" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space/basic,
-/area/space)
 "vXr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -69577,7 +69547,7 @@
 	pixel_y = -6
 	},
 /turf/open/misc/dirt/station,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/medical/morgue)
 "wSZ" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/hallway/abandoned_command)
@@ -94854,10 +94824,10 @@ yeP
 fAf
 iGu
 wWU
-uBy
-uBy
-uBy
-uBy
+xep
+xep
+xep
+xep
 hCr
 mYp
 wlo
@@ -95368,10 +95338,10 @@ yeP
 aYN
 bMU
 wWU
-vXn
-vXn
-vXn
-vXn
+xuF
+xuF
+xuF
+xuF
 hCr
 jEp
 qGk
@@ -95625,10 +95595,10 @@ yeP
 ait
 xaW
 wWU
-enq
-enq
-enq
-enq
+blb
+blb
+blb
+blb
 hCr
 hCr
 qek
@@ -98451,11 +98421,11 @@ fyZ
 wen
 wen
 gcs
-enq
-enq
-enq
-enq
-enq
+blb
+blb
+blb
+blb
+blb
 ycC
 ycC
 iEk
@@ -107515,7 +107485,7 @@ pDU
 pDU
 qgj
 pDU
-qcQ
+pDU
 pDU
 koz
 jOk
@@ -107775,9 +107745,9 @@ ldq
 ldq
 ldq
 ldq
-ldq
-ldq
-ldq
+fmH
+fmH
+fmH
 fmH
 fmH
 fmH
@@ -109061,10 +109031,10 @@ ldq
 cTE
 ldq
 ldq
-awO
+tmV
 ldq
-fmH
-fmH
+ldq
+ldq
 aBv
 aBv
 aBv
@@ -109321,7 +109291,7 @@ xQI
 kuY
 lzf
 yja
-fmH
+ldq
 fjv
 ntW
 mmR
@@ -109560,17 +109530,17 @@ iht
 iht
 iht
 ssz
-uya
-yfQ
 ldq
 yfQ
 ldq
 yfQ
 ldq
 yfQ
-uya
+ldq
 yfQ
-uya
+ldq
+yfQ
+ldq
 yfQ
 ldq
 yfQ
@@ -109578,7 +109548,7 @@ ldq
 xnn
 xnn
 jzj
-fmH
+ldq
 tmr
 vWa
 hkt
@@ -109841,7 +109811,7 @@ nRS
 vIa
 bGk
 dst
-fmH
+ldq
 ssz
 ssz
 ssz
@@ -110092,13 +110062,13 @@ yfQ
 ctu
 ogl
 xGw
-fmH
+ldq
 kdn
 tSH
 jYP
-fmH
-fmH
-fmH
+ldq
+ldq
+ldq
 rff
 xQI
 xGw
@@ -110349,11 +110319,11 @@ ldq
 oFg
 xQI
 jzj
-fmH
-fmH
-fmH
-fmH
-fmH
+ldq
+ldq
+ldq
+ldq
+ldq
 jSX
 jzj
 jzj
@@ -111102,7 +111072,7 @@ ssz
 ssz
 ssz
 ssz
-uya
+ldq
 yfQ
 ldq
 yfQ

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -539,6 +539,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"amz" = (
+/obj/machinery/computer/arcade/amputation,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "amE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2472,11 +2476,17 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen)
 "aVF" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs,
+/area/space)
 "aVT" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -4474,6 +4484,15 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
+"bHc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "abandoned_lab";
+	name = "Abandoned Lab Shutters"
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "bHp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -5779,6 +5798,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"ciX" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "cjc" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6035,6 +6059,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"cng" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "cnn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -9125,6 +9156,19 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"dow" = (
+/obj/structure/rack,
+/obj/item/poster/random_contraband{
+	pixel_y = 8
+	},
+/obj/item/poster/random_contraband{
+	pixel_y = 4
+	},
+/obj/item/poster/random_contraband,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "doJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -9498,6 +9542,12 @@
 "dxf" = (
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical/central)
+"dxq" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "dxv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer4{
 	dir = 5
@@ -10737,6 +10787,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/science/xenobiology)
 "dWz" = (
@@ -11016,6 +11067,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
+"eaX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ebc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -12209,7 +12265,7 @@
 "evv" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
-	name = "Xenobiology Maintenance"
+	name = "Abandoned Lab"
 	},
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
@@ -12252,6 +12308,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
+"ewy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "ewF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -13259,6 +13325,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
+"eNW" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "eOk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15189,6 +15259,13 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"fyR" = (
+/obj/item/trash/shok_roks/tropical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/space)
 "fyW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line,
@@ -15693,6 +15770,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
+"fFI" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "fFO" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -17306,6 +17387,20 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
+"gfX" = (
+/obj/structure/rack,
+/obj/item/poster/random_official{
+	pixel_y = 7
+	},
+/obj/item/poster/random_official{
+	pixel_y = 3
+	},
+/obj/item/poster/random_official,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "gfZ" = (
 /obj/structure/window/spawner/directional/west,
 /obj/effect/turf_decal/sand/plating,
@@ -17778,6 +17873,10 @@
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
+"gof" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/small,
+/area/space)
 "gom" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -18101,6 +18200,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"gwk" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "gwl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18840,6 +18944,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
+"gFM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/item/wrench,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "gFX" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -19433,6 +19548,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"gOl" = (
+/obj/structure/railing/corner/end{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/small,
+/area/space)
 "gOm" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/equipment)
@@ -19767,6 +19893,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"gUB" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "gUC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19808,6 +19938,12 @@
 /obj/structure/sign/departments/medbay/alt/directional/east,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
+"gVk" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor,
+/area/space)
 "gVp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
@@ -19974,6 +20110,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"gZz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "gZM" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/cold/directional/east,
@@ -22879,6 +23019,11 @@
 /obj/machinery/camera/directional/south,
 /turf/open/floor/grass,
 /area/station/service/chapel)
+"hVT" = (
+/obj/structure/railing,
+/obj/machinery/light/small/dim/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/space)
 "hVX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -23696,6 +23841,10 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"ijj" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ijz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
@@ -24558,7 +24707,8 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/solars/port/aft)
 "ixG" = (
-/turf/open/space/basic,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "ixM" = (
 /obj/structure/disposalpipe/segment{
@@ -24849,6 +24999,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"iBn" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/random/food_or_drink/cups,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "iBt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -25010,6 +25166,12 @@
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/iron/white/small,
 /area/station/medical/psychology)
+"iDM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "iDO" = (
 /obj/item/kirbyplants/organic/applebush,
 /obj/effect/turf_decal/tile/yellow{
@@ -25781,7 +25943,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/south,
+/obj/structure/urinal/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "iNV" = (
@@ -25809,6 +25971,12 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/captain)
+"iOa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/furniture_parts,
+/obj/structure/railing/corner/end,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "iOm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26055,6 +26223,13 @@
 /obj/structure/flora/bush/flowers_yw,
 /turf/open/floor/grass,
 /area/station/service/chapel)
+"iRM" = (
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "iRQ" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -26251,6 +26426,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"iUW" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "iVq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -26285,6 +26465,12 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"iVH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/space)
 "iVI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27751,6 +27937,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "jtG" = (
@@ -28255,6 +28442,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"jCj" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jCm" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/misc/dirt/station,
@@ -28673,7 +28868,7 @@
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "jId" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -31607,6 +31802,11 @@
 	dir = 8
 	},
 /area/station/engineering/storage/tech)
+"kEz" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "kEA" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -31838,6 +32038,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kIN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "abandoned_lab";
+	name = "Abandoned Lab Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "kIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31927,6 +32136,12 @@
 /obj/machinery/scanner_gate/preset_guns,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig/entrance)
+"kKj" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "kKD" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/sign/painting/library{
@@ -32501,6 +32716,12 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"kVO" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "kWd" = (
 /obj/machinery/door/airlock{
 	name = "Room 2"
@@ -33205,6 +33426,15 @@
 /obj/item/camera,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"lgW" = (
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor,
+/area/space)
 "lhi" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -33501,6 +33731,15 @@
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"lkC" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/small,
+/area/space)
 "lkJ" = (
 /obj/structure/flora/rock/pile/jungle/style_4,
 /turf/open/floor/grass,
@@ -34217,6 +34456,11 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
+"lwA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "lwI" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/computer/security/mining{
@@ -34343,6 +34587,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"lyT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "lyY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -35217,6 +35466,7 @@
 	name = "Xenobiology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "lOj" = (
@@ -36251,6 +36501,10 @@
 /obj/effect/mapping_helpers/mail_sorting/science/ordnance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"mfs" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "mfB" = (
 /obj/structure/table/wood,
 /obj/item/book/bible,
@@ -36300,6 +36554,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mgU" = (
+/obj/structure/broken_flooring/side/directional/north{
+	color = "#73737a"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "mgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36442,6 +36703,19 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mjw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/geiger_counter{
+	pixel_x = 16;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/small,
+/area/space)
 "mjF" = (
 /obj/structure/table/glass,
 /obj/item/clothing/suit/costume/cyborg_suit,
@@ -37538,6 +37812,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central/fore)
+"mDO" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "mDS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39066,6 +39349,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
+"nfq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "nfG" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -41399,6 +41693,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"nVV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/corner/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "nWa" = (
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/wood,
@@ -42384,6 +42683,11 @@
 /obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"oqn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "oqq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44680,6 +44984,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/station/command/meeting_room)
+"pfI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/east{
+	name = "Abandoned Lab Shutters";
+	id = "abandoned_lab"
+	},
+/obj/item/bot_assembly/medbot,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "pfT" = (
 /obj/structure/training_machine,
 /turf/open/floor/iron/smooth_large,
@@ -45493,6 +45806,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
+"ptQ" = (
+/obj/structure/broken_flooring/corner,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ptX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -45905,6 +46222,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
+"pDI" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/item/trash/tray,
+/turf/open/floor/catwalk_floor,
+/area/space)
 "pDK" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/engineering_all,
@@ -46294,6 +46618,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
+"pIN" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "pIS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -46359,6 +46687,7 @@
 /area/station/ai_monitored/security/armory)
 "pJz" = (
 /obj/machinery/firealarm/directional/west,
+/obj/structure/urinal/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "pKi" = (
@@ -48262,6 +48591,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/eighties/red,
 /area/station/hallway/primary/central/fore)
+"qqZ" = (
+/obj/structure/broken_flooring/side/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qrb" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -49297,6 +49630,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
+"qJe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "qJq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -49816,8 +50155,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "qTv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/furniture_parts,
+/obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "qTz" = (
@@ -52959,6 +53297,9 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
+"rTc" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "rTn" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/misc/dirt/station,
@@ -53030,9 +53371,8 @@
 	},
 /area/station/science/lobby)
 "rUR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/table_or_rack,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "rUV" = (
 /obj/machinery/navbeacon{
@@ -55024,6 +55364,10 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"sDw" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "sDA" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -55300,6 +55644,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
+"sJJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "sJL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding{
@@ -55907,6 +56257,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"sTu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/small,
+/area/space)
 "sTJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -58305,6 +58663,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"tEQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "tFs" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/regular{
@@ -58637,6 +59000,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"tLL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "tMh" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Command Desk";
@@ -59358,6 +59733,10 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
+"tYQ" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/science/xenobiology)
 "tYT" = (
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
@@ -59528,10 +59907,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "ubl" = (
-/obj/structure/easel,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
 /obj/machinery/newscaster/directional/south,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "uby" = (
@@ -60718,6 +61096,20 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/security/office)
+"urW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/medkit{
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "usd" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -62094,6 +62486,12 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/execution/education)
+"uRN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "uRP" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/arcade_boards,
@@ -63977,6 +64375,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"vuQ" = (
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor,
+/area/space)
 "vuR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67011,6 +67415,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
+"wqZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "wrj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67442,6 +67851,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
+"wwH" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "wwI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68176,6 +68589,13 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/secondary/entry)
+"wJI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "wJK" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -72717,6 +73137,10 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
+"xWn" = (
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "xWq" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
@@ -73415,6 +73839,11 @@
 "ygu" = (
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
+"ygz" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ygK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -73655,6 +74084,22 @@
 	},
 /turf/open/floor/carpet,
 /area/station/maintenance/hallway/abandoned_recreation)
+"yjC" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/clothing/gloves/color/fyellow{
+	pixel_y = 2
+	},
+/obj/item/wrench,
+/obj/item/cigarette/xeno{
+	pixel_x = -3;
+	pixel_y = -9
+	},
+/obj/item/clothing/head/utility/welding,
+/turf/open/floor/iron/small,
+/area/space)
 "yjE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine)
@@ -94940,10 +95385,10 @@ yeP
 ait
 xaW
 wWU
-dDB
-dDB
-dDB
-dDB
+enq
+enq
+enq
+enq
 hCr
 hCr
 qek
@@ -95452,13 +95897,13 @@ aJq
 aJq
 aJq
 aJq
-gcs
-blb
-blb
-blb
-blb
-blb
-blb
+aJq
+tYT
+dDB
+dDB
+dDB
+dDB
+dDB
 hCr
 mPx
 vYi
@@ -95708,13 +96153,13 @@ aJq
 vjX
 aJq
 aJq
-tYT
+aJq
+gcs
 blb
-dDB
-dDB
-dDB
-dDB
-dDB
+blb
+blb
+blb
+blb
 ycC
 ycC
 pIS
@@ -95965,7 +96410,7 @@ aJq
 aJq
 aJq
 aJq
-enq
+tYT
 blb
 dDB
 dDB
@@ -97765,12 +98210,12 @@ vfg
 fyZ
 wen
 wen
-blb
-dDB
-dDB
-dDB
-dDB
-dDB
+gcs
+enq
+enq
+enq
+enq
+enq
 ycC
 ycC
 iEk
@@ -103426,14 +103871,14 @@ dDB
 dDB
 dDB
 aJq
-aJq
-gcz
-gcz
-gcz
-gcz
-gcz
-gcz
-gcz
+uvA
+uvA
+uvA
+uvA
+uvA
+uvA
+uvA
+uvA
 ruY
 ryi
 ehj
@@ -103690,7 +104135,7 @@ rNB
 ogG
 auT
 lGE
-gcz
+uvA
 xRH
 jFF
 ehj
@@ -103947,7 +104392,7 @@ xbl
 uhI
 yhW
 clV
-gcz
+uvA
 hyv
 fyH
 xRH
@@ -104204,7 +104649,7 @@ xbl
 flD
 heH
 hUI
-gcz
+uvA
 xkb
 qzi
 qYy
@@ -104461,7 +104906,7 @@ njW
 isI
 owb
 uvA
-gcz
+uvA
 ryi
 xRH
 xRH
@@ -104718,7 +105163,7 @@ gMb
 gXN
 heL
 hjx
-gcz
+uvA
 gDp
 aoL
 eDN
@@ -104975,7 +105420,7 @@ wur
 nOH
 hIi
 hkm
-gcz
+uvA
 jrJ
 xRH
 hVM
@@ -105232,7 +105677,7 @@ gMy
 isQ
 heM
 uvA
-gcz
+uvA
 xRH
 xRH
 fLL
@@ -107333,19 +107778,19 @@ nHN
 vSY
 qzv
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
 ldq
 tRn
 uOH
@@ -107590,19 +108035,19 @@ eNp
 vxM
 hCB
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
 ldq
 cZW
 uOH
@@ -107843,23 +108288,23 @@ qQB
 ufF
 xMr
 slJ
-vxs
+aXU
 xaC
 ubl
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
 ldq
 ukB
 eBT
@@ -108100,23 +108545,23 @@ mNQ
 nkH
 xMr
 slJ
-vxM
-vxM
 aXU
-ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+vxs
+vxM
+jCj
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
 ldq
 lDJ
 jOO
@@ -108361,19 +108806,19 @@ eBy
 vxM
 bMc
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
 ldq
 ldq
 awO
@@ -108618,24 +109063,24 @@ dLq
 vTx
 pHw
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+xQI
+qqZ
+lyT
+nVV
 fmH
 fjv
 ntW
@@ -108890,9 +109335,9 @@ uya
 ldq
 uya
 ldq
-ixG
-ixG
-ixG
+tYQ
+tYQ
+gZz
 fmH
 tmr
 vWa
@@ -109147,9 +109592,9 @@ dDB
 blb
 dDB
 ldq
-ixG
-ixG
-ixG
+mfs
+mfs
+gZz
 tmV
 otQ
 nRS
@@ -109404,9 +109849,9 @@ blb
 blb
 blb
 yfQ
-ixG
-ixG
-ixG
+sJJ
+iRM
+xGw
 fmH
 kdn
 tSH
@@ -109414,11 +109859,11 @@ jYP
 fmH
 fmH
 fmH
-ixG
-ixG
-ixG
-ixG
-ixG
+xWn
+xQI
+xGw
+ptQ
+fFI
 jIc
 bAT
 mvC
@@ -109661,21 +110106,21 @@ dDB
 blb
 dDB
 ldq
-ixG
-ixG
-ixG
+iDM
+xQI
+gZz
 fmH
 fmH
 fmH
 fmH
 fmH
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xQI
+gZz
+gZz
+sDw
+qqZ
+wqZ
+kVO
 ldq
 clZ
 reH
@@ -109918,16 +110363,16 @@ blb
 blb
 blb
 yfQ
+xpY
+pKU
+xpY
 ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+oqn
+xpY
+pKU
+oqn
+xpY
+uRN
 ldq
 ldq
 ldq
@@ -110175,16 +110620,16 @@ dDB
 blb
 dDB
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+gwk
+ldq
+ldq
+ldq
+ldq
+ldq
+cng
+mfs
+kEz
+qTv
 ldq
 sgB
 fhT
@@ -110432,16 +110877,16 @@ yfQ
 ldq
 yfQ
 ldq
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+xpY
+ldq
+tLL
+wJI
+mDO
+ldq
+kKj
+mfs
+xpY
+xpY
 xko
 hPQ
 uNe
@@ -110456,9 +110901,9 @@ pkR
 vtC
 blb
 dDB
-dDB
-dDB
-dDB
+vuQ
+iVH
+pDI
 dDB
 dDB
 dDB
@@ -110679,26 +111124,26 @@ pKU
 wFQ
 pKU
 xpY
-xpY
-xpY
-xpY
-ldq
+ciX
+ygz
+ygz
 pKU
 pKU
 pKU
 pKU
+qJe
 krz
 xpY
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+oqn
+kIN
+ewy
+gZz
+urW
+ldq
+ldq
+ldq
+wwH
+ldq
 ldq
 uLj
 uLj
@@ -110713,9 +111158,9 @@ idp
 vtC
 blb
 dDB
-dDB
-dDB
-dDB
+lgW
+aVF
+gOl
 dDB
 dDB
 dDB
@@ -110937,25 +111382,25 @@ ssz
 ssz
 ssz
 ssz
+gZz
 xQI
+ciX
+rTc
+gUB
+tEQ
+iOa
+gFM
+ijj
 pKU
-pKU
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
-ixG
+bHc
+pfI
+eNW
+nfq
+ldq
+amz
+mgU
+pIN
+gfX
 ldq
 qdR
 naN
@@ -110970,9 +111415,9 @@ xyR
 tuT
 blb
 dDB
-dDB
-dDB
-dDB
+gVk
+mjw
+gof
 dDB
 dDB
 dDB
@@ -111195,12 +111640,12 @@ blb
 blb
 ssz
 ssz
-hDz
-xQI
-pKU
-xGw
+eaX
+dxq
+iUW
+lwA
 rUR
-qTv
+rUR
 aSy
 aSy
 lOi
@@ -111210,9 +111655,9 @@ aSy
 evv
 aSy
 aSy
-ixG
-ixG
-ixG
+iBn
+pIN
+dow
 ldq
 uLj
 uLj
@@ -111227,9 +111672,9 @@ idp
 vtC
 blb
 dDB
-dDB
-dDB
-dDB
+gVk
+lkC
+fyR
 dDB
 dDB
 dDB
@@ -111452,8 +111897,8 @@ tjj
 blb
 blb
 ssz
-pKU
-xQI
+gZz
+ciX
 ssz
 aSy
 aSy
@@ -111484,9 +111929,9 @@ idp
 vtC
 blb
 dDB
-dDB
-dDB
-dDB
+hVT
+yjC
+sTu
 dDB
 dDB
 dDB
@@ -111709,8 +112154,8 @@ tjj
 tjj
 blb
 ssz
+gZz
 pKU
-vxp
 ssz
 heB
 nZQ
@@ -111966,8 +112411,8 @@ rMH
 tjj
 blb
 ssz
-aVF
-ldq
+xGw
+pKU
 ssz
 iWZ
 rfJ
@@ -112223,7 +112668,7 @@ ygK
 tjj
 dDB
 ssz
-pKU
+vxp
 xpY
 ssz
 dmT

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -12357,7 +12357,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "evv" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Abandoned Lab"
 	},
@@ -13279,16 +13278,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/greater)
-"eLx" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "Bridge Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/command/meeting_room)
 "eLB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31120,9 +31109,6 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kqU" = (
@@ -35556,8 +35542,6 @@
 	name = "Xenobiology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "lOj" = (
@@ -38332,7 +38316,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -43146,7 +43129,6 @@
 "owZ" = (
 /obj/item/kirbyplants/organic/applebush,
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -43907,15 +43889,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"oLj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/command/bridge)
 "oLo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46913,7 +46886,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "pLf" = (
@@ -51526,7 +51498,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/space/basic,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/station/engineering/storage/tech)
 "rkM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -54958,7 +54932,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/open/space/basic,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/station/engineering/storage/tech)
 "stH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -94377,7 +94353,7 @@ xSd
 ubT
 sUy
 niT
-eLx
+utF
 qju
 tsF
 xRV
@@ -96684,7 +96660,7 @@ dDB
 pIS
 uAK
 anb
-oLj
+xsh
 owZ
 xsh
 ahE

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -539,10 +539,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
-"amz" = (
-/obj/machinery/computer/arcade/amputation,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "amE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1713,6 +1709,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"aGR" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "aGU" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -2476,17 +2477,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen)
 "aVF" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs,
-/area/space)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "aVT" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -2569,6 +2563,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"aXi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "aXC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2627,6 +2628,24 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
+"aYJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/food/grown/grapes{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/obj/item/food/grown/grapes{
+	pixel_y = 4
+	},
+/obj/item/food/grown/grapes{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "aYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -4484,15 +4503,6 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
-"bHc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "abandoned_lab";
-	name = "Abandoned Lab Shutters"
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "bHp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -5340,6 +5350,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"caG" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/medkit{
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "caI" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable,
@@ -5798,11 +5822,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"ciX" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "cjc" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6059,13 +6078,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"cng" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "cnn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -6397,6 +6409,12 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/work)
+"ctu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ctH" = (
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
@@ -7862,6 +7880,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"cTE" = (
+/obj/machinery/door/airlock{
+	name = "Abandoned Brewery"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "cTK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -8176,11 +8202,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/engine)
 "cYR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "cYS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8933,6 +8960,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"dkw" = (
+/obj/effect/turf_decal/trimline/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "dkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9048,6 +9081,11 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
+"dnc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "dng" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -9156,19 +9194,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"dow" = (
-/obj/structure/rack,
-/obj/item/poster/random_contraband{
-	pixel_y = 8
-	},
-/obj/item/poster/random_contraband{
-	pixel_y = 4
-	},
-/obj/item/poster/random_contraband,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/science/xenobiology)
 "doJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -9350,6 +9375,15 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
+"dsW" = (
+/obj/machinery/door/airlock{
+	name = "Abandoned Brewery"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/maintenance/department/science/xenobiology)
 "dtm" = (
 /obj/structure/window/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -9455,6 +9489,12 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
+"dvb" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "dvd" = (
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
@@ -9468,6 +9508,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
+"dvI" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "dvJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
@@ -9524,15 +9571,18 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
 "dwT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/rack,
+/obj/item/poster/random_contraband{
+	pixel_y = 8
 	},
-/obj/effect/landmark/navigate_destination/techstorage,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/item/poster/random_contraband{
+	pixel_y = 4
+	},
+/obj/item/poster/random_contraband,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "dwX" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9542,12 +9592,6 @@
 "dxf" = (
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical/central)
-"dxq" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "dxv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer4{
 	dir = 5
@@ -10064,6 +10108,17 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
+"dHp" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "dHx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -10076,6 +10131,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"dHy" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "dHL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10195,6 +10254,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"dKo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "dKq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10377,6 +10440,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"dNN" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/reagent_containers/cup/glass{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/glass{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "dNU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -10752,6 +10830,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/cubicle)
+"dUY" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "dVQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -10788,6 +10873,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner,
 /area/station/science/xenobiology)
 "dWz" = (
@@ -10832,7 +10919,7 @@
 /obj/effect/spawner/random/techstorage/security_all,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/north,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "dWW" = (
@@ -11067,11 +11154,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
-"eaX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "ebc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -12130,6 +12212,18 @@
 /obj/structure/sign/departments/medbay/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"esW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "ete" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12308,16 +12402,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
-"ewy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "ewF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -12476,6 +12560,12 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
+"ezy" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "ezE" = (
 /obj/vehicle/ridden/secway,
 /turf/open/floor/plating,
@@ -12776,6 +12866,11 @@
 /obj/item/stamp/head/hos,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
+"eEi" = (
+/obj/structure/broken_flooring/side/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "eEj" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12879,7 +12974,6 @@
 "eFQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination/eva,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark/side{
@@ -13170,6 +13264,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eLf" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "eLn" = (
 /obj/machinery/door/airlock/glass{
 	name = "Gold Standard Law Firm"
@@ -13325,10 +13426,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
-"eNW" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "eOk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13700,6 +13797,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"eVF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "eVH" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -14617,6 +14720,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"fnx" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "fnz" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/disposal/bin,
@@ -15040,6 +15147,9 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/commons/fitness/locker_room)
+"fvm" = (
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "fvs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15259,13 +15369,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"fyR" = (
-/obj/item/trash/shok_roks/tropical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/small,
-/area/space)
 "fyW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line,
@@ -15770,10 +15873,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
-"fFI" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "fFO" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -16020,6 +16119,7 @@
 	dir = 9
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "fJn" = (
@@ -16420,6 +16520,10 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
+"fOw" = (
+/obj/machinery/computer/arcade/amputation,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "fOJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -16550,6 +16654,11 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"fRe" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "fRq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -16636,6 +16745,10 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"fSC" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "fSG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17387,20 +17500,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
-"gfX" = (
-/obj/structure/rack,
-/obj/item/poster/random_official{
-	pixel_y = 7
-	},
-/obj/item/poster/random_official{
-	pixel_y = 3
-	},
-/obj/item/poster/random_official,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/science/xenobiology)
 "gfZ" = (
 /obj/structure/window/spawner/directional/west,
 /obj/effect/turf_decal/sand/plating,
@@ -17873,10 +17972,6 @@
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
-"gof" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/small,
-/area/space)
 "gom" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -18200,11 +18295,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"gwk" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "gwl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18944,17 +19034,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
-"gFM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/structure/steam_vent,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/science/xenobiology)
 "gFX" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -19548,17 +19627,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"gOl" = (
-/obj/structure/railing/corner/end{
-	dir = 1
-	},
-/obj/structure/railing/corner/end/flip{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/small,
-/area/space)
 "gOm" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/equipment)
@@ -19598,6 +19666,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"gOR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "gOS" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/effect/turf_decal/delivery/white,
@@ -19811,6 +19885,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/meeting_room)
 "gTK" = (
@@ -19893,10 +19968,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"gUB" = (
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/science/xenobiology)
 "gUC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19938,12 +20009,6 @@
 /obj/structure/sign/departments/medbay/alt/directional/east,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
-"gVk" = (
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/space)
 "gVp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
@@ -20110,10 +20175,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"gZz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "gZM" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/cold/directional/east,
@@ -20780,6 +20841,10 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hhK" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "hhL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22178,6 +22243,10 @@
 "hGb" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/storage)
+"hGj" = (
+/obj/structure/broken_flooring/corner,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "hGk" = (
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/door/airlock/grunge{
@@ -22488,6 +22557,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security)
+"hMa" = (
+/obj/effect/turf_decal/trimline/dark/filled/warning,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "hMh" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/stool/bamboo{
@@ -23019,11 +23092,6 @@
 /obj/machinery/camera/directional/south,
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"hVT" = (
-/obj/structure/railing,
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/space)
 "hVX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -23276,7 +23344,7 @@
 "iaH" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light/small/dim/directional/south,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
 "iaK" = (
@@ -23298,6 +23366,13 @@
 	dir = 8
 	},
 /area/station/maintenance/starboard/greater)
+"iaV" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "ibe" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/crate/freezer,
@@ -23782,6 +23857,13 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"iis" = (
+/obj/structure/broken_flooring/side/directional/north{
+	color = "#73737a"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "iix" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -23841,10 +23923,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"ijj" = (
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "ijz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
@@ -24031,6 +24109,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
+"ilB" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ilC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -24271,6 +24353,13 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
+"ipM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "ipN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -24707,8 +24796,18 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/solars/port/aft)
 "ixG" = (
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
+"ixH" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "ixM" = (
 /obj/structure/disposalpipe/segment{
@@ -24999,12 +25098,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"iBn" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/random/food_or_drink/cups,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/science/xenobiology)
 "iBt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -25166,12 +25259,6 @@
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/iron/white/small,
 /area/station/medical/psychology)
-"iDM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "iDO" = (
 /obj/item/kirbyplants/organic/applebush,
 /obj/effect/turf_decal/tile/yellow{
@@ -25813,6 +25900,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"iLO" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/stairs,
+/area/station/maintenance/department/science/xenobiology)
 "iLR" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -25971,12 +26067,6 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/captain)
-"iOa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/furniture_parts,
-/obj/structure/railing/corner/end,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/science/xenobiology)
 "iOm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26223,13 +26313,6 @@
 /obj/structure/flora/bush/flowers_yw,
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"iRM" = (
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "iRQ" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -26426,11 +26509,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
-"iUW" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/science/xenobiology)
 "iVq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -26465,12 +26543,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"iVH" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/space)
 "iVI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27755,6 +27827,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
+"jqJ" = (
+/obj/structure/closet/emcloset,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jqK" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -27774,6 +27851,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"jrg" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "jrk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28284,6 +28371,10 @@
 	},
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
+"jzj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "jzo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28442,14 +28533,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"jCj" = (
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "jCm" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/misc/dirt/station,
@@ -28458,6 +28541,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"jCE" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "jCH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -28987,6 +29077,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"jKb" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jKg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29528,6 +29622,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
+"jSX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jTf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -30140,6 +30238,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kdv" = (
@@ -30906,6 +31005,10 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/virology)
+"knY" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "kov" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31334,6 +31437,10 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"kuY" = (
+/obj/structure/broken_flooring/side/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "kvl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -31763,6 +31870,9 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"kDR" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "kEd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -31802,11 +31912,6 @@
 	dir = 8
 	},
 /area/station/engineering/storage/tech)
-"kEz" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "kEA" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -32000,6 +32105,21 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"kHY" = (
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "kIj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -32038,15 +32158,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"kIN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "abandoned_lab";
-	name = "Abandoned Lab Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "kIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32136,12 +32247,6 @@
 /obj/machinery/scanner_gate/preset_guns,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig/entrance)
-"kKj" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "kKD" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/sign/painting/library{
@@ -32716,12 +32821,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"kVO" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "kWd" = (
 /obj/machinery/door/airlock{
 	name = "Room 2"
@@ -33426,15 +33525,6 @@
 /obj/item/camera,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"lgW" = (
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/space)
 "lhi" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -33731,15 +33821,6 @@
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"lkC" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/small,
-/area/space)
 "lkJ" = (
 /obj/structure/flora/rock/pile/jungle/style_4,
 /turf/open/floor/grass,
@@ -34014,7 +34095,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "lox" = (
@@ -34456,11 +34536,6 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
-"lwA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/science/xenobiology)
 "lwI" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/computer/security/mining{
@@ -34517,6 +34592,11 @@
 	dir = 1
 	},
 /area/station/commons/fitness/locker_room)
+"lxC" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lxE" = (
 /obj/effect/spawner/random/structure/closet_empty/crate,
 /turf/open/floor/plating,
@@ -34535,6 +34615,12 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"lxY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lxZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
@@ -34587,11 +34673,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"lyT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "lyY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -34600,6 +34681,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"lzf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "lzg" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/airalarm/directional/north,
@@ -34993,6 +35079,10 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/primary/central/fore)
+"lGp" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lGr" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 6
@@ -35467,6 +35557,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "lOj" = (
@@ -35707,6 +35798,10 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"lSf" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lSh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35866,6 +35961,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"lVo" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "lVy" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
@@ -36501,10 +36606,6 @@
 /obj/effect/mapping_helpers/mail_sorting/science/ordnance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"mfs" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "mfB" = (
 /obj/structure/table/wood,
 /obj/item/book/bible,
@@ -36554,13 +36655,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"mgU" = (
-/obj/structure/broken_flooring/side/directional/north{
-	color = "#73737a"
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "mgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36632,6 +36726,12 @@
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"mij" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "miz" = (
 /obj/structure/table/glass,
 /obj/item/wrench,
@@ -36703,19 +36803,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"mjw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/item/geiger_counter{
-	pixel_x = 16;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/small,
-/area/space)
 "mjF" = (
 /obj/structure/table/glass,
 /obj/item/clothing/suit/costume/cyborg_suit,
@@ -37166,6 +37253,18 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/small,
 /area/station/security/brig)
+"mpU" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/storage/box/matches{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "mql" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
@@ -37812,15 +37911,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central/fore)
-"mDO" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_y = 7;
-	pixel_x = -5
-	},
-/obj/effect/spawner/random/medical/minor_healing,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "mDS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39349,16 +39439,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
-"nfq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+"nfv" = (
+/obj/effect/turf_decal/trimline/dark/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/science/xenobiology)
 "nfG" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -39774,10 +39859,10 @@
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
 "nmZ" = (
-/obj/machinery/light/small/dim/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/ai_monitored/command/storage/eva)
 "nnd" = (
@@ -39834,6 +39919,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -41451,6 +41537,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"nRj" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/entry)
 "nRr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -41693,11 +41783,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"nVV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/broken_flooring/corner/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "nWa" = (
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/wood,
@@ -41713,6 +41798,11 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
+"nWp" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "nWr" = (
 /obj/structure/cable,
 /obj/structure/hedge,
@@ -42135,6 +42225,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
+"ogl" = (
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "ogq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -42506,6 +42603,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
+"omO" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "omW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/white/corner,
@@ -42683,11 +42787,6 @@
 /obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"oqn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "oqq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42988,6 +43087,12 @@
 	dir = 1
 	},
 /area/station/command/gateway)
+"owc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/furniture_parts,
+/obj/structure/railing/corner/end,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "owv" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1;
@@ -43003,6 +43108,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/cytology)
+"owF" = (
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "owH" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/binary/valve/digital{
@@ -43177,6 +43287,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"oAi" = (
+/obj/effect/turf_decal/trimline/dark/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "oAn" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 10
@@ -43195,6 +43311,16 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"oAS" = (
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "oAY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -43447,6 +43573,12 @@
 	dir = 4
 	},
 /area/station/maintenance/starboard/greater)
+"oFg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "oFu" = (
 /turf/closed/wall,
 /area/station/security/office)
@@ -44354,6 +44486,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
 "oUJ" = (
@@ -44984,15 +45117,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/station/command/meeting_room)
-"pfI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/east{
-	name = "Abandoned Lab Shutters";
-	id = "abandoned_lab"
-	},
-/obj/item/bot_assembly/medbot,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "pfT" = (
 /obj/structure/training_machine,
 /turf/open/floor/iron/smooth_large,
@@ -45158,6 +45282,15 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
+"piI" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "piJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
@@ -45394,6 +45527,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"pmZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "pnf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -45418,6 +45561,11 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"pnB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "pnF" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -45806,10 +45954,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
-"ptQ" = (
-/obj/structure/broken_flooring/corner,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "ptX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -45856,6 +46000,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
+"pvU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/science/xenobiology)
 "pvY" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -46222,19 +46371,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
-"pDI" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/item/trash/tray,
-/turf/open/floor/catwalk_floor,
-/area/space)
 "pDK" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/engineering_all,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/bot,
-/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "pDQ" = (
@@ -46618,9 +46760,17 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
-"pIN" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark,
+"pIM" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "pIS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46954,6 +47104,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"pOq" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "pOw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -48032,6 +48186,20 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"qgi" = (
+/obj/structure/rack,
+/obj/item/poster/random_official{
+	pixel_y = 7
+	},
+/obj/item/poster/random_official{
+	pixel_y = 3
+	},
+/obj/item/poster/random_official,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "qgj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -48084,6 +48252,13 @@
 "qgZ" = (
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel/office)
+"qhd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "qhh" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/cytology{
@@ -48485,6 +48660,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
+"qod" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qoj" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -48591,10 +48770,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/eighties/red,
 /area/station/hallway/primary/central/fore)
-"qqZ" = (
-/obj/structure/broken_flooring/side/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "qrb" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -48942,6 +49117,12 @@
 /obj/structure/railing,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qyO" = (
+/obj/structure/broken_flooring/corner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qyT" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -49057,6 +49238,11 @@
 /obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"qAl" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qAn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -49630,12 +49816,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"qJe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "qJq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -50155,8 +50335,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "qTv" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "qTz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51073,6 +51254,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"rff" = (
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rfi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -52042,12 +52227,18 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/execution/education)
 "rxB" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
+	desc = "A set of curtains serving as a fancy theater backdrop. They can only be opened by a button.";
+	id = "abandoned_brewery";
+	name = "Abandoned Brewery"
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/maintenance/department/science/xenobiology)
 "rxD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -52226,6 +52417,13 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"rzO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rzX" = (
 /obj/structure/hedge,
 /obj/machinery/status_display/supply{
@@ -53141,6 +53339,14 @@
 "rQi" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
+"rQr" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/spawner/random/entertainment/dice,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "rQw" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
@@ -53297,9 +53503,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"rTc" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/science/xenobiology)
 "rTn" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/misc/dirt/station,
@@ -55130,6 +55333,10 @@
 "syk" = (
 /turf/closed/wall,
 /area/station/security/warden)
+"sys" = (
+/obj/structure/broken_flooring/side/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "syA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55364,10 +55571,6 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"sDw" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "sDA" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -55377,6 +55580,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"sDE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/button/curtain{
+	id = "abandoned_brewery";
+	name = "curtain control";
+	pixel_y = -24
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "sDZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -55644,12 +55860,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
-"sJJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/girder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "sJL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding{
@@ -56251,20 +56461,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"sTp" = (
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "sTq" = (
 /obj/structure/railing{
 	dir = 10
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"sTu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron/small,
-/area/space)
 "sTJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -56459,6 +56668,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"sXc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "abandoned_lab";
+	name = "Abandoned Lab Shutters"
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "sXi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -56474,6 +56692,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
+"sXo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "sXq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57393,10 +57617,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
 "tmr" = (
-/obj/machinery/newscaster/directional/north,
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "tms" = (
@@ -57944,6 +58168,14 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"tum" = (
+/obj/machinery/door/airlock{
+	name = "Abandoned Brewery"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "tuu" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -58663,11 +58895,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"tEQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/table_or_rack,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/science/xenobiology)
 "tFs" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/regular{
@@ -58730,6 +58957,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
+"tGI" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "tGJ" = (
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/machinery/computer/records/security,
@@ -58770,6 +59004,12 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"tHy" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "tHK" = (
 /turf/closed/wall,
 /area/station/security/prison/shower)
@@ -59000,18 +59240,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"tLL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/directional/south,
-/obj/structure/mirror/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "tMh" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Command Desk";
@@ -59733,10 +59961,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
-"tYQ" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/science/xenobiology)
 "tYT" = (
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
@@ -60214,6 +60438,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/station/hallway/primary/central/fore)
+"ufd" = (
+/obj/effect/turf_decal/trimline/dark/end{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "ufe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61096,20 +61328,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/security/office)
-"urW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/medkit{
-	pixel_y = -2
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "usd" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -62486,12 +62704,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/execution/education)
-"uRN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "uRP" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/arcade_boards,
@@ -62997,6 +63209,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"vaR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "vba" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -63506,6 +63725,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"viO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "viP" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/small,
@@ -63539,6 +63763,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"vje" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "vjp" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/power/floodlight,
@@ -63706,6 +63941,13 @@
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
+"vlr" = (
+/obj/structure/fermenting_barrel,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/department/science/xenobiology)
 "vlB" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -63948,6 +64190,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"vob" = (
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "voe" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -64295,6 +64541,15 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"vtU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/east{
+	name = "Abandoned Lab Shutters";
+	id = "abandoned_lab"
+	},
+/obj/item/bot_assembly/medbot,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "vtX" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/neutral,
@@ -64375,12 +64630,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"vuQ" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/space)
 "vuR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66193,6 +66442,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"vWC" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "vWF" = (
 /obj/docking_port/stationary/laborcamp_home/kilo{
 	dir = 4
@@ -66235,6 +66490,14 @@
 /obj/item/clothing/gloves/boxing/blue,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"vXc" = (
+/obj/effect/turf_decal/trimline/dark/line,
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/department/science/xenobiology)
 "vXd" = (
 /obj/item/flashlight/lantern/on,
 /obj/effect/turf_decal/siding/wood,
@@ -66757,6 +67020,12 @@
 "wfn" = (
 /turf/closed/wall,
 /area/station/engineering/break_room)
+"wfp" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "wfr" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
@@ -67415,11 +67684,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
-"wqZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "wrj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67851,10 +68115,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
-"wwH" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "wwI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68179,6 +68439,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wBF" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "wBI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -68589,13 +68856,6 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/secondary/entry)
-"wJI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
 "wJK" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -69304,6 +69564,7 @@
 /area/station/service/janitor)
 "wRU" = (
 /obj/effect/landmark/start/coroner,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "wSg" = (
@@ -69546,6 +69807,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"wWN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "abandoned_lab";
+	name = "Abandoned Lab Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "wWR" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/orange,
@@ -70323,6 +70593,10 @@
 "xia" = (
 /turf/closed/wall,
 /area/station/science/cubicle)
+"xid" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "xik" = (
 /turf/closed/wall,
 /area/station/security/prison/rec)
@@ -70615,6 +70889,10 @@
 /obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
+"xnn" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/science/xenobiology)
 "xno" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -70727,6 +71005,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
+"xoT" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/random/food_or_drink/cups,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/science/xenobiology)
 "xoW" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -73137,10 +73421,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"xWn" = (
-/obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "xWq" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
@@ -73839,11 +74119,6 @@
 "ygu" = (
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
-"ygz" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "ygK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -74045,6 +74320,11 @@
 /obj/machinery/light/no_nightlight/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"yja" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/corner/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "yjd" = (
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -74084,22 +74364,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/maintenance/hallway/abandoned_recreation)
-"yjC" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/clothing/gloves/color/fyellow{
-	pixel_y = 2
-	},
-/obj/item/wrench,
-/obj/item/cigarette/xeno{
-	pixel_x = -3;
-	pixel_y = -9
-	},
-/obj/item/clothing/head/utility/welding,
-/turf/open/floor/iron/small,
-/area/space)
 "yjE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine)
@@ -87926,7 +88190,7 @@ hFd
 wdo
 tkN
 gBh
-cvJ
+vob
 ybs
 knv
 knv
@@ -94885,7 +95149,7 @@ pof
 vIz
 rto
 gTi
-rxB
+qlP
 uVT
 sQI
 iri
@@ -95142,7 +95406,7 @@ uUe
 vIz
 jaK
 hwx
-qlP
+iaV
 uVT
 rEY
 irQ
@@ -107011,7 +107275,7 @@ lvv
 xJw
 xJw
 xJw
-hhL
+xJw
 xJw
 fMs
 xJw
@@ -107263,21 +107527,21 @@ vEA
 vwh
 vSL
 rIn
+koz
 pDU
 pDU
-qcQ
 nSA
 pDU
-dwT
 pDU
-koz
-qcQ
+pDU
+pDU
+pDU
 pDU
 qgj
 pDU
 qcQ
-koz
 pDU
+koz
 jOk
 rIn
 ibD
@@ -107520,24 +107784,24 @@ sBL
 nla
 nla
 nla
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
-nyH
+ldq
+ldq
+ldq
+ldq
+ldq
+rxB
+rxB
+rxB
+ldq
+dsW
+ldq
+ldq
+ldq
+ldq
+ldq
+ldq
+ldq
+ldq
 fmH
 fmH
 fmH
@@ -107779,18 +108043,18 @@ vSY
 qzv
 ldq
 xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
+lGp
+lSf
+fnx
+dvb
+vaR
+jCE
+nWp
+oAi
+aYJ
+vlr
+viO
+owF
 ldq
 tRn
 uOH
@@ -108035,19 +108299,19 @@ eNp
 vxM
 hCB
 ldq
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
+fvm
+ldq
+ldq
+ldq
+mpU
+rQr
+dNN
+jrg
+dkw
+pmZ
+omO
+aVF
+mij
 ldq
 cZW
 uOH
@@ -108292,19 +108556,19 @@ aXU
 xaC
 ubl
 ldq
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
+qyO
+xid
+eEi
+tum
+dKo
+jSX
+nfv
+sTp
+vXc
+cYR
+sDE
+ldq
+ldq
 ldq
 ukB
 eBT
@@ -108548,19 +108812,19 @@ slJ
 aXU
 vxs
 vxM
-jCj
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
+tGI
+jzj
+jzj
+pOq
+ldq
+ldq
+dUY
+pIM
+kHY
+oAS
+ufd
+hMa
+iLO
 xQI
 ldq
 lDJ
@@ -108806,19 +109070,19 @@ eBy
 vxM
 bMc
 ldq
+jqJ
 xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
+jSX
+xGw
+ldq
+ldq
+ldq
+ldq
+ldq
+ldq
+ldq
+ldq
+cTE
 ldq
 ldq
 awO
@@ -109063,24 +109327,24 @@ dLq
 vTx
 pHw
 ldq
+qod
+eVF
+lxY
+xQI
+fvm
+jzj
+jzj
+sys
+xQI
+jSX
+xid
+jzj
 xQI
 xQI
 xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-xQI
-qqZ
-lyT
-nVV
+kuY
+lzf
+yja
 fmH
 fjv
 ntW
@@ -109321,23 +109585,23 @@ iht
 iht
 ssz
 uya
+yfQ
 ldq
+yfQ
 ldq
-uya
+yfQ
 ldq
+yfQ
 uya
+yfQ
+uya
+yfQ
 ldq
-uya
-uya
+yfQ
 ldq
-uya
-uya
-ldq
-uya
-ldq
-tYQ
-tYQ
-gZz
+xnn
+xnn
+jzj
 fmH
 tmr
 vWa
@@ -109592,9 +109856,9 @@ dDB
 blb
 dDB
 ldq
-mfs
-mfs
-gZz
+lxC
+lxC
+jzj
 tmV
 otQ
 nRS
@@ -109849,8 +110113,8 @@ blb
 blb
 blb
 yfQ
-sJJ
-iRM
+ctu
+ogl
 xGw
 fmH
 kdn
@@ -109859,11 +110123,11 @@ jYP
 fmH
 fmH
 fmH
-xWn
+rff
 xQI
 xGw
-ptQ
-fFI
+hGj
+dHy
 jIc
 bAT
 mvC
@@ -110106,21 +110370,21 @@ dDB
 blb
 dDB
 ldq
-iDM
+oFg
 xQI
-gZz
+jzj
 fmH
 fmH
 fmH
 fmH
 fmH
-xQI
-gZz
-gZz
-sDw
-qqZ
-wqZ
-kVO
+jSX
+jzj
+jzj
+jKb
+kuY
+dnc
+wfp
 ldq
 clZ
 reH
@@ -110363,16 +110627,16 @@ blb
 blb
 blb
 yfQ
-xpY
-pKU
-xpY
+sXo
+rzO
+sXo
+dvI
+aXi
+sXo
+rzO
+aXi
+sXo
 ixG
-oqn
-xpY
-pKU
-oqn
-xpY
-uRN
 ldq
 ldq
 ldq
@@ -110620,16 +110884,16 @@ dDB
 blb
 dDB
 ldq
-gwk
+wBF
 ldq
 ldq
 ldq
 ldq
 ldq
-cng
-mfs
-kEz
-qTv
+eLf
+lGp
+fRe
+vWC
 ldq
 sgB
 fhT
@@ -110877,16 +111141,16 @@ yfQ
 ldq
 yfQ
 ldq
-xpY
+sXo
 ldq
-tLL
-wJI
-mDO
+esW
+ipM
+piI
 ldq
-kKj
-mfs
+ezy
+lGp
 xpY
-xpY
+sXo
 xko
 hPQ
 uNe
@@ -110901,9 +111165,9 @@ pkR
 vtC
 blb
 dDB
-vuQ
-iVH
-pDI
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -111124,25 +111388,25 @@ pKU
 wFQ
 pKU
 xpY
-ciX
-ygz
-ygz
+aGR
+qAl
+qAl
 pKU
 pKU
 pKU
 pKU
-qJe
+gOR
 krz
 xpY
-oqn
-kIN
-ewy
-gZz
-urW
+aXi
+wWN
+lVo
+jzj
+caG
 ldq
 ldq
 ldq
-wwH
+fnx
 ldq
 ldq
 uLj
@@ -111158,9 +111422,9 @@ idp
 vtC
 blb
 dDB
-lgW
-aVF
-gOl
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -111382,25 +111646,25 @@ ssz
 ssz
 ssz
 ssz
-gZz
+jzj
 xQI
-ciX
-rTc
-gUB
-tEQ
-iOa
-gFM
-ijj
-pKU
-bHc
-pfI
-eNW
-nfq
+aGR
+kDR
+fSC
+pvU
+owc
+vje
+ilB
+rzO
+sXc
+vtU
+hhK
+dHp
 ldq
-amz
-mgU
-pIN
-gfX
+fOw
+iis
+knY
+qgi
 ldq
 qdR
 naN
@@ -111415,9 +111679,9 @@ xyR
 tuT
 blb
 dDB
-gVk
-mjw
-gof
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -111640,10 +111904,10 @@ blb
 blb
 ssz
 ssz
-eaX
-dxq
-iUW
-lwA
+pnB
+tHy
+ixH
+qTv
 rUR
 rUR
 aSy
@@ -111655,9 +111919,9 @@ aSy
 evv
 aSy
 aSy
-iBn
-pIN
-dow
+xoT
+knY
+dwT
 ldq
 uLj
 uLj
@@ -111672,9 +111936,9 @@ idp
 vtC
 blb
 dDB
-gVk
-lkC
-fyR
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -111897,8 +112161,8 @@ tjj
 blb
 blb
 ssz
-gZz
-ciX
+jzj
+aGR
 ssz
 aSy
 aSy
@@ -111929,9 +112193,9 @@ idp
 vtC
 blb
 dDB
-hVT
-yjC
-sTu
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -112154,7 +112418,7 @@ tjj
 tjj
 blb
 ssz
-gZz
+jzj
 pKU
 ssz
 heB
@@ -112948,7 +113212,7 @@ bOR
 tUa
 gOq
 vlj
-tuT
+nRj
 ufn
 gOh
 ufn
@@ -113204,8 +113468,8 @@ pQE
 yim
 fEd
 gOq
-cYR
-tuT
+pHq
+mEn
 pHq
 pHq
 kho
@@ -113460,9 +113724,9 @@ xvY
 pQE
 nSl
 yhT
-gOq
-pHq
-mEn
+qhd
+fFC
+nRj
 tXG
 vcd
 pHq
@@ -113717,7 +113981,7 @@ ahD
 pQE
 jSw
 fEd
-vgY
+ufn
 ufn
 tuT
 kTw

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -22,6 +22,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"aau" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai_upload)
 "aav" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -51,9 +55,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "abh" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -108,6 +112,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"acM" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
+/area/station/science/xenobiology)
 "acS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116,29 +125,28 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "adh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "adl" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/light/small/directional/south,
-/obj/structure/table/reinforced,
-/obj/effect/spawner/surgery_tray/full/morgue,
-/turf/open/floor/iron/small,
+/obj/structure/bodycontainer/morgue/beeper_off{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "adL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -159,6 +167,12 @@
 	},
 /turf/open/floor/grass/Airless,
 /area/station/hallway/primary/central/aft)
+"aej" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "aem" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -168,6 +182,15 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"aeA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "aeC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -195,9 +218,6 @@
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -287,30 +307,22 @@
 /area/station/commons/dorms)
 "agy" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/cold/directional/south,
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 4
 	},
-/obj/machinery/light/cold/directional/south,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "agI" = (
+/obj/machinery/firealarm/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"agK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/dock)
 "agR" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -400,9 +412,15 @@
 "aid" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
+"ait" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/rnd_secure_all,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "aiI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
@@ -417,6 +435,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
+"aiX" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/alien/weeds,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "ajg" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "atmospherics - upper"
@@ -464,21 +488,18 @@
 /turf/open/floor/iron,
 /area/station/security)
 "alb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "als" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen)
 "alF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -534,9 +555,6 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -603,8 +621,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aop" = (
-/obj/structure/cable,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "aoz" = (
@@ -638,12 +656,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "apo" = (
@@ -665,9 +683,6 @@
 "apF" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "apP" = (
@@ -706,13 +721,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"aqV" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "aqW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/bench/right{
@@ -798,10 +806,16 @@
 /turf/open/floor/iron/textured_half,
 /area/station/security/prison/workout)
 "asm" = (
-/obj/effect/turf_decal/siding/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"asG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "asS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
@@ -847,13 +861,6 @@
 /obj/structure/sign/poster/contraband/lusty_xenomorph/directional/north,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
-"atB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/lower)
 "atE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -910,9 +917,6 @@
 "auf" = (
 /obj/structure/cable,
 /obj/machinery/light/small/dim/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "aul" = (
@@ -935,12 +939,11 @@
 /turf/open/floor/glass,
 /area/station/hallway/primary/central/aft)
 "auG" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
 "auI" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -968,6 +971,12 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
+"avc" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/station/medical/morgue)
 "avd" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
@@ -1078,12 +1087,12 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/cold/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
 "awH" = (
@@ -1102,13 +1111,18 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "awO" = (
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "awQ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -1201,12 +1215,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"ayu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/station/science/cubicle)
 "ayK" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
@@ -1347,12 +1355,13 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "aAL" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "aAQ" = (
@@ -1422,15 +1431,9 @@
 /turf/open/floor/wood/tile,
 /area/station/science/lower)
 "aBv" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/obj/structure/bodycontainer/morgue/beeper_off{
-	dir = 2
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/small,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aBB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1467,11 +1470,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aBV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/structure/sign/departments/science/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aCi" = (
@@ -1520,6 +1523,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"aDC" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "aEa" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/tram,
@@ -1572,13 +1582,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "aEJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
@@ -1595,7 +1605,6 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "aFh" = (
@@ -1604,10 +1613,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"aFj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance)
 "aFo" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/airless,
@@ -1644,10 +1649,10 @@
 /turf/open/floor/plating,
 /area/station/security/tram)
 "aFY" = (
+/obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/stairs{
 	dir = 8
 	},
@@ -1659,25 +1664,25 @@
 /area/space/nearstation)
 "aGb" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
 /area/station/science/ordnance/testlab)
 "aGq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aGv" = (
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "aGy" = (
@@ -1695,13 +1700,13 @@
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
 "aGH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "aGU" = (
@@ -1732,6 +1737,12 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
+"aHV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "aIb" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -1838,23 +1849,21 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
 "aJX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	id_tag = "AuxToilet3";
-	name = "Unit 3"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
-"aJZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/science/xenobiology)
+"aJZ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
@@ -1871,7 +1880,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/tcommsat/server)
 "aKJ" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
@@ -1882,6 +1890,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aKS" = (
@@ -1911,9 +1920,6 @@
 /area/station/construction/mining/aux_base)
 "aLs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aLv" = (
@@ -1927,12 +1933,6 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
-"aLA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "aLB" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/camera/autoname/directional/north,
@@ -1946,12 +1946,12 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/service)
 "aLC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east{
 	areastring = "/area/station/science/ordnance/burnchamber"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -1982,11 +1982,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"aMy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
-/turf/open/floor/plating,
-/area/station/science/ordnance/testlab)
+"aMp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/station/maintenance/starboard/greater)
 "aMI" = (
 /obj/machinery/mineral/ore_redemption{
 	dir = 4;
@@ -2066,13 +2068,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "aNX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -2114,13 +2116,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "aOz" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /obj/machinery/holopad,
 /obj/machinery/light/floor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aOX" = (
@@ -2163,10 +2165,10 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "aPK" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aPM" = (
@@ -2182,11 +2184,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "aPX" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
 "aQf" = (
@@ -2204,10 +2203,10 @@
 /area/station/security/checkpoint/customs)
 "aQr" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "aQx" = (
@@ -2253,9 +2252,6 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aRo" = (
@@ -2268,17 +2264,11 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "aRv" = (
+/obj/machinery/camera/autoname/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"aRw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/station/maintenance/starboard/greater)
 "aRx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
@@ -2482,9 +2472,9 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen)
 "aVF" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "aVT" = (
@@ -2551,8 +2541,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "aWz" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -2563,6 +2553,12 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"aWB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "aXC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2621,11 +2617,16 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
-"aYR" = (
-/obj/structure/broken_flooring/singular/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+"aYN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/radio/intercom/command/directional/north,
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/engineering/storage/tech)
 "aYU" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -2667,25 +2668,25 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "aZL" = (
-/obj/structure/table,
-/obj/item/aicard,
-/obj/machinery/light/cold/directional/east,
-/obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/area/station/science/robotics/lab)
 "aZS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
 /area/station/command/meeting_room)
 "bah" = (
 /obj/structure/cable,
-/obj/item/kirbyplants/organic/applebush,
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
+/obj/machinery/pdapainter{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
@@ -2712,9 +2713,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "baO" = (
@@ -2775,9 +2773,9 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "bcv" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/small,
 /area/station/medical/medbay/lobby)
@@ -2798,12 +2796,8 @@
 "bcO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/corner{
-	dir = 4
+/turf/open/floor/iron/stairs{
+	dir = 8
 	},
 /area/station/science/xenobiology)
 "bdi" = (
@@ -2846,13 +2840,12 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "bey" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/engineering/storage/tech)
 "beK" = (
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
@@ -2967,32 +2960,30 @@
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "bgA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/small,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bgB" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bgE" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
-"bgQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "bho" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -3026,14 +3017,28 @@
 /area/station/engineering/supermatter/room)
 "biB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/weather/snow/corner{
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/glass/mug/nanotrasen{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/checker,
 /area/station/command/bridge)
 "biM" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "biV" = (
@@ -3041,6 +3046,13 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
+"biZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bja" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -3118,8 +3130,8 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "bka" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3137,26 +3149,29 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bkg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/light/floor,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
 "bkl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"bkD" = (
-/obj/machinery/camera/autoname/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
+"bkX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/dock)
 "bkY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/machinery/requests_console/directional/west{
 	department = "Chief Medical Officer's Desk";
 	name = "Chief Medical Officer's Requests Console"
@@ -3164,21 +3179,12 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
 "blb" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ble" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "blf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -3212,6 +3218,12 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"blm" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/server)
 "blt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer4,
@@ -3220,14 +3232,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"blw" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/rec)
 "bly" = (
 /obj/structure/closet/crate/miningcar,
 /turf/open/floor/iron,
@@ -3239,19 +3243,14 @@
 	},
 /turf/open/floor/eighties/red,
 /area/station/hallway/primary/central/fore)
-"blJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "blP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bmr" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/broadcaster/preset_right,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
@@ -3262,15 +3261,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "bmA" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -3317,6 +3313,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"bnd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/storage/tech)
 "bnn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -3343,9 +3344,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bnr" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "bnz" = (
@@ -3386,12 +3387,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/engineering)
 "bnX" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
@@ -3421,12 +3419,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"boj" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "bor" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -3480,11 +3472,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"boY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "bpe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -3503,7 +3490,6 @@
 /turf/open/floor/iron/white/small,
 /area/station/security/execution/education)
 "bpo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3514,14 +3500,15 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/broken/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "bpI" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/machinery/light/small/directional/west,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "bpS" = (
@@ -3568,24 +3555,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bqu" = (
-/obj/structure/table,
-/obj/item/stack/ore/silver{
-	pixel_y = 16
-	},
-/obj/item/stack/ore/titanium{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/stack/ore/diamond{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/plasma{
-	pixel_y = -8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch/directional/west,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/pai_card,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "bqx" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -3717,12 +3693,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bsv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/fake_snow,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bsy" = (
 /obj/machinery/camera/directional/east{
@@ -3818,15 +3794,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security)
+"buk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "buA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -3869,9 +3859,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "bvh" = (
@@ -3912,12 +3899,10 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"bwP" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/stone,
-/area/station/service/bar)
+"bwT" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "bwW" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/yellow{
@@ -3948,20 +3933,24 @@
 "bxl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/weather/snow,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /obj/machinery/food_cart,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"bxI" = (
+"bxB" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
+"bxI" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/mail_sorting/science/robotics,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
@@ -3975,12 +3964,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"bxY" = (
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/iron/smooth,
+/area/station/security/checkpoint/customs)
 "byq" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/small,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/command/bridge)
 "byt" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -3997,16 +3995,16 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "byx" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -4025,8 +4023,8 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
@@ -4057,6 +4055,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/service)
+"bzm" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side,
+/area/station/science/xenobiology)
 "bzF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4090,12 +4095,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"bAs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "bAI" = (
 /obj/structure/chair/office,
 /obj/structure/sign/poster/official/work_for_a_future/directional/east,
@@ -4103,28 +4102,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "bAT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
-"bAY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
-"bBg" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/misc/dirt/station,
-/area/station/service/chapel)
 "bBh" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -4152,10 +4134,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "bBr" = (
+/obj/item/radio/intercom/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
 "bBL" = (
@@ -4222,10 +4204,10 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "bCQ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -4258,11 +4240,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bDj" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "bDq" = (
@@ -4277,23 +4259,20 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bDD" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "bDN" = (
@@ -4308,7 +4287,6 @@
 	dir = 1
 	},
 /obj/machinery/light/no_nightlight/directional/north,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "bEd" = (
@@ -4379,22 +4357,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bFw" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"bFJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "bFO" = (
 /obj/effect/spawner/random/trash,
 /obj/structure/cable,
@@ -4412,11 +4380,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"bFU" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Research Wing"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured_half{
+	dir = 1
+	},
+/area/station/hallway/primary/starboard)
 "bFW" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/techstorage/rnd_all,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "bGe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4442,13 +4423,13 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "bGk" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/siding/white{
-	dir = 5
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/siding/dark_blue/corner{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/mannequin/skeleton,
-/turf/open/floor/iron/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bGn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4532,6 +4513,13 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"bHF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "bHU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/camera/autoname/directional/south,
@@ -4579,13 +4567,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
-"bJw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/broken_flooring/singular/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "bJx" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -4702,10 +4683,13 @@
 /turf/open/floor/plating,
 /area/station/service/library)
 "bLT" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "bMc" = (
@@ -4716,7 +4700,6 @@
 /area/station/commons/storage/art)
 "bMn" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/effect/turf_decal/weather/snow/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4725,9 +4708,10 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"bMt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"bMU" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/command_all,
+/obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -4742,8 +4726,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bMW" = (
-/obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/iv_drip,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
@@ -4782,16 +4766,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bNP" = (
-/obj/structure/cable,
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "bNQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4809,11 +4793,11 @@
 /turf/closed/wall,
 /area/station/service/kitchen)
 "bON" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "bOR" = (
@@ -4895,12 +4879,6 @@
 /obj/machinery/photobooth/security,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"bQQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "bRf" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -4928,8 +4906,7 @@
 /area/station/maintenance/starboard/greater)
 "bRr" = (
 /obj/structure/chair{
-	dir = 1;
-	pixel_y = -2
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/smooth,
@@ -5025,19 +5002,12 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"bUv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay/aft)
 "bUD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -5091,13 +5061,6 @@
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/iron/small,
 /area/station/security/office)
-"bVR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "bWh" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -5153,12 +5116,6 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"bWK" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "bXi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5177,11 +5134,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "bXG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -5192,9 +5146,6 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bXO" = (
@@ -5206,11 +5157,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
 "bXR" = (
-/obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/fake_snow,
+/obj/structure/table/wood,
+/turf/open/floor/stone,
 /area/station/service/bar)
 "bYf" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -5236,6 +5187,25 @@
 	dir = 1
 	},
 /area/station/engineering/hallway)
+"bYo" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/science/xenobiology)
+"bYC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "bYK" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -5269,12 +5239,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "bZt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
@@ -5302,11 +5272,11 @@
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
 "bZz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
@@ -5352,16 +5322,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "caI" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
 "caK" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "caW" = (
@@ -5429,34 +5396,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/smooth,
 /area/station/command/heads_quarters/qm)
-"cbt" = (
-/obj/structure/cable,
-/obj/structure/table/bronze,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
-	},
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/command/meeting_room)
 "cbH" = (
-/obj/structure/cable,
 /obj/item/kirbyplants/random,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
 "cbO" = (
@@ -5507,18 +5450,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/tram)
-"ccF" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/command{
-	name = "Telecomms Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "comms-entrance-south"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/tcommsat/server)
 "ccG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -5534,9 +5465,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cdg" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/grass,
-/area/station/science/xenobiology)
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/auxiliary)
 "cdn" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/circuit,
@@ -5577,9 +5508,16 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "cea" = (
-/obj/structure/window/spawner/directional/south,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "aibridge"
+	},
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "ceD" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Janitorial Closet"
@@ -5657,20 +5595,13 @@
 /obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai)
-"cfn" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
-"cfH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+"cfy" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "cgs" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
@@ -5684,10 +5615,13 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/service)
 "cgt" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "cgy" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -5781,9 +5715,6 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/flowers_pp/style_random,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "cig" = (
@@ -5803,14 +5734,14 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "cip" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
+/obj/effect/landmark/start/depsec/science,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "cis" = (
@@ -5829,10 +5760,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ciR" = (
-/obj/structure/table,
-/obj/effect/spawner/random/techstorage/command_all,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/science/xenobiology)
 "ciT" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/east,
@@ -5844,11 +5779,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"ciW" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/turf/open/floor/iron/cafeteria,
-/area/station/science/circuits)
 "cjc" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5902,7 +5832,6 @@
 "cjY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/light/cold/directional/east,
@@ -5934,10 +5863,6 @@
 /obj/structure/sign/departments/engineering/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"ckt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "cku" = (
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/noslip,
@@ -5987,13 +5912,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/aft)
 "clf" = (
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock{
-	name = "Auxiliary Bathrooms"
-	},
-/turf/open/floor/plating,
-/area/station/commons/toilet/auxiliary)
+/turf/open/floor/wood/tile,
+/area/station/service/lawoffice)
 "cll" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Fitness Ring"
@@ -6003,18 +5925,29 @@
 /area/station/commons/dorms)
 "clq" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "clt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/blue,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
+"clH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/engineering/storage/tech)
 "clV" = (
 /obj/structure/table,
 /obj/effect/mapping_helpers/broken_floor,
@@ -6031,15 +5964,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/structure/sign/departments/restroom/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
 "cmd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "cmf" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/department/engine/atmos)
@@ -6062,11 +5994,11 @@
 /area/station/engineering/storage/tcomms)
 "cmw" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -6079,11 +6011,17 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"cmA" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
 "cmD" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -6098,20 +6036,14 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "cnn" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
 /turf/open/floor/iron/small,
 /area/station/service/barber)
-"cns" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "cnC" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -6121,10 +6053,6 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
-"cnT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/fake_snow,
-/area/station/hallway/secondary/exit/departure_lounge)
 "cob" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -6159,6 +6087,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"cov" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/science/lobby)
 "cow" = (
 /turf/closed/wall,
 /area/station/engineering/lobby)
@@ -6185,7 +6119,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "cpE" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -6198,12 +6132,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"cpJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "cpP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -6218,6 +6146,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/hop)
+"cpU" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Cubicle"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/research)
 "cqa" = (
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
@@ -6232,8 +6170,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
 "cqn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/side,
 /area/station/science/xenobiology)
 "cqr" = (
@@ -6322,11 +6260,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
-"cru" = (
-/obj/structure/cable,
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "crx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
@@ -6334,9 +6267,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "crE" = (
-/obj/structure/window/spawner/directional/north,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "aibridge"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "crJ" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 6
@@ -6456,18 +6393,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "cuw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/entry)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/wall,
+/area/station/command/corporate_showroom)
 "cuZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6482,9 +6410,6 @@
 /obj/machinery/light/directional/east,
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/five,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cvk" = (
@@ -6580,10 +6505,10 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "cwS" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -6596,11 +6521,11 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "cxy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -6613,22 +6538,22 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "cxO" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
 	name = "Research Director's Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/cubicle)
 "cyf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "cyk" = (
@@ -6726,10 +6651,10 @@
 	},
 /area/station/service/janitor)
 "cAb" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side,
@@ -6751,16 +6676,16 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/surgery/theatre)
 "cAl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/assistant,
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "cAm" = (
@@ -6774,20 +6699,20 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "cAr" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cAt" = (
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id = "mechbay";
 	name = "Mech Bay Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/science/robotics/mechbay)
 "cAv" = (
@@ -6818,14 +6743,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cBu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/fore)
 "cBw" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/filingcabinet/chestdrawer,
@@ -6853,9 +6776,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "cCl" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central/fore)
 "cCv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/siding/wideplating_new/terracotta,
@@ -6893,6 +6824,12 @@
 	},
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
+"cCK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "cCM" = (
 /obj/structure/cable,
 /obj/structure/sink/kitchen/directional/east,
@@ -6927,17 +6864,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
-"cDa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/science/xenobiology)
 "cDb" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -6945,10 +6871,6 @@
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
-"cDf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "cDt" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/transport/linear/tram,
@@ -7093,11 +7015,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/yellow,
-/obj/machinery/button/door/directional/south{
-	id = "bridge blast";
-	name = "Bridge Access Blast Door Control";
-	req_access = list("command")
-	},
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "cFg" = (
@@ -7112,12 +7029,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"cFj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
+"cFo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "cFq" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -7145,6 +7062,15 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/lesser)
+"cFY" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "cGj" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/education)
@@ -7203,16 +7129,25 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/pumproom)
+"cHy" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/science/circuits)
 "cHC" = (
 /obj/structure/chair{
 	pixel_y = -2
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/lawyer,
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/lawyer,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "cHD" = (
@@ -7365,15 +7300,12 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"cKL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
 "cKV" = (
 /obj/machinery/light/floor,
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "cLa" = (
@@ -7433,9 +7365,11 @@
 	dir = 10
 	},
 /obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 6;
+/obj/item/stack/sheet/mineral/plasma/thirty{
 	pixel_y = 4
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
@@ -7533,6 +7467,13 @@
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
+"cNT" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "cNZ" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 8
@@ -7570,14 +7511,19 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "cOC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	id = "XenoPens";
+	name = "Xenobiology Shutters";
+	req_access = list("xenobiology")
 	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -7617,6 +7563,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine/atmos)
+"cPh" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/science/auxlab/firing_range)
 "cPi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -7689,7 +7644,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/stone,
 /area/station/service/bar)
 "cQP" = (
@@ -7704,11 +7658,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "cRc" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/sign/departments/court/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cRm" = (
@@ -7717,9 +7671,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "cRn" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/lobby)
 "cRo" = (
@@ -7830,13 +7784,13 @@
 "cSy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cSC" = (
@@ -7847,10 +7801,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "cTp" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/holopad,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "cTw" = (
@@ -7865,10 +7819,10 @@
 /area/station/medical/surgery/theatre)
 "cTC" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
@@ -7881,6 +7835,16 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/break_room)
+"cTP" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "cTX" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -8020,6 +7984,13 @@
 	dir = 4
 	},
 /area/station/maintenance/fore/lesser)
+"cWm" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4;
+	name = "killroom vent"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/station/science/xenobiology)
 "cWC" = (
 /obj/item/reagent_containers/cup/watering_can/wood,
 /obj/structure/table,
@@ -8029,16 +8000,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/hallway/primary/aft)
+/area/station/medical/morgue)
 "cWZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Primary Docking Bay"
@@ -8050,13 +8023,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"cXa" = (
-/obj/structure/hedge,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "cXb" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/weather/dirt{
@@ -8121,13 +8087,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "cYk" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/departments/telecomms/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/departments/telecomms/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "cYp" = (
@@ -8144,14 +8110,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cYD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
 /obj/item/hemostat{
 	desc = "Ah yes, the Haircutting Device.";
 	name = "Totally Not Scissors"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/small,
 /area/station/service/barber)
 "cYE" = (
@@ -8178,6 +8144,12 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/engine)
+"cYR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "cYS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8196,7 +8168,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/side{
@@ -8245,8 +8217,8 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "cZx" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "cZy" = (
@@ -8286,15 +8258,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
-"dag" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+"cZW" = (
+/obj/structure/closet/crate/grave,
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "dah" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -8336,6 +8303,14 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/ce)
+"daH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "dba" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -8433,11 +8408,11 @@
 /area/station/hallway/primary/port)
 "dcH" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -8503,7 +8478,6 @@
 "ddF" = (
 /mob/living/basic/goat/pete,
 /obj/effect/turf_decal/weather/snow,
-/obj/effect/turf_decal/weather/snow/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -8530,21 +8504,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/service)
-"deb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "deh" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "dex" = (
@@ -8613,6 +8581,10 @@
 	dir = 1
 	},
 /area/station/cargo/storage)
+"dfO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/central)
 "dfT" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -8637,19 +8609,15 @@
 /area/station/engineering/main)
 "dgn" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"dgo" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/corner,
-/area/station/science/lower)
 "dgt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -8681,6 +8649,14 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
+"dhb" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "dhh" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
@@ -8697,18 +8673,12 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "dhy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -8716,20 +8686,16 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "dhC" = (
-/obj/structure/table,
-/obj/item/stack/ore/gold{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/plasma{
-	pixel_y = -6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/vending/assist,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "dhG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2,
@@ -8745,11 +8711,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dim" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -8821,11 +8787,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "diK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
@@ -8853,11 +8819,11 @@
 /area/station/hallway/secondary/command)
 "djc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
 "djf" = (
@@ -8881,6 +8847,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/small,
 /area/station/security/brig)
+"djE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/cafeteria,
+/area/station/science/circuits)
 "djO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8909,9 +8883,9 @@
 	name = "Dorms"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/dorms)
 "dkh" = (
@@ -8940,9 +8914,6 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "dkI" = (
@@ -8986,11 +8957,11 @@
 /turf/open/misc/dirt/station,
 /area/station/service/chapel)
 "dlG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "dlJ" = (
@@ -9006,11 +8977,11 @@
 /area/station/security/checkpoint/customs/auxiliary)
 "dml" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
@@ -9033,9 +9004,6 @@
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -9070,7 +9038,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "dnO" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 4
 	},
@@ -9084,6 +9051,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "dnU" = (
@@ -9195,8 +9163,8 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "dqj" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dqB" = (
@@ -9271,11 +9239,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/engineering/storage/tech)
 "dsb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9300,11 +9269,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "dsp" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/rack,
-/obj/item/pickaxe,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "dss" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple,
@@ -9313,14 +9283,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "dst" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/small,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dsK" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -9342,10 +9306,6 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
-"dtk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall,
-/area/station/science/ordnance/testlab)
 "dtm" = (
 /obj/structure/window/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -9530,9 +9490,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "dwX" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dxf" = (
@@ -9547,10 +9507,10 @@
 "dxw" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/light/warm/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "dxG" = (
@@ -9583,20 +9543,14 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
 "dxZ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
 	name = "Gas Lab Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"dyd" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/misc/dirt/station,
-/area/station/service/chapel)
 "dyp" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -9635,6 +9589,15 @@
 "dyI" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"dyJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
 "dyO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9668,11 +9631,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dzE" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dAn" = (
@@ -9680,9 +9643,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "dAr" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/transit_tube/horizontal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "dAu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9798,6 +9762,13 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"dBO" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8;
+	name = "killroom vent"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/station/science/xenobiology)
 "dBT" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -9855,6 +9826,20 @@
 	dir = 8
 	},
 /area/station/security/office)
+"dDc" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Ordnance Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/storage)
 "dDd" = (
 /obj/structure/table,
 /obj/item/exodrone{
@@ -9898,9 +9883,6 @@
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -9963,12 +9945,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
-"dEL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/science/ordnance/testlab)
 "dEY" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 5
@@ -10051,13 +10027,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "dHL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/command/bridge)
 "dHT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10111,6 +10090,14 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"dJj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dJn" = (
 /obj/machinery/light/small/directional/south{
 	dir = 4
@@ -10132,15 +10119,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"dJJ" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/engineering/main)
 "dJT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10223,12 +10201,12 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/execution/education)
 "dLq" = (
+/obj/structure/cable,
 /obj/structure/table,
 /obj/item/hand_labeler,
 /obj/item/camera,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "dLv" = (
@@ -10240,11 +10218,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"dLQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "dLR" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 8
@@ -10259,6 +10232,17 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"dMe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dMg" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -10292,14 +10276,10 @@
 /area/station/hallway/primary/central/fore)
 "dMM" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dMX" = (
 /obj/machinery/holopad/secure,
-/obj/structure/statue/snow/snowman,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "dMY" = (
@@ -10315,9 +10295,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "dNo" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "dNq" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/aisat/exterior)
@@ -10336,13 +10318,13 @@
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
 "dNL" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/end{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dNU" = (
@@ -10350,7 +10332,6 @@
 	dir = 5
 	},
 /obj/effect/spawner/random/vending/snackvend,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "dOb" = (
@@ -10463,6 +10444,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"dQm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/commons/fitness/recreation)
 "dQn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -10471,12 +10456,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
-"dQE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "dQQ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -10507,24 +10486,45 @@
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/stone,
 /area/station/service/chapel)
+"dRv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Research Wing"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-entrance"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "rdrnd";
+	name = "Research and Development Shutters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured_half{
+	dir = 1
+	},
+/area/station/hallway/primary/starboard)
 "dRz" = (
 /obj/docking_port/stationary/syndicate/northeast,
 /turf/open/space/basic,
 /area/space)
 "dRT" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "dSb" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Secure Pen"
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/hatch{
-	name = "Secure Pen"
-	},
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -10542,9 +10542,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "dSu" = (
@@ -10552,11 +10552,7 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "dSz" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "dSO" = (
@@ -10598,9 +10594,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "dTi" = (
@@ -10698,6 +10691,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
+"dUS" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Cubicle"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/cubicle)
 "dVQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -10717,11 +10721,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
 "dWh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/structure/sign/departments/science/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dWm" = (
@@ -10729,9 +10733,6 @@
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "dWs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10744,9 +10745,6 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "dWF" = (
@@ -10766,8 +10764,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "dWK" = (
@@ -10779,17 +10777,18 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "dWS" = (
-/obj/structure/closet/crate/large,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/security_all,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "dWW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "dXb" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10798,12 +10797,10 @@
 	codes_txt = "delivery;dir=4";
 	location = "Research"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "dXe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance"
 	},
@@ -10812,15 +10809,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lower)
-"dXj" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "dXu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10837,11 +10830,11 @@
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "dXU" = (
+/obj/machinery/portable_atmospherics/canister,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -10918,8 +10911,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "dYW" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "dYX" = (
@@ -10954,10 +10947,10 @@
 /area/station/ai_monitored/turret_protected/ai)
 "dZp" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
 "dZD" = (
@@ -10979,6 +10972,14 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/prison/shower)
+"dZJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "dZT" = (
 /obj/machinery/button/transport/tram/directional/south{
 	id = 2;
@@ -11016,10 +11017,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
 "ebc" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -11130,7 +11131,7 @@
 "ecL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ecY" = (
@@ -11144,10 +11145,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "ede" = (
+/obj/machinery/light/floor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/floor,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -11232,10 +11233,10 @@
 	},
 /area/station/cargo/storage)
 "eem" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "eeD" = (
@@ -11276,21 +11277,21 @@
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "efB" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "efK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -11328,11 +11329,6 @@
 /obj/structure/water_source/puddle,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
-"egr" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/xenobiology)
 "egA" = (
 /obj/machinery/vending/autodrobe,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -11362,7 +11358,6 @@
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
 "egL" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -11372,6 +11367,7 @@
 	id = "rdoffice";
 	name = "Research Director's Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/cubicle)
 "egN" = (
@@ -11391,10 +11387,6 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"ehc" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "ehd" = (
 /obj/item/stack/cable_coil,
 /obj/item/electronics/airlock,
@@ -11423,9 +11415,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "ehf" = (
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "ehj" = (
@@ -11466,11 +11458,11 @@
 /area/station/medical/paramedic)
 "ehZ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/floor/plating,
@@ -11551,10 +11543,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
-"ejx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "ejL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -11673,19 +11661,19 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "elc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/mechbay)
 "elh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2,
 /obj/structure/sign/warning/cold_temp/directional/west,
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "eln" = (
@@ -11705,13 +11693,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/main)
 "elw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
 /obj/machinery/reagentgrinder{
@@ -11727,9 +11715,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
 "elC" = (
@@ -11750,11 +11735,11 @@
 /area/station/command/heads_quarters/cmo)
 "elM" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "elR" = (
@@ -11765,8 +11750,8 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "elT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "emd" = (
@@ -11778,12 +11763,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "emn" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "emz" = (
@@ -11813,22 +11798,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "enb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/navigate_destination/aiupload,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "enq" = (
-/obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/machinery/status_display/ai/directional/north,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "enE" = (
 /obj/item/cultivator/rake,
 /obj/structure/cable,
@@ -11874,9 +11854,6 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -11980,9 +11957,6 @@
 /area/station/science/xenobiology)
 "eqG" = (
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/central/lesser)
 "eqI" = (
@@ -12020,8 +11994,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "erA" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -12064,12 +12038,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"esy" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/station/maintenance/department/engine/atmos)
 "esz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "esF" = (
@@ -12088,8 +12066,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "esP" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -12142,15 +12120,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/stone,
 /area/station/service/chapel)
-"etX" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/stone,
-/area/station/service/bar)
 "etZ" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
@@ -12171,10 +12140,10 @@
 /turf/open/floor/wood,
 /area/station/engineering/main)
 "eul" = (
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/commons/fitness/locker_room)
 "euq" = (
@@ -12207,11 +12176,9 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "euR" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/science/lobby)
+/obj/structure/hedge,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "eva" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -12224,9 +12191,6 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "evj" = (
@@ -12237,26 +12201,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "evq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "evv" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Xenobiology Maintenance"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
+/obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "evw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange{
@@ -12288,8 +12245,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ewt" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -12309,6 +12266,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"exu" = (
+/obj/machinery/status_display/ai/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/lower)
 "exF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -12331,10 +12297,10 @@
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "exR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "exW" = (
@@ -12403,6 +12369,17 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ezb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/science/lobby)
 "ezi" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/cafeteria,
@@ -12473,9 +12450,6 @@
 /area/station/command/heads_quarters/hop)
 "eAf" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "eAm" = (
@@ -12494,12 +12468,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
-"eAo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/commons/vacant_room/office)
 "eAu" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -12508,9 +12476,9 @@
 /area/station/solars/starboard/aft)
 "eAz" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
@@ -12586,12 +12554,9 @@
 /turf/open/floor/noslip,
 /area/station/maintenance/department/medical/central)
 "eBT" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/small,
-/area/station/medical/morgue)
+/obj/item/shovel,
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "eCf" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -12683,11 +12648,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "eDz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "eDF" = (
@@ -12837,24 +12802,23 @@
 /area/station/security/prison)
 "eFO" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "eFQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/landmark/navigate_destination/eva,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/landmark/navigate_destination/eva,
-/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "eFV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12941,10 +12905,10 @@
 /area/station/service/barber)
 "eHe" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -12978,16 +12942,20 @@
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"eHE" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "eHN" = (
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
+"eHP" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/research)
 "eHS" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -13069,9 +13037,6 @@
 	name = "Quartermaster's Fax Machine";
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "eJm" = (
@@ -13099,9 +13064,6 @@
 /obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
-"eKc" = (
-/turf/open/floor/fake_snow,
-/area/station/commons/dorms)
 "eKf" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets/donkpocketpizza,
@@ -13125,14 +13087,15 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "eKP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "eKV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "eKW" = (
@@ -13150,18 +13113,15 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/greater)
 "eLx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A. Storage"
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "Bridge Blast Door"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/station/ai_monitored/command/storage/eva)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/meeting_room)
 "eLB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13196,15 +13156,28 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"eMm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/science/lobby)
 "eMo" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"eMH" = (
+/obj/machinery/button/door/directional/east{
+	id = "AuxToilet3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/toilet,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/department/science/xenobiology)
 "eMQ" = (
 /obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "eMS" = (
@@ -13212,7 +13185,6 @@
 	pixel_y = -2
 	},
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "eMU" = (
@@ -13426,14 +13398,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
-"eQQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/maintenance/starboard/greater)
 "eQY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
@@ -13451,6 +13415,11 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"eRO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "eRX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13458,12 +13427,9 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
 "eSd" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance"
 	},
@@ -13472,12 +13438,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lower)
-"eSj" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/stone,
-/area/station/service/bar)
 "eSA" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -13532,17 +13497,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/random/fullysynthetic,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"eTy" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "eTJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -13557,11 +13513,11 @@
 	},
 /area/station/cargo/lobby)
 "eTT" = (
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light/floor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/floor,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
 "eUb" = (
@@ -13689,9 +13645,6 @@
 /obj/structure/hedge,
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "eVX" = (
@@ -13735,10 +13688,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"eWD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "eWI" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
@@ -13758,10 +13707,10 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "eWY" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
@@ -13773,6 +13722,11 @@
 "eXo" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
+"eXt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/dock)
 "eXy" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/table,
@@ -13804,10 +13758,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "eXW" = (
+/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "eYc" = (
@@ -13838,6 +13792,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"eYx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/engineering/storage/tech)
 "eYB" = (
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood,
@@ -13894,12 +13856,6 @@
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
-"eZs" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
 "eZM" = (
 /obj/structure/cable/layer3,
 /obj/effect/decal/cleanable/dirt,
@@ -14023,10 +13979,10 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "fcs" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "fcE" = (
@@ -14041,13 +13997,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"fcF" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "fcU" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/flora/bush/large/style_random{
@@ -14082,13 +14031,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "fdv" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/structure/cable,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "fdy" = (
 /obj/structure/railing{
 	dir = 1
@@ -14108,14 +14056,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/command/heads_quarters/ce)
-"fdG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/lower)
 "fdM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -14391,6 +14331,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"fjv" = (
+/obj/machinery/computer/operating,
+/obj/machinery/requests_console/auto_name/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "fjL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -14404,15 +14349,6 @@
 "fjQ" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms)
-"fjT" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/station/commons/dorms)
 "fjV" = (
 /obj/item/radio/intercom/directional/south{
@@ -14459,6 +14395,12 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/library)
+"fkK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
 "fkN" = (
 /obj/structure/mannequin/plastic,
 /obj/structure/disposalpipe/segment{
@@ -14509,13 +14451,13 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "flx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/research)
 "flD" = (
@@ -14581,29 +14523,20 @@
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "fmH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/closed/wall,
+/area/station/medical/morgue)
 "fmR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
-"fnd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/testlab)
 "fni" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/depsec/science,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "fnw" = (
@@ -14615,9 +14548,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "fnz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/command/meeting_room)
 "fnI" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/side{
@@ -14697,8 +14637,6 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "foI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/button/door/directional/north{
 	id = "Xenolab";
@@ -14707,6 +14645,8 @@
 	pixel_y = -2;
 	req_access = list("xenobiology")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/white/side{
 	dir = 8
@@ -14734,23 +14674,20 @@
 /area/station/hallway/primary/fore)
 "fpq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
+/turf/open/floor/iron,
+/area/station/maintenance/aft)
+"fpw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible/layer2{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "fpB" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Science Lab Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "fpN" = (
@@ -14774,13 +14711,14 @@
 "fpY" = (
 /turf/closed/mineral/random/stationside,
 /area/station/ai_monitored/aisat/exterior)
-"fqG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"fqv" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white/side,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/lower)
 "fqT" = (
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
@@ -14835,22 +14773,11 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
-"frZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research/glass{
-	name = "Cubicle"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/research)
 "fsk" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
-	dir = 1;
-	pixel_y = -2
+	dir = 1
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -14881,31 +14808,16 @@
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
 "fst" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/mapping_helpers/broken_floor,
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"fsL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/xenobiology)
-"fsT" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
 "fsW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -14970,11 +14882,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
-"ftX" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "fuj" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/siding/dark_red,
@@ -15018,6 +14925,14 @@
 /obj/structure/sign/warning/pods/directional/south,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"fuv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "fuD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15069,11 +14984,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
-"fvz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "fvF" = (
 /obj/effect/turf_decal/siding/dark_red,
 /obj/machinery/modular_computer/preset/id{
@@ -15135,9 +15045,9 @@
 /area/station/engineering/atmos)
 "fwF" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "fwJ" = (
@@ -15149,9 +15059,6 @@
 /turf/open/floor/circuit,
 /area/station/maintenance/port/aft)
 "fwU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Development Division Access"
 	},
@@ -15161,6 +15068,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -15170,7 +15080,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fwZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
@@ -15216,6 +15125,13 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
+"fyh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "fyo" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/east,
@@ -15351,6 +15267,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"fAf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/engineering/storage/tech)
 "fAn" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -15396,12 +15324,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fAP" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "fAY" = (
@@ -15497,6 +15425,62 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
+"fCs" = (
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/subspace/crystal{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/crystal{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/crystal{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "fCu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15527,11 +15511,11 @@
 /area/station/security/brig)
 "fDd" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
@@ -15579,17 +15563,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"fDO" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/command/glass{
-	name = "Telecommunications Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "comms-entrance-south"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/tcommsat/server)
 "fDQ" = (
 /obj/machinery/flasher/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -15617,11 +15590,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
-"fDY" = (
-/obj/structure/cable,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/science/xenobiology)
 "fEd" = (
 /obj/structure/chair{
 	dir = 1
@@ -15667,13 +15635,13 @@
 /turf/open/floor/eighties,
 /area/station/hallway/primary/central/fore)
 "fEM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research/glass{
 	name = "Cytology Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/cytology)
 "fEU" = (
@@ -15703,6 +15671,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
+"fFC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "fFD" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/landmark/start/paramedic,
@@ -15783,12 +15757,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"fGd" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "fGf" = (
 /obj/structure/cable,
 /obj/machinery/modular_computer/preset/engineering{
@@ -15808,6 +15776,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
+"fGE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "fGT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -15841,6 +15815,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"fHk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/server)
 "fHv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -15901,6 +15882,13 @@
 	dir = 8
 	},
 /area/station/cargo/storage)
+"fId" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/engine,
+/area/station/science/ordnance/burnchamber)
 "fIe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 6
@@ -15923,9 +15911,6 @@
 	dir = 8
 	},
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/stone,
 /area/station/service/bar)
 "fIq" = (
@@ -15976,18 +15961,12 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "fJK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -3
-	},
-/obj/item/stack/sheet/mineral/plasma/thirty{
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "fJZ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -16000,14 +15979,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"fKa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "fKc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16015,8 +15986,8 @@
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fKd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "fKl" = (
@@ -16044,13 +16015,9 @@
 "fKx" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
-"fKy" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
 "fKN" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/computer/security/telescreen/test_chamber/directional/west,
@@ -16083,14 +16050,14 @@
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
 "fLk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -16263,6 +16230,15 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fNi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "fNu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16330,6 +16306,8 @@
 /area/station/hallway/primary/port)
 "fNZ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
@@ -16340,8 +16318,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "fOg" = (
@@ -16420,16 +16396,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "fPV" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -16493,23 +16469,12 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"fRl" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "fRq" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/book/manual/wiki/chemistry{
@@ -16554,8 +16519,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fRV" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
@@ -16575,20 +16540,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"fSg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "fSx" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "fSB" = (
@@ -16597,9 +16556,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fSG" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/white/small,
 /area/station/medical/psychology)
@@ -16686,7 +16645,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "fUo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16697,6 +16655,7 @@
 	cycle_id = "sci-entrance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "fUC" = (
@@ -16705,6 +16664,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"fUG" = (
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/station/science/cubicle)
 "fUI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -16712,6 +16675,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"fUN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/construction)
 "fUO" = (
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
@@ -16764,15 +16733,6 @@
 	},
 /turf/open/floor/stone,
 /area/station/service/bar)
-"fVy" = (
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/science/circuits)
 "fVA" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/small,
@@ -16789,9 +16749,6 @@
 "fVM" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "fVU" = (
@@ -16802,11 +16759,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "fWi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "fWj" = (
@@ -16815,9 +16772,6 @@
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -16837,11 +16791,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "fWT" = (
-/obj/machinery/vending/assist,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/button/door/directional/east{
+	id = "AuxToilet2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/toilet,
+/obj/machinery/light/small/directional/west,
+/obj/effect/spawner/random/trash/soap{
+	spawn_scatter_radius = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/department/science/xenobiology)
 "fXg" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -16872,6 +16834,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"fXs" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/engineering/storage/tech)
 "fXB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16953,15 +16925,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
-"fZG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "fZK" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement{
@@ -17092,9 +17055,6 @@
 /area/station/service/kitchen)
 "gby" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "gbD" = (
@@ -17148,12 +17108,6 @@
 "gcz" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
-"gcF" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "gcL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_abandoned,
@@ -17175,7 +17129,8 @@
 /turf/closed/wall/rust,
 /area/station/maintenance/fore/lesser)
 "gdx" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "gdA" = (
@@ -17264,11 +17219,21 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/education)
-"geS" = (
+"geM" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/science/xenobiology)
+"geS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -17304,13 +17269,13 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
 "gfu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/effect/mapping_helpers/airalarm/link{
 	chamber_id = "ordnancefreezer"
 	},
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "gfA" = (
@@ -17320,9 +17285,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"gfB" = (
-/turf/open/floor/fake_snow,
-/area/station/service/hydroponics)
 "gfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -17369,8 +17331,8 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "ggi" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -17400,15 +17362,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"ggD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "ggJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/east,
@@ -17488,11 +17441,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/virology)
 "ghC" = (
-/obj/structure/cable,
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/effect/landmark/start/scientist,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "ghD" = (
@@ -17509,11 +17462,11 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/hop)
 "ghK" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lower)
 "ghL" = (
@@ -17583,19 +17536,22 @@
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"giW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "giY" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "gjg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/turf/open/floor/iron/dark/corner,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gjn" = (
 /obj/structure/disposalpipe/segment{
@@ -17610,14 +17566,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
-"gjL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "gjS" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
@@ -17659,10 +17607,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
-"gky" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "gkE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -17756,6 +17700,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmospherics_engine)
+"gnp" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "gnA" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
@@ -17836,12 +17788,17 @@
 "gow" = (
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
+"goz" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "goA" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -17867,9 +17824,6 @@
 /obj/machinery/incident_display/delam/directional/north,
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "goT" = (
@@ -17929,15 +17883,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"gpT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "gpV" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet/orange,
@@ -18018,8 +17963,8 @@
 /turf/open/floor/iron,
 /area/station/security)
 "gsh" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -18036,21 +17981,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
-"gsT" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry)
-"gsW" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/engineering/main)
 "gsY" = (
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
@@ -18061,14 +17991,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
-"gto" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/research)
 "gtr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
@@ -18091,12 +18013,12 @@
 	},
 /area/station/hallway/secondary/recreation)
 "gtJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/bed/medical/emergency,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "guh" = (
@@ -18190,6 +18112,7 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
 "gwm" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -18200,7 +18123,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "gwx" = (
@@ -18280,8 +18202,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/filingcabinet/employment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "gxo" = (
@@ -18294,11 +18216,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "gxq" = (
+/obj/machinery/light/floor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/light/floor,
 /turf/open/floor/iron/dark/small,
 /area/station/tcommsat/server)
 "gxs" = (
@@ -18379,9 +18301,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "gye" = (
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -18590,12 +18512,22 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/glass,
 /obj/machinery/recharger{
-	pixel_x = 6;
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/machinery/button/door{
+	id = "aibridge";
+	name = "AI Maintenance Space Bridge Control";
+	req_access = list("command");
+	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/machinery/cell_charger{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/machinery/button/door{
+	id = "bridge blast";
+	name = "Bridge Access Blast Door Control";
+	req_access = list("command");
+	pixel_x = -3;
+	pixel_y = -3
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/command/bridge)
@@ -18665,15 +18597,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"gCo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/command/glass{
-	name = "Telecommunications Server Room"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/tcommsat/server)
 "gCq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -18769,6 +18692,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"gDQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "gEa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18839,12 +18768,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"gFc" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "gFg" = (
 /obj/machinery/computer/cargo/request,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -18880,9 +18803,9 @@
 /area/station/hallway/secondary/recreation)
 "gFs" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
 /area/station/medical/psychology)
 "gFu" = (
@@ -18957,12 +18880,12 @@
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
 "gGx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "gGy" = (
@@ -18988,9 +18911,6 @@
 /area/station/security/prison)
 "gGK" = (
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
 "gGO" = (
@@ -18998,15 +18918,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
 "gGQ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/turf/open/floor/iron/small,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "gHe" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -19015,6 +18931,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/item/melee/chainofcommand,
+/obj/item/binoculars,
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
 "gHg" = (
@@ -19022,10 +18939,10 @@
 /turf/open/floor/glass,
 /area/station/hallway/primary/central/aft)
 "gHl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "gHm" = (
@@ -19046,9 +18963,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "gHT" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "gHV" = (
@@ -19067,16 +18985,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"gIk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/medical/chemistry)
 "gIl" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -19110,17 +19018,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "gIv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/camera/autoname/directional/east,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "gIx" = (
@@ -19147,8 +19055,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "gIR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -19158,6 +19064,8 @@
 	id = "rdoffice";
 	name = "Research Director's Shutters"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/research)
 "gIS" = (
@@ -19193,6 +19101,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"gJj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/broken_flooring/pile/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "gJo" = (
 /turf/open/floor/iron/stairs{
 	dir = 8
@@ -19234,10 +19149,10 @@
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
 "gJS" = (
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -19269,11 +19184,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
 "gKQ" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
 	},
 /turf/open/floor/iron/small,
 /area/station/service/barber)
@@ -19382,12 +19297,10 @@
 /turf/open/floor/plating,
 /area/station/command/gateway)
 "gMe" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/server)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "gMq" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -19435,8 +19348,6 @@
 /area/station/command/heads_quarters/rd)
 "gMR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab"
 	},
@@ -19446,6 +19357,9 @@
 	id = "xeno_blastdoor";
 	name = "Biohazard Containment Door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
 "gMV" = (
@@ -19511,14 +19425,22 @@
 /area/station/hallway/primary/port)
 "gNX" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
+"gOh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gOm" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/equipment)
+"gOq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gOt" = (
 /obj/structure/flora/tree/jungle/small/style_2,
 /obj/effect/turf_decal/weather/dirt{
@@ -19613,10 +19535,6 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/sorting)
-"gPR" = (
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/fake_snow,
-/area/station/commons/dorms)
 "gPY" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
@@ -19676,19 +19594,12 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"gSi" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
 "gSk" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/power/floodlight,
 /obj/structure/alien/weeds,
 /obj/effect/gibspawner/human,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "gSr" = (
@@ -19767,26 +19678,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "gTH" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
 /area/station/command/meeting_room)
 "gTK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "gTO" = (
@@ -19825,8 +19734,8 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "gUe" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/aft)
@@ -19834,13 +19743,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/fake_snow,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "gUm" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/delivery,
@@ -19849,9 +19755,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
-/turf/open/floor/iron/dark/textured_half{
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/command/bridge)
 "gUn" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -19923,6 +19830,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
+"gWa" = (
+/obj/effect/turf_decal/siding,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/lab)
 "gWb" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hos)
@@ -19949,11 +19861,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/processing)
-"gWN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "gXf" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -20026,18 +19933,16 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/greater)
 "gYK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/locker_room)
-"gZh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/command/meeting_room)
 "gZi" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -20129,11 +20034,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "haq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -20158,10 +20063,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
 "hbk" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "hbm" = (
@@ -20192,10 +20097,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "hbz" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "hbG" = (
@@ -20240,11 +20145,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hbY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "hcb" = (
@@ -20329,6 +20234,15 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
+"hcz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/station/engineering/storage/tech)
 "hcE" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
@@ -20340,12 +20254,12 @@
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
 "hcQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -20362,12 +20276,12 @@
 /area/station/service/abandoned_gambling_den)
 "hcU" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "hcY" = (
@@ -20382,15 +20296,24 @@
 "hdd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/glass,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 7;
+	pixel_x = 7
+	},
+/obj/machinery/cell_charger{
+	pixel_x = -1;
+	pixel_y = -1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
 "hdg" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
 "hdo" = (
@@ -20429,6 +20352,9 @@
 	id = "bridge blast";
 	name = "Bridge Blast Door"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/command/bridge)
 "hdI" = (
@@ -20466,8 +20392,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "hdZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "hed" = (
@@ -20585,12 +20511,12 @@
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
 "hfI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
 "hgf" = (
@@ -20624,29 +20550,21 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"hgu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"hgt" = (
+/obj/machinery/door/airlock/public{
+	name = "Locker Room"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/turf/open/floor/iron/textured_half,
+/area/station/commons/fitness/recreation)
 "hgv" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"hgy" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "hgF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -20665,14 +20583,14 @@
 /area/station/maintenance/central/greater)
 "hgP" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "hgY" = (
-/obj/structure/cable,
 /obj/structure/lattice/catwalk,
 /obj/machinery/power/tracker,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "hgZ" = (
@@ -20687,12 +20605,12 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/department/medical/central)
 "hhg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/security{
 	name = "Customs Checkpoint"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half,
 /area/station/security/checkpoint/customs)
 "hhk" = (
@@ -20742,12 +20660,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
-"hin" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+"hio" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/science/robotics/mechbay)
 "hiq" = (
 /obj/structure/closet{
 	name = "Evidence Closet 1"
@@ -20779,13 +20695,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"hiU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "hiV" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "hjk" = (
@@ -20807,9 +20719,8 @@
 /turf/open/floor/plating,
 /area/station/command/gateway)
 "hjz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
@@ -20827,18 +20738,8 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"hjP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "hjQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -20887,14 +20788,11 @@
 /turf/open/floor/plating,
 /area/station/command/gateway)
 "hkt" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 9
 	},
-/obj/structure/chair/office/tactical{
-	dir = 1
-	},
-/turf/open/floor/iron/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hky" = (
 /obj/item/kirbyplants/organic/applebush,
@@ -20933,6 +20831,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"hkH" = (
+/obj/machinery/door/window/left/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/ai_monitored/command/storage/eva)
 "hkL" = (
 /obj/structure/cable,
 /turf/open/floor/wood/large,
@@ -20946,9 +20863,6 @@
 /obj/machinery/computer/rdconsole,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "hkW" = (
@@ -20971,17 +20885,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"hlJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Ordnance Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/storage)
 "hlP" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -21022,9 +20925,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
 "hmn" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/central/aft)
 "hmt" = (
@@ -21048,7 +20951,7 @@
 "hmH" = (
 /obj/effect/spawner/xmastree,
 /obj/structure/flora/tree/jungle/style_3,
-/turf/open/floor/fake_snow,
+/turf/open/floor/grass,
 /area/station/service/chapel)
 "hmK" = (
 /obj/machinery/door/airlock/wood{
@@ -21137,32 +21040,34 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "hok" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lobby)
 "hon" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "hop" = (
 /turf/closed/wall,
 /area/station/service/chapel/funeral)
 "hoG" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/scientist,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "hoN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/command/bridge)
 "hoQ" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -21217,10 +21122,10 @@
 /turf/open/floor/stone,
 /area/station/command/corporate_suite)
 "hqc" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -21268,26 +21173,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"hrz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/command/glass{
-	name = "Telecommunications Server Room"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/tcommsat/server)
 "hrC" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "hrE" = (
@@ -21355,7 +21247,6 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
 "hsC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/mecha{
@@ -21364,6 +21255,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "hsH" = (
@@ -21429,11 +21321,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"hua" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "huh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21447,6 +21334,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
 "huj" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -21454,7 +21342,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "hur" = (
@@ -21537,51 +21424,43 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"hvX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+"hwj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/tcommsat/server)
-"hwh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "hwn" = (
-/obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "hwo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/table/bronze,
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
-"hwp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/item/pizzabox/margherita{
+	pixel_x = 4;
+	pixel_y = 24
+	},
+/obj/item/storage/bag/tray{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/command/meeting_room)
 "hwr" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "hwx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/structure/table/glass,
+/obj/item/radio/intercom/command,
+/obj/item/paper/fluff/jobs/engineering/frequencies,
+/turf/open/floor/carpet/executive,
+/area/station/command/meeting_room)
 "hwz" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Xenobiology - Cell 5";
@@ -21633,11 +21512,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
 "hxA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "hxQ" = (
@@ -21723,16 +21602,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
-"hzj" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/service/bar)
 "hzp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/line,
@@ -21776,6 +21645,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/miningoffice)
+"hAe" = (
+/obj/machinery/door/airlock/command{
+	name = "Telecomms Server Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "comms-entrance-south"
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/server)
 "hAu" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -22040,15 +21921,9 @@
 "hDz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"hDC" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
 "hDN" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -22070,12 +21945,14 @@
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "hEm" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/item/kirbyplants/organic/applebush,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/command/meeting_room)
 "hEu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22092,13 +21969,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"hED" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "hEJ" = (
 /turf/open/floor/iron/smooth,
 /area/station/service/library)
@@ -22129,12 +21999,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "hFp" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/start/hangover,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "hFx" = (
@@ -22153,11 +22023,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/fore/lesser)
-"hFD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "hFG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -22173,6 +22038,14 @@
 "hGb" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/storage)
+"hGk" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/door/airlock/grunge{
+	name = "St. Brendan's"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/starboard/greater)
 "hGn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
@@ -22198,16 +22071,13 @@
 "hGA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "hGE" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/stairs,
 /area/station/medical/medbay/central)
 "hHf" = (
@@ -22283,6 +22153,14 @@
 /obj/item/hemostat,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
+"hIF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/server)
 "hJp" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/turret_protected/ai)
@@ -22298,33 +22176,34 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "hJO" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
 /area/station/hallway/secondary/dock)
 "hJP" = (
-/obj/structure/hedge,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/sign/departments/engineering/directional/north,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/sign/departments/engineering/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/hallway/primary/fore)
 "hJR" = (
-/obj/structure/cable,
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "hJT" = (
@@ -22382,7 +22261,16 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "hKX" = (
-/turf/closed/mineral/random/stationside,
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "hKZ" = (
 /obj/structure/flora/bush/jungle/a/style_random,
@@ -22432,16 +22320,16 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "hLU" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
 	name = "Docking Corridor"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
@@ -22470,6 +22358,14 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/hop)
+"hMk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/maintenance/starboard/greater)
 "hMr" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/closet/secure_closet/security/sec,
@@ -22554,9 +22450,6 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/utility/welding,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "hNP" = (
@@ -22582,6 +22475,7 @@
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "hOl" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs{
@@ -22591,6 +22485,10 @@
 "hOp" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
+"hOD" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/command/bridge)
 "hOF" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/chair/office{
@@ -22634,15 +22532,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hPl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.0-StarboardHall-ScienceFoyer";
 	location = "8.0-Pharmacy-StarboardHall"
@@ -22654,6 +22552,13 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
+"hPQ" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/auxiliary)
 "hPU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22674,10 +22579,10 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/port/aft)
 "hQd" = (
+/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 10
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "hQs" = (
@@ -22761,13 +22666,13 @@
 "hRd" = (
 /obj/structure/table/reinforced,
 /obj/item/binoculars,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "hRA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "hRO" = (
@@ -22790,11 +22695,6 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
-"hSg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "hSn" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -22874,9 +22774,6 @@
 /area/station/security/execution/transfer)
 "hUq" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "hUC" = (
@@ -22890,14 +22787,15 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"hUD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "hUH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "hUI" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -22905,12 +22803,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
 "hUO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Lockers"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Lockers"
+	},
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/locker_room)
 "hVb" = (
@@ -22920,9 +22818,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "hVh" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -23020,19 +22918,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
 "hWE" = (
-/obj/machinery/button/door/directional/east{
-	id = "AuxToilet2";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/toilet,
-/obj/machinery/light/small/directional/west,
-/obj/effect/spawner/random/trash/soap{
-	spawn_scatter_radius = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_large,
+/area/station/science/auxlab/firing_range)
 "hWJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -23044,7 +22933,6 @@
 /area/station/security)
 "hWL" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/effect/turf_decal/weather/snow/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -23080,9 +22968,9 @@
 /area/station/commons/storage/tools)
 "hXl" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/white/small,
@@ -23156,8 +23044,8 @@
 /area/station/engineering/atmos)
 "hYK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -23190,37 +23078,14 @@
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
 "hYW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
-"hYX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/bronze,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
-	},
-/obj/item/pizzabox/margherita{
-	pixel_x = 4;
-	pixel_y = 24
-	},
-/obj/item/storage/bag/tray{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/command/meeting_room)
+/obj/machinery/light_switch/directional/east,
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/auxiliary)
 "hZP" = (
-/obj/structure/cable,
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "hZT" = (
@@ -23245,18 +23110,6 @@
 /obj/item/clothing/head/beret/sec/navyofficer,
 /turf/open/floor/plating,
 /area/station/security/tram)
-"iap" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/folder/blue{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/executive,
-/area/station/command/meeting_room)
 "iaw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23276,20 +23129,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "iaH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
-"iaJ" = (
-/obj/structure/transit_tube/crossing/horizontal,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/small/dim/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/command/storage/eva)
 "iaK" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/wine{
@@ -23397,21 +23241,21 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "icN" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "icT" = (
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -23427,11 +23271,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "idd" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ide" = (
@@ -23514,10 +23359,6 @@
 /turf/open/floor/sepia,
 /area/station/maintenance/aft)
 "idJ" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -23533,10 +23374,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/hop)
-"idS" = (
-/obj/structure/table/wood,
-/turf/open/floor/fake_snow,
-/area/station/service/bar)
 "idW" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/small/directional/south,
@@ -23544,8 +23381,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "ief" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/message_server/preset,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "iek" = (
@@ -23585,6 +23422,23 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"ifi" = (
+/obj/structure/table/reinforced,
+/obj/machinery/requests_console/auto_name/directional/east,
+/obj/item/stack/cable_coil{
+	pixel_y = 4
+	},
+/obj/item/stack/cable_coil,
+/obj/item/plant_analyzer{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/item/healthanalyzer{
+	pixel_y = 2;
+	pixel_x = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "ifl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -23671,6 +23525,16 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
+"igS" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "ihb" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -23747,31 +23611,24 @@
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "ihC" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
+"ihJ" = (
+/obj/structure/rack,
+/obj/item/aicard,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/ai_module/reset,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "ihZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"iia" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
-"iij" = (
-/obj/structure/hedge,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "iio" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -23806,9 +23663,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering Supermatter Port"
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iiI" = (
@@ -23838,34 +23692,22 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/miningfoundry)
-"iiW" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/xenobiology)
 "iiX" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"ijk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "ijz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
 "ijB" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "ijF" = (
@@ -23890,8 +23732,17 @@
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/central/fore)
 "ijV" = (
-/turf/open/misc/asteroid,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/storage/tech)
 "ijY" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/item/storage/briefcase/secure{
@@ -23956,6 +23807,16 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
+"ikS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/tcommsat/server)
 "ikU" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -24021,6 +23882,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
+"ilC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ilD" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
@@ -24028,11 +23897,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
 "ilE" = (
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "ilT" = (
@@ -24063,13 +23932,13 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "imI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "imO" = (
@@ -24105,9 +23974,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "inU" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/central/aft)
 "ioa" = (
@@ -24187,20 +24056,18 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "ipf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/kirbyplants/organic/applebush,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
 /area/station/command/meeting_room)
 "ipj" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -24222,9 +24089,6 @@
 /area/station/cargo/miningoffice)
 "ips" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs{
@@ -24241,7 +24105,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "ipx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
@@ -24250,18 +24113,9 @@
 	name = "Research Director's Fax Machine";
 	pixel_y = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"ipD" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/smooth,
-/area/station/command/bridge)
 "ipF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24305,9 +24159,6 @@
 /area/station/service/abandoned_gambling_den)
 "iqp" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/holopad,
 /turf/open/floor/iron/smooth,
@@ -24332,9 +24183,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "iqF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/smooth,
@@ -24357,10 +24205,10 @@
 /turf/open/floor/iron/small,
 /area/station/security/tram)
 "irc" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "iri" = (
@@ -24419,12 +24267,6 @@
 "isj" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
-"isl" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "ist" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24487,12 +24329,6 @@
 	dir = 1
 	},
 /area/station/command/gateway)
-"isR" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "itb" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
@@ -24505,9 +24341,6 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
 "itw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -24609,6 +24442,12 @@
 /obj/item/melee/baseball_bat,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
+"ive" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/starboard)
 "ivh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -24628,7 +24467,7 @@
 /area/station/maintenance/hallway/abandoned_command)
 "ivl" = (
 /obj/item/kirbyplants/organic/applebush,
-/obj/machinery/firealarm/directional/north,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/central/fore)
 "ivm" = (
@@ -24685,11 +24524,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "ivY" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/techstorage/tcomms_all,
-/obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/area/station/hallway/secondary/entry)
 "iwt" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -24720,15 +24558,14 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/solars/port/aft)
 "ixG" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/turf/open/space/basic,
+/area/station/maintenance/department/science/xenobiology)
 "ixM" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ixT" = (
@@ -24782,22 +24619,22 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "iyr" = (
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/light/cold/directional/north,
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
 /area/station/science/ordnance/testlab)
 "iyt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
 "iyC" = (
@@ -24822,9 +24659,6 @@
 /obj/machinery/light/cold/dim/directional/north,
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "izh" = (
@@ -24839,11 +24673,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
 "izo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Comissary"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -24858,10 +24692,10 @@
 /area/station/maintenance/central/greater)
 "izA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "izD" = (
@@ -25024,10 +24858,6 @@
 /obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/service/bar/backroom)
-"iBu" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "iBE" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
@@ -25037,10 +24867,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "iCb" = (
@@ -25118,19 +24948,22 @@
 	},
 /area/station/engineering/main)
 "iCJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/command{
 	name = "Research Division Server Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/server)
 "iDk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/command/meeting_room)
 "iDm" = (
@@ -25249,16 +25082,16 @@
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
 "iFb" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "iFm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -25357,6 +25190,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"iGu" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/ai_all,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "iGA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -25466,14 +25307,6 @@
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
-"iHM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/lower)
 "iHT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -25511,14 +25344,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iIw" = (
-/obj/structure/cable,
 /obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
-"iIz" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "iIA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -25557,12 +25386,12 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "iIN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
 "iIR" = (
@@ -25602,7 +25431,6 @@
 /turf/open/floor/iron/textured_half,
 /area/station/commons/dorms)
 "iJb" = (
-/obj/structure/cable,
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
 	pixel_x = -5;
@@ -25616,6 +25444,7 @@
 	pixel_x = 12;
 	pixel_y = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "iJc" = (
@@ -25701,10 +25530,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "iJL" = (
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
 	},
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "iJS" = (
@@ -25768,6 +25597,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/library)
 "iLp" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25776,7 +25606,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iLA" = (
@@ -25866,23 +25695,29 @@
 /obj/machinery/flasher/portable,
 /turf/open/floor/plating,
 /area/station/security/tram)
+"iMG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "iMI" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
 /area/station/science/xenobiology)
 "iMS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -25910,13 +25745,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
-"iNA" = (
-/obj/machinery/light/cold/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "iNC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -25950,10 +25778,10 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "iNS" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "iNV" = (
@@ -25983,9 +25811,9 @@
 /area/station/command/heads_quarters/captain)
 "iOm" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/door/airlock/medical{
@@ -25994,12 +25822,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/psychology)
 "iOq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "iOs" = (
@@ -26011,12 +25839,12 @@
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/captain/private)
 "iOv" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "iOx" = (
@@ -26032,7 +25860,6 @@
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/captain/private)
 "iOF" = (
-/obj/structure/cable,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -26047,15 +25874,16 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
 "iOL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
 "iOM" = (
@@ -26100,16 +25928,17 @@
 /area/station/engineering/supermatter/room)
 "iPy" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "iPF" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/hallway/primary/aft)
+/area/station/maintenance/starboard/central)
 "iPJ" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 9
@@ -26189,10 +26018,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
 "iQV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
 "iRk" = (
@@ -26234,9 +26063,6 @@
 /obj/item/food/meat/slab/monkey,
 /obj/item/food/meat/slab/monkey,
 /obj/item/food/meat/slab/monkey,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -26257,11 +26083,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/hallway/secondary/dock)
 "iSh" = (
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/tank{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
@@ -26312,21 +26138,21 @@
 /area/station/ai_monitored/command/nuke_storage)
 "iTy" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "iTB" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -26380,12 +26206,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"iUp" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
 "iUA" = (
 /obj/machinery/conveyor{
 	id = "mining"
@@ -26422,9 +26242,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/disposal/bin/tagger,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "iUT" = (
@@ -26434,12 +26251,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
-"iVk" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
 "iVq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -26469,9 +26280,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iVE" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/camera/autoname/directional/west,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "iVI" = (
@@ -26519,12 +26330,12 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "iVT" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/item/flashlight,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "iVY" = (
@@ -26538,21 +26349,17 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
-"iWc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"iWd" = (
-/turf/open/floor/fake_snow,
-/area/station/engineering/supermatter/room)
 "iWe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"iWf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "iWj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -26602,12 +26409,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"iWI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "iWQ" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/landmark/start/chemist,
@@ -26720,6 +26521,27 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"iYo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
+"iYr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "aibridge"
+	},
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "iYu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/photocopier,
@@ -26747,6 +26569,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/security/processing)
+"iZl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "iZs" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -26821,6 +26648,7 @@
 	location = "18.0-ToolStorage-Engineering"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "iZM" = (
@@ -26859,45 +26687,34 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"jaa" = (
-/turf/open/floor/fake_snow,
-/area/station/security/prison/workout)
 "jab" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"jat" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
 "jax" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"jaD" = (
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
 "jaK" = (
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/folder/blue{
+	pixel_x = 4;
+	pixel_y = 2
 	},
-/obj/machinery/holopad,
-/obj/machinery/light/small/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/executive,
+/area/station/command/meeting_room)
 "jaL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26916,12 +26733,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/processing)
 "jbd" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
 	name = "Research Director's Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "jbp" = (
@@ -26984,7 +26801,6 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jcm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/entertainment/plushie,
@@ -26993,6 +26809,7 @@
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "jct" = (
@@ -27014,14 +26831,14 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "jcB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/airlock/wood{
 	name = "Bar Backroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -27056,19 +26873,12 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
-"jdu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "jdx" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/service/library)
 "jdJ" = (
-/obj/structure/statue/snow/snowman,
+/obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -27098,13 +26908,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
-"jeC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "jeF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27133,6 +26936,15 @@
 /obj/structure/sign/departments/medbay/alt/directional/west,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
+"jfj" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jfs" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -27186,11 +26998,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
 "jgb" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
 "jgj" = (
@@ -27262,12 +27074,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jhY" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
@@ -27280,13 +27092,18 @@
 /turf/open/floor/iron/textured_half,
 /area/station/hallway/primary/aft)
 "jie" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"jif" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/secondary/construction)
 "jig" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -27336,10 +27153,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine/atmos)
-"jiR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
 "jiT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner{
@@ -27347,10 +27160,10 @@
 	},
 /area/station/science/lower)
 "jiY" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jje" = (
@@ -27380,7 +27193,6 @@
 /obj/structure/bed/dogbed/renault,
 /mob/living/basic/pet/fox/renault,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
 "jjO" = (
@@ -27390,14 +27202,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"jkz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/science/lobby)
 "jkC" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/light/warm/directional/east,
@@ -27408,22 +27212,15 @@
 /area/station/commons/fitness/recreation/entertainment)
 "jkE" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"jkH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "jkT" = (
 /obj/structure/table/wood,
 /obj/machinery/fax/auto_name,
@@ -27487,9 +27284,6 @@
 /obj/item/lighter,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
 "jlN" = (
@@ -27522,13 +27316,6 @@
 /obj/structure/flora/bush/flowers_pp/style_2,
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"jlZ" = (
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/security/checkpoint/customs)
 "jmd" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -27578,9 +27365,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "jmW" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "jmX" = (
@@ -27608,15 +27395,15 @@
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/break_room)
 "jnh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta/end{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/station/command/meeting_room)
 "jnk" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
@@ -27733,11 +27520,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"jpE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_large,
-/area/station/science/auxlab/firing_range)
+"jpF" = (
+/obj/machinery/button/door/directional/west{
+	id = "aibridge";
+	name = "AI Maintenance Space Bridge Control";
+	req_access = list("command")
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "jpM" = (
 /obj/structure/closet{
 	name = "Evidence Closet 3"
@@ -27745,7 +27535,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
 "jpW" = (
-/obj/structure/cable,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -27756,6 +27545,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "jqd" = (
@@ -27866,11 +27656,14 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "jrU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
+/turf/open/floor/wood/tile,
+/area/station/command/corporate_showroom)
 "jsa" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white/side{
@@ -27913,9 +27706,6 @@
 "jsN" = (
 /obj/structure/hedge,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "jsS" = (
@@ -27954,13 +27744,13 @@
 /area/station/command/heads_quarters/hop)
 "jtB" = (
 /obj/effect/turf_decal/stripes/white/corner,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/corner,
 /area/station/cargo/storage)
 "jtD" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "jtG" = (
@@ -27980,13 +27770,25 @@
 "jtY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/status_display/ai/directional/east,
-/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"juf" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/command/glass{
+	name = "Telecommunications Server Room"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "comms-entrance-north"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/server)
 "juo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -28000,11 +27802,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
 "juU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/west,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/portable_atmospherics/pump/lil_pump,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jvd" = (
@@ -28045,22 +27847,22 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "jvP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "jvQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "jvR" = (
@@ -28084,10 +27886,10 @@
 /turf/open/floor/iron/small,
 /area/station/command/teleporter)
 "jwf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair{
 	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "jwh" = (
@@ -28136,19 +27938,18 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "jxk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/science/lower)
 "jxp" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jxC" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -28326,12 +28127,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"jAb" = (
-/obj/structure/cable,
-/turf/open/floor/iron/stairs{
-	dir = 1
-	},
-/area/station/engineering/storage/tech)
 "jAf" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/chair/stool/bar/directional/east,
@@ -28339,9 +28134,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/barber)
 "jAp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/diagonal,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side,
+/area/station/science/xenobiology)
 "jAq" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -28390,6 +28190,9 @@
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
 "jBu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
@@ -28397,9 +28200,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "jBA" = (
@@ -28515,19 +28315,11 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
-"jDS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "jDT" = (
-/obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/floor,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
@@ -28548,6 +28340,12 @@
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lobby)
+"jEp" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/command/storage/eva)
 "jEu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/kirbyplants/random,
@@ -28736,12 +28534,12 @@
 	},
 /area/station/cargo/storage)
 "jGK" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /turf/open/floor/iron/small,
 /area/station/service/barber)
 "jGL" = (
@@ -28749,11 +28547,11 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/cold_temp/directional/north,
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
 	},
-/obj/structure/sign/warning/cold_temp/directional/north,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "jGN" = (
@@ -28770,9 +28568,9 @@
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "jGT" = (
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "jGW" = (
@@ -28816,11 +28614,6 @@
 /obj/machinery/incident_display/tram/directional/north,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"jHx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden,
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
 "jHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28876,27 +28669,20 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "jIc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
-	name = "Auxiliary Bathrooms"
+	name = "Maintenance"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/commons/toilet/auxiliary)
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jId" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
-"jIj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "jIl" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 10
@@ -28904,9 +28690,9 @@
 /turf/open/floor/iron/small,
 /area/station/security/brig)
 "jIm" = (
-/obj/structure/cable,
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "jIn" = (
@@ -29026,15 +28812,22 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "jKq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"jKC" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "jKJ" = (
 /obj/machinery/door/window/right/directional/north,
 /turf/open/floor/iron,
@@ -29045,8 +28838,13 @@
 	pixel_x = 2;
 	pixel_y = 8
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jKT" = (
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/station/commons/vacant_room/office)
 "jKU" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/storage/gas)
@@ -29056,18 +28854,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"jLl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "jLt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "jLv" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -29082,13 +28872,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"jLF" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4;
-	name = "killroom vent"
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/station/science/xenobiology)
 "jLI" = (
 /turf/open/floor/iron/half{
 	dir = 8
@@ -29119,8 +28902,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jMa" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/server/presets/security,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
@@ -29132,16 +28915,9 @@
 	},
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
-"jMC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "jML" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -29267,7 +29043,9 @@
 "jOF" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "jOM" = (
@@ -29277,6 +29055,12 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"jOO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/department/science/xenobiology)
 "jOS" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/small/directional/south,
@@ -29319,11 +29103,18 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"jPy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/station/science/cubicle)
 "jPM" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/techstorage/security_all,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "jQf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29332,11 +29123,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"jQj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "jQv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -29395,6 +29181,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"jRo" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "jRs" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -29479,13 +29277,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "jSp" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
 "jSw" = (
@@ -29513,8 +29311,8 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "jSR" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jSS" = (
@@ -29527,12 +29325,12 @@
 /turf/open/floor/plating,
 /area/station/command/corporate_showroom)
 "jSU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "jTf" = (
@@ -29567,14 +29365,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"jTu" = (
-/obj/structure/cable,
+"jTp" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/commons/vacant_room/office)
+"jTu" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
 	dir = 9
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "jTA" = (
@@ -29585,8 +29389,8 @@
 "jTC" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "jTD" = (
@@ -29596,11 +29400,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jTU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -29620,9 +29424,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jUc" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jUl" = (
@@ -29646,9 +29450,6 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/instrument/harmonica,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "jUr" = (
@@ -29699,6 +29500,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jVJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/item/bikehorn/rubberducky{
 	color = "#a61a11";
@@ -29714,19 +29516,11 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "jVM" = (
 /turf/closed/wall,
 /area/station/maintenance/central/greater)
-"jVQ" = (
-/obj/effect/spawner/random/trash,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "jVY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -29737,9 +29531,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "jWe" = (
@@ -29787,8 +29578,8 @@
 "jWz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "jWA" = (
@@ -29832,38 +29623,24 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"jXr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/command/glass{
-	name = "Telecommunications Server Room"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "comms-entrance-north"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/tcommsat/server)
 "jXA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Telecomms Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured_half,
 /area/station/engineering/storage/tcomms)
 "jXB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass{
 	name = "Lockers"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
@@ -29953,12 +29730,25 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/service/bar)
+"jYP" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "jYQ" = (
-/obj/effect/turf_decal/weather/snow/corner{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/command/bridge)
 "jYU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -29982,6 +29772,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/command/teleporter)
+"jZa" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tcomms)
 "jZl" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmospherics_engine)
@@ -29997,17 +29794,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "jZL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research/glass{
 	name = "Ordnance Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "kam" = (
@@ -30022,12 +29816,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"kat" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "kau" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
@@ -30120,9 +29908,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kci" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Construction Hatch"
 	},
@@ -30130,6 +29915,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "kcA" = (
@@ -30140,12 +29928,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
-"kcQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "kcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/full,
@@ -30160,9 +29942,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "kdn" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "kdv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange,
 /obj/structure/lattice,
@@ -30183,16 +29967,27 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
 /area/station/science/lower)
 "kea" = (
+/obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
+"kej" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "kel" = (
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/modular_computer/preset/id{
@@ -30253,12 +30048,16 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"kfI" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "kfM" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kfW" = (
@@ -30282,10 +30081,15 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/execution/education)
 "kgk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/engineering/storage/tech)
 "kgn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -30344,13 +30148,13 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "kho" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=6.3-Arrivals";
 	location = "6.2-Arrivals"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "khp" = (
@@ -30385,12 +30189,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "khG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "khQ" = (
@@ -30444,10 +30248,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
 "kit" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "kiB" = (
@@ -30494,11 +30298,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/equipment)
-"kiR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "kiW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -30554,19 +30353,16 @@
 /area/station/engineering/supermatter/room)
 "kjw" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/sign/directions/lavaland/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/sign/directions/lavaland/directional/south,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
 /area/station/hallway/secondary/dock)
 "kjx" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -30696,8 +30492,8 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
 "klf" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "klg" = (
@@ -30714,17 +30510,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "klF" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "klG" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot{
@@ -30752,12 +30543,12 @@
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "kmd" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/fore)
 "kmg" = (
@@ -30802,17 +30593,19 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "kms" = (
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kmC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light_switch/directional/south,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/service_all,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/command/corporate_dock)
+/area/station/engineering/storage/tech)
 "kmD" = (
 /obj/structure/chair/office/light{
 	color = "#6495ED";
@@ -30898,11 +30691,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "knO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
 "knR" = (
@@ -30918,16 +30711,10 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/virology)
-"kop" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "kov" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "koz" = (
@@ -30952,6 +30739,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kpO" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/multitool,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "kpU" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
@@ -30964,8 +30761,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
 "kql" = (
@@ -31013,25 +30810,22 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"kqN" = (
-/obj/machinery/light/cold/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "kqO" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/obj/machinery/door/airlock/medical/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/corner{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
 	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/siding/thinplating_new/corner{
+/obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kqU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31076,10 +30870,31 @@
 /obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
+"krv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "krz" = (
 /obj/structure/cable,
 /turf/open/floor/iron/stairs,
 /area/station/maintenance/department/science/xenobiology)
+"krB" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A. Storage"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/station/ai_monitored/command/storage/eva)
 "krF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -31223,19 +31038,15 @@
 /turf/open/floor/wood,
 /area/station/engineering/atmos/pumproom)
 "ktl" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/ai_module/reset{
-	pixel_y = 14
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side,
+/area/station/science/xenobiology)
 "ktB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -31326,9 +31137,6 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/chair,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "kvl" = (
@@ -31387,12 +31195,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"kwu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "kwy" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -31404,16 +31206,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kwA" = (
+/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
+"kwB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "kwW" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
+"kwX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "kwY" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -31472,16 +31286,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/small,
 /area/station/cargo/lobby)
-"kxE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/research)
 "kxF" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -31546,14 +31350,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kzs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/security/checkpoint/science)
 "kzv" = (
@@ -31705,9 +31509,9 @@
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
 "kCI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
@@ -31749,18 +31553,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"kDi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "kDs" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
+"kDB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "aibridge"
+	},
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "kEd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -31792,12 +31599,14 @@
 	},
 /area/station/cargo/storage)
 "kEx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/storage/tech)
 "kEA" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -31838,13 +31647,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"kFA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "kFD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/autolathe,
@@ -31861,6 +31663,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"kFV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "kFY" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/morgue)
@@ -31946,11 +31757,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
 "kHo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/table/reinforced,
+/obj/machinery/firealarm/directional/east,
+/obj/item/storage/box/bodybags,
+/obj/item/clothing/mask/gas/plaguedoctor,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "kHp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31962,6 +31774,11 @@
 /obj/effect/turf_decal/siding/wideplating/corner,
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
+"kHJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "kHL" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -32090,10 +31907,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"kJW" = (
-/obj/structure/cable,
-/turf/open/floor/iron/stairs,
-/area/station/engineering/storage/tech)
 "kKa" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -32121,6 +31934,12 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
+"kKN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "kKT" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -32201,11 +32020,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"kML" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "kMW" = (
+/obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "kMY" = (
@@ -32235,15 +32058,17 @@
 /area/station/cargo/bitrunning/den)
 "kNf" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/warning,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"kNk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/commons/vacant_room/office)
 "kNn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32275,11 +32100,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "kNJ" = (
-/obj/structure/cable,
 /obj/machinery/power/solar_control{
 	id = "forestarboard";
 	name = "Starboard Bow Solar Control"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
 "kNK" = (
@@ -32293,17 +32118,18 @@
 /area/station/commons/dorms)
 "kNZ" = (
 /obj/structure/cable,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "kOh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/mechbay)
 "kOm" = (
@@ -32320,7 +32146,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "kOG" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
 	},
@@ -32328,6 +32153,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/fore)
 "kOH" = (
@@ -32343,11 +32169,11 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "kOT" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
@@ -32431,9 +32257,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "kQk" = (
@@ -32448,12 +32271,9 @@
 /area/station/maintenance/starboard/aft)
 "kQM" = (
 /obj/machinery/holopad,
-/turf/open/floor/fake_snow,
+/turf/open/floor/iron,
 /area/station/cargo/storage)
 "kRb" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "kRi" = (
@@ -32520,8 +32340,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "kSd" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "kSj" = (
@@ -32531,18 +32351,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "kSv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/starboard/central)
 "kSA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32608,16 +32420,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/hallway/secondary/command)
-"kTM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/station/security/courtroom)
 "kTX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line{
@@ -32629,10 +32434,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
-"kUa" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "kUf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32641,11 +32442,12 @@
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
 "kUF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/science/research)
 "kUL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32656,6 +32458,21 @@
 "kUN" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
+"kUR" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/science/lab)
+"kUW" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "kVb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32705,11 +32522,11 @@
 /turf/open/floor/iron/small,
 /area/station/security/office)
 "kWF" = (
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -32723,6 +32540,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"kWN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "kWR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Docking Corridor"
@@ -32769,10 +32596,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "kXQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "kXS" = (
@@ -32809,8 +32636,6 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/escape)
 "kYY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32822,6 +32647,8 @@
 	name = "emergency shower";
 	pixel_y = -11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "kZh" = (
@@ -33005,12 +32832,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "lcw" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
@@ -33089,11 +32916,11 @@
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig)
 "lee" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "lei" = (
@@ -33116,12 +32943,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
-"les" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/misc/dirt/station,
-/area/station/service/chapel)
 "ley" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33178,6 +32999,15 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"leW" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/command/glass{
+	name = "Telecommunications Server Room"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/server)
 "lfa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -33327,16 +33157,16 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/electrical)
 "lgw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
 "lgx" = (
-/obj/structure/disposalpipe/junction/flip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -33344,6 +33174,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -33392,10 +33223,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "lhm" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side,
@@ -33410,18 +33241,6 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
-"lht" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "lhv" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -33494,9 +33313,6 @@
 	dir = 4
 	},
 /obj/machinery/incident_display/tram/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "liJ" = (
@@ -33504,14 +33320,20 @@
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
 "liL" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/command/glass{
+	name = "Telecommunications Server Room"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/server)
+"liP" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 6
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
-"liP" = (
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "liQ" = (
@@ -33553,9 +33375,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "ljg" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/icecream_vat,
@@ -33572,6 +33391,13 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
+"ljj" = (
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "ljl" = (
 /obj/structure/lattice,
 /obj/structure/railing/corner{
@@ -33597,9 +33423,9 @@
 	},
 /area/station/cargo/storage)
 "ljw" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "ljz" = (
@@ -33609,21 +33435,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
-"ljN" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/command/meeting_room)
 "ljP" = (
-/obj/structure/disposalpipe/trunk,
 /obj/structure/cable,
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -33670,20 +33484,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"lkd" = (
-/obj/structure/cable,
-/obj/structure/alien/weeds,
-/turf/open/misc/asteroid,
-/area/station/maintenance/starboard/greater)
-"lko" = (
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "lku" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -33692,11 +33492,15 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"lkv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 9
+	},
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
 "lkJ" = (
 /obj/structure/flora/rock/pile/jungle/style_4,
 /turf/open/floor/grass,
@@ -33710,9 +33514,6 @@
 /obj/item/pen{
 	pixel_x = -2;
 	pixel_y = 3
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -33742,22 +33543,20 @@
 "lkV" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
+"llr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "llC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"llH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
 "llP" = (
 /obj/structure/cable,
 /obj/structure/bed/medical{
@@ -33782,23 +33581,18 @@
 /turf/closed/wall,
 /area/station/ai_monitored/security/armory)
 "llY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wideplating_new/terracotta{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/central/lesser)
 "lmb" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Xenobiology Maintenance"
-	},
-/obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "lmm" = (
 /mob/living/basic/frog,
 /obj/effect/turf_decal/weather/dirt{
@@ -33830,14 +33624,6 @@
 "lmJ" = (
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"lmK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/station/security/courtroom)
 "lmZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33965,15 +33751,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "lom" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 9
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "lon" = (
@@ -34013,6 +33799,13 @@
 /obj/machinery/light/no_nightlight/directional/south,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/office)
+"lpt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "lpC" = (
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
@@ -34114,8 +33907,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lrh" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "lrE" = (
@@ -34148,11 +33941,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lsh" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/small,
 /area/station/service/barber)
@@ -34222,13 +34015,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
 "ltE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/area/station/engineering/storage/tech)
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "ltP" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/siding/wood{
@@ -34285,13 +34076,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"lup" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tcomms)
 "lut" = (
 /obj/structure/table/wood/fancy/red,
 /obj/structure/sign/painting/large/library{
@@ -34322,10 +34106,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "lve" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
 "lvk" = (
@@ -34339,13 +34125,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lvy" = (
@@ -34407,11 +34193,11 @@
 /area/station/security/execution/education)
 "lwk" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -34431,12 +34217,6 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
-"lwu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "lwI" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/computer/security/mining{
@@ -34466,11 +34246,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "lxa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "lxh" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/engine,
@@ -34624,11 +34402,18 @@
 /area/station/security/tram)
 "lzT" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/command{
-	name = "Council Chambers"
-	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/airlock/command{
+	name = "E.V.A. Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "Bridge Blast Door"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -34796,16 +34581,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "lCS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Coroner Office Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
-/turf/open/floor/plating,
-/area/station/medical/morgue)
+/obj/structure/closet/crate/grave/fresh,
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "lCT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
@@ -34813,9 +34591,6 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "lDc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command{
 	name = "Telecomms Server Room"
 	},
@@ -34824,6 +34599,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "comms-entrance-south"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "lDo" = (
@@ -34843,12 +34621,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"lDr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "lDw" = (
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
@@ -34866,19 +34638,14 @@
 /obj/item/toy/crayon/spraycan/roboticist,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"lDJ" = (
+/obj/structure/flora/bush/jungle,
+/obj/structure/marker_beacon/yellow,
+/turf/open/floor/grass,
+/area/station/maintenance/department/science/xenobiology)
 "lEa" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central/fore)
-"lEg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/broken_flooring/pile/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "lEs" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
@@ -34997,27 +34764,24 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
 "lGL" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/light/cold/directional/north,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lower)
 "lHb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/robotics,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "lHc" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "lHd" = (
@@ -35105,6 +34869,12 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
+"lHZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "lIa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35131,20 +34901,17 @@
 /area/station/medical/medbay/lobby)
 "lIh" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "lIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/organic/applebush,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "lIt" = (
@@ -35155,13 +34922,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/engine/atmos)
 "lIL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/left/directional/east{
 	name = "Maximum Security Test Chamber";
 	req_access = list("xenobiology")
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -35172,9 +34939,9 @@
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
 "lJg" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35222,8 +34989,8 @@
 	name = "Recreation"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/recreation/entertainment)
@@ -35253,9 +35020,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "lKV" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
 "lLb" = (
@@ -35454,7 +35218,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/science/xenobiology)
 "lOj" = (
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
@@ -35472,12 +35236,16 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/electrical)
 "lOO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
+"lOS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/command/corporate_dock)
 "lOY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35522,15 +35290,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
-"lPz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/exit/departure_lounge)
 "lPC" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -35541,11 +35300,19 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/announcement_system,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 8
 	},
-/obj/machinery/announcement_system,
 /turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
+"lPJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/tcommsat/server)
 "lPO" = (
 /obj/structure/table,
@@ -35594,11 +35361,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lQZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
@@ -35614,22 +35381,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
-"lRj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "lRm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -35677,6 +35436,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
+"lSa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/lower)
 "lSb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -35686,6 +35453,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"lSc" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
 "lSh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35704,6 +35475,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
+"lSw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/engineering/storage/tech)
 "lSy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/engine/co2,
@@ -35737,15 +35516,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "lTg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
-"lTk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/fake_snow,
-/area/station/commons/fitness/locker_room)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/science/breakroom)
 "lTt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35794,6 +35569,10 @@
 "lUo" = (
 /turf/open/floor/iron,
 /area/station/science/lobby)
+"lUt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "lUE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35834,7 +35613,7 @@
 /area/station/cargo/sorting)
 "lVg" = (
 /obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "lVy" = (
@@ -35871,9 +35650,6 @@
 /area/station/maintenance/disposal/incinerator)
 "lWk" = (
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central/fore)
 "lWp" = (
@@ -35936,22 +35712,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
 /area/station/science/xenobiology)
+"lXs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "lXw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/radiation/rad_area/directional/east,
-/turf/open/floor/iron/stairs/right{
-	dir = 1
-	},
+/turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "lXC" = (
 /obj/structure/cable,
@@ -35981,18 +35758,18 @@
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel/office)
 "lXR" = (
-/obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lXT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "lXU" = (
@@ -36006,6 +35783,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"lXV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/robotics/augments)
 "lXX" = (
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron,
@@ -36022,13 +35804,13 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "lYf" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lYj" = (
@@ -36070,23 +35852,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "lYV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
 "lZa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
 /obj/machinery/computer/telecomms/monitor{
 	dir = 8;
 	network = "tcommsat"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
@@ -36174,6 +35956,16 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"lZD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "lZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36207,13 +35999,9 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/maintenance/central/greater)
-"maf" = (
-/turf/closed/wall/rust,
-/area/station/hallway/primary/fore)
 "mag" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "mak" = (
@@ -36223,27 +36011,14 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
-"mau" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/station/science/cubicle)
-"maw" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron/smooth,
-/area/station/command/bridge)
 "maE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/clothing/head/cone{
 	pixel_x = 6;
 	pixel_y = 17
 	},
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "maK" = (
@@ -36263,6 +36038,12 @@
 	},
 /turf/open/floor/sepia,
 /area/station/maintenance/aft)
+"mbk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/station/science/cubicle)
 "mbp" = (
 /obj/structure/hedge,
 /obj/machinery/light_switch/directional/east,
@@ -36274,10 +36055,6 @@
 /obj/machinery/pdapainter/medbay,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"mbx" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/wood,
-/area/station/engineering/main)
 "mbG" = (
 /obj/structure/fluff/broken_canister_frame,
 /turf/open/floor/plating,
@@ -36302,14 +36079,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
-"mch" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "mcj" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/table/reinforced/titaniumglass,
@@ -36327,14 +36096,14 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "mcn" = (
-/obj/machinery/status_display/ai/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/lower)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "mco" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/checker,
@@ -36370,10 +36139,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
 "mcS" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -36404,13 +36173,20 @@
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
 "mdG" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
+"mdV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "aibridge"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "meh" = (
 /obj/structure/railing{
 	dir = 4
@@ -36434,20 +36210,15 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain)
 "meG" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
-"meJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "meN" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -36457,19 +36228,10 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"meS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "mfl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side{
 	dir = 8
@@ -36513,6 +36275,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/machinery/recharger,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "mgt" = (
@@ -36567,13 +36330,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"mhZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
+"mhW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 8
 	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
+"mhZ" = (
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/lawoffice)
 "mib" = (
@@ -36628,13 +36397,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"miT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "mjc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -36759,11 +36521,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
 "mkZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
 "mle" = (
@@ -36776,8 +36538,8 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/command/heads_quarters/cmo)
 "mlm" = (
-/obj/structure/cable,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "mln" = (
@@ -36803,6 +36565,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
 "mlD" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -36811,7 +36574,6 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mlK" = (
@@ -36834,34 +36596,33 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
+"mmv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/engineering/storage/tech)
 "mmw" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutter";
 	name = "E.V.A. Storage Shutter"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
 /area/station/ai_monitored/command/storage/eva)
 "mmy" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/south{
-	id = "XenoPens";
-	name = "Xenobiology Shutters";
-	req_access = list("xenobiology")
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "mmE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36880,6 +36641,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
+"mmR" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/surgery_tray/full/morgue,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mmT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36928,6 +36697,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"mnj" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/corporate_dock)
 "mnl" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/coffeemaker/impressa,
@@ -36939,18 +36713,8 @@
 "mnw" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
-"mny" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
 "mnC" = (
 /obj/structure/table,
 /obj/item/phone{
@@ -36970,15 +36734,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "mnN" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
 "mnU" = (
@@ -37087,12 +36846,21 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"mpE" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white/small,
+/area/station/science/cubicle)
 "mpJ" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/half{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron/dark/textured_half,
+/area/station/command/bridge)
+"mpK" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
 	},
-/area/station/hallway/primary/central/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/security/checkpoint/customs)
 "mpL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
@@ -37113,12 +36881,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
-"mpM" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "mpQ" = (
 /obj/structure/bed{
 	dir = 4
@@ -37147,22 +36909,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"mqD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "mqH" = (
 /obj/structure/cable,
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/aft)
 "mqO" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/table,
 /obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
 "mrc" = (
@@ -37178,6 +36935,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"mrs" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/command/glass{
+	name = "Telecommunications Server Room"
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/server)
 "mrt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
@@ -37227,9 +36992,6 @@
 /obj/structure/dresser,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "mtc" = (
@@ -37241,12 +37003,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/maintenance/central/lesser)
-"mtI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/fake_snow,
-/area/station/engineering/atmos)
 "mtP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37256,7 +37012,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "mud" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
@@ -37267,13 +37022,17 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"mur" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
+"mus" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "mut" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -37296,6 +37055,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"muB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance)
 "muI" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -37317,19 +37080,14 @@
 "muS" = (
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
-"muW" = (
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
 "mvd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "mvh" = (
@@ -37350,7 +37108,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "mvC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
 "mvP" = (
@@ -37383,10 +37140,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "mwu" = (
-/obj/structure/cable,
-/obj/structure/hedge,
-/turf/open/floor/plating,
-/area/station/engineering/storage/tech)
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "mwx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -37410,9 +37169,6 @@
 /obj/item/multitool,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "mwN" = (
@@ -37465,8 +37221,8 @@
 /turf/open/floor/noslip,
 /area/station/maintenance/port/aft)
 "mxP" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -37508,6 +37264,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"myp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "myt" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -37549,15 +37312,6 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/station/command/teleporter)
-"mzb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/radio/intercom/command,
-/obj/item/paper/fluff/jobs/engineering/frequencies,
-/turf/open/floor/carpet/executive,
-/area/station/command/meeting_room)
 "mze" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37574,11 +37328,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
 "mzl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "mzo" = (
@@ -37617,17 +37371,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
 "mAs" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/multitool,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/area/station/hallway/primary/starboard)
 "mAv" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -37640,13 +37394,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "mAP" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/door/airlock{
-	id_tag = "AuxToilet2";
-	name = "Unit 2"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "mAR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37743,6 +37494,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"mDs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "mDA" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole{
@@ -37783,15 +37545,25 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
 "mDW" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
+"mEn" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Zoo"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured_half,
+/area/station/hallway/secondary/entry)
 "mEq" = (
 /obj/structure/closet/crate/wooden{
 	name = "Alms Box"
@@ -37864,14 +37636,14 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "mFt" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Cytology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mFx" = (
@@ -37913,6 +37685,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"mFT" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side,
+/area/station/science/xenobiology)
 "mGg" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -38040,32 +37821,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"mHZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
-"mIe" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/prison/workout)
 "mIg" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/xenobiology)
 "mIh" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mIi" = (
@@ -38073,15 +37840,13 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/lawyer,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
 "mIm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -38140,9 +37905,6 @@
 "mIR" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "mIT" = (
@@ -38156,10 +37918,10 @@
 /turf/open/floor/iron/white/small,
 /area/station/security/warden)
 "mIW" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -38191,27 +37953,30 @@
 /turf/open/floor/stone,
 /area/station/maintenance/aft)
 "mJy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
 /area/station/science/xenobiology)
 "mJB" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "mJC" = (
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
+/obj/structure/bodycontainer/morgue/beeper_off{
+	dir = 1
 	},
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/small,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mJK" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -38242,8 +38007,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "mKe" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -38320,41 +38085,34 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mLA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
-/area/station/science/xenobiology)
+/area/station/maintenance/starboard/greater)
 "mLH" = (
-/obj/machinery/light/cold/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "mLM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 8
 	},
-/obj/structure/filingcabinet,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
 "mLO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "mLZ" = (
@@ -38427,7 +38185,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "mNv" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
@@ -38435,16 +38192,9 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"mNz" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "mNQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -38453,12 +38203,6 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"mNS" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
 "mOc" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Airlock"
@@ -38467,13 +38211,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"mOk" = (
-/obj/structure/table/glass,
-/obj/item/folder/blue{
-	pixel_y = 2
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/meeting_room)
 "mOm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38520,11 +38257,11 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "mOM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/chair/stool/directional/north,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
 "mOV" = (
@@ -38548,25 +38285,37 @@
 /turf/open/floor/iron,
 /area/station/security)
 "mPu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Zoo"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mPv" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "mPx" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/door/window/right/directional/south{
+	name = "Jetpack Storage"
 	},
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/ai_monitored/command/storage/eva)
 "mPB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
@@ -38584,8 +38333,8 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
 "mQD" = (
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
 "mQF" = (
@@ -38607,24 +38356,18 @@
 "mRl" = (
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
-"mRB" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/end,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "mRD" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "mRK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mRQ" = (
@@ -38666,11 +38409,11 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "mTc" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -38714,10 +38457,6 @@
 "mTB" = (
 /turf/closed/wall,
 /area/station/command/gateway)
-"mTM" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
 "mTN" = (
 /obj/structure/chair/stool/directional/south,
 /obj/structure/mirror/directional/north,
@@ -38781,13 +38520,13 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "mUn" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mUO" = (
@@ -38795,11 +38534,20 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "mUQ" = (
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"mUX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/left{
+	dir = 1
+	},
+/area/station/maintenance/hallway/abandoned_command)
 "mUY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -38810,6 +38558,7 @@
 "mVc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -38817,7 +38566,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/aft)
 "mVm" = (
@@ -38838,6 +38586,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
+"mVy" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "mVC" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -38868,20 +38620,14 @@
 	dir = 4
 	},
 /area/station/medical/medbay/central)
-"mWc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/science/lower)
 "mWB" = (
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "mWE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "mWF" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -38928,14 +38674,10 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "mXk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/broken_flooring/singular/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/secondary/command)
 "mXt" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/stripes/box,
@@ -38970,11 +38712,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mYd" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "mYj" = (
@@ -38991,6 +38733,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
+"mYp" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/command/storage/eva)
 "mYq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39000,15 +38749,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/prison/shower)
-"mYu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "mYE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39067,15 +38807,15 @@
 	},
 /area/station/security/execution/education)
 "mZd" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mZA" = (
@@ -39094,21 +38834,19 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"naa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "nah" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
-"nay" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/public/glass{
-	name = "Research Wing"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/textured_half{
-	dir = 1
-	},
-/area/station/hallway/primary/starboard)
 "naz" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -39116,12 +38854,6 @@
 "naB" = (
 /turf/closed/wall/rust,
 /area/station/cargo/lobby)
-"naC" = (
-/obj/structure/cable,
-/obj/structure/broken_flooring/singular/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "naF" = (
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
@@ -39152,6 +38884,18 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
+"nbv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "nbF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
@@ -39208,12 +38952,12 @@
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
 "ncr" = (
-/obj/structure/cable,
 /obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/lawyer,
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "ncD" = (
@@ -39224,10 +38968,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ncH" = (
-/obj/structure/table,
-/obj/item/wirecutters,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/science/xenobiology)
 "ncL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -39237,11 +38983,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ncQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "nde" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
@@ -39294,9 +39039,6 @@
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "neF" = (
@@ -39312,21 +39054,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"nfl" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/stone,
-/area/station/service/bar)
-"nfm" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/construction)
 "nfn" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -39367,11 +39094,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "nhl" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "nhu" = (
@@ -39398,7 +39125,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "nhC" = (
-/obj/structure/cable,
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Creature Pen";
 	req_access = list("research")
@@ -39407,6 +39133,7 @@
 	name = "Creature Pen";
 	req_access = list("research")
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
 "nhU" = (
@@ -39431,11 +39158,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
 "nhZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nib" = (
@@ -39456,35 +39183,25 @@
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "niw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/closet/firecloset,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "niF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
 /area/station/science/lower)
-"niI" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay/aft)
 "niR" = (
 /obj/structure/chair,
 /obj/machinery/light/small/directional/north,
@@ -39500,6 +39217,8 @@
 	id = "bridge blast";
 	name = "Bridge Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/command/meeting_room)
 "niW" = (
@@ -39508,10 +39227,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/service/barber)
-"niZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
 "nje" = (
 /obj/structure/railing{
 	dir = 1
@@ -39528,10 +39243,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "njh" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/starboard/aft)
 "njs" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -39559,9 +39274,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/hop)
 "njL" = (
@@ -39663,15 +39375,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"nlk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
 "nln" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39694,10 +39397,6 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
-"nlP" = (
-/obj/structure/cable,
-/turf/open/floor/fake_snow,
-/area/station/commons/fitness/locker_room)
 "nlQ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/thinplating{
@@ -39734,6 +39433,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"nmq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "aibridge"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "nmC" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -39770,6 +39479,13 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
+"nmZ" = (
+/obj/machinery/light/small/dim/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "nnd" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -39800,12 +39516,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
-"nnD" = (
-/turf/open/floor/fake_snow,
-/area/station/hallway/secondary/entry)
 "noe" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -39820,16 +39533,16 @@
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
 "noz" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/hallway/primary/fore)
 "noB" = (
 /obj/structure/table/reinforced/rglass,
@@ -39862,12 +39575,16 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
+"noJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "noN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "noS" = (
@@ -39940,6 +39657,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"nqG" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "nqJ" = (
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/siding/wood,
@@ -40007,6 +39731,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"nrD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "nsc" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/organic/applebush,
@@ -40042,9 +39770,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
 	},
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/central/aft)
@@ -40139,12 +39864,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "ntW" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
 	},
-/turf/open/floor/iron/small,
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ntZ" = (
 /obj/machinery/door/airlock/public/glass{
@@ -40182,17 +39907,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"nuz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nuC" = (
 /obj/effect/turf_decal/siding,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
 "nuL" = (
@@ -40205,9 +39923,9 @@
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "nuO" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "nuS" = (
@@ -40246,8 +39964,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "nvB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -40263,9 +39979,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -40302,10 +40015,10 @@
 	},
 /area/station/hallway/secondary/dock)
 "nwk" = (
+/obj/effect/spawner/random/trash/bin,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
 	},
-/obj/effect/spawner/random/trash/bin,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "nwK" = (
@@ -40327,15 +40040,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"nxD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"nxp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/dead_body_placer{
-	bodycount = 2
+/turf/open/floor/iron/white/corner,
+/area/station/science/lower)
+"nxy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden{
+	dir = 1
 	},
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
+"nxD" = (
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "nxI" = (
@@ -40357,21 +40076,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "nyd" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"nye" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8;
-	name = "killroom vent"
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/station/science/xenobiology)
 "nyf" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -40434,9 +40146,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "nyZ" = (
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/fake_snow,
-/area/station/cargo/storage)
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nzc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40532,9 +40248,9 @@
 /turf/open/space/basic,
 /area/space)
 "nAn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/command)
 "nAo" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -40544,11 +40260,16 @@
 /turf/open/misc/sandy_dirt,
 /area/station/maintenance/starboard/aft)
 "nAF" = (
+/obj/effect/landmark/start/roboticist,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"nAI" = (
+/obj/structure/alien/weeds,
+/obj/structure/cable,
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/greater)
 "nAJ" = (
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
@@ -40569,9 +40290,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "nBq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
 "nBw" = (
@@ -40586,21 +40304,21 @@
 /turf/open/floor/stone,
 /area/station/command/corporate_suite)
 "nBF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
 "nBG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -40621,10 +40339,10 @@
 	},
 /area/station/science/xenobiology)
 "nCo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "nCt" = (
@@ -40658,10 +40376,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "nCU" = (
-/obj/vehicle/ridden/wheelchair{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/vehicle/ridden/wheelchair{
 	dir = 4
 	},
 /obj/structure/sign/departments/psychology/directional/south,
@@ -40748,13 +40466,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"nEC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "nEG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/effect/turf_decal/siding/wideplating{
@@ -40774,13 +40485,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "nFa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/open/floor/iron/textured_half,
+/turf/closed/wall,
 /area/station/engineering/storage/tech)
 "nFc" = (
 /obj/structure/chair/stool/bar/directional/east,
@@ -40789,15 +40494,6 @@
 "nFo" = (
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
-"nFp" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "nFs" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit,
@@ -40988,12 +40684,12 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
 "nIx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
 "nIA" = (
@@ -41007,21 +40703,19 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "nIJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/machinery/light/cold/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/small,
 /area/station/medical/virology)
 "nIT" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "nIY" = (
 /turf/closed/mineral/random/stationside,
@@ -41046,13 +40740,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/fore)
-"nJn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "nJo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -41064,14 +40751,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nJG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "Bridge Blast Door"
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/command/meeting_room)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nJK" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -41103,13 +40791,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nKj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 10
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "nKz" = (
@@ -41125,8 +40813,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/miningfoundry)
 "nLk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -41136,6 +40822,8 @@
 	id = "rdoffice";
 	name = "Research Director's Shutters"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/command/heads_quarters/rd)
 "nLJ" = (
@@ -41149,18 +40837,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nLM" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/electronics/airlock{
-	pixel_y = 13
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "nLQ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -41186,11 +40868,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "nMn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
 "nMq" = (
@@ -41225,9 +40907,7 @@
 /area/station/holodeck/rec_center)
 "nNe" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -41243,6 +40923,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
 "nNz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41251,9 +40934,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nNA" = (
@@ -41273,10 +40953,10 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "nOD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/power/apc/auto_name/directional/west{
 	areastring = "/area/station/science/ordnance/freezerchamber"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -41340,9 +41020,6 @@
 "nPH" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "nPM" = (
@@ -41404,11 +41081,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "nQo" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -41473,11 +41150,11 @@
 /area/station/security/checkpoint/escape)
 "nRd" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "Bridge Blast Door"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "nRr" = (
@@ -41491,12 +41168,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
-"nRP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted,
-/turf/open/floor/iron/smooth,
-/area/station/security/checkpoint/customs)
+"nRS" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "nSb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -41518,6 +41198,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"nSl" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/hallway/secondary/entry)
 "nSA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -41566,23 +41251,16 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/machinery/chem_dispenser,
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "nTC" = (
 /turf/open/floor/iron/white/small,
 /area/station/security/prison/safe)
 "nTE" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/turf/open/floor/iron/small,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "nTP" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Cubicle"
@@ -41591,6 +41269,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/cubicle)
+"nTU" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "nUd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -41683,12 +41367,12 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/service)
 "nVx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -41702,16 +41386,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "nVF" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
-"nVS" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/central)
 "nVU" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -41752,6 +41430,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/eighties/red,
 /area/station/hallway/primary/central/fore)
+"nXf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	id_tag = "AuxToilet3";
+	name = "Unit 3"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/department/science/xenobiology)
 "nXt" = (
 /obj/effect/turf_decal/tile/yellow/full,
 /obj/structure/table/reinforced,
@@ -41794,18 +41480,12 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "nXP" = (
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/grass,
 /area/station/medical/virology)
-"nXQ" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/fake_snow,
-/area/station/service/bar)
 "nXS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41821,10 +41501,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "nYl" = (
+/obj/machinery/firealarm/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -41883,14 +41563,6 @@
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"nZF" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "nZG" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/kitchen/small,
@@ -41929,10 +41601,10 @@
 	pixel_y = -28
 	},
 /obj/machinery/status_display/ai/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "oaK" = (
@@ -41972,8 +41644,6 @@
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "obb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Research and Development Lab"
 	},
@@ -41982,6 +41652,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/lab)
 "obe" = (
@@ -42001,11 +41673,11 @@
 /turf/open/space/basic,
 /area/station/solars/port)
 "obs" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "obN" = (
@@ -42047,14 +41719,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "odh" = (
-/obj/effect/landmark/atmospheric_sanity/ignore_area,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
-"odk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/commons/vacant_room/office)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/engineering/storage/tech)
 "odD" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/table/wood,
@@ -42073,7 +41744,8 @@
 /turf/open/floor/stone,
 /area/station/service/chapel)
 "odP" = (
-/obj/machinery/firealarm/directional/west,
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "odX" = (
@@ -42101,10 +41773,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "oez" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
 "oeI" = (
@@ -42139,6 +41811,7 @@
 	dir = 6
 	},
 /obj/machinery/vending/coffee,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "ofu" = (
@@ -42173,13 +41846,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ogr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ogv" = (
@@ -42220,26 +41893,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab/firing_range)
-"ogW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/entry)
+/turf/open/floor/iron/white,
+/area/station/science/auxlab/firing_range)
 "ohf" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/bot{
@@ -42316,6 +41978,14 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs)
+"oib" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/obj/machinery/door/airlock/grunge{
+	name = "On-Station Burial Site"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/medical/morgue)
 "oig" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
@@ -42336,9 +42006,6 @@
 	dir = 4
 	},
 /obj/structure/sign/warning/no_smoking/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "ois" = (
@@ -42356,11 +42023,11 @@
 /area/station/maintenance/starboard/aft)
 "oiA" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
@@ -42370,18 +42037,15 @@
 	},
 /obj/machinery/chem_master,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "oiT" = (
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "oiU" = (
@@ -42428,6 +42092,7 @@
 "okk" = (
 /obj/structure/table,
 /obj/item/screwdriver,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "okl" = (
@@ -42451,9 +42116,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "okW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance"
 	},
@@ -42467,6 +42129,9 @@
 	id = "rdordnance";
 	name = "Ordnance Lab Shutters"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/ordnance)
 "okZ" = (
@@ -42490,6 +42155,11 @@
 /obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
+"olG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden,
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
 "olI" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs{
@@ -42505,6 +42175,13 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
+"olO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "olV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42530,12 +42207,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
-"omw" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/prison/workout)
 "omW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/white/corner,
@@ -42606,16 +42277,14 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/brig)
 "oom" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner,
+/area/station/science/xenobiology)
 "ooo" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -42636,6 +42305,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"opg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/auxiliary)
 "opn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42673,9 +42348,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "opN" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "opV" = (
@@ -42685,30 +42360,28 @@
 /turf/open/floor/stone,
 /area/station/service/bar)
 "opW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
 /area/station/science/xenobiology)
 "oqg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
 "oqi" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "oqq" = (
@@ -42721,12 +42394,6 @@
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/wood,
 /area/station/engineering/atmospherics_engine)
-"oqB" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "oqK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -42784,11 +42451,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
 "orW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "osa" = (
@@ -42801,19 +42468,19 @@
 "ose" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "osj" = (
-/obj/structure/cable,
 /obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
 "osp" = (
@@ -42843,12 +42510,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "osy" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/small,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/starboard)
 "osP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -42868,15 +42533,24 @@
 /obj/structure/broken_flooring/corner/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"otB" = (
+"otk" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
 /obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/station/science/robotics/mechbay)
+"otB" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "otJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -42884,10 +42558,11 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"otQ" = (
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "otX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43009,12 +42684,6 @@
 	dir = 1
 	},
 /area/station/command/gateway)
-"owm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "owv" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1;
@@ -43023,18 +42692,18 @@
 /turf/open/floor/circuit,
 /area/station/science/server)
 "owD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "owH" = (
+/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "owJ" = (
@@ -43062,6 +42731,10 @@
 /area/station/hallway/primary/central/fore)
 "owZ" = (
 /obj/item/kirbyplants/organic/applebush,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "oxc" = (
@@ -43079,12 +42752,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
-"oxg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+"oxl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/science/lobby)
 "oxm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/window/right/directional/south{
@@ -43198,14 +42873,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"ozV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/maintenance/starboard/greater)
 "oAn" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 10
@@ -43250,10 +42917,10 @@
 /area/station/security/processing)
 "oBA" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
@@ -43306,7 +42973,6 @@
 	},
 /area/station/security/warden)
 "oBX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -43314,6 +42980,7 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -43325,10 +42992,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "oCg" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/techstorage/medical_all,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "oCi" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/small/directional/east,
@@ -43346,10 +43014,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"oCB" = (
-/obj/machinery/atmospherics/components/binary/tank_compressor,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
 "oCE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43496,11 +43160,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/fore)
-"oFI" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "oGk" = (
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
@@ -43515,33 +43174,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_half,
 /area/station/cargo/storage)
-"oGo" = (
-/obj/structure/table/glass,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 11;
-	pixel_y = 6
-	},
-/obj/item/folder/blue{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/meeting_room)
 "oGL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
 "oGQ" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "oHa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -43562,10 +43212,10 @@
 /turf/open/floor/iron/stairs,
 /area/station/maintenance/port/greater)
 "oHp" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oHw" = (
@@ -43575,12 +43225,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
 "oHy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "oHG" = (
@@ -43594,6 +43244,12 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
+"oIa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "oIf" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/modular_computer/preset/engineering{
@@ -43603,10 +43259,13 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/electrical)
 "oIx" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side,
+/area/station/science/xenobiology)
 "oIE" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -43675,11 +43334,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/supermatter/room)
 "oJn" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/science/rd_office,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
 "oJv" = (
@@ -43710,10 +43369,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "oJz" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "oJA" = (
@@ -43746,10 +43403,10 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
 "oJO" = (
@@ -43763,8 +43420,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "oJP" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/broadcaster/preset_left,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
@@ -43789,13 +43446,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
-"oKs" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tcomms)
 "oKz" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/security{
@@ -43821,6 +43471,15 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"oLj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/command/bridge)
 "oLo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43894,18 +43553,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
-"oNH" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "oNN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -43916,12 +43569,12 @@
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "oNX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research/glass{
 	name = "Cytology Zoo"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -43944,11 +43597,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "oOh" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -44022,6 +43675,12 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
+"oOR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/transit_tube/horizontal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "oOV" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
@@ -44076,10 +43735,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/command/heads_quarters/rd)
 "oPM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "oPQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -44128,10 +43790,10 @@
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
 "oQJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "oQK" = (
@@ -44180,6 +43842,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oRv" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
@@ -44189,11 +43852,7 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/south,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
 "oRw" = (
@@ -44219,9 +43878,9 @@
 	},
 /area/station/service/chapel/storage)
 "oRB" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "oRJ" = (
@@ -44241,6 +43900,7 @@
 	name = "St. Brendan's"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/greater)
 "oRW" = (
@@ -44279,13 +43939,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel/office)
-"oSH" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/misc/dirt/station,
-/area/station/service/chapel)
 "oTf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44390,19 +44043,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "oUB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
-"oUC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "oUJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -44453,12 +44102,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"oVD" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "oVE" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -44473,9 +44116,10 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
 "oVF" = (
-/mob/living/basic/mining/lobstrosity,
-/turf/open/misc/asteroid/airless,
-/area/station/maintenance/department/engine)
+/obj/structure/hedge,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "oVK" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -44503,6 +44147,12 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
+"oWf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "oWg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44523,27 +44173,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
 "oWr" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Xenobiology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"oWC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
 "oXa" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "oXs" = (
@@ -44580,11 +44222,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oYj" = (
-/obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "oYv" = (
@@ -44595,6 +44234,14 @@
 	dir = 8
 	},
 /area/station/engineering/main)
+"oYx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "oYF" = (
 /obj/structure/reflector/box/anchored{
 	dir = 4
@@ -44615,6 +44262,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/command/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
 "oZi" = (
@@ -44667,13 +44315,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oZY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "oZZ" = (
@@ -44708,17 +44353,6 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/security/tram)
-"paT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research/glass{
-	name = "Cubicle"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/cubicle)
 "paX" = (
 /obj/structure/chair/bronze{
 	dir = 8
@@ -44795,17 +44429,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
-"pbO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "pbV" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -44813,12 +44436,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "pca" = (
+/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/line,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
@@ -44838,14 +44461,22 @@
 	dir = 8
 	},
 /area/station/command/heads_quarters/hos)
-"pcE" = (
-/obj/structure/cable,
+"pcy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/research)
+"pcE" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Break Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/research)
 "pcK" = (
@@ -44861,12 +44492,12 @@
 	},
 /area/station/hallway/primary/central/fore)
 "pcL" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
 	dir = 6
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -44918,7 +44549,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "pdU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -44926,6 +44556,7 @@
 	pixel_x = -8;
 	pixel_y = -4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "pdY" = (
@@ -44951,6 +44582,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"pem" = (
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "peE" = (
 /obj/structure/closet,
 /turf/open/floor/iron/smooth,
@@ -45025,16 +44668,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pfC" = (
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 5
-	},
-/obj/structure/tank_dispenser/oxygen{
-	pixel_x = -1;
+/obj/structure/table/glass,
+/obj/item/folder/blue{
 	pixel_y = 2
 	},
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/executive,
+/area/station/command/meeting_room)
 "pfT" = (
 /obj/structure/training_machine,
 /turf/open/floor/iron/smooth_large,
@@ -45075,7 +44720,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/radio/intercom/directional/north,
-/obj/item/kirbyplants/fern,
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "phd" = (
@@ -45135,11 +44780,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/stone,
 /area/station/service/bar)
+"phM" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/science/breakroom)
 "phY" = (
 /obj/structure/railing{
 	dir = 1
@@ -45241,10 +44892,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "pjA" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
@@ -45254,11 +44905,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pjT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "pjX" = (
@@ -45345,9 +44996,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"ple" = (
-/turf/open/floor/fake_snow,
-/area/station/service/chapel)
 "plf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45366,23 +45014,21 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/starboard)
 "plz" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "Bridge Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/corporate_showroom)
 "plB" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/centcom{
 	name = "Frozeno!"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
-"plE" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/locker_room)
 "plJ" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/siding/wood{
@@ -45436,8 +45082,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "pnf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -45448,10 +45094,10 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/electrical)
 "pnq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public{
 	name = "Locker Room"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/recreation)
 "pnt" = (
@@ -45508,10 +45154,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pof" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/commons/vacant_room/office)
+/obj/effect/turf_decal/siding/thinplating_new/terracotta,
+/obj/machinery/vending/coffee,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/command/meeting_room)
 "pog" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/freezer,
@@ -45581,24 +45228,24 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ppm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/item/clothing/head/cone{
 	pixel_x = 6;
 	pixel_y = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "ppp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/structure/chair{
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/siding/blue,
-/obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
 "pps" = (
@@ -45692,15 +45339,12 @@
 "pqT" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "prf" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electric_shock,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "prh" = (
@@ -45739,13 +45383,13 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/command/teleporter)
 "psn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/research/glass{
 	name = "Gun Range"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -45807,10 +45451,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ptj" = (
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/diagonal,
 /area/station/science/auxlab/firing_range)
 "ptl" = (
@@ -45913,12 +45557,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"pwA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side,
-/area/station/science/research)
 "pwN" = (
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
@@ -45969,17 +45607,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"pyh" = (
-/obj/structure/cable,
-/obj/structure/broken_flooring/singular/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "pyk" = (
 /obj/structure/closet/crate/trashcart/filled,
 /obj/structure/spider/stickyweb,
 /obj/effect/spawner/random/maintenance/four,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
 "pys" = (
@@ -46007,6 +45640,12 @@
 "pzd" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation/entertainment)
+"pzg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "pzk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46014,16 +45653,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"pzs" = (
-/obj/effect/turf_decal/box/red/corners,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "pzy" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -46035,11 +45664,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"pzK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding,
-/turf/open/floor/iron/white/small,
-/area/station/science/lab)
 "pzL" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46052,14 +45676,22 @@
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
+"pAg" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "pAl" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "pAo" = (
@@ -46095,11 +45727,12 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"pAC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "pAH" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -46120,16 +45753,16 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "pAY" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -46202,11 +45835,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/project)
 "pCv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "pCC" = (
@@ -46223,8 +45856,15 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/brig)
+"pCT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "pCU" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Supply Closet"
 	},
@@ -46232,6 +45872,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pDr" = (
@@ -46246,6 +45887,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "pDw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
@@ -46253,25 +45895,25 @@
 	name = "Medical Supplies";
 	req_access = list("medical")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
 "pDD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "pDK" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/engineering_all,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "pDQ" = (
-/obj/structure/cable,
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/folder/blue,
@@ -46280,6 +45922,7 @@
 /obj/item/clothing/glasses/sunglasses{
 	pixel_y = 15
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "pDU" = (
@@ -46293,15 +45936,6 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
-"pEe" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "pEo" = (
 /obj/item/radio/intercom/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -46319,10 +45953,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pEq" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -46353,12 +45987,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"pEy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
 "pEB" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
@@ -46431,11 +46059,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "pFI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
@@ -46444,6 +46070,8 @@
 	codes_txt = "patrol;next_patrol=11.0-StarboardHall-RecreationHall";
 	location = "10.0-ScienceFoyer-StarboardHall"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "pFK" = (
@@ -46473,19 +46101,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "pGp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"pGD" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "pGE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46498,11 +46122,10 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "pGK" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/misc/sandy_dirt,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "pGR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -46542,16 +46165,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/chapel,
 /area/station/maintenance/starboard/greater)
-"pHn" = (
-/obj/structure/cable,
-/obj/structure/broken_flooring/singular/directional/east,
-/obj/structure/alien/weeds,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "pHq" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/weather/snow/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pHw" = (
@@ -46580,9 +46197,12 @@
 	},
 /area/station/commons/storage/tools)
 "pHI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/commons/fitness/recreation)
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/command/corporate_showroom)
 "pHJ" = (
 /turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/greater)
@@ -46704,14 +46324,19 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pJr" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
-"pJu" = (
 /obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
+"pJu" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecommunications Server Room"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
@@ -46733,7 +46358,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/security/armory)
 "pJz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
@@ -46774,31 +46398,45 @@
 /area/station/medical/medbay/lobby)
 "pKS" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
 "pKU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "pKW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"pLe" = (
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/storage/tech)
 "pLf" = (
 /obj/machinery/griddle,
 /obj/effect/turf_decal/siding{
@@ -46806,15 +46444,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
-"pLj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
 "pLl" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -46826,19 +46455,17 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/airlock/command{
+	name = "Council Chambers"
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "Bridge Blast Door"
 	},
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/command/corporate_showroom)
 "pLI" = (
 /obj/structure/table/reinforced,
@@ -46880,11 +46507,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
-"pMs" = (
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "pMA" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -46965,8 +46587,8 @@
 /obj/effect/turf_decal/siding{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
 "pNZ" = (
@@ -47032,6 +46654,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
+"pOL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "pOM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line{
@@ -47059,15 +46687,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "pOX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/trimline/neutral/end{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/small,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "pPj" = (
 /obj/structure/mirror/directional/east,
@@ -47088,12 +46711,16 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
 "pPp" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
 	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"pPD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall,
+/area/station/science/ordnance/testlab)
 "pPK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47135,7 +46762,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
 "pQE" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Xenolab";
@@ -47145,6 +46771,7 @@
 	id = "XenoPens";
 	name = "Xenobiology Lockdown"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/hallway/secondary/entry)
 "pQP" = (
@@ -47152,14 +46779,10 @@
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/office)
-"pQY" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side,
-/area/station/science/xenobiology)
+"pQW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "pRc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47272,23 +46895,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "pST" = (
-/obj/structure/table,
-/obj/item/plant_analyzer,
-/obj/item/healthanalyzer{
-	pixel_x = 5
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "pTh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/secondary/command)
+"pTi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/secondary/dock)
 "pTk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47364,11 +46984,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "pUy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating_new/terracotta,
+/obj/structure/bookcase/random,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 6
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood/tile,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
 "pUA" = (
 /obj/machinery/space_heater,
@@ -47390,6 +47011,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
 "pUM" = (
@@ -47413,10 +47035,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/processing)
 "pVa" = (
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
 "pVj" = (
@@ -47427,17 +47049,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"pVq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "pVK" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/closed/wall,
@@ -47462,15 +47073,6 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"pVU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side,
-/area/station/science/xenobiology)
 "pVV" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/stairs{
@@ -47478,10 +47080,10 @@
 	},
 /area/station/cargo/lobby)
 "pWl" = (
+/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -47496,12 +47098,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pWw" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/misc/dirt/station,
-/area/station/service/chapel)
 "pWB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -47510,9 +47106,9 @@
 /area/station/command/heads_quarters/hop)
 "pWC" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Primary Treatment Centre"
 	},
@@ -47580,8 +47176,12 @@
 	},
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/storage/box/monkeycubes{
 	pixel_x = 6;
-	pixel_y = 4
+	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
@@ -47650,18 +47250,15 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "pXQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
 "pXS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /obj/structure/broken_flooring/pile/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "pYi" = (
@@ -47764,10 +47361,16 @@
 /obj/item/shard/titanium,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"qac" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/lower)
 "qak" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/fake_snow,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "qan" = (
 /obj/structure/cable/layer3,
@@ -47835,12 +47438,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/dock)
-"qbo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/robotics/augments)
 "qbq" = (
 /obj/structure/chair{
 	dir = 1
@@ -47853,13 +47450,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
-"qbz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "qbA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
@@ -47878,12 +47468,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "qbN" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "qbP" = (
@@ -47900,20 +47490,15 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
-"qcf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/side,
-/area/station/hallway/secondary/construction)
 "qcr" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "qcv" = (
+/obj/effect/landmark/navigate_destination/dockarrival,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination/dockarrival,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qcB" = (
@@ -47965,11 +47550,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"qdN" = (
-/obj/machinery/status_display/ai/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "qdR" = (
 /obj/structure/toilet,
 /obj/machinery/light/small/directional/west,
@@ -47978,9 +47558,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
@@ -48014,6 +47591,36 @@
 "qei" = (
 /turf/closed/wall,
 /area/station/science/ordnance/storage)
+"qek" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/tank_dispenser/oxygen{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/ai_monitored/command/storage/eva)
+"qem" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "qen" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/boxing,
@@ -48069,12 +47676,12 @@
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
 "qfA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Law Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/lawoffice)
 "qfK" = (
@@ -48104,12 +47711,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"qgq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/lower)
 "qgs" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -48130,11 +47731,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qgx" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Law Office Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "qgJ" = (
@@ -48155,7 +47756,6 @@
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel/office)
 "qhh" = (
-/obj/structure/cable,
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/cytology{
 	pixel_x = 6;
@@ -48170,18 +47770,23 @@
 	pixel_y = 2
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"qhD" = (
+"qhl" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/rnd_all,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
+"qhv" = (
+/obj/structure/broken_flooring/corner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/dock)
 "qhF" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
 	},
@@ -48189,6 +47794,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/mid_joiner,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "qhR" = (
@@ -48293,14 +47899,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"qiN" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "qjh" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
@@ -48354,10 +47952,10 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/aft)
 "qka" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "qke" = (
@@ -48437,28 +48035,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qly" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/thinplating_new/terracotta,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
+"qlP" = (
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
-"qlz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 9
-	},
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
-"qlP" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/spawner/directional/east,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "qlV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -48467,17 +48052,10 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"qmb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/broken_flooring/corner/directional/south,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/dock)
 "qme" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qmv" = (
@@ -48487,6 +48065,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"qmy" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "qmz" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -48546,17 +48133,17 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/processing)
 "qnt" = (
-/obj/structure/cable,
 /obj/machinery/power/solar{
 	id = "forestarboard";
 	name = "Fore-Starboard Solar Array"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/fore)
 "qnJ" = (
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "qnU" = (
@@ -48570,13 +48157,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
 "qoj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/right/directional/west{
-	name = "Corpse Arrivals"
+/obj/structure/bodycontainer/morgue{
+	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "qop" = (
 /obj/structure/cable,
@@ -48592,12 +48176,14 @@
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "qoA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/holopad,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "qoD" = (
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
@@ -48646,13 +48232,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
-"qqd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "qqB" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -48695,13 +48274,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/captain/private)
 "qrm" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
 "qrB" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "qrJ" = (
@@ -48716,8 +48295,8 @@
 "qsg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal,
-/obj/structure/cable,
 /obj/structure/chair/stool/directional/east,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "qsj" = (
@@ -48746,15 +48325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
-"qsV" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/freezerchamber)
 "qsY" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -48802,6 +48372,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/central/greater)
+"qug" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/storage/tech)
 "quq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/crate/cardboard,
@@ -48865,6 +48440,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"qvF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "qvL" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants/random,
@@ -48878,14 +48462,12 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"qwi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
+"qwc" = (
+/obj/structure/broken_flooring/singular/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical/central)
+/area/station/maintenance/starboard/greater)
 "qwq" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/computer/prisoner/management{
@@ -48953,11 +48535,11 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port)
 "qxi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "qxv" = (
@@ -48969,12 +48551,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"qxB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/server)
 "qxN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48985,8 +48561,8 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/command/heads_quarters/cmo)
 "qxP" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "qxX" = (
@@ -49003,9 +48579,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating/corner,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/station/engineering/main)
 "qyx" = (
@@ -49289,24 +48862,24 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "qCc" = (
 /obj/machinery/light/cold/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "qCj" = (
 /obj/machinery/airalarm/directional/south,
 /obj/item/kirbyplants/organic/applebush,
-/turf/open/floor/wood/tile,
-/area/station/command/corporate_showroom)
-"qCq" = (
-/obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/wood/tile,
+/area/station/command/corporate_showroom)
+"qCx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "qCG" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -49352,9 +48925,6 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/hop)
 "qCK" = (
@@ -49386,27 +48956,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
-"qCY" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/station/tcommsat/server)
 "qDd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Theater Greenroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49416,12 +48973,12 @@
 	},
 /area/station/service/greenroom)
 "qDi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
@@ -49516,10 +49073,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs)
-"qEB" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/lower)
 "qEO" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/status_display/evac/directional/east,
@@ -49545,13 +49098,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "qFb" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
 "qFc" = (
@@ -49585,12 +49138,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"qFL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/herringbone,
-/area/station/commons/dorms)
 "qGc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -49620,6 +49167,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass/Airless,
 /area/station/hallway/primary/central/aft)
+"qGk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "qGu" = (
 /obj/effect/turf_decal/siding/dark_red,
 /obj/item/radio/intercom/directional/south,
@@ -49629,14 +49183,14 @@
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
 "qGB" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "qGH" = (
@@ -49657,10 +49211,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"qHt" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "qHH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
@@ -49676,10 +49226,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
 "qHY" = (
+/obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
 "qIb" = (
@@ -49704,7 +49254,6 @@
 /turf/closed/wall,
 /area/station/medical/cryo)
 "qIk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/science/xenobiology)
 "qIp" = (
@@ -49719,28 +49268,22 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"qIC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
 "qID" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
 "qIM" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/siding/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "qIQ" = (
@@ -49748,10 +49291,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "qIZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/broken_flooring/pile/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "qJq" = (
@@ -49790,12 +49333,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
-"qKt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/xenobiology)
 "qKx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49883,6 +49420,11 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"qLE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
 "qLU" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -49906,10 +49448,10 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "qMb" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "qMj" = (
@@ -49921,9 +49463,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "qMG" = (
@@ -50007,8 +49546,8 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "qOG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wideplating_new/terracotta{
 	dir = 1
 	},
@@ -50061,9 +49600,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/office)
 "qPJ" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
 "qPN" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/safe)
@@ -50094,7 +49635,6 @@
 	dir = 6
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
 "qQv" = (
@@ -50132,29 +49672,26 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
+"qRa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
 "qRb" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qRh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "qRo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public{
 	name = "Abandoned Dock"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "qRs" = (
@@ -50182,11 +49719,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"qRO" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "qRU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
@@ -50214,8 +49746,8 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "qSh" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "qSk" = (
@@ -50255,10 +49787,10 @@
 /area/station/hallway/secondary/command)
 "qTb" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -50275,11 +49807,11 @@
 	},
 /area/station/science/research)
 "qTk" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -50324,24 +49856,14 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"qUa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
-"qUe" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "qUf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qUm" = (
@@ -50388,12 +49910,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "qUL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "qUR" = (
@@ -50402,9 +49924,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qUS" = (
@@ -50417,17 +49936,17 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "qUZ" = (
-/obj/structure/cable,
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "qVa" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -50439,12 +49958,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/eighties/red,
 /area/station/hallway/primary/central/fore)
-"qVn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "qVo" = (
 /obj/structure/cable,
 /obj/structure/chair/sofa/corp/left{
@@ -50503,10 +50016,10 @@
 /turf/open/floor/wood,
 /area/station/cargo/boutique)
 "qWg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Bathrooms"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/toilet/restrooms)
 "qWh" = (
@@ -50530,13 +50043,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"qWD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "qWF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50550,17 +50056,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"qWJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/station/science/research)
 "qWL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "Bridge Blast Door"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Council Chambers"
+	},
+/turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/science/breakroom)
+/area/station/command/heads_quarters/hop)
 "qWQ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -50615,16 +50125,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
 "qXh" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -50636,10 +50146,6 @@
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"qXk" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/dark,
-/area/station/security/prison/workout)
 "qXl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50731,9 +50237,9 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/service)
 "qYv" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "qYy" = (
@@ -50823,11 +50329,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qZw" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormatories"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
@@ -50928,13 +50434,10 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "raZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "rbc" = (
@@ -50968,11 +50471,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/treatment_center)
 "rbH" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light_switch/directional/west,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/science/ordnance/testlab)
 "rbI" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -50985,9 +50488,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rbT" = (
@@ -50999,11 +50499,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rbW" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "rce" = (
@@ -51037,8 +50537,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "rci" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -51092,19 +50594,16 @@
 /area/station/service/abandoned_gambling_den/gaming)
 "rdA" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wideplating_new/terracotta{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/wood/tile,
 /area/station/maintenance/central/lesser)
 "rdH" = (
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
 "rdM" = (
@@ -51140,10 +50639,10 @@
 /turf/open/floor/iron/white/small,
 /area/station/security/warden)
 "reg" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "reh" = (
@@ -51183,17 +50682,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/central/lesser)
-"reE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+"rez" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/terracotta,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
+"reE" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "reG" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -51222,10 +50721,6 @@
 "reM" = (
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/escape)
-"reN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
 "reS" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -51261,9 +50756,6 @@
 "rfB" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "rfD" = (
@@ -51275,9 +50767,9 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rfO" = (
+/obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "rfP" = (
@@ -51292,6 +50784,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rfW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -51299,15 +50794,8 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"rfZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/station/commons/vacant_room/office)
 "rgA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -51319,9 +50807,6 @@
 	dir = 8
 	},
 /obj/item/kirbyplants/random/fullysynthetic,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rgM" = (
@@ -51397,19 +50882,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"rhH" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/dock)
 "rhL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "rig" = (
@@ -51422,25 +50898,25 @@
 /turf/open/misc/dirt/station,
 /area/station/service/chapel)
 "riq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "Secure Creature Pen";
 	req_access = list("research")
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "rir" = (
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "riS" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -51456,9 +50932,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rjo" = (
@@ -51517,15 +50990,21 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
 "rkI" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	desc = "An outlet for the pneumatic disposal system. This one seems designed for rapid corpse disposal.";
-	name = "rapid corpse mover 9000"
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage"
 	},
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/plating,
-/area/station/medical/morgue)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/station/engineering/storage/tech)
 "rkM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -51559,6 +51038,11 @@
 	dir = 1
 	},
 /area/station/commons/dorms)
+"rln" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "rlq" = (
 /obj/structure/bed{
 	dir = 4
@@ -51577,22 +51061,16 @@
 "rlr" = (
 /turf/closed/wall,
 /area/station/medical/storage)
-"rlH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "rlM" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "rma" = (
+/obj/machinery/camera/autoname/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
 	},
-/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "rmc" = (
@@ -51620,18 +51098,15 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "rnc" = (
+/obj/structure/cable,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
@@ -51672,18 +51147,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
-"roz" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
-"roC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/station/science/xenobiology)
 "roD" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -51704,6 +51167,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"rpc" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/science/xenobiology)
 "rpg" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -51788,9 +51264,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "rqF" = (
@@ -51803,8 +51276,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rrb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/science/xenobiology)
 "rro" = (
 /obj/structure/railing,
@@ -51817,10 +51300,10 @@
 	},
 /area/station/engineering/main)
 "rrp" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "rrt" = (
@@ -51873,14 +51356,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "rsl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table,
 /obj/item/stock_parts/subspace/ansible,
@@ -51890,14 +51372,12 @@
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "rsr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
@@ -51931,24 +51411,48 @@
 "rsL" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
+"rsX" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/lab)
 "rsZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
+"rta" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "rth" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "rto" = (
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 11;
+	pixel_y = 6
 	},
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
+/obj/item/folder/blue{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/executive,
+/area/station/command/meeting_room)
 "rtH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52018,7 +51522,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "atmospherics - lower"
 	},
-/turf/open/floor/fake_snow,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rui" = (
 /obj/structure/cable,
@@ -52030,6 +51534,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
+"ruB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "ruC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
@@ -52127,9 +51638,6 @@
 "rwo" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rwq" = (
@@ -52195,6 +51703,13 @@
 /obj/item/razor,
 /turf/open/floor/iron/dark/small,
 /area/station/security/execution/education)
+"rxB" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "rxD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -52274,12 +51789,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"ryh" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "ryi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52288,9 +51797,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "ryk" = (
+/obj/machinery/status_display/ai/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -52335,14 +51844,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"rza" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/science/breakroom)
 "rzb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52356,6 +51857,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "rze" = (
@@ -52451,6 +51955,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig/entrance)
+"rBc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "rBe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52460,18 +51970,13 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"rBg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "rBq" = (
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/item/restraints/handcuffs,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "rBy" = (
@@ -52479,10 +51984,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "rBz" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "rBE" = (
@@ -52511,14 +52017,14 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rBY" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rCa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -52578,14 +52084,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "rDD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/dorms)
@@ -52662,11 +52168,11 @@
 /area/station/hallway/primary/port)
 "rEY" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/pdapainter{
+/obj/machinery/light/directional/north,
+/obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 2
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -52678,11 +52184,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"rFi" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "rFm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -52697,11 +52198,11 @@
 /area/station/hallway/primary/central/fore)
 "rFp" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -52736,7 +52237,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/xenobiology)
 "rFH" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52744,6 +52244,7 @@
 	name = "Research Delivery";
 	req_access = list("science")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
@@ -52759,13 +52260,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rGp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research/glass{
 	name = "Testing Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
 "rGB" = (
@@ -52782,16 +52283,13 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rGO" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/screwdriver,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
 "rHe" = (
@@ -52810,9 +52308,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central/fore)
 "rHp" = (
@@ -52915,6 +52410,7 @@
 /mob/living/carbon/human/species/monkey{
 	name = "George"
 	},
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
 "rJB" = (
@@ -52969,6 +52465,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/cytology)
+"rKE" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/lower)
 "rKR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -53002,9 +52507,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/engine,
 /area/station/science/explab)
 "rLp" = (
@@ -53019,20 +52521,13 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "rLt" = (
-/obj/item/clothing/head/cone{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/effect/decal/cleanable/glass/titanium,
-/obj/effect/decal/cleanable/insectguts,
-/obj/machinery/light/small/dim/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/medical_all,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "rLx" = (
 /obj/effect/turf_decal/siding/thinplating/terracotta,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53057,8 +52552,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
 "rMb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "rMf" = (
@@ -53125,11 +52620,11 @@
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
 "rNd" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "rNn" = (
@@ -53200,8 +52695,8 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "rOW" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/server)
 "rOX" = (
@@ -53215,13 +52710,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"rPm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/science/robotics/mechbay)
 "rPx" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -53315,24 +52803,10 @@
 "rQi" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
-"rQm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/lawoffice)
 "rQw" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"rQA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "rQC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53429,19 +52903,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "rSt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Coroner's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
-/turf/open/floor/iron/small,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "rSy" = (
 /obj/machinery/door/airlock{
@@ -53457,7 +52921,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "rSB" = (
@@ -53559,9 +53022,9 @@
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
 "rUI" = (
+/obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -53572,13 +53035,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rUV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=7.0-Arrivals-Pharmacy";
 	location = "6.3-Arrivals"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rVj" = (
@@ -53619,15 +53082,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
-"rVy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/science/auxlab/firing_range)
 "rVH" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/table/glass,
@@ -53666,9 +53120,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/lobby)
 "rWm" = (
+/obj/machinery/camera/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -53766,17 +53220,18 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/sorting)
+"rWS" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "rWU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"rXh" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/stone,
-/area/station/service/bar)
 "rXm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -53785,9 +53240,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rXv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/secondary/command)
 "rXw" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -53798,13 +53258,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"rXM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "rXW" = (
 /obj/structure/flora/bush/flowers_yw,
 /obj/machinery/door/window/left/directional/west{
@@ -53846,10 +53299,10 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "rYx" = (
-/obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron/small,
 /area/station/service/barber)
 "rYD" = (
@@ -53920,7 +53373,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "rZz" = (
@@ -53974,14 +53426,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"saA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "saL" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "saY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/augments)
 "sbq" = (
@@ -53997,9 +53457,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sbN" = (
@@ -54107,6 +53564,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"sdm" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "sdZ" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -54119,9 +53583,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sea" = (
+/obj/effect/turf_decal/siding/white/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "seq" = (
@@ -54157,21 +53621,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
-"seV" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "sfk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "sfq" = (
+/obj/machinery/light/cold/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -54236,6 +53694,17 @@
 /obj/item/clothing/head/costume/festive,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"sgm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
+"sgt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/transit_tube/horizontal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "sgw" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 1
@@ -54263,18 +53732,16 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/recreation)
 "shm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "shD" = (
 /turf/closed/wall,
-/area/station/hallway/secondary/recreation)
-"shG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "shL" = (
 /obj/machinery/door/airlock/external{
@@ -54295,8 +53762,8 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "sib" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
 "sip" = (
@@ -54341,11 +53808,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/private)
-"sjp" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
 "sjq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -54403,11 +53865,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/security/execution/transfer)
-"skd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/fitness/locker_room)
 "skm" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -54455,9 +53912,6 @@
 /area/station/security/warden)
 "skT" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "skU" = (
@@ -54545,14 +53999,11 @@
 	codes_txt = "patrol;next_patrol=23.4-Evac";
 	location = "23.3-Evac"
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "smk" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
@@ -54589,9 +54040,6 @@
 "sny" = (
 /obj/machinery/holopad,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "snB" = (
@@ -54605,14 +54053,12 @@
 "snJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small/directional/south,
+/obj/item/kirbyplants/fern,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "snK" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "snW" = (
@@ -54626,16 +54072,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sok" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/light/cold/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -54710,9 +54156,6 @@
 	pixel_y = -2
 	},
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs/auxiliary)
 "spk" = (
@@ -54755,19 +54198,16 @@
 /turf/open/floor/iron/small,
 /area/station/service/bar)
 "spK" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/cafeteria,
+/area/station/science/circuits)
 "spP" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
 "sqa" = (
@@ -54827,9 +54267,6 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "sqY" = (
@@ -54886,25 +54323,25 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "srE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecommunications Server Room"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "comms-entrance-south"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "srH" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
@@ -54916,13 +54353,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"srT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
 "sso" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -54949,9 +54379,6 @@
 /area/station/maintenance/department/science/xenobiology)
 "ssY" = (
 /obj/structure/kitchenspike,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -54978,13 +54405,18 @@
 	},
 /area/station/hallway/primary/central/fore)
 "stj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs{
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/open/space/basic,
+/area/station/engineering/storage/tech)
 "stH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown/half,
@@ -54993,20 +54425,13 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/miningoffice)
-"stP" = (
-/obj/effect/turf_decal/siding{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white/small,
-/area/station/science/lab)
 "stV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "stX" = (
@@ -55061,6 +54486,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"suU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "svd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -55068,11 +54497,11 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/pumproom)
 "svh" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "svo" = (
@@ -55103,14 +54532,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "svz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Secure Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "svD" = (
@@ -55181,32 +54610,36 @@
 /area/station/commons/vacant_room/office)
 "swk" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"swn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/station/science/xenobiology)
 "swu" = (
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "swB" = (
+/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/starboard)
 "swF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "swJ" = (
@@ -55225,12 +54658,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
-"swL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron/dark/herringbone,
-/area/station/security/courtroom)
 "swM" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -55289,11 +54716,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "sxF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -55364,11 +54791,11 @@
 /turf/closed/wall,
 /area/station/security/warden)
 "syA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass{
 	name = "Dorms"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -55378,18 +54805,6 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
-"syK" = (
-/obj/effect/turf_decal/box/red/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "syN" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -55432,6 +54847,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"sBc" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai_upload)
 "sBm" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/fluff/tram_rail/floor,
@@ -55455,11 +54877,12 @@
 /obj/item/clothing/gloves/color/orange,
 /obj/item/clothing/shoes/galoshes,
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/service/janitor)
+"sBA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/testlab)
 "sBL" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -55551,13 +54974,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"sCB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public{
-	name = "Locker Room"
-	},
-/turf/open/floor/iron/textured_half,
-/area/station/commons/fitness/recreation)
 "sCC" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "ATMOS PROJECT Airlock"
@@ -55606,9 +55022,6 @@
 "sDs" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "sDA" = (
@@ -55620,13 +55033,8 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"sDM" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "sDZ" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -55638,7 +55046,6 @@
 	codes_txt = "patrol;next_patrol=15.0-CentralStarboard-CentralFore";
 	location = "14.0-Dormatories-CentralStarboard"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sEd" = (
@@ -55711,9 +55118,6 @@
 	dir = 6
 	},
 /obj/structure/flora/bush/flowers_yw,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "sGp" = (
@@ -55729,11 +55133,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
 "sGE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "sGN" = (
@@ -55821,10 +55225,10 @@
 /area/station/science/cytology)
 "sIj" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "sIA" = (
@@ -55852,11 +55256,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "sJg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Research Division Server Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/server)
 "sJi" = (
@@ -55864,9 +55268,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
 "sJr" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
 "sJv" = (
@@ -55881,11 +55285,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "sJw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "sJE" = (
@@ -55905,10 +55309,22 @@
 /area/station/service/kitchen)
 "sJN" = (
 /obj/effect/turf_decal/siding,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
+"sJO" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "sJR" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
@@ -55944,14 +55360,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sKm" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
 "sKq" = (
@@ -55977,14 +55393,15 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "sKB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "sKE" = (
@@ -56054,13 +55471,7 @@
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/tram,
 /area/station/security/tram)
-"sLU" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/dock)
 "sMh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
@@ -56072,6 +55483,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -56096,11 +55508,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/central/aft)
-"sMu" = (
-/obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/secondary/entry)
 "sMB" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/rack,
@@ -56141,11 +55548,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
-"sMU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "sNb" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
@@ -56183,10 +55585,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"sOf" = (
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/fake_snow,
-/area/station/engineering/atmos/project)
 "sOi" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
@@ -56216,13 +55614,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/sofa/bench{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "sOy" = (
@@ -56254,15 +55652,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/storage/art)
-"sPa" = (
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/door/airlock/grunge{
-	name = "St. Brendan's"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/starboard/greater)
 "sPb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -56285,12 +55674,6 @@
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"sPO" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "sQb" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -56386,15 +55769,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"sQX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "sRf" = (
 /obj/machinery/power/turbine/inlet_compressor{
 	dir = 8
@@ -56436,6 +55810,14 @@
 "sRL" = (
 /turf/closed/wall,
 /area/station/service/janitor)
+"sRN" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/door/airlock{
+	id_tag = "AuxToilet2";
+	name = "Unit 2"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/department/science/xenobiology)
 "sRT" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/thinplating{
@@ -56509,14 +55891,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "sTi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/clothing/head/cone{
 	pixel_x = -8;
 	pixel_y = 17
 	},
 /obj/structure/broken_flooring/singular/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "sTq" = (
@@ -56549,24 +55931,27 @@
 /area/station/service/library/private)
 "sTR" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Cold Room"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/medical/coldroom)
 "sUe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/fitness/recreation)
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/coffeemaker/impressa{
+	pixel_x = 2
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/station/command/bridge)
 "sUg" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -56635,11 +56020,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/security)
-"sVk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/greater)
 "sVp" = (
 /obj/structure/table,
 /obj/structure/sign/poster/official/corporate_perks_vacation/directional/east,
@@ -56668,10 +56048,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "sVG" = (
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "sVN" = (
@@ -56716,12 +56096,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/greater)
 "sWQ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "sXi" = (
@@ -56771,19 +56148,10 @@
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"sXz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "sXD" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "sXE" = (
@@ -56794,11 +56162,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
 "sXG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
@@ -56806,12 +56174,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"sXL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/science/ordnance/storage)
 "sXO" = (
 /obj/structure/chair{
 	dir = 4
@@ -56841,11 +56203,11 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/outlet_injector{
 	dir = 8;
 	pixel_x = -4
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "sYg" = (
@@ -56862,9 +56224,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sYs" = (
@@ -56875,22 +56234,18 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sYt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage"
+/obj/structure/table/reinforced,
+/obj/machinery/newscaster/directional/east,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/engineering/storage/tech)
-"sYu" = (
-/obj/machinery/status_display/ai/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/t_scanner,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/engineering/storage/tech)
 "sYw" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -56923,6 +56278,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
+"sZh" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "sZo" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 10
@@ -56933,7 +56292,6 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
 "sZx" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -56943,6 +56301,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "sZA" = (
@@ -56954,14 +56313,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"sZH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
 "sZJ" = (
 /obj/structure/chair{
 	dir = 1;
@@ -57032,13 +56383,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs/auxiliary)
 "taL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "taT" = (
@@ -57069,10 +56420,10 @@
 /turf/open/floor/iron/textured_half,
 /area/station/security/execution/transfer)
 "tbk" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/hatch{
 	name = "Experimentation Chamber"
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
@@ -57113,18 +56464,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/lab)
-"tbI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"tbK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "tbS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -57134,8 +56473,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tcz" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tcC" = (
@@ -57187,10 +56526,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "tdE" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "tdF" = (
@@ -57214,7 +56553,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical/central)
 "tdS" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -57222,6 +56560,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -57233,10 +56572,10 @@
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/electrical)
 "tec" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "teo" = (
@@ -57371,6 +56710,14 @@
 /obj/item/clipboard,
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
+"tfH" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "tfM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
@@ -57420,9 +56767,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/medical/cryo)
 "thb" = (
@@ -57434,10 +56778,10 @@
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "the" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -57480,6 +56824,11 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"tis" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "tit" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -57510,9 +56859,6 @@
 "tiQ" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "tiW" = (
@@ -57546,10 +56892,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tje" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "tjg" = (
@@ -57564,6 +56910,15 @@
 "tjj" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"tjm" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/research)
 "tjs" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/spawner/random/entertainment/arcade{
@@ -57626,12 +56981,6 @@
 /obj/item/broken_bottle,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
-"tkS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
 "tkU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot{
@@ -57685,6 +57034,13 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
+"tmr" = (
+/obj/machinery/newscaster/directional/north,
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "tms" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -57697,6 +57053,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"tmI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Recreation"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "tmK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57740,6 +57104,14 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/lesser)
+"tmV" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/turf/open/floor/plating,
+/area/station/medical/morgue)
 "tnb" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
@@ -57803,6 +57175,14 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
+"tob" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/maintenance/starboard/greater)
 "tof" = (
 /turf/closed/wall/rust,
 /area/station/ai_monitored/turret_protected/ai)
@@ -57887,9 +57267,9 @@
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
 "toU" = (
-/obj/structure/disposalpipe/junction/flip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "toX" = (
@@ -57907,8 +57287,15 @@
 /area/station/service/lawoffice)
 "tpl" = (
 /obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/station/science/cubicle)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/command/bridge)
 "tpm" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/noslip,
@@ -57922,14 +57309,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"tpI" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "tpK" = (
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 4
@@ -57987,15 +57366,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "tqs" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/window/right/directional/east{
+	name = "Corpse Arrivals"
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark/small,
+/turf/open/floor/plating,
 /area/station/medical/morgue)
 "tqD" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "tqF" = (
@@ -58016,15 +57395,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "tqX" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -58035,12 +57414,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
+"trl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "trp" = (
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
 "trz" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -58073,9 +57458,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tsb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/departments/aiupload/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "tsk" = (
@@ -58101,23 +57486,23 @@
 /turf/open/floor/iron/textured_half,
 /area/station/service/chapel/office)
 "tst" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/preopen{
 	id = "Xenolab";
 	name = "Test Chamber Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
 "tsA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
@@ -58227,11 +57612,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"tuE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "tuP" = (
 /obj/machinery/light/small/directional/east,
 /obj/item/kirbyplants/random,
@@ -58249,10 +57629,11 @@
 /area/station/hallway/secondary/entry)
 "tuW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/checker,
 /area/station/command/bridge)
 "tuY" = (
 /obj/effect/spawner/random/structure/closet_private,
@@ -58296,13 +57677,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
-"tvU" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "tvW" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -58335,9 +57709,9 @@
 /area/space/nearstation)
 "twi" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "twm" = (
@@ -58362,24 +57736,10 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/small,
 /area/station/security/tram)
-"twx" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "twA" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
-"twE" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Recreation"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "twF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -58450,16 +57810,9 @@
 /turf/closed/wall,
 /area/station/security/prison/workout)
 "txV" = (
-/obj/machinery/button/door/directional/east{
-	id = "AuxToilet3";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/toilet,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "txW" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -58474,12 +57827,20 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "tye" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A. Storage"
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/station/ai_monitored/command/storage/eva)
 "tyh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58647,10 +58008,10 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "tAs" = (
@@ -58699,19 +58060,25 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tAP" = (
-/obj/effect/landmark/blobstart,
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/dead_body_placer{
+	bodycount = 2
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "tAQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "tAS" = (
@@ -58801,15 +58168,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
 /area/space/nearstation)
-"tCG" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/science/robotics/mechbay)
 "tCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tDb" = (
@@ -58828,9 +58190,6 @@
 	dir = 4
 	},
 /obj/machinery/shower/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "tDn" = (
@@ -58927,23 +58286,23 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "tEC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/lab)
 "tEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tFs" = (
@@ -58998,24 +58357,16 @@
 /area/station/security/tram)
 "tGB" = (
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
 "tGF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
-"tGI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/server)
 "tGJ" = (
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/machinery/computer/records/security,
@@ -59060,12 +58411,9 @@
 /turf/closed/wall,
 /area/station/security/prison/shower)
 "tHL" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/entry)
 "tIa" = (
@@ -59084,17 +58432,17 @@
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
 "tIB" = (
-/obj/item/clothing/head/cone{
-	pixel_x = 16;
-	pixel_y = 7
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/item/clothing/head/cone{
-	pixel_x = -1;
-	pixel_y = -5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/engineering/storage/tech)
 "tIN" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow{
@@ -59133,14 +58481,14 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "tJw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Secure Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "tJz" = (
@@ -59152,6 +58500,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/brig/entrance)
+"tJC" = (
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "tJF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -59205,9 +58558,6 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/light/no_nightlight/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tKG" = (
@@ -59245,19 +58595,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "tLc" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/techstorage/service_all,
-/obj/machinery/light/cold/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/starboard)
 "tLj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/machinery/light/small/broken/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/broken/directional/south,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "tLn" = (
@@ -59288,19 +58638,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "tMh" = (
-/obj/structure/fireaxecabinet/directional/south,
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Command Desk";
 	req_access = list("command")
 	},
-/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
 /area/station/command/bridge)
 "tMs" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/server/presets/service,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
@@ -59333,7 +58682,6 @@
 /turf/open/floor/wood,
 /area/station/engineering/atmos/pumproom)
 "tNn" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
@@ -59341,6 +58689,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "tNs" = (
@@ -59365,23 +58714,23 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tNy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Gun Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/auxlab/firing_range)
 "tNz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "tNA" = (
@@ -59401,12 +58750,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
-"tNR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark/side,
-/area/station/science/xenobiology)
 "tNT" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/kitchen/small,
@@ -59439,22 +58782,14 @@
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
 "tOk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"tOs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tOu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -59484,11 +58819,11 @@
 /turf/open/misc/sandy_dirt,
 /area/station/service/lawoffice)
 "tOZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/cold/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "tPf" = (
@@ -59496,11 +58831,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "tPm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "tPE" = (
@@ -59509,19 +58844,30 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/barber)
-"tPH" = (
+"tPF" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/engineering/storage/tech)
+"tPH" = (
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "tPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tPP" = (
@@ -59581,25 +58927,29 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tQA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"tQQ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+"tQM" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tcomms)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/science/xenobiology)
 "tQR" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Airlock"
@@ -59641,10 +58991,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"tRr" = (
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/stone,
-/area/station/service/chapel)
+"tRn" = (
+/obj/structure/closet/crate/grave/filled,
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "tRw" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -59680,13 +59030,13 @@
 	},
 /area/station/security/prison/safe)
 "tSq" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/processor/preset_three,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "tSu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "tSv" = (
@@ -59704,6 +59054,25 @@
 	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
+"tSH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 8;
+	pixel_y = 1
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
+"tSI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/broken_flooring/singular/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "tTg" = (
 /obj/structure/table,
 /obj/item/trash/cheesie{
@@ -59715,28 +59084,18 @@
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
 "tTp" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/caution/stand_clear/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"tTs" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "tTx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -59769,48 +59128,16 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "tUa" = (
-/obj/effect/gibspawner/human,
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
-	},
-/mob/living/carbon/human/species/monkey{
-	name = "Charles";
-	real_name = "Charles"
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/flora/rock/pile/jungle/style_random,
+/obj/structure/sign/departments/restroom/directional/west,
+/turf/open/misc/sandy_dirt,
+/area/station/hallway/secondary/entry)
 "tUc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/public/glass{
-	name = "Research Wing"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-entrance"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "rdrnd";
-	name = "Research and Development Shutters"
-	},
-/turf/open/floor/iron/white/textured_half{
-	dir = 1
-	},
-/area/station/hallway/primary/starboard)
-"tUg" = (
-/obj/structure/cable,
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/command/meeting_room)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/stairs,
+/area/station/hallway/primary/central/fore)
 "tUj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59825,21 +59152,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
-"tUq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "tUz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -59853,17 +59171,18 @@
 /area/station/medical/pharmacy)
 "tUH" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "tUZ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "tVc" = (
@@ -59899,10 +59218,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"tWl" = (
-/obj/structure/statue/snow/snowman,
-/turf/open/floor/fake_snow,
-/area/station/medical/chemistry)
 "tWm" = (
 /obj/structure/flora/bush/jungle/c/style_3,
 /obj/effect/turf_decal/weather/dirt,
@@ -59937,10 +59252,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tWG" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
@@ -59988,9 +59303,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "tXL" = (
@@ -60046,10 +59358,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
-"tYN" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "tYT" = (
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
@@ -60154,23 +59462,23 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uax" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "uaF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "uaT" = (
@@ -60214,6 +59522,11 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
+"ubk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "ubl" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
@@ -60231,21 +59544,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/central/fore)
 "ubT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/hedge,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/hallway/primary/fore)
 "ubV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -60255,12 +59570,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "uch" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "ucm" = (
@@ -60328,17 +59643,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "ucY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
 /area/station/hallway/secondary/construction)
+"udd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "ude" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -60394,17 +59713,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "udK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=4.0-TechStorage-AftHall";
 	location = "3.0-StarboardHall-TechStorage"
@@ -60413,7 +59732,6 @@
 /area/station/hallway/primary/starboard)
 "udO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "udW" = (
@@ -60506,11 +59824,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output,
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
+"ueT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/cytology)
 "ueX" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/fore)
 "ufb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
@@ -60535,8 +59856,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ufE" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -60549,10 +59870,10 @@
 /area/station/hallway/primary/aft)
 "ufF" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
@@ -60571,27 +59892,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig/entrance)
-"uge" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"ugh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ugj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60615,15 +59915,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
-"ugC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ugF" = (
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/stripes/line{
@@ -60632,11 +59923,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
 "ugH" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
@@ -60645,11 +59936,11 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "ugJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "uhe" = (
@@ -60671,14 +59962,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uhk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/small,
+/obj/machinery/smartfridge/organ,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "uhq" = (
 /obj/structure/chair/bronze,
@@ -60730,11 +60016,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
 "uid" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
@@ -60757,18 +60043,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"uiz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/construction)
 "uiB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "uiK" = (
@@ -60796,14 +60075,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
-"uiS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/research)
 "uiU" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -60813,10 +60084,10 @@
 /area/station/cargo/office)
 "uiY" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
@@ -60875,20 +60146,27 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "ujT" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Sec Post Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"ujZ" = (
+"ujX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"ujZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
 "ukf" = (
@@ -60899,6 +60177,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/cargo/miningfoundry)
+"ukk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/lower)
 "uku" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -60907,9 +60193,6 @@
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ukA" = (
@@ -60918,22 +60201,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
 "ukB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
-"ukE" = (
-/obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/department/science/xenobiology)
 "ukI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -60943,9 +60216,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "ukQ" = (
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -60983,16 +60256,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"ulq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/kirbyplants/organic/applebush,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 8
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/command/meeting_room)
 "ulC" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot{
@@ -61011,9 +60274,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "ulK" = (
-/obj/structure/cable,
 /obj/machinery/ntnet_relay,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "ulO" = (
@@ -61034,9 +60297,6 @@
 "umr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -61062,29 +60322,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"umJ" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "umL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "unc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "unf" = (
@@ -61105,11 +60356,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "unT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -61147,10 +60398,10 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "upe" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "upg" = (
@@ -61165,18 +60416,17 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/port)
 "upr" = (
+/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
 /area/station/science/research)
 "upy" = (
-/obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -61215,10 +60465,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "upP" = (
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
@@ -61230,8 +60480,8 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "uqc" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "uqe" = (
@@ -61274,10 +60524,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uqH" = (
+/obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "uqL" = (
@@ -61290,19 +60540,19 @@
 /area/station/maintenance/starboard/aft)
 "uqO" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "uqU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trap/stun,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "uqV" = (
@@ -61364,9 +60614,8 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "urm" = (
@@ -61422,6 +60671,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"ury" = (
+/obj/structure/transit_tube/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/space/basic,
+/area/space/nearstation)
 "urz" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -61509,15 +60764,12 @@
 	},
 /area/station/hallway/secondary/construction)
 "utF" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "Bridge Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/meeting_room)
 "utP" = (
@@ -61534,10 +60786,6 @@
 /obj/effect/landmark/navigate_destination/dockescpod,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"uub" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "uur" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/storage/wallet{
@@ -61587,14 +60835,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research/glass{
 	name = "Gun Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/auxlab/firing_range)
 "uvb" = (
@@ -61638,17 +60886,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"uwF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/command/corporate_dock)
 "uwI" = (
+/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uwO" = (
@@ -61676,15 +60917,21 @@
 /area/station/maintenance/starboard/greater)
 "uya" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/storage/tech)
+/turf/closed/wall,
+/area/station/maintenance/department/science/xenobiology)
 "uyA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"uyF" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/construction)
 "uyH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -61711,14 +60958,6 @@
 "uzJ" = (
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"uzK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/lower)
 "uzY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -61730,10 +60969,10 @@
 /area/station/hallway/secondary/dock)
 "uzZ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -61770,6 +61009,14 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"uAX" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "uAY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
@@ -61795,12 +61042,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
 "uBo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -61814,11 +61061,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "uBy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs,
-/area/station/engineering/storage/tech)
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/space/basic,
+/area/space)
 "uBE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/light/no_nightlight/directional/north,
@@ -61903,11 +61148,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "uDg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -61969,6 +61215,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"uDI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "uDQ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -62029,11 +61281,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "uEQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uES" = (
@@ -62055,12 +61306,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmospherics_engine)
-"uFc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "uFe" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -62084,20 +61329,12 @@
 	dir = 1
 	},
 /area/station/command/bridge)
-"uFo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "uFt" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -62113,12 +61350,12 @@
 /turf/open/floor/iron/textured_half,
 /area/station/security/lockers)
 "uFA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
 	name = "Research Wing"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -62137,9 +61374,6 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/service/janitor)
 "uGj" = (
@@ -62156,7 +61390,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
 	name = "Research Wing"
 	},
@@ -62169,6 +61402,7 @@
 	id = "rdrnd";
 	name = "Research and Development Shutters"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -62199,11 +61433,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "uGO" = (
@@ -62220,40 +61454,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "uGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/science/research,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/station/science/research)
-"uGW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/side,
-/area/station/science/research)
-"uGX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side,
 /area/station/science/research)
 "uHc" = (
 /obj/structure/frame/machine,
@@ -62267,8 +61482,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/sign/departments/rndserver/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
 "uHo" = (
@@ -62327,9 +61542,9 @@
 	},
 /area/station/service/chapel/office)
 "uHR" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "uIj" = (
@@ -62353,10 +61568,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
-"uIy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "uIA" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 9
@@ -62376,12 +61587,12 @@
 "uIP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -62399,6 +61610,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
+"uJc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Applied Sciences"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-entrance"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured_half,
+/area/station/science/lobby)
 "uJi" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -62486,10 +61709,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "uKH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north,
 /obj/machinery/status_display/ai/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -62522,14 +61745,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "uLD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "uLO" = (
@@ -62570,9 +61793,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/medical/cryo)
 "uMu" = (
@@ -62582,16 +61802,9 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "uME" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/greyscale,
-/obj/item/bodypart/leg/left/monkey{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/scalpel,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/white/diagonal,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/starboard)
 "uMF" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -62635,13 +61848,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "uNe" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/smooth,
-/area/station/security/checkpoint/customs)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/auxiliary)
 "uNz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark_red{
@@ -62650,12 +61861,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
+"uNK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "uNR" = (
-/obj/structure/cable,
 /obj/structure/chair{
 	dir = 4;
 	pixel_y = -2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "uNX" = (
@@ -62696,15 +61912,8 @@
 /turf/open/floor/wood/tile,
 /area/station/maintenance/central/lesser)
 "uOH" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
-"uOP" = (
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood/tile,
-/area/station/command/meeting_room)
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "uPf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -62732,15 +61941,15 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "uPJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uPM" = (
@@ -62760,10 +61969,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "uQb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "uQc" = (
@@ -62885,13 +62094,18 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/execution/education)
+"uRP" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/arcade_boards,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "uRR" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "uRW" = (
@@ -62920,30 +62134,30 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "uSi" = (
+/obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "uSj" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/central)
 "uSo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "uSB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
 /obj/effect/landmark/navigate_destination/tcomms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lower)
 "uSM" = (
@@ -62971,8 +62185,8 @@
 /turf/open/floor/iron/textured_half,
 /area/station/commons/storage/art)
 "uTb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/table/glass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "uTz" = (
@@ -63018,34 +62232,36 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "uTO" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
 "uTR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "uUe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/command/corporate_dock)
+/obj/effect/turf_decal/siding/thinplating_new/terracotta,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/item/kirbyplants/organic/applebush,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/command/meeting_room)
 "uUf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "uUj" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uUq" = (
@@ -63109,16 +62325,9 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uVc" = (
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "uVo" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -63126,7 +62335,6 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uVB" = (
@@ -63152,13 +62360,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
-"uVO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "uVT" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -63185,23 +62386,17 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/augments)
 "uWn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "uWo" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
-"uWr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/science/circuits)
 "uWv" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -63218,6 +62413,10 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
+"uWz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/command/corporate_dock)
 "uWG" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/status_display/ai/directional/south,
@@ -63225,10 +62424,10 @@
 /area/station/hallway/primary/starboard)
 "uWQ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "uWZ" = (
@@ -63254,7 +62453,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "uXV" = (
-/obj/structure/cable,
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Creature Pen";
 	req_access = list("research")
@@ -63263,6 +62461,7 @@
 	name = "Creature Pen";
 	req_access = list("research")
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
 "uXY" = (
@@ -63304,11 +62503,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "uYO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/broken_flooring/singular/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "uYY" = (
@@ -63323,6 +62522,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"uZf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/science/research)
 "uZk" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/chair{
@@ -63330,13 +62537,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"uZr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
 "uZA" = (
 /obj/structure/chair{
 	dir = 1;
@@ -63395,25 +62595,16 @@
 "vaw" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"vaF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/kirbyplants/organic/applebush,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "vba" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
@@ -63423,10 +62614,10 @@
 /area/station/maintenance/starboard/central)
 "vbq" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "vbA" = (
@@ -63434,6 +62625,12 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
+"vbJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/fitness/recreation)
 "vbK" = (
 /turf/closed/wall,
 /area/station/science/research)
@@ -63465,17 +62662,10 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "vbR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
-"vbS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/status_display/ai/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "vcd" = (
 /obj/structure/chair{
 	dir = 8
@@ -63515,12 +62705,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Law Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -63529,11 +62719,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "vdg" = (
@@ -63542,10 +62732,10 @@
 /area/space/nearstation)
 "vdj" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 2
-	},
-/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -63582,12 +62772,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"vdN" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "vdX" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -63609,10 +62793,10 @@
 /obj/effect/turf_decal/siding{
 	dir = 6
 	},
+/obj/item/assembly/igniter,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/assembly/igniter,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "vej" = (
@@ -63624,10 +62808,6 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/engine/atmos)
-"veq" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
 "vex" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -63701,6 +62881,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
+"vfH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vfI" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/siding/end{
@@ -63712,18 +62900,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen)
 "vfK" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "vfN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63788,27 +62968,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "vgy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
 /area/station/hallway/secondary/dock)
 "vgz" = (
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/tcommsat/server)
 "vgL" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
@@ -63839,12 +63017,11 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
 "vgY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "vhr" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -63859,15 +63036,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"vhC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"vhu" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/command/glass{
+	name = "Telecommunications Server Room"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "comms-entrance-south"
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/server)
 "vhI" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -63877,14 +63056,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"vhJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "vid" = (
-/obj/structure/closet/emcloset,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/aft)
 "vij" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -63904,15 +63079,15 @@
 	},
 /area/station/science/research)
 "viy" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "viA" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/server)
 "viE" = (
@@ -63924,13 +63099,13 @@
 /area/station/maintenance/department/electrical)
 "viK" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "viP" = (
@@ -63939,19 +63114,8 @@
 /area/station/maintenance/starboard/central)
 "viT" = (
 /obj/machinery/light/cold/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"viV" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
 "viW" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -63978,10 +63142,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vjp" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/power/floodlight,
 /obj/structure/alien/weeds,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "vjs" = (
@@ -64000,31 +63164,34 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/toilet/restrooms)
+"vjV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/lower)
+"vjX" = (
+/mob/living/basic/mining/lobstrosity,
+/turf/open/misc/asteroid/airless,
+/area/space/nearstation)
 "vkh" = (
 /turf/closed/wall,
 /area/station/service/bar)
 "vkr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/fore)
-"vks" = (
-/obj/structure/cable,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "vkt" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "vkC" = (
@@ -64035,16 +63202,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vkD" = (
-/obj/structure/table,
-/obj/item/stack/ore/gold{
-	pixel_x = 5;
-	pixel_y = 13
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_y = 3;
+	pixel_x = 1
 	},
-/obj/item/stack/ore/uranium{
-	pixel_y = 6
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 2;
+	pixel_x = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "vkI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -64062,9 +63231,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "vkN" = (
@@ -64101,9 +63267,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
 "vkV" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
 "vkW" = (
@@ -64157,7 +63323,6 @@
 /area/station/maintenance/aft)
 "vlX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
@@ -64200,19 +63365,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "vmr" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "vmt" = (
@@ -64238,9 +63400,9 @@
 	},
 /area/station/service/chapel/office)
 "vmJ" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "vmL" = (
@@ -64266,10 +63428,10 @@
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "vnf" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side,
@@ -64398,8 +63560,8 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "voh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "voj" = (
@@ -64488,7 +63650,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central/fore)
 "vpZ" = (
@@ -64545,13 +63706,13 @@
 /turf/open/floor/circuit,
 /area/station/science/server)
 "vqX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecommunications Server Room"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "vrf" = (
@@ -64569,13 +63730,6 @@
 	dir = 8
 	},
 /area/station/engineering/main)
-"vrj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "vrn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -64597,9 +63751,6 @@
 /area/station/security/detectives_office)
 "vrB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "vrO" = (
@@ -64660,9 +63811,7 @@
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
 "vsi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "vso" = (
@@ -64684,17 +63833,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/augments)
 "vsQ" = (
-/obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
@@ -64708,6 +63857,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"vtd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "vtr" = (
 /obj/machinery/light/floor,
 /turf/open/floor/wood/parquet,
@@ -64763,10 +63919,10 @@
 /area/station/cargo/drone_bay)
 "vum" = (
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
 "vun" = (
@@ -64801,12 +63957,12 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
 "vuB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/door/airlock/research/glass{
 	name = "Xenobiology Kill Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
 "vuD" = (
@@ -64876,10 +64032,10 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "vve" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Aft Corridor"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/hallway/primary/aft)
 "vvs" = (
@@ -64966,23 +64122,15 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/medical/central)
-"vwx" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/tcommsat/server)
 "vwE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
 /obj/item/kirbyplants/random{
 	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
@@ -64994,13 +64142,13 @@
 /turf/open/floor/iron/checker,
 /area/station/command/heads_quarters/hos)
 "vwJ" = (
+/obj/item/radio/intercom/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "vwQ" = (
@@ -65053,9 +64201,6 @@
 /area/station/maintenance/department/science/xenobiology)
 "vxs" = (
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "vxt" = (
@@ -65085,13 +64230,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "vyi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
@@ -65145,12 +64290,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"vzh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
 "vzt" = (
 /obj/structure/hedge,
 /obj/machinery/light/cold/directional/east,
@@ -65163,24 +64302,12 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"vzy" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "vzA" = (
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "vzD" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/storage)
 "vzE" = (
@@ -65203,11 +64330,11 @@
 /turf/open/floor/engine/helium,
 /area/station/ai_monitored/turret_protected/ai)
 "vzN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/research/glass{
 	name = "Cytology Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/research)
 "vzV" = (
@@ -65258,9 +64385,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vAx" = (
@@ -65291,18 +64415,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"vAT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Applied Sciences"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-entrance"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/textured_half,
-/area/station/science/lobby)
 "vAX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Applied Sciences"
@@ -65327,12 +64439,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"vBZ" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "vCc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Lockers"
@@ -65354,13 +64460,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"vCl" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tcomms)
 "vCm" = (
 /obj/structure/railing{
 	dir = 1
@@ -65382,11 +64481,12 @@
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
 "vCs" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vCu" = (
@@ -65408,8 +64508,8 @@
 /area/station/science/ordnance/storage)
 "vCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vDe" = (
@@ -65430,9 +64530,9 @@
 /area/station/medical/medbay/central)
 "vDC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "vDG" = (
@@ -65452,15 +64552,6 @@
 "vDX" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
-"vDZ" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/service/bar)
 "vEa" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen/small,
@@ -65480,15 +64571,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"vEn" = (
-/obj/effect/turf_decal/tile/blue,
+"vEm" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/dock)
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tcomms)
 "vEz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -65536,11 +64625,11 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/shower)
 "vFh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/central)
 "vFm" = (
@@ -65570,11 +64659,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "vFB" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "vFD" = (
@@ -65616,12 +64705,12 @@
 /turf/open/floor/iron,
 /area/station/security/tram)
 "vGe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /obj/effect/landmark/start/clown,
 /turf/open/floor/iron/smooth,
@@ -65664,12 +64753,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "vGX" = (
-/obj/structure/bodycontainer/morgue{
+/obj/structure/disposaloutlet{
+	desc = "An outlet for the pneumatic disposal system. This one seems designed for rapid corpse disposal.";
+	name = "rapid corpse mover 9000";
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light_switch/directional/west,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark/small,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating,
 /area/station/medical/morgue)
 "vHu" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
@@ -65684,12 +64777,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vHH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
@@ -65721,9 +64814,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
+"vIa" = (
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "vId" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/station/science/lower)
 "vIt" = (
@@ -65736,17 +64835,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "vIz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/structure/chair,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "vIC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "vIJ" = (
@@ -65841,11 +64939,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "vJR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/medical{
 	name = "Medbay"
 	},
@@ -65875,9 +64973,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "vKe" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/power/smes/full,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
 "vKi" = (
@@ -65920,13 +65018,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "vKX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/machinery/camera/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/science/lower)
 "vKY" = (
@@ -65969,12 +65067,6 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
-"vLv" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/station/science/xenobiology)
 "vLC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
@@ -65993,12 +65085,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Augment Corridor"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/augments)
 "vLQ" = (
@@ -66020,6 +65112,11 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
+"vMi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "vMr" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/alien/weeds,
@@ -66058,8 +65155,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "vMJ" = (
-/obj/structure/disposalpipe/sorting/mail,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -66136,19 +65233,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"vOb" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry)
 "vOf" = (
-/obj/structure/cable,
 /obj/structure/chair{
 	dir = 1;
 	pixel_y = -2
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lower)
 "vOg" = (
@@ -66160,11 +65251,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
-"vOr" = (
+"vOt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "vOL" = (
 /obj/structure/railing{
 	dir = 1
@@ -66198,8 +65291,8 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "vPs" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -66229,11 +65322,11 @@
 /area/station/command/corporate_suite)
 "vPS" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "vQk" = (
@@ -66294,13 +65387,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"vRh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/research)
 "vRt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66350,8 +65436,8 @@
 /turf/open/floor/wood,
 /area/station/engineering/atmos/pumproom)
 "vSw" = (
-/obj/effect/landmark/start/hangover,
 /obj/structure/cable,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vSx" = (
@@ -66363,10 +65449,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
 "vSI" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/small,
 /area/station/service/bar)
 "vSL" = (
@@ -66380,9 +65466,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vSM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command{
 	name = "Telecomms Server Room"
 	},
@@ -66391,6 +65474,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "comms-entrance-north"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "vSW" = (
@@ -66405,17 +65491,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "vTf" = (
+/obj/machinery/air_sensor/ordnance_freezer_chamber,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 4
 	},
-/obj/machinery/air_sensor/ordnance_freezer_chamber,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
 "vTg" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecommunications Server Room"
@@ -66423,6 +65508,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "comms-entrance-north"
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "vTj" = (
@@ -66455,12 +65541,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"vTv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "vTx" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -66648,23 +65728,23 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "vVX" = (
-/obj/structure/cable,
 /obj/machinery/telecomms/processor/preset_one,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "vWa" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 5
+/obj/effect/landmark/start/coroner,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 2
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop,
-/turf/open/floor/iron/small,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vWe" = (
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/corner,
 /area/station/science/lobby)
 "vWr" = (
@@ -66766,9 +65846,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "vXn" = (
-/obj/item/wirecutters,
-/turf/open/floor/iron/white/diagonal,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/space/basic,
+/area/space)
 "vXr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -66800,8 +65880,8 @@
 	},
 /area/station/science/lobby)
 "vXH" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/lower)
 "vXL" = (
@@ -66815,17 +65895,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
+"vYi" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "vYj" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"vYv" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "vYx" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
@@ -66872,9 +65953,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -66886,8 +65967,8 @@
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
 "vYS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/central)
 "vYT" = (
@@ -66920,6 +66001,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vZf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "vZm" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
@@ -66969,9 +66055,6 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/item/folder/red,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "wap" = (
@@ -66989,9 +66072,6 @@
 "wat" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -67036,9 +66116,6 @@
 "waY" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/gibber,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
@@ -67088,8 +66165,6 @@
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "wbO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding{
 	dir = 6
 	},
@@ -67097,22 +66172,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white/small,
-/area/station/science/lab)
-"wco" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/station/science/research)
+/turf/open/floor/iron/white/small,
+/area/station/science/lab)
 "wcp" = (
 /turf/closed/wall/r_wall,
 /area/station/science/genetics)
 "wcq" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
@@ -67146,12 +66216,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "wcP" = (
 /obj/machinery/modular_computer/preset/cargochat/cargo,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "wcR" = (
@@ -67161,11 +66225,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"wcT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/cubicle)
 "wcV" = (
 /obj/structure/closet/crate,
 /obj/item/food/breadslice/plain,
@@ -67190,18 +66259,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/meter,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"wdd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
 "wdk" = (
 /turf/closed/mineral/random/stationside,
 /area/station/maintenance/starboard/greater)
@@ -67221,10 +66280,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wdS" = (
+/obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "wdY" = (
@@ -67242,14 +66301,14 @@
 /area/station/science/robotics/mechbay)
 "wed" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Augment Corridor"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/augments)
 "wen" = (
@@ -67297,12 +66356,6 @@
 "wfr" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
-"wfu" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "wfG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
@@ -67320,6 +66373,7 @@
 "wgp" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "wgs" = (
@@ -67424,14 +66478,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "whu" = (
-/obj/structure/cable,
 /obj/machinery/blackbox_recorder,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "whA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Construction Hatch"
@@ -67440,6 +66491,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "whD" = (
@@ -67488,9 +66542,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wie" = (
@@ -67499,9 +66550,6 @@
 	},
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/lobby)
 "win" = (
@@ -67510,24 +66558,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/security/brig/entrance)
-"wir" = (
-/obj/effect/turf_decal/box/red/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
-"wiw" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/locker_room)
 "wiC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -67547,19 +66577,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"wiO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/commons/vacant_room/office)
 "wiP" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "wja" = (
-/turf/closed/wall/r_wall,
-/area/station/commons/toilet/auxiliary)
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "wjq" = (
 /obj/structure/sign/painting/large/library{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -67609,16 +66642,20 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"wkq" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/command/meeting_room)
 "wkF" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/recreation)
 "wkG" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -67634,6 +66671,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"wlo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "wme" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -67644,15 +66688,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "wmu" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/fireaxecabinet/directional/east,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
 /area/station/command/meeting_room)
 "wmx" = (
 /obj/structure/cable,
@@ -67680,9 +66723,9 @@
 /area/station/hallway/secondary/dock)
 "wmD" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "wmE" = (
@@ -67774,6 +66817,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"wnI" = (
+/obj/machinery/door/airlock/glass,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
+"wnO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/science/research)
 "wnR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67795,11 +66851,6 @@
 "woi" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/fore)
-"wos" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "woz" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/camera/autoname/directional/east,
@@ -67818,7 +66869,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
@@ -67860,9 +66914,6 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "woY" = (
@@ -67902,8 +66953,6 @@
 /turf/closed/wall/r_wall,
 /area/station/security/processing)
 "wqb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
@@ -67912,6 +66961,8 @@
 	name = "Xenobiology Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "wqj" = (
@@ -67958,9 +67009,6 @@
 "wqY" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
 "wrj" = (
@@ -68010,10 +67058,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/end{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "wrO" = (
@@ -68035,26 +67083,30 @@
 /turf/open/floor/carpet/lone,
 /area/station/service/abandoned_gambling_den)
 "wrW" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/security{
 	dir = 8
 	},
 /obj/machinery/camera/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
 "wrZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "wsa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
@@ -68062,9 +67114,6 @@
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
@@ -68088,9 +67137,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "wsL" = (
@@ -68102,21 +67148,21 @@
 /area/station/maintenance/starboard/fore)
 "wsR" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "wtc" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/side,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "wtd" = (
 /obj/effect/turf_decal/delivery,
@@ -68142,12 +67188,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
-"wtp" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/misc/dirt/station,
-/area/station/service/chapel)
 "wtq" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -68169,9 +67209,6 @@
 /turf/closed/wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "wtu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload"
@@ -68180,6 +67217,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "wtv" = (
@@ -68235,9 +67275,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wtT" = (
+/obj/machinery/light/cold/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -68256,27 +67296,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "wuj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wum" = (
 /turf/closed/wall/r_wall,
 /area/station/security/medical)
-"wuo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/science/lobby)
 "wup" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
@@ -68287,10 +67316,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wuq" = (
-/obj/structure/table,
-/obj/effect/spawner/random/techstorage/rnd_secure_all,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/dead_body_placer{
+	bodycount = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "wur" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line,
@@ -68359,9 +67393,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "wvM" = (
+/obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/floor,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
 "wvZ" = (
@@ -68398,7 +67432,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wwz" = (
-/obj/structure/cable,
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
@@ -68406,21 +67439,32 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
 "wwI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
 /area/station/science/lower)
+"wwK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "wwQ" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
+"wwT" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "wwU" = (
 /obj/structure/hedge,
 /obj/machinery/camera/autoname/directional/east,
@@ -68432,18 +67476,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "wxd" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/fore)
-"wxu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/central)
 "wxG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/dim/directional/north,
@@ -68490,18 +67530,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"wxZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/science/xenobiology)
 "wya" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
@@ -68509,9 +67537,6 @@
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "wyb" = (
@@ -68537,6 +67562,12 @@
 /obj/effect/spawner/random/decoration/flower,
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
+"wyo" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/security/checkpoint/customs)
 "wyy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/scan_consolenew{
@@ -68636,11 +67667,14 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/breakroom)
 "wAf" = (
-/obj/structure/chair/plastic{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "wAh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68665,6 +67699,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
+"wAl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/starboard)
 "wAS" = (
 /obj/structure/table/wood,
 /obj/item/hand_labeler,
@@ -68696,10 +67737,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wBi" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Supplies Depot"
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
@@ -68730,16 +67771,16 @@
 /turf/open/floor/plating,
 /area/station/science/cytology)
 "wBN" = (
-/obj/structure/bed/maint,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "wCa" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "wCc" = (
@@ -68750,9 +67791,6 @@
 "wCt" = (
 /obj/machinery/flasher/directional/east{
 	id = "hopflash"
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
 	},
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central/fore)
@@ -68861,13 +67899,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"wEf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "wEs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68887,15 +67918,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/service/hydroponics)
-"wEC" = (
-/obj/structure/disposalpipe/segment,
+"wEw" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/science/lower)
+/turf/open/space/basic,
+/area/space/nearstation)
 "wEF" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -68917,12 +67944,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wFa" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "wFd" = (
@@ -68955,9 +67982,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wFQ" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "wFV" = (
@@ -68981,10 +68008,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "wGq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "wGu" = (
@@ -69038,15 +68065,26 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wGU" = (
-/obj/structure/table,
-/obj/effect/spawner/random/techstorage/ai_all,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "wHg" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
+"wHl" = (
+/obj/structure/transit_tube/crossing/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/space/basic,
+/area/space/nearstation)
+"wHJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/iron/dark/small,
+/area/station/tcommsat/server)
 "wHN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69068,12 +68106,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "wHS" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -69084,13 +68122,10 @@
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
 "wIm" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Centcom Dock"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/command/storage/eva)
 "wIp" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/space/basic,
@@ -69105,11 +68140,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"wIY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
 "wJd" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/construction)
@@ -69118,10 +68148,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"wJo" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "wJv" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -69217,10 +68243,12 @@
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "wKm" = (
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/dark_blue/corner{
+	dir = 1
 	},
-/turf/open/floor/iron/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "wKn" = (
 /obj/machinery/camera/autoname/directional/north,
@@ -69300,12 +68328,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wLZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wMg" = (
@@ -69330,7 +68358,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "wME" = (
-/obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/spawner/round_default_module,
@@ -69338,6 +68365,7 @@
 /obj/item/radio/intercom/directional/north{
 	pixel_x = 27
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "wMG" = (
@@ -69363,7 +68391,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/server)
 "wMP" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69371,6 +68398,7 @@
 /obj/machinery/light/cold/directional/north,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/lobby)
 "wMT" = (
@@ -69386,13 +68414,13 @@
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "wNb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/assembly/timer{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -69401,13 +68429,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"wNg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/science/robotics/mechbay)
 "wNs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69455,9 +68476,9 @@
 /turf/open/floor/tram,
 /area/station/security/tram)
 "wNT" = (
+/obj/machinery/light_switch/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "wNU" = (
@@ -69483,6 +68504,17 @@
 /obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/sepia,
 /area/station/maintenance/aft)
+"wOc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/science/xenobiology)
 "wOh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/glass,
@@ -69655,7 +68687,6 @@
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "wPX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/office{
 	dir = 4
@@ -69663,6 +68694,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -69732,15 +68764,15 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "wQP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Network Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "wQT" = (
@@ -69767,10 +68799,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "wRd" = (
+/obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
@@ -69779,11 +68811,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"wRo" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
-	dir = 10
+"wRm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input,
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
+"wRo" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
+	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
 "wRy" = (
@@ -69819,6 +68859,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "wRP" = (
+/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Atmospherics - South"
 	},
@@ -69839,12 +68880,11 @@
 /obj/item/flashlight{
 	pixel_y = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "wRU" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/plating,
+/obj/effect/landmark/start/coroner,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "wSg" = (
 /obj/effect/turf_decal/tile/blue{
@@ -69873,19 +68913,14 @@
 /obj/item/stack/medical/gauze,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"wSH" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/open/floor/iron/textured_half,
-/area/station/engineering/storage/tech)
 "wSL" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/techstorage/engineering_all,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/obj/structure/bonfire,
+/obj/item/storage/box/matches{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/turf/open/misc/dirt/station,
+/area/station/maintenance/department/science/xenobiology)
 "wSZ" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/hallway/abandoned_command)
@@ -69994,9 +69029,6 @@
 	req_access = list("medical")
 	},
 /obj/machinery/keycard_auth/wall_mounted/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
 "wTX" = (
@@ -70040,8 +69072,8 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "wVg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "wVr" = (
@@ -70100,9 +69132,6 @@
 /obj/item/restraints/handcuffs,
 /obj/item/reagent_containers/spray/pepper,
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "wWS" = (
@@ -70110,9 +69139,9 @@
 /area/station/security/prison)
 "wWU" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/trash,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/engineering/storage/tech)
 "wWX" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
@@ -70194,12 +69223,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/tile,
 /area/station/science/lower)
-"wYd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
 "wYv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
@@ -70213,14 +69236,6 @@
 "wYA" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
-"wYH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/commons/dorms)
 "wYK" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/wideplating{
@@ -70248,12 +69263,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/hallway/secondary/exit/departure_lounge)
-"wZk" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
 "wZp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -70290,10 +69299,10 @@
 /area/station/hallway/primary/central/aft)
 "wZA" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "wZF" = (
@@ -70317,13 +69326,13 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xam" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"xae" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/station/science/research)
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "xap" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -70331,16 +69340,6 @@
 "xat" = (
 /turf/closed/wall,
 /area/station/cargo/office)
-"xau" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "xaC" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -70354,14 +69353,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xaI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/ai/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "xaN" = (
@@ -70376,10 +69375,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
 "xaW" = (
-/obj/structure/cable,
 /obj/structure/hedge,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
 "xba" = (
 /obj/effect/turf_decal/stripes/line{
@@ -70396,8 +69393,13 @@
 /area/station/cargo/miningoffice)
 "xbe" = (
 /obj/structure/cable,
-/turf/open/floor/grass,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/hallway/secondary/command)
 "xbg" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -70430,13 +69432,6 @@
 /obj/structure/hedge,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
-"xbT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "xbV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floor,
@@ -70528,10 +69523,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/cytology)
-"xdc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "xdo" = (
 /obj/machinery/firealarm/directional/north,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -70541,19 +69532,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "xds" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
 /area/station/science/research)
 "xdu" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xdv" = (
@@ -70603,13 +69594,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xer" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
 	name = "Research Director's Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/research)
 "xeC" = (
@@ -70658,9 +69649,6 @@
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -70735,13 +69723,6 @@
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
 /turf/open/floor/iron,
 /area/station/security)
-"xfu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
 "xfy" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/fluff/tram_rail/floor{
@@ -70805,9 +69786,6 @@
 "xgg" = (
 /obj/structure/chair{
 	pixel_y = -2
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs/auxiliary)
@@ -70879,14 +69857,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/fore)
-"xhl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "xhC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70908,9 +69878,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/navigate_destination/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "xhM" = (
@@ -70936,14 +69906,6 @@
 "xik" = (
 /turf/closed/wall,
 /area/station/security/prison/rec)
-"xil" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/command/meeting_room)
 "xin" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70966,28 +69928,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"xiN" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Equipment Storage";
-	pixel_x = -1;
-	req_access = list("eva")
-	},
-/obj/structure/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - South"
-	},
-/turf/open/floor/iron/large,
-/area/station/ai_monitored/command/storage/eva)
 "xiS" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -71001,13 +69941,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xiT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "xjb" = (
@@ -71033,13 +69973,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "xjo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/warning/pods/directional/north,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -71051,10 +69991,10 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "xjE" = (
@@ -71118,20 +70058,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"xko" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "xkt" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
-"xkK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/science/xenobiology)
 "xkO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
@@ -71253,11 +70195,6 @@
 /obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
-"xnk" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
 "xno" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -71292,7 +70229,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "xnR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
@@ -71300,21 +70236,28 @@
 	chamber_id = "ordnanceburn"
 	},
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"xnY" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "xoa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xoh" = (
@@ -71336,19 +70279,38 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "xoS" = (
+/obj/structure/cable,
+/obj/structure/table/bronze,
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
-	dir = 9
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/small,
-/area/station/ai_monitored/command/storage/eva)
-"xoW" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/command/meeting_room)
+"xoW" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -71404,26 +70366,15 @@
 /turf/closed/wall,
 /area/station/maintenance/hallway/abandoned_command)
 "xpR" = (
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"xpU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "xpV" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/thermoplastic,
@@ -71431,17 +70382,8 @@
 /area/station/security/tram)
 "xpY" = (
 /obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/t_scanner,
-/obj/item/multitool,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "xqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken/directional/east,
@@ -71453,11 +70395,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"xqn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/small,
-/area/station/science/cubicle)
 "xqp" = (
 /obj/structure/railing{
 	dir = 4
@@ -71481,13 +70418,10 @@
 /area/station/service/abandoned_gambling_den/gaming)
 "xqv" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/turf_decal/weather/snow/corner{
+/obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_half{
@@ -71518,22 +70452,22 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "xrc" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "xre" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/augments)
 "xrt" = (
@@ -71545,7 +70479,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central/fore)
 "xru" = (
@@ -71603,15 +70536,12 @@
 	},
 /area/station/command/heads_quarters/ce)
 "xrX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/right/directional/south{
 	name = "Upload Console Window";
 	req_access = list("ai_upload")
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xrZ" = (
@@ -71623,26 +70553,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"xsa" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
 "xsb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xsf" = (
@@ -71650,9 +70570,6 @@
 /area/station/security/breakroom)
 "xsh" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half{
@@ -71708,6 +70625,7 @@
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "xsK" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -71718,13 +70636,12 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/starboard)
 "xsM" = (
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -71744,30 +70661,30 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xsT" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xsV" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/aft)
 "xsW" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -71804,12 +70721,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "xtD" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "xtI" = (
@@ -71822,13 +70739,12 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "xtP" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner,
+/turf/open/floor/wood/tile,
+/area/station/command/meeting_room)
 "xtU" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/effect/landmark/navigate_destination/med,
@@ -71854,13 +70770,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=10.0-ScienceFoyer-StarboardHall";
 	location = "9.0-StarboardHall-ScienceFoyer"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xuv" = (
@@ -71873,9 +70789,9 @@
 /area/station/command/heads_quarters/ce)
 "xuD" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Chemistry Lab"
@@ -71910,17 +70826,17 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms)
 "xuW" = (
+/obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
 /area/station/science/research)
 "xva" = (
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -71941,7 +70857,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xvv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
@@ -71949,14 +70864,14 @@
 	},
 /area/station/science/research)
 "xvx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/effect/landmark/start/depsec/science,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "xvF" = (
@@ -71965,19 +70880,13 @@
 "xvK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
-"xvM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/recreation)
 "xvR" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/stripes,
@@ -71999,16 +70908,20 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "xvV" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"xvY" = (
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/science/xenobiology)
 "xwd" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -72040,7 +70953,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
@@ -72052,21 +70964,17 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
 /area/station/science/research)
 "xwu" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
-"xww" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
 "xwz" = (
 /turf/closed/wall,
 /area/station/cargo/miningfoundry)
@@ -72096,10 +71004,15 @@
 /obj/structure/bed/maint,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"xxa" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+"xwU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/science/ordnance/storage)
 "xxj" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -72132,9 +71045,6 @@
 /area/station/maintenance/starboard/greater)
 "xxD" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "xxL" = (
@@ -72160,9 +71070,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "xyh" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/airlock/medical/glass{
@@ -72241,11 +71151,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/entry)
 "xyZ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/broken_flooring/pile/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xzd" = (
@@ -72311,11 +71221,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "xAv" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xAA" = (
@@ -72324,9 +71234,6 @@
 	},
 /obj/structure/chair{
 	pixel_y = -2
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -72339,10 +71246,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"xAM" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
 "xAO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72358,9 +71261,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"xAU" = (
-/turf/open/floor/fake_snow,
-/area/station/engineering/atmos/project)
 "xBd" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7";
@@ -72380,13 +71280,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xBp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "xBx" = (
@@ -72397,9 +71297,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -72432,7 +71329,6 @@
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
 "xCl" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs,
@@ -72459,7 +71355,7 @@
 /area/station/security/execution/transfer)
 "xCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
@@ -72515,19 +71411,19 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/starboard)
 "xDS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "xEd" = (
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
 "xEe" = (
@@ -72535,26 +71431,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "xEn" = (
+/obj/machinery/airlock_sensor/incinerator_ordmix{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_x = 24
-	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "xEo" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/flowers_yw,
-/turf/open/floor/grass,
-/area/station/science/xenobiology)
-"xEq" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
+/turf/open/floor/iron/smooth_large,
+/area/station/science/robotics/mechbay)
 "xEv" = (
 /obj/structure/sign/departments/holy/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72577,12 +71471,12 @@
 /turf/open/misc/sandy_dirt,
 /area/station/commons/fitness/locker_room)
 "xEQ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
-	dir = 1
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/freezerchamber)
@@ -72608,20 +71502,8 @@
 	pixel_x = -5
 	},
 /obj/machinery/light/cold/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/small,
 /area/station/medical/cryo)
-"xFd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/command/glass{
-	name = "Telecommunications Server Room"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/tcommsat/server)
 "xFe" = (
 /turf/closed/wall,
 /area/station/security/lockers)
@@ -72654,11 +71536,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "xFI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/door/airlock/research/glass{
 	name = "Freezer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/freezerchamber)
 "xFL" = (
@@ -72745,13 +71627,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"xGY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "xHc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -72768,16 +71643,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/security/checkpoint/escape)
-"xHf" = (
-/obj/structure/chair{
-	dir = 1;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/checkpoint/customs/auxiliary)
 "xHi" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
@@ -72815,15 +71680,20 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"xHS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tcomms)
 "xIf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "xIj" = (
@@ -72835,11 +71705,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"xIk" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/science/lobby)
 "xIl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72893,8 +71758,8 @@
 	},
 /area/station/hallway/secondary/dock)
 "xJm" = (
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "xJw" = (
@@ -72929,6 +71794,19 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos/storage)
+"xJW" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/ai_monitored/command/storage/eva)
 "xJZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72999,6 +71877,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/processing)
+"xKA" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "xKG" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -73036,9 +71920,6 @@
 	c_tag = "Xenobiology - Killroom Chamber";
 	name = "xenobiology camera";
 	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/science/xenobiology)
@@ -73089,9 +71970,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xLS" = (
@@ -73140,6 +72018,9 @@
 /area/station/maintenance/port/lesser)
 "xMk" = (
 /obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "xMo" = (
@@ -73165,13 +72046,13 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
 "xMK" = (
+/obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "xMM" = (
@@ -73208,6 +72089,14 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
+"xNL" = (
+/obj/machinery/door/airlock{
+	name = "Auxiliary Bathrooms"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/entry)
 "xNX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -73255,9 +72144,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/storage/dice,
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "xPd" = (
@@ -73306,17 +72192,17 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "xPv" = (
+/obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "xPx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
 "xPH" = (
@@ -73324,17 +72210,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "xPJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xPN" = (
@@ -73350,11 +72236,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "xPY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/departments/aiupload/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "xQa" = (
@@ -73374,10 +72260,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "xQj" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -73402,9 +72288,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xQD" = (
@@ -73421,11 +72304,6 @@
 "xQJ" = (
 /turf/closed/wall,
 /area/station/service/abandoned_gambling_den/gaming)
-"xQW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "xQX" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/diagonal,
@@ -73439,15 +72317,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"xRg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "xRh" = (
 /obj/structure/chair{
 	dir = 8
@@ -73472,13 +72341,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"xRr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "xRA" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -73494,8 +72356,8 @@
 	},
 /area/station/hallway/primary/central/fore)
 "xRB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "xRC" = (
@@ -73510,9 +72372,9 @@
 /turf/closed/wall,
 /area/station/maintenance/fore/lesser)
 "xRI" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -73540,13 +72402,12 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
 "xSd" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "xSe" = (
 /obj/structure/table/glass,
@@ -73569,12 +72430,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"xSx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/hallway/secondary/command)
 "xSF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -73613,13 +72468,6 @@
 /obj/structure/sign/departments/med/directional/north,
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/sorting)
-"xSZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "xTf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -73629,9 +72477,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xTo" = (
-/obj/structure/cable,
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "xTr" = (
@@ -73705,9 +72553,6 @@
 	name = "Medbay Lockdown Control";
 	req_access = list("medical")
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xUr" = (
@@ -73717,11 +72562,8 @@
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xUt" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xUy" = (
@@ -73730,14 +72572,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "xUB" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/sign/plaques/kiddie{
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xUK" = (
@@ -73777,11 +72616,8 @@
 /obj/effect/turf_decal/siding/thinplating/terracotta/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "xUV" = (
@@ -73807,22 +72643,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"xUX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
+"xVd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"xVd" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/item/stack/ore/slag,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
-"xVj" = (
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
+"xVj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -73831,10 +72659,10 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "xVn" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/conveyor_switch/oneway{
@@ -73842,29 +72670,14 @@
 	pixel_x = 10;
 	pixel_y = 11
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"xVv" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/small,
-/area/station/science/cubicle)
-"xVG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/side,
-/area/station/science/research)
 "xVV" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "xVY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/restraints/handcuffs,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -73874,6 +72687,8 @@
 	pixel_x = -5;
 	pixel_y = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "xWd" = (
@@ -73913,9 +72728,6 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/science/robotics/mechbay)
 "xWw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
@@ -73923,6 +72735,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/science,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "xWz" = (
@@ -73961,8 +72776,8 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "xWL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
 "xWW" = (
@@ -73993,8 +72808,8 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
 "xXr" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -74006,21 +72821,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"xXv" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/station/security/courtroom)
 "xXy" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xXD" = (
@@ -74113,12 +72919,13 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "xYE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "xYG" = (
 /turf/closed/wall,
 /area/station/engineering/supermatter/room)
@@ -74151,10 +72958,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xZs" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/siding/white,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
@@ -74172,17 +72979,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"xZJ" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
 "xZN" = (
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 8
@@ -74196,11 +72994,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
 "xZX" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xZY" = (
@@ -74267,15 +73065,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
-"yba" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"ybf" = (
-/turf/open/floor/fake_snow,
-/area/station/engineering/main)
 "ybh" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -74304,13 +73093,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "ybD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Arrivals"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
@@ -74370,18 +73159,11 @@
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
 "ycj" = (
+/obj/structure/broken_flooring/singular/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"ycm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "ycq" = (
 /obj/machinery/modular_computer/preset/cargochat/science{
 	dir = 1
@@ -74458,12 +73240,6 @@
 "yeh" = (
 /turf/closed/wall,
 /area/station/hallway/primary/starboard)
-"yel" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "yep" = (
 /obj/structure/rack,
 /obj/item/storage/box/bodybags{
@@ -74519,6 +73295,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"yeI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "yeO" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -74528,12 +73311,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
 "yeQ" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Xenolab";
 	name = "Test Chamber Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "yeS" = (
@@ -74573,20 +73356,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/xenobiology)
-"yfz" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/aft)
 "yfA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/area/station/science/research)
+/turf/open/floor/iron/dark/textured,
+/area/station/command/heads_quarters/hop)
 "yfC" = (
 /turf/closed/wall,
 /area/station/service/hydroponics)
@@ -74634,9 +73410,6 @@
 	c_tag = "Xenobiology Lab - Test Chamber";
 	network = list("ss13","rd","xeno")
 	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "ygu" = (
@@ -74670,15 +73443,20 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "yha" = (
-/obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/door/window/right/directional/north{
 	name = "Core Modules";
 	req_access = list("captain")
 	},
 /obj/effect/spawner/random/aimodule/harmless,
+/obj/structure/cable,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"yhn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/server)
 "yhq" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -74693,8 +73471,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "yhF" = (
@@ -74719,6 +73495,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"yhT" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "yhW" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -74813,12 +73596,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/starboard)
-"yiU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
 "yiY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -74843,10 +73620,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "yjt" = (
+/obj/machinery/newscaster/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
 "yjy" = (
@@ -74935,12 +73712,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"ykn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "ykz" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -74957,10 +73728,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/brig)
 "ylo" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
@@ -74972,11 +73743,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ylq" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding,
+/obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/science/lobby)
 "yly" = (
@@ -75012,12 +73783,6 @@
 /obj/structure/alien/resin/wall,
 /obj/structure/alien/weeds,
 /turf/open/floor/wood,
-/area/station/maintenance/starboard/greater)
-"ymh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 
 (1,1,1) = {"
@@ -81232,9 +79997,9 @@ dDB
 blb
 oBP
 mHG
-iIz
-gFc
-jYQ
+lmJ
+lmJ
+lmJ
 lmJ
 yaT
 cwf
@@ -81489,10 +80254,10 @@ tYT
 liQ
 oBP
 mHG
-iIz
-xAU
-xAU
-oqB
+lmJ
+lmJ
+lmJ
+lmJ
 yaT
 cwf
 gbh
@@ -81746,10 +80511,10 @@ aJq
 liQ
 oBP
 mHG
-gcF
-sOf
-xAU
-gFc
+lmJ
+lmJ
+lmJ
+lmJ
 rDU
 hYC
 bLp
@@ -82003,10 +80768,10 @@ aJq
 aJq
 pCn
 bDQ
-xAU
-xAU
-xAU
-bWK
+lmJ
+lmJ
+lmJ
+lmJ
 yaT
 cwf
 gbh
@@ -82260,9 +81025,9 @@ tYT
 liQ
 oBP
 mHG
-hgy
-hgy
-hgy
+lmJ
+lmJ
+lmJ
 lmJ
 yaT
 krb
@@ -84085,7 +82850,7 @@ ybO
 ybO
 xNX
 fAD
-iWc
+civ
 ruh
 ybO
 tYT
@@ -84342,8 +83107,8 @@ dEw
 cwf
 amb
 fAD
-iWc
-mtI
+civ
+gbh
 ybO
 tYT
 aJq
@@ -84599,8 +83364,8 @@ lRy
 klg
 gjU
 eyY
-iWc
-mtI
+civ
+gbh
 ybO
 ybO
 bNq
@@ -84857,9 +83622,9 @@ cwf
 amb
 fAD
 civ
-pTh
-nuz
-dag
+urh
+pUQ
+pZp
 bNq
 aJq
 aJq
@@ -85178,7 +83943,7 @@ aNZ
 rQS
 rQS
 dBH
-fGd
+snZ
 mni
 rQS
 jGN
@@ -85434,8 +84199,8 @@ yal
 tWB
 yal
 yal
-kDi
-cnT
+yal
+tms
 smh
 tms
 lxZ
@@ -85692,7 +84457,7 @@ yaI
 xyM
 yaI
 xQy
-cBu
+qRN
 erg
 yaI
 xdv
@@ -86196,7 +84961,7 @@ tzq
 mhk
 mhk
 aRa
-lPz
+onw
 onw
 onw
 gdn
@@ -86434,9 +85199,9 @@ lPi
 uzJ
 eib
 knk
-vrj
-nyZ
-vbS
+ppk
+uzJ
+ovQ
 oSb
 edA
 uzJ
@@ -86691,7 +85456,7 @@ lOj
 jTA
 qYG
 pZK
-cfn
+xKI
 kQM
 kQj
 pZK
@@ -86949,7 +85714,7 @@ moz
 vjs
 odX
 odX
-ggD
+odX
 odX
 odX
 rWK
@@ -86961,7 +85726,7 @@ ozt
 sqz
 bHw
 mhk
-pWw
+iSD
 pbw
 twN
 mSQ
@@ -87201,7 +85966,7 @@ cvP
 rWP
 kMY
 jWA
-boj
+uzJ
 jtB
 jJw
 fxO
@@ -87458,7 +86223,7 @@ ggn
 nyf
 ejq
 oEL
-boj
+uzJ
 vzD
 amq
 mRD
@@ -87481,8 +86246,8 @@ uoR
 neF
 hed
 hAB
-oSH
-wtp
+jCm
+iSD
 bnQ
 fVF
 wBm
@@ -87739,7 +86504,7 @@ hmC
 xZe
 eWk
 hAB
-ple
+iSD
 cib
 vTn
 wBm
@@ -87996,7 +86761,7 @@ sOi
 tts
 dRn
 keL
-pWw
+iSD
 rnr
 aCz
 wAW
@@ -88434,8 +87199,8 @@ yil
 pnl
 wFZ
 oLc
-hin
-wZk
+jDi
+jDi
 jDi
 pnl
 emz
@@ -88507,7 +87272,7 @@ oyz
 tmi
 klN
 nDj
-tRr
+miF
 oiZ
 lvJ
 xYD
@@ -88690,9 +87455,9 @@ pWm
 aNn
 pnl
 jDi
-fKy
-iVk
-eZs
+jDi
+jDi
+jDi
 jDi
 pnl
 oCE
@@ -89023,7 +87788,7 @@ rYs
 dPx
 nqY
 oiZ
-bBg
+iSD
 fGW
 bIJ
 cdB
@@ -90248,8 +89013,8 @@ dgm
 kEo
 hkd
 hkd
-gsW
-gsW
+hkd
+hkd
 eue
 dfT
 bNq
@@ -90504,9 +89269,9 @@ bsG
 wqW
 jHS
 tdb
-mbx
-ybf
-ybf
+tdb
+tdb
+tdb
 qyr
 mLZ
 naK
@@ -90663,7 +89428,7 @@ hTZ
 wjZ
 jUp
 lku
-blw
+ume
 tyh
 pDu
 egb
@@ -90762,8 +89527,8 @@ ayR
 kEo
 aQX
 aQX
-dJJ
-dJJ
+aQX
+aQX
 oRW
 qsr
 bNq
@@ -90860,7 +89625,7 @@ erZ
 tCh
 eiy
 wuc
-jVQ
+npH
 sos
 jXi
 lhn
@@ -91075,7 +89840,7 @@ jQv
 mhk
 rqF
 aFb
-ple
+qzP
 sQy
 miF
 yhX
@@ -91117,7 +89882,7 @@ lyc
 iTe
 gEG
 wuc
-oVD
+xul
 sos
 wuc
 wuc
@@ -91164,7 +89929,7 @@ kws
 xAG
 lQA
 xAG
-dXj
+dSu
 nPH
 wWR
 pzy
@@ -91374,7 +90139,7 @@ bqx
 bqx
 uvf
 wuc
-oVD
+xul
 qTG
 wuc
 wpw
@@ -91631,7 +90396,7 @@ dOd
 nVs
 lrP
 wuc
-oVD
+xul
 sos
 wuc
 ufg
@@ -91888,8 +90653,8 @@ xur
 xYu
 xur
 wuc
-yfz
-qbz
+xul
+sos
 wuc
 mqH
 tiW
@@ -92145,7 +90910,7 @@ jaQ
 jWs
 lnz
 wuc
-wfu
+xul
 auf
 wuc
 ufg
@@ -92403,7 +91168,7 @@ fvL
 lnZ
 wuc
 xul
-mqD
+sos
 wuc
 ufg
 iVY
@@ -92621,7 +91386,7 @@ lFm
 ftC
 oUb
 vXd
-dyd
+iSD
 gVL
 pyt
 tXy
@@ -92660,7 +91425,7 @@ jiq
 bBk
 wuc
 rWU
-mqD
+sos
 wuc
 ufg
 rWs
@@ -92878,7 +91643,7 @@ mXb
 kZI
 oUb
 yhX
-dyd
+iSD
 ojA
 uPW
 rPW
@@ -93174,7 +91939,7 @@ leB
 dYj
 wuc
 aTn
-mqD
+sos
 wuc
 wuc
 wuc
@@ -93477,8 +92242,8 @@ hrO
 wtr
 skn
 wsG
-tUq
-bAY
+wtr
+skn
 eoa
 wtr
 leC
@@ -93603,13 +92368,13 @@ knv
 cvJ
 mid
 knv
-knv
+esy
 blb
 blb
 blb
 blb
 blb
-hem
+hwJ
 sRg
 dOz
 dOz
@@ -93652,7 +92417,7 @@ bej
 spk
 iSD
 iSD
-les
+iSD
 wAW
 wXk
 qjt
@@ -93965,7 +92730,7 @@ trp
 trp
 yhQ
 xqd
-vdN
+xul
 trp
 vJH
 vJH
@@ -94258,7 +93023,7 @@ wbf
 bJZ
 yeO
 muS
-mIe
+muS
 muS
 jKJ
 cMS
@@ -94333,12 +93098,12 @@ ayK
 ayK
 tpW
 udO
-iWd
-iWd
-iWd
-iWd
-iWd
-mpM
+aNd
+aNd
+aNd
+aNd
+aNd
+aNd
 abc
 aNd
 aNd
@@ -94383,13 +93148,13 @@ gwV
 hNY
 gBk
 hNY
-hNY
+sJO
 gxR
 inh
 jvB
 inh
 iZK
-pVq
+hBt
 hBt
 jQW
 uAo
@@ -94428,7 +93193,7 @@ rPA
 iUh
 sXs
 atS
-ftX
+aLs
 udA
 mJB
 vDe
@@ -94514,9 +93279,9 @@ cLW
 wbf
 bJZ
 yeO
-qXk
-jaa
-omw
+muS
+muS
+muS
 fOQ
 ulp
 sVN
@@ -94590,11 +93355,11 @@ lsF
 ayK
 rzb
 qme
-iWd
-pEe
-iWd
-mpM
-ble
+aNd
+aNd
+aNd
+aNd
+aNd
 aNd
 wqz
 wqz
@@ -94625,13 +93390,13 @@ fQL
 gnS
 eiN
 eVY
-eVY
+llr
 eVY
 dAz
 eVY
 ccG
 oyU
-eVY
+qCx
 eVY
 eVY
 eVY
@@ -94639,11 +93404,11 @@ eVY
 msg
 msg
 hsc
-msg
 toU
-hYW
+dZJ
+toU
 inR
-toU
+cBu
 cjY
 jax
 eFQ
@@ -94883,13 +93648,13 @@ rjv
 hem
 hFp
 bgE
-lpJ
+jRo
 hKX
-hKX
-hem
-hem
-qtG
-qtG
+cFY
+yeP
+yeP
+yeP
+yeP
 qtG
 qtG
 qtG
@@ -94901,10 +93666,10 @@ noz
 niw
 xSd
 ubT
-lYj
-mmw
+sUy
+niT
 eLx
-hCr
+qju
 tsF
 xRV
 aEd
@@ -95135,33 +93900,33 @@ yeY
 dQi
 aeX
 cow
-vxt
-vxt
-vxt
-vxt
-vxt
-vxt
-vnI
-vnI
-vnI
-hem
-hem
+nFa
+nFa
+nFa
+nFa
+pLe
+bnd
+bnd
+bnd
+yeP
+ihJ
+xaW
+wWU
 blb
 blb
 blb
 blb
-blb
-maf
+hCr
+hCr
+mmw
+tye
+hCr
 sUy
-nJG
-qju
-niT
-qju
 utF
 sUy
 xoS
 hwo
-hDC
+noF
 tsF
 ijN
 mDL
@@ -95392,40 +94157,40 @@ lBm
 iIW
 kSc
 jAz
-vxt
+nFa
 dhC
 bqu
 vkD
 dsp
-vnI
-vnI
-vnI
-vnI
-aJq
-aJq
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
+pem
+fCs
+euR
+yeP
+fAf
+iGu
+wWU
+uBy
+uBy
+uBy
+uBy
+hCr
+mYp
+wlo
+olO
+wIm
 sUy
-tUg
-cbt
-hYX
-noF
 mnN
-sUy
-jaD
+vbR
+iDk
 cmd
-qly
+alb
 uVT
 uVT
 ueH
 xQw
 uVT
 jsN
-mpJ
+jLI
 xZS
 vrn
 nzK
@@ -95649,33 +94414,33 @@ yjE
 wyH
 vxt
 vxt
-vxt
+nFa
 kEx
-wAf
+odh
 odh
 ijV
-vnI
-vnI
-vnI
-vnI
-aJq
-aJq
-tYT
-dDB
-dDB
-dDB
-dDB
-dDB
-sUy
-mur
-mNS
+odh
+hcz
+fNi
+stj
+bey
+lSw
+rkI
+kgk
+tPF
+kgk
+kgk
+krB
+nbv
+xJW
+fuv
 iaH
-gSi
-iDk
 sUy
+pof
+vIz
 rto
-hwp
-qlP
+gTi
+rxB
 uVT
 sQI
 iri
@@ -95906,33 +94671,33 @@ yjE
 pek
 uUA
 vTj
-vxt
+nFa
 ncQ
 qoA
 xVd
-vnI
-vnI
-vnI
-vnI
-vnI
-aJq
-aJq
-aJq
-dDB
-dDB
-dDB
-dDB
-dDB
+qug
+mmv
+eYx
+kpO
+yeP
+aYN
+bMU
+wWU
+vXn
+vXn
+vXn
+vXn
+hCr
+jEp
+qGk
+bxB
+wIm
 sUy
-muW
-mOk
-iap
-oGo
-iDk
-sUy
+uUe
+vIz
 jaK
 hwx
-xiN
+qlP
 uVT
 rEY
 irQ
@@ -96164,35 +94929,35 @@ tZI
 nSd
 nSd
 drO
-bUF
+clH
 tIB
-vnI
-vnI
-vnI
-vnI
+mmv
+fXs
+ifi
+sYt
 oVF
-vnI
-aJq
-aJq
-aJq
+yeP
+ait
+xaW
+wWU
 dDB
 dDB
 dDB
 dDB
-dDB
+hCr
+hCr
+qek
+igS
 sUy
-uOP
-hur
-mzb
-gTi
+sUy
 pUy
-sUy
+vIz
 pfC
-pLj
+hur
 xtP
 uVT
 vdj
-irQ
+yfA
 iJg
 eHk
 xQw
@@ -96420,34 +95185,34 @@ yjE
 vxt
 fBf
 dhK
-vxt
+nFa
 rLt
 cgt
-vnI
-vnI
-vnI
-vnI
-vnI
-vnI
-aJq
-aJq
-aJq
+uRP
+nFa
+nFa
+nFa
+nFa
+yeP
+yeP
+yeP
+yeP
 dDB
 dDB
 dDB
 dDB
 dDB
-sUy
-srT
-mPx
-nlk
-mPx
+hCr
+hkH
+nmZ
+wkq
+fnz
 aZS
-sUy
-sUy
+gMe
+mcn
 reE
 qly
-uVT
+qWL
 idJ
 itw
 iKe
@@ -96677,15 +95442,15 @@ vxt
 iOx
 iOx
 mCL
-vxt
+nFa
 pDK
-vxt
-vxt
-vnI
-vnI
-vnI
-vnI
-vnI
+cgt
+kmC
+nFa
+aJq
+aJq
+aJq
+aJq
 aJq
 gcs
 blb
@@ -96694,14 +95459,14 @@ blb
 blb
 blb
 blb
-sUy
-ulq
-xil
-ljN
+hCr
+mPx
+vYi
+wkq
 gTH
 ipf
 wmu
-sUy
+gYK
 jnh
 hEm
 uVT
@@ -96934,16 +95699,16 @@ dhK
 dhK
 vxt
 ffp
-vxt
+nFa
 dWS
-vxt
+aDC
+qhl
+nFa
+aJq
+vjX
 aJq
 aJq
-aJq
-aJq
-aJq
-aJq
-aJq
+tYT
 blb
 dDB
 dDB
@@ -96952,15 +95717,15 @@ dDB
 dDB
 ycC
 ycC
-iEk
+pIS
 lzT
-qMK
+hOD
 gUm
-iEk
+mpJ
 xGJ
-qoD
+xGJ
 pLr
-qoD
+xGJ
 uVT
 qXb
 pux
@@ -97191,16 +95956,16 @@ vxt
 ddy
 vxt
 ddy
-vxt
-ddy
-vxt
-vmL
+nFa
+bnd
+bnd
+bnd
+nFa
 aJq
 aJq
-gcs
 aJq
-tYT
-dDB
+aJq
+enq
 blb
 dDB
 dDB
@@ -97210,13 +95975,13 @@ dDB
 pIS
 uAK
 anb
-uFm
+oLj
 owZ
 xsh
 ahE
 plz
-sDq
-jwi
+pHI
+jrU
 qCj
 uVT
 uVT
@@ -97249,7 +96014,7 @@ pIC
 mWT
 pIC
 oun
-uVc
+wBc
 mKY
 mka
 vCi
@@ -97260,7 +96025,7 @@ trB
 trB
 ryW
 diP
-hFD
+kHX
 tYX
 blb
 blb
@@ -97439,24 +96204,24 @@ aJq
 aJq
 aJq
 aJq
-vxt
-ddy
-yhB
-ddy
-vxt
 dDB
-dDB
-blb
+kDB
+lZD
+mdV
 dDB
 dDB
 dDB
 blb
+dDB
+dDB
+dDB
+blb
+vmL
+aJq
+aJq
+gcs
+aJq
 tYT
-tYT
-dDB
-blb
-dDB
-dDB
 dDB
 blb
 dDB
@@ -97469,9 +96234,9 @@ bQm
 wkh
 jdJ
 xMk
-xsh
+jYQ
 hcc
-xGJ
+cuw
 bBN
 jwi
 qtd
@@ -97502,11 +96267,11 @@ wEv
 uJi
 ntu
 uMJ
-nJn
+uMJ
 uMJ
 dvd
 tRJ
-uVc
+wBc
 kxY
 bMV
 dPp
@@ -97726,7 +96491,7 @@ gBx
 mvh
 nNe
 tuW
-xsh
+tpl
 hcd
 plz
 pkh
@@ -97758,12 +96523,12 @@ dEq
 yfC
 lZf
 qCK
-ehc
-gfB
+dvd
+dvd
 gNX
 dvd
 tRJ
-uVc
+wBc
 oIY
 bMV
 dPp
@@ -97955,7 +96720,7 @@ dDB
 dDB
 dDB
 cea
-yhB
+uAX
 crE
 dDB
 dDB
@@ -97982,7 +96747,7 @@ pIS
 gBz
 qqC
 tMh
-qMK
+sUe
 xqv
 cEX
 xGJ
@@ -98016,7 +96781,7 @@ yfC
 edk
 wyg
 qbA
-qWD
+qbA
 hLb
 dvd
 tRJ
@@ -98240,7 +97005,7 @@ gBT
 mxa
 nNe
 biB
-xsh
+tpl
 hcE
 plz
 pkh
@@ -98467,11 +97232,11 @@ dDB
 blb
 dDB
 dDB
-wen
-ddy
-yhB
-ddy
-wen
+dDB
+iYr
+cTP
+nmq
+dDB
 dDB
 dDB
 blb
@@ -98495,11 +97260,11 @@ dDB
 ycC
 ydk
 gFv
-uFm
+hoN
 cKV
-xsh
+dHL
 giU
-xGJ
+cuw
 mID
 jwi
 jwi
@@ -98725,9 +97490,9 @@ blb
 blb
 wen
 wen
-vxt
+wen
 cpA
-vxt
+wen
 wen
 rPf
 bSs
@@ -98982,7 +97747,7 @@ dDB
 dDB
 bSs
 wBf
-wpa
+jpF
 cpP
 csl
 dDG
@@ -99268,7 +98033,7 @@ ycC
 gHe
 noq
 hMK
-ipD
+ueC
 hdd
 hhk
 xGJ
@@ -99525,7 +98290,7 @@ ycC
 omj
 mPJ
 mPJ
-ipD
+ueC
 opH
 oSv
 xGJ
@@ -100296,8 +99061,8 @@ ycC
 ycC
 ycC
 ycC
-maw
-ueC
+noq
+byq
 tJF
 qoD
 jnZ
@@ -100558,7 +99323,7 @@ hdH
 nRd
 qoD
 lIk
-xRr
+jVe
 hUq
 qSZ
 rpY
@@ -100811,7 +99576,7 @@ gHV
 pRz
 pbE
 oUd
-soO
+rXv
 oUd
 fbl
 pPK
@@ -101068,20 +99833,20 @@ mks
 soO
 gCA
 gVc
+xbe
 kTH
-kTH
-soO
-jVe
+pTh
+mXk
 wgp
-jVe
-soO
+kVe
+pTh
 kTH
 kTH
-soO
-gfs
+pTh
+nAn
 ivl
-mzM
-wCM
+tUc
+cCl
 ePk
 tgx
 jVM
@@ -101329,12 +100094,12 @@ jVe
 oUd
 pPK
 hxA
-hED
-xSx
-xSx
-iBu
-kVe
-xSx
+soO
+pPK
+pPK
+oUd
+jVe
+pPK
 jxC
 ufb
 xCl
@@ -101579,7 +100344,7 @@ qjy
 nWr
 hsO
 mzz
-iij
+qjy
 vPP
 otX
 hei
@@ -101590,8 +100355,8 @@ gIb
 nsc
 vzt
 mnw
-meS
-vaF
+soO
+lIk
 jye
 jOs
 mAv
@@ -101614,7 +100379,7 @@ fYJ
 eGU
 eTJ
 vkI
-nfl
+oeZ
 wuY
 oeZ
 luP
@@ -101870,8 +100635,8 @@ fzw
 bKO
 qhR
 pPU
-eSj
-idS
+xkV
+gyy
 phG
 gyy
 xkV
@@ -101931,7 +100696,7 @@ yfL
 wgL
 tLt
 sSQ
-nVS
+uOw
 dZT
 sSQ
 ndp
@@ -102128,7 +100893,7 @@ fVl
 qJz
 ebk
 xkV
-hzj
+mDf
 mDf
 aYU
 dao
@@ -102387,7 +101152,7 @@ pPU
 ecC
 cIX
 ofU
-rXh
+xkV
 ecC
 cvV
 spH
@@ -102445,7 +101210,7 @@ wCY
 wgL
 ngq
 sSQ
-qwi
+ewW
 uOw
 cku
 ndp
@@ -102643,13 +101408,13 @@ vgS
 pPU
 xkV
 oDX
-etX
-nXQ
-bwP
+oeZ
+oeZ
+xkV
 cvV
 spH
 nUd
-dPp
+nJG
 aww
 bje
 tYX
@@ -102901,8 +101666,8 @@ pPU
 xkV
 cQN
 bXR
-idS
-bwP
+gyy
+xkV
 swW
 vkh
 kPh
@@ -103158,7 +101923,7 @@ lTy
 wAa
 uUB
 fIl
-vDZ
+aYU
 pPO
 jFm
 jYM
@@ -104170,8 +102935,8 @@ iZO
 awC
 gwm
 xPJ
-pbO
-pbO
+mut
+mut
 icN
 mZd
 sDZ
@@ -104182,13 +102947,13 @@ mut
 pjA
 mut
 otJ
-pbO
-pbO
+mut
+mut
 rfW
 mlD
 xPJ
-pbO
-mRB
+mut
+aRJ
 jSp
 klf
 oHp
@@ -104494,7 +103259,7 @@ uBl
 tNF
 bZa
 sJE
-niI
+cqc
 cqc
 aPa
 gLb
@@ -104706,7 +103471,7 @@ xJB
 xJB
 xJB
 wZO
-xpU
+nkH
 uBY
 ygu
 mHb
@@ -104963,9 +103728,9 @@ vYH
 isi
 xJB
 mNQ
-xpU
+nkH
 uBY
-lht
+ygu
 gVi
 dba
 dse
@@ -105009,7 +103774,7 @@ vdY
 jjO
 wYA
 glY
-bUv
+gFH
 cSk
 gLb
 nlS
@@ -105214,9 +103979,9 @@ uLD
 vmr
 qLt
 vrY
-swL
-lmK
-kTM
+vrY
+vrY
+vrY
 sXq
 wGu
 lNU
@@ -105251,14 +104016,14 @@ xSO
 tFQ
 tFQ
 xSO
-cXa
+qNw
 xUL
 xrC
 wYA
 wnY
 wfi
 wfi
-gIk
+wfi
 wCx
 wCx
 piG
@@ -105473,7 +104238,7 @@ azN
 vcN
 vrY
 mIi
-xXv
+vcN
 xpp
 xJB
 bUD
@@ -105514,9 +104279,9 @@ xrC
 wYA
 uia
 tAS
-vOb
-tWl
-gsT
+tAS
+tAS
+tAS
 tXP
 jrG
 aCi
@@ -105717,7 +104482,7 @@ niW
 ylX
 jwf
 bmz
-wiw
+mSa
 tPW
 qUt
 bxk
@@ -105734,7 +104499,7 @@ qUu
 sXO
 xJB
 xaH
-xpU
+nkH
 xMr
 yij
 qir
@@ -105973,8 +104738,8 @@ pBO
 jyd
 ylX
 eMS
-nlP
-lTk
+tzZ
+thx
 caK
 qUt
 rex
@@ -105991,7 +104756,7 @@ jWy
 jWy
 wJx
 npZ
-xpU
+nkH
 xMr
 lqg
 qir
@@ -106230,7 +104995,7 @@ jAf
 vpF
 eeJ
 wKn
-gYK
+tzZ
 eMQ
 xxD
 qUt
@@ -106248,7 +105013,7 @@ vZD
 sZJ
 wJx
 xbC
-xpU
+nkH
 xMr
 uSN
 uWo
@@ -106505,7 +105270,7 @@ vZX
 sZJ
 wJx
 xbW
-xpU
+nkH
 xMr
 yiq
 uWo
@@ -106730,8 +105495,8 @@ azO
 fLL
 iQl
 xlZ
-xlZ
 oNs
+xlZ
 hVJ
 xlZ
 jZK
@@ -106742,7 +105507,7 @@ pwq
 oyn
 fSU
 fRV
-skd
+ciV
 ciV
 rrp
 wqj
@@ -106987,7 +105752,7 @@ oWg
 lSh
 bgy
 bgy
-bgy
+mUX
 lXw
 pIn
 kTG
@@ -107790,13 +106555,13 @@ gfJ
 tnb
 qyY
 xvh
-xpU
+nkH
 izA
 swB
 vve
 vSw
 wrF
-tTs
+xJw
 lvv
 xJw
 xJw
@@ -107814,7 +106579,7 @@ xJw
 hhL
 ezw
 jOh
-vfK
+xJw
 xJw
 xGX
 xJw
@@ -108071,7 +106836,7 @@ pDU
 jOk
 rIn
 ibD
-pKU
+pDU
 pDU
 qZn
 jWl
@@ -108310,31 +107075,31 @@ sBL
 nla
 nla
 nla
-ldq
-ldq
-oom
-ssz
-yeP
-sYt
-yeP
-yeP
-iPF
-iPF
-vSg
-iPF
-iPF
-yeP
-yeP
-sYt
-yeP
-ssz
-kSv
-ldq
-ldq
 nyH
 nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+nyH
+fmH
+fmH
+fmH
+fmH
+fmH
 cWM
-nyH
+avc
 vSg
 vSg
 vSg
@@ -108558,39 +107323,39 @@ tnb
 wua
 xgg
 dqO
-xHf
+taD
 pzL
 xvh
-xpU
+nkH
 ntF
 nla
 nHN
 vSY
 qzv
 ldq
-roz
-roz
-ssz
-rbH
-wYd
-mAs
-yeP
-blb
-blb
-blb
-blb
-blb
-yeP
-fWT
-wYd
-uOH
-ssz
-kUF
-lxa
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
+tRn
+uOH
+lCS
+fmH
+lxa
+lxa
 oJz
 odP
-hjz
+wAf
 vGX
 xaP
 mfT
@@ -108818,33 +107583,33 @@ pFQ
 wsa
 pzL
 xvh
-xpU
+nkH
 xMr
 sOR
 eNp
 vxM
 hCB
 ldq
-wWU
-xQI
-ssz
 ixG
-wYd
-fdv
-yeP
-uya
-uya
-yeP
-uya
-uya
-yeP
-oFI
-wYd
-dNo
-ssz
-vxp
-xYE
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
+cZW
+uOH
+ciR
+oib
+nqG
+wuq
 rBz
 liP
 hjz
@@ -108853,13 +107618,13 @@ xaP
 tGJ
 mYj
 uax
-nRP
+wyo
 hhg
 stV
-qhD
+mus
 mRK
-qhD
-mYu
+mus
+aeA
 oXM
 sSQ
 muz
@@ -109082,41 +107847,41 @@ vxs
 xaC
 ubl
 ldq
-roz
-ssz
-ssz
-qdN
-ukB
-awO
-yeP
-xaW
-ncH
-wGU
-pST
-mwu
-yeP
-qPJ
-ukB
-dQE
-ssz
-ssz
-xYE
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
+ukB
+eBT
+pAg
+fmH
+xYE
+wwT
 gHT
 tAP
 nxD
 ihC
 xaP
 rXY
-jlZ
+mpK
 kMW
 pXz
 xaP
 nwN
-umJ
-jIj
 ufn
-tbK
+fFC
+ufn
+pHq
 ykT
 sSQ
 muz
@@ -109311,7 +108076,7 @@ gnK
 piJ
 hBh
 eeJ
-plE
+mSa
 dtv
 uQG
 vCc
@@ -109335,44 +108100,44 @@ mNQ
 nkH
 xMr
 slJ
-ryh
+vxM
 vxM
 aXU
 ldq
-qRO
-ssz
-bFW
-pGD
-wYd
-pGD
-wSH
-kJW
-rXM
-pGD
-bMt
-jAb
-wSH
-pGD
-wYd
-pGD
-wSL
-ssz
-kHo
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
-rkI
+lDJ
+jOO
+wSL
+fmH
+kHo
+qoj
+qoj
 qoj
 rSt
 wRU
-kFY
-kFY
-uNe
+xaP
+bxY
+mYj
 fVG
 eJe
 cwt
-bFJ
-nnD
+nwN
+ufn
 dMM
-nAn
+nIT
 rUV
 xqe
 whX
@@ -109596,41 +108361,41 @@ eBy
 vxM
 bMc
 ldq
-qRO
-ssz
-oCg
-pGD
-sMU
-wYd
-nFa
-uBy
-sMU
-kop
-sMU
-ltE
-nFa
-wYd
-sMU
-pGD
-jPM
-ssz
-fmH
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
+ldq
+awO
+ldq
+fmH
+fmH
 aBv
-osy
+aBv
+aBv
 kqO
 uhk
-gGQ
 kFY
+xaP
 hrC
 gHl
 elT
 frP
-wEf
-jdu
-uub
-uub
-tbK
+vOt
+bwT
+bwT
+bwT
+pHq
 oDB
 sSQ
 tAq
@@ -109853,32 +108618,32 @@ dLq
 vTx
 pHw
 ldq
-qRO
-ssz
-ssz
-xpY
-tLc
-ktl
-yeP
-xaW
-wuq
-aZL
-ciR
-mwu
-yeP
-enq
-ivY
-nLM
-ssz
-ssz
-kHo
-ldq
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+fmH
+fjv
 ntW
+mmR
 bgA
-byq
 pOX
 adl
-kFY
+xaP
 aQm
 qEz
 aQm
@@ -109887,7 +108652,7 @@ aZG
 wQG
 uro
 itP
-tbK
+pHq
 kBA
 sSQ
 sSQ
@@ -110110,32 +108875,32 @@ iht
 iht
 iht
 ssz
-qRO
-pJr
-ssz
 uya
-yeP
-uya
-yeP
-uya
-uya
-yeP
-uya
-uya
-yeP
-uya
-yeP
-uya
-ssz
-pJr
-kHo
 ldq
+ldq
+uya
+ldq
+uya
+ldq
+uya
+uya
+ldq
+uya
+uya
+ldq
+uya
+ldq
+ixG
+ixG
+ixG
+fmH
+tmr
 vWa
 hkt
 wKm
-eBT
+pOX
 mJC
-kFY
+xaP
 nUQ
 ohM
 nUQ
@@ -110144,15 +108909,15 @@ ltP
 bho
 blh
 qvL
-tbK
+pHq
 oDB
 ufn
 iAJ
 cqa
 ufn
 ufn
-ycm
-bkD
+eKP
+jcu
 jiY
 ufn
 yhF
@@ -110162,9 +108927,9 @@ ufn
 ufn
 jcu
 iAJ
-kqN
+ljj
 ufn
-qRh
+gOh
 jFh
 cjm
 tuT
@@ -110338,14 +109103,14 @@ gdF
 kkS
 oZO
 kkS
-fjT
-fjT
+kkS
+kkS
 xjC
 xuQ
 rqw
 fcU
 rem
-xvM
+gGQ
 uDE
 qUt
 lhi
@@ -110359,17 +109124,15 @@ sqY
 ata
 taZ
 shD
-xaH
-nkH
-xMr
+oGQ
+dMe
+uEQ
 tBv
 xbR
 jDM
 uMN
 ssz
-qRO
-pJr
-ldq
+dDB
 dDB
 dDB
 blb
@@ -110384,44 +109147,46 @@ dDB
 blb
 dDB
 ldq
-xQI
-kHo
-ldq
-ldq
-ldq
+ixG
+ixG
+ixG
+tmV
+otQ
+nRS
+vIa
 bGk
 dst
-nTE
-kFY
-wja
-wja
-wja
-wja
-uLj
+fmH
+ssz
+ssz
+ssz
+ssz
+ssz
+ldq
 hKw
 ydf
 tfh
-tbK
-lRj
-vbR
+pHq
+pCT
+ivY
 dwX
-vbR
-vbR
-vbR
-vbR
-vbR
+ivY
+ivY
+ivY
+ivY
+ivY
 qcv
-vbR
-ykn
-vbR
-vbR
-vbR
+ivY
+kKN
+ivY
+ivY
+ivY
 kms
 uwI
-xhl
-xhl
-fnz
-fnz
+ivY
+ivY
+wwK
+wwK
 ufn
 yhH
 tuT
@@ -110586,7 +109351,7 @@ rqw
 qAj
 jsU
 xFM
-wYH
+qak
 bnX
 jUA
 pzd
@@ -110616,15 +109381,13 @@ srA
 lrH
 aaH
 rtZ
-xvh
-ugh
-xMr
-uUe
+mPu
+buk
+uEQ
+lOS
 vyF
 vTJ
 wrQ
-ssz
-qRO
 xzU
 xzU
 xzU
@@ -110640,25 +109403,27 @@ blb
 blb
 blb
 blb
-ldq
-xQI
-kUF
+yfQ
+ixG
+ixG
+ixG
+fmH
 kdn
-lxa
-ldq
-ldq
-lCS
-ldq
-ldq
-sgB
-fhT
-qIC
-pJz
+tSH
+jYP
+fmH
+fmH
+fmH
+ixG
+ixG
+ixG
+ixG
+ixG
 jIc
 bAT
 mvC
 fwZ
-tbK
+pHq
 oDB
 ufn
 ufn
@@ -110842,9 +109607,9 @@ gpV
 fjp
 xcF
 gpA
-qFL
+fYH
 qak
-eKc
+ctH
 xIf
 lKs
 fex
@@ -110859,7 +109624,7 @@ vaw
 jWz
 bAb
 dWG
-bQQ
+iMG
 bji
 pjT
 pCv
@@ -110869,19 +109634,17 @@ unc
 sWQ
 raZ
 sVG
-qUa
-qUa
-qUa
+gdx
+gdx
+gdx
 iOq
 nhZ
-ufF
-xMr
+xsT
+uEQ
 vzX
 vyR
 vyR
 vyR
-wIm
-roz
 xzZ
 xQI
 xzZ
@@ -110898,24 +109661,26 @@ dDB
 blb
 dDB
 ldq
+ixG
+ixG
+ixG
+fmH
+fmH
+fmH
+fmH
+fmH
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
-ldq
-ldq
-kUF
-kdn
-kdn
-vgY
-qVn
-fpq
-liL
-nBq
-nBq
-tkS
-uLj
 clZ
 reH
 ico
-tbK
+pHq
 wBh
 lcC
 rUb
@@ -111101,7 +109866,7 @@ lXX
 rLx
 fYH
 vrB
-eKc
+ctH
 gby
 ntZ
 jpp
@@ -111126,22 +109891,20 @@ jRs
 jRs
 xhG
 mHf
-kFA
-gdx
+fyh
+sZh
 qSh
-twE
-tOs
+tmI
+vfH
 pFI
-uEQ
-uwF
+dJj
+uWz
 vze
 vUe
-kmC
-wJo
-qRO
+vUe
+ssz
 xzU
 xzU
-xzU
 blb
 blb
 blb
@@ -111154,25 +109917,27 @@ blb
 blb
 blb
 blb
+yfQ
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
-uME
-jAp
 ldq
-lTg
-dAr
-hDz
 ldq
-qVn
 ldq
-uLj
-uLj
-aid
-auG
-uLj
+ldq
+ldq
 dNU
 off
 okl
-ogW
+mDs
 idp
 tuT
 tuT
@@ -111387,17 +110152,15 @@ vDX
 tNn
 vDX
 vDX
-mNQ
-xsT
-xMr
-tBv
+oPM
+mAs
+kwB
+mnj
 oYS
 pUL
 wrW
 ssz
-roz
-wBN
-ldq
+dDB
 dDB
 dDB
 blb
@@ -111412,19 +110175,21 @@ dDB
 blb
 dDB
 ldq
-tUa
-vXn
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
-ldq
-ldq
-xGw
-ldq
-qqd
-ldq
-qdR
-naN
-vOr
-mdG
+sgB
+fhT
+fhT
+pJz
 uLj
 oig
 oig
@@ -111641,7 +110406,7 @@ uTb
 rrU
 vwc
 vDX
-xww
+mWE
 sso
 vDX
 dWh
@@ -111652,9 +110417,7 @@ ssz
 ssz
 ssz
 ssz
-roz
-xQI
-ldq
+uya
 yfQ
 ldq
 yfQ
@@ -111669,18 +110432,20 @@ yfQ
 ldq
 yfQ
 ldq
-ldq
-vgz
-ldq
-vid
-ldq
-xGw
-ldq
-spK
-ldq
-uLj
-uLj
-vOr
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+xko
+hPQ
+uNe
+uNe
 iNS
 uLj
 blb
@@ -111898,52 +110663,52 @@ qUm
 rrU
 rZw
 vDX
-xww
+mWE
 ruD
 vDX
-wZO
-uge
-uFo
+nyZ
+ujX
+ilC
 uUj
-vzy
-sPO
-qRO
-qRO
-qRO
-qRO
+jfj
+hDz
+pKU
+pKU
+pKU
+pKU
 wFQ
-qRO
-roz
-roz
-roz
-roz
+pKU
+xpY
+xpY
+xpY
+xpY
 ldq
-qRO
-qRO
-qRO
-qRO
+pKU
+pKU
+pKU
+pKU
 krz
-roz
-xGY
-evq
-qVn
-qVn
-qVn
-qVn
-stj
-qqd
-qqd
-qqd
+xpY
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
-hWE
-mAP
-vOr
-vzh
+uLj
+uLj
+aid
+cdg
 uLj
 foL
 blb
 oig
-cuw
+oqg
 idp
 vtC
 blb
@@ -112147,7 +110912,7 @@ oss
 yio
 ibv
 sCc
-rQm
+pTz
 pTz
 qfA
 mlK
@@ -112155,10 +110920,10 @@ npV
 rsg
 rSz
 vDX
-xww
+mWE
 vDX
 vDX
-nay
+bFU
 upz
 uFA
 uWe
@@ -112173,28 +110938,28 @@ ssz
 ssz
 ssz
 xQI
-qRO
-hua
-hua
-xGw
-rUR
-qTv
-ssz
-ssz
-lOi
-ssz
-ssz
-ssz
-lmb
-ssz
-ssz
-njh
-kgk
-xQI
+pKU
+pKU
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
+ixG
 ldq
-uLj
-uLj
-vOr
+qdR
+naN
+aid
 jtD
 uLj
 blb
@@ -112412,12 +111177,12 @@ vDX
 vDX
 vDX
 vDX
-xww
+mWE
 vDX
 eDr
-xdc
+uME
 xtL
-xQW
+osy
 uWG
 yeh
 blb
@@ -112430,34 +111195,34 @@ blb
 blb
 ssz
 ssz
-sPO
+hDz
 xQI
-ssz
-ssz
-ssz
-ssz
-ssz
-mLA
-dWs
-lXg
-cJL
-klF
+pKU
+xGw
+rUR
+qTv
+aSy
+aSy
+lOi
+aSy
+aSy
+aSy
 evv
-ktB
-ssz
-ssz
-ssz
-ssz
-ssz
-txV
-aJX
-vOr
-oIx
+aSy
+aSy
+ixG
+ixG
+ixG
+ldq
+uLj
+uLj
+opg
+nBq
 uLj
 foL
 blb
 oig
-cuw
+oqg
 idp
 vtC
 blb
@@ -112658,7 +111423,7 @@ bqy
 bqy
 pzd
 djO
-deb
+nvB
 wkF
 gxl
 pDD
@@ -112666,15 +111431,15 @@ dvY
 vDX
 vDX
 vDX
-xww
-xww
-xww
-veq
+mWE
+mWE
+mWE
+hUH
 vDX
 twZ
-xdc
+uME
 ugj
-xQW
+osy
 uYo
 urv
 dDB
@@ -112687,27 +111452,27 @@ tjj
 blb
 blb
 ssz
-qRO
+pKU
 xQI
 ssz
-heB
-nZQ
-wir
-yeQ
+aSy
+aSy
+aSy
+aSy
 gjg
-hUH
-fsL
-fsL
-qKt
+dWs
+rrb
+cJL
+lXg
 mJy
-bcO
-yeQ
-pzs
-nZQ
-srb
+ktB
+aSy
+aSy
+aSy
+aSy
 ssz
-ldq
-ldq
+fWT
+sRN
 aid
 dSz
 uLj
@@ -112897,7 +111662,7 @@ exM
 nFW
 uKD
 bFt
-gPR
+xcF
 sDs
 aFu
 bbT
@@ -112915,23 +111680,23 @@ bqy
 nMX
 rnD
 oss
-hSg
+yio
 wkF
 pkS
 pDQ
-xnk
+clf
 qgx
-xww
+mWE
 uHR
-veq
+hUH
 wPd
 wPd
 wPd
 wPd
 txl
-xdc
+uME
 fTM
-xQW
+osy
 uto
 yeh
 blb
@@ -112944,28 +111709,28 @@ tjj
 tjj
 blb
 ssz
-qRO
+pKU
 vxp
 ssz
-iWZ
-rfJ
-rcl
-nhC
-oUB
-bLT
-hAJ
-gPY
-vsW
-aAL
-wxZ
-uXV
-euO
-rfJ
-mOI
+heB
+nZQ
+srb
+yeQ
+oom
+dhb
+ncH
+ncH
+aJX
+kej
+wOc
+yeQ
+pus
+nZQ
+srb
 ssz
-xQI
 ldq
-vOr
+ldq
+aid
 hwn
 uLj
 oig
@@ -113154,7 +111919,7 @@ reS
 nFW
 xFD
 xIW
-eHE
+xcF
 rax
 uek
 pTZ
@@ -113186,8 +111951,8 @@ pNF
 vmn
 pqm
 pqm
-uWn
-ugC
+tLc
+qvF
 xPY
 ykL
 ykL
@@ -113195,8 +111960,8 @@ ykL
 tjj
 wKc
 xol
-uZr
-xAM
+aau
+aau
 rMH
 tjj
 blb
@@ -113204,26 +111969,26 @@ ssz
 aVF
 ldq
 ssz
-dmT
-wlk
-dDO
-yeQ
-pVU
-bLT
-tEj
-bqD
-tvU
-aAL
-xkK
-yeQ
-cNZ
-wlk
-hwz
+iWZ
+rfJ
+rcl
+nhC
+ktl
+nLM
+hAJ
+gPY
+vsW
+wtc
+tQM
+uXV
+euO
+rfJ
+mOI
 ssz
-ldq
-ldq
-clf
-uLj
+eMH
+nXf
+aid
+hYW
 uLj
 vyU
 sVA
@@ -113435,58 +112200,58 @@ gCI
 jpW
 tpk
 vDX
-xww
+mWE
 lVN
 wPd
 bjL
 vMt
-vCl
+vEm
 vMt
 pqm
 tPm
 fTM
-bAs
+ive
 ykL
 lJB
 oah
 wtt
 fDQ
-xoW
+sBc
 oPc
 xUt
 ygK
 tjj
 dDB
 ssz
-qRO
-roz
+pKU
+xpY
 ssz
-aSy
-aSy
-aSy
-aSy
-pVU
-iTB
-vHT
+dmT
 wlk
-rce
+dDO
+yeQ
+jAp
+nLM
+tEj
+bqD
+rcl
 wtc
-mmy
-aSy
-aSy
-aSy
-aSy
+uDg
+yeQ
+cNZ
+wlk
+hwz
 xnE
-bOR
-pGK
-gWN
-jFh
+tuT
+tuT
+xNL
+tuT
 tuT
 xCI
 ufn
-rFi
-vbR
-miT
+rln
+ivY
+oDB
 rwo
 eVM
 tuT
@@ -113692,15 +112457,15 @@ vDX
 vDX
 vDX
 vDX
-xww
+mWE
 qUF
 wPd
 rVj
 vMt
 sJw
-lup
+jZa
 jXA
-xRg
+uWn
 xuu
 enb
 wQP
@@ -113716,36 +112481,36 @@ tqD
 dDB
 ssz
 ppL
-roz
+xpY
 ssz
-vLv
-jLF
-yeQ
-fJl
+aSy
+aSy
+aSy
+aSy
 lgw
 iTB
-aSy
-kkd
-aSy
-wtc
+vHT
+wlk
+rce
+mFT
 cOC
-fJK
-yeQ
-cdg
-xEo
-pQE
-yim
-fEd
-gWN
-bey
+aSy
+aSy
+aSy
+aSy
+xnE
+bOR
+tUa
+gOq
+vlj
 tuT
 ufn
-qRh
+gOh
 ufn
-vbR
-miT
-twx
-vYv
+ivY
+oDB
+ufn
+ufn
 sqh
 bEN
 afJ
@@ -113945,17 +112710,17 @@ fLR
 qOJ
 yio
 iOv
-veq
-xww
-veq
+hUH
+mWE
+hUH
 aop
-xww
-xww
+mWE
+mWE
 wPd
 cmn
 vMt
-tQQ
-oKs
+xHS
+vMt
 pqm
 eDz
 fTM
@@ -113965,7 +112730,7 @@ ipj
 jyw
 wtt
 kSd
-xsa
+xoW
 ldF
 xUt
 yig
@@ -113975,53 +112740,53 @@ ssz
 ldq
 reg
 ssz
-vLv
 qIk
+cWm
 yeQ
-shm
-tNR
-uDg
-xvF
-xvF
-mIg
-pQY
-iFm
+fJl
+lve
+iTB
+aSy
+kkd
+aSy
+mFT
+rpc
 kau
 yeQ
-fDY
-xbe
+acM
+eAY
 pQE
-sMu
-vks
-gWN
-hjP
-mPu
-tbK
-tbK
+yim
+fEd
+gOq
+cYR
+tuT
+pHq
+pHq
 kho
-vbR
-lRj
-vbR
+ivY
+pCT
+ivY
 dwX
-vbR
-vbR
-eKP
-vbR
-vbR
-vbR
-vbR
-ykn
-vbR
-vbR
-vbR
+ivY
+ivY
+nTU
+ivY
+ivY
+ivY
+ivY
+kKN
+ivY
+ivY
+ivY
 mUQ
-vbR
-vbR
-vbR
-vbR
-vbR
+ivY
+ivY
+ivY
+ivY
+ivY
 ufn
-mNz
+yhH
 tuT
 blb
 dDB
@@ -114207,7 +112972,7 @@ vDX
 vDX
 vDX
 vDX
-xww
+mWE
 wPd
 wPd
 mzo
@@ -114215,68 +112980,68 @@ rsl
 pqm
 pqm
 tOZ
-alb
+biZ
 tsb
 ykL
 ykL
 ykL
 tjj
 wME
-xAM
-tye
-xAM
+aau
+aau
+aau
 rMH
 tjj
 blb
 ssz
 jiB
-qRO
+pKU
 ssz
 xLk
-qIk
+swn
 vuB
 orW
-lve
-uDg
-pMA
+bzm
+geM
 xvF
 xvF
-pQY
+mIg
+oIx
 iFm
 sWc
 yeQ
 rJw
-eAY
+xvY
 pQE
-jSw
-fEd
-yel
+nSl
+yhT
+gOq
 pHq
-tuT
+mEn
 tXG
 vcd
-tbK
+pHq
 jUc
 ixM
 cwS
 ufn
 hMA
-jIj
+fFC
 ufn
 vJB
 uKN
 lNk
 ufn
-jkH
+yhF
 viT
-sYu
+hMA
 ufn
 ufn
 uKN
 qlr
-iNA
+mwu
 ufn
-yel
+vgY
 jFh
 cjm
 tuT
@@ -114457,14 +113222,14 @@ baO
 pzd
 gMz
 rem
-rQA
+iMG
 shD
 xbg
 rOK
 ebe
 sKt
 vDX
-xww
+mWE
 ruD
 wPd
 vMC
@@ -114487,28 +113252,28 @@ tjj
 blb
 ssz
 aZg
-qRO
+pKU
 ssz
-vLv
-nye
+qIk
+dBO
 aSy
 jGL
 iOL
-iTB
-aSy
-vWI
-aSy
-wtc
+geM
+pMA
+xvF
+xvF
+oIx
 opW
 bWs
 yeQ
 mYW
 ahD
 pQE
-nIT
+jSw
 fEd
+vgY
 ufn
-vlj
 tuT
 kTw
 kOV
@@ -114714,15 +113479,15 @@ baO
 pzd
 ycQ
 rem
-nvB
+klF
 jqq
 xbg
 pGU
 aRo
 qhF
 svh
-xww
-veq
+mWE
+hUH
 vDX
 gaU
 wxU
@@ -114730,7 +113495,7 @@ vMC
 kxp
 tSu
 uhj
-xSZ
+wAl
 uZA
 urv
 dDB
@@ -114744,19 +113509,19 @@ blb
 blb
 ssz
 xtv
-sPO
+hDz
 ssz
 aSy
 aSy
 aSy
 aSy
-pVU
+oUB
 iTB
-tNw
-nZQ
-syK
-wtc
-xkK
+aSy
+vWI
+aSy
+mFT
+uDg
 aSy
 aSy
 aSy
@@ -114768,8 +113533,8 @@ hRd
 jKS
 tuT
 jOF
-wOC
-rlH
+jLt
+trl
 okk
 kTw
 tqX
@@ -114971,11 +113736,11 @@ xQJ
 xQJ
 xQJ
 ryt
-nvB
-uIy
+klF
+lmb
 pnq
-pHI
-vsi
+dQm
+vbJ
 tPH
 wPd
 wPd
@@ -114985,9 +113750,9 @@ gsv
 wMN
 tbB
 ygu
-xdc
+uME
 ugj
-xSZ
+wAl
 vaf
 yeh
 blb
@@ -115001,19 +113766,19 @@ blb
 ssz
 ssz
 xQI
-roz
+xpY
 ssz
 pus
 cYG
 srb
 yeQ
-pVU
-ukE
-tEj
-rfJ
-rcl
-qCq
-xkK
+jAp
+bLT
+tNw
+nZQ
+qem
+aAL
+uDg
 yeQ
 heB
 cYG
@@ -115024,9 +113789,9 @@ tuT
 tuT
 tuT
 tuT
-kNZ
-kiR
-rlH
+wOC
+nrD
+trl
 oZL
 kTw
 qXh
@@ -115236,15 +114001,15 @@ tpK
 dnO
 vMC
 krd
-sDM
+kUR
 cKa
-stP
-pzK
+rsX
+gWa
 tbD
 ygu
-xdc
-ugC
-xSZ
+uME
+qvF
+wAl
 qld
 ssz
 ssz
@@ -115258,19 +114023,19 @@ ssz
 ssz
 xQI
 xQI
-roz
+xpY
 ssz
 iWZ
 oMI
 okB
 nhC
-oUB
-bLT
-oEB
-sGh
-uEC
-aAL
-wxZ
+ktl
+nLM
+tEj
+rfJ
+rcl
+wtc
+tQM
 uXV
 tEj
 bqD
@@ -115283,11 +114048,11 @@ dxO
 wOC
 wOC
 nyQ
-hiU
+giW
 ktD
 kTw
 sok
-rhH
+qmy
 grm
 blb
 blb
@@ -115485,10 +114250,10 @@ pmq
 xMo
 xQJ
 wcR
-rQA
-shG
-sCB
-sUe
+iMG
+suU
+hgt
+vsi
 tpO
 cZx
 vMC
@@ -115496,12 +114261,12 @@ apF
 vfk
 rWr
 tLn
-pzK
+gWa
 tbD
 tyA
 tTx
 hYf
-xSZ
+wAl
 vbA
 vAK
 xQI
@@ -115523,9 +114288,9 @@ jlS
 yeQ
 buA
 idd
-iiW
-iiW
-egr
+oEB
+sGh
+uEC
 vCs
 nVx
 yeQ
@@ -115539,7 +114304,7 @@ ozs
 dMm
 wOC
 aHu
-rXv
+noJ
 nCo
 uHv
 rIY
@@ -115742,7 +114507,7 @@ mrc
 xMT
 xQJ
 rTC
-rQA
+iMG
 boi
 xbg
 sUE
@@ -115756,7 +114521,7 @@ sul
 nuC
 veK
 yeh
-tUc
+dRv
 hnV
 uGA
 yeh
@@ -115772,7 +114537,7 @@ ldq
 ldq
 ldq
 ssz
-dgo
+vId
 scj
 aSy
 aSy
@@ -116017,7 +114782,7 @@ tUo
 uiB
 uGN
 vdf
-vAT
+uJc
 vWe
 xsM
 wNb
@@ -116035,13 +114800,13 @@ wMH
 hLc
 hLc
 aSy
-roC
+hOl
 kTC
 xQh
 dUF
 kKT
 woI
-hOl
+bcO
 eWI
 eXK
 mJr
@@ -116255,8 +115020,8 @@ bfE
 rIo
 xQJ
 jIn
-oUC
-oPM
+udd
+iZl
 sDj
 uqw
 uqw
@@ -116276,14 +115041,14 @@ ylo
 ylq
 cRn
 gsh
-euR
-xIk
-xIk
-xIk
-xIk
-xIk
-euR
 hok
+eMm
+eMm
+eMm
+eMm
+eMm
+hok
+cov
 oOh
 aXI
 qHY
@@ -116298,7 +115063,7 @@ qZe
 xvF
 eqz
 cLS
-hOl
+bcO
 eWI
 eWI
 wNZ
@@ -116513,7 +115278,7 @@ nou
 xQJ
 ifg
 xlL
-oPM
+iZl
 wBI
 pnQ
 pIp
@@ -116533,14 +115298,14 @@ uGT
 veg
 vAX
 vXy
-wuo
+ezb
 hqc
 afA
 qEe
 qEe
 qEe
 sRj
-jkz
+oxl
 ifU
 eGc
 cAb
@@ -116552,7 +115317,7 @@ cvH
 xiT
 blk
 fxi
-rrb
+xvF
 fxi
 ibI
 bON
@@ -116769,8 +115534,8 @@ fik
 xqS
 xQJ
 tOa
-oPM
-oPM
+iZl
+iZl
 wBI
 xTO
 xPj
@@ -117026,8 +115791,8 @@ mFh
 noB
 xQJ
 avN
-oPM
-jLt
+iZl
+rWS
 wBI
 sEr
 dQQ
@@ -117039,16 +115804,16 @@ vir
 vir
 vir
 oNN
-yfA
-mfl
 xds
-yfA
+mfl
+uZf
+xds
 uGU
 vfT
 uMU
 iPJ
 ilD
-wNg
+otk
 mYm
 mdt
 fdM
@@ -117275,7 +116040,7 @@ xXT
 bsu
 opA
 goA
-jDS
+xdu
 uFt
 plB
 caI
@@ -117292,10 +116057,10 @@ wJL
 vbK
 uKH
 qWF
-wco
-wco
-wco
-wco
+kUF
+kUF
+kUF
+kUF
 jtI
 jtI
 jtI
@@ -117305,7 +116070,7 @@ xWD
 uMU
 pQr
 xWs
-tCG
+hio
 vfD
 uMU
 lDI
@@ -117315,7 +116080,7 @@ mMN
 ljZ
 uHd
 vnf
-mcn
+exu
 rOX
 rOX
 sYa
@@ -117540,7 +116305,7 @@ mGp
 vUz
 qNn
 pgy
-owm
+aHV
 sXi
 bfe
 sXi
@@ -117557,16 +116322,16 @@ wOs
 wOs
 vbK
 xuW
-xam
-vhJ
+myp
+kwX
 kOh
 wec
 gGK
 aPX
 smk
 elc
-wIY
-wIY
+aZL
+aZL
 nAF
 srK
 srK
@@ -117804,7 +116569,7 @@ pnU
 xlL
 xlL
 mok
-vRh
+xvv
 uMH
 vbK
 hVY
@@ -117819,17 +116584,17 @@ rpk
 uMU
 vYx
 xWs
-tCG
+hio
 xwr
 uMU
 xVn
-yiU
+aej
 tNu
-pEy
+ltE
 udw
 uHd
 lhm
-wEC
+rKE
 wed
 vsJ
 sYa
@@ -117839,7 +116604,7 @@ foI
 gJS
 lIL
 gJS
-cDa
+bYo
 mOm
 uLT
 oWr
@@ -118052,31 +116817,31 @@ xRq
 pCa
 xdu
 mFt
-nEC
+saA
 nXS
 kYY
 oQj
 pdz
 pps
-sXz
+lHZ
 xkO
 sQb
-vRh
+xvv
 uMH
 xfc
 rYm
-tpI
+phm
 vmp
 phm
 wPK
 xfc
-vRh
+xvv
 xUV
 rpk
 uMU
 eAn
 bZN
-rPm
+xEo
 wwz
 uMU
 rwB
@@ -118304,22 +117069,22 @@ blb
 ukI
 wkG
 ebc
-jDS
+xdu
 cmD
 pEq
 lYf
 rsL
 iJb
-oUC
+udd
 mLO
 oQJ
 pdU
 qka
 voh
-eWD
+ueT
 vzN
-vRh
-pwA
+xvv
+cFo
 rvX
 ixT
 svy
@@ -118564,15 +117329,15 @@ xXT
 wsL
 vwd
 fzq
-xau
+mTc
 rsL
 qhh
 ghC
 vmJ
 hbk
 qIM
-xfu
-xbT
+kNZ
+lpt
 snJ
 vbK
 upr
@@ -118584,7 +117349,7 @@ rXW
 tdw
 uaV
 xfc
-vRh
+xvv
 kqb
 vbK
 xia
@@ -118608,7 +117373,7 @@ sYa
 sYa
 xlP
 xlP
-fSg
+fGE
 xlP
 xlP
 eWI
@@ -118821,7 +117586,7 @@ rsL
 rsL
 rsL
 rsL
-xau
+mTc
 rsL
 xSe
 miz
@@ -118841,8 +117606,8 @@ sKz
 uWv
 uaV
 vbK
-uiS
-uGW
+upy
+kWN
 sQb
 mbZ
 fIf
@@ -118885,7 +117650,7 @@ fla
 keO
 vlV
 qXh
-rhH
+qmy
 grm
 blb
 blb
@@ -119078,7 +117843,7 @@ orC
 oPQ
 kbm
 rsL
-xau
+mTc
 rsL
 xSt
 xWq
@@ -119089,17 +117854,17 @@ prf
 dSb
 hiV
 vbK
-upy
-qWJ
+tjm
+tis
 flx
 oBX
 mzl
 aOz
-fRl
+mzl
 skV
-kxE
-gto
-fqG
+eHP
+pcy
+fdv
 sQb
 kZh
 wJY
@@ -119116,13 +117881,13 @@ uHd
 meG
 wML
 rrt
+lXV
 saY
-qbo
 hnP
 sYa
 xlP
 xlP
-jMC
+yeI
 xlP
 xlP
 eWI
@@ -119131,7 +117896,7 @@ tNT
 vlV
 tJX
 tJX
-gky
+vid
 vlV
 vlV
 vlV
@@ -119139,7 +117904,7 @@ vlV
 vlV
 uhT
 uhT
-niZ
+fpq
 pCU
 tqX
 kfy
@@ -119352,22 +118117,22 @@ vbK
 dtC
 vym
 phm
-fcF
+phm
 dss
 vbK
 sfq
-uGX
-frZ
-xqn
-xqn
+kFV
+cpU
+wcT
+wcT
 wvM
-xqn
+wcT
 xwu
 xEd
 bBr
 yjt
 eTT
-paT
+dUS
 jxk
 vKX
 vnf
@@ -119388,18 +118153,18 @@ clb
 vlV
 fSB
 eWI
-gky
-gky
+vid
+vid
 lrh
-gky
-gky
+vid
+vid
 mNv
-niZ
-niZ
-niZ
+fpq
+fpq
+fpq
 vlV
 tqX
-vEn
+xnY
 svs
 grm
 grm
@@ -119613,17 +118378,17 @@ pjn
 tzH
 vbK
 the
-fqG
+fdv
 uUS
 ocb
-mau
+mbk
 ocb
 bYk
-ayu
-xVv
+jPy
+mpE
 ocb
 ocb
-mau
+mbk
 nTP
 dNz
 erE
@@ -119870,7 +118635,7 @@ wcp
 wcp
 xFA
 ryk
-xVG
+iYo
 sQb
 rxT
 vYF
@@ -119892,9 +118657,9 @@ ryy
 boW
 sYa
 mwJ
-vBZ
+xlP
 ygf
-isR
+xlP
 fvH
 eWI
 blb
@@ -119913,10 +118678,10 @@ nsW
 geS
 aWz
 xsW
-agK
+tfH
 qRo
 wGq
-hgu
+oWf
 jzp
 ogF
 grm
@@ -120118,23 +118883,23 @@ vBG
 bpI
 qiM
 urd
-qWL
+lTg
 viA
 vqU
 mUO
 mUO
-tuE
+uNK
 owv
 rOW
-vRh
-fqG
+xvv
+fdv
 sQb
 mbZ
 wHg
 wwU
 wHg
 mbZ
-tpl
+fUG
 xYK
 jSl
 mbZ
@@ -120157,9 +118922,9 @@ eWI
 dDB
 blb
 eXo
-wos
-wos
-wos
+vgz
+vgz
+vgz
 eXo
 blb
 eWI
@@ -120173,8 +118938,8 @@ nwj
 kfy
 mVD
 jzp
-hgu
-aLA
+oWf
+lXs
 cpE
 grm
 dDB
@@ -120368,7 +119133,7 @@ xXT
 qNF
 rej
 wBs
-ijk
+jSR
 jSR
 wxd
 qYv
@@ -120380,10 +119145,10 @@ viA
 sbN
 iXM
 oKn
-tuE
+uNK
 owv
 rOW
-xvv
+wnO
 uHf
 vbK
 xia
@@ -120423,7 +119188,7 @@ eWI
 eWI
 eWI
 eWI
-cDf
+pTi
 xQj
 svs
 uzY
@@ -120431,7 +119196,7 @@ qbn
 svs
 kNK
 qIZ
-cfH
+vtd
 svs
 svs
 dDB
@@ -120653,7 +119418,7 @@ xnC
 rfO
 aGv
 nLk
-vId
+nxp
 icT
 bxI
 wwI
@@ -120669,18 +119434,18 @@ eWI
 eWI
 eWI
 blb
-wos
+vgz
 nFs
-bgQ
-hvX
-fsT
+hwj
+wGU
+yhn
 eXo
 blb
 blb
 blb
 blb
-sLU
-tYN
+eXt
+kML
 imI
 svs
 ewF
@@ -120926,10 +119691,10 @@ dDB
 dDB
 blb
 blb
-wos
+vgz
 jMa
-mWE
-gZh
+wHJ
+oCg
 oJP
 eXo
 blb
@@ -120937,7 +119702,7 @@ eXo
 eXo
 eXo
 eXo
-qCc
+tJC
 xBp
 svs
 grm
@@ -121139,14 +119904,14 @@ rsL
 lRh
 pfT
 kaD
-jpE
-jpE
+hWE
+hWE
 sJr
 kaD
 tCD
 vtA
+phM
 urk
-rza
 viK
 dSq
 xok
@@ -121173,26 +119938,26 @@ vnf
 wML
 pwn
 eXo
-iUp
+auG
 wdS
 eXo
-wos
-wos
-wos
+vgz
+vgz
+vgz
 eXo
-wos
-wos
-wos
+vgz
+vgz
+vgz
 eXo
 srH
 vqX
-gCo
-gjL
+liL
+naa
 eXo
 eXo
 eXo
-jat
-iUp
+cmA
+auG
 nVF
 msJ
 xQj
@@ -121201,7 +119966,7 @@ dDB
 dDB
 svs
 mrt
-hgu
+oWf
 gRX
 svs
 dDB
@@ -121396,7 +120161,7 @@ rsL
 cgy
 seM
 seM
-rVy
+cPh
 seM
 oGL
 gfQ
@@ -121427,12 +120192,12 @@ eQt
 wYa
 dBh
 vnf
-fdG
+lSa
 uXC
 eXo
 hQd
-jHx
-wos
+olG
+vgz
 sXw
 vVX
 sTK
@@ -121440,16 +120205,16 @@ hGr
 vbQ
 iVE
 ksg
-wos
+vgz
 mLM
 iIN
 nIx
 lPI
 iOF
 ePX
-wos
-jrU
-qlz
+vgz
+nxy
+lkv
 nVF
 msJ
 cYk
@@ -121458,7 +120223,7 @@ blb
 blb
 svs
 gFX
-hgu
+oWf
 lxN
 svs
 svs
@@ -121628,7 +120393,7 @@ wgv
 dDB
 dDB
 vdg
-gzY
+wEw
 wdB
 wdB
 hrL
@@ -121662,7 +120427,7 @@ oyQ
 uuY
 tCD
 xok
-vhC
+iPF
 xok
 xok
 xok
@@ -121684,31 +120449,31 @@ xok
 xok
 xok
 qID
-iHM
+fqv
 uSB
 vSM
-qxB
+blm
 nKj
-jXr
-mny
-oWC
-mny
+juf
+fJK
+daH
+fJK
 gxq
-oWC
-oWC
-oWC
-hrz
+daH
+daH
+daH
+pJu
 tsA
 vyi
 qDi
 aEJ
 bZt
-mHZ
+gnp
 srE
 lom
-tGI
+hIF
 lDc
-fKa
+pGK
 pGp
 svs
 dDB
@@ -121919,7 +120684,7 @@ qjh
 qzL
 kbI
 xok
-vhC
+iPF
 sHV
 wcs
 xaN
@@ -121943,29 +120708,29 @@ xok
 qFb
 wML
 gDB
-ccF
-gMe
+hAe
+fHk
 nRr
 vTg
 rqm
-vwx
+lPJ
 rYp
 aKx
 rYp
-viV
+bYC
 rqm
-pJu
-nFp
+mrs
+mhW
 hfI
+ikS
 woD
-qCY
 toh
 tAT
-fDO
+vhu
 ldx
-gMe
-ccF
-eTy
+fHk
+hAe
+msJ
 xQj
 svs
 svs
@@ -122178,7 +120943,7 @@ wgC
 xok
 vzg
 vPS
-wdd
+jKC
 twi
 iBZ
 xok
@@ -122186,24 +120951,24 @@ ukV
 uHo
 vkJ
 xok
-sZH
-xEq
-xEq
-xEq
+mYd
+txV
+txV
+txV
 xok
 cnG
 cZl
 gMQ
 xok
-sjp
+kSv
 rNd
 vnf
-uzK
+ukk
 dde
 nVF
 qsg
 kcW
-wos
+vgz
 udv
 tSq
 mvo
@@ -122211,26 +120976,26 @@ hGr
 bFw
 ulK
 cdn
-wos
+vgz
 vwE
 ujZ
 mkZ
 lZa
 fZp
 xHc
-wos
+vgz
 oGk
 eFV
 nVF
-eTy
+msJ
 xQj
 grm
 blb
 blb
 grm
 oqK
-qmb
-cfH
+qhv
+vtd
 aqW
 grm
 dDB
@@ -122437,22 +121202,22 @@ dex
 bxT
 qNO
 xaN
-vhC
+iPF
 xok
 xok
 xok
 xok
 xok
-sZH
+mYd
 xaN
 uGK
-xEq
+txV
 xok
 xok
 xok
 xok
 xok
-sjp
+kSv
 xaN
 xjo
 qQK
@@ -122461,18 +121226,18 @@ nVF
 aAD
 sCk
 eXo
-wos
-wos
-wos
+vgz
+vgz
+vgz
 eXo
-wos
-wos
-wos
+vgz
+vgz
+vgz
 eXo
-qiN
-xFd
-gCo
-qiN
+oYx
+leW
+liL
+oYx
 eXo
 eXo
 eXo
@@ -122486,7 +121251,7 @@ blb
 blb
 grm
 wHP
-iia
+bkX
 msJ
 tuP
 grm
@@ -122703,13 +121468,13 @@ vDC
 esz
 xaN
 wQx
-xEq
+txV
 tec
-xEq
-xEq
+txV
+txV
 uqc
-xEq
-sjp
+txV
+kSv
 xaN
 eSd
 vXH
@@ -122725,10 +121490,10 @@ dDB
 dDB
 blb
 blb
-wos
+vgz
 tMs
-mWE
-gZh
+wHJ
+oCg
 bmr
 eXo
 blb
@@ -122736,7 +121501,7 @@ eXo
 eXo
 eXo
 eXo
-cru
+qCc
 xaI
 svs
 svs
@@ -122970,7 +121735,7 @@ fWJ
 xaN
 bCQ
 llT
-qEB
+kfI
 vXH
 blb
 blb
@@ -122982,18 +121747,18 @@ ifa
 ifa
 ifa
 blb
-wos
+vgz
 aoa
-llH
-cKL
-mTM
+asG
+gDQ
+lSc
 eXo
 blb
 blb
 blb
 blb
-sLU
-tYN
+eXt
+kML
 apl
 svs
 dDB
@@ -123226,7 +121991,7 @@ xok
 fWJ
 bNl
 bCQ
-qgq
+qac
 vOf
 uXC
 scj
@@ -123472,13 +122237,13 @@ gnY
 mOM
 vFh
 vYS
-wxu
+dfO
 xok
 xok
 xok
 xok
 dTi
-tbI
+evq
 xok
 qNO
 xaN
@@ -123498,9 +122263,9 @@ ifa
 dDB
 blb
 eXo
-wos
-wos
-wos
+vgz
+vgz
+vgz
 eXo
 blb
 kQt
@@ -123731,25 +122496,25 @@ vFn
 qNO
 sbq
 wRd
-qsV
+wRo
 xEQ
 elh
-yba
-lDr
+fpw
+pOL
 xok
 geg
 xok
 bEB
-mWc
+vjV
 eYH
-atB
+ruB
 vXH
 jnk
 gqh
 bcK
 kXQ
 jId
-ciW
+spK
 qKe
 ifa
 blb
@@ -123762,7 +122527,7 @@ blb
 blb
 kQt
 lxo
-uFc
+aWB
 pil
 cxy
 cyf
@@ -123987,14 +122752,14 @@ lOG
 xaN
 xCV
 sbq
-wRo
+cNT
 vTf
 xFI
 gfu
-ckt
-ckt
+pQW
+pQW
 nOD
-lwu
+pzg
 lkV
 whF
 okW
@@ -124003,10 +122768,10 @@ fUo
 hyE
 xKl
 vkW
-uWr
+djE
 kCI
 gqh
-ciW
+spK
 jJT
 kQt
 kQt
@@ -124018,7 +122783,7 @@ kQt
 kQt
 kQt
 kQt
-dHL
+bFW
 leP
 hyE
 iVT
@@ -124247,13 +123012,13 @@ sbq
 sbq
 sbq
 sbq
-aFj
+muB
 lkV
 iJL
-rci
-vTv
+dNo
+uDI
 juU
-boY
+vMi
 agI
 kQt
 xZX
@@ -124262,7 +123027,7 @@ gTS
 nUo
 bGe
 iqD
-fVy
+cHy
 nQo
 pcL
 kQt
@@ -124502,12 +123267,12 @@ dDB
 blb
 rLr
 xtW
-jiR
-reN
-hRA
-reN
-xUX
-nZF
+lUt
+wBN
+fId
+wBN
+cCK
+rci
 kpX
 lnu
 enG
@@ -124761,17 +123526,17 @@ rLr
 naz
 rlM
 oZz
-xZJ
+hRA
 aVT
-isl
-kUa
-kUa
-kUa
-vIz
+enG
+pJr
+pJr
+pJr
+hUD
 xpR
 kQt
 nhl
-kat
+rBc
 dzE
 oTj
 eLB
@@ -124789,7 +123554,7 @@ osY
 hyE
 hyE
 lSb
-mch
+tUZ
 hyE
 wmB
 qGB
@@ -125016,7 +123781,7 @@ dDB
 blb
 rLr
 xtW
-xxa
+wja
 nWh
 xEn
 nWh
@@ -125024,7 +123789,7 @@ xnR
 aLC
 wLZ
 eKV
-cns
+jPM
 vwJ
 kQt
 kQt
@@ -125275,14 +124040,14 @@ yeZ
 yeZ
 yeZ
 yeZ
-fnd
+sBA
 yeZ
 yeZ
 qei
 qei
 qei
-hlJ
 jZL
+dDc
 hGb
 iSh
 kQt
@@ -125298,11 +124063,11 @@ hyE
 oix
 hyE
 iZH
-mXk
+shm
 lKG
 scv
 hyE
-dHL
+bFW
 hyE
 blb
 grm
@@ -125530,16 +124295,16 @@ dDB
 blb
 yeZ
 rma
-oCB
+oqi
 xFL
-dtk
+pPD
 kZF
 pSB
 qei
 qZU
 jeG
-oxg
-fZG
+wRm
+dyJ
 hQD
 cqx
 kQt
@@ -125555,7 +124320,7 @@ hyE
 mME
 hyE
 mJS
-bJw
+tSI
 eoC
 cRS
 hyE
@@ -125564,7 +124329,7 @@ hyE
 blb
 grm
 eUC
-hoN
+oIa
 grm
 dDB
 dDB
@@ -125786,17 +124551,17 @@ dDB
 dDB
 blb
 rle
-oqi
+xKA
 xFL
-rCa
+rbH
 lwn
-aMy
+vZf
 nNZ
 qei
 rss
 hcb
 owH
-sQX
+rzd
 idt
 tKG
 kQt
@@ -126044,7 +124809,7 @@ dDB
 blb
 yeZ
 iyr
-dEL
+rCa
 wVg
 nzL
 nzL
@@ -126052,8 +124817,8 @@ nzL
 qei
 vCQ
 qSC
-kcQ
-gpT
+rez
+xwU
 bVD
 agy
 kQt
@@ -126073,7 +124838,7 @@ uqL
 bGL
 pjb
 jLP
-dHL
+bFW
 bRk
 hyE
 blb
@@ -126302,20 +125067,20 @@ blb
 rle
 wTJ
 lDw
-ejx
+pAC
 bry
 heT
 teE
 qei
 xwQ
 wCH
-sXL
-rzd
+fkK
+qPJ
 sGE
 hon
 kQt
 lHc
-pyh
+njh
 xyZ
 pxZ
 xTf
@@ -126327,8 +125092,8 @@ xap
 ieY
 kks
 dof
-uVO
-lEg
+sdm
+gJj
 rWO
 wrD
 bHs
@@ -126565,9 +125330,9 @@ bHy
 rxP
 qei
 whD
-hwh
+qRa
 cTp
-rzd
+qPJ
 uQb
 ijB
 kQt
@@ -126819,17 +125584,17 @@ rud
 aGb
 rFp
 yly
-rBg
+kHJ
 rGp
-blJ
+qLE
 qnJ
 oiT
 obs
 ilE
 nwk
 kQt
-jeC
-dLQ
+bHF
+mdG
 jie
 vHx
 hyE
@@ -127335,13 +126100,13 @@ yeZ
 oXa
 dYW
 dxZ
-dLQ
-dLQ
-dLQ
-dLQ
+mdG
+mdG
+mdG
+mdG
 irc
 hyE
-jeC
+bHF
 xAv
 hyE
 dDB
@@ -127353,22 +126118,22 @@ dDB
 dDB
 dDB
 hyE
+dAr
+afF
+afF
 lVg
-afF
-afF
-pMs
 hyE
 wWz
 nQz
 sSS
 fLC
 hgP
-uiz
+uyF
 bmA
 xZs
-qcf
+jif
 wBi
-nfm
+fUN
 kGB
 bzZ
 flo
@@ -127597,8 +126362,8 @@ hyE
 hyE
 hyE
 kit
-dLQ
-tUZ
+mdG
+rta
 hyE
 hyE
 dDB
@@ -127610,10 +126375,10 @@ dDB
 dDB
 dDB
 hyE
-iWI
-hyE
-hyE
 ecL
+hyE
+hyE
+oOR
 hyE
 pNC
 luo
@@ -127867,10 +126632,10 @@ dDB
 dDB
 dDB
 dDB
+ury
+blb
+blb
 fKx
-blb
-blb
-seV
 wJd
 nle
 lnA
@@ -128124,10 +126889,10 @@ dDB
 dDB
 dDB
 dDB
-iaJ
+wHl
 blb
 blb
-seV
+fKx
 wJd
 wJd
 wJd
@@ -128381,7 +127146,7 @@ dDB
 dDB
 dDB
 dDB
-iaJ
+wHl
 blb
 blb
 vVT
@@ -128638,10 +127403,10 @@ dDB
 dDB
 dDB
 dDB
+ury
+blb
+blb
 fKx
-blb
-blb
-seV
 dDB
 blb
 dDB
@@ -128895,7 +127660,7 @@ ylD
 dDB
 dDB
 ylD
-cpJ
+sgt
 ylD
 ylD
 mTU
@@ -129410,8 +128175,8 @@ wNK
 pnt
 ylD
 ksN
-sVk
-jQj
+ubk
+eRO
 xpb
 ylD
 lVz
@@ -129424,9 +128189,9 @@ dDB
 ylD
 urn
 pHk
-vlX
+aMp
 wla
-aRw
+vlX
 egN
 oFf
 cbg
@@ -129649,25 +128414,25 @@ sge
 lVz
 idq
 oRB
-oGQ
-oGQ
-cCl
-cCl
-oGQ
-oGQ
+vfK
+vfK
+pST
+pST
+vfK
+vfK
 bnr
 bnr
 qkp
-rfZ
+jKT
 sEB
-odk
-pof
+kNk
+wiO
 eLn
 xlx
 sEn
 csI
-bVR
-jLl
+xae
+sgm
 xlx
 sOF
 cFq
@@ -129681,10 +128446,10 @@ dDB
 ylD
 ylD
 ylD
-sPa
-ylD
-ylD
 oRV
+ylD
+ylD
+hGk
 ylD
 ylD
 ylD
@@ -129918,13 +128683,13 @@ ylD
 rhL
 rTq
 rMb
-eAo
+jTp
 sWA
-kwu
+mmy
 ouL
-aqV
-kwu
-kwu
+cfy
+mmy
+mmy
 vLs
 qeT
 ylD
@@ -129937,11 +128702,11 @@ ylD
 ylD
 ylD
 mEq
-ozV
+xCT
 bsI
 ylD
 wBa
-xCT
+tob
 kRN
 ylD
 wdk
@@ -130169,7 +128934,7 @@ wKG
 lAO
 ncb
 mMr
-oNH
+mLA
 pFk
 ylD
 rir
@@ -130185,15 +128950,15 @@ xBF
 sVp
 oyR
 ylD
-ymh
-meJ
+iWf
+nTE
 xkn
 xEv
-meJ
-meJ
-meJ
-sPa
-eQQ
+nTE
+nTE
+nTE
+oRV
+hMk
 gYq
 aUA
 ylD
@@ -130427,7 +129192,7 @@ oiU
 oiU
 mZA
 uqU
-naC
+qwc
 ylD
 rlg
 tTA
@@ -130442,7 +129207,7 @@ ylD
 ylD
 ylD
 ylD
-ymh
+iWf
 ylD
 ylD
 ylD
@@ -130684,7 +129449,7 @@ lQu
 mMr
 mMr
 oWk
-qHt
+mVy
 ylD
 ylD
 ylD
@@ -130693,13 +129458,13 @@ ylD
 mMr
 dOb
 ovB
-lko
-meJ
-meJ
-meJ
-meJ
+kUW
+nTE
+nTE
+nTE
+nTE
 xkn
-ymh
+iWf
 ylD
 xqq
 xLY
@@ -130940,13 +129705,13 @@ mwx
 wgF
 ylD
 rZG
-cFj
+krv
 bNP
 fii
 fNv
 jwh
-fvz
-aYR
+mAP
+goz
 vNt
 kIY
 vqb
@@ -131198,7 +129963,7 @@ ylD
 ylD
 xcH
 xmg
-pHn
+aiX
 mlm
 vlb
 xgz
@@ -131456,7 +130221,7 @@ ylD
 ylD
 ylD
 vnv
-qUe
+wnI
 vnv
 ylD
 ylD
@@ -131713,7 +130478,7 @@ ylD
 wFz
 baE
 fcq
-lkd
+nAI
 fkT
 fcq
 sQv
@@ -131971,10 +130736,10 @@ olm
 fcq
 fkT
 jcm
-lkd
-lkd
-lkd
-lkd
+nAI
+nAI
+nAI
+nAI
 vjp
 wdk
 wdk
@@ -132228,7 +130993,7 @@ fcq
 fcq
 mcl
 xYz
-lkd
+nAI
 fcq
 fkT
 fcq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tech Storage is now located right under engineering, with a bridge connecting EVA and secure tech storage.

![image](https://github.com/user-attachments/assets/d4158ab4-4d82-4b20-911d-81f9b75fffff)

To achieve this, EVA and council chamber swapped places, making the bridge into a corridor (like on all other maps) instead of a dead end. HoP also now has a way to enter their office without exiting the bridge and entering from the public hallway (unless you count maintenance as a way)

![image](https://github.com/user-attachments/assets/0366131b-3569-4220-b564-9a0cb25303c7)

In place of old tech storage we now have a remapped morgue and an abandoned brewery with mechanical curtains (similar to ones on Delta, they essentially act as shutters)

![image](https://github.com/user-attachments/assets/f780f4c5-78be-43ce-ba10-3b5453f7dc1c)

Closes #89422

## Why It's Good For The Game

Birdshot's layout is rather bad and tech storage is one of the top offenders, having no right to be located near arrivals so far away from engineering. Also the morgue is kinda scuffed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Moved Birdshot's tech storage to be between bridge and engineering, with a brand old abandoned brewery in its former place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
