### PR TITLE
Fixes flipped sanity check values in mood amulet code

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -168,7 +168,7 @@
 		return
 	if(!hit.mob_mood)
 		return
-	if(hit.mob_mood.sanity_level < SANITY_LEVEL_UNSTABLE)
+	if(hit.mob_mood.sanity_level > SANITY_LEVEL_UNSTABLE)
 		user.balloon_alert(user, "their mind is too strong!")
 		hit.add_mood_event("Moon Amulet Insanity", /datum/mood_event/amulet_insanity)
 		hit.mob_mood.set_sanity(hit.mob_mood.sanity - sanity_damage)


### PR DESCRIPTION

## About The Pull Request

Closes #89540

## Changelog
:cl:
fix: Moon amulet now properly turns insane people into converts and drains sanity of sane people, instead of doing the inverse
/:cl:
