### PR TITLE
Readds Swarmers (Helper turf procs)

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -478,9 +478,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 ///Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes.
 /turf/proc/is_nearby_planetary_atmos()
 	. = FALSE
-	for(var/t in RANGE_TURFS(1, src))
-		if(!isopenturf(t))
-			continue
-		var/turf/open/turf_adjacent = t
+	for(var/turf/open/turf_adjacent in RANGE_TURFS(1, src))
 		if(turf_adjacent.planetary_atmos)
 			return TRUE

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -462,7 +462,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return blueprint_data_returned
 
 /// Returns the diffrence in pressure between a turf from surrounding turfs
-
 /turf/proc/return_turf_delta_p()
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY //Freaking terrified to use INFINITY, man

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -477,7 +477,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 ///Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes.
 /turf/proc/is_nearby_planetary_atmos()
-	. = FALSE
 	for(var/turf/open/turf_adjacent in RANGE_TURFS(1, src))
 		if(turf_adjacent.planetary_atmos)
 			return TRUE

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -480,3 +480,4 @@ Turf and target are separate in case you want to teleport some distance from a t
 	for(var/turf/open/turf_adjacent in RANGE_TURFS(1, src))
 		if(turf_adjacent.planetary_atmos)
 			return TRUE
+	return FALSE

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -466,10 +466,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 /turf/proc/return_turf_delta_p()
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY //Freaking terrified to use INFINITY, man
-	for(var/t in RANGE_TURFS(1, src)) //Begin processing the delta pressure across the wall.
-		var/turf/open/turf_adjacent = t
-		if(!istype(turf_adjacent))
-			continue
+	for(var/turf/open/turf_adjacent in RANGE_TURFS(1, src)) //Begin processing the delta pressure across the wall.
 		pressure_greatest = max(pressure_greatest, turf_adjacent.air.return_pressure())
 		pressure_smallest = min(pressure_smallest, turf_adjacent.air.return_pressure())
 

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -461,6 +461,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 			blueprint_data_returned += nearby_turf.blueprint_data
 	return blueprint_data_returned
 
+/// Returns the diffrence in pressure between a turf from surrounding turfs
+
 /turf/proc/return_turf_delta_p()
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY //Freaking terrified to use INFINITY, man

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -460,3 +460,25 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if(nearby_turf.blueprint_data)
 			blueprint_data_returned += nearby_turf.blueprint_data
 	return blueprint_data_returned
+
+/turf/proc/return_turf_delta_p()
+	var/pressure_greatest = 0
+	var/pressure_smallest = INFINITY //Freaking terrified to use INFINITY, man
+	for(var/t in RANGE_TURFS(1, src)) //Begin processing the delta pressure across the wall.
+		var/turf/open/turf_adjacent = t
+		if(!istype(turf_adjacent))
+			continue
+		pressure_greatest = max(pressure_greatest, turf_adjacent.air.return_pressure())
+		pressure_smallest = min(pressure_smallest, turf_adjacent.air.return_pressure())
+
+	return pressure_greatest - pressure_smallest
+
+///Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes.
+/turf/proc/is_nearby_planetary_atmos()
+	. = FALSE
+	for(var/t in RANGE_TURFS(1, src))
+		if(!isopenturf(t))
+			continue
+		var/turf/open/turf_adjacent = t
+		if(turf_adjacent.planetary_atmos)
+			return TRUE


### PR DESCRIPTION
## About The Pull Request

Readds the helper turf procs that swarmers had. return_turf_delta_p() and is_nearby_planetary_atmos()

We lost what was once great in #63989. Not swarmers tho, they were trash.
## Why It's Good For The Game

This was actually a pretty solid way to check for wall safety. 

## Changelog

:cl:
code: Readds return_turf_delta_p() and is_nearby_planetary_atmos() as turf helpers.
/:cl:

