### PR TITLE
Fix the component printer not showing item icons in its UI

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -88,7 +88,8 @@
 
 /obj/machinery/component_printer/ui_assets(mob/user)
 	return list(
-		get_asset_datum(/datum/asset/spritesheet/sheetmaterials)
+		get_asset_datum(/datum/asset/spritesheet/sheetmaterials),
+		get_asset_datum(/datum/asset/spritesheet/research_designs)
 	)
 
 /obj/machinery/component_printer/RefreshParts()


### PR DESCRIPTION
## About The Pull Request
Whilst testing a PR for Monkestation, I found out the component printer wasn't showing icons for the items in its UI. This PR fixes that.

In fairness, the icons don't really do much here - most of the component printer designs are the same icon (screenshot taken from monkestation):

![image](https://github.com/user-attachments/assets/af81ce46-4351-467b-bc72-3ec95cd60ca1)

But they're already in the asset datum, and it makes this UI look a little nicer, so why not use them?

## Why It's Good For The Game
Makes this UI more consistent with other UIs that look like it (i.e. the protolathe).

## Changelog

:cl:MichiRecRoom
fix: The component printer now shows icons for the items in its UI.
/:cl: