### PR TITLE
Fixes a runtime preventing cyborg dogtag quirk from working roundstart

### DIFF
--- a/code/datums/quirks/neutral_quirks/borg_ready.dm
+++ b/code/datums/quirks/neutral_quirks/borg_ready.dm
@@ -8,7 +8,7 @@
 	medical_record_text = "Patient is a registered brain donor for Robotics research."
 
 /datum/quirk/item_quirk/borg_ready/add_unique(client/client_source)
-	if(is_banned_from(quirk_holder.ckey, JOB_CYBORG))
+	if(is_banned_from(client_source.ckey, JOB_CYBORG))
 		return FALSE
 	var/obj/item/clothing/accessory/dogtag/borg_ready/borgtag = new(get_turf(quirk_holder))
 	give_item_to_holder(borgtag, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))


### PR DESCRIPTION
## About The Pull Request

Mob ckey is null roundstart as players are still new_player mobs at this point, but valid post-roundstart when quirks are initialized.

## Changelog
:cl:
fix: Roundstart crew will receive their Cyborg Pre-screening dogtags as intended
/:cl:
