### PR TITLE
gives the smartgun aimbot

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -67,6 +67,8 @@
 	icon_state = "smartgun_casing"
 	caliber = CALIBER_160SMART
 	projectile_type = /obj/projectile/bullet/c160smart
+	/// How many tiles away should we check for smart auto-locking
+	var/auto_lock_range = 2
 
 /obj/item/ammo_casing/c160smart/Initialize(mapload)
 	. = ..()
@@ -76,3 +78,15 @@
 	. = ..()
 	if(!isturf(target))
 		loaded_projectile.set_homing_target(target)
+		new /obj/effect/temp_visual/smartgun_target(get_turf(target))
+	else
+		var/atom/aimbot_target = locate(/mob/living) in range(auto_lock_range, target)
+		if(aimbot_target)
+			loaded_projectile.set_homing_target(aimbot_target)
+			new /obj/effect/temp_visual/smartgun_target(get_turf(aimbot_target))
+
+/obj/effect/temp_visual/smartgun_target
+	name = "smartgun target reticle"
+	desc = "A holographic crosshair that probably means you should start running."
+	icon_state = "launchpad_pull"
+	duration = 0.25 SECONDS


### PR DESCRIPTION

## About The Pull Request

The smartgun, instead of tracking targets if you click directly on them, will now track the closest target within 2 tiles of wherever you clicked if you don't click directly on someone.
Also adds a reticle overlay that gets put over anyone targetted by the smartgun so you can know ahead of time that you're about to die.

https://github.com/user-attachments/assets/0408132d-c02b-45fc-ad55-2fef0301b51b
## Why It's Good For The Game

I tried to argue this is a good new player gun while making it's entire gimmick only work if you click directly on the spacemen. What kinda smartgun doesn't have aimbot built into it.
## Changelog
:cl:
balance: The syndie smartgun has 2 tile aimbot now
/:cl:
