### PR TITLE
Stops random maintenance spawners from being able to spawn ashes in space

### DIFF
--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -19,7 +19,7 @@
 	. += span_info("This spawner has an effective loot count of [get_effective_lootcount()].")
 
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
-	if(is_space_or_openspace(loc))
+	if(!istype(src, /obj/effect/spawner/random/maintenance/no_decals) && is_space_or_openspace(loc))
 		if(mapload)
 			stack_trace("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
 		else

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -21,7 +21,7 @@
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	if(is_space_or_openspace(loc))
 		if(mapload)
-			log_mapping("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
+			stack_trace("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
 		else
 			new /obj/effect/spawner/random/maintenance/no_decals(loc) // if this happens outside of mapload, just spawn a no_decals version and move on
 		return INITIALIZE_HINT_QDEL

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -23,7 +23,12 @@
 		if(mapload)
 			stack_trace("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead! Note: the coords might be for a ruin so keep that in mind.")
 		else
-			new /obj/effect/spawner/random/maintenance/no_decals(loc) // if this happens outside of mapload, just spawn a no_decals version and move on
+			// if this happens outside of mapload, just spawn a no_decals version and move on
+			var/regex/no_decal_regex = regex("maintenance")
+			var/new_path_string = no_decal_regex.Replace("[type]", "maintenance/no_decals")
+			var/no_decals_type = text2path(new_path_string)
+			new no_decals_type(loc)
+
 		return INITIALIZE_HINT_QDEL
 
 	loot = GLOB.maintenance_loot

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -21,7 +21,7 @@
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	if(!istype(src, /obj/effect/spawner/random/maintenance/no_decals) && is_space_or_openspace(loc))
 		if(mapload)
-			stack_trace("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
+			stack_trace("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead! Note: the coords might be for a ruin so keep that in mind.")
 		else
 			new /obj/effect/spawner/random/maintenance/no_decals(loc) // if this happens outside of mapload, just spawn a no_decals version and move on
 		return INITIALIZE_HINT_QDEL

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -19,6 +19,13 @@
 	. += span_info("This spawner has an effective loot count of [get_effective_lootcount()].")
 
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
+	if(is_space_or_openspace(loc))
+		if(mapload)
+			log_mapping("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
+		else
+			new /obj/effect/spawner/random/maintenance/no_decals(loc) // if this happens outside of mapload, just spawn a no_decals version and move on
+		return INITIALIZE_HINT_QDEL
+
 	loot = GLOB.maintenance_loot
 	return ..()
 

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -21,7 +21,7 @@
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	if(is_space_or_openspace(loc))
 		if(mapload)
-			log_mapping("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead! (Also, Keep in mind the coords might be ruin coords)")
+			log_mapping("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
 		else
 			new /obj/effect/spawner/random/maintenance/no_decals(loc) // if this happens outside of mapload, just spawn a no_decals version and move on
 		return INITIALIZE_HINT_QDEL

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -21,7 +21,7 @@
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	if(is_space_or_openspace(loc))
 		if(mapload)
-			log_mapping("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead!")
+			log_mapping("[src] at [AREACOORD(src)] tried to spawn in a space or openspace tile! Mappers please use /obj/effect/spawner/random/maintenance/no_decals instead! (Also, Keep in mind the coords might be ruin coords)")
 		else
 			new /obj/effect/spawner/random/maintenance/no_decals(loc) // if this happens outside of mapload, just spawn a no_decals version and move on
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -206,7 +206,7 @@
 									forced_ruins[linked] = SSmapping.get_isolated_ruin_z()
 
 
-			log_mapping("Successfully placed [current_pick.name] ruin at [COORD(placed_turf)].")
+			log_mapping("Successfully placed [current_pick.name] ruin.")
 
 		//Update the available list
 		for(var/datum/map_template/ruin/R in ruins_available)

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -206,7 +206,7 @@
 									forced_ruins[linked] = SSmapping.get_isolated_ruin_z()
 
 
-			log_mapping("Successfully placed [current_pick.name] ruin.")
+			log_mapping("Successfully placed [current_pick.name] ruin at [COORD(placed_turf)].")
 
 		//Update the available list
 		for(var/datum/map_template/ruin/R in ruins_available)


### PR DESCRIPTION
## About The Pull Request

True to their name, 'maintenance spawners' have been spawning more work for maintainers for the past few years with this annoying runtime. It is rng whether or not it occurs, but it happens frequently enough..and sometimes in multiple tests if you are lucky!

![firefox_Fokh0Dehp3](https://github.com/user-attachments/assets/67224048-d08c-46e2-a404-924dba71ef34)

See: a triple whammy

![image](https://github.com/user-attachments/assets/6fe84969-c952-4f8a-bd9a-4b051a53e0a0)

Finally, inspired by this recent event I have made it my mission to put an end to this for good.

This pr:

1) Prevents mappers from placing `/obj/effect/spawner/random/maintenance` in space or openspace turfs, insisting that they must use the safe `/obj/effect/spawner/random/maintenance/no_decals` subtype instead which does not spawn ashes.

2) If somehow this ends up on a space or openspace turf outside of mapload, we will just delete the offending spawner and spawn the `/obj/effect/spawner/random/maintenance/no_decals` in place. There's literally no reason we should be wasting any more of our maintainers' time with this!

Hopefully this puts this runtime into the crematorium for good because it's stupid.

![image](https://github.com/user-attachments/assets/3612de52-1604-4f83-a217-cdae9f22e6c4)

## Why It's Good For The Game

No more rng garbage in the CI runs.

## Changelog

:cl:
fix: random maintenance spawners can no longer end up in space, spawn ashes, and annoy maintainers.
/:cl: