### PR TITLE
[Fix] Lobsters ignoring the profound fisher blacklist

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 		final_table -= FISHING_DUD
 
 
-	if(HAS_TRAIT(fisherman, TRAIT_PROFOUND_FISHER) && !fisherman.client)
+	if(!fisherman.client)
 		final_table -= profound_fisher_blacklist
 	for(var/result in final_table)
 		final_table[result] *= rod.hook.get_hook_bonus_multiplicative(result)


### PR DESCRIPTION

## About The Pull Request
debugged and tested, NPC's with the profound fishing component never passed the check for the trait, so they never got their blacklist working

## Why It's Good For The Game
Well, it meant that lobstrocities always fished the tendril chest and in ice box they always generated lots and lots of more lobsters, so being able for a player to get the chest via the fishing methods and for lobsters to not inifinitevely spawn is a good thing.

![image](https://github.com/user-attachments/assets/b4eab60a-5b29-40e5-a34e-51c21a518c60)


## Changelog
:cl:
fix: Fixed Lobsters fishing the tendril chest and more lobsters.
/:cl:
