### PR TITLE
Adds a Config for Auto-Deadminning on Ready Up and Latejoining

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -253,6 +253,7 @@
 	var/mob/dead/new_player/new_player = hud.mymob
 	ready = !ready
 	if(ready)
+		new_player.auto_deadmin_on_ready_or_latejoin()
 		new_player.ready = PLAYER_READY_TO_PLAY
 		base_icon_state = "ready"
 	else
@@ -314,6 +315,8 @@
 			SSticker.queued_players += new_player
 			to_chat(new_player, span_notice("You have been added to the queue to join the game. Your position in queue is [SSticker.queued_players.len]."))
 		return
+
+	new_player.auto_deadmin_on_ready_or_latejoin()
 
 	if(!LAZYACCESS(params2list(params), CTRL_CLICK))
 		GLOB.latejoin_menu.ui_interact(new_player)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -7,7 +7,7 @@
 	default = "Game Master"
 	protection = CONFIG_ENTRY_LOCKED
 
-/datum/config_entry/flag/auto_deadmin_players
+/datum/config_entry/flag/auto_deadmin_always
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/number/auto_deadmin_timegate

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -20,6 +20,9 @@
 /datum/config_entry/flag/auto_deadmin_heads
 	protection = CONFIG_ENTRY_LOCKED
 
+/datum/config_entry/flag/auto_deadmin_on_ready_or_latejoin
+	protection = CONFIG_ENTRY_LOCKED
+
 /datum/config_entry/flag/auto_deadmin_silicons
 	protection = CONFIG_ENTRY_LOCKED
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -590,7 +590,7 @@ SUBSYSTEM_DEF(job)
 	job.announce_job(equipping)
 
 	if(player_client?.holder)
-		if(CONFIG_GET(flag/auto_deadmin_players) || (player_client.prefs?.toggles & DEADMIN_ALWAYS))
+		if(CONFIG_GET(flag/auto_deadmin_always) || (player_client.prefs?.toggles & DEADMIN_ALWAYS))
 			player_client.holder.auto_deadmin()
 		else
 			handle_auto_deadmin_roles(player_client, job.title)

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -302,7 +302,7 @@ ADMIN_VERB(edit_admin_permissions, R_PERMISSIONS, "Permissions Panel", "Edit adm
 /datum/admins/proc/auto_deadmin()
 	if(owner.is_localhost())
 		return FALSE
-	if(owner.prefs.read_preference(/datum/preference/toggle/bypass_deadmin_in_centcom) && is_centcom_level(owner.mob.z))
+	if(owner.prefs.read_preference(/datum/preference/toggle/bypass_deadmin_in_centcom) && is_centcom_level(owner.mob.z) && !istype(owner.mob, /mob/dead/new_player))
 		return FALSE
 
 	to_chat(owner, span_interface("You are now a normal player."), confidential = TRUE)

--- a/code/modules/client/preferences/admin.dm
+++ b/code/modules/client/preferences/admin.dm
@@ -73,3 +73,16 @@
 		return FALSE
 
 	return is_admin(preferences.parent)
+
+/datum/preference/toggle/auto_deadmin_on_ready_or_latejoin
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "auto_deadmin_on_ready_or_latejoin"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/auto_deadmin_on_ready_or_latejoin/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+	if (preferences.toggles & DEADMIN_ALWAYS) //No reason to show if they're deadminning always, because deadmin always also deadmins on ready / latejoin
+		return FALSE
+
+	return is_admin(preferences.parent)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -370,4 +370,11 @@
 	to_chat(new_player, span_info("Lobby Menu HUD reset. You may reset the HUD again in <b>[DisplayTimeText(RESET_HUD_INTERVAL)]</b>."))
 	hud_used.show_hud(hud_used.hud_version)
 
+///Auto deadmins an admin when they click to toggle the ready button in the menu
+/mob/dead/new_player/proc/auto_deadmin_on_ready_or_latejoin()
+	if(!client?.holder) //If they aren't an admin we dont care
+		return TRUE
+	if(CONFIG_GET(flag/auto_deadmin_on_ready_or_latejoin) || (client.prefs?.toggles & DEADMIN_ALWAYS))
+		return client.holder.auto_deadmin()
+
 #undef RESET_HUD_INTERVAL

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -374,7 +374,7 @@
 /mob/dead/new_player/proc/auto_deadmin_on_ready_or_latejoin()
 	if(!client?.holder) //If they aren't an admin we dont care
 		return TRUE
-	if(CONFIG_GET(flag/auto_deadmin_on_ready_or_latejoin) || (client.prefs?.toggles & DEADMIN_ALWAYS))
+	if(CONFIG_GET(flag/auto_deadmin_on_ready_or_latejoin) || (client.prefs.read_preference(/datum/preference/toggle/auto_deadmin_on_ready_or_latejoin)) || (client.prefs?.toggles & DEADMIN_ALWAYS))
 		return client.holder.auto_deadmin()
 
 #undef RESET_HUD_INTERVAL

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -370,7 +370,7 @@
 	to_chat(new_player, span_info("Lobby Menu HUD reset. You may reset the HUD again in <b>[DisplayTimeText(RESET_HUD_INTERVAL)]</b>."))
 	hud_used.show_hud(hud_used.hud_version)
 
-///Auto deadmins an admin when they click to toggle the ready button in the menu
+///Auto deadmins an admin when they click to toggle the ready button or join game button in the menu
 /mob/dead/new_player/proc/auto_deadmin_on_ready_or_latejoin()
 	if(!client?.holder) //If they aren't an admin we dont care
 		return TRUE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -141,7 +141,7 @@
  * Checks if the attached client is an admin and may deadmin them
  *
  * Configs:
- * * flag/auto_deadmin_players
+ * * flag/auto_deadmin_always
  * * client.prefs?.toggles & DEADMIN_ALWAYS
  * * User is antag and flag/auto_deadmin_antagonists or client.prefs?.toggles & DEADMIN_ANTAGONIST
  * * or if their job demands a deadminning SSjob.handle_auto_deadmin_roles()
@@ -151,7 +151,7 @@
 /mob/proc/auto_deadmin_on_login() //return true if they're not an admin at the end.
 	if(!client?.holder)
 		return TRUE
-	if(CONFIG_GET(flag/auto_deadmin_players) || (client.prefs?.toggles & DEADMIN_ALWAYS))
+	if(CONFIG_GET(flag/auto_deadmin_always) || (client.prefs?.toggles & DEADMIN_ALWAYS))
 		return client.holder.auto_deadmin()
 	if(mind.has_antag_datum(/datum/antagonist) && (CONFIG_GET(flag/auto_deadmin_antagonists) || client.prefs?.toggles & DEADMIN_ANTAGONIST))
 		return client.holder.auto_deadmin()

--- a/config/config.txt
+++ b/config/config.txt
@@ -371,6 +371,9 @@ AUTOADMIN_RANK Game Master
 ## Uncomment to automatically deadmin players when the game starts.
 #AUTO_DEADMIN_PLAYERS
 
+## Uncomment to automatically deadmin players when they click to ready up or join game. For latejoining, does it before they pick a role because it's best done early to limit metainfo.
+AUTO_DEADMIN_ON_READY_OR_LATEJOIN
+
 ## Uncomment to automatically deadmin antagonists when they gain the role.
 #AUTO_DEADMIN_ANTAGONISTS
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -368,11 +368,11 @@ AUTOADMIN_RANK Game Master
 #AUTOADMIN
 
 
-## Uncomment to automatically deadmin players when the game starts.
-#AUTO_DEADMIN_PLAYERS
+## Uncomment to automatically deadmin players whenever they are controlling a mob.
+#AUTO_DEADMIN_ALWAYS
 
 ## Uncomment to automatically deadmin players when they click to ready up or join game. For latejoining, does it before they pick a role because it's best done early to limit metainfo.
-AUTO_DEADMIN_ON_READY_OR_LATEJOIN
+#AUTO_DEADMIN_ON_READY_OR_LATEJOIN
 
 ## Uncomment to automatically deadmin antagonists when they gain the role.
 #AUTO_DEADMIN_ANTAGONISTS

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -53,3 +53,12 @@ export const comms_notification: FeatureToggle = {
   category: 'ADMIN',
   component: CheckboxInput,
 };
+
+export const auto_deadmin_on_ready_or_latejoin: FeatureToggle = {
+  name: 'Auto deadmin - Ready or Latejoin',
+  category: 'ADMIN',
+  description: `
+    When enabled, you will automatically deadmin when you click to ready up or latejoin a round.
+`,
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request
Fixes #89458
Adds a config for auto-deadminning admins who ready up before the round starts, or click join game after.
The deadminning happens as soon as the button is pressed, not when a job is selected or the round starts. I figure it's better to do it straight away since both have opportunities for metainfo to be posted in admin chat. Before there's admins messing with dynamic config / plotting events etc. and during the round there's basically everything that gets posted to admin logs.

I've had to add a typecheck to the auto_deadmin proc, since the lobby menu technically happens on the centcom Z-level, and there's a pref for ignoring deadminning on centcom Z, so it checks to see if the admin is a new player mob.

Changed the old config from auto_deadmin_player to auto_deadmin_always to make it less deceptive.
Was suggested a pref could be added to do this. I can do that if people want it maybe, but it's not in this PR at the time of posting it.

Is now a pref
<img src="https://i.ibb.co/211sBMYd/Deadmin-Prefs1.png">
<img src="https://i.ibb.co/r20Srbw4/Deadmin-Prefs2.png">

I dunno if the latejoin proccall is in the right spot in the click sequence thing I can move it if people want.
## Why It's Good For The Game

Admins spawning themselves on station is very important for both shenanigans and troubleshooting. It's annoying to have to click readmin every time and I'm too lazy to figure out how to perms escalate my way into disabling that config every round (Though I have tried).

This PR is marginally more likely to convince Timber to turn that off than cussing him out in adminbus.
## Changelog
:cl:
admin: Added a new config to force admins to deadmin when readying up or latejoining the round.
/:cl:
