### PR TITLE
Fixes circuit connections on 516

### DIFF
--- a/tgui/packages/tgui/interfaces/common/Connections.tsx
+++ b/tgui/packages/tgui/interfaces/common/Connections.tsx
@@ -48,6 +48,7 @@ export const Connections = (props: {
         position: 'absolute',
         pointerEvents: 'none',
         zIndex: zLayer,
+        overflow: 'visible',
       }}
     >
       {connections.map((val, index) => {


### PR DESCRIPTION

## About The Pull Request
Fixes circuit connections not being drawn outside their svg box on 516. This also affects the Edit/Debug-Planes
## Why It's Good For The Game
Less bugs
## Changelog
:cl:
fix: fixed circuit connections not being drawn outside initial screen on 516
/:cl:
