### PR TITLE
Fixes two chemmaster exploits

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -401,6 +401,10 @@
 
 	switch(action)
 		if("eject")
+			if(is_printing)
+				say("The buffer is locked while printing.")
+				return
+
 			replace_beaker(ui.user)
 			return TRUE
 
@@ -498,7 +502,8 @@
 				item_name_default,
 				max_length = MAX_NAME_LEN,
 			)
-			if(!item_name)
+
+			if(!item_name || is_printing)
 				return FALSE
 
 			//start printing
@@ -506,7 +511,7 @@
 			printing_progress = 0
 			printing_total = item_count
 			update_appearance(UPDATE_OVERLAYS)
-			create_containers(ui.user, item_count, item_name, volume_in_each)
+			create_containers(ui.user, item_count, item_name, volume_in_each, selected_container)
 			return TRUE
 
 /**
@@ -518,7 +523,7 @@
  * * item_name - the name for each container printed
  * * volume_in_each - volume in each container created
  */
-/obj/machinery/chem_master/proc/create_containers(mob/user, item_count, item_name, volume_in_each)
+/obj/machinery/chem_master/proc/create_containers(mob/user, item_count, item_name, volume_in_each, chosen_container)
 	PRIVATE_PROC(TRUE)
 
 	//lost power or manually stopped
@@ -532,7 +537,7 @@
 		return
 
 	//print the stuff
-	var/obj/item/reagent_containers/item = new selected_container(drop_location())
+	var/obj/item/reagent_containers/item = new chosen_container(drop_location())
 	adjust_item_drop_location(item)
 	item.name = item_name
 	item.reagents.clear_reagents()
@@ -543,7 +548,7 @@
 	//print more items
 	item_count --
 	if(item_count > 0)
-		addtimer(CALLBACK(src, PROC_REF(create_containers), user, item_count, item_name, volume_in_each), printing_speed)
+		addtimer(CALLBACK(src, PROC_REF(create_containers), user, item_count, item_name, volume_in_each, chosen_container), printing_speed)
 	else
 		is_printing = FALSE
 		update_appearance(UPDATE_OVERLAYS)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -522,6 +522,7 @@
  * * item_count - number of containers to print
  * * item_name - the name for each container printed
  * * volume_in_each - volume in each container created
+ * * chosen_container - type of the container we're going to print
  */
 /obj/machinery/chem_master/proc/create_containers(mob/user, item_count, item_name, volume_in_each, chosen_container)
 	PRIVATE_PROC(TRUE)


### PR DESCRIPTION

## About The Pull Request

Closes #89530
Also prevents users from being able to swap types mid-print

## Changelog
:cl:
fix: You can no longer dupe reagents or swap types mid-print with chemmaster
/:cl:
