### PR TITLE
Last Resort is no longer innate power for changelings

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -4,7 +4,7 @@
 	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us."
 	button_icon_state = "last_resort"
 	chemical_cost = 20
-	dna_cost = CHANGELING_POWER_INNATE
+	dna_cost = 1
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
 	disabled_by_fire = FALSE


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/86605 included a change to make last resort an innate ability for all lings. This PR reverts that specific change.

## Why It's Good For The Game

In what is unfortunately the ![image](https://github.com/user-attachments/assets/9e29deea-b42b-4813-9335-b86345472b23) of ling changes, this change in particular is fine on the surface until you consider that lings actually have a very, very particular interaction with one another.

Killing and absorbing one another in order to improve their own power.

If every single ling, upon death, can just explode immediately, there is no possible way for a ling to be absorbed by another ling under most any circumstance that isn't highly specific and that the majority of lings are not reliable affected by. Sleepy chems and stuff don't really stick to lings. Lings have the few remaining adrenals left in the game. And killing whatsoever and trying to absorb them will just result in you getting blown up.

So, this interaction may as well be near impossible, and was already VERY difficult. This being as hard as it is means that lings kind of lose their antagonistic nature towards their own kind. The only good that can come from killing another ling is the removal of a ling from the round and to no benefit to you. That ling also cannot reasonably do the same to you, as you will also just explode and leave them with nothing for their efforts. This means that there is a much greater encouragement towards these lings working together instead.

The game is more interesting if there is the potential for betrayal. So removing that aspect really cheapens the potential outcomes of inter-antagonist conflict.

## Changelog
:cl:
balance: Last resort is no longer an innate changeling ability. Changeling on changeling violence is back on the menu. (literally)
/:cl:
