### PR TITLE
Partially reverts the crusher "buff", making marks work instantly again

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -354,29 +354,26 @@
 	var/boosted = FALSE
 	/// How long before the mark is ready to be detonated. Used for both the visual overlay and to determine when it's ready
 	var/ready_delay = 0.8 SECONDS
-	/// Tracks world.time when the mark was applied
-	var/mark_applied
 
 /datum/status_effect/crusher_mark/on_creation(mob/living/new_owner, was_boosted)
 	. = ..()
 	boosted = was_boosted
-	mark_applied = world.time
 
 /datum/status_effect/crusher_mark/on_apply()
-	if(owner.mob_size >= MOB_SIZE_LARGE)
-		marked_underlay = new()
-		marked_underlay.pixel_x = -owner.pixel_x
-		marked_underlay.pixel_y = -owner.pixel_y
+	if(owner.mob_size < MOB_SIZE_LARGE)
+		return FALSE
 
-		var/list/new_color = list(
-			0, 1, 0,
-			0, 1, 0,
-			0, 1, 0
-		)
-		owner.vis_contents += marked_underlay
-		animate(marked_underlay, color = new_color, time = ready_delay, loop = 1)
-		return TRUE
-	return FALSE
+	marked_underlay = new()
+	marked_underlay.pixel_x = -owner.pixel_x
+	marked_underlay.pixel_y = -owner.pixel_y
+	marked_underlay.transform *= 0.5
+	owner.vis_contents += marked_underlay
+	animate(marked_underlay, ready_delay, transform = matrix() * 1.2, flags = CIRCULAR_EASING | EASE_IN)
+	addtimer(CALLBACK(src, PROC_REF(scale_back)), ready_delay) // Animate chains do not function with vis_contents
+	return TRUE
+
+/datum/status_effect/crusher_mark/proc/scale_back()
+	animate(marked_underlay, time = 0.1 SECONDS, transform = matrix(), flags = CUBIC_EASING | EASE_OUT)
 
 /datum/status_effect/crusher_mark/Destroy()
 	if(owner)
@@ -389,14 +386,9 @@
 	name = "Crusher mark underlay"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield"
-	appearance_flags = TILE_BOUND|LONG_GLIDE|RESET_COLOR
+	appearance_flags = TILE_BOUND|LONG_GLIDE|RESET_COLOR|PIXEL_SCALE
 	vis_flags = VIS_UNDERLAY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	color = list(
-		1, 0, 0,
-		1, 0, 0,
-		1, 0, 0
-	)
 
 /datum/status_effect/stacking/saw_bleed
 	id = "saw_bleed"

--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
@@ -170,8 +170,6 @@
 	if(!mark)
 		return
 	var/boosted_mark = mark.boosted
-	if(world.time < mark.mark_applied + mark.ready_delay) // Simple way to prevent right+left click at the same time to detonate the mark for free
-		return
 	if(!target.remove_status_effect(mark))
 		return
 	// Detonation effect
@@ -205,6 +203,7 @@
 		balloon_alert(user, "can't aim at yourself!")
 		return ITEM_INTERACT_BLOCKING
 	fire_kinetic_blast(interacting_with, user, modifiers)
+	user.changeNext_move(CLICK_CD_MELEE)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/kinetic_crusher/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)


### PR DESCRIPTION

## About The Pull Request

Reverts new crusher marks from #88171. Crusher marks now can be instantly detonated, but firing one puts you on an attack cooldown again. 

I did, however, add a fancy animation to them.

https://github.com/user-attachments/assets/ff09084e-36a9-445e-bb27-d7ba4822e37d

## Why It's Good For The Game

This change caused two major issues:
A) Color-based animation doesn't provide you with a clear hint when the mark is actually ready to be burst, as it can look green but be just a tiny bit short. Before, mistimed clicks didn't punish you aside from potentially getting attacked by entering melee range, while now doing so puts you on another 0.8 second melee cooldown, which feels ***really*** bad as there's no way to see if a mark is actually ready or not.

B) It also removed the potential co-op nuking of mobs/megafauna that crusher duos could do, switching betwen applying and bursting marks for doubled DPS, which while rare, I was kinda fond of.

## Changelog
:cl:
balance: Crusher marks now can be instantly detonated, but firing one puts you on an attack cooldown again
/:cl:
