### PR TITLE
Removes some traitor item timelocks

### DIFF
--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -60,15 +60,12 @@
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
 	item = /obj/item/storage/backpack/duffelbag/clown/syndie
 	purchasable_from = ALL
-	progression_minimum = 70 MINUTES
 
 /datum/uplink_item/badass/costumes/tactical_naptime
 	name = "Sleepy Time Pajama Bundle"
 	desc = "Even soldiers need to get a good nights rest. Comes with blood-red pajamas, a blankie, a hot mug of cocoa and a fuzzy friend."
 	item = /obj/item/storage/box/syndie_kit/sleepytime
 	purchasable_from = ALL
-	progression_minimum = 90 MINUTES
-	cost = 4
 	limited_stock = 1
 	cant_discount = TRUE
 
@@ -77,7 +74,6 @@
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
 			Please note that this kit did NOT pass quality control."
 	purchasable_from = ALL
-	progression_minimum = 90 MINUTES
 	item = /obj/item/storage/box/syndie_kit/chameleon/broken
 
 /datum/uplink_item/badass/costumes/centcom_official
@@ -85,7 +81,7 @@
 	desc = "Ask the crew to \"inspect\" their nuclear disk and weapons system, and then when they decline, pull out a fully automatic rifle and gun down the Captain. \
 			Radio headset does not include encryption key. No gun included."
 	purchasable_from = ALL
-	progression_minimum = 110 MINUTES
+	cost = 12
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
 
 /datum/uplink_item/badass/stickers

--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -81,7 +81,7 @@
 	desc = "Ask the crew to \"inspect\" their nuclear disk and weapons system, and then when they decline, pull out a fully automatic rifle and gun down the Captain. \
 			Radio headset does not include encryption key. No gun included."
 	purchasable_from = ALL
-	cost = 12
+	cost = 8
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
 
 /datum/uplink_item/badass/stickers

--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -59,13 +59,11 @@
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
 	item = /obj/item/storage/backpack/duffelbag/clown/syndie
-	purchasable_from = ALL
 
 /datum/uplink_item/badass/costumes/tactical_naptime
 	name = "Sleepy Time Pajama Bundle"
 	desc = "Even soldiers need to get a good nights rest. Comes with blood-red pajamas, a blankie, a hot mug of cocoa and a fuzzy friend."
 	item = /obj/item/storage/box/syndie_kit/sleepytime
-	purchasable_from = ALL
 	limited_stock = 1
 	cant_discount = TRUE
 
@@ -73,15 +71,12 @@
 	name = "Broken Chameleon Kit"
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
 			Please note that this kit did NOT pass quality control."
-	purchasable_from = ALL
 	item = /obj/item/storage/box/syndie_kit/chameleon/broken
 
 /datum/uplink_item/badass/costumes/centcom_official
 	name = "CentCom Official Costume"
 	desc = "Ask the crew to \"inspect\" their nuclear disk and weapons system, and then when they decline, pull out a fully automatic rifle and gun down the Captain. \
 			Radio headset does not include encryption key. No gun included."
-	purchasable_from = ALL
-	cost = 8
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
 
 /datum/uplink_item/badass/stickers

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -81,7 +81,6 @@
 	name = "Holoparasites"
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
-	progression_minimum = 20 MINUTES
 	item = /obj/item/guardian_creator/tech
 	cost = 18
 	surplus = 0

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -38,7 +38,6 @@
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be \
 			pocketed when inactive. Activating it produces a loud, distinctive noise."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/melee/energy/sword/saber
 	cost = 6
 	purchasable_from = ~UPLINK_CLOWN_OPS
@@ -49,7 +48,6 @@
 			Upon hitting a target, the piston-ram will extend forward to make contact for some serious damage. \
 			Using a wrench on the piston valve will allow you to tweak the amount of gas used per punch to \
 			deal extra damage and hit targets further. Use a screwdriver to take out any attached tanks."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/melee/powerfist
 	cost = 6
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
@@ -57,7 +55,6 @@
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/clothing/gloves/rapid
 	cost = 8
 

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -38,7 +38,7 @@
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be \
 			pocketed when inactive. Activating it produces a loud, distinctive noise."
-	progression_minimum = 20 MINUTES
+	progression_minimum = 15 MINUTES
 	item = /obj/item/melee/energy/sword/saber
 	cost = 6
 	purchasable_from = ~UPLINK_CLOWN_OPS
@@ -49,7 +49,7 @@
 			Upon hitting a target, the piston-ram will extend forward to make contact for some serious damage. \
 			Using a wrench on the piston valve will allow you to tweak the amount of gas used per punch to \
 			deal extra damage and hit targets further. Use a screwdriver to take out any attached tanks."
-	progression_minimum = 20 MINUTES
+	progression_minimum = 15 MINUTES
 	item = /obj/item/melee/powerfist
 	cost = 6
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
@@ -57,7 +57,7 @@
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
-	progression_minimum = 20 MINUTES
+	progression_minimum = 15 MINUTES
 	item = /obj/item/clothing/gloves/rapid
 	cost = 8
 
@@ -84,7 +84,7 @@
 	name = "Holoparasites"
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
-	progression_minimum = 30 MINUTES
+	progression_minimum = 20 MINUTES
 	item = /obj/item/guardian_creator/tech
 	cost = 18
 	surplus = 0

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -31,7 +31,6 @@
 	desc = "Contains 3 X-4 shaped plastic explosives. Similar to C4, but with a stronger blast that is directional instead of circular. \
 			X-4 can be placed on a solid surface, such as a wall or window, and it will blast through the wall, injuring anything on the opposite side, while being safer to the user. \
 			For when you want a controlled explosion that leaves a wider, deeper, hole."
-	progression_minimum = 20 MINUTES
 	item = /obj/item/storage/backpack/duffelbag/syndie/x4
 	cost = 4
 	cant_discount = TRUE
@@ -67,7 +66,6 @@
 	name = "Pizza Bomb"
 	desc = "A pizza box with a bomb cunningly attached to the lid. The timer needs to be set by opening the box; afterwards, \
 			opening the box again will trigger the detonation after the timer has elapsed. Comes with free pizza, for you or your target!"
-	progression_minimum = 15 MINUTES
 	item = /obj/item/pizzabox/bomb
 	cost = 6
 	surplus = 8

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -318,7 +318,6 @@
 			Attach to an exosuit with an existing equipment to disguise the bay as that equipment. The sacrificed equipment will be lost.\
 			Alternatively, you can attach the bay to an empty equipment slot, but the bay will not be concealed. Once the bay is \
 			attached, an exosuit weapon can be fitted inside."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay
 	cost = 3
 	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -105,7 +105,6 @@
 	name = "Combat Bakery Kit"
 	desc = "A kit of clandestine baked weapons. Contains a baguette which a skilled mime could use as a sword, \
 		a pair of throwing croissants, and the recipe to make more on demand. Once the job is done, eat the evidence."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/storage/box/syndie_kit/combat_baking
 	cost = 7
 	restricted_roles = list(JOB_COOK, JOB_MIME)
@@ -217,7 +216,6 @@
 	name = "Reverse Revolver"
 	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \
 	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a box of hugs. Honk."
-	progression_minimum = 30 MINUTES
 	cost = 14
 	item = /obj/item/storage/box/hug/reverse_revolver
 	restricted_roles = list(JOB_CLOWN)
@@ -226,8 +224,6 @@
 	name = "Kinetic Accelerator Pressure Mod"
 	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
 			Occupies 35% mod capacity."
-	// While less deadly than a revolver it does have infinite ammo
-	progression_minimum = 15 MINUTES
 	item = /obj/item/borg/upgrade/modkit/indoors
 	cost = 5 //you need two for full damage, so total of 10 for maximum damage
 	limited_stock = 2 //you can't use more than two!
@@ -246,7 +242,6 @@
 /datum/uplink_item/role_restricted/laser_arm
 	name = "Laser Arm Implant"
 	desc = "An implant that grants you a recharging laser gun inside your arm. Weak to EMPs. Comes with a syndicate autosurgeon for immediate self-application."
-	progression_minimum = 20 MINUTES
 	cost = 10
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)
@@ -255,7 +250,6 @@
 /datum/uplink_item/role_restricted/chemical_gun
 	name = "Reagent Dartgun"
 	desc = "A heavily modified syringe gun which is capable of synthesizing its own chemical darts using input reagents. Can hold 90u of reagents."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/gun/chem
 	cost = 12
 	restricted_roles = list(JOB_CHEMIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_BOTANIST)
@@ -324,7 +318,7 @@
 			Attach to an exosuit with an existing equipment to disguise the bay as that equipment. The sacrificed equipment will be lost.\
 			Alternatively, you can attach the bay to an empty equipment slot, but the bay will not be concealed. Once the bay is \
 			attached, an exosuit weapon can be fitted inside."
-	progression_minimum = 30 MINUTES
+	progression_minimum = 15 MINUTES
 	item = /obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay
 	cost = 3
 	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -131,7 +131,7 @@
 	desc = "When purchased, a virus will be uploaded to the engineering processing servers to force a routine power grid check, forcing all APCs on the station to be temporarily disabled."
 	item = ABSTRACT_UPLINK_ITEM
 	surplus = 0
-	progression_minimum = 20 MINUTES
+	progression_minimum = 15 MINUTES
 	limited_stock = 1
 	cost = 6
 	restricted = TRUE

--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -27,6 +27,13 @@
 	item = /obj/item/storage/box/syndie_kit/space
 	cost = 4
 
+/datum/uplink_item/suits/modsuit
+	name = "Syndicate MODsuit"
+	desc = "The feared MODsuit of a Syndicate agent. Features armoring and a set of inbuilt modules."
+	item = /obj/item/mod/control/pre_equipped/traitor
+	cost = 8
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS //you can't buy it in nuke, because the elite modsuit costs the same while being better
+
 /datum/uplink_item/suits/thermal
 	name = "MODsuit Thermal Visor Module"
 	desc = "A visor for a MODsuit. Lets you see living beings through walls."
@@ -62,17 +69,6 @@
 	desc = "A MODsuit module preventing the user from getting knocked down by batons."
 	item = /obj/item/mod/module/shock_absorber
 	cost = 2
-
-/datum/uplink_item/suits/modsuit/elite_traitor
-	name = "Elite Syndicate MODsuit"
-	desc = "An upgraded, elite version of the Syndicate MODsuit. It features fireproofing, and also \
-			provides the user with superior armor and mobility compared to the standard Syndicate MODsuit."
-	item = /obj/item/mod/control/pre_equipped/traitor_elite
-	// This one costs more than the nuke op counterpart
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
-	progression_minimum = 60 MINUTES
-	cost = 16
-	cant_discount = TRUE
 
 /datum/uplink_item/suits/modsuit/wraith
 	name = "MODsuit wraith cloaking module"

--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -27,13 +27,6 @@
 	item = /obj/item/storage/box/syndie_kit/space
 	cost = 4
 
-/datum/uplink_item/suits/modsuit
-	name = "Syndicate MODsuit"
-	desc = "The feared MODsuit of a Syndicate agent. Features armoring and a set of inbuilt modules."
-	item = /obj/item/mod/control/pre_equipped/traitor
-	cost = 8
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS //you can't buy it in nuke, because the elite modsuit costs the same while being better
-
 /datum/uplink_item/suits/thermal
 	name = "MODsuit Thermal Visor Module"
 	desc = "A visor for a MODsuit. Lets you see living beings through walls."

--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -77,7 +77,7 @@
 	item = /obj/item/mod/control/pre_equipped/traitor_elite
 	// This one costs more than the nuke op counterpart
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
-	progression_minimum = 90 MINUTES
+	progression_minimum = 60 MINUTES
 	cost = 16
 	cant_discount = TRUE
 


### PR DESCRIPTION
## About The Pull Request

It's been a while since the last time I did this in #78852 and I think we can afford to be a little looser on some items.
This PR _has_ evidently been made with the context that I have another PR open which removes the ability for you to fast-forward these timers, however I also think that these changes should stand alone fine even if we did not end up merging that other one.
This one I haven't pre-cleared with anyone else first though so I'm prepared to be told my judgement is wrong and bad.

My basic philosophy when considering the reputation timelocks is that we don't necessarily care considerably about items that are "good" or that make you really good at killing specifically one person at a time, winning duels is the expectation for a traitor and their gear.

The reasons we _might_ want to timelock something are instead:
- If it causes widespread destruction such that simply deploying it may lead to the shuttle being called (Syndicate Bomb, Hacked AI module).
- If it makes you significantly more difficult to kill such that even a group of people may have to try unusual tactics (Dual Esword, Sleeping Carp).
- If it creates a second antagonist (allied or not), as another player is a significant force multiplier (Holoparasites and Spider Toxin).
- If you buy something and it immediately effects the entire station, even if the impact isn't that high, it might be kind of annoying if it has no time limit (Blackout and Comms Blackout).

So applying those criteria, here are my proposed changes.

**Timer reduced to 15 minutes:**

- Station Blackout (was 20 minutes)

To be honest this is mostly just so that it matches the other global service (Comms Blackout). If anything I think this one is actually frequently _less_ useful than the other one which we made available slightly earlier.

**Timer removed:**

- Energy Sword, Powerfist, Gloves of the North Star (Previously 20 minutes)

These function as "items that make you really good at killing one person". They're very _scary_ but they don't turn you into a threat that can take on a group of people by themselves.  

The Energy Sword has a projectile deflection chance but it isn't so reliable as to consistently overwhelm a group of people. Arguably it's better _as_ a shield than a primary weapon. It's common pairing (the ebow) is frankly more dangerous on its own than the esword is, but the sword is the one with the timelock.   
I'm not touching the _Dual_ esword because that one _does_ come with enough of a block chance that by itself it can be very impactful to how people need to approach you.  

The powerfist is arguably the _best_ weapon for killing one guy, but doesn't protect you from being shot by a group of people. Ditto north star.
Plus it's sad that of the iconic traitor items, the revolver has no timelock and the energy sword does...

- Concealed Mech Weapons Bay (was 30 minutes)

This doesn't give your mech a cool weapon, it only allows you to place an existing mech weapon you already had onto a surprising mech. By the time you have a cool mech weapon to use this with it may already have been 30 minutes anyway, and also you will already be able to build a mech which is better at combat and which this item is not useful for. This is largely just an item for gimmicks where one person is caught unaware that you had something in your back pocket, not a long-term plan which makes you significantly more dangerous or durable (the most durable and dangerous mechs don't need this item).

- Holoparasite (was 30 minutes)

While this summons another player, it costs basically your entire budget and also comes with significant downsides. You could say that rather than making you harder to kill this actually often makes you significantly easier to remove from the round. This item is self-balancing because the other player gets you round-removed after 5 minutes virtually all the time.

- Pizza Bomb (was 15 minutes)

I actually said I removed the timer from this in my last PR but I didn't? 
This is a bomb, but it's really only strong enough to kill and dismember one person. Your best case requires a group of people to be crowded around someone opening some pizza and even then a lot of the bystanders will be heavily wounded but alive. The explosion isn't strong enough to cause people to want to call the shuttle.

- Bag of X4 (was 20 minutes)

This provides three small bombs that are essentially breaching tools. You'd have to buy a lot of these to cause enough damage to make someone want to call the shuttle. C4 already has no timelock and X4 is just a slightly more directed version of C4 which is more useful for breaking through a series of walls.

- Combat Bakery Kit (was 15 minutes)

This is a mime-only item which gives you a dangerous baguette and some throwing croissants, functionally a worse-but-stealthier eblade basically. This is firmly in the category of "item you use to kill one guy" and it's not even amazing for that.

- Reverse Revolver (was 30 minutes)

I think this one was just an oversight; we removed the timelock from the revolver entirely but left a 30 minute one on the clown revolver.

- Kinetic Accelerator Upgrade Mod (was 15 minutes)

This gives miners a shorter-range but infinite ammo gun that they can use to kill one guy. It's loud and has no defensive benefits. Another revolver. 

- Laser Arm Implant (was 20 minutes)

Being concealable, rechargeable, and difficult to disarm is a good benefit over the revolver... but it's still basically another revolver with the same use case as a revolver.
Again I don't think we want to timelock things because they are "good", only because we think delaying their release into the round would have some tangible benefit.

- Chemical Dart Gun (was 15 minutes)

This one I am actually the most scared of out of anything I listed here purely because chems are a world of strange possibilites I don't quite understand. Still, I am hesitantly classing this as a "cool revolver" with the additional caveat that as you need time to prep your crazy chem mixes I am not sure that the 15 minutes on it were really doing very much anyway.

**Removed from the Uplink**
- Elite Syndicate Modsuit and various previously nukie-only costumes

It's so over.
Actually originally I was just going to remove the timelock from the non-modsuit costumes but I was convinced while talking about it with various maintainers that if there's no status symbol attached with "unlocking" these then they shouldn't be there in the first place and should return to being a silly team gimmick for nukies as originally designed.
The Elite Suit itself sounds very cool, but it's functionally not really much better than other suits you can buy immediately and is also way more expensive. Removing it from selection is removing a noob trap from the game.

## Why It's Good For The Game

Timelocks aren't fun, they're _useful_ as a tool for directing behaviour but we should probably apply them as minimally as possible.
Given the principles outlined above I think these changes make sense.

## Changelog

:cl:
balance: The reputation "time locks" on various items in the Traitor uplink have been reduced or removed. Effected items include the holoparasite kit, energy sword, power fist, gloves of the northstar, pizza bomb, bag of x4, combat bakery kit, reverse revolver, kinetic accelerator modkit, laser arm implant, concealed weapon bay, chemical dart gun, and stationwide APC check.
balance: The centcom inspector costume is now more expensive.
del: Several previously nukie-only wardrobe options in the traitor uplink are now once more only available to nuclear operatives.
del: Spies can no longer receive an elite nuclear operative suit. 
/:cl:
