### PR TITLE
Fixes borgs not being able to navigate through access restricted doors

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -495,3 +495,6 @@
 	law_list += laws.get_law_list(include_zeroth = TRUE, render_html = FALSE)
 	for(var/borg_laws in law_list)
 		. += borg_laws
+
+/mob/living/silicon/get_access()
+	return REGION_ACCESS_ALL_GLOBAL

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -497,4 +497,4 @@
 		. += borg_laws
 
 /mob/living/silicon/get_access()
-	return REGION_ACCESS_ALL_GLOBAL
+	return REGION_ACCESS_ALL_STATION

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -486,3 +486,6 @@
 /mob/living/silicon/pai/proc/remove_messenger_ability()
 	if(messenger_ability)
 		messenger_ability.Remove(src)
+
+/mob/living/silicon/pai/get_access()
+	return list()


### PR DESCRIPTION

## About The Pull Request
Currently if a borg attempts to use nav to access a waypoint in a restricted area of the station (brig for example) it will fail with "no valid path with current access" because get_access on a borg return nothing because they don't have an ID. get_access for silicons will now return all station accesses.
## Why It's Good For The Game

Borgs need to find things, and not being able to nav into any restricted areas is annoying.
## Changelog
:cl:
add: Added the ability for borgs to pathfind into and through restricted areas.
/:cl:
