### PR TITLE
Fix hauntinum reagent to work when exposed to item objects

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3161,10 +3161,12 @@
 //gives 15 seconds of haunting effect for every unit of it that touches an object
 /datum/reagent/hauntium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
+	if(!isitem(exposed_obj))
+		return
 	if(HAS_TRAIT_FROM(exposed_obj, TRAIT_HAUNTED, HAUNTIUM_REAGENT_TRAIT))
 		return
 	exposed_obj.make_haunted(HAUNTIUM_REAGENT_TRAIT, "#f8f8ff")
-	addtimer(CALLBACK(exposed_obj, TYPE_PROC_REF(/atom/movable/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), volume * 20 SECONDS)
+	addtimer(CALLBACK(exposed_obj, TYPE_PROC_REF(/atom/movable/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), reac_volume * 20 SECONDS)
 
 /datum/reagent/hauntium/on_mob_metabolize(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3158,7 +3158,7 @@
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-//gives 15 seconds of haunting effect for every unit of it that touches an object
+//gives 20 seconds of haunting effect for every unit of it that touches an object
 /datum/reagent/hauntium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
 	if(!isitem(exposed_obj))


### PR DESCRIPTION

## About The Pull Request
Hauntium would cause a bunch of runtimes if it was exposed to objects on a tile that weren't items. (structures, machinery, etc.) This was due to the element rejecting non-item objects and forcing a crash message. 

It also had used the wrong reagent volume settings to determine when it should remove the effect. This caused it to instantly remove the haunted effect as soon as it was applied.

Although I would have loved to adjust the length of time per reagent to not be stupidly OP (20 secs per 1u) I feel like that's touching balance.

## Why It's Good For The Game
Code that breaks is bad.

## Changelog
:cl:
fix: Fix hauntinum reagent to work when it is exposed to item objects.
/:cl:
