### PR TITLE
Discord PR announcement workflow

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -16,7 +16,7 @@ jobs:
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Send Discord notification
-        uses: TiviPlus/discord-notify@v2
+        uses: tgstation/discord-notify@v2
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED &&
           github.event.pull_request.author_association != 'FIRST_TIMER' &&

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -1,7 +1,7 @@
 name: 'New PR Notification'
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, closed]
 
 jobs:
   notify:
@@ -19,6 +19,7 @@ jobs:
         uses: tgstation/discord-notify@v2
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED &&
+          (github.event.pull_request.merged == true || github.event.action == 'opened') &&
           github.event.pull_request.author_association != 'FIRST_TIMER' &&
           github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
         with:

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -1,0 +1,26 @@
+name: 'New PR Notification'
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check for DISCORD_WEBHOOK"
+        id: secrets_set
+        env:
+          ENABLER_SECRET: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          unset SECRET_EXISTS
+          if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
+          echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
+      - name: Send Discord notification
+        uses: TiviPlus/discord-notify@v2
+        if: steps.secrets_set.outputs.SECRETS_ENABLED
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
+          include_image: true
+          avatar_url: https://raw.githubusercontent.com/tgstation/tgstation/refs/heads/master/icons/ui/common/tg_32.png
+          username: GitHub
+          title_url: "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -17,7 +17,10 @@ jobs:
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Send Discord notification
         uses: TiviPlus/discord-notify@v2
-        if: steps.secrets_set.outputs.SECRETS_ENABLED
+        if: >
+          steps.secrets_set.outputs.SECRETS_ENABLED &&
+          github.event.pull_request.author_association != 'FIRST_TIMER' &&
+          github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           include_image: true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Readds the discord webhook PR announcer thingy as a workflow.
Discord webhook to the wanted channel(s) as a secret. Supports open/close/merge/reopen pr, but only open is enabled for tg like the old one used to work

https://github.com/TiviPlus/discord-notify

To set up: add the action, then create a webhook on a channel in discord, then add those (comma seperated) to the DISCORD_WEBHOOK secret

My first actual action with secrets I mostly made myself with so idk if i did the secrets/pr target thing right

![image](https://github.com/user-attachments/assets/31f2ced6-4384-4e65-aacb-071ee3d4f9f3)
## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/85c72e44-5891-4be3-862e-76232bd00b7a)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: The Discord Announcer for PRs is back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
