### PR TITLE
Sprayed reagents can pass through machines, equipment, and structures

### DIFF
--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -2,7 +2,7 @@
 /obj/effect/decal/chempuff
 	name = "chemicals"
 	icon = 'icons/obj/medical/chempuff.dmi'
-	pass_flags = PASSTABLE | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE
 	layer = FLY_LAYER
 	plane = ABOVE_GAME_PLANE
 	///The mob who sourced this puff, if one exists


### PR DESCRIPTION

## About The Pull Request
Copycat of:
- #89636

Sprayed reagents can now pass through machines, equipment, and structures.

## Why It's Good For The Game
It's weird when your sprayed reagent is blocked by random computers and structures that it should be able to cross.

## Changelog
:cl:
balance: Sprayed reagents now passes through machines, equipment, and several other dense structures.
/:cl:
