### PR TITLE
[NO GBP] Brings back missing space suit slowdown

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -67,7 +67,7 @@
 		/obj/item/tank/internals,
 		/obj/item/tank/jetpack/oxygen/captain,
 		)
-	slowdown = 0.5
+	slowdown = 1
 	armor_type = /datum/armor/suit_space
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS


### PR DESCRIPTION

## About The Pull Request

#89497 reverted the change from #85704 and moved the slowdown from helmets back to the space suits... except on the actual EVA suit, and it slipped past the reviews.

## Why It's Good For The Game

Missed in the original PR

## Changelog
:cl:
balance: Gave space suits back half of their missing slowdown due to an oversight in a prior change.
/:cl:
