### PR TITLE
Fixes hat stabilizers not detaching clothing traits

### DIFF
--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -206,7 +206,7 @@
 
 	var/former_hat = attached_hat
 	var/obj/item/clothing/apparel = parent
-	apparel.detach_clothing_traits(attached_hat)
+	apparel.detach_clothing_traits(attached_hat.clothing_traits)
 	apparel.flags_cover = former_flags
 	apparel.visor_flags_cover = former_visor_flags
 	apparel.update_appearance()


### PR DESCRIPTION

## About The Pull Request

Closes #89782

## Changelog
:cl:
fix: Fixed hat stabilizers not detaching clothing traits, turning any helmet with a pacifism bud attached into one.
/:cl:
