### PR TITLE
Fix some more HTML UIs for 516

### DIFF
--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -380,21 +380,15 @@
 		return
 	var/list/bans = sticky_banned_ckeys()
 	var/list/banhtml = list()
+	banhtml += "<h2>All Sticky Bans:</h2> <a href='byond://?_src_=holder;[HrefToken()];stickyban=add'>\[+\]</a><br>"
 	for(var/key in bans)
 		var/ckey = ckey(key)
 		banhtml += "<br /><hr />\n"
 		banhtml += stickyban_gethtml(ckey)
 
-	var/html = {"
-	<head>
-		<title>Sticky Bans</title>
-	</head>
-	<body>
-		<h2>All Sticky Bans:</h2> <a href='byond://?_src_=holder;[HrefToken()];stickyban=add'>\[+\]</a><br>
-		[banhtml.Join("")]
-	</body>
-	"}
-	usr << browse(html,"window=stickybans;size=700x400")
+	var/datum/browser/browser = new(usr, "stickybans", "Sticky Bans", 800, 500)
+	browser.set_content(jointext(banhtml, ""))
+	browser.open()
 
 /proc/sticky_banned_ckeys()
 	if (SSdbcore.Connect() || length(SSstickyban.dbcache))

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -83,13 +83,16 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			title = "Resolved Tickets"
 	if(!l2b)
 		return
-	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>[title]</title></head>")
-	dat += "<A href='byond://?_src_=holder;[HrefToken()];ahelp_tickets=[state]'>Refresh</A><br><br>"
+
+	var/list/parts = list()
+	parts += "<A href='byond://?_src_=holder;[HrefToken()];ahelp_tickets=[state]'>Refresh</A><br>"
 	for(var/I in l2b)
 		var/datum/admin_help/AH = I
-		dat += "[span_adminnotice("[span_adminhelp("Ticket #[AH.id]")]: <A href='byond://?_src_=holder;[HrefToken()];ahelp=[REF(AH)];ahelp_action=ticket'>[AH.initiator_key_name]: [AH.name]</A>")]<br>"
+		parts += "[span_adminnotice("[span_adminhelp("Ticket #[AH.id]")]: <A href='byond://?_src_=holder;[HrefToken()];ahelp=[REF(AH)];ahelp_action=ticket'>[AH.initiator_key_name]: [AH.name]</A>")]"
 
-	usr << browse(dat.Join(), "window=ahelp_list[state];size=600x480")
+	var/datum/browser/browser = new(usr, "help_list[state]", title, 600, 480)
+	browser.set_content(jointext(parts, "<br>"))
+	browser.open()
 
 //Tickets statpanel
 /datum/admin_help_tickets/proc/stat_entry()

--- a/code/modules/admin/verbs/list_exposer.dm
+++ b/code/modules/admin/verbs/list_exposer.dm
@@ -1,34 +1,35 @@
 // All the procs that admins can use to view something like a global list in a cleaner manner than just View Variables are contained in this file.
 
-/datum/admins/proc/list_bombers()
+
+/datum/admins/proc/list_investigate_log(list/log, name)
 	if(!SSticker.HasRoundStarted())
 		tgui_alert(usr, "The game hasn't started yet!")
 		return
-	var/data = "<b>Bombing List</b><hr>"
-	for(var/entry in GLOB.bombers)
-		data += "[entry]<br>"
-	usr << browse(data, "window=bombers;size=800x500")
+
+	var/title = "[full_capitalize(name)] Log"
+	var/parts = list()
+	if(length(log))
+		parts += "<b>Showing last [length(log)] [name]s.</b>"
+		parts += "<hr>"
+		parts += "<ul>"
+		for(var/entry in log)
+			parts += "<li>[entry]</li>"
+		parts += "</ul>"
+	else
+		parts += "<i>The [name] log is empty.</i>"
+
+	var/datum/browser/browser = new(usr, ckey(title), title, 800, 500)
+	browser.set_content(jointext(parts, ""))
+	browser.open()
+
+/datum/admins/proc/list_bombers()
+	list_investigate_log(GLOB.bombers, "bomber")
 
 /datum/admins/proc/list_signalers()
-	if(!SSticker.HasRoundStarted())
-		tgui_alert(usr, "The game hasn't started yet!")
-		return
-	var/data = "<b>Showing last [length(GLOB.investigate_signaler)] signalers.</b><hr>"
-	for(var/entry in GLOB.investigate_signaler)
-		data += "[entry]<BR>"
-	usr << browse(data, "window=lastsignalers;size=800x500")
+	list_investigate_log(GLOB.investigate_signaler, "signaler")
 
 /datum/admins/proc/list_law_changes()
-	if(!SSticker.HasRoundStarted())
-		tgui_alert(usr, "The game hasn't started yet!")
-		return
-	var/data = "<b>Showing last [length(GLOB.lawchanges)] law changes.</b><hr>"
-	for(var/entry in GLOB.lawchanges)
-		data += "[entry]<BR>"
-
-	var/datum/browser/browser = new(usr, "lawchanges", "Law Changes", 800, 500)
-	browser.set_content(data)
-	browser.open()
+	list_investigate_log(GLOB.lawchanges, "law change")
 
 /datum/admins/proc/list_dna()
 	var/data = "<b>Showing DNA from blood.</b><hr>"


### PR DESCRIPTION

## About The Pull Request

this fixes the Bomber, Signaler, and Law Change investigate UIs so they use `/datum/browser` and work on 516. I also refactored those 3 verbs to just use a shared proc, to avoid otherwise duplicated code between the 3.

I also fixed the stickyban panel and the ticket list.

<details>
<summary><h3>Testing Screenshots</h3></summary>


![2025-02-26 (1740612683)](https://github.com/user-attachments/assets/31242dce-4334-4c28-b813-ebdcdbcf43da)
![2025-02-26 (1740612665)](https://github.com/user-attachments/assets/e81961cb-7b1c-446b-9955-9bcf89bd2e49)
![2025-02-26 (1740612659)](https://github.com/user-attachments/assets/d50755fa-4e8d-4da6-a2b8-e8899830210c)
![2025-02-26 (1740612654)](https://github.com/user-attachments/assets/1cf63c71-3592-47d4-b6d0-40262a6a4a1c)
![2025-02-26 (1740612649)](https://github.com/user-attachments/assets/c555a0f5-9bcd-45a1-8935-0360165069ad)
![2025-02-26 (1740612646)](https://github.com/user-attachments/assets/86fd11a7-9eba-46dd-a638-8800ab236dd7)
![2025-02-26 (1740612640)](https://github.com/user-attachments/assets/0dcd25fc-6120-4856-910d-01a3c3325674)

</details>

## Why It's Good For The Game

things working on 516 is good

## Changelog
:cl:
fix: Fixed some admin UIs on BYOND 516.
/:cl:
