### PR TITLE
Adds a couple of absent turf nullchecks

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -246,6 +246,8 @@ multiple modular subtrees with behaviors
  * Returns AI_STATUS_ON otherwise.
  */
 /datum/ai_controller/proc/get_expected_ai_status()
+	if (isnull(get_turf(pawn)))
+		return AI_STATUS_OFF
 
 	if (!ismob(pawn))
 		return AI_STATUS_ON

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -210,6 +210,9 @@
 
 /// Validates that the teleport being attempted is valid or not
 /proc/check_teleport_valid(atom/teleported_atom, atom/destination, channel, atom/original_destination = null)
+	if(isnull(destination))
+		return FALSE // Teleporting FROM nullspace is fine, but TO nullspace is not
+
 	var/area/origin_area = get_area(teleported_atom)
 	var/turf/origin_turf = get_turf(teleported_atom)
 

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -324,7 +324,7 @@
 
 /obj/item/warp_cube/attack_self(mob/user)
 	var/turf/current_location = get_turf(user)
-	if(!linked || !check_teleport_valid(src, current_location))
+	if(!linked || isnull(get_turf(linked)) || !check_teleport_valid(src, current_location))
 		to_chat(user, span_warning("[src] fizzles uselessly."))
 		return
 	if(teleporting)
@@ -341,7 +341,7 @@
 	if(QDELETED(user))
 		qdel(link_holder)
 		return
-	if(QDELETED(linked))
+	if(QDELETED(linked) || isnull(get_turf(linked)))
 		user.forceMove(get_turf(link_holder))
 		qdel(link_holder)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes a handful of minor misc issues detected while trying to break #89591

These are basically summed up as:
- check_teleport_valid (used in a couple of places) never actually nullchecked the destination then runtimes later if it is null. We'd rather it just returns false if you're trying to teleport to nowhere I think.
- Warp Cubes (a mining item) did something similar if one of them ended up in nullspace somehow.
- AI controllers in nullspace would runtime repeatedly while trying to check their Z level, we never want an AI controller to be awake in nullspace so we'll just tell them to shut off in there.

Sometimes items and mobs go to nullspace for holding reasons, but I don't think any of these were commonly encountered issues.

## Changelog

:cl:
fix: The Warp Cube will now fail if it tries to teleport you to nowhere, instead of turning you blue and then failing
/:cl:

I don't know if the other ones were actually player facing they just runtimed