### PR TITLE
Allow more complex regex for chat highlights

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -216,7 +216,8 @@ class ChatRenderer {
             str &&
             str.length > 1 &&
             // Must be alphanumeric (with some punctuation)
-            allowedRegex.test(str) &&
+            (allowedRegex.test(str) ||
+              (str.charAt(0) === '/' && str.charAt(str.length - 1) === '/')) &&
             // Reset lastIndex so it does not mess up the next word
             ((allowedRegex.lastIndex = 0) || true),
         );


### PR DESCRIPTION

## About The Pull Request

So, turns out, you couldn't actually do more complex regex in chat highlights, specifically because highlights got filtered by this regex:

```js
const allowedRegex = /^[a-zа-яё0-9_\-$/^[\s\]\\]+$/gi;
```

I discovered this while trying to use negative lookaheads in regex (to avoid matching different last names, as an example), and that regex filtered it out due to the use of parentheses.

I made it so the `allowedRegex.test(str)` isn't needed if the line is a regex (starts and ends with a `/`)

## Comparison

**Regex**:
```
/Shio(?=n)/
```

**Before fix**:
![2025-02-26 (1740632218) ~ dreamseeker](https://github.com/user-attachments/assets/517f1503-2f04-4290-946e-52ce1d26986c)

**After fix**:
![image](https://github.com/user-attachments/assets/199b8fee-c3bc-4204-bfa7-ab8b0c32e964)

## Why It's Good For The Game

i am a masochist who writes complex regex and want to use that in spess

## Changelog
:cl:
fix: Fixed more advanced regex-based chat highlights not working.
/:cl:
