### PR TITLE
Holosign QoL: signs on doors, holofans on doors/windows/grilles

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -20,6 +20,11 @@
 	//holosign image that is projected
 	var/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
+	/// List of special things we can project holofans under/through.
+	var/list/projectable_through = list(
+		/obj/machinery/door,
+		/obj/structure/mineral_door,
+	)
 
 /obj/item/holosign_creator/Initialize(mapload)
 	. = ..()
@@ -49,7 +54,7 @@
 
 	if(target_holosign)
 		return ITEM_INTERACT_BLOCKING
-	if(target_turf.is_blocked_turf(TRUE)) //can't put holograms on a tile that has dense stuff
+	if(target_turf.is_blocked_turf(TRUE, ignore_atoms = projectable_through, type_list = TRUE)) //can't put holograms on a tile that has dense stuff
 		return ITEM_INTERACT_BLOCKING
 	if(holocreator_busy)
 		balloon_alert(user, "busy making a hologram!")
@@ -68,7 +73,7 @@
 		holocreator_busy = FALSE
 		if(LAZYLEN(signs) >= max_signs)
 			return ITEM_INTERACT_BLOCKING
-		if(target_turf.is_blocked_turf(TRUE)) //don't try to sneak dense stuff on our tile during the wait.
+		if(target_turf.is_blocked_turf(TRUE, ignore_atoms = projectable_through, type_list = TRUE)) //don't try to sneak dense stuff on our tile during the wait.
 			return ITEM_INTERACT_BLOCKING
 
 	target_holosign = create_holosign(interacting_with, user)
@@ -135,6 +140,12 @@
 	holosign_type = /obj/structure/holosign/barrier/atmos
 	creation_time = 0
 	max_signs = 6
+	projectable_through = list(
+		/obj/machinery/door,
+		/obj/structure/mineral_door,
+		/obj/structure/window,
+		/obj/structure/grille,
+	)
 	/// Clearview holograms don't catch clicks and are more transparent
 	var/clearview = FALSE
 	/// Timer for auto-turning off clearview


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/user-attachments/assets/0bb720a5-1c95-4923-a8e9-c0de46682d5d)
This PR makes it so that you can project holographic signs (e.g. PENLITE holobarriers, engineering holobarriers, etc.) onto doors (e.g. airlocks, material doors), while ATMOS holofan projectors can project their holofans under doors, windows, and grilles.

Doors specifically means "anything under /obj/machinery/door" and material/mineral doors, e.g. sandstone ones.
## Why It's Good For The Game
Holofans being weirdly offset off doors out of necessity irks me from a visuals perspective and I think putting holofans in doors looks way nicer. Holosigns can get this too as a treat, I guess.

## Changelog

:cl:
qol: Holosigns (engineering holobarriers, janitor holosigns, PENLITE holobarriers, etc.) can now be projected onto doors.
qol: Holofans from ATMOS holoprojectors can now be projected onto doors, windows, and grilles.
/:cl: