### PR TITLE
Fundamentally Evil people hold no love in their hearts, and are allergic to it (feat. reagent allergies component)

### DIFF
--- a/code/datums/components/reagent_allergies.dm
+++ b/code/datums/components/reagent_allergies.dm
@@ -1,0 +1,41 @@
+
+/// Component used by plasmeme limbs. Ignites the owner and prevents fire armor from working if they're exposed to oxygen
+/datum/component/reagent_allergies
+	dupe_mode = COMPONENT_DUPE_ALLOWED
+	
+	/// List of reagent types we are allergic to
+	var/list/allergies
+
+/datum/component/reagent_allergies/Initialize(list/allergy_types)
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+	allergies = string_list(allergy_types)
+
+/datum/component/reagent_allergies/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_LIVING_LIFE, PROC_REF(on_life))
+
+/datum/component/reagent_allergies/proc/on_life(mob/living/carbon/human/owner, seconds_per_tick, times_fired)
+	if(HAS_TRAIT(owner, TRAIT_STASIS))
+		return
+	if(owner.stat == DEAD)
+		return
+
+	//Just halts the progression, I'd suggest you run to medbay asap to get it fixed
+	if(owner.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
+		for(var/allergy in allergies)
+			var/datum/reagent/instantiated_med = owner.reagents.has_reagent(allergy)
+			if(isnull(instantiated_med))
+				continue
+			instantiated_med.reagent_removal_skip_list |= ALLERGIC_REMOVAL_SKIP
+		return //block damage so long as epinephrine exists
+
+	for(var/allergy in allergies)
+		var/datum/reagent/instantiated_med = owner.reagents.has_reagent(allergy)
+		if(isnull(instantiated_med))
+			continue
+		instantiated_med.reagent_removal_skip_list -= ALLERGIC_REMOVAL_SKIP
+		owner.adjustToxLoss(3 * seconds_per_tick)
+		owner.reagents.add_reagent(/datum/reagent/toxin/histamine, 3 * seconds_per_tick)
+		if(SPT_PROB(10, seconds_per_tick))
+			owner.vomit(VOMIT_CATEGORY_DEFAULT)
+			owner.adjustOrganLoss(pick(ORGAN_SLOT_BRAIN, ORGAN_SLOT_APPENDIX, ORGAN_SLOT_LUNGS, ORGAN_SLOT_HEART, ORGAN_SLOT_LIVER, ORGAN_SLOT_STOMACH), 10)

--- a/code/datums/components/reagent_allergies.dm
+++ b/code/datums/components/reagent_allergies.dm
@@ -14,6 +14,9 @@
 /datum/component/reagent_allergies/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
+/datum/component/reagent_allergies/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_LIVING_LIFE)
+
 /datum/component/reagent_allergies/proc/on_life(mob/living/carbon/human/owner, seconds_per_tick, times_fired)
 	SIGNAL_HANDLER
 

--- a/code/datums/components/reagent_allergies.dm
+++ b/code/datums/components/reagent_allergies.dm
@@ -15,6 +15,8 @@
 	RegisterSignal(parent, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
 /datum/component/reagent_allergies/proc/on_life(mob/living/carbon/human/owner, seconds_per_tick, times_fired)
+	SIGNAL_HANDLER
+
 	if(HAS_TRAIT(owner, TRAIT_STASIS))
 		return
 	if(owner.stat == DEAD)

--- a/code/datums/components/reagent_allergies.dm
+++ b/code/datums/components/reagent_allergies.dm
@@ -24,14 +24,14 @@
 	if(owner.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
 		for(var/allergy in allergies)
 			var/datum/reagent/instantiated_med = owner.reagents.has_reagent(allergy)
-			if(isnull(instantiated_med))
+			if(!instantiated_med)
 				continue
 			instantiated_med.reagent_removal_skip_list |= ALLERGIC_REMOVAL_SKIP
 		return //block damage so long as epinephrine exists
 
 	for(var/allergy in allergies)
 		var/datum/reagent/instantiated_med = owner.reagents.has_reagent(allergy)
-		if(isnull(instantiated_med))
+		if(!instantiated_med)
 			continue
 		instantiated_med.reagent_removal_skip_list -= ALLERGIC_REMOVAL_SKIP
 		owner.adjustToxLoss(3 * seconds_per_tick)

--- a/code/datums/components/reagent_allergies.dm
+++ b/code/datums/components/reagent_allergies.dm
@@ -1,5 +1,5 @@
 
-/// Component used by plasmeme limbs. Ignites the owner and prevents fire armor from working if they're exposed to oxygen
+/// Component used to make a person allergic to a list of reagents
 /datum/component/reagent_allergies
 	dupe_mode = COMPONENT_DUPE_ALLOWED
 	

--- a/code/datums/components/reagent_allergies.dm
+++ b/code/datums/components/reagent_allergies.dm
@@ -7,7 +7,7 @@
 	var/list/allergies
 
 /datum/component/reagent_allergies/Initialize(list/allergy_types)
-	if(!isliving(parent))
+	if(!ishuman(parent))
 		return COMPONENT_INCOMPATIBLE
 	allergies = string_list(allergy_types)
 

--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -10,8 +10,11 @@
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
 	mail_goodies = list(/obj/item/reagent_containers/hypospray/medipen) // epinephrine medipen stops allergic reactions
 	no_process_traits = list(TRAIT_STASIS)
-	var/list/allergies = list()
-	var/list/blacklist = list(
+
+	/// Weak reference to the component handling our allergies
+	var/datum/weakref/added_allergies
+	/// Reagents we are blacklisted from rolling
+	var/static/list/blacklist = list(
 		/datum/reagent/medicine/c2,
 		/datum/reagent/medicine/epinephrine,
 		/datum/reagent/medicine/adminordrazine,
@@ -26,15 +29,17 @@
 
 /datum/quirk/item_quirk/allergic/add_unique(client/client_source)
 	var/list/chem_list = subtypesof(/datum/reagent/medicine) - blacklist
+	var/list/allergies = list()
 	var/list/allergy_chem_names = list()
 	for(var/i in 0 to 5)
 		var/datum/reagent/medicine/chem_type = pick_n_take(chem_list)
 		allergies += chem_type
 		allergy_chem_names += initial(chem_type.name)
+	added_allergies = WEAKREF(quirk_holder.AddComponent(/datum/component/reagent_allergies, allergy_types = allergies))
 
-	allergy_string = allergy_chem_names.Join(", ")
+	allergy_string = english_list(allergy_chem_names)
 	name = "Extreme [allergy_string] Allergies"
-	medical_record_text = "Patient's immune system responds violently to [allergy_string]"
+	medical_record_text = "Patient's immune system responds violently to [allergy_string]."
 
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/clothing/accessory/dogtag/allergy/dogtag = new(get_turf(human_holder), allergy_string)
@@ -45,24 +50,5 @@
 	quirk_holder.add_mob_memory(/datum/memory/key/quirk_allergy, allergy_string = allergy_string)
 	to_chat(quirk_holder, span_boldnotice("You are allergic to [allergy_string], make sure not to consume any of these!"))
 
-/datum/quirk/item_quirk/allergic/process(seconds_per_tick)
-	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
-	//Just halts the progression, I'd suggest you run to medbay asap to get it fixed
-	if(carbon_quirk_holder.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
-		for(var/allergy in allergies)
-			var/datum/reagent/instantiated_med = carbon_quirk_holder.reagents.has_reagent(allergy)
-			if(!instantiated_med)
-				continue
-			instantiated_med.reagent_removal_skip_list |= ALLERGIC_REMOVAL_SKIP
-		return //block damage so long as epinephrine exists
-
-	for(var/allergy in allergies)
-		var/datum/reagent/instantiated_med = carbon_quirk_holder.reagents.has_reagent(allergy)
-		if(!instantiated_med)
-			continue
-		instantiated_med.reagent_removal_skip_list -= ALLERGIC_REMOVAL_SKIP
-		carbon_quirk_holder.adjustToxLoss(3 * seconds_per_tick)
-		carbon_quirk_holder.reagents.add_reagent(/datum/reagent/toxin/histamine, 3 * seconds_per_tick)
-		if(SPT_PROB(10, seconds_per_tick))
-			carbon_quirk_holder.vomit(VOMIT_CATEGORY_DEFAULT)
-			carbon_quirk_holder.adjustOrganLoss(pick(ORGAN_SLOT_BRAIN,ORGAN_SLOT_APPENDIX,ORGAN_SLOT_LUNGS,ORGAN_SLOT_HEART,ORGAN_SLOT_LIVER,ORGAN_SLOT_STOMACH),10)
+/datum/quirk/item_quirk/allergic/remove()
+	QDEL_NULL(added_allergies)

--- a/code/datums/quirks/neutral_quirks/evil.dm
+++ b/code/datums/quirks/neutral_quirks/evil.dm
@@ -11,7 +11,23 @@
 	medical_record_text = "Patient has passed all our social fitness tests with flying colours, but had trouble on the empathy tests."
 	mail_goodies = list(/obj/item/food/grown/citrus/lemon)
 
+	/// Weak reference to the component handling our allergy to *love*
+	var/datum/weakref/added_allergies
+
+/datum/quirk/evil/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_quirkholder = quirk_holder
+	var/obj/item/organ/heart/holder_heart = human_quirkholder.get_organ_slot(ORGAN_SLOT_HEART)
+	if(isnull(holder_heart) || isnull(holder_heart.reagents))
+		return
+	// Our actions have evaporated all the love that was once in our heart
+	holder_heart.reagents.del_reagent(/datum/reagent/love)
+
 /datum/quirk/evil/post_add()
 	var/evil_policy = get_policy("[type]") || "Please note that while you may be [LOWER_TEXT(name)], this does NOT give you any additional right to attack people or cause chaos."
 	// We shouldn't need this, but it prevents people using it as a dumb excuse in ahelps.
 	to_chat(quirk_holder, span_big(span_info(evil_policy)))
+	// The power of love conquers all.
+	added_allergies = WEAKREF(quirk_holder.AddComponent(/datum/component/reagent_allergies, allergy_types = list(/datum/reagent/love)))
+
+/datum/quirk/item_quirk/allergic/remove()
+	QDEL_NULL(added_allergies)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1221,6 +1221,7 @@
 #include "code\datums\components\radioactive_exposure.dm"
 #include "code\datums\components\ranged_attacks.dm"
 #include "code\datums\components\ranged_mob_full_auto.dm"
+#include "code\datums\components\reagent_allergies.dm"
 #include "code\datums\components\reagent_refiller.dm"
 #include "code\datums\components\recharging_attacks.dm"
 #include "code\datums\components\redirect_attack_hand_from_turf.dm"


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin, for the most part.
This refactors the Extreme Medicine Allergies reagent allergy system onto a dupeable component, and slaps it onto Extreme Medicine Allergies and Fundamentally Evil, the latter now being allergic to love.
In line with that also removes the love chem from Fundamentally Evil people.

As a side it makes Extreme Medicine Allergies use `english_list(...)` and adds a missing period to its medical records text.
## Why It's Good For The Game

Spellchecks are self-explanatory.

Fundamentally Evil people having no love in their hearts is a funny parallel to Friendly people getting more love in their hearts.
I just think being allergic to love is funny and in line with their other interactions, really.
## Changelog
:cl:
add: Fundamentally Evil people are now allergic to love. Like the reagent, love.
balance: The hearts of Fundamentally Evil people are now utterly devoid of love.
spellcheck: Generated allergy list of extreme medicine allergies used for the chat message, memory, and medical records now is a proper list and uses 'and' for the final chem.
spellcheck: Medical records text for extreme medicine allergies actually ends on a period.
/:cl:
