### PR TITLE
Fix illiterate people writing messages with crayons and spraycans

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -316,7 +316,7 @@
 		ui = new(user, src, "Crayon", name)
 		ui.open()
 
-/obj/item/toy/crayon/proc/staticDrawables()
+/obj/item/toy/crayon/proc/staticDrawables(is_literate_user)
 	. = list()
 
 	var/list/g_items = list()
@@ -352,20 +352,23 @@
 	var/list/rand_items = list()
 	. += list(list(name = "Random", "items" = rand_items))
 	for(var/i in randoms)
+		if(!is_literate_user) // no spelling allowed
+			if(i == RANDOM_LETTER || i == RANDOM_NUMBER || i == RANDOM_PUNCTUATION)
+				continue
 		rand_items += list(list("item" = i))
 
+/obj/item/toy/crayon/ui_data(mob/user)
+	var/list/crayon_drawables
+	var/is_literate_user = user.is_literate()
 
-/obj/item/toy/crayon/ui_data()
-	var/static/list/crayon_drawables
-
-	if (!crayon_drawables)
-		crayon_drawables = staticDrawables()
+	if(!crayon_drawables)
+		crayon_drawables = staticDrawables(is_literate_user)
 
 	. = list()
 	.["drawables"] = crayon_drawables
 	.["selected_stencil"] = drawtype
 	.["text_buffer"] = text_buffer
-
+	.["is_literate_user"] = is_literate_user
 	.["has_cap"] = has_cap
 	.["is_capped"] = is_capped
 	.["can_change_colour"] = can_change_colour

--- a/tgui/packages/tgui/interfaces/Crayon.tsx
+++ b/tgui/packages/tgui/interfaces/Crayon.tsx
@@ -11,6 +11,7 @@ type Data = {
   drawables: Drawable[];
   is_capped: BooleanLike;
   selected_stencil: string;
+  is_literate_user: BooleanLike;
   text_buffer: string;
 };
 
@@ -27,6 +28,7 @@ export const Crayon = (props) => {
     drawables = [],
     is_capped,
     selected_stencil,
+    is_literate_user,
     text_buffer,
   } = data;
   const capOrChanges = has_cap || can_change_colour;
@@ -78,14 +80,16 @@ export const Crayon = (props) => {
             })}
           </LabeledList>
         </Section>
-        <Section title="Text">
-          <LabeledList>
-            <LabeledList.Item label="Current Buffer">
-              {text_buffer}
-            </LabeledList.Item>
-          </LabeledList>
-          <Button content="New Text" onClick={() => act('enter_text')} />
-        </Section>
+        {!!is_literate_user && (
+          <Section title="Text">
+            <LabeledList>
+              <LabeledList.Item label="Current Buffer">
+                {text_buffer}
+              </LabeledList.Item>
+            </LabeledList>
+            <Button content="New Text" onClick={() => act('enter_text')} />
+          </Section>
+        )}
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION

## About The Pull Request
Right now people can use crayons and spraycans to write messages on the floor to communicate while being illiterate. While this is kinda funny, it does defeat the purpose of this quirk which is to disable nonverbal communication methods.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix illiterate people writing messages with crayons and spraycans.
/:cl:
