### PR TITLE
Adds bomb implants to the Cybersun ghost role that automatically detonate when you enter a station level

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -125,6 +125,7 @@
  */
 /obj/item/implant/explosive/proc/timed_explosion()
 	active = TRUE
+	balloon_alert(imp_in, "your implant beeps!")
 	if (isnull(imp_in))
 		visible_message(span_warning("[src] starts beeping ominously!"))
 	else

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -301,7 +301,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
 
-	implants = list(/obj/item/implant/weapons_auth)
+	implants = list(/obj/item/implant/weapons_auth, /obj/item/implant/explosive/stationhating)
 
 /datum/outfit/syndicatespace/post_equip(mob/living/carbon/human/syndie_scum)
 	syndie_scum.faction |= ROLE_SYNDICATE


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.

## Why It's Good For The Game

The forgotten ship ruin has been on the blacklist for quite a while, and now that it's back, people have been using it as diet nukies to go to the station and shoot people. However, it's also not clear if you are allowed to go to the station, so this ruin is also a relatively painful noob trap and it only serves to give the admin team a headache.

This doesn't actually give the ghost role anything new to do, that part still has to be figured out.

## Changelog

:cl:
add: Cybersun ship protocols have been updated: In the event of dereliction to the enemy, an automated bomb implant will detonate to automatically dispose of traitorous Cybersun personnel.
/:cl:
