### PR TITLE
Renames order computers "express" -> "autodelivery", autodelivery now has transit time

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/golem_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/golem_order.dm
@@ -1,8 +1,8 @@
 /obj/machinery/computer/order_console/mining/golem
 	name = "golem ship equipment vendor"
 	circuit = /obj/item/circuitboard/computer/order_console/mining/golem
-	forced_express = TRUE
-	express_cost_multiplier = 1
+	forced_autodelivery = TRUE
+	autodelivery_cost_multiplier = 1
 	order_categories = list(
 		CATEGORY_GOLEM,
 		CATEGORY_MINING,

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -9,6 +9,7 @@
 	icon_screen = null
 	circuit = /obj/item/circuitboard/computer/order_console/mining
 	cooldown_time = 10 SECONDS //just time to let you know your order went through.
+	autodelivery_delay_time = 30 SECONDS
 	cargo_cost_multiplier = 0.65
 	autodelivery_cost_multiplier = 1
 	purchase_tooltip = @{"Your purchases will arrive at cargo,

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -10,11 +10,11 @@
 	circuit = /obj/item/circuitboard/computer/order_console/mining
 	cooldown_time = 10 SECONDS //just time to let you know your order went through.
 	cargo_cost_multiplier = 0.65
-	express_cost_multiplier = 1
+	autodelivery_cost_multiplier = 1
 	purchase_tooltip = @{"Your purchases will arrive at cargo,
 	and hopefully get delivered by them.
-	35% cheaper than express delivery."}
-	express_tooltip = @{"Sends your purchases instantly."}
+	35% cheaper than autodelivery."}
+	autodelivery_tooltip = @{"Sends your purchases without cargo! Will take 2 minutes to arrive."}
 	credit_type = CREDIT_TYPE_MINING
 
 	order_categories = list(

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -9,10 +9,10 @@ GLOBAL_LIST_EMPTY(order_console_products)
 	icon_keyboard = "generic_key"
 	light_color = LIGHT_COLOR_ORANGE
 	///Tooltip for the autodelivery button in TGUI
-	var/autodelivery_tooltip = @{"Sends your purchases without cargo! Will take 2 minutes to arrive, and lock the console for longer."}
+	var/autodelivery_tooltip = @{"Sends your purchases without cargo! Will take time to arrive, and lock the console for longer."}
 	///Tooltip for the purchase button in TGUI
 	var/purchase_tooltip = @{"Your purchases will arrive at cargo,
-	and hopefully get delivered by them. 50% cheaper than autodelivery."}
+	and hopefully get delivered by them. Always cheaper than autodelivery."}
 
 	///Cooldown between order uses.
 	COOLDOWN_DECLARE(order_cooldown)
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
 	///Whether the console can only use autodelivery mode ONLY
 	var/forced_autodelivery = FALSE
 	///How long the autodelivery takes to arrive
-	var/autodelivery_delay_time = 1 MINUTES
+	var/autodelivery_delay_time = 2 MINUTES
 	///Multiplied cost to use for cargo mode
 	var/cargo_cost_multiplier = 1
 	///Multiplied cost to use for autodelivery mode

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -4,20 +4,19 @@ GLOBAL_LIST_EMPTY(order_console_products)
 
 /obj/machinery/computer/order_console
 	name = "Orders Console"
-	desc = "An interface for ordering specific ingredients from Cargo, with an express option at the cost of more money."
+	desc = "An interface for ordering specific ingredients from Cargo, with an autodeliver option at the cost of more money."
 	icon_screen = "request"
 	icon_keyboard = "generic_key"
 	light_color = LIGHT_COLOR_ORANGE
-	///Tooltip for the express button in TGUI
-	var/express_tooltip = @{"Sends your purchases instantly,
-	but locks the console longer and increases the price!"}
+	///Tooltip for the autodelivery button in TGUI
+	var/autodelivery_tooltip = @{"Sends your purchases without cargo! Will take 2 minutes to arrive, and lock the console for longer."}
 	///Tooltip for the purchase button in TGUI
 	var/purchase_tooltip = @{"Your purchases will arrive at cargo,
-	and hopefully get delivered by them."}
+	and hopefully get delivered by them. 50% cheaper than autodelivery."}
 
 	///Cooldown between order uses.
 	COOLDOWN_DECLARE(order_cooldown)
-	///Cooldown time between uses, express console will have extra time depending on express_cost_multiplier.
+	///Cooldown time between uses, autodelivery console will have extra time depending on autodelivery_cost_multiplier.
 	var/cooldown_time = 60 SECONDS
 	///The channel we will attempt to speak into through our radio.
 	var/radio_channel = RADIO_CHANNEL_SUPPLY
@@ -26,12 +25,14 @@ GLOBAL_LIST_EMPTY(order_console_products)
 
 	///The kind of cash does the console use.
 	var/credit_type = CREDIT_TYPE_CREDIT
-	///Whether the console can only use express mode ONLY
-	var/forced_express = FALSE
+	///Whether the console can only use autodelivery mode ONLY
+	var/forced_autodelivery = FALSE
+	///How long the autodelivery takes to arrive
+	var/autodelivery_delay_time = 1 MINUTES
 	///Multiplied cost to use for cargo mode
 	var/cargo_cost_multiplier = 1
-	///Multiplied cost to use for express mode
-	var/express_cost_multiplier = 2
+	///Multiplied cost to use for autodelivery mode
+	var/autodelivery_cost_multiplier = 2
 	///The categories of orderable items this console can view and purchase.
 	var/list/order_categories = list()
 	///The current list of things we're trying to order, waiting for checkout.
@@ -93,12 +94,12 @@ GLOBAL_LIST_EMPTY(order_console_products)
 /obj/machinery/computer/order_console/ui_static_data(mob/user)
 	var/list/data = list()
 	data["credit_type"] = credit_type
-	data["express_tooltip"] = express_tooltip
+	data["autodelivery_tooltip"] = autodelivery_tooltip
 	data["purchase_tooltip"] = purchase_tooltip
-	data["forced_express"] = forced_express
+	data["forced_autodelivery"] = forced_autodelivery
 	data["cargo_value"] = CARGO_CRATE_VALUE
 	data["cargo_cost_multiplier"] = cargo_cost_multiplier
-	data["express_cost_multiplier"] = express_cost_multiplier
+	data["autodelivery_cost_multiplier"] = autodelivery_cost_multiplier
 	data["order_categories"] = order_categories
 	data["order_datums"] = list()
 	for(var/datum/orderable_item/item as anything in GLOB.order_console_products)
@@ -150,8 +151,8 @@ GLOBAL_LIST_EMPTY(order_console_products)
 		if("purchase")
 			if(!grocery_list.len || !COOLDOWN_FINISHED(src, order_cooldown))
 				return
-			if(forced_express)
-				return ui_act(action = "express")
+			if(forced_autodelivery)
+				return ui_act(action = "autodelivery")
 			//So miners cant spam buy crates for a very low price
 			if(get_total_cost() < CARGO_CRATE_VALUE)
 				return
@@ -163,26 +164,26 @@ GLOBAL_LIST_EMPTY(order_console_products)
 			if(!purchase_items(used_id_card))
 				return
 			if(blackbox_key)
-				SSblackbox.record_feedback("tally", "non_express_[blackbox_key]_order", 1, name)
+				SSblackbox.record_feedback("tally", "non_autodelivery_[blackbox_key]_order", 1, name)
 			order_groceries(living_user, used_id_card, grocery_list)
 			grocery_list.Cut()
 			COOLDOWN_START(src, order_cooldown, cooldown_time)
-		if("express")
+		if("autodelivery")
 			if(!grocery_list.len || !COOLDOWN_FINISHED(src, order_cooldown))
 				return
 			var/obj/item/card/id/used_id_card = living_user.get_idcard(TRUE)
 			if(!used_id_card || !used_id_card.registered_account)
 				say("No bank account detected!")
 				return
-			if(!purchase_items(used_id_card, express = TRUE))
+			if(!purchase_items(used_id_card, autodelivery = TRUE))
 				return
 			var/say_message = "Thank you for your purchase!"
-			if(express_cost_multiplier > 1)
-				say_message += " Please note: The charge of this purchase and machine cooldown has been multiplied by [express_cost_multiplier]!"
-			COOLDOWN_START(src, order_cooldown, cooldown_time * express_cost_multiplier)
+			if(autodelivery_cost_multiplier > 1)
+				say_message += " Please note: The charge of this purchase and machine cooldown has been multiplied by [autodelivery_cost_multiplier]!"
+			COOLDOWN_START(src, order_cooldown, cooldown_time * autodelivery_cost_multiplier)
 			say(say_message)
 			if(blackbox_key)
-				SSblackbox.record_feedback("tally", "express_[blackbox_key]_order", 1, name)
+				SSblackbox.record_feedback("tally", "autodelivery_[blackbox_key]_order", 1, name)
 			var/list/ordered_paths = list()
 			for(var/datum/orderable_item/item as anything in grocery_list)//every order
 				if(!(item.category_index in order_categories))
@@ -191,10 +192,16 @@ GLOBAL_LIST_EMPTY(order_console_products)
 					continue
 				for(var/amt in 1 to grocery_list[item])//every order amount
 					ordered_paths += item.purchase_path
+			var/delivery_delay = list(POD_TRANSIT = 30, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
+			// if the console forces autodelivery, there's no reason to add a punishment waiting time
+			// because there was no alternative (working with cargo) to get around it
+			if(!forced_autodelivery)
+				delivery_delay = list(POD_TRANSIT = autodelivery_delay_time, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
 			podspawn(list(
 				"target" = get_turf(living_user),
 				"style" = /datum/pod_style/advanced,
 				"spawn" = ordered_paths,
+				"delays" = delivery_delay,
 			))
 			grocery_list.Cut()
 	return TRUE
@@ -204,11 +211,11 @@ GLOBAL_LIST_EMPTY(order_console_products)
  * and deducts the cost if they can.
  * Args:
  * card - The ID card we check for balance
- * express - Boolean on whether we need to add the express cost mulitplier
+ * autodelivery - Boolean on whether we need to add the autodelivery cost mulitplier
  * returns TRUE if we can afford, FALSE otherwise.
  */
-/obj/machinery/computer/order_console/proc/purchase_items(obj/item/card/id/card, express = FALSE)
-	var/final_cost = round(get_total_cost() * (express ? express_cost_multiplier : cargo_cost_multiplier))
+/obj/machinery/computer/order_console/proc/purchase_items(obj/item/card/id/card, autodelivery = FALSE)
+	var/final_cost = round(get_total_cost() * (autodelivery ? autodelivery_cost_multiplier : cargo_cost_multiplier))
 	if(subtract_points(final_cost, card))
 		return TRUE
 	say("Sorry, but you do not have enough [credit_type].")

--- a/code/modules/bitrunning/objects/vendor.dm
+++ b/code/modules/bitrunning/objects/vendor.dm
@@ -10,11 +10,11 @@
 	circuit = /obj/item/circuitboard/computer/order_console/bitrunning
 	cooldown_time = 10 SECONDS
 	cargo_cost_multiplier = 0.65
-	express_cost_multiplier = 1
+	autodelivery_cost_multiplier = 1
 	purchase_tooltip = @{"Your purchases will arrive at cargo,
 	and hopefully get delivered by them.
-	35% cheaper than express delivery."}
-	express_tooltip = @{"Sends your purchases instantly."}
+	35% cheaper than autodelivery."}
+	autodelivery_tooltip = @{"Sends your purchases without anyone else involved."}
 	credit_type = CREDIT_TYPE_BITRUNNING
 
 	order_categories = list(

--- a/tgui/packages/tgui/interfaces/ProduceConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.tsx
@@ -303,7 +303,7 @@ const CheckoutTab = (props) => {
                 disabled={total_cost <= 0}
                 tooltip={
                   total_cost <= 0
-                    ? 'Order atleast 1 item'
+                    ? 'Order at least 1 item'
                     : autodelivery_tooltip
                 }
                 tooltipPosition="top-start"

--- a/tgui/packages/tgui/interfaces/ProduceConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.tsx
@@ -39,12 +39,12 @@ type Data = {
   credit_type: string;
   off_cooldown: BooleanLike;
   points: number;
-  express_tooltip: string;
+  autodelivery_tooltip: string;
   purchase_tooltip: string;
-  forced_express: string;
+  forced_autodelivery: string;
   cargo_value: number;
   cargo_cost_multiplier: number;
-  express_cost_multiplier: number;
+  autodelivery_cost_multiplier: number;
   order_categories: string[];
   order_datums: OrderDatum[];
   item_amts: Item[];
@@ -200,13 +200,13 @@ const CheckoutTab = (props) => {
   const {
     credit_type,
     purchase_tooltip,
-    express_tooltip,
-    forced_express,
+    autodelivery_tooltip,
+    forced_autodelivery,
     cargo_value,
     order_datums,
     total_cost,
     cargo_cost_multiplier,
-    express_cost_multiplier,
+    autodelivery_cost_multiplier,
     item_amts,
   } = data;
   const total_cargo_cost = Math.floor(total_cost * cargo_cost_multiplier);
@@ -275,9 +275,9 @@ const CheckoutTab = (props) => {
           <Stack>
             <Stack.Item grow mt={0.5}>
               Total:{total_cargo_cost}&#40;Express:
-              {total_cost * express_cost_multiplier}&#41;
+              {total_cost * autodelivery_cost_multiplier}&#41;
             </Stack.Item>
-            {!forced_express && (
+            {!forced_autodelivery && (
               <Stack.Item grow textAlign="center">
                 <Button
                   fluid
@@ -302,10 +302,12 @@ const CheckoutTab = (props) => {
                 content="Express"
                 disabled={total_cost <= 0}
                 tooltip={
-                  total_cost <= 0 ? 'Order atleast 1 item' : express_tooltip
+                  total_cost <= 0
+                    ? 'Order atleast 1 item'
+                    : autodelivery_tooltip
                 }
                 tooltipPosition="top-start"
-                onClick={() => act('express')}
+                onClick={() => act('autodelivery')}
               />
             </Stack.Item>
           </Stack>


### PR DESCRIPTION

## About The Pull Request

- All mentions of "express" have been renamed to "autodelivery"
- Autodelivering goods now comes with transit time. Mining console gets 30 seconds, the chef console gets 2 minutes
- Golem ordering remains the same as before. Forced autodelivery skips any kind of transit time.

## Why It's Good For The Game

So this has been in the game for awhile, and I think it's a positive element. But I think I messed up with the balance between the two choices, because it's clearly far better to autodeliver and eat the cost. I could change every other factor, and the only relevant one would be the fact that express delivery instantly gives you what you want, while the other option doesn't.

This change is meant to replicate the time you'd have to wait for cargo. It may remain quicker than regular orders, but any amount of delay on getting what you ordered is going to make the other delay (that comes with discounts, and kickbacks, etc) more appealing to the orderee. Ideally, if cargo is active, it should be a no-brainer to run a regular order instead of express. Not sure if this does that without testing, but it brings us closer.

I decided to make the delay far less for the mining console, mostly because of distance to cargo and the cooldown also already mostly removed.

## Changelog
:cl:
balance: The cargo console now has a delay to express orders (renamed to autodelivery)
/:cl:
