### PR TITLE
Fix map vote revert, add admin verb

### DIFF
--- a/code/controllers/subsystem/map_vote.dm
+++ b/code/controllers/subsystem/map_vote.dm
@@ -152,7 +152,7 @@ SUBSYSTEM_DEF(map_vote)
 	next_map_config = change_to
 	return TRUE
 
-/datum/controller/subsystem/map_vote/proc/revert_next_map()
+/datum/controller/subsystem/map_vote/proc/revert_next_map(client/user)
 	if(!next_map_config)
 		return
 	if(previous_cache)
@@ -161,6 +161,11 @@ SUBSYSTEM_DEF(map_vote)
 
 	already_voted = FALSE
 	admin_override = FALSE
+	next_map_config = null
+
+	if(!isnull(user))
+		message_admins("[key_name_admin(user)] has reverted the next map selection. Voting re-enabled.")
+		log_admin("[key_name_admin(user)] reverted the next map selection.")
 	send_map_vote_notice("Next map reverted. Voting re-enabled.")
 
 #undef MAP_VOTE_CACHE_LOCATION

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -114,3 +114,6 @@ ADMIN_VERB(admin_change_map, R_SERVER, "Change Map", "Set the next map.", ADMIN_
 		if (SSmap_vote.set_next_map(virtual_map))
 			message_admins("[key_name_admin(user)] has changed the map to [virtual_map.map_name]")
 			SSmap_vote.admin_override = TRUE
+
+ADMIN_VERB(admin_revert_map, R_SERVER, "Revert Map Vote", "Revert the map vote, allowing a new vote.", ADMIN_CATEGORY_SERVER)
+	SSmap_vote.revert_next_map(user)


### PR DESCRIPTION
## About The Pull Request

Fixes revert_next_map() not actually reverting the map vote. Also added an admin verb for it for ease of access.

## Why It's Good For The Game

Fix bug, revert map vote without having to poke around in the subsystem.

## Changelog

:cl: LT3
fix: Revert next map command actually reverts the map vote
admin: Admins now have a verb to revert the map vote
/:cl: