### PR TITLE
[NO GBP] Remove the call to `install_node.sh` from the Windows CI build script

### DIFF
--- a/tools/ci/build.ps1
+++ b/tools/ci/build.ps1
@@ -4,7 +4,6 @@ if(!(Test-Path -Path "C:/byond")){
     Remove-Item C:/byond.zip
 }
 
-bash tools/ci/install_node.sh
 bash tools/build/build -Werror
 
 exit $LASTEXITCODE


### PR DESCRIPTION
## About The Pull Request
Back when I moved all of the CI to use `actions/setup-node` in https://github.com/tgstation/tgstation/pull/89363, it seems I forgot to remove a line from the Windows build script that attempts to call `tools/ci/install_node.sh`.

Thankfully, nothing was broken - it just complains that the script doesn't exist, and continues on as if nothing happened.

That said, there's also no point to the error - so this PR removes that line. 