### PR TITLE
Removes redundant MySQL Server

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -27,14 +27,6 @@ jobs:
     name: Run Tests (${{ inputs.major && format('{0}.{1}; ', inputs.major, inputs.minor) || '' }}${{ inputs.map }}; ${{ inputs.max_required_byond_client }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
       - name: Setup database


### PR DESCRIPTION
Port of https://github.com/DaedalusDock/daedalusdock/pull/1220
## About The Pull Request

Test runs bleed ~26 seconds on average starting a completely unused and misconfigured MySQL Docker container. Let's.... Not do that?

## Why It's Good For The Repository

TG tests 10 maps, at 26 seconds each, that's 260 seconds of pointless time.

## Changelog
No User-Facing Changes
