### PR TITLE
Various telepathic/remote messages are now labeled as "radio" chat messages

### DIFF
--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -83,17 +83,17 @@ it will be sent to all connected chats.
 #define EXAMINE_HINT(text) ("<b>" + text + "</b>")
 
 /// Sends a message to all dead and observing players, if a source is provided a follow link will be attached.
-/proc/send_to_observers(message, source)
+/proc/send_to_observers(message, source, message_type = null)
 	var/list/all_observers = GLOB.dead_player_list + GLOB.current_observers_list
 	for(var/mob/observer as anything in all_observers)
 		if (isnull(source))
-			to_chat(observer, "[message]")
+			to_chat(observer, "[message]", type = message_type)
 			continue
 		var/link = FOLLOW_LINK(observer, source)
-		to_chat(observer, "[link] [message]")
+		to_chat(observer, "[link] [message]", type = message_type)
 
 /// Sends a message to everyone within the list, as well as all observers.
-/proc/relay_to_list_and_observers(message, list/mob_list, source)
+/proc/relay_to_list_and_observers(message, list/mob_list, source, message_type = null)
 	for(var/mob/creature as anything in mob_list)
-		to_chat(creature, message)
+		to_chat(creature, message, type = message_type)
 	send_to_observers(message, source)

--- a/code/datums/components/blob_minion.dm
+++ b/code/datums/components/blob_minion.dm
@@ -142,7 +142,7 @@
 	minion.log_talk(message, LOG_SAY, tag = "blob hivemind telepathy")
 	var/spanned_message = minion.say_quote(message)
 	var/rendered = span_blob("<b>\[Blob Telepathy\] [minion.real_name]</b> [spanned_message]")
-	relay_to_list_and_observers(rendered, GLOB.blob_telepathy_mobs, minion)
+	relay_to_list_and_observers(rendered, GLOB.blob_telepathy_mobs, minion, MESSAGE_TYPE_RADIO)
 	return COMPONENT_CANNOT_SPEAK
 
 /// Called when a blob minion is transformed into something else, hopefully a spore into a zombie

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -41,10 +41,10 @@
 		// can't receive messages on the hivemind right now
 		if(HAS_TRAIT(ling_mob, TRAIT_CHANGELING_HIVEMIND_MUTE))
 			continue
-		to_chat(ling_mob, msg)
+		to_chat(ling_mob, msg, type = MESSAGE_TYPE_RADIO, avoid_highlighting = ling_mob == user)
 
 	for(var/mob/dead/ghost as anything in GLOB.dead_mob_list)
-		to_chat(ghost, "[FOLLOW_LINK(ghost, user)] [msg]")
+		to_chat(ghost, "[FOLLOW_LINK(ghost, user)] [msg]", type = MESSAGE_TYPE_RADIO)
 	return FALSE
 
 /datum/saymode/xeno

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -325,7 +325,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 	var/message_a = say_quote(message)
 	var/rendered = span_big(span_blob("<b>\[Blob Telepathy\] [name](<font color=\"[blobstrain.color]\">[blobstrain.name]</font>)</b> [message_a]"))
-	relay_to_list_and_observers(rendered, GLOB.blob_telepathy_mobs, src)
+	relay_to_list_and_observers(rendered, GLOB.blob_telepathy_mobs, src, MESSAGE_TYPE_RADIO)
 
 /mob/eye/blob/blob_act(obj/structure/blob/B)
 	return

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -59,12 +59,12 @@
 	else if(!ishuman(user))
 		title = "Construct"
 	my_message = "<span class='[span]'><b>[title] [findtextEx(user.name, user.real_name) ? user.name : "[user.real_name] (as [user.name])"]:</b> [message]</span>"
-	for(var/mob/M as anything in GLOB.player_list)
-		if(IS_CULTIST(M))
-			to_chat(M, my_message)
-		else if(M in GLOB.dead_mob_list)
-			var/link = FOLLOW_LINK(M, user)
-			to_chat(M, "[link] [my_message]")
+	for(var/mob/listener as anything in GLOB.player_list)
+		if(IS_CULTIST(listener))
+			to_chat(listener, my_message, type = MESSAGE_TYPE_RADIO, avoid_highlighting = listener == user)
+		else if(listener in GLOB.dead_mob_list)
+			var/link = FOLLOW_LINK(listener, user)
+			to_chat(listener, "[link] [my_message]", type = MESSAGE_TYPE_RADIO)
 
 	user.log_talk(message, LOG_SAY, tag="cult")
 

--- a/code/modules/mob/living/carbon/alien/alien_say.dm
+++ b/code/modules/mob/living/carbon/alien/alien_say.dm
@@ -9,12 +9,12 @@
 	if(big_voice)
 		hivemind_spans += " big"
 	var/rendered = "<i><span class='[hivemind_spans]'>Hivemind, [span_name("[shown_name]")] <span class='message'>[message_a]</span></span></i>"
-	for(var/mob/S in GLOB.player_list)
-		if(!S.stat && S.hivecheck())
-			to_chat(S, rendered)
-		if(S in GLOB.dead_mob_list)
-			var/link = FOLLOW_LINK(S, src)
-			to_chat(S, "[link] [rendered]")
+	for(var/mob/player in GLOB.player_list)
+		if(!player.stat && player.hivecheck())
+			to_chat(player, rendered, type = MESSAGE_TYPE_RADIO, avoid_highlighting = player == src)
+		else if(player in GLOB.dead_mob_list)
+			var/link = FOLLOW_LINK(player, src)
+			to_chat(player, "[link] [rendered]", type = MESSAGE_TYPE_RADIO)
 
 /mob/living/carbon/alien/adult/royal/queen/alien_talk(message, shown_name = name)
 	..(message, shown_name, TRUE)

--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -35,6 +35,7 @@
 						<a href='byond://?src=[REF(M)];track=[html_encode(namepart)]'>[span_name("[namepart] ([designation])")]</a> \
 						<span class='message'>[quoted_message]</span>\
 					"),
+					type = MESSAGE_TYPE_RADIO,
 					avoid_highlighting = src == M
 				)
 			else
@@ -44,6 +45,7 @@
 						Robotic Talk, \
 						[span_name("[namepart]")] <span class='message'>[quoted_message]</span>\
 					"),
+					type = MESSAGE_TYPE_RADIO,
 					avoid_highlighting = src == M
 				)
 
@@ -66,6 +68,7 @@
 					Robotic Talk, \
 					[span_name("[namepart]")] <span class='message'>[quoted_message]</span>\
 				"),
+				type = MESSAGE_TYPE_RADIO,
 				avoid_highlighting = src == M
 			)
 

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -396,11 +396,11 @@
 		if(!istype(tongue))
 			continue
 		if(mothership == tongue.mothership)
-			to_chat(living_mob, rendered)
+			to_chat(living_mob, rendered, type = MESSAGE_TYPE_RADIO, avoid_highlighting = user == living_mob)
 
 	for(var/mob/dead_mob in GLOB.dead_mob_list)
 		var/link = FOLLOW_LINK(dead_mob, user)
-		to_chat(dead_mob, "[link] [rendered]")
+		to_chat(dead_mob, "[link] [rendered]", type = MESSAGE_TYPE_RADIO)
 
 	speech_args[SPEECH_MESSAGE] = ""
 

--- a/code/modules/surgery/organs/internal/vocal_cords/_vocal_cords.dm
+++ b/code/modules/surgery/organs/internal/vocal_cords/_vocal_cords.dm
@@ -114,7 +114,7 @@
 		if(iscarbon(player))
 			var/mob/living/carbon/speaker = player
 			if(speaker.get_organ_slot(ORGAN_SLOT_ADAMANTINE_RESONATOR))
-				to_chat(speaker, msg)
-		if(isobserver(player))
+				to_chat(speaker, msg, type = MESSAGE_TYPE_RADIO, avoid_highlighting = speaker == owner)
+		else if(isobserver(player))
 			var/link = FOLLOW_LINK(player, owner)
-			to_chat(player, "[link] [msg]")
+			to_chat(player, "[link] [msg]", type = MESSAGE_TYPE_RADIO)


### PR DESCRIPTION
## About The Pull Request

This explicitly specifies `type = MESSAGE_TYPE_RADIO` in `to_chat` for various methods of communication (blood cult communion, abductor telepathy, xeno hivemind, golem resonator, blob telepathy, changeling hivemind, and binary chat), so that they will always be considered under the "Radio" category by tgchat.

Also added `avoid_highlighting` to some, so they won't highlight your own messages.

## Why It's Good For The Game

Makes going thru older messages find things that I accidentally missed much easier.

## Changelog
:cl:
qol: Messages from blood cult communion, abductor telepathy, xeno hivemind, golem resonator, blob telepathy, changeling hivemind, and binary chat are now considered "radio" messages by the chat, so they can properly be sorted via chat tabs.
qol: Your own messages in blood cult communion, abductor/xenomorph/changeling hivemind, or golem telepathy will no longer be highlighted in chat (to prevent highlight spam whenever you talk if you highlight your own name, mainly)
/:cl:
