### PR TITLE
Minor entertainment monitor refactor

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -106,3 +106,6 @@
 
 /// Global signal sent when a mob is spawned from a ghost in a dynamic ruleset (mob/spawned_mob)
 #define COMSIG_RULESET_BODY_GENERATED_FROM_GHOSTS "!ruleset_body_generated_from_ghosts"
+
+/// Global signal whenever a camera network broadcast is started/stopped/updated: (camera_net, is_show_active, announcement)
+#define COMSIG_GLOB_NETWORK_BROADCAST_UPDATED "!network_broadcast_updated"

--- a/code/game/machinery/computer/telescreen.dm
+++ b/code/game/machinery/computer/telescreen.dm
@@ -67,11 +67,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 	. = ..()
 	find_and_hang_on_wall()
 	register_context()
+	RegisterSignal(SSdcs, COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, PROC_REF(on_network_broadcast_updated))
 	speakers = new(src)
 
 /obj/machinery/computer/security/telescreen/entertainment/Destroy()
-	. = ..()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NETWORK_BROADCAST_UPDATED)
 	QDEL_NULL(speakers)
+	return ..()
 
 /obj/machinery/computer/security/telescreen/entertainment/examine(mob/user)
 	. = ..()
@@ -144,7 +146,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 		say(announcement)
 
 /// Adds a camera network ID to the entertainment monitor, and turns off the monitor if network list is empty
-/obj/machinery/computer/security/telescreen/entertainment/proc/update_shows(is_show_active, tv_show_id, announcement)
+/obj/machinery/computer/security/telescreen/entertainment/proc/on_network_broadcast_updated(datum/source, tv_show_id, is_show_active, announcement)
+	SIGNAL_HANDLER
 	if(!network)
 		return
 
@@ -153,7 +156,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 	else
 		network -= tv_show_id
 
-	notify(network.len, announcement)
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, update_static_data_for_all_viewers))
+	notify(length(network), announcement)
 
 /**
  * Adds a camera network to all entertainment monitors.
@@ -162,12 +166,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
  * * announcement - Optional, what announcement to make when the show starts.
  */
 /proc/start_broadcasting_network(camera_net, announcement)
-	for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		tv.update_shows(
-			is_show_active = TRUE,
-			tv_show_id = camera_net,
-			announcement = announcement,
-		)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, camera_net, TRUE, announcement)
 
 /**
  * Removes a camera network from all entertainment monitors.
@@ -176,12 +175,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
  * * announcement - Optional, what announcement to make when the show ends.
  */
 /proc/stop_broadcasting_network(camera_net, announcement)
-	for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		tv.update_shows(
-			is_show_active = FALSE,
-			tv_show_id = camera_net,
-			announcement = announcement,
-		)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, camera_net, FALSE, announcement)
 
 /**
  * Sets the camera network status on all entertainment monitors.
@@ -195,12 +189,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
  * Likewise, there's no way to differentiate off -> on and on -> off, unless you handle that yourself.
  */
 /proc/set_network_broadcast_status(camera_net, is_show_active, announcement)
-	for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		tv.update_shows(
-			is_show_active = is_show_active,
-			tv_show_id = camera_net,
-			announcement = announcement,
-		)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, camera_net, is_show_active, announcement)
 
 /obj/machinery/computer/security/telescreen/rd
 	name = "\improper Research Director's telescreen"


### PR DESCRIPTION

## About The Pull Request

Partial port of the refactors in https://github.com/Monkestation/Monkestation2.0/pull/4995

This gets rid of the hardcoded `for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))`, and adds a new global signal, `COMSIG_GLOB_NETWORK_BROADCAST_UPDATED`, which all entertainment monitors now register instead.

## Why It's Good For The Game

future-proofing to allow for stuff other than entertainment monitors to tune into those stream in the future

## Changelog
:cl:
refactor: Refactored some code relating to how entertainment monitors are notified of active feeds.
/:cl:
