### PR TITLE
Stops anomalies from running off during CI and causing a flaky mapping nearstation error

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -80,7 +80,7 @@
 
 /// Move in a direction
 /obj/effect/anomaly/proc/move_anomaly()
-#ifndef UNIT_TESTS
+#ifndef UNIT_TESTS // These might move away during a CI run and cause a flaky mapping nearstation errors
 	step(src, pick(GLOB.alldirs))
 #endif
 

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -80,7 +80,9 @@
 
 /// Move in a direction
 /obj/effect/anomaly/proc/move_anomaly()
+#ifndef UNIT_TESTS
 	step(src, pick(GLOB.alldirs))
+#endif
 
 /obj/effect/anomaly/proc/detonate()
 	return

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -75,14 +75,14 @@
 	return ..()
 
 /obj/effect/anomaly/proc/anomalyEffect(seconds_per_tick)
+#ifndef UNIT_TESTS // These might move away during a CI run and cause a flaky mapping nearstation errors
 	if(SPT_PROB(move_chance, seconds_per_tick))
 		move_anomaly()
+#endif
 
 /// Move in a direction
 /obj/effect/anomaly/proc/move_anomaly()
-#ifndef UNIT_TESTS // These might move away during a CI run and cause a flaky mapping nearstation errors
 	step(src, pick(GLOB.alldirs))
-#endif
 
 /obj/effect/anomaly/proc/detonate()
 	return

--- a/code/game/objects/effects/anomalies/anomalies_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomalies_hallucination.dm
@@ -85,8 +85,10 @@
 	)
 
 /obj/effect/anomaly/hallucination/decoy/anomalyEffect(seconds_per_tick)
+#ifndef UNIT_TESTS // These might move away during a CI run and cause a flaky mapping nearstation errors
 	if(SPT_PROB(move_chance, seconds_per_tick))
 		move_anomaly()
+#endif
 
 /obj/effect/anomaly/hallucination/decoy/analyzer_act(mob/living/user, obj/item/analyzer/tool)
 	to_chat(user, span_notice("You activate [tool]. [replacetext(report_text, "%TOOL%", "[tool]")]"))


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/ff3c9fff-89b6-4802-bfe7-18e5e1135c34)

The anomaly ruin has several anomalies floating in space. They have a nearstation area on their tile, but the problem is there is a chance that they can move before the mapping_nearstation unit test completes, causing them to be in a non-area and ruining the run.

![firefox_KwaFDrmmrF](https://github.com/user-attachments/assets/3732dd9d-fbe7-44b3-b799-a1edd1ad5748)

This PR just ensures that they stay in place during unit tests.

## Why It's Good For The Game

Less RNG CI failure

## Changelog

Nothing player facing
