### PR TITLE
Fixes a lot of procs not checking the return value of Life() when they should

### DIFF
--- a/code/modules/mob/living/basic/cult/constructs/harvester.dm
+++ b/code/modules/mob/living/basic/cult/constructs/harvester.dm
@@ -208,6 +208,9 @@
 // Don't let them be near you!
 /mob/living/basic/construct/harvester/heretic/Life(seconds_per_tick, times_fired)
 	. = ..()
+	if(!.) //dead or deleted
+		return
+
 	if(!SPT_PROB(7, seconds_per_tick))
 		return
 

--- a/code/modules/mob/living/basic/heretic/rust_walker.dm
+++ b/code/modules/mob/living/basic/heretic/rust_walker.dm
@@ -39,8 +39,8 @@
 	icon_living = icon_state
 
 /mob/living/basic/heretic_summon/rust_walker/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(stat == DEAD)
-		return ..()
+	if(!.) //dead or deleted
+		return
 	var/turf/our_turf = get_turf(src)
 	if(HAS_TRAIT(our_turf, TRAIT_RUSTY))
 		adjustBruteLoss(-3 * seconds_per_tick)

--- a/code/modules/mob/living/basic/heretic/rust_walker.dm
+++ b/code/modules/mob/living/basic/heretic/rust_walker.dm
@@ -39,6 +39,7 @@
 	icon_living = icon_state
 
 /mob/living/basic/heretic_summon/rust_walker/Life(seconds_per_tick = SSMOBS_DT, times_fired)
+	. = ..()
 	if(!.) //dead or deleted
 		return
 	var/turf/our_turf = get_turf(src)

--- a/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
+++ b/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
@@ -117,6 +117,8 @@
 
 /mob/living/basic/pet/dog/breaddog/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
+	if(!.) //dead or deleted
+		return
 	if(stat)
 		return
 

--- a/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
+++ b/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
@@ -119,7 +119,7 @@
 	. = ..()
 	if(!.) //dead or deleted
 		return
-	if(stat)
+	if(stat) // consciousness check
 		return
 
 	if(health < maxHealth)

--- a/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
+++ b/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
@@ -268,6 +268,8 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 
 /mob/living/basic/mimic/copy/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
+	if(!.) //dead or deleted
+		return
 	if(idledamage && !ckey && !ai_controller?.blackboard[BB_BASIC_MOB_CURRENT_TARGET]) //Objects eventually revert to normal if no one is around to terrorize
 		adjustBruteLoss(0.5 * seconds_per_tick)
 	for(var/mob/living/victim in contents) //a fix for animated statues from the flesh to stone spell

--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -1,7 +1,7 @@
 
 /mob/living/basic/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
-	if(QDELETED(src))
+	if(!.) //dead or deleted
 		return
 
 	if(!HAS_TRAIT(src, TRAIT_STASIS)) //No hunger in stasis

--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -1,6 +1,8 @@
 
 /mob/living/basic/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	..()
+	. = ..()
+	if(QDELETED(src)) //dead or deleted
+		return
 
 	if(!HAS_TRAIT(src, TRAIT_STASIS)) //No hunger in stasis
 		handle_nutrition(seconds_per_tick)

--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -1,7 +1,7 @@
 
 /mob/living/basic/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
-	if(QDELETED(src)) //dead or deleted
+	if(QDELETED(src))
 		return
 
 	if(!HAS_TRAIT(src, TRAIT_STASIS)) //No hunger in stasis

--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -58,7 +58,9 @@
 	make_migo_sound()
 
 /mob/living/basic/migo/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	..()
+	. = ..()
+	if(!.) //dead or deleted
+		return
 	if(stat)
 		return
 	if(SPT_PROB(5, seconds_per_tick))

--- a/code/modules/mob/living/basic/tree.dm
+++ b/code/modules/mob/living/basic/tree.dm
@@ -61,7 +61,9 @@
 	AddComponent(/datum/component/aggro_emote, emote_list = string_list(list("growls")), emote_chance = 20)
 
 /mob/living/basic/tree/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	..()
+	. = ..()
+	if(!.) //dead or deleted
+		return
 	if(!isopenturf(loc))
 		return
 	var/turf/open/our_turf = src.loc

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,6 +1,7 @@
 /mob/living/carbon/alien/Life(seconds_per_tick = SSMOBS_DT, times_fired)
+	if(!.) //dead or deleted
+		return
 	findQueen()
-	return..()
 
 /mob/living/carbon/alien/check_breath(datum/gas_mixture/breath)
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
@@ -43,4 +44,6 @@
 
 /mob/living/carbon/alien/adult/Life(seconds_per_tick, times_fired)
 	. = ..()
+	if(QDELETED(src))
+		return
 	handle_organs(seconds_per_tick, times_fired)

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/alien/Life(seconds_per_tick = SSMOBS_DT, times_fired)
+	. = ..()
 	if(!.) //dead or deleted
 		return
 	findQueen()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -2,7 +2,7 @@
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
-	..()
+	. = ..()
 	handle_robot_hud_updates()
 	handle_robot_cell(seconds_per_tick, times_fired)
 

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -64,7 +64,7 @@
 	var/nutrition_change = ooze_nutrition_loss
 
 	//Eat a bit of all the reagents we have. Gaining nutrition for actual nutritional ones.
-	for(var/i in reagents.reagent_list)
+	for(var/i in reagents?.reagent_list)
 		var/datum/reagent/reagent = i
 		var/consumption_amount = min(reagents.get_reagent_amount(reagent.type), ooze_metabolism_modifier * REAGENTS_METABOLISM * seconds_per_tick)
 		if(istype(reagent, /datum/reagent/consumable))

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -55,6 +55,9 @@
 /mob/living/simple_animal/hostile/ooze/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
 
+	if(!.) //dead or deleted
+		return
+
 	if(!mind && stat != DEAD)//no mind no change
 		return
 


### PR DESCRIPTION
## About The Pull Request

![firefox_iLQqvDAiws](https://github.com/user-attachments/assets/d88c71ae-2f23-4799-865b-4b355c5bfe83)

Goal of this PR was to fix this annoying CI runtime that most likely occurs on a Life() tick that happens on a dead or deleted mob. Ending up finding more issues than I set out to fix.

The short of it is: the base call of `Life()` actually has a return value of `1` if the mob is alive, or `null` if the mob is dead or qdeleted. There are many procs which should be stopping operations once the mob is either qdeleted or dead, but many procs were not even checking the return value of `..()`.

This fixes that.

Note: For some procs, it _DOES_ actually matter to differentiate between being qdeleted and being dead... `handle_organs()` comes to mind iirc. So I was careful to respect that. That is why some are checking for `!.` while others are checking for `QDELETED(src)`

## Why It's Good For The Game

Less spurious runtimes.

## Changelog

Not player facing