### PR TITLE
MODSuits don't slow you down when they're not deployed

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -310,7 +310,6 @@
 			if(!module.active || (module.allow_flags & MODULE_ALLOW_INACTIVE))
 				continue
 			module.deactivate(display_message = FALSE)
-	update_speed()
 	update_charge_alert()
 	update_appearance(UPDATE_ICON_STATE)
 	generate_suit_mask()

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -144,7 +144,7 @@
 		return FALSE
 	else if(!wearer && (!has_gravity() || !isturf(loc)))
 		return FALSE
-	COOLDOWN_START(src, cooldown_mod_move, movedelay * timemodifier + slowdown_active)
+	COOLDOWN_START(src, cooldown_mod_move, movedelay * timemodifier + slowdown_deployed)
 	subtract_charge(CHARGE_PER_STEP)
 	playsound(src, 'sound/vehicles/mecha/mechmove01.ogg', 25, TRUE)
 	if(ismovable(wearer?.loc))

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -58,8 +58,6 @@
 	var/complexity = 0
 	/// Power usage of the MOD.
 	var/charge_drain = DEFAULT_CHARGE_DRAIN
-	/// Slowdown of the MOD when not active.
-	var/slowdown_inactive = 1.25
 	/// Slowdown of the MOD when active.
 	var/slowdown_active = 0.75
 	/// How long this MOD takes each part to seal.
@@ -691,7 +689,7 @@
 
 /obj/item/mod/control/proc/update_speed()
 	for(var/obj/item/part as anything in get_parts(all = TRUE))
-		part.slowdown = (get_part_datum(part).sealed ? slowdown_active : slowdown_inactive) / length(mod_parts)
+		part.slowdown = get_part_datum(part).sealed ? slowdown_active / length(mod_parts) : 0
 	wearer?.update_equipment_speed_mods()
 
 /obj/item/mod/control/proc/power_off()
@@ -750,7 +748,7 @@
 /obj/item/mod/control/proc/on_potion(atom/movable/source, obj/item/slimepotion/speed/speed_potion, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(slowdown_inactive <= 0)
+	if(slowdown_active <= 0)
 		to_chat(user, span_warning("[src] has already been coated with red, that's as fast as it'll go!"))
 		return SPEED_POTION_STOP
 	if(active)
@@ -758,7 +756,6 @@
 		return SPEED_POTION_STOP
 	to_chat(user, span_notice("You slather the red gunk over [src], making it faster."))
 	set_mod_color(color_transition_filter(COLOR_RED))
-	slowdown_inactive = 0
 	slowdown_active = 0
 	update_speed()
 	qdel(speed_potion)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -688,8 +688,8 @@
 	wearer.update_spacesuit_hud_icon(state_to_use || "0")
 
 /obj/item/mod/control/proc/update_speed()
-	for(var/obj/item/part as anything in get_parts(all = TRUE))
-		part.slowdown = get_part_datum(part).sealed ? slowdown_active / length(mod_parts) : 0
+	for(var/obj/item/part as anything in get_parts())
+		part.slowdown = slowdown_active / (length(mod_parts) - 1)
 	wearer?.update_equipment_speed_mods()
 
 /obj/item/mod/control/proc/power_off()

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -58,8 +58,8 @@
 	var/complexity = 0
 	/// Power usage of the MOD.
 	var/charge_drain = DEFAULT_CHARGE_DRAIN
-	/// Slowdown of the MOD when active.
-	var/slowdown_active = 0.75
+	/// Slowdown of the MOD when all of its pieces are deployed.
+	var/slowdown_deployed = 0.75
 	/// How long this MOD takes each part to seal.
 	var/activation_step_time = MOD_ACTIVATION_STEP_TIME
 	/// Extended description of the theme.
@@ -689,7 +689,7 @@
 
 /obj/item/mod/control/proc/update_speed()
 	for(var/obj/item/part as anything in get_parts())
-		part.slowdown = slowdown_active / (length(mod_parts) - 1)
+		part.slowdown = slowdown_deployed / (length(mod_parts) - 1)
 	wearer?.update_equipment_speed_mods()
 
 /obj/item/mod/control/proc/power_off()
@@ -748,7 +748,7 @@
 /obj/item/mod/control/proc/on_potion(atom/movable/source, obj/item/slimepotion/speed/speed_potion, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(slowdown_active <= 0)
+	if(slowdown_deployed <= 0)
 		to_chat(user, span_warning("[src] has already been coated with red, that's as fast as it'll go!"))
 		return SPEED_POTION_STOP
 	if(active)
@@ -756,7 +756,7 @@
 		return SPEED_POTION_STOP
 	to_chat(user, span_notice("You slather the red gunk over [src], making it faster."))
 	set_mod_color(color_transition_filter(COLOR_RED))
-	slowdown_active = 0
+	slowdown_deployed = 0
 	update_speed()
 	qdel(speed_potion)
 	return SPEED_POTION_STOP

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -37,8 +37,8 @@
 	var/complexity_max = DEFAULT_MAX_COMPLEXITY
 	/// How much battery power the MOD uses by just being on
 	var/charge_drain = DEFAULT_CHARGE_DRAIN
-	/// Slowdown of the MOD when active.
-	var/slowdown_active = 0.75
+	/// Slowdown of the MOD when all of its pieces are deployed.
+	var/slowdown_deployed = 0.75
 	/// How long this MOD takes each part to seal.
 	var/activation_step_time = MOD_ACTIVATION_STEP_TIME
 	/// Theme used by the MOD TGUI.
@@ -100,7 +100,7 @@
 	var/list/parts = list(mod)
 	mod.slot_flags = slot_flags
 	mod.extended_desc = extended_desc
-	mod.slowdown_active = slowdown_active
+	mod.slowdown_deployed = slowdown_deployed
 	mod.activation_step_time = activation_step_time
 	mod.complexity_max = complexity_max
 	mod.ui_theme = ui_theme
@@ -188,7 +188,7 @@
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 3
-	slowdown_active = 0
+	slowdown_deployed = 0
 	variants = list(
 		"civilian" = list(
 			/obj/item/clothing/head/mod = list(
@@ -242,7 +242,7 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_active = 1
+	slowdown_deployed = 1
 	allowed_suit_storage = list(
 		/obj/item/construction/rcd,
 		/obj/item/fireaxe/metal_h2_axe,
@@ -307,7 +307,7 @@
 	armor_type = /datum/armor/mod_theme_atmospheric
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	slowdown_active = 1
+	slowdown_deployed = 1
 	allowed_suit_storage = list(
 		/obj/item/analyzer,
 		/obj/item/extinguisher,
@@ -376,7 +376,7 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_active = 0.5
+	slowdown_deployed = 0.5
 	inbuilt_modules = list(/obj/item/mod/module/magboot/advanced)
 	allowed_suit_storage = list(
 		/obj/item/analyzer,
@@ -562,7 +562,7 @@
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	siemens_coefficient = 0.25
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	slowdown_active = 0
+	slowdown_deployed = 0
 	allowed_suit_storage = list(
 		/obj/item/mail,
 		/obj/item/delivery/small,
@@ -623,7 +623,7 @@
 	default_skin = "medical"
 	armor_type = /datum/armor/mod_theme_medical
 	charge_drain = DEFAULT_CHARGE_DRAIN * 1.5
-	slowdown_active = 0.5
+	slowdown_deployed = 0.5
 	allowed_suit_storage = list(
 		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/dropper,
@@ -733,7 +733,7 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	charge_drain = DEFAULT_CHARGE_DRAIN * 1.5
-	slowdown_active = 0.25
+	slowdown_deployed = 0.25
 	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced)
 	allowed_suit_storage = list(
 		/obj/item/healthanalyzer,
@@ -814,7 +814,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	slowdown_active = 1.25
+	slowdown_deployed = 1.25
 	inbuilt_modules = list(/obj/item/mod/module/reagent_scanner/advanced)
 	allowed_suit_storage = list(
 		/obj/item/analyzer,
@@ -881,7 +881,7 @@
 	default_skin = "security"
 	armor_type = /datum/armor/mod_theme_security
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 2
-	slowdown_active = 0.5
+	slowdown_deployed = 0.5
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
@@ -949,7 +949,7 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked)
-	slowdown_active = 0.25
+	slowdown_deployed = 0.25
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
@@ -1020,7 +1020,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	slowdown_active = 0.25
+	slowdown_deployed = 0.25
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1084,7 +1084,7 @@
 	default_skin = "cosmohonk"
 	armor_type = /datum/armor/mod_theme_cosmohonk
 	charge_drain = DEFAULT_CHARGE_DRAIN * 0.25
-	slowdown_active = 1.25
+	slowdown_deployed = 1.25
 	allowed_suit_storage = list(
 		/obj/item/bikehorn,
 		/obj/item/food/grown/banana,
@@ -1156,7 +1156,7 @@
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_active = 0.5
+	slowdown_deployed = 0.5
 	ui_theme = "syndicate"
 	resistance_flags = FIRE_PROOF
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
@@ -1263,7 +1263,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
 	siemens_coefficient = 0
-	slowdown_active = 0.5
+	slowdown_deployed = 0.5
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
@@ -1335,7 +1335,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	siemens_coefficient = 0
-	slowdown_active = 0
+	slowdown_deployed = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.5
 	ui_theme = "syndicate"
 	slot_flags = ITEM_SLOT_BELT
@@ -1407,7 +1407,7 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_active = -0.5
+	slowdown_deployed = -0.5
 	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced)
 	allowed_suit_storage = list(
 		/obj/item/assembly/flash,
@@ -1493,7 +1493,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	slowdown_active = 0.25
+	slowdown_deployed = 0.25
 	ui_theme = "wizard"
 	inbuilt_modules = list(/obj/item/mod/module/anti_magic/wizard)
 	allowed_suit_storage = list(
@@ -1560,7 +1560,7 @@
 	resistance_flags = LAVA_PROOF|FIRE_PROOF|ACID_PROOF
 	charge_drain = DEFAULT_CHARGE_DRAIN * 0.5
 	siemens_coefficient = 0
-	slowdown_active = 0
+	slowdown_deployed = 0
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/welding/camera_vision, /obj/item/mod/module/hacker, /obj/item/mod/module/weapon_recall, /obj/item/mod/module/adrenaline_boost, /obj/item/mod/module/energy_net)
 	allowed_suit_storage = list(
@@ -1630,7 +1630,7 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_active = 1
+	slowdown_deployed = 1
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/anomaly_locked/kinesis/prototype)
 	allowed_suit_storage = list(
@@ -1696,7 +1696,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
 	siemens_coefficient = 0
-	slowdown_active = 0.5
+	slowdown_deployed = 0.5
 	ui_theme = "terminal"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
@@ -1764,7 +1764,7 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_active = 0
+	slowdown_deployed = 0
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1946,7 +1946,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_active = 0
+	slowdown_deployed = 0
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -2010,7 +2010,7 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 10
-	slowdown_active = 0
+	slowdown_deployed = 0
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 	)
@@ -2074,7 +2074,7 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = 50
 	siemens_coefficient = 0
-	slowdown_active = 0
+	slowdown_deployed = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.2
 	allowed_suit_storage = list(
 		/obj/item/gun,
@@ -2140,7 +2140,7 @@
 	complexity_max = 1000
 	charge_drain = DEFAULT_CHARGE_DRAIN * 0
 	siemens_coefficient = 0
-	slowdown_active = 0
+	slowdown_deployed = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.01
 	allowed_suit_storage = list(
 		/obj/item/gun,

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -37,8 +37,6 @@
 	var/complexity_max = DEFAULT_MAX_COMPLEXITY
 	/// How much battery power the MOD uses by just being on
 	var/charge_drain = DEFAULT_CHARGE_DRAIN
-	/// Slowdown of the MOD when not active.
-	var/slowdown_inactive = 1.25
 	/// Slowdown of the MOD when active.
 	var/slowdown_active = 0.75
 	/// How long this MOD takes each part to seal.
@@ -102,7 +100,6 @@
 	var/list/parts = list(mod)
 	mod.slot_flags = slot_flags
 	mod.extended_desc = extended_desc
-	mod.slowdown_inactive = slowdown_inactive
 	mod.slowdown_active = slowdown_active
 	mod.activation_step_time = activation_step_time
 	mod.complexity_max = complexity_max
@@ -191,7 +188,6 @@
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 3
-	slowdown_inactive = 0.5
 	slowdown_active = 0
 	variants = list(
 		"civilian" = list(
@@ -246,7 +242,6 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_inactive = 1.5
 	slowdown_active = 1
 	allowed_suit_storage = list(
 		/obj/item/construction/rcd,
@@ -312,7 +307,6 @@
 	armor_type = /datum/armor/mod_theme_atmospheric
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	slowdown_inactive = 1.5
 	slowdown_active = 1
 	allowed_suit_storage = list(
 		/obj/item/analyzer,
@@ -382,7 +376,6 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_inactive = 1
 	slowdown_active = 0.5
 	inbuilt_modules = list(/obj/item/mod/module/magboot/advanced)
 	allowed_suit_storage = list(
@@ -569,7 +562,6 @@
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	siemens_coefficient = 0.25
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
 		/obj/item/mail,
@@ -631,7 +623,6 @@
 	default_skin = "medical"
 	armor_type = /datum/armor/mod_theme_medical
 	charge_drain = DEFAULT_CHARGE_DRAIN * 1.5
-	slowdown_inactive = 1
 	slowdown_active = 0.5
 	allowed_suit_storage = list(
 		/obj/item/healthanalyzer,
@@ -742,7 +733,6 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	charge_drain = DEFAULT_CHARGE_DRAIN * 1.5
-	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced)
 	allowed_suit_storage = list(
@@ -824,7 +814,6 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	slowdown_inactive = 1.75
 	slowdown_active = 1.25
 	inbuilt_modules = list(/obj/item/mod/module/reagent_scanner/advanced)
 	allowed_suit_storage = list(
@@ -892,7 +881,6 @@
 	default_skin = "security"
 	armor_type = /datum/armor/mod_theme_security
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 2
-	slowdown_inactive = 1
 	slowdown_active = 0.5
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
@@ -961,7 +949,6 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked)
-	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
@@ -1033,7 +1020,6 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
@@ -1098,7 +1084,6 @@
 	default_skin = "cosmohonk"
 	armor_type = /datum/armor/mod_theme_cosmohonk
 	charge_drain = DEFAULT_CHARGE_DRAIN * 0.25
-	slowdown_inactive = 1.75
 	slowdown_active = 1.25
 	allowed_suit_storage = list(
 		/obj/item/bikehorn,
@@ -1171,7 +1156,6 @@
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_inactive = 1
 	slowdown_active = 0.5
 	ui_theme = "syndicate"
 	resistance_flags = FIRE_PROOF
@@ -1279,7 +1263,6 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
 	siemens_coefficient = 0
-	slowdown_inactive = 1
 	slowdown_active = 0.5
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
@@ -1352,7 +1335,6 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	siemens_coefficient = 0
-	slowdown_inactive = 0
 	slowdown_active = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.5
 	ui_theme = "syndicate"
@@ -1425,7 +1407,6 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_inactive = 0.0
 	slowdown_active = -0.5
 	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced)
 	allowed_suit_storage = list(
@@ -1512,7 +1493,6 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	ui_theme = "wizard"
 	inbuilt_modules = list(/obj/item/mod/module/anti_magic/wizard)
@@ -1580,7 +1560,6 @@
 	resistance_flags = LAVA_PROOF|FIRE_PROOF|ACID_PROOF
 	charge_drain = DEFAULT_CHARGE_DRAIN * 0.5
 	siemens_coefficient = 0
-	slowdown_inactive = 0.5
 	slowdown_active = 0
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/welding/camera_vision, /obj/item/mod/module/hacker, /obj/item/mod/module/weapon_recall, /obj/item/mod/module/adrenaline_boost, /obj/item/mod/module/energy_net)
@@ -1651,7 +1630,6 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_inactive = 1.5
 	slowdown_active = 1
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/anomaly_locked/kinesis/prototype)
@@ -1718,7 +1696,6 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
 	siemens_coefficient = 0
-	slowdown_inactive = 1
 	slowdown_active = 0.5
 	ui_theme = "terminal"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
@@ -1787,7 +1764,6 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
@@ -1970,7 +1946,6 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
@@ -2035,7 +2010,6 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 10
-	slowdown_inactive = 0
 	slowdown_active = 0
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
@@ -2100,7 +2074,6 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = 50
 	siemens_coefficient = 0
-	slowdown_inactive = 0.5
 	slowdown_active = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.2
 	allowed_suit_storage = list(
@@ -2167,7 +2140,6 @@
 	complexity_max = 1000
 	charge_drain = DEFAULT_CHARGE_DRAIN * 0
 	siemens_coefficient = 0
-	slowdown_inactive = 0
 	slowdown_active = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.01
 	allowed_suit_storage = list(

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -51,7 +51,7 @@
 /obj/item/mod/module/armor_booster/on_activation()
 	playsound(src, 'sound/vehicles/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	balloon_alert(mod.wearer, "armor boosted, EVA lost")
-	actual_speed_added = max(0, min(mod.slowdown_active, speed_added))
+	actual_speed_added = max(0, min(mod.slowdown_deployed, speed_added))
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)
 		RegisterSignal(mod, COMSIG_MOD_PART_SEALED, PROC_REF(seal_helmet))

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -443,7 +443,7 @@
 			mod.wearer.color = list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,3) //make them super light
 			animate(mod.wearer, 1 SECONDS, color = null, flags = ANIMATION_PARALLEL)
 			playsound(src, 'sound/effects/sparks/sparks1.ogg', 100, TRUE)
-			actual_speed_added = max(0, min(mod.slowdown_active, speed_added))
+			actual_speed_added = max(0, min(mod.slowdown_deployed, speed_added))
 			mod.slowdown -= actual_speed_added
 			mod.wearer.update_equipment_speed_mods()
 	else if(is_type_in_typecache(mod.wearer.loc, keep_turfs))


### PR DESCRIPTION
## About The Pull Request

MODSuits now slow you progressively as parts are deployed, and not at all when no parts are deployed.
Previous to this change MODsuits would slow you _more_ for having a part not deployed than for having it deployed and powered, meaning you would be slower using it as a backpack than you would be when using it as a suit. This leads to people typically taking it off entirely and holding it in their hands instead of wearing it.

## Why It's Good For The Game

We talked about this in the coderbus meeting and the general reasoning is;

- We want people to use MODsuits for the utility they provide. It's good when people think these items are desirable and ask the roboticist to make one for them.
- MODsuits being slower when unpowered makes sense but is _mostly_ just that way for flavour reasons.
- Moving slower is (perhaps unintuitively?) one of the strongest detriments we have in the game for using something.
- MODsuits when used as backpacks are _already_ worse than a standard backpack (less storage space unless complexity is dedicated to increase it again) and it's not necessarily clear that they need an additional downside. 
- It feels odd to be penalised _more_ strongly penalised when just wearing a backpack and not benefiting from any utility aspect of the suit than you are when actively benefiting from having the suit.
- It also feels odd to be penalised at all for having it while not benefiting from it.
- The fact that they have a deployment time already reduces their effectiveness in terms of being "snapped" on and off in response to loss of atmosphere.
- The "juggling" behaviour that players resort to when they can't just wear their suit as a backpack (swapping between a held backpack and a held modsuit control with keybindings) is the kind of powergaming trick I don't really like but is reasonably easy to do in order to bypass the downside anyway, removing this removes any need to train players to do this.
- Personally I feel that if people are wearing their MODsuit undeployed while wandering around the station that's actually preferable to me than if they had it deployed full-time, which is what they are more likely to be doing if leaving it undeployed makes them slower (even if the undeployed speed was the same as the deployed speed). At that point, they might as well simply have it powered in order to benefit from being atmospherics-proof and deal with having to charge it every so often.

**Doesn't this just make a MODsuit into a better backpack?**
No, it has lower capacity.
A standard MODsuit storage has a max weight capacity of 15 split across up to 7 items.
A regular backpack has a max weight capacity of 21 split across up to 21 items (significantly more granularity).

**Won't this make people wear MODsuits all the time?**
Apart from ones that you get with your job, the Roboticist only starts with a handful of mod cores to make more suits out of.
If we achieved even 1/3rd crew saturation on a busy round that would mean a significant use of cargo to acquire more cores, which is a design goal. I think the idea that it would reach total crew saturation is basically unthinkable, we already limit the number of suits that can exist at once via cargo.

Also, most suits with good utility _still_ make you slower _when deployed_ so any time you are actually benefiting from its utility you are experiencing a drawback. 

## Changelog

:cl:
balance: MODSuit parts now slow you only when deployed, regardless of whether they are sealed.
balance: MODSuit parts no longer slow you when they aren't deployed.
/:cl:
