### PR TITLE
Being exposed to radioactive reagents causes irradiate effects

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -1,6 +1,9 @@
 /// Whether or not it's possible for this atom to be irradiated
 #define CAN_IRRADIATE(atom) (ishuman(##atom) || isitem(##atom))
 
+/// Calculates the max chance for a radiation_pulse via a radioactive reagent
+#define CALCULATE_RAD_MAX_CHANCE(rad_power) (20 + (15 * (rad_power - 1)))
+
 /// Sends out a pulse of radiation, eminating from the source.
 /// Radiation is performed by collecting all radiatables within the max range (0 means source only, 1 means adjacent, etc),
 /// then makes their way towards them. A number, starting at 1, is multiplied

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1245,7 +1245,7 @@
 			source = affected_mob,
 			max_range = 0,
 			threshold = RAD_VERY_LIGHT_INSULATION,
-			chance = min(volume/10 * rad_power, 2*rad_power),
+			chance = min(volume / (20 - rad_power * 5), rad_power),
 		)
 	if(affected_mob.adjustToxLoss(tox_damage * seconds_per_tick * REM, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1241,12 +1241,9 @@
 /datum/reagent/uranium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
-		radiation_pulse(
-			source = affected_mob,
-			max_range = 0,
-			threshold = RAD_VERY_LIGHT_INSULATION,
-			chance = min(volume / (20 - rad_power * 5), rad_power),
-		)
+		var/chance = min(volume / (20 - rad_power * 5), rad_power)
+		if(SPT_PROB(chance, seconds_per_tick)) // ignore rad protection calculations bc it's inside of us
+			affected_mob.AddComponent(/datum/component/irradiated)
 	if(affected_mob.adjustToxLoss(tox_damage * seconds_per_tick * REM, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -592,12 +592,9 @@
 /datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
-		radiation_pulse(
-			source = affected_mob,
-			max_range = 0,
-			threshold = RAD_VERY_LIGHT_INSULATION,
-			chance = min(volume / (20 - rad_power * 5), rad_power),
-		)
+		var/chance = min(volume / (20 - rad_power * 5), rad_power)
+		if(SPT_PROB(chance, seconds_per_tick)) // ignore rad protection calculations bc it's inside of us
+			affected_mob.AddComponent(/datum/component/irradiated)
 	else
 		if(affected_mob.adjustToxLoss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -596,7 +596,7 @@
 			source = affected_mob,
 			max_range = 0,
 			threshold = RAD_VERY_LIGHT_INSULATION,
-			chance = min(volume/10 * rad_power, 2*rad_power),
+			chance = min(volume / (20 - rad_power * 5), rad_power),
 		)
 	else
 		if(affected_mob.adjustToxLoss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -586,14 +586,53 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	/// How radioactive is this reagent
+	var/rad_power = 3
 
 /datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	if (!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
-		affected_mob.AddComponent(/datum/component/irradiated)
+	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
+		radiation_pulse(
+			source = affected_mob,
+			max_range = 0,
+			threshold = RAD_VERY_LIGHT_INSULATION,
+			chance = min(volume/10 * rad_power, 2*rad_power),
+		)
 	else
 		if(affected_mob.adjustToxLoss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
+
+/datum/reagent/toxin/polonium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
+	. = ..()
+
+	if(!SSradiation.can_irradiate_basic(exposed_obj))
+		return
+
+	radiation_pulse(
+		source = exposed_obj,
+		max_range = 0,
+		threshold = RAD_VERY_LIGHT_INSULATION,
+		chance = (min(reac_volume * rad_power, CALCULATE_RAD_MAX_CHANCE(rad_power))),
+	)
+
+/datum/reagent/toxin/polonium/expose_mob(mob/living/exposed_mob, methods, reac_volume)
+	. = ..()
+
+	if(!SSradiation.can_irradiate_basic(exposed_mob))
+		return
+
+	if(ishuman(exposed_mob) && SSradiation.wearing_rad_protected_clothing(exposed_mob))
+		return
+
+	if(!(methods & (TOUCH|VAPOR)))
+		return
+
+	radiation_pulse(
+		source = exposed_mob,
+		max_range = 0,
+		threshold = RAD_VERY_LIGHT_INSULATION,
+		chance = (min(reac_volume * rad_power, CALCULATE_RAD_MAX_CHANCE(rad_power))),
+	)
 
 /datum/reagent/toxin/histamine
 	name = "Histamine"


### PR DESCRIPTION

## About The Pull Request
There are 3 radioactive reagents in the game with almost no effects related to radiation.

Polonium causes irradiation but only when the reagent is inside the mob. The rest do toxin damage, which seems silly to me. I've reworked these 3 reagents to now trigger a radiation pulse when exposed to an object or mob. This radiation pulse only affects the target and does not apply to surrounding areas. The chance of irradiation is determined by how radioactive the reagent is which is now:
- Uranium (rad_power = 1) (max chance is 20 when TOUCH or VAPOR, max chance is 1 when INGEST)
- Radium (rad_power = 2) (max chance is 35 when TOUCH or VAPOR, max chance is 2 when INGEST)
- Polonium (rad_power = 3) (max chance is 50 when TOUCH or VAPOR, max chance is 3 when INGEST)

The irradiation chance calculations follows a simple formula:
```
// if reagent is TOUCH or VAPOR the irradiate chance is
chance = reac_volume * rad_power

// if reagent is INGEST the irradiate chance is (per tick)
chance = volume / (20 - rad_power * 5)
```
This system is setup so that you can't just fill up a beaker or bottle and toss it at someone and it guarantees they are irradiated. (that's why there is a max chance restriction) Likewise I lowered the chance significantly when the radioactive reagent is ingested so you can't just slip 1u into someones drink and it guarantees irradiation.

## Why It's Good For The Game
Radioactive reagents were under utilized. The irradiation system also sees very little action once the SM removed a lot of the old radiation methods. This gives more interesting ways to cause chaos and deal long term lasting damage besides brute/burn.

This can combo nicely with sabotaging a shower used for radiation treatment by filling it with... radium. Also for my weather PR, radioactive rain is cool as fuck and should irradiate things it touches otherwise it ends up being purely cosmetic.

## Changelog
:cl:
add: Add irradiation to radioactive reagents uranium, radium, and polonium.
balance: Radioactive reagents uranium, radium, and polonium now cause irradiate effects when they come into contact with mobs or objects. This can be via several means, ingestion, touch, or vapors. The more radioactive the reagent, the more likely it is to irradiate. Polonium is the most radioactive with a x3 multiplier, radium is next with a x2 multiplier, and uranium is the weakest with just a x1 multiplier.
balance: Polonium no longer guarantees instant irradiation when the reagent is inside a mob.
/:cl:
