### PR TITLE
Fixes borgs not accepting encryption keys, converts them to balloon alerts

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -627,7 +627,7 @@
 		secure_radio_connections[ch_name] = null
 
 	if (!user.put_in_hands(keyslot))
-		keyslot.forceMove(get_turf(user) || get_turf(src))
+		keyslot.forceMove(drop_location())
 
 	keyslot = null
 	recalculateChannels()
@@ -648,7 +648,7 @@
 
 	keyslot = tool
 	recalculateChannels()
-	playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 	loc.balloon_alert(user, "encryption key installed")
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -603,11 +603,11 @@
 
 /obj/item/radio/borg/resetChannels()
 	. = ..()
-
-	var/mob/living/silicon/robot/R = loc
-	if(istype(R))
-		for(var/ch_name in R.model.radio_channels)
-			channels[ch_name] = TRUE
+	if (!iscyborg(loc))
+		return
+	var/mob/living/silicon/robot/borg = loc
+	for(var/ch_name in borg.model.radio_channels)
+		channels[ch_name] = TRUE
 
 /obj/item/radio/borg/syndicate
 	special_channels = RADIO_SPECIAL_SYNDIE
@@ -619,37 +619,38 @@
 
 /obj/item/radio/borg/screwdriver_act(mob/living/user, obj/item/tool)
 	if(!keyslot)
-		to_chat(user, span_warning("This radio doesn't have any encryption keys!"))
+		loc.balloon_alert(user, "no encryption keys!")
 		return
 
 	for(var/ch_name in channels)
 		SSradio.remove_object(src, GLOB.radiochannels[ch_name])
 		secure_radio_connections[ch_name] = null
 
-	if(keyslot)
-		var/turf/user_turf = get_turf(user)
-		if(user_turf)
-			keyslot.forceMove(user_turf)
-			keyslot = null
+	if (!user.put_in_hands(keyslot))
+		keyslot.forceMove(get_turf(user) || get_turf(src))
 
+	keyslot = null
 	recalculateChannels()
-	to_chat(user, span_notice("You pop out the encryption key in the radio."))
+	loc.balloon_alert(user, "encryption key removed")
 	return ..()
 
-/obj/item/radio/borg/attackby(obj/item/attacking_item, mob/user, params)
+/obj/item/radio/borg/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if (!istype(tool, /obj/item/encryptionkey))
+		return NONE
 
-	if(istype(attacking_item, /obj/item/encryptionkey))
-		if(keyslot)
-			to_chat(user, span_warning("The radio can't hold another key!"))
-			return
+	if(keyslot)
+		loc.balloon_alert(user, "cannot hold another key!")
+		return ITEM_INTERACT_BLOCKING
 
-		if(!keyslot)
-			if(!user.transferItemToLoc(attacking_item, src))
-				return
-			keyslot = attacking_item
+	if(!user.transferItemToLoc(tool, src))
+		loc.balloon_alert(user, "cannot install!")
+		return ITEM_INTERACT_BLOCKING
 
-		recalculateChannels()
-
+	keyslot = tool
+	recalculateChannels()
+	playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
+	loc.balloon_alert(user, "encryption key installed")
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/radio/off // Station bounced radios, their only difference is spawning with the speakers off, this was made to help the lag.
 	dog_fashion = /datum/dog_fashion/back


### PR DESCRIPTION

## About The Pull Request

Closes #89553 as aftermath of #89274 changing radio interaction to item_interaction despite radios still using attackby
Also converted them to balloon alerts, cleaned up the code and made removing the key put it into user's offhand instead of dropping it on the ground.

## Changelog
:cl:
fix: Fixes borgs not accepting encryption keys
qol: Borg encryption key interactions now use balloon alerts, and popping out a key puts it in your hands instead of dropping it on the ground.
/:cl:
