### PR TITLE
[no gbp] Don't show traitor reputation on roundend screen

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -358,7 +358,6 @@
 	if(uplink_handler)
 		if (uplink_handler.contractor_hub)
 			result += contractor_round_end()
-		result += "<br>The traitor had a total of [DISPLAY_PROGRESSION(uplink_handler.progression_points)] Reputation and [uplink_handler.telecrystals] Unused Telecrystals."
 
 	var/special_role_text = LOWER_TEXT(name)
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -355,9 +355,8 @@
 
 	result += objectives_text
 
-	if(uplink_handler)
-		if (uplink_handler.contractor_hub)
-			result += contractor_round_end()
+	if(uplink_handler && uplink_handler.contractor_hub)
+		result += contractor_round_end()
 
 	var/special_role_text = LOWER_TEXT(name)
 


### PR DESCRIPTION
## About The Pull Request

I forgot to remove traitor reputation from the roundend report.
As every traitor in a round will now have basically the same rep and that rep is based purely on how much time has elapsed (with a modified function based on player count) this seems like totally pointless information.

I very briefly considered making progression simply be a singleton and not stored individually on every uplink, but I figure that _maybe_ admins might sometimes want to set someone's progression to 9999999 without it effecting everyone on the server idk.

## Changelog

:cl:
fix: Traitor reputation (which is now basically just a number representing how many seconds were in the round) is no longer displayed on the roundend screen.
/:cl:
