### PR TITLE
[NO GBP] A quick fix for the previous bait can pr

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -591,7 +591,7 @@
 	if(fishing_line || GLOB.fishing_challenges_by_user[user])
 		return
 	// If the new item is a bait can, try to get bait from it
-	if(istype(new_item, /obj/item/bait_can))
+	if(slot == ROD_SLOT_BAIT && istype(new_item, /obj/item/bait_can))
 		var/obj/item/bait_can/can = new_item
 		var/bait = can.retrieve_bait(user)
 		if(!bait)


### PR DESCRIPTION

## About The Pull Request
This should have GBP no update right?

Well as it turns out my previous pr #89528 made it so the bug it fixed now appears in different circumstance, which I just now realised. The bait can triggers no matter what slot in the fishing rod's UI is clicked, which means that if you click on a slot which is not the bait slot, it just wastes the bait.
This adds a slot check to the if statement for the bait retrieval.
## Why It's Good For The Game
Actually fixes the bug without causing a different one
## Changelog
:cl:
fix: You can no longer "use" can of bait on non-bait slots in fishing rod
/:cl:
