### PR TITLE
Fix random TGchat BSOD on 516

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -83,7 +83,7 @@ const handleImageError = (e) => {
   setTimeout(() => {
     /** @type {HTMLImageElement} */
     const node = e.target;
-    if(!node) {
+    if (!node) {
       return;
     }
     const attempts = parseInt(node.getAttribute('data-reload-n'), 10) || 0;

--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -83,6 +83,9 @@ const handleImageError = (e) => {
   setTimeout(() => {
     /** @type {HTMLImageElement} */
     const node = e.target;
+    if(!node) {
+      return;
+    }
     const attempts = parseInt(node.getAttribute('data-reload-n'), 10) || 0;
     if (attempts >= IMAGE_RETRY_LIMIT) {
       logger.error(`failed to load an image after ${attempts} attempts`);

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -22,6 +22,7 @@ img {
 img.icon {
   height: 1em;
   min-height: 16px;
+  min-width: 16px;
   width: auto;
   vertical-align: bottom;
 }


### PR DESCRIPTION
## About The Pull Request
Fixing random chat BSOD on 516

Proof of BSOD
![image](https://github.com/user-attachments/assets/e9fdcf45-637e-4adf-9dff-f49cd3a2483b)

And also adds min image width, so icons will not make text "flexing"

## Why It's Good For The Game
No BSOD on 516

## Changelog

:cl:
fix: Fixed random chat BSOD on Byond 516
/:cl:

