### PR TITLE
Corrects an error with emagged medical kiosk boards.

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -178,7 +178,7 @@
 			user.visible_message(span_warning("[user] waves a suspicious card by the [src]'s biometric scanner!"))
 		balloon_alert(user, "sensors overloaded")
 	obj_flags |= EMAGGED
-	var/obj/item/circuitboard/machine/medical_kiosk/board = circuit
+	var/obj/item/circuitboard/board = circuit
 	board.obj_flags |= EMAGGED //Mirrors emag status onto the board as well.
 	pandemonium = TRUE
 	return TRUE

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -178,7 +178,7 @@
 			user.visible_message(span_warning("[user] waves a suspicious card by the [src]'s biometric scanner!"))
 		balloon_alert(user, "sensors overloaded")
 	obj_flags |= EMAGGED
-	var/obj/item/circuitboard/computer/cargo/board = circuit
+	var/obj/item/circuitboard/machine/medical_kiosk/board = circuit
 	board.obj_flags |= EMAGGED //Mirrors emag status onto the board as well.
 	pandemonium = TRUE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Came across this while scrolling, it's a clear and present error likely due to old copypaste.

The Medical Kiosk board has a similar feature to the cargo console where if emagged, the emag state is copied over to the circuit board. The circuit board, however, is typed to literally be a cargo console. There's no point in it being anything other than a circuitboard path for adding the appropriate object flag to the item, and reduces blatantly wrong copypaste.

## Why It's Good For The Game

World's smalled code cleanup. Results in less bad copypaste.

## Changelog

No player facing changes.