### PR TITLE
Support sending channel announcements to multiple channel tags

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -246,7 +246,8 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 
 	to_chat(world, span_infoplain(span_big(span_bold("<BR><BR><BR>The round has ended."))))
 	log_game("The round has ended.")
-	send2chat(new /datum/tgs_message_content("[GLOB.round_id ? "Round [GLOB.round_id]" : "The round has"] just ended."), CONFIG_GET(string/channel_announce_end_game))
+	for(var/channel_tag in CONFIG_GET(str_list/channel_announce_end_game))
+		send2chat(new /datum/tgs_message_content("[GLOB.round_id ? "Round [GLOB.round_id]" : "The round has"] just ended."), channel_tag)
 	send2adminchat("Server", "Round just ended.")
 
 	if(length(CONFIG_GET(keyed_list/cross_server)))

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -571,24 +571,24 @@
 	integer = FALSE
 
 /datum/config_entry/flag/irc_announce_new_game
-	deprecated_by = /datum/config_entry/string/channel_announce_new_game
+	deprecated_by = /datum/config_entry/str_list/channel_announce_new_game
 
 /datum/config_entry/flag/irc_announce_new_game/DeprecationUpdate(value)
 	return "" //default broadcast
 
 /datum/config_entry/string/chat_announce_new_game
-	deprecated_by = /datum/config_entry/string/channel_announce_new_game
+	deprecated_by = /datum/config_entry/str_list/channel_announce_new_game
 
 /datum/config_entry/string/chat_announce_new_game/DeprecationUpdate(value)
 	return "" //default broadcast
 
-/datum/config_entry/string/channel_announce_new_game
+/datum/config_entry/str_list/channel_announce_new_game
 	default = null
 
-/datum/config_entry/string/channel_announce_end_game
+/datum/config_entry/str_list/channel_announce_end_game
 	default = null
 
-/datum/config_entry/string/chat_new_game_notifications
+/datum/config_entry/str_list/chat_new_game_notifications
 	default = null
 
 /// validate ownership of admin flags for chat commands

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -69,7 +69,9 @@ SUBSYSTEM_DEF(discord)
 	var/notifymsg = jointext(people_to_notify, ", ")
 	if(notifymsg)
 		notifymsg += ", a new round is starting!"
-		send2chat(new /datum/tgs_message_content(trim(notifymsg)), CONFIG_GET(string/chat_new_game_notifications)) // Sends the message to the discord, using same config option as the roundstart notification
+		for(var/channel_tag in CONFIG_GET(str_list/chat_new_game_notifications))
+			// Sends the message to the discord, using same config option as the roundstart notification
+			send2chat(new /datum/tgs_message_content(trim(notifymsg)), channel_tag)
 	fdel(notify_file) // Deletes the file
 	return SS_INIT_SUCCESS
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -160,7 +160,8 @@ SUBSYSTEM_DEF(ticker)
 			for(var/client/C in GLOB.clients)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, span_notice("<b>Welcome to [station_name()]!</b>"))
-			send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), CONFIG_GET(string/channel_announce_new_game))
+			for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
+				send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag)
 			current_state = GAME_STATE_PREGAME
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
 

--- a/code/modules/discord/tgs_commands.dm
+++ b/code/modules/discord/tgs_commands.dm
@@ -38,7 +38,7 @@
 	help_text = "Pings the invoker when the round ends"
 
 /datum/tgs_chat_command/notify/Run(datum/tgs_chat_user/sender, params)
-	if(!CONFIG_GET(string/channel_announce_new_game))
+	if(!CONFIG_GET(str_list/channel_announce_new_game))
 		return new /datum/tgs_message_content("Notifcations are currently disabled")
 
 	for(var/member in SSdiscord.notify_members) // If they are in the list, take them out

--- a/config/config.txt
+++ b/config/config.txt
@@ -429,18 +429,20 @@ MINUTE_CLICK_LIMIT 400
 ## Various messages to be sent to connected chat channels.
 ## Uncommenting these will enable them, by default they will be broadcast to Game chat channels on TGS3 or non-admin channels on TGS>=4.
 ## If using TGS>=4, the string option can be set as one of more chat channel tags (separated by ','s) to limit the message to channels with that tag name (case-sensitive). This will have no effect on TGS3.
-## i.e. CHANNEL_ANNOUNCE_NEW_GAME chat_channel_tag
+## You can also specify multiple channel tags by using the config option multiple times,
+## i.e. CHANNEL_ANNOUNCE_NEW_GAME chat_channel_tag_1
+## i.e. CHANNEL_ANNOUNCE_NEW_GAME chat_channel_tag_2
 
-## Which channel will have a message about a new game starting, message includes the station name.
+## Which channels will have a message about a new game starting, message includes the station name.
 #CHANNEL_ANNOUNCE_NEW_GAME
 
-## Which channel will have a message about a new game starting, message includes the round ID of the game that has just ended.
+## Which channels will have a message about a new game starting, message includes the round ID of the game that has just ended.
 #CHANNEL_ANNOUNCE_END_GAME
 
 ## Ping users who use the `notify` command when a new game starts.
 #CHAT_NEW_GAME_NOTIFICATIONS
 
-## Uncomment this to validate admin commands from discord by requiring they come from linked discord accounts and that those discord accounts link to a ckey with the right admin permissions.
+## Uncomment this flag to validate admin commands from discord by requiring they come from linked discord accounts and that those discord accounts link to a ckey with the right admin permissions.
 # SECURE_CHAT_COMMANDS
 
 ## Allow admin hrefs that don't use the new token system, will eventually be removed


### PR DESCRIPTION
previous system was weird, you had to add a comma separated list in the channel tag in TGS itself. this is much more intuitive. also it should not break older configs

:cl:
config: Added support for multiple chat channel configs for channel announcements.
/:cl:
