### PR TITLE
Fixes setting the emergency variable on request consoles

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -162,6 +162,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 		if("set_emergency")
 			if(emergency)
 				return
+			emergency = params["emergency"]
 			switch(params["emergency"])
 				if(REQ_EMERGENCY_SECURITY) //Security
 					aas_config_announce(/datum/aas_config_entry/rc_emergency, list("LOCATION" = department), null, list(RADIO_CHANNEL_SECURITY), REQ_EMERGENCY_SECURITY)


### PR DESCRIPTION
## About The Pull Request

The last automated announcer PR has accidentally erased a line that sets the stored emergency type of the requests console. This means the user gets no feedback on a successful emergency call, and also, the button can be spammed. This PR fixes that.

## Why It's Good For The Game
Closes #89665

## Changelog

:cl:
fix: Request consoles once again enter emergency mode when you hit an emergency button
/:cl:


