### PR TITLE
Play the final objective jingle when setting your own traitor objective

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -559,17 +559,18 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /**
  * Allows player to replace their objectives with a new one they wrote themselves.
+ * Returns true if they did it successfully.
  * * retain_existing - If true, will just be added as a new objective instead of replacing existing ones.
  * * retain_escape - If true, will retain specifically 'escape alive' objectives (or similar)
  * * force - Skips the check about whether this antagonist is supposed to set its own objectives, for badminning
  */
 /datum/antagonist/proc/submit_player_objective(retain_existing = FALSE, retain_escape = TRUE, force = FALSE)
 	if (isnull(owner) || isnull(owner.current))
-		return
+		return FALSE
 	var/mob/living/owner_mob = owner.current
 	if (!force && !can_assign_self_objectives)
 		owner_mob.balloon_alert(owner_mob, "can't do that!")
-		return
+		return FALSE
 	var/custom_objective_text = tgui_input_text(
 		owner_mob,
 		message = "Specify your new objective.",
@@ -578,7 +579,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 		max_length = CUSTOM_OBJECTIVE_MAX_LENGTH,
 	)
 	if (QDELETED(src) || QDELETED(owner_mob) || isnull(custom_objective_text))
-		return // Some people take a long-ass time to type maybe they got dusted
+		return FALSE // Some people take a long-ass time to type maybe they got dusted
 
 	log_game("[key_name(owner_mob)] [retain_existing ? "" : "opted out of their original objectives and "]chose a custom objective: [custom_objective_text]")
 	message_admins("[ADMIN_LOOKUPFLW(owner_mob)] has chosen a custom antagonist objective: [span_syndradio("[custom_objective_text]")] | [ADMIN_SMITE(owner_mob)] | [ADMIN_SYNDICATE_REPLY(owner_mob)]")
@@ -607,5 +608,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	can_assign_self_objectives = FALSE
 	owner.announce_objectives()
+
+	return TRUE
 
 #undef CUSTOM_OBJECTIVE_MAX_LENGTH

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -211,6 +211,12 @@
 	for(var/datum/component/codeword_hearing/component as anything in datum_owner.GetComponents(/datum/component/codeword_hearing))
 		component.delete_if_from_source(src)
 
+/datum/antagonist/traitor/submit_player_objective(retain_existing, retain_escape, force)
+	. = ..()
+	if (!.)
+		return
+	owner.current.playsound_local(get_turf(owner.current), 'sound/music/antag/traitor/final_objective.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+
 /datum/antagonist/traitor/ui_static_data(mob/user)
 	var/datum/component/uplink/uplink = uplink_ref?.resolve()
 	var/list/data = list()


### PR DESCRIPTION
## About The Pull Request

We have this cool jingle that used to play when you picked a Final Objective, however those don't exist any more so this sound is sitting unused.
I attached it to "selecting your own objective" instead.

## Why It's Good For The Game

Makes you feel like a badass.

## Changelog

:cl:
sound: When you set your own objective as a traitor it makes a cool sound
/:cl:
