### PR TITLE
Adds policy text for the evil quirk

### DIFF
--- a/code/datums/quirks/neutral_quirks/evil.dm
+++ b/code/datums/quirks/neutral_quirks/evil.dm
@@ -10,3 +10,8 @@
 	lose_text = span_notice("You suddenly care more about others and their needs.")
 	medical_record_text = "Patient has passed all our social fitness tests with flying colours, but had trouble on the empathy tests."
 	mail_goodies = list(/obj/item/food/grown/citrus/lemon)
+
+/datum/quirk/evil/post_add()
+	var/evil_policy = get_policy("[type]") || "Please note that while you may be [LOWER_TEXT(name)], this does NOT give you any additional right to attack people or cause chaos."
+	// We shouldn't need this, but it prevents people using it as a dumb excuse in ahelps.
+	to_chat(quirk_holder, span_big(span_info(evil_policy)))

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -84,6 +84,7 @@
 	name = "Holoparasites"
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
+	progression_minimum = 30 MINUTES
 	item = /obj/item/guardian_creator/tech
 	cost = 18
 	surplus = 0

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -84,7 +84,6 @@
 	name = "Holoparasites"
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
-	progression_minimum = 30 MINUTES
 	item = /obj/item/guardian_creator/tech
 	cost = 18
 	surplus = 0


### PR DESCRIPTION
## About The Pull Request

Adds a text output to your chat (customisable via policy config) if you take the quirk "Fundamentally Evil", similar to "Reality Dissociation Syndrome", explaining that while your soul is filled with darkness you also are still a space station employee. It's just that a lot of evil people work for Nanotrasen.

## Why It's Good For The Game

At least one person has apparently attempted to tell an admin that taking a quirk at roundstart lets them act as an antagonist, which it obviously doesn't. The lack of this text doesn't prevent admins from smiting anyone who tries to use this as an argument, but it doesn't hurt to have it.
In a just world we would not need to add this but unfortunately players.

## Changelog

:cl:
add: Players who choose to be evil via the quirk menu will be reminded at roundstart that this doesn't exempt them from server rules.
/:cl:
