### PR TITLE
Fixes vehicle elevation

### DIFF
--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -22,6 +22,12 @@
 		var/atom/movable/__movable_target = target; \
 		__final_pixel_z = __movable_target.base_pixel_z; \
 	}; \
+	if(isliving(target)) { \
+		var/mob/living/__living_target = target; \
+		for(var/__offset_key in LAZYACCESS(__living_target.offsets, PIXEL_Z_OFFSET)) { \
+			__final_pixel_z += __living_target.offsets[PIXEL_Z_OFFSET][__offset_key]; \
+		}; \
+	}; \
 	animate(target, pixel_z = __final_pixel_z, time = 1 SECONDS)
 
 /// The duration of the animate call in mob/living/update_transform

--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -20,13 +20,11 @@
 	var/__final_pixel_z = 0; \
 	if(ismovable(target)) { \
 		var/atom/movable/__movable_target = target; \
-		__final_pixel_z = __movable_target.base_pixel_z; \
+		__final_pixel_z += __movable_target.base_pixel_z; \
 	}; \
 	if(isliving(target)) { \
 		var/mob/living/__living_target = target; \
-		for(var/__offset_key in LAZYACCESS(__living_target.offsets, PIXEL_Z_OFFSET)) { \
-			__final_pixel_z += __living_target.offsets[PIXEL_Z_OFFSET][__offset_key]; \
-		}; \
+		__final_pixel_z += __living_target.has_offset(pixel = PIXEL_Z_OFFSET); \
 	}; \
 	animate(target, pixel_z = __final_pixel_z, time = 1 SECONDS)
 

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -191,6 +191,8 @@
 /// Reverts elevation of the mob.
 /datum/element/elevation_core/proc/deelevate_mob(mob/living/target, elevate_time = ELEVATE_TIME)
 	target.remove_offsets(ELEVATION_SOURCE(src), animate = elevate_time > 0)
+	if(isvehicle(target.buckled))
+		animate(target.buckled, pixel_z = -pixel_shift, time = elevate_time, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 
 /**
  * If the mob is buckled or unbuckled to/from a vehicle, shift it up/down

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -173,7 +173,7 @@
 		return
 	// while the offset system can natively handle this,
 	// we want to avoid accidentally double-elevating anything they're buckled to (namely vehicles)
-	if(target.has_offset(ELEVATION_SOURCE(src)))
+	if(target.has_offset(source = ELEVATION_SOURCE(src)))
 		return
 	// We are buckled to something
 	if(target.buckled)

--- a/code/datums/elements/movetype_handler.dm
+++ b/code/datums/elements/movetype_handler.dm
@@ -69,7 +69,8 @@
 /// Called when the TRAIT_NO_FLOATING_ANIM trait is added to the movable. Stops it from bobbing up and down.
 /datum/element/movetype_handler/proc/on_no_floating_anim_trait_gain(atom/movable/source, trait)
 	SIGNAL_HANDLER
-	STOP_FLOATING_ANIM(source)
+	if(source.movement_type & (FLOATING|FLYING))
+		STOP_FLOATING_ANIM(source)
 
 /// Called when the TRAIT_NO_FLOATING_ANIM trait is removed from the mob. Restarts the bobbing animation.
 /datum/element/movetype_handler/proc/on_no_floating_anim_trait_loss(atom/movable/source, trait)

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -151,17 +151,31 @@
  * Checks if we are offset by the passed source for the passed pixel.
  *
  * * source: The source of the offset
+ * If not supplied, it will report the total offset of the passed pixel.
  * * pixel: Optional, The pixel to check.
  * If not supplied, just reports if it's offset by the source at all (returning the first offset found).
  *
  * Returns the offset if we are, 0 otherwise.
  */
 /mob/living/proc/has_offset(source, pixel)
+	if(isnull(source) && isnull(pixel))
+		stack_trace("has_offset() requires at least one argument.")
+		return 0
+
+	if(isnull(source))
+		if(!length(offsets?[pixel]))
+			return 0
+
+		var/total_found_offset = 0
+		for(var/found_offset in offsets[pixel])
+			total_found_offset += has_offset(found_offset, pixel)
+		return total_found_offset
+
 	if(isnull(pixel))
 		for(var/found_pixel in offsets)
-			var/pixel_source = has_offset(source, found_pixel)
-			if(pixel_source)
-				return pixel_source
+			var/found_offset = has_offset(source, found_pixel)
+			if(found_offset)
+				return found_offset
 
 		return 0
 


### PR DESCRIPTION
## About The Pull Request

Fixes #89481

I removed the code which de-elevated vehicles

Also `TRAIT_NO_FLOATING_ANIMATION` continues to be a burden, causing the offset to reset. I fixed that as well.

## Changelog

:cl: Melbert
fix: Fixed offset during vehicle traversal over boxes and tables, as well as while floating
/:cl:
