### PR TITLE
[NO GBP] Fixing trophy fishes not loading mats

### DIFF
--- a/code/controllers/subsystem/persistence/trophy_fishes.dm
+++ b/code/controllers/subsystem/persistence/trophy_fishes.dm
@@ -27,8 +27,9 @@
 	fish.update_size_and_weight(data[PERSISTENCE_FISH_SIZE], data[PERSISTENCE_FISH_WEIGHT])
 	var/material_path = text2path(data[PERSISTENCE_FISH_MATERIAL])
 	if(material_path)
-		//setting the list inside the proccall doesn't seem to work
-		var/list/mat_list = list(material_path = fish.weight)
+		//setting the list otherwise seems to cause some issues, thank you Byond.
+		var/list/mat_list = list()
+		mat_list[material_path] = fish.weight
 		fish.set_custom_materials(mat_list)
 	fish.persistence_load(data)
 	fish.name = data[PERSISTENCE_FISH_NAME]


### PR DESCRIPTION
## About The Pull Request
For some reason, that either wasn't an issue before, or it always was and I did not fix it. Either way, `List()` is a proc and `material_path` variable is being read as an arg called "material_path" which is what the key is being set to, instead of the stored value of the variable, I think.

## Why It's Good For The Game
Fixing stuff.

## Changelog

:cl:
fix: Fixing loaded trophy fishes possibly not having materials.
/:cl:
