### PR TITLE
Adds a very simple admin verb to view everything in the policy json

### DIFF
--- a/code/modules/admin/verbs/policy_panel.dm
+++ b/code/modules/admin/verbs/policy_panel.dm
@@ -22,7 +22,7 @@ ADMIN_VERB(policy_panel, R_ADMIN, "Policy Panel", "View all policy the server ha
 /datum/policy_panel/ui_close(mob/user)
 	qdel(src)
 
-/datum/policy_panel/ui_data(mob/user)
+/datum/policy_panel/ui_static_data(mob/user)
 	var/list/data = list()
 	data["policy"] = global.config.policy
 	return data

--- a/code/modules/admin/verbs/policy_panel.dm
+++ b/code/modules/admin/verbs/policy_panel.dm
@@ -1,0 +1,28 @@
+ADMIN_VERB(policy_panel, R_ADMIN, "Policy Panel", "View all policy the server has set.", ADMIN_CATEGORY_MAIN)
+	if(!length(global.config?.policy))
+		tgui_alert(usr, "Policy hasn't loaded yet (or the server has none set).", "Policy Panel", list("OK"))
+		return
+
+	var/datum/policy_panel/tgui = new
+	tgui.ui_interact(user.mob)
+	BLACKBOX_LOG_ADMIN_VERB("Policy Panel")
+
+// Very simple panel that reports all the policy the server has set.
+/datum/policy_panel
+
+/datum/policy_panel/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "Policypanel")
+		ui.open()
+
+/datum/policy_panel/ui_state(mob/user)
+	return ADMIN_STATE(R_ADMIN)
+
+/datum/policy_panel/ui_close(mob/user)
+	qdel(src)
+
+/datum/policy_panel/ui_data(mob/user)
+	var/list/data = list()
+	data["policy"] = global.config.policy
+	return data

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3035,6 +3035,7 @@
 #include "code\modules\admin\verbs\plane_debugger.dm"
 #include "code\modules\admin\verbs\player_ticket_history.dm"
 #include "code\modules\admin\verbs\playsound.dm"
+#include "code\modules\admin\verbs\policy_panel.dm"
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\reestablish_db_connection.dm"

--- a/tgui/packages/tgui/interfaces/Policypanel.tsx
+++ b/tgui/packages/tgui/interfaces/Policypanel.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import {
+  BlockQuote,
+  Dropdown,
+  Flex,
+  Input,
+  Section,
+  Stack,
+} from 'tgui-core/components';
+
+import { useBackend } from '../backend';
+import { Window } from '../layouts';
+
+type Data = {
+  policy: Record<string, string>;
+};
+
+function searchForPolicy(policy: Record<string, string>, token: string) {
+  return Object.keys(policy).filter((key) =>
+    key.toLowerCase().includes(token.toLowerCase()),
+  );
+}
+
+export const Policypanel = () => {
+  const { data } = useBackend<Data>();
+  const { policy } = data;
+
+  const [currentPolicy, setCurrentPolicy] = useState<string>();
+
+  return (
+    <Window title="Policy Panel" theme="admin" width={400} height={300}>
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <Flex>
+              <Flex.Item width="50%">
+                <Dropdown
+                  options={Object.keys(policy)}
+                  selected={currentPolicy}
+                  onSelected={setCurrentPolicy}
+                  fill
+                />
+              </Flex.Item>
+              <Flex.Item width="50%">
+                <Input
+                  placeholder="Search..."
+                  fluid
+                  onEnter={(e, value) => {
+                    const results = searchForPolicy(policy, value);
+                    if (results.length === 1) {
+                      setCurrentPolicy(results[0]);
+                    }
+                  }}
+                  // clear search after enter
+                  onEnterClear
+                />
+              </Flex.Item>
+            </Flex>
+          </Stack.Item>
+          <Stack.Item height="100%">
+            <Section scrollable fill>
+              <BlockQuote fontSize="16px">
+                {policy[currentPolicy] ||
+                  `Select a policy to view. These policies are displayed
+                    to players upon gaining the relevant role.`}
+              </BlockQuote>
+            </Section>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Policypanel.tsx
+++ b/tgui/packages/tgui/interfaces/Policypanel.tsx
@@ -25,7 +25,7 @@ export const Policypanel = () => {
   const { data } = useBackend<Data>();
   const { policy } = data;
 
-  const [currentPolicy, setCurrentPolicy] = useState<string>();
+  const [currentPolicy, setCurrentPolicy] = useState<string>('');
 
   return (
     <Window title="Policy Panel" theme="admin" width={400} height={300}>
@@ -38,7 +38,6 @@ export const Policypanel = () => {
                   options={Object.keys(policy)}
                   selected={currentPolicy}
                   onSelected={setCurrentPolicy}
-                  fill
                 />
               </Flex.Item>
               <Flex.Item width="50%">

--- a/tgui/packages/tgui/interfaces/Policypanel.tsx
+++ b/tgui/packages/tgui/interfaces/Policypanel.tsx
@@ -51,8 +51,6 @@ export const Policypanel = () => {
                       setCurrentPolicy(results[0]);
                     }
                   }}
-                  // clear search after enter
-                  onEnterClear
                 />
               </Flex.Item>
             </Flex>


### PR DESCRIPTION
## About The Pull Request

Adds `Policy Panel` admin verb. It opens up a very plain, very simple tgui that shows you a dropdown of all `policy.json` entries, allowing you to refer to them if necessary. 

There's also a search bar.

![image](https://github.com/user-attachments/assets/11e5c4b1-815b-488d-8566-943145c2d64c)

## Why It's Good For The Game

Half request, half something I thought would be useful.

While admins could VV into config and find the `policy.json`, they generally appreciate something more user-facing.

## Changelog

:cl: Melbert
admin: Adds the Policy Panel verb, which shows you all the policy the server has set. 
/:cl:
