### PR TITLE
Fixes Deathloop For AIs Who Died of Powerloss

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -13,7 +13,7 @@
 		view_core()
 
 	// Handle power damage (oxy)
-	if (battery <= 0)
+	if (battery <= 0 && lacks_power())
 		to_chat(src, span_warning("Your backup battery's output drops below usable levels. It takes only a moment longer for your systems to fail, corrupted and unusable."))
 		adjustOxyLoss(200)
 


### PR DESCRIPTION

## About The Pull Request
Makes it check to make sure the AI doesnt have power before killing the AI for not having power. Right now if an AI dies of no battery and you fix restore it, it has a 50/50 chance of dying as soon at it's revived, and a 100% chance of dying if you put it back in its core. Making a new core seems to fix it but that sucks and is annoying.

Used to be handled with the power routine thing but I'm reliably informed that handling it that way breaks something with the APC charger upgrade, so I'm doing it by just straight checking for power before killing the AI. Have tested with the upgrade and everything seems to work properly. AI dies when it should, and survives when it should.
## Why It's Good For The Game
Deathloops are bad.
## Changelog
:cl:
fix: AI will no longer deathloop after being revived with 0 backup power.
/:cl:
