### PR TITLE
Don't send an event right before rebooting because that's a terrible time performance wise

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -335,9 +335,6 @@ GLOBAL_PROTECT(tracy_init_reason)
 	return
 	#else
 	if(TgsAvailable())
-		if(!fast_track)
-			TgsTriggerEvent("tg-PreReboot", wait_for_completion = TRUE)
-
 		var/do_hard_reboot
 		// check the hard reboot counter
 		var/ruhr = CONFIG_GET(number/rounds_until_hard_restart)


### PR DESCRIPTION
We have a new config sync event we're using. See #89536 