### PR TITLE
Fix (un)installing git hooks erroring if you have any global merge drivers

### DIFF
--- a/tools/hooks/install.py
+++ b/tools/hooks/install.py
@@ -49,6 +49,8 @@ def uninstall(target=None, keep=()):
 
     # Remove merge driver configuration
     for entry in repo.config:
+        if entry.level != pygit2.GIT_CONFIG_LEVEL_LOCAL:
+            continue
         match = re.match(r'^merge\.([^.]+)\.driver$', entry.name)
         if match and f"{match.group(1)}.merge" not in keep:
             print('Removing merge driver:', match.group(1))


### PR DESCRIPTION
## About The Pull Request

`tools/hooks/install.py` iterates through all git config entries, and tries to remove any merge drivers it finds.

However, this includes global `~/.gitconfig` entries and such, which will result in an error if you have any merge drivers defined in the global config.

I made it so it will only check local (`.git/config`) entries for merge drivers.

## Why It's Good For The Game

fixes a rare but still annoying edge-case error

## Changelog

No user-facing changes, this is only a fix for development tools.