### PR TITLE
Harvesting botany plants now uses `drop_location()` instead of `loc`

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -208,7 +208,7 @@
 	///List of plants all harvested from the same batch.
 	var/list/result = list()
 	///Tile of the harvester to deposit the growables.
-	var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
+	var/output_loc = parent.Adjacent(user) ? user.drop_location() : parent.drop_location() //needed for TK
 	///Name of the grown products.
 	var/product_name
 	///The Number of products produced by the plant, typically the yield. Modified by certain traits.


### PR DESCRIPTION

## About The Pull Request

So previously harvesting botany plants would use `user.loc` if you were adjacent. This, however, caused the issue where a monkey hardworker on a ~~bug~~ big manipulator harvesting plants would send them directly into the contents of the big manipulator they're riding.
Here we just make it use `drop_location()`, so it actually drops in a valid location.
## Why It's Good For The Game

Fix jank :+1:
## Changelog
:cl:
fix: Harvesting botany plants actually uses the right drop location. Botany plants harvested by monkey hardworkers on big manipulators harvesting using a full plant bag no longer puts the resulting items inside of the big manipulator.
/:cl:
