### PR TITLE
Makes falsewalls leanable

### DIFF
--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -40,7 +40,7 @@
 		if(fall)
 			to_chat(leaner, span_danger("You lose balance!"))
 			leaner.Paralyze(0.5 SECONDS)
-	leaning_mobs = null
+	leaning_mobs.Cut()
 
 /datum/component/leanable/proc/on_moved(datum/source)
 	SIGNAL_HANDLER

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -147,6 +147,10 @@
 	to_chat(user, span_notice("The outer plating is <b>welded</b> firmly in place."))
 	return null
 
+/obj/structure/falsewall/mouse_drop_receive(mob/living/dropping, mob/user, params)
+	. = ..()
+	LoadComponent(/datum/component/leanable, dropping)
+
 /*
  * False R-Walls
  */


### PR DESCRIPTION

## About The Pull Request

Closes #89676
Also fixed an evil and bad runtime that prevented leaners from falling when the atom is destroyed/moved

## Changelog
:cl:
fix: You can now lean on falsewalls
/:cl:
