### PR TITLE
Replaces mineral selling on the galactic material market with flat static exports.

### DIFF
--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -44,7 +44,12 @@ Simple datum which is instanced once per type and is used for every object of sa
 	///This is a modifier for integrity, and resembles the strength of the material
 	var/integrity_modifier = 1
 
-	///This is the amount of value per 1 unit of the material
+	/***
+	 * This is the amount of credit value per 1 unit of the material.
+	 * A given sheet of material will multiply this number by 100.
+	 * Used in determining value of coins as well as materials exports.
+	 * Price fluxuations will range from 0.5 to 3x that of value per unit.
+	 */
 	var/value_per_unit = 0
 	///This is the minimum value of the material, used in the stock market for any mat that isn't set to null
 	var/minimum_value_override = null

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -44,7 +44,7 @@
 	material_id = /datum/material/bananium
 	message = "cm3 of bananium"
 
-/datum/export/material/diamond
+/datum/export/material/adamantine
 	cost = CARGO_CRATE_VALUE
 	material_id = /datum/material/adamantine
 	message = "cm3 of adamantine"
@@ -77,33 +77,41 @@
 	export_types = /obj/item/stack/sheet/mineral/metal_hydrogen
 
 /datum/export/material/market
+	k_elasticity = 0
 
 /datum/export/material/market/diamond
+	cost = CARGO_CRATE_VALUE * 1.3
 	material_id = /datum/material/diamond
 	message = "cm3 of diamonds"
 
-/datum/export/material/market/uranium
-	material_id = /datum/material/uranium
-	message = "cm3 of uranium"
-
 /datum/export/material/market/gold
+	cost = CARGO_CRATE_VALUE * 0.35
 	material_id = /datum/material/gold
 	message = "cm3 of gold"
 
-/datum/export/material/market/silver
-	material_id = /datum/material/silver
-	message = "cm3 of silver"
-
 /datum/export/material/market/titanium
+	cost = CARGO_CRATE_VALUE * 0.35
 	material_id = /datum/material/titanium
 	message = "cm3 of titanium"
 
+/datum/export/material/market/uranium
+	cost = CARGO_CRATE_VALUE * 0.3
+	material_id = /datum/material/uranium
+	message = "cm3 of uranium"
+
+/datum/export/material/market/silver
+	cost = CARGO_CRATE_VALUE * 0.15
+	material_id = /datum/material/silver
+	message = "cm3 of silver"
+
 /datum/export/material/market/bscrystal
-	message = "of bluespace crystals"
+	cost = CARGO_CRATE_VALUE * 0.8
+	message = "cm3 of bluespace crystals"
 	material_id = /datum/material/bluespace
 	export_types = list(/obj/item/stack/sheet/bluespace_crystal, /obj/item/stack/ore) //For whatever reason, bluespace crystals are not a mineral
 
 /datum/export/material/market/iron
+	cost = CARGO_CRATE_VALUE * 0.015
 	message = "cm3 of iron"
 	material_id = /datum/material/iron
 	export_types = list(
@@ -115,6 +123,7 @@
 	)
 
 /datum/export/material/market/glass
+	cost = CARGO_CRATE_VALUE * 0.015
 	message = "cm3 of glass"
 	material_id = /datum/material/glass
 	export_types = list(
@@ -122,14 +131,6 @@
 		/obj/item/stack/ore,
 		/obj/item/shard
 	)
-
-/datum/export/material/market/get_cost(obj/O, apply_elastic = FALSE)
-	var/obj/item/I = O
-	var/amount = get_amount(I)
-	if(!amount)
-		return 0
-	var/material_value = (SSstock_market.materials_prices[material_id]) * amount * MARKET_PROFIT_MODIFIER
-	return round(material_value)
 
 /datum/export/material/market/sell_object(obj/sold_item, datum/export_report/report, dry_run, apply_elastic)
 	. = ..()
@@ -139,29 +140,5 @@
 
 	//This formula should impact lower quantity materials greater, and higher quantity materials less. Still, it's  a bit rough. Tweaking may be needed.
 	if(!dry_run)
-		//decrease the market price
-		SSstock_market.adjust_material_price(material_id, -SSstock_market.materials_prices[material_id] * (amount / (amount + SSstock_market.materials_quantity[material_id])))
-
 		//increase the stock
 		SSstock_market.adjust_material_quantity(material_id, amount)
-
-
-// Stock blocks are a special type of export that can be used to sell a quantity of materials at a specific price on the market.
-/datum/export/stock_block
-	cost = 0
-	message = "stock block"
-	export_types = list(/obj/item/stock_block)
-
-/datum/export/stock_block/get_cost(obj/O, apply_elastic = FALSE)
-	var/obj/item/stock_block/block = O
-	return block.export_value
-
-/datum/export/stock_block/sell_object(obj/sold_item, datum/export_report/report, dry_run, apply_elastic)
-	. = ..()
-	if(dry_run)
-		return
-	var/obj/item/stock_block/sold_block = sold_item
-	var/sale_value = sold_block.export_value
-	SSstock_market.materials_quantity[sold_block.export_mat] += sold_block.quantity
-	SSstock_market.materials_prices[sold_block.export_mat] -= round((sale_value) * (sold_block.quantity / (sold_block.quantity + SSstock_market.materials_quantity[sold_block.export_mat])))
-	SSstock_market.materials_prices[sold_block.export_mat] = round(clamp(SSstock_market.materials_prices[sold_block.export_mat], initial(sold_block.export_mat.value_per_unit) * SHEET_MATERIAL_AMOUNT * 0.5 , initial(sold_block.export_mat.value_per_unit) * SHEET_MATERIAL_AMOUNT * 3))

--- a/tgui/packages/tgui/interfaces/MatMarket.tsx
+++ b/tgui/packages/tgui/interfaces/MatMarket.tsx
@@ -81,10 +81,9 @@ export const MatMarket = (props) => {
               Buy orders for material sheets placed here will be ordered on the
               next cargo shipment.
               <br /> <br />
-              To sell materials, please insert sheets or similar stacks of
-              materials. All minerals sold on the market directly are subject to
-              an 20% market fee. To prevent market manipulation, all registered
-              traders can buy a total of 10 full stacks of materials at a time.
+              Material purchases are subject to a <i>static sale value</i>,
+              independent of their purchase price as per nanotrasen insider
+              trading regulations.
               <br /> <br />
               All new purchases will include the cost of the shipped crate,
               which may be recycled afterwards.


### PR DESCRIPTION
## About The Pull Request
This pull request changes how the GMM works, so that instead of pulling the export price of minerals sold from their going market rate, they instead have a static export rate.

Compared to their original export rates however, they are slightly buffed. This allows for all materials previously purchasable on the stock market to still have some margin of profit potentially from the stock market, but it's far lower than before to disincentivize players using it to effectively cheese credit gathering methods in cargo and instead looking for more dynamic credit gathering methods than the stock market. Instead, this is to attempt to keep the material market doing what it was meant to do, serve as a means to supplement materials on the station.

Of note, selling sheets of materials does still re-add their quantities back into the stock market for the purposes of price adjustments and inflation. Additionally, unlike before, I've given all sheets an elasticity of 0, to allow for a consistent sale price for anything that can be bought from the market.

## Why It's Good For The Game

Alright, I fucked up.

The stock market being a method of generating money breaks a few core tenants of economy design and I was under the impression that it wasn't going to be as obnoxiously bad as it turned out to be. A short list of the issues:

* To properly take advantage of the Stock market, you need to be camped in front of the UI 24/7. This is the same issue as genetics has, which is, put bluntly, quite bad.
* Due to the nature of how selling materials onto the market effects the low quantities of purchasable materials, it results in wide swings to the prices of materials, which at optimal quantities, makes for a rather simple pendulum of "Buy stack of material -> quantity decreases, price increases -> Sell at profit margin -> quantity increases, price decreases".
* People... were not using the material market to actually supply the station with materials.

This change attempts to reign in the feature back to it's intended scope while keeping the profitability as a smaller scope benefit to the feature.

## Changelog

:cl:
balance: Minerals and materials sold through cargo are now sold at a static price, without elasticity.
del: Sheets can no longer be converted into stock blocks, as it was only required by the GMM's dynamic pricing.
/:cl:
