### PR TITLE
Fixes cheesing megafauna with a polybelt.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -265,7 +265,7 @@
 			var/mob/living/L = the_target
 			var/faction_check = faction_check_atom(L)
 			if(robust_searching)
-				if(L.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)) // Prevents polymorph belt cheese
+				if(L.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
 					return TRUE
 				if(faction_check && !attack_same)
 					return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -265,6 +265,8 @@
 			var/mob/living/L = the_target
 			var/faction_check = faction_check_atom(L)
 			if(robust_searching)
+				if(L.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)) // Prevents polymorph belt cheese
+					return TRUE
 				if(faction_check && !attack_same)
 					return FALSE
 				if(L.stat > stat_attack)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -264,9 +264,9 @@
 		if(isliving(the_target))
 			var/mob/living/L = the_target
 			var/faction_check = faction_check_atom(L)
+			if(!L.has_status_effect(/datum/status_effect/shapechange_mob))
+				faction_check = FALSE
 			if(robust_searching)
-				if(L.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
-					return TRUE
 				if(faction_check && !attack_same)
 					return FALSE
 				if(L.stat > stat_attack)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -174,6 +174,8 @@
 	if(!isliving(the_target))
 		return TRUE
 	var/mob/living/living_target = the_target
+	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
+		return !isnull(living_target.ckey)
 	return !living_target.has_status_effect(/datum/status_effect/gutted)
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -170,7 +170,7 @@
 /mob/living/simple_animal/hostile/megafauna/CanAttack(atom/the_target)
 	. = ..()
 	var/mob/living/living_target = the_target
-	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob) && !isnull(living_target.ckey)) // Prevents polymorph belt cheese
+	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
 		return TRUE
 	if (!.)
 		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -169,11 +169,9 @@
 
 /mob/living/simple_animal/hostile/megafauna/CanAttack(atom/the_target)
 	. = ..()
-	var/mob/living/living_target = the_target
-	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob/from_spell && !isnull(living_target.ckey))) // Prevents polymorph belt cheese
-		return TRUE
 	if (!.)
 		return FALSE
+	var/mob/living/living_target = the_target
 	if(!isliving(the_target))
 		return TRUE
 	return !living_target.has_status_effect(/datum/status_effect/gutted)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -174,8 +174,6 @@
 	if(!isliving(the_target))
 		return TRUE
 	var/mob/living/living_target = the_target
-	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
-		return !isnull(living_target.ckey)
 	return !living_target.has_status_effect(/datum/status_effect/gutted)
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -169,13 +169,13 @@
 
 /mob/living/simple_animal/hostile/megafauna/CanAttack(atom/the_target)
 	. = ..()
+	var/mob/living/living_target = the_target
+	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob) && !isnull(living_target.ckey)) // Prevents polymorph belt cheese
+		return TRUE
 	if (!.)
 		return FALSE
 	if(!isliving(the_target))
 		return TRUE
-	var/mob/living/living_target = the_target
-	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
-		return !isnull(living_target.ckey)
 	return !living_target.has_status_effect(/datum/status_effect/gutted)
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -171,9 +171,9 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	var/mob/living/living_target = the_target
 	if(!isliving(the_target))
 		return TRUE
+	var/mob/living/living_target = the_target
 	return !living_target.has_status_effect(/datum/status_effect/gutted)
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -170,7 +170,7 @@
 /mob/living/simple_animal/hostile/megafauna/CanAttack(atom/the_target)
 	. = ..()
 	var/mob/living/living_target = the_target
-	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob)) // Prevents polymorph belt cheese
+	if(living_target.has_status_effect(/datum/status_effect/shapechange_mob/from_spell && !isnull(living_target.ckey))) // Prevents polymorph belt cheese
 		return TRUE
 	if (!.)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
fixes: #87908

Fixes an exploit where you are immune to megafauna by transforming into a mining mob. Classic faction check issue with simple mobs. Megafauna will now not care if you're a funny little guy.

## Why It's Good For The Game

You should die if you fuck with these things.

## Changelog

:cl:
fix: You can no longer be immune to megafauna with a polybelt as a mining mob.
/:cl:

