### PR TITLE
You can use tables as makeshift lava bridges

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -279,6 +279,8 @@
 
 	if(HAS_TRAIT(burn_target, immunity_trait))
 		return LAVA_BE_PROCESSING
+	if(HAS_TRAIT(burn_target, TRAIT_MOB_ELEVATED))
+		return LAVA_BE_PROCESSING
 	var/mob/living/burn_living = burn_target
 	var/atom/movable/burn_buckled = burn_living.buckled
 	if(burn_buckled)


### PR DESCRIPTION

## About The Pull Request

A comment under #85456 and #89636 as a whole inspired me to add this. Tables still burn ***really*** quickly in lava, I'm not sure if you have enough time to make a bridge of more than 1 table before the table you're on burns to ashes without an RCD/construction gauntlets (does anyone even remember these?) but its highly amusing.

## Why It's Good For The Game

I think this is really neat, having assistants bridge into sec on icebox with tables would be absolute sandbox peak.

## Changelog
:cl:
add: You can use tables as makeshift lava bridges
/:cl:
