### PR TITLE
Partially reverts #87936; the mech PKA AOE only harms mining mobs, reduces the damage and increases the attack cooldown

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -73,8 +73,12 @@
 #define MOB_PLANT (1 << 10)
 ///The mob is a goopy creature, probably coming from xenobiology.
 #define MOB_SLIME (1 << 11)
-/// Mob is fish or water-related.
+///The mob is fish or water-related.
 #define MOB_AQUATIC (1 << 12)
+///The mob is a mining-related mob. It's the plasma, you see. Gets in ya bones.
+#define MOB_MINING (1 << 13)
+///The mob is a crustacean. Like crabs. Or lobsters.
+#define MOB_CRUSTACEAN (1 << 14)
 
 //Lung respiration type flags
 #define RESPIRATION_OXYGEN (1 << 0)

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -306,7 +306,7 @@
 	default_damage_type = BRUTE
 	boxing_traits = list(TRAIT_BOXING_READY)
 	/// The mobs we are looking for to pass the honor check
-	var/honorable_mob_biotypes = MOB_BEAST | MOB_SPECIAL | MOB_PLANT | MOB_BUG
+	var/honorable_mob_biotypes = MOB_BEAST | MOB_SPECIAL | MOB_PLANT | MOB_BUG | MOB_MINING
 	/// Our crit shout words. First word is then paired with a second word to form an attack name.
 	var/list/first_word_strike = list("Extinction", "Brutalization", "Explosion", "Adventure", "Thunder", "Lightning", "Sonic", "Atomizing", "Whirlwind", "Tornado", "Shark", "Falcon")
 	var/list/second_word_strike = list(" Punch", " Pawnch", "-punch", " Jab", " Hook", " Fist", " Uppercut", " Straight", " Strike", " Lunge")

--- a/code/modules/mob/living/basic/boss/thing/thing.dm
+++ b/code/modules/mob/living/basic/boss/thing/thing.dm
@@ -11,6 +11,7 @@
 	armour_penetration = 40
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	mob_biotypes = MOB_ORGANIC|MOB_SPECIAL|MOB_MINING
 	sharpness = SHARP_EDGED
 	melee_attack_cooldown = CLICK_CD_SLOW
 	attack_verb_continuous = "eviscerates"

--- a/code/modules/mob/living/basic/lavaland/bileworm/_bileworm.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/_bileworm.dm
@@ -5,7 +5,7 @@
 	icon_state = "bileworm"
 	icon_living = "bileworm"
 	icon_dead = "bileworm_dead"
-	mob_biotypes = MOB_BUG
+	mob_biotypes = MOB_ORGANIC|MOB_BUG|MOB_MINING
 	maxHealth = 100
 	health = 100
 	verb_say = "spittles"

--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -10,7 +10,7 @@
 	speed = 5
 	pixel_x = -12
 	base_pixel_x = -12
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	mob_biotypes = MOB_ORGANIC|MOB_BUG|MOB_MINING
 	friendly_verb_continuous = "harmlessly rolls into"
 	friendly_verb_simple = "harmlessly roll into"
 	maxHealth = 45

--- a/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
+++ b/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
@@ -11,7 +11,7 @@
 	combat_mode = FALSE
 	icon_living = "gutlunch"
 	icon_dead = "gutlunch"
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	mob_biotypes = MOB_ORGANIC|MOB_BUG|MOB_MINING
 	basic_mob_flags = DEL_ON_DEATH
 	speak_emote = list("warbles", "quavers")
 	faction = list(FACTION_ASHWALKER)

--- a/code/modules/mob/living/basic/lavaland/hivelord/hivelord.dm
+++ b/code/modules/mob/living/basic/lavaland/hivelord/hivelord.dm
@@ -8,7 +8,7 @@
 	// icon_aggro = "hivelord_alert"
 	icon_dead = "hivelord_dead"
 	icon_gib = "syndicate_gib"
-	mob_biotypes = MOB_ORGANIC
+	mob_biotypes = MOB_ORGANIC|MOB_MINING
 	speed = 2
 	maxHealth = 75
 	health = 75

--- a/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -10,7 +10,7 @@
 	icon_living = "legion"
 	icon_dead = "legion"
 	icon_gib = "syndicate_gib"
-	mob_biotypes = MOB_ORGANIC|MOB_SPECIAL|MOB_UNDEAD
+	mob_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_MINING
 	basic_mob_flags = DEL_ON_DEATH
 	speed = 3
 	maxHealth = 75

--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -10,7 +10,7 @@
 	basic_mob_flags = DEL_ON_DEATH
 	mob_size = MOB_SIZE_SMALL
 	pass_flags = PASSTABLE | PASSMOB
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	mob_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_MINING
 	faction = list(FACTION_MINING)
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -12,7 +12,7 @@
 	maxHealth = 150
 	health = 150
 	obj_damage = 15
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST|MOB_AQUATIC
+	mob_biotypes = MOB_ORGANIC|MOB_CRUSTACEAN|MOB_AQUATIC|MOB_MINING
 	melee_damage_lower = 15
 	melee_damage_upper = 19
 	attack_verb_continuous = "snips"

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -4,7 +4,7 @@
 	combat_mode = TRUE
 	status_flags = NONE //don't inherit standard basicmob flags
 	mob_size = MOB_SIZE_LARGE
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	mob_biotypes = MOB_ORGANIC|MOB_BEAST|MOB_MINING
 	faction = list(FACTION_MINING, FACTION_ASHWALKER)
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0

--- a/code/modules/mob/living/basic/lavaland/mook/mook.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook.dm
@@ -7,7 +7,7 @@
 	icon_state = "mook"
 	icon_living = "mook"
 	icon_dead = "mook_dead"
-	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_MINING
 	gender = FEMALE
 	maxHealth = 150
 	faction = list(FACTION_MINING, FACTION_NEUTRAL)

--- a/code/modules/mob/living/basic/ruin_defender/blob_of_flesh.dm
+++ b/code/modules/mob/living/basic/ruin_defender/blob_of_flesh.dm
@@ -18,6 +18,7 @@
 	icon = 'icons/mob/simple/animal.dmi'
 	icon_state = "fleshblob"
 	icon_living = "fleshblob"
+	mob_biotypes = MOB_ORGANIC|MOB_MINING
 	mob_size = MOB_SIZE_LARGE
 	gender = NEUTER
 	basic_mob_flags = DEL_ON_DEATH

--- a/code/modules/mob/living/basic/vermin/crab.dm
+++ b/code/modules/mob/living/basic/vermin/crab.dm
@@ -9,6 +9,7 @@
 	speak_emote = list("clicks")
 	melee_damage_lower = 2
 	melee_damage_upper = 2
+	mob_biotypes = MOB_ORGANIC|MOB_CRUSTACEAN|MOB_AQUATIC
 	butcher_results = list(/obj/item/food/meat/slab/rawcrab = 2)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -6,7 +6,7 @@
 	combat_mode = TRUE
 	sentience_type = SENTIENCE_BOSS
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
-	mob_biotypes = MOB_ORGANIC|MOB_SPECIAL
+	mob_biotypes = MOB_ORGANIC|MOB_SPECIAL|MOB_MINING
 	obj_damage = 400
 	light_range = 3
 	faction = list(FACTION_MINING, FACTION_BOSS)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -27,7 +27,7 @@ Difficulty: Medium
 	icon_living = "miner"
 	icon = 'icons/mob/simple/broadMobs.dmi'
 	health_doll_icon = "miner"
-	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_SPECIAL
+	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_SPECIAL|MOB_MINING
 	light_color = COLOR_LIGHT_GRAYISH_RED
 	speak_emote = list("roars")
 	speed = 3

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/clockwork_knight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/clockwork_knight.dm
@@ -23,6 +23,7 @@ I'd rather there be something than the clockwork ruin be entirely empty though s
 	armour_penetration = 40
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	mob_biotypes = MOB_ROBOTIC|MOB_SPECIAL|MOB_MINING
 	vision_range = 9
 	aggro_vision_range = 9
 	speed = 5

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -18,7 +18,7 @@ Difficulty: Extremely Hard
 	attack_verb_continuous = "pummels"
 	attack_verb_simple = "pummel"
 	attack_sound = 'sound/items/weapons/sonic_jackhammer.ogg'
-	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_SPECIAL
+	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_SPECIAL|MOB_MINING
 	light_color = COLOR_LIGHT_GRAYISH_RED
 	movement_type = GROUND
 	weather_immunities = list(TRAIT_SNOWSTORM_IMMUNE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -53,6 +53,7 @@ Difficulty: Hard
 	armour_penetration = 50
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	mob_biotypes = MOB_ROBOTIC|MOB_SPECIAL|MOB_MINING
 	speed = 10
 	move_to_delay = 10
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -38,6 +38,7 @@
 	armour_penetration = 50
 	melee_damage_lower = 25
 	melee_damage_upper = 25
+	mob_biotypes = MOB_ORGANIC|MOB_SPECIAL|MOB_UNDEAD|MOB_MINING
 	speed = 5
 	ranged = TRUE
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -40,7 +40,7 @@
 	throw_message = "does nothing to the rocky hide of the"
 	speed = 2
 	move_to_delay = 5
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	mob_biotypes = MOB_ORGANIC|MOB_BEAST|MOB_MINING
 	mouse_opacity = MOUSE_OPACITY_ICON
 	death_message = "explodes into gore!"
 	loot_drop = /obj/item/crusher_trophy/broodmother_tongue

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -32,6 +32,7 @@
 	health = 1000
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	mob_biotypes = MOB_ORGANIC|MOB_MINING
 	attack_verb_continuous = "preaches to"
 	attack_verb_simple = "preach to"
 	attack_sound = 'sound/effects/magic/clockwork/ratvar_attack.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -37,6 +37,7 @@
 	speed = 1
 	move_to_delay = 3
 	mouse_opacity = MOUSE_OPACITY_ICON
+	mob_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_MINING
 	death_sound = 'sound/effects/magic/curse.ogg'
 	death_message = "'s arms reach out before it falls apart onto the floor, lifeless."
 	loot_drop = /obj/item/crusher_trophy/legionnaire_spine

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -36,6 +36,7 @@
 	speed = 3
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
+	mob_biotypes = MOB_ROBOTIC|MOB_MINING
 	death_sound = 'sound/effects/magic/repulse.ogg'
 	death_message = "'s lights flicker, before its top part falls down."
 	loot_drop = /obj/item/clothing/accessory/pandora_hope

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
@@ -5,7 +5,7 @@
 	icon_state = "polarbear"
 	icon_living = "polarbear"
 	icon_dead = "polarbear_dead"
-	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	mob_biotypes = MOB_ORGANIC|MOB_BEAST|MOB_MINING
 	mouse_opacity = MOUSE_OPACITY_ICON
 	friendly_verb_continuous = "growls at"
 	friendly_verb_simple = "growl at"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -263,17 +263,13 @@
 //mecha_kineticgun version of the projectile
 /obj/projectile/kinetic/mech
 	range = 5
-	damage = 80
+	damage = 50
 
 /obj/projectile/kinetic/mech/strike_thing(atom/target)
 	. = ..()
-	new /obj/effect/temp_visual/explosion/fast(target)
+	new /obj/effect/temp_visual/explosion/fast(get_turf(target))
 	for(var/turf/closed/mineral/mineral_turf in RANGE_TURFS(1, target) - target)
 		mineral_turf.gets_drilled(firer, TRUE)
-	for(var/mob/living/living_mob in range(1, target) - firer - target)
-		var/armor = living_mob.run_armor_check(def_zone, armor_flag, armour_penetration = armour_penetration)
-		living_mob.apply_damage(damage, damage_type, def_zone, armor)
-		to_chat(living_mob, span_userdanger("You're struck by a [name]!"))
 
 //Modkits
 /obj/item/borg/upgrade/modkit
@@ -388,10 +384,10 @@
 
 // Recalculate recharge time after adding or removing cooldown mods.
 /obj/item/borg/upgrade/modkit/cooldown/proc/get_recharge_time(obj/item/gun/energy/recharge/kinetic_accelerator/KA)
-	
+
 	var/new_recharge_time = initial(KA.recharge_time)
 	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in KA.modkits)
-		if(istype(modkit_upgrade, src))	
+		if(istype(modkit_upgrade, src))
 			new_recharge_time -= modifier
 
 	return new_recharge_time

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -264,12 +264,21 @@
 /obj/projectile/kinetic/mech
 	range = 5
 	damage = 50
+	//the multiplier we apply to our PKa's AOE effect.
+	var/aoe_damage_multiplier = 0.3
 
 /obj/projectile/kinetic/mech/strike_thing(atom/target)
 	. = ..()
 	new /obj/effect/temp_visual/explosion/fast(get_turf(target))
-	for(var/turf/closed/mineral/mineral_turf in RANGE_TURFS(1, target) - target)
-		mineral_turf.gets_drilled(firer, TRUE)
+
+	for(var/mob/living/living_mob in range(1, target) - firer - target)
+
+		if(!(living_mob.mob_biotypes & MOB_MINING))
+			continue
+
+		var/armor = living_mob.run_armor_check(def_zone, armor_flag, armour_penetration = armour_penetration)
+		living_mob.apply_damage(damage*aoe_damage_multiplier, damage_type, def_zone, armor)
+		to_chat(living_mob, span_userdanger("You're struck by a [name]!"))
 
 //Modkits
 /obj/item/borg/upgrade/modkit

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -172,7 +172,7 @@
 	icon_state = "mecha_kineticgun"
 	energy_drain = 30
 	projectile = /obj/projectile/kinetic/mech
-	equip_cooldown = 1 SECONDS
+	equip_cooldown = 1.6 SECONDS
 	fire_sound = 'sound/items/weapons/kinetic_accel.ogg'
 	harmful = TRUE
 	mech_flags = EXOSUIT_MODULE_COMBAT | EXOSUIT_MODULE_WORKING

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -167,12 +167,12 @@
 
 //Exosuit-mounted kinetic accelerator
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/mecha_kineticgun
-	equip_cooldown = 10
 	name = "Exosuit Proto-kinetic Accelerator"
 	desc = "An exosuit-mounted mining tool that does increased damage in low pressure. Drawing from an onboard power source allows it to project further than the handheld version."
 	icon_state = "mecha_kineticgun"
 	energy_drain = 30
 	projectile = /obj/projectile/kinetic/mech
+	equip_cooldown = 1 SECONDS
 	fire_sound = 'sound/items/weapons/kinetic_accel.ogg'
 	harmful = TRUE
 	mech_flags = EXOSUIT_MODULE_COMBAT | EXOSUIT_MODULE_WORKING


### PR DESCRIPTION
## About The Pull Request

Mech PKA damage is now 50, down from 80.

Mech PKA attack cooldown is now 1.6 seconds, which is the same value for standard PKA's by default.

Mech PKA does not mine, but instead damages all mining only mobs for 30% of the projectiles damage.

The mech PKA AOE blast visual effect now properly appears when hitting a mob directly.

I've added MOB_MINING to distinguish mining mobs specifically in case of subtyping issues. I also added MOB_CRUSTACEAN...because I could and lobstrocities are crustaceans, clearly. I audited a lot of the various mining mob biotypes, and also made crabs crustaceans because obviously they are crustaceans.

Closes https://github.com/tgstation/tgstation/issues/89521

## Why It's Good For The Game

A) The damage increase was just a bit too much. 80 is higher than a normal PKA's potential value, and also by default comes with half maxed cooldown and half maxed range mods on top. There wasn't really much reason to NOT use the mech PKA if you could given that it had such substantial damage output compared to any other mining tool. Rather than completely neuter the Mech PKA, I've just reduced it down to 50 so that ideally this thing is a good all-rounder option rather than the peak potential ranged damage in mining. Not too good in any particular area, just good. On top of that, 

I've reduced the attack cooldown to equal the PKA so that it doesn't have much more than 110% mod capacity used compared to a normal PKA. In its previous iteration, it had around 290% effective mod capacity. (x4 damage [30%], x2 range [25%], x2 cooldown [30%], mob aoe [30% but arguably higher given it was a full damage aoe], turf aoe [30%])

~~B) The AOE was just kind of overkill for damage. It matched the force of the PKA's direct hit, and so would trivialize many lavaland dangers. Miners usually die to getting swarmed, and the PKA could obliterate swarms of foes. I changed it to a mining AOE because I think it's a good addition to have, but I fundamentally disagree with giving the PKA both mob and turf AOE mods. Especially given its weaponizability in other contexts. It also happened to hit vent drones, and I don't feel like snowflaking this because it would only make it stronger when doing vents and further trivializes that content, which involves fighting swarms of foes.~~ I ended up snowflaking it back in on request.

I do like people using mining mechs, both Ripley and Clarke, and feeling like they have a place. They're reliable, they're fast and they have some good utility attached as well. They feel like a reasonable alternative approach to mining, especially given that it requires robotics assistance to get operational.

At the moment, however, I do feel like they overtrivialize some aspects of lavaland in a not particularly healthy way. Strip mining quickly isn't a bad niche to fill, but also just having the best DPS and defense and speed is not as good. Other miner options usually aren't so all-rounded in safety to offensive power to utility as mining mechs can be. That, and how quickly they can pop out of robotics after only a few bits of research does mean that you can bypass a lot of terrestrial mining progression to just be at full power immediately while in them.

I would be ideally aiming for about the power scaling of miners at the point of that research being completed. They're still fairly good in some aspects, but miners also have options for speed (raptors), high defense (mining MODsuit and crafted modsuits) and stripmining (resonators) and can source these about the same point in time.

Ideally we should look at this as a sidegrade and try to keep the power to a sidegrade option.

## Changelog
:cl:
balance: Mech PKA low-pressure damage has been reduced to 50, from 80. Increased the attack cooldown to match the standard PKA.
balance: Mech PKA AOE blast does not mine turfs, and only does 30% of the main projectiles damage to mining mobs in the AOE effect.
fix: The mech PKA AOE blast visual effect now properly appears when hitting a mob directly.
code: MOB_MINING and MOB_CRUSTACEAN are now defined biotypes.
code: Audits some mining mob biotypes to make more sense based on what kind of creature they are and to include MOB_MINING in their defines.
/:cl:
