### PR TITLE
Pointblank shots in combat mode!

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -284,8 +284,6 @@
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
-	if(user.combat_mode && isliving(interacting_with))
-		return ITEM_INTERACT_SKIP_TO_ATTACK // Gun bash / bayonet attack
 	if(try_fire_gun(interacting_with, user, list2params(modifiers)))
 		return ITEM_INTERACT_SUCCESS
 	return NONE
@@ -293,6 +291,9 @@
 /obj/item/gun/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!can_hold_up || !isliving(interacting_with))
 		return interact_with_atom(interacting_with, user, modifiers)
+
+	if(user.combat_mode && isliving(interacting_with))
+		return ITEM_INTERACT_SKIP_TO_ATTACK // Gun bash / bayonet attack
 
 	var/datum/component/gunpoint/gunpoint_component = user.GetComponent(/datum/component/gunpoint)
 	if (gunpoint_component)
@@ -333,7 +334,7 @@
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || user.combat_mode) //melee attack
+		if(!ismob(target)) //melee attack
 			return
 		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
 			return

--- a/code/modules/unit_tests/combat_pistol_whip.dm
+++ b/code/modules/unit_tests/combat_pistol_whip.dm
@@ -15,27 +15,27 @@
 	TEST_ASSERT_EQUAL(gun.get_ammo(countchambered = TRUE), expected_ammo, "Gun spawned without a full magazine, \
 		when it should spawn with mag size + 1 (chambered) rounds.")
 
-	// Combat mode in melee range -> pistol whip
+	// Combat mode in melee range with RMB -> pistol whip
 	attacker.set_combat_mode(TRUE)
-	click_wrapper(attacker, victim)
+	click_wrapper(attacker, victim, list(RIGHT_CLICK = TRUE, BUTTON = RIGHT_CLICK))
 	TEST_ASSERT_NOTEQUAL(victim.getBruteLoss(), 0, "Victim did not take brute damage from being pistol-whipped.")
 	TEST_ASSERT_EQUAL(gun.get_ammo(countchambered = TRUE), expected_ammo, "The gun fired a shot when it was used for a pistol whip.")
 	victim.fully_heal()
 
-	// No combat mode -> point blank shot
-	attacker.set_combat_mode(FALSE)
+	// Combat mode LMB -> point blank shot
+	attacker.set_combat_mode(TRUE)
 	click_wrapper(attacker, victim)
 	TEST_ASSERT_NOTEQUAL(victim.getBruteLoss(), 0, "Victim did not take brute damage from being fired upon point-blank.")
 	TEST_ASSERT(locate(/obj/item/ammo_casing/c9mm) in attacker.loc, "The gun did not eject a casing when it was used for a point-blank shot.")
 	TEST_ASSERT_EQUAL(gun.get_ammo(countchambered = TRUE), expected_ammo - 1, "The gun did not fire a shot when it was used for a point-blank shot.")
 	victim.fully_heal()
 
-	// Combat mode in melee range with bayonet -> bayonet stab
+	// Combat mode RMB click in melee range with bayonet -> bayonet stab
 	var/obj/item/knife/combat/knife = EASY_ALLOCATE()
 	gun.AddComponent(/datum/component/bayonet_attachable, starting_bayonet = knife)
 
 	attacker.set_combat_mode(TRUE)
-	click_wrapper(attacker, victim)
+	click_wrapper(attacker, victim, list(RIGHT_CLICK = TRUE, BUTTON = RIGHT_CLICK))
 	TEST_ASSERT_NOTEQUAL(victim.getBruteLoss(), 0, "Victim did not take brute damage from being bayonet stabbed.")
 	victim.fully_heal()
 
@@ -56,5 +56,5 @@
 	butcher_comp.speed = 1 SECONDS
 
 	butcher.put_in_active_hand(gun, forced = TRUE)
-	click_wrapper(butcher, meat)
+	click_wrapper(butcher, meat, list(RIGHT_CLICK = TRUE, BUTTON = RIGHT_CLICK))
 	TEST_ASSERT(DOING_INTERACTION(butcher, meat), "The butcher did not start butchering the monkey when using a bayonetted weapon.")


### PR DESCRIPTION
## About The Pull Request

This PR will allow you to shoot guns pointblank in combat mode by remaping melee only attack to RMB in combat mode. You still can hold people on a gunpoint, just use non combat mode to do so.

## Why It's Good For The Game

I think it's much more convenient and intuitive to be able to shoot pointblank in combat mode.

## Changelog

:cl:
qol: Now you can shoot guns pointblank in combat mode! If you want to attack melee only: use combat mode + right mouse button.
/:cl:

