### PR TITLE
RTD Icon Improvements

### DIFF
--- a/code/_globalvars/lists/rtd.dm
+++ b/code/_globalvars/lists/rtd.dm
@@ -1,6 +1,3 @@
-//dont create icons for TGUI if direction is any of these values cause its handled inside CSS
-GLOBAL_LIST_INIT(tile_dont_rotate, list(NORTH, EAST, SOUTH, WEST))
-
 ///all designs supported by the RTD
 GLOBAL_LIST_INIT(floor_designs, list(
 	//what players will use most of the time
@@ -11,21 +8,21 @@ GLOBAL_LIST_INIT(floor_designs, list(
 			list("name" = "Small", "type" = /obj/item/stack/tile/iron/small, "tile_cost" = 3),
 			list("name" = "Large", "type" = /obj/item/stack/tile/iron/large, "tile_cost" = 7),
 			list("name" = "Diagonal", "type" = /obj/item/stack/tile/iron/diagonal, "tile_cost" = 5),
-			list("name" = "Edge", "type" = /obj/item/stack/tile/iron/edge, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Half", "type" = /obj/item/stack/tile/iron/half, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Corner", "type" = /obj/item/stack/tile/iron/corner, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Edge", "type" = /obj/item/stack/tile/iron/edge, "tile_cost" = 5),
+			list("name" = "Half", "type" = /obj/item/stack/tile/iron/half, "tile_cost" = 5),
+			list("name" = "Corner", "type" = /obj/item/stack/tile/iron/corner, "tile_cost" = 5),
 			list("name" = "Textured", "type" = /obj/item/stack/tile/iron/textured, "tile_cost" = 5),
-			list("name" = "Textured Edge", "type" = /obj/item/stack/tile/iron/textured_edge, "tile_cost" = 6, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Textured Half", "type" = /obj/item/stack/tile/iron/textured_half, "tile_cost" = 6, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Textured Corner", "type" = /obj/item/stack/tile/iron/textured_corner, "tile_cost" = 6, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Textured Edge", "type" = /obj/item/stack/tile/iron/textured_edge, "tile_cost" = 6),
+			list("name" = "Textured Half", "type" = /obj/item/stack/tile/iron/textured_half, "tile_cost" = 6),
+			list("name" = "Textured Corner", "type" = /obj/item/stack/tile/iron/textured_corner, "tile_cost" = 6),
 			list("name" = "Textured Large", "type" = /obj/item/stack/tile/iron/textured_large, "tile_cost" = 6),
 		),
 		//Looks slightly transparent or faded
 		"Translucent" = list(
 			list("name" = "Smooth", "type" = /obj/item/stack/tile/iron/smooth, "tile_cost" = 4),
-			list("name" = "Smooth Edge", "type" = /obj/item/stack/tile/iron/smooth_edge, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Smooth Half", "type" = /obj/item/stack/tile/iron/smooth_half, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Smooth Corner", "type" = /obj/item/stack/tile/iron/smooth_corner, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Smooth Edge", "type" = /obj/item/stack/tile/iron/smooth_edge, "tile_cost" = 4),
+			list("name" = "Smooth Half", "type" = /obj/item/stack/tile/iron/smooth_half, "tile_cost" = 4),
+			list("name" = "Smooth Corner", "type" = /obj/item/stack/tile/iron/smooth_corner, "tile_cost" = 4),
 			list("name" = "Smooth Large", "type" = /obj/item/stack/tile/iron/smooth_large, "tile_cost" = 7),
 			list("name" = "Freezer", "type" = /obj/item/stack/tile/iron/freezer, "tile_cost" = 5),
 			list("name" = "Showroom", "type" = /obj/item/stack/tile/iron/showroomfloor, "tile_cost" = 5),
@@ -49,42 +46,42 @@ GLOBAL_LIST_INIT(floor_designs, list(
 		//Dark Colored tiles
 		"Dark Colored" = list(
 			list("name" = "Base", "type" = /obj/item/stack/tile/iron/dark, "tile_cost" = 4),
-			list("name" = "Smooth Edge", "type" = /obj/item/stack/tile/iron/dark/smooth_edge, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Smooth Half", "type" = /obj/item/stack/tile/iron/dark/smooth_half, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Smooth Corner" ,"type" = /obj/item/stack/tile/iron/dark/smooth_corner, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Smooth Edge", "type" = /obj/item/stack/tile/iron/dark/smooth_edge, "tile_cost" = 4),
+			list("name" = "Smooth Half", "type" = /obj/item/stack/tile/iron/dark/smooth_half, "tile_cost" = 4),
+			list("name" = "Smooth Corner" ,"type" = /obj/item/stack/tile/iron/dark/smooth_corner, "tile_cost" = 4),
 			list("name" = "Smooth Large", "type" = /obj/item/stack/tile/iron/dark/smooth_large, "tile_cost" = 7),
 			list("name" = "Small", "type" = /obj/item/stack/tile/iron/dark/small, "tile_cost" = 4),
 			list("name" = "Diagonal", "type" = /obj/item/stack/tile/iron/dark/diagonal, "tile_cost" = 4),
 			list("name" = "Herringbone", "type" = /obj/item/stack/tile/iron/dark/herringbone, "tile_cost" = 4),
-			list("name" = "Half Dark", "type" = /obj/item/stack/tile/iron/dark_side, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST, SOUTHEAST, SOUTHWEST, NORTHEAST, NORTHWEST)),
-			list("name" = "Dark Corner" ,"type" = /obj/item/stack/tile/iron/dark_corner, "tile_cost" = 4, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Half Dark", "type" = /obj/item/stack/tile/iron/dark_side, "tile_cost" = 4),
+			list("name" = "Dark Corner" ,"type" = /obj/item/stack/tile/iron/dark_corner, "tile_cost" = 4),
 		),
 
 		//White Colored tiles
 		"White Colored" = list(
 			list("name" = "Base", "type" = /obj/item/stack/tile/iron/white, "tile_cost" = 5),
-			list("name" = "Smooth Edge", "type" = /obj/item/stack/tile/iron/white/smooth_edge, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Smooth Half", "type" = /obj/item/stack/tile/iron/white/smooth_half, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Smooth Corner", "type" = /obj/item/stack/tile/iron/white/smooth_corner, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Smooth Edge", "type" = /obj/item/stack/tile/iron/white/smooth_edge, "tile_cost" = 5),
+			list("name" = "Smooth Half", "type" = /obj/item/stack/tile/iron/white/smooth_half, "tile_cost" = 5),
+			list("name" = "Smooth Corner", "type" = /obj/item/stack/tile/iron/white/smooth_corner, "tile_cost" = 5),
 			list("name" = "Smooth Large", "type" = /obj/item/stack/tile/iron/white/smooth_large, "tile_cost" = 7),
 			list("name" = "Small", "type" = /obj/item/stack/tile/iron/white/small, "tile_cost" = 5),
 			list("name" = "Diagonal", "type" = /obj/item/stack/tile/iron/white/diagonal, "tile_cost" = 5),
 			list("name" = "Herringbone", "type" = /obj/item/stack/tile/iron/white/herringbone, "tile_cost" = 5),
-			list("name" = "Half White", "type" = /obj/item/stack/tile/iron/white_side, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST, SOUTHEAST, SOUTHWEST, NORTHEAST, NORTHWEST)),
-			list("name" = "White Corner", "type" = /obj/item/stack/tile/iron/white_corner, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Half White", "type" = /obj/item/stack/tile/iron/white_side, "tile_cost" = 5),
+			list("name" = "White Corner", "type" = /obj/item/stack/tile/iron/white_corner, "tile_cost" = 5),
 		),
 
 		//Textured tiles
 		"Textured" = list(
 			list("name" = "Textured White", "type" = /obj/item/stack/tile/iron/white/textured, "tile_cost" = 5),
-			list("name" = "Textured White Edge", "type" = /obj/item/stack/tile/iron/white/textured_edge, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Textured White Half", "type" = /obj/item/stack/tile/iron/white/textured_half, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Textured White Corner", "type" = /obj/item/stack/tile/iron/white/textured_corner, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Textured White Edge", "type" = /obj/item/stack/tile/iron/white/textured_edge, "tile_cost" = 5),
+			list("name" = "Textured White Half", "type" = /obj/item/stack/tile/iron/white/textured_half, "tile_cost" = 5),
+			list("name" = "Textured White Corner", "type" = /obj/item/stack/tile/iron/white/textured_corner, "tile_cost" = 5),
 			list("name" = "Textured White Large", "type" = /obj/item/stack/tile/iron/white/textured_large, "tile_cost" = 7),
 			list("name" = "Textured Dark", "type" = /obj/item/stack/tile/iron/dark/textured, "tile_cost" = 5),
-			list("name" = "Textured Dark Edge", "type" = /obj/item/stack/tile/iron/dark/textured_edge, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
-			list("name" = "Textured Dark Half", "type" = /obj/item/stack/tile/iron/dark/textured_half, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH)),
-			list("name" = "Textured Dark Corner", "type" = /obj/item/stack/tile/iron/dark/textured_corner, "tile_cost" = 5, "tile_rotate_dirs" = list(SOUTH, NORTH, EAST, WEST)),
+			list("name" = "Textured Dark Edge", "type" = /obj/item/stack/tile/iron/dark/textured_edge, "tile_cost" = 5),
+			list("name" = "Textured Dark Half", "type" = /obj/item/stack/tile/iron/dark/textured_half, "tile_cost" = 5),
+			list("name" = "Textured Dark Corner", "type" = /obj/item/stack/tile/iron/dark/textured_corner, "tile_cost" = 5),
 			list("name" = "Textured Dark Large", "type" = /obj/item/stack/tile/iron/dark/textured_large, "tile_cost" = 7),
 		)
 	),
@@ -114,3 +111,11 @@ GLOBAL_LIST_INIT(floor_designs, list(
 		)
 	)
 ))
+
+/// Lazy-initialize the datum field on all the designs
+/proc/populate_rtd_datums()
+	for(var/main_root in GLOB.floor_designs)
+		for(var/sub_category in GLOB.floor_designs[main_root])
+			for(var/list/design in GLOB.floor_designs[main_root][sub_category])
+				var/datum/tile_info/tile_data = new /datum/tile_info(design)
+				design["datum"] = tile_data

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -34,79 +34,62 @@
 	var/design_category = "Standard"
 	/// design selected by player
 	var/datum/tile_info/selected_design
-	/// temp var to store an single design from GLOB.floor_design while iterating through this list
-	var/datum/tile_info/tile_design
+	/// direction currently selected
+	var/selected_direction = SOUTH
 	/// overlays on a tile
 	var/list/design_overlays = list()
 	var/ranged = TRUE
+
 /// stores the name, type, icon & cost for each tile type
 /datum/tile_info
 	/// name of this tile design for ui
 	var/name
 	/// path to create this tile type
 	var/obj/item/stack/tile/tile_type
-	/// icon for this tile to display for ui
+	/// path for the turf
+	var/turf/open/floor/turf_type
+	/// icon file used by the turf
+	var/icon_file
+	/// icon_state for this tile to display for ui
 	var/icon_state
 	/// rcd units to consume for this tile creation
 	var/cost
 
 	///directions this tile can be placed on the turf
-	var/list/tile_directions
-	/// user friendly names of the tile_directions to be sent to ui
-	var/list/ui_directional_data
-	/// current direction this tile should be rotated in before being placed on the plating
-	var/selected_direction
+	var/list/tile_directions_text
+	var/list/tile_directions_numbers
+
+	/// CSS selector for the icon in TGUI
+	var/icon_css_class
 
 /// decompress a single tile design list element from GLOB.floor_designs into its individual variables
-/datum/tile_info/proc/set_info(list/design)
+/datum/tile_info/New(list/design)
 	name = design["name"]
 	tile_type = design["type"]
-	icon_state = initial(tile_type.icon_state)
+	turf_type = initial(tile_type.turf_type)
+	icon_file = initial(turf_type.icon)
+	icon_state = initial(turf_type.icon_state)
+	icon_css_class = sanitize_css_class_name("[icon_file]-[icon_state]")
+	var/obj/item/stack/tile/tile_obj = new tile_type  // lists stored on types compile to be inside New()
+	tile_directions_text = assoc_to_keys(tile_obj.tile_rotate_dirs)
+	tile_directions_numbers = tile_obj.tile_rotate_dirs_number
+	qdel(tile_obj)
 	cost = design["tile_cost"]
 
-	tile_directions = design["tile_rotate_dirs"]
-	if(!tile_directions)
-		selected_direction = null
-		ui_directional_data = null
-		return
-
-	ui_directional_data = list()
-	for(var/tile_direction in tile_directions)
-		ui_directional_data += dir2text(tile_direction)
-	selected_direction = tile_directions[1]
-
 /// fill all information to be sent to the UI
-/datum/tile_info/proc/fill_ui_data(list/data)
+/datum/tile_info/proc/fill_ui_data(list/data, selected_direction)
 	data["selected_recipe"] = name
-	data["selected_icon"] = get_icon_state()
+	data["selected_icon"] = icon_css_class
 
-	if(!tile_directions)
+	if(!tile_directions_text)
 		data["selected_direction"] = null
 		return
 
-	data["tile_dirs"] = ui_directional_data
+	data["tile_dirs"] = tile_directions_text
 	data["selected_direction"] = dir2text(selected_direction)
 
-/// change the direction the tile is laid on the turf
-/datum/tile_info/proc/set_direction(direction)
-	if(tile_directions == null || !(direction in tile_directions))
-		return
-	selected_direction = direction
-
-/**
- * retrieve the icon for this tile design based on its direction
- * for complex directions like NORTHSOUTH etc we create an seperated blended icon in the asset file for example floor-northsouth
- * so we check which icons we want to retrieve based on its direction
- * for basic directions its rotated with CSS so there is no need for icon
- */
-/datum/tile_info/proc/get_icon_state()
-	var/prefix = ""
-	if(selected_direction)
-		prefix = (selected_direction in GLOB.tile_dont_rotate) ? "" : "-[dir2text(selected_direction)]"
-	return icon_state + prefix
-
 ///convinience proc to quickly convert the tile design into an physical tile to lay on the plating
-/datum/tile_info/proc/new_tile(loc)
+/datum/tile_info/proc/new_tile(loc, selected_direction)
 	var/obj/item/stack/tile/final_tile = new tile_type(loc, 1)
 	final_tile.turf_dir = selected_direction
 	return final_tile
@@ -142,13 +125,13 @@
 
 /obj/item/construction/rtd/Initialize(mapload)
 	. = ..()
-	selected_design = new
-	tile_design = new
-	selected_design.set_info(GLOB.floor_designs[root_category][design_category][1])
+	var/list/design = GLOB.floor_designs[root_category][design_category][1]
+	if(!design["datum"])
+		populate_rtd_datums()
+	selected_design = design["datum"]
 
 /obj/item/construction/rtd/Destroy()
-	QDEL_NULL(selected_design)
-	QDEL_NULL(tile_design)
+	selected_design = null
 	QDEL_LIST(design_overlays)
 	return ..()
 
@@ -182,8 +165,11 @@
 
 		var/list/designs = list() //initialize all designs under this category
 		for(var/list/design as anything in target_category)
-			tile_design.set_info(design)
-			designs += list(list("name" = tile_design.name, "icon" = tile_design.get_icon_state()))
+			var/datum/tile_info/tile_design = design["datum"]
+			if(!istype(tile_design))
+				populate_rtd_datums()
+				tile_design = design["datum"]
+			designs += list(list("name" = tile_design.name, "icon" = tile_design.icon_css_class))
 
 		data["categories"] += list(list("category_name" = sub_category, "recipes" = designs))
 
@@ -193,7 +179,7 @@
 	var/list/data = ..()
 
 	data["selected_category"] = design_category
-	selected_design.fill_ui_data(data)
+	selected_design.fill_ui_data(data, selected_direction)
 
 	return data
 
@@ -212,7 +198,7 @@
 			var/direction = text2dir(params["dir"])
 			if(!direction)
 				return FALSE
-			selected_design.set_direction(direction)
+			selected_direction = direction
 
 		if("recipe")
 			var/list/main_root = floor_designs[root_category]
@@ -227,7 +213,10 @@
 
 			QDEL_LIST(design_overlays)
 			design_category = params["category_name"]
-			selected_design.set_info(target_design)
+			if(!target_design["datum"])
+				populate_rtd_datums()
+			selected_design = target_design["datum"]
+			selected_direction = SOUTH
 			blueprint_changed = TRUE
 
 	return TRUE
@@ -285,8 +274,8 @@
 					//store all information about this tile
 					root_category = main_root
 					design_category = sub_category
-					selected_design.set_info(design_info)
-					selected_design.set_direction(floor.dir)
+					selected_design = design_info["datum"]
+					selected_direction = floor.dir
 					balloon_alert(user, "tile changed to [selected_design.name]")
 
 					return ITEM_INTERACT_SUCCESS
@@ -320,7 +309,7 @@
 		return ITEM_INTERACT_BLOCKING
 	activate()
 	//step 1 create tile
-	var/obj/item/stack/tile/final_tile = selected_design.new_tile(user.drop_location())
+	var/obj/item/stack/tile/final_tile = selected_design.new_tile(user.drop_location(), selected_direction)
 	if(QDELETED(final_tile)) //if you were standing on a stack of tiles this newly spawned tile could get merged with it cause its spawned on your location
 		qdel(rcd_effect)
 		balloon_alert(user, "tile got merged with the stack beneath you!")

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -26,6 +26,8 @@
 	var/list/tile_reskin_types
 	/// Cached associative lazy list to hold the radial options for tile dirs. See tile_reskinning.dm for more information.
 	var/list/tile_rotate_dirs
+	/// tile_rotate_dirs but before it gets converted to text
+	var/list/tile_rotate_dirs_number
 
 /obj/item/stack/tile/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
 	. = ..()
@@ -35,6 +37,7 @@
 	if(tile_reskin_types)
 		tile_reskin_types = tile_reskin_list(tile_reskin_types)
 	if(tile_rotate_dirs)
+		tile_rotate_dirs_number = tile_rotate_dirs.Copy()
 		var/list/values = list()
 		for(var/set_dir in tile_rotate_dirs)
 			values += dir2text(set_dir)

--- a/code/modules/asset_cache/assets/rtd.dm
+++ b/code/modules/asset_cache/assets/rtd.dm
@@ -9,46 +9,13 @@
 	for(var/main_root in GLOB.floor_designs)
 		for(var/sub_category in GLOB.floor_designs[main_root])
 			for(var/list/design in  GLOB.floor_designs[main_root][sub_category])
-				var/obj/item/stack/tile/type = design["type"]
-				var/icon_state = initial(type.icon_state)
-				if(registered[icon_state])
-					continue
-
-				Insert(sprite_name = icon_state, I = 'icons/obj/tiles.dmi', icon_state = icon_state)
-				registered[icon_state] = TRUE
-
-				var/list/tile_directions = design["tile_rotate_dirs"]
-				if(tile_directions == null)
-					continue
-
-				for(var/direction as anything in tile_directions)
-					//we can rotate the icon is css for these directions
-					if(direction in GLOB.tile_dont_rotate)
+				if(!design["datum"])
+					populate_rtd_datums()
+				var/datum/tile_info/tile_data = design["datum"]
+				var/list/directions = tile_data.tile_directions_numbers || list(SOUTH)
+				for(var/direction as anything in directions)
+					var/sprite_name = sanitize_css_class_name("[tile_data.icon_file]-[tile_data.icon_state]-[dir2text(direction)]")
+					if(registered[sprite_name])
 						continue
-
-					//but for these directions we have to do some hacky stuff
-					var/icon/img = icon(icon = 'icons/obj/tiles.dmi', icon_state = icon_state)
-					switch(direction)
-						if(NORTHEAST)
-							img.Turn(-180)
-							var/icon/east_rotated = icon(icon = 'icons/obj/tiles.dmi', icon_state = icon_state)
-							east_rotated.Turn(-90)
-							img.Blend(east_rotated,ICON_MULTIPLY)
-							img.SetIntensity(2,2,2)
-						if(NORTHWEST)
-							img.Turn(-180)
-							var/icon/west_rotated = icon(icon = 'icons/obj/tiles.dmi', icon_state = icon_state)
-							west_rotated.Turn(90)
-							img.Blend(west_rotated,ICON_MULTIPLY)
-							img.SetIntensity(2,2,2)
-						if(SOUTHEAST)
-							var/icon/east_rotated = icon(icon = 'icons/obj/tiles.dmi', icon_state = icon_state)
-							east_rotated.Turn(-90)
-							img.Blend(east_rotated,ICON_MULTIPLY)
-							img.SetIntensity(2,2,2)
-						if(SOUTHWEST)
-							var/icon/west_rotated = icon(icon = 'icons/obj/tiles.dmi', icon_state = icon_state)
-							west_rotated.Turn(90)
-							img.Blend(west_rotated,ICON_MULTIPLY)
-							img.SetIntensity(2,2,2)
-					Insert(sprite_name = "[icon_state]-[dir2text(direction)]", I = img)
+					Insert(sprite_name, icon(tile_data.icon_file, tile_data.icon_state, direction))
+					registered[sprite_name] = TRUE

--- a/tgui/packages/tgui/interfaces/RapidTilingDevice.tsx
+++ b/tgui/packages/tgui/interfaces/RapidTilingDevice.tsx
@@ -26,12 +26,6 @@ type Design = {
   icon: string;
 };
 
-const ROTATION_MAP = {
-  north: 'rotateZ(-180deg)',
-  west: 'rotateZ(90deg)',
-  east: 'rotateZ(-90deg)',
-} as const;
-
 const TilePreview = (props) => {
   const { data } = useBackend<Data>();
   const { selected_icon, selected_direction } = data;
@@ -45,12 +39,10 @@ const TilePreview = (props) => {
       }}
     >
       <Box
-        className={classes(['rtd32x32', selected_icon])}
-        style={{
-          transform:
-            'scale(1.5) translate(9.5%, 9.5%) ' +
-            (ROTATION_MAP[selected_direction] || ''),
-        }}
+        className={classes([
+          'rtd32x32',
+          `${selected_icon}${selected_direction ? `${selected_direction}` : 'south'}`,
+        ])}
       />
     </Section>
   );
@@ -140,10 +132,7 @@ const TileDesignSection = (props) => {
             inline
             verticalAlign="middle"
             mr="20px"
-            className={classes(['rtd32x32', recipe.icon])}
-            style={{
-              transform: 'scale(1.2) translate(9.5%, 9.5%)',
-            }}
+            className={classes(['rtd32x32', `${recipe.icon}south`])}
           />
           <span>{capitalizeAll(recipe.name)}</span>
         </Button>


### PR DESCRIPTION
## About The Pull Request

RTDs try to use tile item icons instead of turf icons for code that was clearly intended to work with turfs themselves (they support combination dirs, but none of the items actually have these!)

They also recreate datums with static data *every single time* you select a new tile in *each individual RTD*. They now make much smarter use of this data and quit storing stuff inside temporary datums that get deleted every time you select something else.

FYI this thing is still pretty busted but I don't have time to fix every problem with it. I'm mainly doing this to get rid of the Turn() procs and broken, nonexistent dirs being inserted into the spritesheet for #89478.

## Why It's Good For The Game

Code improvements, better previews of the turfs you're going to get in the RTD.

![image](https://github.com/user-attachments/assets/3732370b-36ba-4221-8571-e80a20ff21d8)

## Changelog

:cl:
tweak: RTDs now show the icon of the actual turf being placed rather than its tile item.
/:cl: