### PR TITLE
You can now craft multi-dimensional payloads with dimensional anomalies

### DIFF
--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -18,6 +18,14 @@
 /// Small vents, giving small boulders.
 #define SMALL_VENT_TYPE "small"
 
+//gibtonite strength
+/// Gibtonite was deactivated right before it could explode
+#define GIBTONITE_QUALITY_HIGH 3
+/// Gibtonite was deactivated a few seconds before it could explode
+#define GIBTONITE_QUALITY_MEDIUM 2
+/// Gibtonite was deactivated right after it was struck.
+#define GIBTONITE_QUALITY_LOW 1
+
 // Timers for the ore vents to perform wave defense.
 /// Duration for wave defense for a small vent.
 #define WAVE_DURATION_SMALL 60 SECONDS

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -440,7 +440,7 @@
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
-/datum/crafting_recipe/dismensional_bombcore
+/datum/crafting_recipe/dimensional_bombcore
 	name = "Multi-Dimensional Payload"
 	result = /obj/item/bombcore/dimensional
 	reqs = list(

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -439,3 +439,19 @@
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
+
+/datum/crafting_recipe/dismensional_bombcore
+	name = "Multi-Dimensional Payload"
+	result = /obj/item/bombcore/dimensional
+	reqs = list(
+		/obj/item/gibtonite = 1,
+		/obj/item/grenade/chem_grenade = 2,
+		/obj/item/assembly/signaler/anomaly/dimensional = 1,
+	)
+	parts = list(/obj/item/gibtonite = 1, /obj/item/grenade/chem_grenade = 2)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER)
+	time = 12 SECONDS
+	category = CAT_WEAPON_RANGED
+	steps = list(
+		"use high quality gibtonite and advanced release or large grenades for better yield",
+	)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -595,6 +595,23 @@
 	chosen_theme = null
 	return ..()
 
+/obj/item/bombcore/dimensional/CheckParts(list/parts_list)
+	. = ..()
+	var/new_range = 13
+	for(var/obj/item/grenade/chem_grenade/nade in src)
+		if(istype(nade, /obj/item/grenade/chem_grenade/large) || istype(nade, /obj/item/grenade/chem_grenade/adv_release))
+			new_range += 1
+		for(var/obj/item/thing as anything in nade.beakers) //remove beakers, then delete the grenade.
+			thing.forceMove(drop_location())
+		qdel(nade)
+	var/obj/item/gibtonite/ore = locate() in src
+	switch(ore.quality)
+		if(GIBTONITE_QUALITY_LOW)
+			new_range -= 2
+		if(GIBTONITE_QUALITY_HIGH)
+			new_range += 4
+	qdel(ore)
+
 /obj/item/bombcore/dimensional/examine(mob/user)
 	. = ..()
 	. += span_notice("Use in hand to change the linked dimension. Current dimension: [chosen_theme?.name || "None, output will be random"].")

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -597,19 +597,19 @@
 
 /obj/item/bombcore/dimensional/CheckParts(list/parts_list)
 	. = ..()
-	var/new_range = 13
+	range_heavy = 13
 	for(var/obj/item/grenade/chem_grenade/nade in src)
 		if(istype(nade, /obj/item/grenade/chem_grenade/large) || istype(nade, /obj/item/grenade/chem_grenade/adv_release))
-			new_range += 1
+			range_heavy += 1
 		for(var/obj/item/thing as anything in nade.beakers) //remove beakers, then delete the grenade.
 			thing.forceMove(drop_location())
 		qdel(nade)
 	var/obj/item/gibtonite/ore = locate() in src
 	switch(ore.quality)
 		if(GIBTONITE_QUALITY_LOW)
-			new_range -= 2
+			range_heavy -= 2
 		if(GIBTONITE_QUALITY_HIGH)
-			new_range += 4
+			range_heavy += 4
 	qdel(ore)
 
 /obj/item/bombcore/dimensional/examine(mob/user)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -655,9 +655,9 @@
 		if(!theme_to_use.can_convert(affected))
 			continue
 		num_affected++
-		var/skip_sound = TRUE
+		var/skip_sound = FALSE
 		if(num_affected % 5) //makes it play the sound more sparingly
-			skip_sound = FALSE
+			skip_sound = TRUE
 		var/time_mult = round(get_dist_euclidean(get_turf(src), affected)) + 1
 		addtimer(CALLBACK(theme_to_use, TYPE_PROC_REF(/datum/dimension_theme, apply_theme), affected, skip_sound, TRUE), 0.1 SECONDS * time_mult)
 	qdel(src)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -848,13 +848,13 @@
 		stage = GIBTONITE_DETONATE
 		explosion(bombturf, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 5, flame_range = 0, flash_range = 0, adminlog = FALSE, explosion_cause = src)
 	if(stage == GIBTONITE_STABLE) //Gibtonite deposit is now benign and extractable. Depending on how close you were to it blowing up before defusing, you get better quality ore.
-		var/obj/item/gibtonite/G = new (src)
+		var/obj/item/gibtonite/ore = new (src)
 		if(det_time <= 0)
-			G.quality = 3
-			G.icon_state = "gibtonite_3"
+			ore.quality = GIBTONITE_QUALITY_HIGH
+			ore.icon_state = "gibtonite_3"
 		if(det_time >= 1 && det_time <= 2)
-			G.quality = 2
-			G.icon_state = "gibtonite_2"
+			ore.quality = GIBTONITE_QUALITY_MEDIUM
+			ore.icon_state = "gibtonite_2"
 
 	var/flags = NONE
 	var/old_type = type

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -188,7 +188,7 @@
 			new /obj/item/clothing/suit/hooded/ian_costume(src)
 		if(67 to 68)
 			var/obj/item/gibtonite/free_bomb = new /obj/item/gibtonite(src)
-			free_bomb.quality = rand(1, 3)
+			free_bomb.quality = rand(GIBTONITE_QUALITY_LOW, GIBTONITE_QUALITY_HIGH)
 			free_bomb.GibtoniteReaction(null, "A secure loot closet has spawned a live")
 		if(69 to 70)
 			new /obj/item/stack/ore/bluespace_crystal(src, 5)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -1,8 +1,3 @@
-
-#define GIBTONITE_QUALITY_HIGH 3
-#define GIBTONITE_QUALITY_MEDIUM 2
-#define GIBTONITE_QUALITY_LOW 1
-
 #define ORESTACK_OVERLAYS_MAX 10
 
 /**********************Mineral ores**************************/
@@ -665,7 +660,4 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 
-#undef GIBTONITE_QUALITY_HIGH
-#undef GIBTONITE_QUALITY_LOW
-#undef GIBTONITE_QUALITY_MEDIUM
 #undef ORESTACK_OVERLAYS_MAX

--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -85,7 +85,7 @@
 
 /obj/item/assembly/signaler/anomaly/dimensional/Initialize(mapload)
 	. = ..()
-	var/static/list/recipes = list(/datum/crafting_recipe/dismensional_bombcore)
+	var/static/list/recipes = list(/datum/crafting_recipe/dimensional_bombcore)
 	AddElement(/datum/element/slapcrafting, recipes)
 
 /obj/item/assembly/signaler/anomaly/ectoplasm

--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -83,6 +83,11 @@
 	icon_state = "dimensional_core"
 	anomaly_type = /obj/effect/anomaly/dimensional
 
+/obj/item/assembly/signaler/anomaly/dimensional/Initialize(mapload)
+	. = ..()
+	var/static/list/recipes = list(/datum/crafting_recipe/dismensional_bombcore)
+	AddElement(/datum/element/slapcrafting, recipes)
+
 /obj/item/assembly/signaler/anomaly/ectoplasm
 	name = "\improper ectoplasm anomaly core"
 	desc = "The neutralized core of an ectoplasmic anomaly. When you hold it close, you can hear faint murmuring from inside. It'd probably be valuable for research."


### PR DESCRIPTION
## About The Pull Request
Remember the overpriced, rare bomb core from the black market, the one you can use to convert an area to pizza or plasma?
Looking back, I think I should've made it craftable with a dimensional anomaly rather than simply lock it to the back market, that was a real shame to its potential. Another thing, the power of the crafted dimensional bomb core varies with the strength of the gibtonite and if the grenade casings used are of large or advance release variants or not.

Using low power gibtonite (deactivated too hastily) results in a radius of 11 (not counting the epicenter) tiles, roughly 70% of what you would get from the blackmarket core (17 tiles).
Using a medium power gibtonite results in a radius of 13, or 82% of 17.
Using two advanced/large grenades results in a radius of 15, 88% of 17.
Using high power gibtonite results in a radius equal to the bm standard.
Using both high power gibtonite and advanced/large grenades results in a radius of 19, for a 11.5% increase from 17.

This is done so that using the anomaly to its fullest requires some steps beside the refined core itself, kinda in line with other anomaly tech but without filling the techweb with more clutter.

## Why It's Good For The Game
This gives an use to the dimensional anomaly core beside the reactive armor and bounties. If it ever becomes problematic, it can be easily tuned later.

## Changelog

:cl:
add: You can now craft multi-dimensional payloads with dimensional anomalies.
/:cl:
