### PR TITLE
Fix ion storms having a 25% chance to wipe the ai (3 year old bug)

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -36,10 +36,8 @@
 		M.laws_sanity_check()
 		if(M.stat != DEAD && !M.incapacitated)
 			if(prob(replaceLawsetChance))
-				var/datum/ai_laws/ion_lawset = pick_weighted_lawset()
-				// pick_weighted_lawset gives us a typepath,
-				// so we have to instantiate it to access its laws
-				ion_lawset = new()
+				var/ion_lawset_type = pick_weighted_lawset()
+				var/datum/ai_laws/ion_lawset = new ion_lawset_type()
 				// our inherent laws now becomes the picked lawset's laws!
 				M.laws.inherent = ion_lawset.inherent.Copy()
 				// and clean up after.


### PR DESCRIPTION
## About The Pull Request

It was setting the ai's lawset to a blank lawset rather than the selected replacement


## Changelog

:cl: Melbert
fix: Ion Storms should be far far far less likely to purge ais and far far far more likely to replace the ai's lawset with a new set
/:cl:


