### PR TITLE
DUPE_SOURCES is no longer just a fancier DUPE_ALLOWED

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -328,7 +328,7 @@
 	var/datum/component/old_component
 
 	raw_args[1] = src
-	if(dupe_mode != COMPONENT_DUPE_ALLOWED && dupe_mode != COMPONENT_DUPE_SELECTIVE && dupe_mode != COMPONENT_DUPE_SOURCES)
+	if(dupe_mode != COMPONENT_DUPE_ALLOWED && dupe_mode != COMPONENT_DUPE_SELECTIVE)
 		old_component = GetComponent(component_type)
 
 		if(old_component)
@@ -377,12 +377,6 @@
 				break
 		if(!new_component && make_new_component)
 			new_component = new component_type(raw_args)
-
-	else if(dupe_mode == COMPONENT_DUPE_SOURCES)
-		new_component = new component_type(raw_args)
-		if(new_component.on_source_add(arglist(list(source) + raw_args.Copy(2))) == COMPONENT_INCOMPATIBLE)
-			stack_trace("incompatible source added to a [new_component.type]. Args: [json_encode(raw_args)]")
-			return null
 
 	else if(!new_component)
 		new_component = new component_type(raw_args) // Dupes are allowed, act like normal

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -382,6 +382,9 @@
 		new_component = new component_type(raw_args) // Dupes are allowed, act like normal
 
 	if(!old_component && !QDELETED(new_component)) // Nothing related to duplicate components happened and the new component is healthy
+		if(source && new_component.on_source_add(arglist(list(source) + raw_args.Copy(2))) == COMPONENT_INCOMPATIBLE)
+			stack_trace("incompatible source added to a [new_component.type]. Args: [json_encode(raw_args)]")
+			return null
 		SEND_SIGNAL(src, COMSIG_COMPONENT_ADDED, new_component)
 		return new_component
 


### PR DESCRIPTION
## About The Pull Request
Small logical mistake where dupe sources would spawn a new component everytime a source is being added. The code containing the correct logic with the source being added to the old component is indented under a check that it can never pass.

## Why It's Good For The Game
Fixing a backend issue with the component mode.

## Changelog
N/A