### PR TITLE
SecurEye now properly follows moving cameras

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -46,14 +46,12 @@
 // Operates TGUI
 /obj/item/modular_computer/ui_interact(mob/user, datum/tgui/ui)
 	if(!enabled || !user.can_read(src, READING_CHECK_LITERACY))
-		if(ui)
-			ui.close()
+		ui?.close()
 		return
 
 	// Robots don't really need to see the screen, their wireless connection works as long as computer is on.
 	if(!screen_on && !issilicon(user))
-		if(ui)
-			ui.close()
+		ui?.close()
 		return
 
 	if(honkvirus_amount > 0) // EXTRA annoying, huh!
@@ -63,6 +61,8 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		update_tablet_open_uis(user)
+	else if(active_program?.always_update_ui)
+		active_program.ui_interact(user, ui)
 
 /obj/item/modular_computer/ui_assets(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -42,6 +42,8 @@
 	var/alert_silenced = FALSE
 	/// Whether to highlight our program in the main screen. Intended for alerts, but loosely available for any need to notify of changed conditions. Think Windows task bar highlighting. Available even if alerts are muted.
 	var/alert_pending = FALSE
+	/// Whether the UI should *always* be updated while active.
+	var/always_update_ui = FALSE
 	/// How well this program will help combat detomatix viruses.
 	var/detomatix_resistance = NONE
 	/// Unremovable circuit componentn added to the physical computer while the program is installed

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -13,6 +13,7 @@
 	size = 5
 	tgui_id = "NtosSecurEye"
 	program_icon = "eye"
+	always_update_ui = TRUE
 
 	///Boolean on whether or not the app will make noise when flipping around the channels.
 	var/spying = FALSE


### PR DESCRIPTION

## About The Pull Request

Port of a fix from https://github.com/Monkestation/Monkestation2.0/pull/4995

Due to how modular computers worked with the nested tgui stuff, the SecurEye app wouldn't properly autoupdate whenever a camera it was watching moved (when there's not any tracking going on)

This "fixes" that issue by adding a new var, `always_update_ui`, to modular computer programs, which will make the modpc call the active program's `ui_interact` even after the UI is opened.

## Why It's Good For The Game

bugfix good. if the whole "watch broadcast camera streams on PDA" thing ever gets ported here, this is a needed fix for that.

## Changelog
:cl:
fix: SecurEye now properly follows moving cameras.
/:cl:
