### PR TITLE
Remove an unused var from `/turf/open/space`

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -53,7 +53,6 @@ GLOBAL_LIST_EMPTY(starlight)
 	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000
-	var/starlight_source_count = 0
 
 	var/destination_z
 	var/destination_x


### PR DESCRIPTION

## About The Pull Request

`/turf/open/space/var/starlight_source_count` was gonna be used one of @LemonInTheDark's PRs at some point, but its use never came to fruition. but the var remained. despite never being neither used or set by anything. so let's get rid of that.

## Why It's Good For The Game

an unused var is wasted memory, especially on something as widespread as space turfs

## Changelog
:cl:
code: Removed a random unused var on space turfs.
/:cl:
