### PR TITLE
unblacklists botany fruits and vegetables from unit tests.

### DIFF
--- a/code/__HELPERS/randoms.dm
+++ b/code/__HELPERS/randoms.dm
@@ -15,7 +15,6 @@
 			/obj/item/food/grown/ash_flora,
 			/obj/item/food/grown/mushroom,
 			/obj/item/food/grown/nettle,
-			/obj/item/food/grown/shell,
 			/obj/item/food/kebab,
 			/obj/item/food/meat,
 			/obj/item/food/meat/slab,

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -137,7 +137,7 @@
 
 /datum/bounty/item/botany/eggplant_eggy
 	name = "Egg-plants"
-	wanted_types = list(/obj/item/food/grown/shell/eggy = TRUE)
+	wanted_types = list(/obj/item/food/grown/eggy = TRUE)
 	bonus_desc = "Not to be confused with eggplants."
 	multiplier = 2
 

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -30,13 +30,13 @@
 	icon_state = "seed-eggy"
 	species = "eggy"
 	plantname = "Egg-Plants"
-	product = /obj/item/food/grown/shell/eggy
+	product = /obj/item/food/grown/eggy
 	lifespan = 75
 	production = 12
 	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 
-/obj/item/food/grown/shell/eggy
+/obj/item/food/grown/eggy
 	seed = /obj/item/seeds/eggplant/eggy
 	name = "egg-plant"
 	desc = "There MUST be a chicken inside."

--- a/code/modules/hydroponics/grown/gatfruit.dm
+++ b/code/modules/hydroponics/grown/gatfruit.dm
@@ -6,7 +6,7 @@
 	icon_state = "seed-gatfruit"
 	species = "gatfruit"
 	plantname = "Gatfruit Tree"
-	product = /obj/item/food/grown/shell/gatfruit
+	product = /obj/item/food/grown/gatfruit
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	lifespan = 20
 	endurance = 20
@@ -19,7 +19,7 @@
 	growing_icon = 'icons/obj/service/hydroponics/growing_fruits.dmi'
 	reagents_add = list(/datum/reagent/sulfur = 0.1, /datum/reagent/carbon = 0.1, /datum/reagent/nitrogen = 0.07, /datum/reagent/potassium = 0.05, /datum/reagent/toxin/gatfruit = 0.3)
 
-/obj/item/food/grown/shell/gatfruit
+/obj/item/food/grown/gatfruit
 	seed = /obj/item/seeds/gatfruit
 	name = "gatfruit"
 	desc = "It smells like burning gunpowder."
@@ -30,11 +30,11 @@
 	tastes = list("gunpowder" = 1)
 	wine_power = 90 //It burns going down, too.
 
-/obj/item/food/grown/shell/gatfruit/Initialize(mapload, obj/item/seeds/new_seed)
+/obj/item/food/grown/gatfruit/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
 	reagents.flags &= ~INJECTABLE //id rather not have this be filled with initropidril without effort
 
-/obj/item/food/grown/shell/gatfruit/generate_trash(atom/location)
+/obj/item/food/grown/gatfruit/generate_trash(atom/location)
 	//if you set this to anything but the revolver i will find you... and... downvote your pr...
 	var/obj/item/gun/ballistic/revolver/peashooter/gun = new trash_type(location || drop_location())
 	var/potency_percentage = CLAMP01(seed.potency / 100)

--- a/code/modules/unit_tests/food_edibility_check.dm
+++ b/code/modules/unit_tests/food_edibility_check.dm
@@ -7,7 +7,7 @@
 		/obj/item/food/grown/mushroom,
 		/obj/item/food/clothing,
 		/obj/item/food/meat/slab/human/mutant,
-		/obj/item/food/grown/shell)
+	)
 
 	var/list/food_paths = subtypesof(/obj/item/food) - not_food
 

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -271,6 +271,9 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 		/obj/item/organ/wings,
 		//Not meant to spawn without the machine wand
 		/obj/effect/bug_moving,
+		//The abstract grown item expects a seed, but doesn't have one
+
+		/obj/item/food/grown,
 	)
 
 	// Everything that follows is a typesof() check.
@@ -286,8 +289,6 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	returnable_list += typesof(/obj/item/modular_computer/processor)
 	//Very finiky, blacklisting to make things easier
 	returnable_list += typesof(/obj/item/poster/wanted)
-	//This expects a seed, we can't pass it
-	returnable_list += typesof(/obj/item/food/grown)
 	//Needs clients / mobs to observe it to exist. Also includes hallucinations.
 	returnable_list += typesof(/obj/effect/client_image_holder)
 	//Same to above. Needs a client / mob / hallucination to observe it to exist.


### PR DESCRIPTION
## About The Pull Request
subtypes of `/obj/item/food/grown` have no reason to not be spawned by the `create_and_destroy` unit test, which prevents us from knowing if a type fruit or veggie doesn't have a set seed in the tests. The only path that needs to be blacklisted is the common `/obj/item/food/grown` path itself, since its seed variable needs to remain null so that we can be warned about any subtype that hasn't overriden that value.
This PR also removes the `/obj/item/food/grown/shell` path which serves no purpose anymore.

## Why It's Good For The Game
Backend improvements. Atomizing changes from my refactor.

## Changelog
N/A