### PR TITLE
Recolor acid, water, and radioactive reagents

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1258,7 +1258,7 @@
 /datum/reagent/uranium/radium
 	name = "Radium"
 	description = "Radium is an alkaline earth metal. It is extremely radioactive."
-	color = "#31b83f"
+	color = "#7FFF00"
 	taste_description = "the colour blue and regret"
 	tox_damage = 1
 	material = null

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1226,7 +1226,7 @@
 /datum/reagent/uranium
 	name = "Uranium"
 	description = "A jade-green metallic chemical element in the actinide series, weakly radioactive."
-	color = "#5E9964" //this used to be silver, but liquid uranium can still be green and it's more easily noticeable as uranium like this so why bother?
+	color = "#5E9964"
 	taste_description = "the inside of a reactor"
 	ph = 4
 	material = /datum/material/uranium
@@ -1258,7 +1258,7 @@
 /datum/reagent/uranium/radium
 	name = "Radium"
 	description = "Radium is an alkaline earth metal. It is extremely radioactive."
-	color = "#00CC00" // ditto
+	color = "#31b83f"
 	taste_description = "the colour blue and regret"
 	tox_damage = 1
 	material = null

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -222,7 +222,7 @@
 /datum/reagent/water
 	name = "Water"
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen."
-	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha)
+	color = "#516a91e3"
 	taste_description = "water"
 	var/cooling_temperature = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS
@@ -351,7 +351,6 @@
 /datum/reagent/water/salt
 	name = "Saltwater"
 	description = "Water, but salty. Smells like... the station infirmary?"
-	color = "#aaaaaa9d" // rgb: 170, 170, 170, 77 (alpha)
 	taste_description = "the sea"
 	cooling_temperature = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS
@@ -400,7 +399,7 @@
 /datum/reagent/water/holywater
 	name = "Holy Water"
 	description = "Water blessed by some deity."
-	color = "#E0E8EF" // rgb: 224, 232, 239
+	color = "#E0E8EF"
 	self_consuming = TRUE //divine intervention won't be limited by the lack of a liver
 	ph = 7.5 //God is alkaline
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_UNAFFECTED_BY_METABOLISM // Operates at fixed metabolism for balancing memes.

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -582,7 +582,7 @@
 /datum/reagent/toxin/polonium
 	name = "Polonium"
 	description = "An extremely radioactive material in liquid form. Ingestion results in fatal irradiation."
-	color = "#52f852"
+	color = "#35ff49"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -1039,7 +1039,7 @@
 /datum/reagent/toxin/acid
 	name = "Sulfuric Acid"
 	description = "A strong mineral acid with the molecular formula H2SO4."
-	color = "#00df2d"
+	color = "#00be26"
 	toxpwr = 1
 	taste_description = "acid"
 	self_consuming = TRUE
@@ -1109,7 +1109,7 @@
 /datum/reagent/toxin/acid/nitracid
 	name = "Nitric Acid"
 	description = "Nitric acid is an extremely corrosive chemical substance that violently reacts with living organic tissue."
-	color = "#00a721"
+	color = "#007718"
 	creation_purity = REAGENT_STANDARD_PURITY
 	purity = REAGENT_STANDARD_PURITY
 	toxpwr = 3

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1087,7 +1087,7 @@
 /datum/reagent/toxin/acid/fluacid
 	name = "Fluorosulfuric Acid"
 	description = "Fluorosulfuric acid is an extremely corrosive chemical substance."
-	color = "#00FF32"
+	color = "#339966"
 	creation_purity = REAGENT_STANDARD_PURITY
 	purity = REAGENT_STANDARD_PURITY
 	toxpwr = 2
@@ -1109,7 +1109,7 @@
 /datum/reagent/toxin/acid/nitracid
 	name = "Nitric Acid"
 	description = "Nitric acid is an extremely corrosive chemical substance that violently reacts with living organic tissue."
-	color = "#007718"
+	color = "#669900"
 	creation_purity = REAGENT_STANDARD_PURITY
 	purity = REAGENT_STANDARD_PURITY
 	toxpwr = 3

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -582,7 +582,7 @@
 /datum/reagent/toxin/polonium
 	name = "Polonium"
 	description = "An extremely radioactive material in liquid form. Ingestion results in fatal irradiation."
-	color = "#35ff49"
+	color = "#39FF14"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -582,7 +582,7 @@
 /datum/reagent/toxin/polonium
 	name = "Polonium"
 	description = "An extremely radioactive material in liquid form. Ingestion results in fatal irradiation."
-	color = "#787878"
+	color = "#52f852"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -1039,7 +1039,7 @@
 /datum/reagent/toxin/acid
 	name = "Sulfuric Acid"
 	description = "A strong mineral acid with the molecular formula H2SO4."
-	color = "#00FF32"
+	color = "#00df2d"
 	toxpwr = 1
 	taste_description = "acid"
 	self_consuming = TRUE
@@ -1087,7 +1087,7 @@
 /datum/reagent/toxin/acid/fluacid
 	name = "Fluorosulfuric Acid"
 	description = "Fluorosulfuric acid is an extremely corrosive chemical substance."
-	color = "#5050FF"
+	color = "#00FF32"
 	creation_purity = REAGENT_STANDARD_PURITY
 	purity = REAGENT_STANDARD_PURITY
 	toxpwr = 2
@@ -1109,7 +1109,7 @@
 /datum/reagent/toxin/acid/nitracid
 	name = "Nitric Acid"
 	description = "Nitric acid is an extremely corrosive chemical substance that violently reacts with living organic tissue."
-	color = "#5050FF"
+	color = "#00a721"
 	creation_purity = REAGENT_STANDARD_PURITY
 	purity = REAGENT_STANDARD_PURITY
 	toxpwr = 3


### PR DESCRIPTION
## About The Pull Request
This changes the following reagent colors:
- Water went from being a transparent grey to being a blueish grey with minor transparency
- All acids and radioactive reagents are now all different shades of green (the more brighter green the stronger type of acid/radioactive reagent it is)

| reagent  | old color  | new color |
| :----: |:------------------------------------------------:|:------------------------------------------------:|
| water  | $\color{#AAAAAA77}&#9724;$ |  $\color{#516a91e3}&#9724;$ |
| -  | - | - |
| uranium  | $\color{#5E9964}&#9724;$ | $\color{#5E9964}&#9724;$ |
| radium | $\color{#00CC00}&#9724;$| $\color{#31b83f}&#9724;$ |
| polonium | $\color{#787878}&#9724;$ | $\color{#35ff49}&#9724;$ |
| -  | - | - |
| sulfuric acid  | $\color{#00FF32}&#9724;$ | $\color{#00be26}&#9724;$ |
| fluorosulfuric acid  | $\color{#5050FF}&#9724;$ | $\color{#339966}&#9724;$ |
| nitric acid | $\color{#5050FF}&#9724;$ | $\color{#669900}&#9724;$ |

## Why It's Good For The Game
Something I noticed when I was testing:
- #89550

Is that several acids/radioactive reagents was not the color I was expecting. 2 out of 3 acids were blue, radioactive reagents were blue, and water was grey. What's interesting is that the real life colors for these substances is accurate, but sci-fi lore teaches us they are all green. (and water should be blue)

In this case, I think it's better for realism to take a backseat.

## Changelog
:cl:
qol: Change acid and radioactive reagents color to be green. Change water reagent color to be a blueish grey.
/:cl:
