### PR TITLE
Fix some filteriffic filters bluescreening it

### DIFF
--- a/tgui/packages/tgui/interfaces/Filteriffic.jsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.jsx
@@ -23,7 +23,7 @@ const FilterIntegerEntry = (props) => {
   const { act } = useBackend();
   return (
     <NumberInput
-      value={value ? value : 0}
+      value={value || 0}
       minValue={-500}
       maxValue={500}
       step={1}
@@ -49,7 +49,7 @@ const FilterFloatEntry = (props) => {
   return (
     <>
       <NumberInput
-        value={value ? value : 0}
+        value={value || 0}
         minValue={-500}
         maxValue={500}
         stepPixelSize={4}

--- a/tgui/packages/tgui/interfaces/Filteriffic.jsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.jsx
@@ -23,7 +23,7 @@ const FilterIntegerEntry = (props) => {
   const { act } = useBackend();
   return (
     <NumberInput
-      value={value}
+      value={value ? value : 0}
       minValue={-500}
       maxValue={500}
       step={1}
@@ -49,7 +49,7 @@ const FilterFloatEntry = (props) => {
   return (
     <>
       <NumberInput
-        value={value}
+        value={value ? value : 0}
         minValue={-500}
         maxValue={500}
         stepPixelSize={4}


### PR DESCRIPTION

## About The Pull Request
At some point value = null started pulling a cannot tostring error for NumberInput so we just default it to 0 instead if its null
Might be a better fix by just changing it in tguicore but I assume this was intended

P.s. this should be tsxed

## Changelog
:cl:
fix: fixed some filters (e.g displacement) in filteriffic bluescreening the UI
/:cl:
