### PR TITLE
[NO GBP] Fixes external organs not being colored by colorful reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2232,7 +2232,7 @@
 	. = ..()
 	var/picked_color = pick(random_color_list)
 	var/color_filter = color_transition_filter(picked_color, SATURATION_OVERRIDE)
-	if (can_color_clothing && (methods & TOUCH|VAPOR|INHALE))
+	if (can_color_clothing && (methods & (TOUCH|VAPOR|INHALE)))
 		var/include_flags = INCLUDE_HELD|INCLUDE_ACCESSORIES
 		if (methods & VAPOR|INHALE)
 			include_flags |= INCLUDE_POCKETS
@@ -2252,15 +2252,13 @@
 		exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 		return
 
-	if (!(methods & TOUCH|VAPOR|INHALE))
-		return
-
 	var/mob/living/carbon/exposed_carbon = exposed_mob
-	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
-		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
 	for (var/obj/item/organ/organ as anything in exposed_carbon.organs)
 		organ.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
+
+	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
+		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
 /datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1017,6 +1017,10 @@
 			actual_color = apply_matrix_to_color(COLOR_WHITE, color_filter["color"], color_filter["space"] || COLORSPACE_RGB)
 		add_color_override(actual_color, LIMB_COLOR_ATOM_COLOR + i)
 	update_limb()
+	// Recolors mutant overlays to match new mutant colors
+	for(var/datum/bodypart_overlay/mutant/overlay in bodypart_overlays)
+		overlay.inherit_color(src, force = TRUE)
+	// Update either owner's bodyparts or our icon if we don't have one
 	if (owner)
 		owner.update_body_parts()
 	else


### PR DESCRIPTION

## About The Pull Request
Closes #89209
Also fixed clothing being colored on ingestion, and removed a nonfunctional check which I didn't notice because, well, it was nonfunctional (otherwise only splashing would color you, which isn't what I was aiming with the original PR)

## Changelog
:cl:
fix: Fixed external organs not being colored by colorful reagent
/:cl:
