### PR TITLE
`/datum/ai_behavior/execute_clean/finish_action` will no longer return early if the emagged phrases list is empty

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -145,13 +145,10 @@
 		controller.clear_blackboard_key(target_key)
 		return
 	var/list/speech_list = controller.blackboard[BB_CLEANBOT_EMAGGED_PHRASES]
-	if(!length(speech_list))
-		return
-	var/mob/living/living_pawn = controller.pawn
-	if(QDELETED(living_pawn)) // pawn can be null at this point
-		controller.clear_blackboard_key(target_key)
-		return
-	living_pawn.say(pick(controller.blackboard[BB_CLEANBOT_EMAGGED_PHRASES]), forced = "ai controller")
+	if(length(speech_list))
+		var/mob/living/living_pawn = controller.pawn
+		if(!QDELETED(living_pawn)) // pawn can be null at this point
+			living_pawn.say(pick(speech_list), forced = "ai controller")
 	controller.clear_blackboard_key(target_key)
 
 /datum/ai_planning_subtree/use_mob_ability/foam_area


### PR DESCRIPTION
## About The Pull Request
For some reason, `/datum/ai_behavior/execute_clean/finish_action` was coded such that it returns early if the list of cleanbot emagged phrases was empty (or null).

This shouldn't be a problem with regular cleanbots - they come with emagged phrases already set. However, it makes this ai behavior unsuitable for use with non-cleanbot controllers (such as Monkestation's cleaner slimes - cute little slimes that will dissolve trash and blood!), as the statement to clear the `target_key` blackboard value was after this.

This PR handles this by changing around the `if` statements - where we previously ended early if the emagged phrase list was empty, we now only perform an emagged phrase if the list has any length. (and if you're wondering - `length(null) == 0`)

## Why It's Good For The Game
Avoids potentially buggy behavior on admin-made mobs (or those made by downstreams).

Also has the benefit of makes the code shorter and easier to understand!

## Changelog
:cl:MichiRecRoom
fix: The cleaning AI behavior (generally used by cleanbots) will no longer return early if the list of emagged phrases is empty.
/:cl: