### PR TITLE
Changeling egg uses monkeyize() instead of changing species to monkey

### DIFF
--- a/code/modules/antagonists/changeling/headslug_eggs.dm
+++ b/code/modules/antagonists/changeling/headslug_eggs.dm
@@ -26,7 +26,7 @@
 /// Once the egg is fully grown, we gib the host and spawn a monkey (with the changeling's player controlling it). Very descriptive proc name.
 /obj/item/organ/body_egg/changeling_egg/proc/pop()
 	var/mob/living/carbon/human/spawned_monkey = new(owner)
-	spawned_monkey.set_species(/datum/species/monkey)
+	spawned_monkey.monkeyize(instant = TRUE)
 
 	for(var/obj/item/organ/insertable in src)
 		insertable.Insert(spawned_monkey, 1)


### PR DESCRIPTION

## About The Pull Request
When changeling egg bursts out of a corpse, it will now use proc/monkeyize() instead of proc/set_species(). Doing so basically uses Lesser Form's transform and fixes getting a random name when changeling is bursted instead of getting `monkey (123)`

## Why It's Good For The Game
Less meta about monkeys with names?

## Changelog
:cl:
fix: Changeling egg burst now correctly gives "monkey (123)" name for the changeling-monkey instead of getting a random human name.
/:cl:
