### PR TITLE
Fixes alert modal button layout not being correct in cases

### DIFF
--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -33,10 +33,29 @@ export function AlertModal(props) {
     title,
   } = data;
 
+  // Stolen wholesale from fontcode
+  function textWidth(text: string, font: string, fontsize: number) {
+    // default font height is 12 in tgui
+    font = fontsize + 'x ' + font;
+    const c = document.createElement('canvas');
+    const ctx = c.getContext('2d') as CanvasRenderingContext2D;
+    ctx.font = font;
+    return ctx.measureText(text).width;
+  }
+
   const [selected, setSelected] = useState(0);
 
+  const windowWidth = 345 + (buttons.length > 2 ? 55 : 0);
+
+  // very accurate estimate of padding for each num of buttons
+  const paddingMagicNumber = 67 / buttons.length + 23;
+
   // At least one of the buttons has a long text message
-  const isVerbose = buttons.some((button) => button.length > 10);
+  const isVerbose = buttons.some(
+    (button) =>
+      textWidth(button, '', large_buttons ? 14 : 12) > // 14 is the larger font size for large buttons
+      windowWidth / buttons.length - paddingMagicNumber,
+  );
   const largeSpacing = isVerbose && large_buttons ? 20 : 15;
 
   // Dynamically sets window dimensions
@@ -45,8 +64,6 @@ export function AlertModal(props) {
     (isVerbose ? largeSpacing * buttons.length : 0) +
     (message.length > 30 ? Math.ceil(message.length / 4) : 0) +
     (message.length && large_buttons ? 5 : 0);
-
-  const windowWidth = 345 + (buttons.length > 2 ? 55 : 0);
 
   /** Changes button selection, etc */
   function keyDownHandler(event: KeyboardEvent<HTMLDivElement>) {

--- a/tgui/packages/tgui/interfaces/PlaneMasterDebug.tsx
+++ b/tgui/packages/tgui/interfaces/PlaneMasterDebug.tsx
@@ -125,14 +125,14 @@ type PlaneDebugData = {
 };
 
 // Stolen wholesale from fontcode
-const textWidth = (text, font, fontsize) => {
+function textWidth(text: string, font: string, fontsize: number) {
   // default font height is 12 in tgui
   font = fontsize + 'x ' + font;
   const c = document.createElement('canvas');
   const ctx = c.getContext('2d') as CanvasRenderingContext2D;
   ctx.font = font;
   return ctx.measureText(text).width;
-};
+}
 
 const planeToPosition = function (plane: Plane, index, is_incoming): Position {
   return {


### PR DESCRIPTION

## About The Pull Request

This fixes the fixes introduced in https://github.com/tgstation/tgstation/pull/82714

In many cases, "10 chars" is the absolute worst case scenario that does not reflect actual reality like see below
![image](https://github.com/user-attachments/assets/cbcffaaa-5cc6-48a0-b67e-22f339ee5253)
Therefore what I have done is use the actual text width instead of char count to make it correctly decide when to layout it vertically instead of horizontally

Instead we now have this:
OLD
Normal
![image](https://github.com/user-attachments/assets/cdce1e35-189e-4fa6-a6d7-272c14c7b123)
Large
![image](https://github.com/user-attachments/assets/9f927242-34ea-4965-bf25-b843a5293539)
NEW
Normal
![image](https://github.com/user-attachments/assets/ea8be0d7-75ad-458a-9568-537fa34ce192)

Large
![image](https://github.com/user-attachments/assets/62d0bd9a-ae7a-40d9-abed-34d57311d552)





## Changelog
:cl:
fix: fixed tgui alerts sometimes having a lot of empty space in their layout
/:cl:
