### PR TITLE
[NO GBP] Prevents Cryogeledia trapping you in stasis hell...AGAIN

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -102,7 +102,7 @@
 	if(HAS_TRAIT(exposed_mob, TRAIT_RESISTCOLD))
 		holder.remove_reagent(type, volume)
 		return
-	if(!(methods & INJECT))
+	if(!(methods & INGEST))
 		exposed_mob.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
 		if(!exposed_mob.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT))
 			exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -102,7 +102,7 @@
 	if(HAS_TRAIT(exposed_mob, TRAIT_RESISTCOLD))
 		holder.remove_reagent(type, volume)
 		return
-	if(methods & INJECT)
+	if(!(methods & INJECT))
 		exposed_mob.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
 		if(!exposed_mob.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT))
 			exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -84,12 +84,13 @@
 /*
 * Freezes the player in a block of ice, 1s = 1u
 * Will be removed when the required reagent is removed too
+* Only works with the INJECT method (syringes)
 * is processed on the dead.
 */
 
 /datum/reagent/inverse/cryostylane
 	name = "Cryogelidia"
-	description = "Freezes the live or dead patient in a cryostasis ice block."
+	description = "Freezes the live or dead patient in a cryostasis ice block. Only works via injection."
 	color = "#03dbfc"
 	taste_description = "your tongue freezing, shortly followed by your thoughts. Brr!"
 	ph = 14

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -93,7 +93,7 @@
 	color = "#03dbfc"
 	taste_description = "your tongue freezing, shortly followed by your thoughts. Brr!"
 	ph = 14
-	chemical_flags = REAGENT_DEAD_PROCESS | REAGENT_IGNORE_STASIS | REAGENT_DONOTSPLIT
+	chemical_flags = REAGENT_DEAD_PROCESS | REAGENT_IGNORE_STASIS | REAGENT_DONOTSPLIT | REAGENT_UNAFFECTED_BY_METABOLISM
 	metabolization_rate = 1 * REM
 
 /datum/reagent/inverse/cryostylane/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE)
@@ -101,10 +101,10 @@
 	if(HAS_TRAIT(exposed_mob, TRAIT_RESISTCOLD))
 		holder.remove_reagent(type, volume)
 		return
-
-	exposed_mob.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
-	if(!exposed_mob.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT))
-		exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
+	if(methods & INJECT)
+		exposed_mob.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
+		if(!exposed_mob.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT))
+			exposed_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
 
 /datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -84,13 +84,13 @@
 /*
 * Freezes the player in a block of ice, 1s = 1u
 * Will be removed when the required reagent is removed too
-* Only works with the INJECT method (syringes)
+* Does not work via INGEST method (pills, drinking)
 * is processed on the dead.
 */
 
 /datum/reagent/inverse/cryostylane
 	name = "Cryogelidia"
-	description = "Freezes the live or dead patient in a cryostasis ice block. Only works via injection."
+	description = "Freezes the live or dead patient in a cryostasis ice block. Won't work if you drink it."
 	color = "#03dbfc"
 	taste_description = "your tongue freezing, shortly followed by your thoughts. Brr!"
 	ph = 14


### PR DESCRIPTION
## About The Pull Request

Foolishly, I thought stomachs at least respected reagent flags. They do not.

However, if I use the previous proc and allow the stomach > bloodstream trickling method, it will result in a different kind of stasis hell as it will constantly reapply the stasis effects over and over again.

All in all, I'm just limiting this down to not ingest rather than disentangling whatever is going on with stomach code.

Fixes https://github.com/tgstation/tgstation/issues/89525

## Why It's Good For The Game

I worked all this out but then, not testing it, I just assumed that flag worked with stomachs and let any method of exposure work...

This is a lesson. Don't trust my gut.

## Changelog
:cl:
fix: Prevents Cryogelidia from putting you into a permanent stasis until someone injects you with the reagent.
/:cl:
