### PR TITLE
The radioactive mutation now ensures it has an owner before modifying the radioactivity

### DIFF
--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -24,7 +24,8 @@
 
 /datum/mutation/human/radioactive/modify()
 	. = ..()
-	make_radioactive(owner)
+	if(!QDELETED(owner))
+		make_radioactive(owner)
 
 /**
  * Makes the passed mob radioactive, or if they're already radioactive,


### PR DESCRIPTION
## About The Pull Request
https://github.com/Monkestation/Monkestation2.0/pull/5690 exposed the fact that `/datum/mutation/human/radioactive/modify()` assumes we have an owner.

However, the parent proc, `/datum/mutation/human/modify()`, does not make this assumption - and as such, `/datum/mutation/human/radioactive/modify()` shouldn't either.

This PR modifies `/datum/mutation/human/radioactive/modify()` to check if our `owner` variable is set (and valid!) before applying the radioactivity changes.

## Why It's Good For The Game
Avoids a runtime if `owner` is unset.

## Changelog

:cl:
fix: Fixes a potential runtime with the radioactivity mutation.
/:cl: