### PR TITLE
Remove the abandoned crate puzzle

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -23325,7 +23325,6 @@
 /area/station/maintenance/department/science)
 "ikc" = (
 /obj/structure/closet/crate/secure/loot{
-	codelen = 2;
 	name = "malfunctioning abandoned crate"
 	},
 /turf/open/misc/asteroid,

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -6,10 +6,6 @@
 	icon_state = "securecrate"
 	base_icon_state = "securecrate"
 	integrity_failure = 0 //no breaking open the crate
-	var/code = null
-	var/lastattempt = null
-	var/attempts = 10
-	var/codelen = 4
 	var/qdel_on_open = FALSE
 	var/spawned_loot = FALSE
 	tamperproof = 90
@@ -18,86 +14,10 @@
 	divable = FALSE
 
 /obj/structure/closet/crate/secure/loot/Initialize(mapload)
+	if(locked && !spawned_loot)
+		spawn_loot()
 	. = ..()
-	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
-	code = ""
-	for(var/i in 1 to codelen)
-		var/dig = pick(digits)
-		code += dig
-		digits -= dig  //there are never matching digits in the answer
 
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/structure/closet/crate/secure/loot/attack_hand(mob/user, list/modifiers)
-	if(locked)
-		to_chat(user, span_notice("The crate is locked with a Deca-code lock."))
-		var/input = input(usr, "Enter [codelen] digits. All digits must be unique.", "Deca-Code Lock", "") as text|null
-		if(user.can_perform_action(src) && locked)
-			var/list/sanitised = list()
-			var/sanitycheck = TRUE
-			var/char = ""
-			var/length_input = length(input)
-			for(var/i = 1, i <= length_input, i += length(char)) //put the guess into a list
-				char = input[i]
-				sanitised += text2num(char)
-			for(var/i in 1 to length(sanitised) - 1) //compare each digit in the guess to all those following it
-				for(var/j in i + 1 to length(sanitised))
-					if(sanitised[i] == sanitised[j])
-						sanitycheck = FALSE //if a digit is repeated, reject the input
-			if(input == code)
-				if(!spawned_loot)
-					spawn_loot()
-				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
-				togglelock(user)
-			else if(!input || !sanitycheck || length(sanitised) != codelen)
-				to_chat(user, span_notice("You leave the crate alone."))
-			else
-				to_chat(user, span_warning("A red light flashes."))
-				lastattempt = input
-				attempts--
-				if(attempts == 0)
-					boom(user)
-		return
-
-	return ..()
-
-/obj/structure/closet/crate/secure/loot/click_alt(mob/living/user)
-	attack_hand(user) //this helps you not blow up so easily by overriding unlocking which results in an immediate boom.
-	return CLICK_ACTION_SUCCESS
-
-/obj/structure/closet/crate/secure/loot/attackby(obj/item/W, mob/user)
-	if(locked)
-		if(W.tool_behaviour == TOOL_MULTITOOL)
-			to_chat(user, span_notice("DECA-CODE LOCK REPORT:"))
-			if(attempts == 1)
-				to_chat(user, span_warning("* Anti-Tamper Bomb will activate on next failed access attempt."))
-			else
-				to_chat(user, span_notice("* Anti-Tamper Bomb will activate after [attempts] failed access attempts."))
-			if(lastattempt != null)
-				var/bulls = 0 //right position, right number
-				var/cows = 0 //wrong position but in the puzzle
-
-				var/lastattempt_char = ""
-				var/length_lastattempt = length(lastattempt)
-				var/lastattempt_it = 1
-
-				var/code_char = ""
-				var/length_code = length(code)
-				var/code_it = 1
-
-				while(lastattempt_it <= length_lastattempt && code_it <= length_code) // Go through list and count matches
-					lastattempt_char = lastattempt[lastattempt_it]
-					code_char = code[code_it]
-					if(lastattempt_char == code_char)
-						++bulls
-					else if(findtext(code, lastattempt_char))
-						++cows
-
-					lastattempt_it += length(lastattempt_char)
-					code_it += length(code_char)
-
-				to_chat(user, span_notice("Last code attempt, [lastattempt], had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions."))
-			return
-	return ..()
 
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user, obj/item/card/emag/emag_card)
 	. = ..()
@@ -107,18 +27,6 @@
 		return TRUE
 	return
 
-/obj/structure/closet/crate/secure/loot/togglelock(mob/user, silent = FALSE)
-	if(!locked)
-		. = ..() //Run the normal code.
-		if(locked) //Double check if the crate actually locked itself when the normal code ran.
-			//reset the anti-tampering, number of attempts and last attempt when the lock is re-enabled.
-			tamperproof = initial(tamperproof)
-			attempts = initial(attempts)
-			lastattempt = null
-		return
-	if(tamperproof)
-		return
-	return ..()
 
 /obj/structure/closet/crate/secure/loot/atom_deconstruct(disassembled = TRUE)
 	if(locked)


### PR DESCRIPTION

## About The Pull Request
![alladream](https://github.com/user-attachments/assets/7341fc3c-c8d9-4283-a6d1-074956ef5e27)
Removes the abandoned crate puzzle (bulls and cows) and all associated code. Loot table wasn't changed - I think we can tweak it after seeing how it goes.
## Why It's Good For The Game
The abandoned crate puzzle is bad for the game because:
1) The puzzle is hard, which is punishing for people who can't solve it
2) People can use external resources to skip the puzzle, which is uncool
3) It's not very engaging - all it comes down to is typing some numbers and doing some clicks
4) People are not encouraged to experiment with it - once you learn one way to solve it, you don't need anything else
5) Once you know the algorithm to solve it, all you have to do is to repeat it, which is boring
5) We can replace it with a better system in the future if someone decides to code it

Therefore, we need to remove it.
## Changelog
:cl:
balance: removed abandoned crate puzzle
/:cl:
