### PR TITLE
Add air alarm wire knowledge to the Engineer skillchip

### DIFF
--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -73,3 +73,9 @@
 			A.update_appearance()
 		if(WIRE_SPEAKER)
 			A.speaker_enabled = mend
+
+/datum/wires/airalarm/can_reveal_wires(mob/user)
+	if(HAS_TRAIT(user, TRAIT_KNOW_ENGI_WIRES))
+		return TRUE
+
+	return ..()


### PR DESCRIPTION
## About The Pull Request

Add air alarm wires to the list of things that the engineer skillchip gives you knowledge of

## Why It's Good For The Game

Engineers have access to air alarms so there's no real problem with them knowing these, and it's helpful for fixing them.

## Changelog

:cl:
qol: air alarm wires are now labeled if you have the engineering skillchip
/:cl:

