### PR TITLE
Honorific don't care about mononyms

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -920,20 +920,15 @@
 
 /// Re-generates the honorific title. Returns the compiled honorific_title value
 /obj/item/card/id/proc/update_honorific()
-	var/is_mononym = is_mononym(registered_name)
 	switch(honorific_position)
 		if(HONORIFIC_POSITION_FIRST)
 			honorific_title = "[chosen_honorific] [first_name(registered_name)]"
 		if(HONORIFIC_POSITION_LAST)
 			honorific_title = "[chosen_honorific] [last_name(registered_name)]"
 		if(HONORIFIC_POSITION_FIRST_FULL)
-			honorific_title = "[chosen_honorific] [first_name(registered_name)]"
-			if(!is_mononym)
-				honorific_title += " [last_name(registered_name)]"
+			honorific_title = "[chosen_honorific] [registered_name]"
 		if(HONORIFIC_POSITION_LAST_FULL)
-			if(!is_mononym)
-				honorific_title += "[first_name(registered_name)] "
-			honorific_title += "[last_name(registered_name)][chosen_honorific]"
+			honorific_title = "[registered_name][chosen_honorific]"
 	return honorific_title
 
 /// Returns the trim assignment name.


### PR DESCRIPTION
## About The Pull Request

Currently if you have a hyphenated name, either being a lizard (`Wines-And-Dines`) or as someone with a joined name (`Jessica Smith-Rose`), and choose a "Full Name" honorific, your name gets a little butchered, producing `Cpt. Wines` or `Cpt. Jessica Rose` respectively

I find this odd - you ask for "full name" and you only get most-to-some of your name under some circumstances. So this PR just makes the "Full name" honorifics actually use the full name, thus including middle names, hyphenated names, and whole lizard names.

If you are a lizard and only want your first name (current behavior), you can just select "first name", anyways.

The only thing I can think of that this would negatively affect are people who have a middle name, and don't want it displayed. But if that *is* a notable problem, we can introduce a setting for `Full name sans middle name` or something.

## Why It's Good For The Game

Full name means full name!

## Changelog

:cl: Melbert
del: Honorific "full name" setting no longer cares about mononyms, meaning Lizards and people with similarly hyphenated names will no longer get their name butchered.
/:cl:

