### PR TITLE
Makes shapeshift store your original mob inside nullspace instead of the contents of the mob you became. (+ misc fixes)

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -81,7 +81,7 @@
 #endif // REFERENCE_TRACKING_STANDARD
 
 // If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
-#define UNIT_TESTS
+//#define UNIT_TESTS
 
 // If this is uncommented, will attempt to load and initialize prof.dll/libprof.so by default.
 // Even if it's not defined, you can pass "tracy" via -params in order to try to load it.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -81,7 +81,7 @@
 #endif // REFERENCE_TRACKING_STANDARD
 
 // If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
-//#define UNIT_TESTS
+#define UNIT_TESTS
 
 // If this is uncommented, will attempt to load and initialize prof.dll/libprof.so by default.
 // Even if it's not defined, you can pass "tracy" via -params in order to try to load it.

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -34,6 +34,7 @@
 	caster_mob.moveToNullspace()
 	ADD_TRAIT(caster_mob, TRAIT_NO_TRANSFORM, TRAIT_STATUS_EFFECT(id))
 	caster_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_SHAPECHANGE_EFFECT)
+	caster_mob.ai_controller = null
 
 	RegisterSignal(owner, COMSIG_LIVING_PRE_WABBAJACKED, PROC_REF(on_pre_wabbajack))
 	RegisterSignal(owner, COMSIG_PRE_MOB_CHANGED_TYPE, PROC_REF(on_pre_type_change))

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -46,7 +46,7 @@
 
 /datum/status_effect/shapechange_mob/on_remove()
 	// If the owner was straight up deleted we shouldn't restore anyone
-	// (the caster's stored in the owner's contents so if it's qdel'd so is the caster)
+	// (the caster's stored in nullspace so if it's qdel'd so is the caster)
 	if(!QDELETED(owner))
 		restore_caster()
 

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -173,9 +173,8 @@
 
 		if(source_spell.convert_damage)
 			var/damage_to_apply = owner.maxHealth * (caster_mob.get_total_damage() / caster_mob.maxHealth)
-			var/clamp_damage = clamp(damage_to_apply, -1, owner.maxHealth - 1) // Barely alive
 
-			owner.apply_damage(clamp_damage, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
+			owner.apply_damage(damage_to_apply, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
 			// Only transfer blood if both mobs are supposed to have a blood volume
 			if (initial(owner.blood_volume) > 0 && initial(caster_mob.blood_volume) > 0 && !HAS_TRAIT(owner, TRAIT_NOBLOOD) && !HAS_TRAIT(caster_mob, TRAIT_NOBLOOD))
 				owner.blood_volume = caster_mob.blood_volume

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -172,8 +172,9 @@
 
 		if(source_spell.convert_damage)
 			var/damage_to_apply = owner.maxHealth * (caster_mob.get_total_damage() / caster_mob.maxHealth)
+			var/clamp_damage = clamp(damage_to_apply, -1, owner.maxHealth - 1) // Barely alive
 
-			owner.apply_damage(damage_to_apply, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
+			owner.apply_damage(clamp_damage, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
 			// Only transfer blood if both mobs are supposed to have a blood volume
 			if (initial(owner.blood_volume) > 0 && initial(caster_mob.blood_volume) > 0 && !HAS_TRAIT(owner, TRAIT_NOBLOOD) && !HAS_TRAIT(caster_mob, TRAIT_NOBLOOD))
 				owner.blood_volume = caster_mob.blood_volume
@@ -213,7 +214,9 @@
 
 	caster_mob.fully_heal(HEAL_DAMAGE) // Remove all of our damage before setting our health to a proportion of the former transformed mob's health
 	var/damage_to_apply = caster_mob.maxHealth * (owner.get_total_damage() / owner.maxHealth)
-	caster_mob.apply_damage(damage_to_apply, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
+	var/clamp_damage = clamp(damage_to_apply, -1, caster_mob.maxHealth - 1) // Barely alive
+
+	caster_mob.apply_damage(clamp_damage, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
 	// Only transfer blood if both mobs are supposed to have a blood volume
 	if (initial(owner.blood_volume) > 0 && initial(caster_mob.blood_volume) > 0 && !HAS_TRAIT(owner, TRAIT_NOBLOOD) && !HAS_TRAIT(caster_mob, TRAIT_NOBLOOD))
 		caster_mob.blood_volume = owner.blood_volume

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -214,7 +214,6 @@
 
 	caster_mob.fully_heal(HEAL_DAMAGE) // Remove all of our damage before setting our health to a proportion of the former transformed mob's health
 	var/damage_to_apply = caster_mob.maxHealth * (owner.get_total_damage() / owner.maxHealth)
-
 	caster_mob.apply_damage(damage_to_apply, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
 	// Only transfer blood if both mobs are supposed to have a blood volume
 	if (initial(owner.blood_volume) > 0 && initial(caster_mob.blood_volume) > 0 && !HAS_TRAIT(owner, TRAIT_NOBLOOD) && !HAS_TRAIT(caster_mob, TRAIT_NOBLOOD))

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -34,7 +34,7 @@
 	caster_mob.moveToNullspace()
 	ADD_TRAIT(caster_mob, TRAIT_NO_TRANSFORM, TRAIT_STATUS_EFFECT(id))
 	caster_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_SHAPECHANGE_EFFECT)
-	caster_mob.ai_controller = null
+	QDEL_NULL(caster_mob.ai_controller)
 
 	RegisterSignal(owner, COMSIG_LIVING_PRE_WABBAJACKED, PROC_REF(on_pre_wabbajack))
 	RegisterSignal(owner, COMSIG_PRE_MOB_CHANGED_TYPE, PROC_REF(on_pre_type_change))

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -214,9 +214,8 @@
 
 	caster_mob.fully_heal(HEAL_DAMAGE) // Remove all of our damage before setting our health to a proportion of the former transformed mob's health
 	var/damage_to_apply = caster_mob.maxHealth * (owner.get_total_damage() / owner.maxHealth)
-	var/clamp_damage = clamp(damage_to_apply, -1, caster_mob.maxHealth - 1) // Barely alive
 
-	caster_mob.apply_damage(clamp_damage, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
+	caster_mob.apply_damage(damage_to_apply, source_spell.convert_damage_type, forced = TRUE, spread_damage = TRUE, wound_bonus = CANT_WOUND)
 	// Only transfer blood if both mobs are supposed to have a blood volume
 	if (initial(owner.blood_volume) > 0 && initial(caster_mob.blood_volume) > 0 && !HAS_TRAIT(owner, TRAIT_NOBLOOD) && !HAS_TRAIT(caster_mob, TRAIT_NOBLOOD))
 		caster_mob.blood_volume = owner.blood_volume

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -31,7 +31,7 @@
 
 /datum/status_effect/shapechange_mob/on_apply()
 	caster_mob.mind?.transfer_to(owner)
-	caster_mob.forceMove(owner)
+	caster_mob.moveToNullspace()
 	ADD_TRAIT(caster_mob, TRAIT_NO_TRANSFORM, TRAIT_STATUS_EFFECT(id))
 	caster_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_SHAPECHANGE_EFFECT)
 

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -117,7 +117,7 @@
 
 /// Validates that shapeshifting carries health or death between forms properly, if it is supposed to
 /datum/unit_test/shapeshift_health
-
+/*
 /datum/unit_test/shapeshift_health/Run()
 	for(var/spell_type in subtypesof(/datum/action/cooldown/spell/shapeshift))
 		var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent, run_loc_floor_bottom_left)
@@ -131,11 +131,11 @@
 
 		if (shift_spell.convert_damage)
 			shift_spell.Trigger()
-			TEST_ASSERT(istype(dummy.loc, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type]using [shift_spell.name].")
+			//TEST_ASSERT(istype(dummy.loc, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] using [shift_spell.name].")
 			var/mob/living/shifted_mob = dummy.loc
 			shifted_mob.apply_damage(shifted_mob.maxHealth * EXPECTED_HEALTH_RATIO, BRUTE, forced = TRUE)
 			TRIGGER_RESET_COOLDOWN(shift_spell)
-			TEST_ASSERT(!istype(dummy.loc, shift_spell.shapeshift_type), "Failed to unfransform from [shift_spell.shapeshift_type] using [shift_spell.name].")
+			//TEST_ASSERT(!istype(dummy.loc, shift_spell.shapeshift_type), "Failed to unfransform from [shift_spell.shapeshift_type] using [shift_spell.name].")
 			TEST_ASSERT_EQUAL(dummy.get_total_damage(), dummy.maxHealth * EXPECTED_HEALTH_RATIO, "Failed to transfer damage from [shift_spell.shapeshift_type] to original form using [shift_spell.name].")
 			TRIGGER_RESET_COOLDOWN(shift_spell)
 			TEST_ASSERT(istype(dummy.loc, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] after taking damage using [shift_spell.name].")
@@ -154,6 +154,6 @@
 			TEST_ASSERT_EQUAL(dummy.stat, DEAD, "Failed to kill original mob when transformed mob died using [shift_spell.name].")
 
 		qdel(shift_spell)
-
+*/
 #undef EXPECTED_HEALTH_RATIO
 #undef TRIGGER_RESET_COOLDOWN

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -134,6 +134,7 @@
 
 		if (istype(shift_spell, /datum/action/cooldown/spell/shapeshift/polymorph_belt))
 			var/datum/action/cooldown/spell/shapeshift/polymorph_belt/belt_spell = shift_spell
+			belt_spell.possible_shapes = list(/mob/living/basic/mouse) // I hate cockroaches. A maxhealth of 1 rounds down to 0 in this unit test.
 			belt_spell.channel_time = 0 SECONDS // No do-afters
 
 		if(shift_spell.convert_damage)

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -96,18 +96,21 @@
 	test_stand.set_summoner(dummy)
 
 	// The stand's summoner is dummy.
+/*
 	TEST_ASSERT_EQUAL(test_stand.summoner, dummy, "Holoparasite failed to set the summoner to the correct mob.")
-
+*/
 	// Dummy casts shapeshift. The stand's summoner should become the shape the dummy is within.
 	shift.Trigger()
+	/*
 	TEST_ASSERT(istype(dummy.loc, shift.shapeshift_type), "Shapeshift spell failed to transform the dummy into the shape [initial(shift.shapeshift_type.name)].")
 	TEST_ASSERT_EQUAL(test_stand.summoner, dummy.loc, "Shapeshift spell failed to transfer the holoparasite to the dummy's shape.")
-
+	*/
 	// Dummy casts shapeshfit back, the stand's summoner should become the dummy again.
 	TRIGGER_RESET_COOLDOWN(shift)
+	/*
 	TEST_ASSERT(!istype(dummy.loc, shift.shapeshift_type), "Shapeshift spell failed to transform the dummy back into human form.")
 	TEST_ASSERT_EQUAL(test_stand.summoner, dummy, "Shapeshift spell failed to transfer the holoparasite back to the dummy's human form.")
-
+	*/
 	qdel(shift)
 
 #define EXPECTED_HEALTH_RATIO 0.5

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -134,7 +134,6 @@
 
 		if (istype(shift_spell, /datum/action/cooldown/spell/shapeshift/polymorph_belt))
 			var/datum/action/cooldown/spell/shapeshift/polymorph_belt/belt_spell = shift_spell
-			belt_spell.possible_shapes = list(/mob/living/basic/mouse) // I hate cockroaches. A maxhealth of 1 rounds down to 0 in this unit test.
 			belt_spell.channel_time = 0 SECONDS // No do-afters
 
 		if(shift_spell.convert_damage)
@@ -171,6 +170,12 @@
 	if(isnull(status_effect))
 		return TEST_FAIL("Shapeshift spell: Failed to return /datum/status_effect/shapechange_mob/from_spell on [shifted.owner]")
 	return shifted.owner.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
-
+/*
+/datum/unit_test/shapeshift_health/proc/health_sanity(mob/to_check) // Prevents rounding errors
+	var/mob/living/checked_mob = to_check
+	if(checked_mob.maxHealth <= 1)
+		checked_mob.maxHealth = checked_mob.maxHealth + 1
+		checked
+*/
 #undef EXPECTED_HEALTH_RATIO
 #undef TRIGGER_RESET_COOLDOWN

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -56,24 +56,29 @@
 		qdel(mindbound_shift)
 
 /datum/unit_test/shapeshift_spell/proc/test_spell(mob/living/carbon/human/dummy, datum/action/cooldown/spell/shapeshift/shift, forced_shape)
+/*
 	if(forced_shape)
 		shift.shapeshift_type = forced_shape
-/*
+	var/mob/original_mob = locate(/datum/status_effect/shapechange_mob) */
 	TRIGGER_RESET_COOLDOWN(shift)
+/*
 	var/mob/expected_shape = shift.shapeshift_type
 	if(!istype(dummy.loc, expected_shape))
 		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy into the shape [initial(expected_shape.name)]. \
 			([dummy] was located within [dummy.loc], which is a [dummy.loc?.type || "null"]).")
+*/
 
+/*
 	var/mob/living/shape = dummy.loc
 	if(!(shift in shape.actions))
 		return TEST_FAIL("Shapeshift spell: [shift.name] failed to grant the spell to the dummy's shape.")
-
+*/
 	TRIGGER_RESET_COOLDOWN(shift)
+/*
 	if(istype(dummy.loc, shift.shapeshift_type))
 		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy back into a human.")
-
 */
+
 /**
  * Validates that shapeshifts function properly with holoparasites.
  */

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -58,8 +58,12 @@
 /datum/unit_test/shapeshift_spell/proc/test_spell(mob/living/carbon/human/dummy, datum/action/cooldown/spell/shapeshift/shift, forced_shape)
 	if(forced_shape)
 		shift.shapeshift_type = forced_shape
-
+/*
 	TRIGGER_RESET_COOLDOWN(shift)
+	var/mob/expected_shape = shift.shapeshift_type
+	if(!istype(dummy.loc, expected_shape))
+		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy into the shape [initial(expected_shape.name)]. \
+			([dummy] was located within [dummy.loc], which is a [dummy.loc?.type || "null"]).")
 
 	var/mob/living/shape = dummy.loc
 	if(!(shift in shape.actions))
@@ -69,7 +73,7 @@
 	if(istype(dummy.loc, shift.shapeshift_type))
 		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy back into a human.")
 
-
+*/
 /**
  * Validates that shapeshifts function properly with holoparasites.
  */

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -170,12 +170,6 @@
 	if(isnull(status_effect))
 		return TEST_FAIL("Shapeshift spell: Failed to return /datum/status_effect/shapechange_mob/from_spell on [shifted.owner]")
 	return shifted.owner.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
-/*
-/datum/unit_test/shapeshift_health/proc/health_sanity(mob/to_check) // Prevents rounding errors
-	var/mob/living/checked_mob = to_check
-	if(checked_mob.maxHealth <= 1)
-		checked_mob.maxHealth = checked_mob.maxHealth + 1
-		checked
-*/
+
 #undef EXPECTED_HEALTH_RATIO
 #undef TRIGGER_RESET_COOLDOWN

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -60,10 +60,6 @@
 		shift.shapeshift_type = forced_shape
 
 	TRIGGER_RESET_COOLDOWN(shift)
-	var/mob/expected_shape = shift.shapeshift_type
-	if(!istype(dummy.loc, expected_shape))
-		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy into the shape [initial(expected_shape.name)]. \
-			([dummy] was located within [dummy.loc], which is a [dummy.loc?.type || "null"]).")
 
 	var/mob/living/shape = dummy.loc
 	if(!(shift in shape.actions))

--- a/code/modules/unit_tests/spell_shapeshift.dm
+++ b/code/modules/unit_tests/spell_shapeshift.dm
@@ -56,32 +56,36 @@
 		qdel(mindbound_shift)
 
 /datum/unit_test/shapeshift_spell/proc/test_spell(mob/living/carbon/human/dummy, datum/action/cooldown/spell/shapeshift/shift, forced_shape)
-/*
+
 	if(forced_shape)
 		shift.shapeshift_type = forced_shape
-	var/mob/original_mob = locate(/datum/status_effect/shapechange_mob) */
-	TRIGGER_RESET_COOLDOWN(shift)
-/*
-	var/mob/expected_shape = shift.shapeshift_type
-	if(!istype(dummy.loc, expected_shape))
-		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy into the shape [initial(expected_shape.name)]. \
-			([dummy] was located within [dummy.loc], which is a [dummy.loc?.type || "null"]).")
-*/
 
-/*
-	var/mob/living/shape = dummy.loc
-	if(!(shift in shape.actions))
-		return TEST_FAIL("Shapeshift spell: [shift.name] failed to grant the spell to the dummy's shape.")
-*/
 	TRIGGER_RESET_COOLDOWN(shift)
-/*
-	if(istype(dummy.loc, shift.shapeshift_type))
-		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform the dummy back into a human.")
-*/
+
+	var/datum/status_effect/shapechange_mob/shapechange_status = shift.owner.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
+	var/mob/expected_shape = shift.shapeshift_type
+
+	if(!isnull(dummy.loc)) // Checks to see if the dummy is in nullspace. Will fail if the client fails to transfer.
+		return TEST_FAIL("Shapeshift spell: [shift.name] failed to send dummy to nullspace when transforming into [initial(expected_shape.name)].")
+
+	if(isnull(shapechange_status))
+		return TEST_FAIL("Shapeshift spell: [shift.name] failed to apply /datum/status_effect/shapechange_mob/ on the shape [initial(expected_shape.name)].")
+
+	if(!istype(shapechange_status.owner, expected_shape))
+		return TEST_FAIL("Shapeshift spell: [shift.name] failed to transform dummy into the shape [initial(expected_shape.name)].")
+
+	if(!(shift in shapechange_status.owner.actions))
+		return TEST_FAIL("Shapeshift spell: [shift.name] failed to grant the spell to the transformed dummy's shape")
+
+	TRIGGER_RESET_COOLDOWN(shift)
+
+	if(isnull(dummy.loc)) // Did we pull them out of nullspace?
+		return TEST_FAIL("Shapeshift spell: [shift.name] failed to pull the dummy out of nullspace when transforming to original mob")
 
 /**
  * Validates that shapeshifts function properly with holoparasites.
  */
+
 /datum/unit_test/shapeshift_holoparasites
 
 /datum/unit_test/shapeshift_holoparasites/Run()
@@ -96,32 +100,35 @@
 	test_stand.set_summoner(dummy)
 
 	// The stand's summoner is dummy.
-/*
+
 	TEST_ASSERT_EQUAL(test_stand.summoner, dummy, "Holoparasite failed to set the summoner to the correct mob.")
-*/
+
 	// Dummy casts shapeshift. The stand's summoner should become the shape the dummy is within.
+
 	shift.Trigger()
-	/*
-	TEST_ASSERT(istype(dummy.loc, shift.shapeshift_type), "Shapeshift spell failed to transform the dummy into the shape [initial(shift.shapeshift_type.name)].")
-	TEST_ASSERT_EQUAL(test_stand.summoner, dummy.loc, "Shapeshift spell failed to transfer the holoparasite to the dummy's shape.")
-	*/
+	var/datum/status_effect/shapechange_mob/status = shift.owner.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
+	TEST_ASSERT(!isnull(status), "Shapeshift spell failed to properly assign /datum/status_effect/shapechange_mob/from_spell while transforming the dummy into shape [initial(shift.shapeshift_type.name)]")
+	TEST_ASSERT(istype(status.owner, shift.shapeshift_type), "Shapeshift spell failed to transform the dummy into the shape [initial(shift.shapeshift_type.name)].")
+	TEST_ASSERT_EQUAL(test_stand.summoner, status.owner, "Shapeshift spell failed to transfer the holoparasite to the dummy's shape.")
+
 	// Dummy casts shapeshfit back, the stand's summoner should become the dummy again.
 	TRIGGER_RESET_COOLDOWN(shift)
-	/*
-	TEST_ASSERT(!istype(dummy.loc, shift.shapeshift_type), "Shapeshift spell failed to transform the dummy back into human form.")
+	TEST_ASSERT(!isnull(dummy.loc), "Shapeshift spell failed to transfer dummy from nullspace.")
 	TEST_ASSERT_EQUAL(test_stand.summoner, dummy, "Shapeshift spell failed to transfer the holoparasite back to the dummy's human form.")
-	*/
+
 	qdel(shift)
 
 #define EXPECTED_HEALTH_RATIO 0.5
 
 /// Validates that shapeshifting carries health or death between forms properly, if it is supposed to
 /datum/unit_test/shapeshift_health
-/*
+
 /datum/unit_test/shapeshift_health/Run()
+
 	for(var/spell_type in subtypesof(/datum/action/cooldown/spell/shapeshift))
 		var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent, run_loc_floor_bottom_left)
 		var/datum/action/cooldown/spell/shapeshift/shift_spell = new spell_type(dummy)
+		var/datum/status_effect/status_effect
 		shift_spell.Grant(dummy)
 		shift_spell.shapeshift_type = shift_spell.possible_shapes[1]
 
@@ -129,31 +136,40 @@
 			var/datum/action/cooldown/spell/shapeshift/polymorph_belt/belt_spell = shift_spell
 			belt_spell.channel_time = 0 SECONDS // No do-afters
 
-		if (shift_spell.convert_damage)
-			shift_spell.Trigger()
-			//TEST_ASSERT(istype(dummy.loc, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] using [shift_spell.name].")
-			var/mob/living/shifted_mob = dummy.loc
-			shifted_mob.apply_damage(shifted_mob.maxHealth * EXPECTED_HEALTH_RATIO, BRUTE, forced = TRUE)
-			TRIGGER_RESET_COOLDOWN(shift_spell)
-			//TEST_ASSERT(!istype(dummy.loc, shift_spell.shapeshift_type), "Failed to unfransform from [shift_spell.shapeshift_type] using [shift_spell.name].")
-			TEST_ASSERT_EQUAL(dummy.get_total_damage(), dummy.maxHealth * EXPECTED_HEALTH_RATIO, "Failed to transfer damage from [shift_spell.shapeshift_type] to original form using [shift_spell.name].")
-			TRIGGER_RESET_COOLDOWN(shift_spell)
-			TEST_ASSERT(istype(dummy.loc, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] after taking damage using [shift_spell.name].")
-			shifted_mob = dummy.loc
-			TEST_ASSERT_EQUAL(shifted_mob.get_total_damage(), shifted_mob.maxHealth * EXPECTED_HEALTH_RATIO, "Failed to transfer damage from original form to [shift_spell.shapeshift_type] using [shift_spell.name].")
-			TRIGGER_RESET_COOLDOWN(shift_spell)
+		if(shift_spell.convert_damage)
+			shift_spell.Trigger() // Monster
+			status_effect = get_status_effect(shift_spell)
+			TEST_ASSERT(istype(status_effect.owner, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] using [shift_spell.name].")
+			status_effect.owner.apply_damage(status_effect.owner.maxHealth * EXPECTED_HEALTH_RATIO, BRUTE, forced = TRUE)
 
-		if (shift_spell.die_with_shapeshifted_form)
-			TRIGGER_RESET_COOLDOWN(shift_spell)
-			TEST_ASSERT(istype(dummy.loc, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type]")
-			var/mob/living/shifted_mob = dummy.loc
-			shifted_mob.health = 0 // Fucking megafauna
-			shifted_mob.death()
-			if (shift_spell.revert_on_death)
-				TEST_ASSERT(!istype(dummy.loc, shift_spell.shapeshift_type), "Failed to untransform after death using [shift_spell.name].")
+			TRIGGER_RESET_COOLDOWN(shift_spell) // Human
+			TEST_ASSERT(!isnull(dummy.loc), "Shapeshift spell: [shift_spell.name] failed to pull dummy from nullspace")
+			TEST_ASSERT_EQUAL(dummy.get_total_damage(), dummy.maxHealth * EXPECTED_HEALTH_RATIO, "Failed to transfer damage from [shift_spell.shapeshift_type] to original form using [shift_spell.name].")
+
+			TRIGGER_RESET_COOLDOWN(shift_spell) // Monster
+			status_effect = get_status_effect(shift_spell)
+			TEST_ASSERT(istype(status_effect.owner, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] after taking damage using [shift_spell.name]. \ Failed type match [status_effect.owner.type] : [shift_spell.shapeshift_type]")
+			TEST_ASSERT_EQUAL(status_effect.owner.get_total_damage(), status_effect.owner.maxHealth * EXPECTED_HEALTH_RATIO, "Failed to transfer damage from original form to [shift_spell.shapeshift_type] using [shift_spell.name].")
+			TRIGGER_RESET_COOLDOWN(shift_spell) // Human
+
+		if(shift_spell.die_with_shapeshifted_form)
+			TRIGGER_RESET_COOLDOWN(shift_spell) // Monster
+			status_effect = get_status_effect(shift_spell)
+			TEST_ASSERT(istype(status_effect.owner, shift_spell.shapeshift_type), "Failed to transform into [shift_spell.shapeshift_type] using [shift_spell.name]")
+			status_effect.owner.health = 0 // Fucking Megafauna
+			status_effect.owner.death()
+			if(shift_spell.revert_on_death)
+				TEST_ASSERT(!isnull(dummy.loc), "Shapeshift spell: [shift_spell.name] failed to pull dummy from nullspace after death()")
 			TEST_ASSERT_EQUAL(dummy.stat, DEAD, "Failed to kill original mob when transformed mob died using [shift_spell.name].")
 
-		qdel(shift_spell)
-*/
+			qdel(shift_spell)
+
+/datum/unit_test/shapeshift_health/proc/get_status_effect(spell)
+	var/datum/action/cooldown/spell/shapeshift/shifted = spell
+	var/status_effect = shifted.owner.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
+	if(isnull(status_effect))
+		return TEST_FAIL("Shapeshift spell: Failed to return /datum/status_effect/shapechange_mob/from_spell on [shifted.owner]")
+	return shifted.owner.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
+
 #undef EXPECTED_HEALTH_RATIO
 #undef TRIGGER_RESET_COOLDOWN


### PR DESCRIPTION
## About The Pull Request

- This will store caster_mob inside nullspace instead of the contents of the owner. 
- Ensures your ai_controller is null when shapeshifted.
- Rewrites the shapeshift CI checks to ensure nullspace is being properly handled while preserving the same checks.

fixes: #81747 
(You are litterally stored inside the crate as you become the crate)

fixes: #82319 
(Bileworms store the people they kill inside their contents. More unintended jank.)

## Why It's Good For The Game

Storing it inside your contents has some incredibly cursed behavior when the things you're becoming interacts with contents. 

Also just general bugfixing is good.


## Changelog

:cl:
fix: You can now turn into mimics without your old self popping out if opened.
fix: You can now turn into bileworms without deleting yourself.
fix: If you fall SSD while shapeshifted, you should no longer inheret the mob AI.
/:cl:
