### PR TITLE
You can no longer use cans of bait on fishing rods while fishing with them

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -533,16 +533,9 @@
 		use_slot(ROD_SLOT_HOOK, user, attacking_item)
 		SStgui.update_uis(src)
 		return TRUE
-	else if(slot_check(attacking_item,ROD_SLOT_BAIT))
+	else if(slot_check(attacking_item,ROD_SLOT_BAIT) || istype(attacking_item, /obj/item/bait_can)) //Can click on the fishing rod with bait can directly
 		use_slot(ROD_SLOT_BAIT, user, attacking_item)
 		SStgui.update_uis(src)
-		return TRUE
-	else if(istype(attacking_item, /obj/item/bait_can)) //Quicker filling from bait can
-		var/obj/item/bait_can/can = attacking_item
-		var/bait = can.retrieve_bait(user)
-		if(bait)
-			use_slot(ROD_SLOT_BAIT, user, bait)
-			SStgui.update_uis(src)
 		return TRUE
 	. = ..()
 
@@ -597,6 +590,13 @@
 /obj/item/fishing_rod/proc/use_slot(slot, mob/user, obj/item/new_item)
 	if(fishing_line || GLOB.fishing_challenges_by_user[user])
 		return
+	// If the new item is a bait can, try to get bait from it
+	if(istype(new_item, /obj/item/bait_can))
+		var/obj/item/bait_can/can = new_item
+		var/bait = can.retrieve_bait(user)
+		if(!bait)
+			return
+		new_item = bait
 	var/obj/item/current_item
 	switch(slot)
 		if(ROD_SLOT_BAIT)


### PR DESCRIPTION

## About The Pull Request
Can of bait can be used on a fishing rod directly to quickly put a bait into it's bait slot. However the proc that retrieves the bait from the can is called before the code actually checks if you can put anything into the fishing rod. This causes the can to go on cooldown and decrement its bait count without it actually doing anything with the bait.

This moves the bait retrieval from attackby into use_slot, after it checks if it can use the item.

This also allows the can of bait to be used on the bait slot inside the rod's UI, which works the same way as clicking on the rod.
## Why It's Good For The Game
Fixes #88216 and makes the use of fishing rod's UI and direct clicking more consistent.
## Changelog
:cl:
fix: Can of fishing bait no longer evaporates its bait when used on an active fishing rod
fix: Can of fishing bait's quick refill can be used with the fishing rod's UI too
/:cl:
