### PR TITLE
Make too low vols and no soundin scream for playsound instead of failing silently

### DIFF
--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -40,14 +40,18 @@
 			footstep_sounds = GLOB.footstep
 		if(FOOTSTEP_MOB_RUST)
 			footstep_sounds = 'sound/effects/footstep/rustystep1.ogg'
+			volume = 90*volume
 		if(FOOTSTEP_MOB_SLIME)
 			footstep_sounds = 'sound/effects/footstep/slime1.ogg'
+			volume = 90*volume
 		if(FOOTSTEP_OBJ_MACHINE)
 			footstep_sounds = 'sound/effects/bang.ogg'
+			volume = 90*volume
 			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(play_simplestep_machine))
 			return
 		if(FOOTSTEP_OBJ_ROBOT)
 			footstep_sounds = 'sound/effects/tank_treads.ogg'
+			volume = 90*volume
 			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(play_simplestep_machine))
 			return
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(play_simplestep))
@@ -126,6 +130,7 @@
 		return
 
 	if(isfile(footstep_sounds) || istext(footstep_sounds))
+		/// the volume for this is defined on attach when the sound gets set footstep_sounds
 		playsound(source.loc, footstep_sounds, volume, falloff_distance = 1, vary = sound_vary)
 		return
 

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -40,18 +40,18 @@
 			footstep_sounds = GLOB.footstep
 		if(FOOTSTEP_MOB_RUST)
 			footstep_sounds = 'sound/effects/footstep/rustystep1.ogg'
-			volume = 90*volume
+			src.volume = 90*volume
 		if(FOOTSTEP_MOB_SLIME)
 			footstep_sounds = 'sound/effects/footstep/slime1.ogg'
-			volume = 90*volume
+			src.volume = 90*volume
 		if(FOOTSTEP_OBJ_MACHINE)
 			footstep_sounds = 'sound/effects/bang.ogg'
-			volume = 90*volume
+			src.volume = 90*volume
 			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(play_simplestep_machine))
 			return
 		if(FOOTSTEP_OBJ_ROBOT)
 			footstep_sounds = 'sound/effects/tank_treads.ogg'
-			volume = 90*volume
+			src.volume = 90*volume
 			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(play_simplestep_machine))
 			return
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(play_simplestep))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -859,7 +859,8 @@
 		if(throw_drop_sound)
 			playsound(src, throw_drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE, vary = sound_vary)
 			return
-		playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE, vary = sound_vary)
+		else if(drop_sound)
+			playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE, vary = sound_vary)
 		return
 
 	if(.) //it's been caught.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -694,7 +694,7 @@
 	item_flags &= ~IN_INVENTORY
 	UnregisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_NO_WORN_ICON), SIGNAL_REMOVETRAIT(TRAIT_NO_WORN_ICON)))
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
-	if(!silent)
+	if(!silent && drop_sound)
 		playsound(src, drop_sound, DROP_SOUND_VOLUME, vary = sound_vary, ignore_walls = FALSE)
 	user?.update_equipment_speed_mods()
 
@@ -761,7 +761,7 @@
 	if(!initial)
 		if(equip_sound && (slot_flags & slot))
 			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE)
-		else if(slot & ITEM_SLOT_HANDS)
+		else if(slot & ITEM_SLOT_HANDS && pickup_sound)
 			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, sound_vary, ignore_walls = FALSE)
 	user.update_equipment_speed_mods()
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -867,6 +867,8 @@
 		return
 
 	var/volume = get_volume_by_throwforce_and_or_w_class()
+	if(!volume)
+		return
 	if (throwforce > 0 || HAS_TRAIT(src, TRAIT_CUSTOM_TAP_SOUND))
 		if (mob_throw_hit_sound)
 			playsound(hit_atom, mob_throw_hit_sound, volume, TRUE, -1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -877,7 +877,7 @@
 		else
 			playsound(hit_atom, 'sound/items/weapons/genhit.ogg',volume, TRUE, -1)
 	else
-		playsound(hit_atom, 'sound/items/weapons/throwtap.ogg', 1, volume, -1)
+		playsound(hit_atom, 'sound/items/weapons/throwtap.ogg', volume, TRUE, -1)
 
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, gentle = FALSE, quickstart = TRUE)
 	if(HAS_TRAIT(src, TRAIT_NODROP))

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -46,12 +46,14 @@
 	if(islist(soundin))
 		CRASH("playsound(): soundin attempted to pass a list! Consider using pick()")
 
-	var/turf/turf_source = get_turf(source)
-
-	if (!turf_source || !soundin || !vol)
-		return
+	if(!soundin)
+		CRASH("playsound(): no soundin passed")
 
 	if(vol < SOUND_AUDIBLE_VOLUME_MIN) // never let sound go below SOUND_AUDIBLE_VOLUME_MIN or bad things will happen
+		CRASH("playsound(): volume below SOUND_AUDIBLE_VOLUME_MIN. [vol] < [SOUND_AUDIBLE_VOLUME_MIN]")
+
+	var/turf/turf_source = get_turf(source)
+	if (!turf_source)
 		return
 
 	//allocate a channel if necessary now so its the same for everyone

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -182,7 +182,7 @@
 		return clamp((throwforce + w_class) * 5, 30, 100)// Add the item's throwforce to its weight class and multiply by 5, then clamp the value between 30 and 100
 	if(w_class)
 		return clamp(w_class * 8, 20, 100) // Multiply the item's weight class by 8, then clamp the value between 20 and 100
-	return 0
+	return 0 // plays no sound
 
 /mob/living/proc/set_combat_mode(new_mode, silent = TRUE)
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -378,7 +378,8 @@
 
 	///even INVOCATION_NONE should go through this because the signal might change that
 	invocation(invoker)
-	playsound(invoker, sound, 50, vary = TRUE)
+	if(sound)
+		playsound(invoker, sound, 50, vary = TRUE)
 
 /// The invocation that accompanies the spell, called from spell_feedback() before cast().
 /datum/action/cooldown/spell/proc/invocation(mob/living/invoker)


### PR DESCRIPTION
…ing silently
## About The Pull Request
While reviewing the recent sound optimization PR I noticed that a bunch of checks here really make no sense to just fail silently when nobody should be doing this in the first place

Immediately started screaming on run so thats a good sign

## Changelog
:cl:
code: previously silent failures due to empty sounds or too low volumes will now create a runtime in the runtime log
fix: some footstep sounds like robotic or slimes are no longer silent
/:cl:
