### PR TITLE
Fix invalid code in pipe's `set_init_directions()`

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		for (var/i in 1 to 4)
 			if (init_dir & j)
 				volume += UNARY_PIPE_VOLUME
-			j << 1
+			j <<= 1
 		volume = max(volume, UNARY_PIPE_VOLUME * 2) // Minimum 2 directions
 	else
 		initialize_directions = ALL_CARDINALS


### PR DESCRIPTION

## About The Pull Request

I discovered this due to OpenDream erroring on the invalid output operation. This code is trying to do `1 << 1` which is equivalent to a no-op. The code appears to intend `j <<= 1` which will actually cycle through directions.

## Why It's Good For The Game

Probably fixes the volume of some pipes somewhere.
