### PR TITLE
Fix deprecated mob path from basketball map

### DIFF
--- a/_maps/map_files/Basketball/stadium.dmm
+++ b/_maps/map_files/Basketball/stadium.dmm
@@ -491,10 +491,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/basketball)
-"Ev" = (
-/mob/living/simple_animal/robot_customer,
-/turf/open/floor/wood,
-/area/centcom/basketball)
 "Gh" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -983,7 +979,7 @@ nE
 pu
 ZM
 kc
-Ev
+tX
 Cw
 ku
 xP
@@ -1199,7 +1195,7 @@ nE
 pu
 pu
 kc
-Ev
+tX
 Cw
 HH
 dJ


### PR DESCRIPTION
## About The Pull Request
Removes the robots from the basketball stadium. Even thou the path no longer exists, adding the robots back would probably cause some AI controller issues.

s
## Why It's Good For The Game
Broken path is gone.

## Changelog
:cl:
fix: Fix deprecated mob robot path from basketball stadium map
/:cl:
