### PR TITLE
Removes flatpacker flatpacks from maps, adds it to science and engineering vendors

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -8921,11 +8921,6 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -6;
-	pixel_y = 5
-	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "djY" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76009,9 +76009,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker
-	},
 /obj/item/multitool,
 /turf/open/floor/iron,
 /area/station/science/lab)
@@ -78472,11 +78469,6 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -6;
-	pixel_y = 5
-	},
 /obj/item/multitool{
 	pixel_x = 8
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -73011,9 +73011,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/item/multitool,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker
-	},
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -81778,10 +81775,6 @@
 /obj/effect/turf_decal/siding/yellow/corner,
 /obj/machinery/status_display/evac/directional/south,
 /obj/structure/table,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -5
-	},
 /obj/item/multitool{
 	pixel_x = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18733,9 +18733,6 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker
-	},
 /obj/item/multitool,
 /turf/open/floor/iron,
 /area/station/science/lab)
@@ -58721,10 +58718,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -5
 	},
 /obj/item/multitool{
 	pixel_x = 8

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -41518,9 +41518,6 @@
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
 /obj/item/multitool,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker
-	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "nDX" = (
@@ -49395,10 +49392,6 @@
 /obj/structure/table,
 /obj/item/multitool{
 	pixel_x = 8
-	},
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -141,6 +141,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/storage/backpack/satchel/eng = 3,
 		/obj/item/storage/backpack/duffelbag/engineering = 3,
 		/obj/item/storage/backpack/messenger/eng = 3,
+		/obj/item/flatpack/flatpacker = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 	payment_department = ACCOUNT_ENG
@@ -273,6 +274,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/storage/backpack/duffelbag/science = 3,
 		/obj/item/storage/backpack/messenger/science = 3,
 		/obj/item/radio/headset/headset_sci = 3,
+		/obj/item/flatpack/flatpacker = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 	payment_department = ACCOUNT_SCI


### PR DESCRIPTION
## About The Pull Request
as the name says, moves flatpacked flatpacker into rnd and engi vendor (like cargo's sorter)
![image](https://github.com/user-attachments/assets/e1c00f51-58cb-47ad-b1f6-33da4a29703e)

![image](https://github.com/user-attachments/assets/6bbf247e-c7ff-4e89-9b8f-189edac92333)

## Why It's Good For The Game
no need for mappers to place two flatpackers (birdshot has only one)
## Changelog
:cl:
add: Science and Engineering vendors now sells flatpacked flatpackers, in exchange for them being removed from station itself.
/:cl:
