### PR TITLE
Cybernetic arm implants now automatically change insertion zones

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -183,9 +183,13 @@
 		preop_sound = 'sound/items/handling/surgery/hemostat1.ogg'
 		success_sound = 'sound/items/handling/surgery/organ2.ogg'
 		target_organ = tool
+		if(!target_organ.pre_surgical_insertion(user, target, target_zone, tool))
+			return SURGERY_STEP_FAIL
+
 		if(target_zone != target_organ.zone || target.get_organ_slot(target_organ.slot))
 			to_chat(user, span_warning("There is no room for [target_organ] in [target]'s [target.parse_zone_with_bodypart(target_zone)]!"))
 			return SURGERY_STEP_FAIL
+
 		var/obj/item/organ/meatslab = tool
 		if(!meatslab.useable)
 			to_chat(user, span_warning("[target_organ] seems to have been chewed on, you can't use this!"))

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -178,7 +178,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/examine(mob/user)
 	. = ..()
 
-	. += span_notice("It should be inserted in the [parse_zone(zone)].")
+	. += zones_tip()
 
 	if(HAS_MIND_TRAIT(user, TRAIT_ENTRAILS_READER) || isobserver(user))
 		if(HAS_TRAIT(src, TRAIT_CLIENT_STARTING_ORGAN))
@@ -193,6 +193,10 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 			. += span_warning("[src] seems to be malfunctioning.")
 			return
 		. += span_warning("[src] is starting to look discolored.")
+
+/// Returns a line to be displayed regarding valid insertion zones
+/obj/item/organ/proc/zones_tip()
+	return span_notice("It should be inserted in the [parse_zone(zone)].")
 
 ///Used as callbacks by object pooling
 /obj/item/organ/proc/exit_wardrobe()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -80,9 +80,12 @@
 	to_chat(user, span_notice("You modify [src] to be installed on the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."))
 
 /obj/item/organ/cyberimp/arm/pre_surgical_insertion(mob/living/user, mob/living/carbon/new_owner, target_zone)
-	if (target_zone == BODY_ZONE_R_ARM || target_zone == BODY_ZONE_L_ARM) // Ensure that in case we're somehow placed elsewhere (HARS-esque bs) we don't break our zone
-		zone = target_zone
-		SetSlotFromZone()
+	// Ensure that in case we're somehow placed elsewhere (HARS-esque bs) we don't break our zone
+	if (target_zone != BODY_ZONE_R_ARM && target_zone != BODY_ZONE_L_ARM)
+		return FALSE
+
+	zone = target_zone
+	SetSlotFromZone()
 	return ..()
 
 /obj/item/organ/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -32,7 +32,6 @@
 		var/atom/new_item = new typepath(src)
 		items_list += WEAKREF(new_item)
 
-	update_appearance()
 	SetSlotFromZone()
 
 /obj/item/organ/cyberimp/arm/Destroy()
@@ -57,6 +56,7 @@
 			slot = right_arm_organ_slot
 		else
 			CRASH("Invalid zone for [type]")
+	update_appearance()
 
 /obj/item/organ/cyberimp/arm/update_icon()
 	. = ..()
@@ -78,7 +78,12 @@
 		zone = BODY_ZONE_R_ARM
 	SetSlotFromZone()
 	to_chat(user, span_notice("You modify [src] to be installed on the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."))
-	update_appearance()
+
+/obj/item/organ/cyberimp/arm/pre_surgical_insertion(mob/living/user, mob/living/carbon/new_owner, target_zone)
+	if (target_zone == BODY_ZONE_R_ARM || target_zone == BODY_ZONE_L_ARM) // Ensure that in case we're somehow placed elsewhere (HARS-esque bs) we don't break our zone
+		zone = target_zone
+		SetSlotFromZone()
+	return ..()
 
 /obj/item/organ/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)
 	. = ..()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -58,27 +58,6 @@
 			CRASH("Invalid zone for [type]")
 	update_appearance()
 
-/obj/item/organ/cyberimp/arm/update_icon()
-	. = ..()
-	transform = (zone == BODY_ZONE_R_ARM) ? null : matrix(-1, 0, 0, 0, 1, 0)
-
-/obj/item/organ/cyberimp/arm/examine(mob/user)
-	. = ..()
-	if(IS_ROBOTIC_ORGAN(src))
-		. += span_info("[src] is assembled in the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm configuration. You can use a screwdriver to reassemble it.")
-
-/obj/item/organ/cyberimp/arm/screwdriver_act(mob/living/user, obj/item/screwtool)
-	. = ..()
-	if(.)
-		return TRUE
-	screwtool.play_tool_sound(src)
-	if(zone == BODY_ZONE_R_ARM)
-		zone = BODY_ZONE_L_ARM
-	else
-		zone = BODY_ZONE_R_ARM
-	SetSlotFromZone()
-	to_chat(user, span_notice("You modify [src] to be installed on the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."))
-
 /obj/item/organ/cyberimp/arm/pre_surgical_insertion(mob/living/user, mob/living/carbon/new_owner, target_zone)
 	// Ensure that in case we're somehow placed elsewhere (HARS-esque bs) we don't break our zone
 	if (target_zone != BODY_ZONE_R_ARM && target_zone != BODY_ZONE_L_ARM)
@@ -87,6 +66,9 @@
 	zone = target_zone
 	SetSlotFromZone()
 	return ..()
+
+/obj/item/organ/cyberimp/arm/zones_tip()
+	return span_notice("It should be inserted in the [parse_zone(right_arm_organ_slot)] or [parse_zone(left_arm_organ_slot)].")
 
 /obj/item/organ/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)
 	. = ..()

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -287,3 +287,7 @@
 /obj/item/organ/proc/on_surgical_insertion(mob/living/user, mob/living/carbon/new_owner, target_zone, obj/item/tool)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ORGAN_SURGICALLY_INSERTED, user, new_owner, target_zone, tool)
+
+/// Proc that gets called when someone starts surgically inserting the organ
+/obj/item/organ/proc/pre_surgical_insertion(mob/living/user, mob/living/carbon/new_owner, target_zone)
+	return TRUE


### PR DESCRIPTION

## About The Pull Request

Removes weird requirement to screwdriver arm implants to change them into a specific configuration. Instead, they now automatically slot into whichever zone the user has selected.

## Why It's Good For The Game

Its kinda unintuitive and a result of organs only being able to slot into a single zone. I'm not generalizing this to organ layer because arm implants are the only thing that does this, but if we ever get leg enhancements it may be worth moving down into the base class.

## Changelog
:cl:
qol: Cybernetic arm implants now automatically change insertion zones without the need to screwdriver them.
/:cl:
