### PR TITLE
some fixes for the heretic eldritch id

### DIFF
--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -151,8 +151,10 @@
 
 ///Deletes and nulls our portal pair
 /obj/item/card/id/advanced/heretic/proc/clear_portals()
-	QDEL_NULL(portal_one)
-	QDEL_NULL(portal_two)
+	if(!isnull(portal_one))
+		QDEL_NULL(portal_one)
+	if(!isnull(portal_two))
+		QDEL_NULL(portal_two)
 
 ///Clears portal references
 /obj/item/card/id/advanced/heretic/proc/clear_portal_refs()

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -220,8 +220,6 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/heretic/Destroy()
-	for(var/I in fused_ids)
-		log_world("[I] is in fusedids, value [fused_ids[I]]")
 	QDEL_LIST(fused_ids)
 	link = null
 	clear_portals()

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -220,7 +220,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/heretic/Destroy()
-	QDEL_LIST_ASSOC(fused_ids)
+	QDEL_LIST(fused_ids)
 	link = null
 	clear_portals()
 	return ..()

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -151,10 +151,8 @@
 
 ///Deletes and nulls our portal pair
 /obj/item/card/id/advanced/heretic/proc/clear_portals()
-	if(!isnull(portal_one))
-		QDEL_NULL(portal_one)
-	if(!isnull(portal_two))
-		QDEL_NULL(portal_two)
+	QDEL_NULL(portal_one)
+	QDEL_NULL(portal_two)
 
 ///Clears portal references
 /obj/item/card/id/advanced/heretic/proc/clear_portal_refs()

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -220,6 +220,8 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/heretic/Destroy()
+	for(var/I in fused_ids)
+		log_world("[I] is in fusedids, value [fused_ids[I]]")
 	QDEL_LIST(fused_ids)
 	link = null
 	clear_portals()

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -124,6 +124,9 @@
 	if(!cardname)
 		balloon_alert(user, "no options!")
 		return ..()
+	if(!user.is_holding(src))
+		to_chat(user, span_warning("You must be holding \the [src] to continue!"))
+		return
 	var/obj/item/card/id/card = fused_ids[cardname]
 	shapeshift(card)
 
@@ -137,6 +140,9 @@
 ///Changes our appearance to the passed ID card
 /obj/item/card/id/advanced/heretic/proc/shapeshift(obj/item/card/id/advanced/card)
 	trim = card.trim
+	if(!trim && ishuman(loc))
+		var/mob/living/carbon/human/wearing = loc
+		wearing.sec_hud_set_ID()
 	assignment = card.assignment
 	registered_age = card.registered_age
 	registered_name = card.registered_name
@@ -182,15 +188,15 @@
 		return //no self vore
 	fused_ids[card.name] = card
 	card.moveToNullspace()
-	playsound(drop_location(), 'sound/items/eatfood.ogg', rand(10,30), TRUE)
-	access += card.access
+	access |= card.access
 	if(!isnull(user))
+		playsound(drop_location(), 'sound/items/eatfood.ogg', rand(10,30), TRUE)
 		balloon_alert(user, "consumed card")
 
 /obj/item/card/id/advanced/heretic/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(!IS_HERETIC(user))
 		return NONE
-	if(istype(target, /obj/item/card/id))
+	if(istype(target, /obj/item/card/id/advanced))
 		eat_card(target, user)
 		return ITEM_INTERACT_SUCCESS
 	if(istype(target, /obj/effect/lock_portal))

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -137,7 +137,7 @@
 ///Changes our appearance to the passed ID card
 /obj/item/card/id/advanced/heretic/proc/shapeshift(obj/item/card/id/advanced/card)
 	trim = card.trim
-	if(!trim && ishuman(loc))
+	if(ishuman(loc))
 		var/mob/living/carbon/human/wearing = loc
 		wearing.sec_hud_set_ID()
 	assignment = card.assignment

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -124,9 +124,6 @@
 	if(!cardname)
 		balloon_alert(user, "no options!")
 		return ..()
-	if(!user.is_holding(src))
-		to_chat(user, span_warning("You must be holding \the [src] to continue!"))
-		return
 	var/obj/item/card/id/card = fused_ids[cardname]
 	shapeshift(card)
 

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -220,7 +220,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/heretic/Destroy()
-	QDEL_LIST(fused_ids)
+	QDEL_LIST_ASSOC_VAL(fused_ids)
 	link = null
 	clear_portals()
 	return ..()

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -91,18 +91,29 @@
 		You can ctrl-click the card to invert this behavior for created portals. \
 		Each card may only sustain a single pair of portals at the same time. \
 		It also functions and appears the same as a regular ID Card. \
-		Attacking it with a normal ID card consumes it and gains its access, and you can use it in-hand to change its appearance to a card you fused. \
-		Does not preserve the card originally used in the ritual."
+		Attacking it with a normal ID card consumes it and gains its access, and you can use it in-hand to change its appearance to a card you fused."
 	gain_text = "The Keeper sneered. \"These plastic rectangles are a mockery of keys, and I curse every door that desires them.\""
 	required_atoms = list(
 		/obj/item/storage/wallet = 1,
 		/obj/item/stack/rods = 1,
-		/obj/item/card/id = 1,
+		/obj/item/card/id/advanced = 1,
 	)
 	result_atoms = list(/obj/item/card/id/advanced/heretic)
 	cost = 1
 	research_tree_icon_path = 'icons/obj/card.dmi'
 	research_tree_icon_state = "card_gold"
+
+/datum/heretic_knowledge/key_ring/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	var/obj/item/card/id = locate(/obj/item/card/id/advanced) in selected_atoms
+	if(isnull(id))
+		return FALSE
+	var/obj/item/card/id/advanced/heretic/result_item = new(loc)
+	if(!istype(result_item))
+		return FALSE
+	selected_atoms -= id
+	result_item.eat_card(id)
+	result_item.shapeshift(id)
+	return TRUE
 
 /datum/heretic_knowledge/mark/lock_mark
 	name = "Mark of Lock"


### PR DESCRIPTION
## About The Pull Request

first and primarily the ritual preserves the ID card used
the id itself may not consume (and cant use in the ritual) non-advanced (advanced IDs are mainly the crew and whoever IDs) IDs because it wasnt intentional and it kinda breaks a few things and its such a super edge case to find a not advanced id and use it with the id
closes  #89697

## Why It's Good For The Game

makes the ritual not screw people over

## Changelog
:cl:
fix: the eldritch id (Lock path) now preserves the ID used.
/:cl:
