### PR TITLE
Hides two do_afters which should be invisible

### DIFF
--- a/code/datums/components/basic_mob_attack_telegraph.dm
+++ b/code/datums/components/basic_mob_attack_telegraph.dm
@@ -73,7 +73,7 @@
 
 	on_began_forecast?.Invoke(target)
 	//we stop the do_after if the target moves out of neighboring turfs but if they dance around us they get their face smashed
-	if (!do_after(source, delay = telegraph_duration, target = target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(source, TYPE_PROC_REF(/atom/movable, Adjacent), target), interaction_key = INTERACTION_BASIC_ATTACK_FORCEAST), hidden = TRUE)
+	if (!do_after(source, delay = telegraph_duration, target = target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(source, TYPE_PROC_REF(/atom/movable, Adjacent), target), interaction_key = INTERACTION_BASIC_ATTACK_FORCEAST, hidden = TRUE))
 		forget_target(target)
 		return
 	if (isnull(target)) // They got out of the way :(

--- a/code/datums/components/basic_mob_attack_telegraph.dm
+++ b/code/datums/components/basic_mob_attack_telegraph.dm
@@ -73,7 +73,7 @@
 
 	on_began_forecast?.Invoke(target)
 	//we stop the do_after if the target moves out of neighboring turfs but if they dance around us they get their face smashed
-	if (!do_after(source, delay = telegraph_duration, target = target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(source, TYPE_PROC_REF(/atom/movable, Adjacent), target), interaction_key = INTERACTION_BASIC_ATTACK_FORCEAST))
+	if (!do_after(source, delay = telegraph_duration, target = target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(source, TYPE_PROC_REF(/atom/movable, Adjacent), target), interaction_key = INTERACTION_BASIC_ATTACK_FORCEAST), hidden = TRUE)
 		forget_target(target)
 		return
 	if (isnull(target)) // They got out of the way :(

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_gaze.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_gaze.dm
@@ -27,7 +27,7 @@
 	stage_timer = addtimer(CALLBACK(src, PROC_REF(show_indicator_overlay), "eye_pulse"), animation_time, TIMER_STOPPABLE)
 	StartCooldown(360 SECONDS, 360 SECONDS)
 	owner.visible_message(span_warning("[owner]'s eye glows ominously!"))
-	if (do_after(owner, delay = wait_delay, target = owner))
+	if (do_after(owner, delay = wait_delay, target = owner, hidden = TRUE))
 		trigger_effect()
 	else
 		deltimer(stage_timer)


### PR DESCRIPTION
## About The Pull Request and also Why It's Good For The Game

Lately I noticed that watchers display the do_after "working" cog while channeling their "look away" ability, which looks silly because it already has its own indicator. That should be hidden.

![dreamseeker_6cSCMzJ14f](https://github.com/user-attachments/assets/b7e15cf1-1936-4a7b-8b18-2b799a96dd4a)

Actually now I look at this gif again the offset on the cog is fucked up, probably need to update that for larger-than-usual mobs...

While I was at it I also added "hidden" to mob basic attack forecasts. I can't think it's _likely_ that anyone will add a mob with a > 1 second forecast (they are only displayed if the length is at least one second) but it's not totally impossible.

## Changelog

:cl:
image: Watchers won't display an animated cog at the same time as using their gaze attack.
/:cl:
