### PR TITLE
removes wildcard limit from agent IDs

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -28,12 +28,6 @@
 #define WILDCARD_LIMIT_CENTCOM list(WILDCARD_NAME_CENTCOM = list(limit = -1, usage = list()))
 /// Wildcard slot define for Prisoner orange cards. No wildcard slots.
 #define WILDCARD_LIMIT_PRISONER list()
-/// Wildcard slot define for Chameleon/Agent ID grey cards. Can hold 6 common, 2 command and 1 captain access.
-#define WILDCARD_LIMIT_CHAMELEON list( \
-	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
-	WILDCARD_NAME_CAPTAIN = list(limit = 1, usage = list()) \
-)
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.
 #define WILDCARD_LIMIT_ADMIN list(WILDCARD_NAME_ALL = list(limit = -1, usage = list()))
 

--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -28,6 +28,12 @@
 #define WILDCARD_LIMIT_CENTCOM list(WILDCARD_NAME_CENTCOM = list(limit = -1, usage = list()))
 /// Wildcard slot define for Prisoner orange cards. No wildcard slots.
 #define WILDCARD_LIMIT_PRISONER list()
+/// Wildcard slot define for the cargo variant of agent ID. Can hold 6 common, 2 command and 1 captain access.
+#define WILDCARD_LIMIT_CHAMELEON list( \
+	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
+	WILDCARD_NAME_CAPTAIN = list(limit = 1, usage = list()) \
+)
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.
 #define WILDCARD_LIMIT_ADMIN list(WILDCARD_NAME_ALL = list(limit = -1, usage = list()))
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1912,11 +1912,10 @@
 		return CONTEXTUAL_SCREENTIP_SET
 	return .
 
-/// A special variant of the classic chameleon ID card which accepts all access.
+/// A special variant of the classic chameleon ID card which is black. Cool!
 /obj/item/card/id/advanced/chameleon/black
 	icon_state = "card_black"
 	assigned_icon_state = "assigned_syndicate"
-	wildcard_slots = WILDCARD_LIMIT_GOLD
 
 /obj/item/card/id/advanced/engioutpost
 	registered_name = "George 'Plastic' Miller"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1621,7 +1621,7 @@
 	var/datum/weakref/theft_target
 
 /obj/item/card/id/advanced/chameleon/crummy
-	desc = "A surplus version of a chameleon ID card. Can only hold a limited number of access codes.
+	desc = "A surplus version of a chameleon ID card. Can only hold a limited number of access codes."
 	wildcard_slots = WILDCARD_LIMIT_CHAMELEON
 
 /obj/item/card/id/advanced/chameleon/Initialize(mapload)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1610,7 +1610,7 @@
 	desc = "A highly advanced chameleon ID card. Touch this card on another ID card or player to choose which accesses to copy. \
 		Has special magnetic properties which force it to the front of wallets."
 	trim = /datum/id_trim/chameleon
-	wildcard_slots = WILDCARD_LIMIT_CHAMELEON
+	wildcard_slots = WILDCARD_LIMIT_GOLD
 	actions_types = list(/datum/action/item_action/chameleon/change/id, /datum/action/item_action/chameleon/change/id_trim)
 
 	/// Have we set a custom name and job assignment, or will we use what we're given when we chameleon change?

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1620,6 +1620,10 @@
 	/// Weak ref to the ID card we're currently attempting to steal access from.
 	var/datum/weakref/theft_target
 
+/obj/item/card/id/advanced/chameleon/crummy
+	desc = "A surplus version of a chameleon ID card. Can only hold a limited number of access codes.
+	wildcard_slots = WILDCARD_LIMIT_CHAMELEON
+
 /obj/item/card/id/advanced/chameleon/Initialize(mapload)
 	. = ..()
 	register_item_context()

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -199,7 +199,7 @@
 		/obj/item/clothing/mask/chameleon,
 		/obj/item/clothing/under/chameleon,
 		/obj/item/storage/belt/chameleon,
-		/obj/item/card/id/advanced/chameleon,
+		/obj/item/card/id/advanced/chameleon/crummy,
 		/obj/item/switchblade,
 		/obj/item/grenade/mirage = 5,
 	)


### PR DESCRIPTION
## About The Pull Request

With the trim system added years ago, agent IDs have become essentially worthless. This is because they can only hold SIX COMMON ACCESSES, TWO COMMAND ACCESSES, AND ONE CAPTAIN LEVEL ACCESS. This leads to the current situation, where agent IDs are essentially legacy content included in certain bundles like Contractor, but ultimately go entirely unused, with players instead opting to simply steal ID cards off of people and juggle them around.

This PR makes them act more like they used to, where scanning an ID with one will let you take all of the access codes on the ID card, and add them to your agent ID.

## Why It's Good For The Game

Having your ID card stolen is extremely frustrating. It's also very frustrating for traitors to need to carry literally a box of stolen ID cards to have access to various parts of the station, and it also hinders stealthy gameplay, since the stealthy ID card doesn't actually hold access.

## Changelog
:cl:
balance: wildcard limits have been removed from Agent ID cards
balance: the specops crate gets a variation of the agent ID card which can only hold limited access (same as it is now)
/:cl:
