### PR TITLE
Prisoners aren't given get-out-of-jail-free hooks at roundstart

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -14,6 +14,10 @@
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
 	/// Are we crafted?
 	var/crafted = FALSE
+	/// Should we contain an escape hook on maps with z-levels?
+	var/give_hook = TRUE
+	/// Do we get to benefit from Nanotrasen's largesse?
+	var/give_premium_goods = TRUE
 
 /obj/item/storage/box/survival/Initialize(mapload)
 	. = ..()
@@ -36,14 +40,14 @@
 	if(!isnull(medipen_type))
 		new medipen_type(src)
 
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
+	if(give_premium_goods && HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)
 		new /obj/item/radio/off(src)
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_RADIOACTIVE_NEBULA))
 		new /obj/item/storage/pill_bottle/potassiodide(src)
 
-	if(length(SSmapping.levels_by_trait(ZTRAIT_STATION)) > 1)
+	if(give_hook && length(SSmapping.levels_by_trait(ZTRAIT_STATION)) > 1)
 		new /obj/item/climbing_hook/emergency(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
@@ -58,6 +62,11 @@
 	new /obj/item/tank/internals/plasmaman/belt(src)
 	qdel(mask) // Get rid of the items that shouldn't be
 	qdel(internals)
+
+// Prisoners don't get an escape hook
+/obj/item/storage/box/survival/prisoner
+	give_hook = FALSE
+	give_premium_goods = FALSE
 
 // Mining survival box
 /obj/item/storage/box/survival/mining

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -59,6 +59,7 @@
 	belt = null
 	ears = null
 	shoes = /obj/item/clothing/shoes/sneakers/orange
+	box = /obj/item/storage/box/survival/prisoner
 
 /datum/outfit/job/prisoner/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

Fixes #89487
When we added "escape from falling into a deep hole" hooks to survival boxes _17 months ago_ we forgot that roundstart prisoners get given survival boxes and escaping from the Tram permabrig just requires you to ascend out of a hole.
You could maybe find a way to use these to escape on Icebox too, although it would require going to the gulag probably.

While I was there I also made it so that when everyone in the round starts with extra goodies in their internals box, prisoners don't. The HoS is embezzling the money that was supposed to go towards that, sorry.

## Why It's Good For The Game

You probably shouldn't spawn with an item that allows you to escape jail.

## Changelog

:cl:
fix: Prisoners will no longer spawn on Tram with an item which allows them to immediately exit the jail.
balance: Prisoners also don't get bonus goodies in their internals box when the station trait rolls, because we're mean.
/:cl:
