### PR TITLE
Fix config FPS/ Ticklag auto handling

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -220,7 +220,7 @@
 		sync_validate = TRUE
 		var/datum/config_entry/number/ticklag/TL = config.entries_by_type[/datum/config_entry/number/ticklag]
 		if(!TL.sync_validate)
-			TL.ValidateAndSet(10 / config_entry_value)
+			TL.ValidateAndSet("[10 / config_entry_value]")
 		sync_validate = FALSE
 
 /datum/config_entry/number/ticklag
@@ -238,7 +238,7 @@
 		sync_validate = TRUE
 		var/datum/config_entry/number/fps/FPS = config.entries_by_type[/datum/config_entry/number/fps]
 		if(!FPS.sync_validate)
-			FPS.ValidateAndSet(10 / config_entry_value)
+			FPS.ValidateAndSet("[10 / config_entry_value]")
 		sync_validate = FALSE
 
 /datum/config_entry/flag/allow_holidays


### PR DESCRIPTION

FPS / Ticklag should be independent configs, but due to the use of `trim()` at https://github.com/tgstation/tgstation/blob/49f8d1e81dacfc75c635b13bf182edf1ce59df79/code/controllers/configuration/config_entry.dm#L116
the number we hand over will simply be turned into an empty string...


https://github.com/tgstation/tgstation/blob/49f8d1e81dacfc75c635b13bf182edf1ce59df79/code/controllers/configuration/entries/general.dm#L223
https://github.com/tgstation/tgstation/blob/49f8d1e81dacfc75c635b13bf182edf1ce59df79/code/controllers/configuration/entries/general.dm#L241


No player facing changes
## About The Pull Request
## Why It's Good For The Game
Timers can get fucked up when someone only sets one or the other currently...
## Changelog
