### PR TITLE
Improves hitscan projectile chunking

### DIFF
--- a/code/datums/actions/mobs/create_legion_turrets.dm
+++ b/code/datums/actions/mobs/create_legion_turrets.dm
@@ -93,6 +93,7 @@
 /// Used for the legion turret.
 /obj/projectile/beam/legion
 	name = "blood pulse"
+	icon_state = null
 	hitsound = 'sound/effects/magic/magic_missile.ogg'
 	damage = 19
 	range = 6

--- a/code/modules/capture_the_flag/ctf_equipment.dm
+++ b/code/modules/capture_the_flag/ctf_equipment.dm
@@ -112,6 +112,7 @@
 
 /obj/projectile/beam/ctf/marksman
 	damage = 30
+	icon_state = null
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -42,7 +42,7 @@
 
 /obj/projectile/beam/event_horizon
 	name = "anti-existential beam"
-	icon = null
+	icon_state = null
 	hitsound = 'sound/effects/explosion/explosion3.ogg'
 	damage = 100 // Does it matter?
 	damage_type = BURN

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -999,7 +999,8 @@
 				moving_turfs = FALSE
 			// If we've impacted something, we need to animate our movement until the actual hit
 			// Otherwise the projectile visually disappears slightly before the actual impact
-			if (deletion_queued)
+			// Not if we're hitscan, however, microop time!
+			if (deletion_queued && !hitscan)
 				// distance_to_move is how much we have to step to get to the next turf, hypotenuse is how much we need
 				// to move in the next turf to get from entry to impact position
 				delete_distance = distance_to_move + sqrt((impact_x - entry_x) ** 2 + (impact_y - entry_y) ** 2)
@@ -1016,6 +1017,10 @@
 				delete_distance = distance_to_move - (ICON_SIZE_ALL - pixels_moved_last_tile)
 
 		if (deletion_queued)
+			// Hitscans don't need to wait before deleting
+			if (hitscan)
+				return movements_done
+
 			// We moved to the next turf first, then impacted something
 			// This means that we need to offset our visual position back to the previous turf, then figure out
 			// how much we moved on the next turf (or we didn't move at all in which case we both shifts are 0 anyways)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1101,7 +1101,7 @@
 		if (QDELETED(src))
 			return
 
-		if (!TICK_CHECK && paused)
+		if (!TICK_CHECK && !paused)
 			continue
 
 		create_hitscan_point()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1105,6 +1105,7 @@
 			create_hitscan_point()
 			// Create tracers if we get timestopped or lagchunk so there aren't weird delays
 			generate_hitscan_tracers(impact_point = FALSE, impact_visual = FALSE)
+			record_hitscan_start(offset = FALSE)
 			return
 
 /// Creates (or wipes clean) list of tracer keypoints and creates a first point.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -149,6 +149,9 @@
 	var/datum/point/last_point
 	/// Next forceMove will not create tracer end/start effects
 	var/free_hitscan_forceMove = FALSE
+	// Used to prevent duplicate effects during lag chunking
+	/// If a hitscan muzzle effect has been created for this "path", reset during forceMoves.
+	var/spawned_muzzle = FALSE
 
 	/// Hitscan tracer effect left behind the projectile
 	var/tracer_type
@@ -1087,9 +1090,18 @@
 		qdel(src)
 		return
 
+	var/test = 0
 	while (isturf(loc) && !QDELETED(src))
 		process_movement(ICON_SIZE_ALL, hitscan = TRUE)
-		if (TICK_CHECK || paused || QDELETED(src))
+		test += 1
+
+		if (QDELETED(src))
+			return
+
+		if (TICK_CHECK || paused || test >= 2)
+			create_hitscan_point()
+			// Create tracers if we get timestopped or lagchunk so there aren't weird delays
+			generate_hitscan_tracers(impact_point = FALSE, impact_visual = FALSE)
 			return
 
 /// Creates (or wipes clean) list of tracer keypoints and creates a first point.
@@ -1125,15 +1137,16 @@
 	if (isnull(movement_vector) || free_hitscan_forceMove)
 		return
 	// Create firing VFX and start a new chain because we most likely got teleported
-	generate_hitscan_tracers(impact = FALSE)
+	generate_hitscan_tracers(impact_point = FALSE)
 	original_angle = angle
+	spawned_muzzle = FALSE
 	record_hitscan_start(offset = FALSE)
 
-/obj/projectile/proc/generate_hitscan_tracers(impact = TRUE)
+/obj/projectile/proc/generate_hitscan_tracers(impact_point = TRUE, impact_visual = TRUE)
 	if (!length(beam_points))
 		return
 
-	if (impact)
+	if (impact_point)
 		create_hitscan_point(impact = TRUE)
 
 	if (tracer_type)
@@ -1143,7 +1156,8 @@
 		for (var/beam_point in beam_points)
 			generate_tracer(beam_point, passed_turfs)
 
-	if (muzzle_type)
+	if (muzzle_type && !spawned_muzzle)
+		spawned_muzzle = TRUE
 		var/datum/point/start_point = beam_points[1]
 		var/atom/movable/muzzle_effect = new muzzle_type(loc)
 		start_point.move_atom_to_src(muzzle_effect)
@@ -1154,7 +1168,7 @@
 		muzzle_effect.set_light(muzzle_flash_range, muzzle_flash_intensity, muzzle_flash_color_override || color)
 		QDEL_IN(muzzle_effect, PROJECTILE_TRACER_DURATION)
 
-	if (impact_type)
+	if (impact_type && impact_visual)
 		var/atom/movable/impact_effect = new impact_type(loc)
 		last_point.move_atom_to_src(impact_effect)
 		var/matrix/matrix = new

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1101,12 +1101,14 @@
 		if (QDELETED(src))
 			return
 
-		if (TICK_CHECK || paused)
-			create_hitscan_point()
-			// Create tracers if we get timestopped or lagchunk so there aren't weird delays
-			generate_hitscan_tracers(impact_point = FALSE, impact_visual = FALSE)
-			record_hitscan_start(offset = FALSE)
-			return
+		if (!TICK_CHECK && paused)
+			continue
+
+		create_hitscan_point()
+		// Create tracers if we get timestopped or lagchunk so there aren't weird delays
+		generate_hitscan_tracers(impact_point = FALSE, impact_visual = FALSE)
+		record_hitscan_start(offset = FALSE)
+		return
 
 /// Creates (or wipes clean) list of tracer keypoints and creates a first point.
 /obj/projectile/proc/record_hitscan_start(offset = TRUE)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1090,15 +1090,13 @@
 		qdel(src)
 		return
 
-	var/test = 0
 	while (isturf(loc) && !QDELETED(src))
 		process_movement(ICON_SIZE_ALL, hitscan = TRUE)
-		test += 1
 
 		if (QDELETED(src))
 			return
 
-		if (TICK_CHECK || paused || test >= 2)
+		if (TICK_CHECK || paused)
 			create_hitscan_point()
 			// Create tracers if we get timestopped or lagchunk so there aren't weird delays
 			generate_hitscan_tracers(impact_point = FALSE, impact_visual = FALSE)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -201,6 +201,7 @@
 	return //don't want the emitters to miss
 
 /obj/projectile/beam/emitter/hitscan
+	icon_state = null
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
 	tracer_type = /obj/effect/projectile/tracer/laser/emitter
@@ -244,6 +245,7 @@
 	impact_type = /obj/effect/projectile/impact/laser
 
 /obj/projectile/beam/lasertag/redtag/hitscan
+	icon_state = null
 	hitscan = TRUE
 
 /obj/projectile/beam/lasertag/bluetag
@@ -254,6 +256,7 @@
 	impact_type = /obj/effect/projectile/impact/laser/blue
 
 /obj/projectile/beam/lasertag/bluetag/hitscan
+	icon_state = null
 	hitscan = TRUE
 
 /obj/projectile/magic/shrink/alien

--- a/code/modules/projectiles/projectile/bullets/junk.dm
+++ b/code/modules/projectiles/projectile/bullets/junk.dm
@@ -91,6 +91,7 @@
 
 /obj/projectile/bullet/junk/reaper
 	name = "junk reaper bullet"
+	icon_state = null
 	tracer_type = /obj/effect/projectile/tracer/sniper
 	impact_type = /obj/effect/projectile/impact/sniper
 	muzzle_type = /obj/effect/projectile/muzzle/sniper

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -55,6 +55,7 @@
 
 /obj/projectile/bullet/c10mm/reaper
 	name = "10mm reaper pellet"
+	icon_state = null
 	damage = 50
 	armour_penetration = 40
 	tracer_type = /obj/effect/projectile/tracer/sniper

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -92,6 +92,7 @@
 
 /obj/projectile/bullet/p50/marksman
 	name = ".50 BMG marksman round"
+	icon_state = null
 	damage = 50
 	range = 50
 	paralyze = 0

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -44,6 +44,7 @@
 /// Marksman Shot
 /obj/projectile/bullet/marksman
 	name = "marksman nanoshot"
+	icon_state = null
 	hitscan = TRUE
 	damage = 30
 	tracer_type = /obj/effect/projectile/tracer/solar

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -27,6 +27,7 @@
 
 /obj/projectile/energy/tesla_cannon
 	name = "tesla bolt"
+	icon_state = null
 	hitscan = TRUE
 	damage = 5
 	var/shock_damage = 10

--- a/code/modules/projectiles/projectile/special/saboteur.dm
+++ b/code/modules/projectiles/projectile/special/saboteur.dm
@@ -6,7 +6,7 @@
 
 /obj/projectile/energy/fisher
 	name = "attenuated kinetic force"
-	alpha = 0
+	icon_state = null
 	damage = 0
 	damage_type = BRUTE
 	armor_flag = BOMB

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -1,6 +1,6 @@
 /obj/projectile/beam/wormhole
 	name = "bluespace beam"
-	icon_state = "spark"
+	icon_state = null
 	hitsound = SFX_SPARKS
 	damage = 0
 	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB


### PR DESCRIPTION

## About The Pull Request

Hitscan projectiles that run out of dedicated tick time before they hit anything abort their movement, ensuring that firing an emitter beam into space won't cause horrible lag. However, most hitscans also have icons and have visible (albeit unanimated) movement in such a case, making it look like projectile code is exploding as tracers appear only after a rather visible and tangible projectile hits its target.

This PR resolves the issue by making hitscans "chunk" their trails in such cases, ensuring that they always look like actual hitscans. Video below has an artificial speed cap on hitscans, to showcase how it'd look during extreme lag.

https://github.com/user-attachments/assets/eeac034d-d08e-45b0-b7d2-8589376f1c7d

Also some minor hitscan code improvements because I can.

## Changelog
:cl:
fix: Hitscan projectiles like emitter beams should look less weird during extreme lag spikes
/:cl:
