### PR TITLE
`/datum/reagent/consumable/ethanol/New()` will now treat `addiction_types` as a lazylist

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -47,7 +47,8 @@
 			name = "Natural " + name
 		if(data["boozepwr"])
 			boozepwr = data["boozepwr"]
-	addiction_types = list(/datum/addiction/alcohol = 0.05 * boozepwr)
+	if(boozepwr) // anything other than 0
+		LAZYSET(addiction_types, /datum/addiction/alcohol, 0.05 * boozepwr)
 	return ..()
 
 /datum/reagent/consumable/ethanol/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)


### PR DESCRIPTION
## About The Pull Request
Normally `addiction_types` isn't defined for any subtypes of `/datum/reagent/consumable/ethanol`, and is instead calculated by `/datum/reagent/consumable/ethanol/New()`.

However, the way it handles this actually overrides any previously-set addiction types, forcing any subtypes that would want to have other addiction types to define them in `New()` *after* `/datum/reagent/consumable/ethanol/New()` runs.

As an example of this, take a look at <https://github.com/Monkestation/Monkestation2.0/pull/5750>. It adds a coffee addiction to any alcoholic reagents which contain coffee - but it had to edit `/datum/reagent/consumable/ethanol/New()` to account for the fact that the addiction types list may not be empty.

Thing is, `addiction_types` is already sort of a lazylist - its initial value (defined in `/datum/reagent/var/addiction_types`) is `null`, so it was kind of asking to be used this way anyways.

So, to handle the possibility of a subtype setting other addiction types, and additionally to make the code a little nicer by using `addiction_types` as the lazylist it seems to want to be, I've modified `/datum/reagent/consumable/ethanol/New()` to use `LAZYSET` when adding the alcohol addiction.

--

I also changed it such that the alcohol addiction is only added if `boozepwr` is any value other than `0`. This ensures that, if the reagent in question doesn't use `boozepwr`, and has no other addiction types, `addiction_types` will stay `null`. This saves a little bit of memory - admittedly, not much, but still!

## Why It's Good For The Game
Subtypes of `/datum/reagent/consumable/ethanol` can now have default addiction types other than `/datum/addiction/alcohol`.

## Changelog
No player-facing changes.