### PR TITLE
Team antags no longer hide all of someone's other antags from the roundend report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -615,12 +615,8 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	for(var/datum/team/active_teams as anything in all_teams)
 		//check if we should show the team
 		if(!active_teams.show_roundend_report)
+			all_teams -= active_teams
 			continue
-
-		//remove the team's individual antag reports, if the team actually shows up in the report.
-		for(var/datum/mind/team_minds as anything in active_teams.members)
-			if(!isnull(team_minds.antag_datums)) // is_special_character passes if they have a special role instead of an antag
-				all_antagonists -= team_minds.antag_datums
 
 		result += active_teams.roundend_report()
 		result += " "//newline between teams
@@ -633,6 +629,10 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 
 	for(var/datum/antagonist/antagonists in all_antagonists)
 		if(!antagonists.show_in_roundend)
+			continue
+		// if the antag datum is associated with a team that appeared in the report, skip it.
+		var/datum/team/antag_team = antagonists.get_team()
+		if(!isnull(antag_team) && (antag_team in all_teams))
 			continue
 		if(antagonists.roundend_category != currrent_category)
 			if(previous_category)


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/82128

if anyone was in an antag team, it'd remove _all of their antag datums_ from being listed in the roundend report - so if, say, someone was a BB+traitor, they wouldn't appear as a traitor in the roundend report at all.

this fixes that - instead, only antag datums associated with a team that appeared in the report will be skipped.

<details>
<summary>Before/After (both of these have both BB and traitor)</summary>

<h3>Before</h3>

![image](https://github.com/user-attachments/assets/8d0eff9a-e6b7-42ec-940d-b745edc5ae80)

<h3>After</h3>

![2025-02-19 (1739945577)](https://github.com/user-attachments/assets/58ed6e06-930a-4a35-a6e5-47e577565750)

</details>


## Why It's Good For The Game

reduces confusion and such.

## Changelog
:cl:
fix: Being a team antagonist will no longer hide all of your other antagonist roles from the roundend report, i.e a BB+traitor will properly show as both a BB and a traitor in the roundend report.
/:cl:
