### PR TITLE
Touch protection actually...checks for touch. Multiple fats can no longer lethally deepfry you through literally any protection if hot enough, bypassing expected limitations.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -671,7 +671,7 @@
 /** Handles exposing a mob to reagents.
  *
  * If the methods include INGEST or INHALE, the mob tastes the reagents.
- * If the methods include VAPOR it incorporates permiability protection.
+ * If the methods include VAPOR or TOUCH it incorporates permiability protection.
  */
 /mob/living/expose_reagents(list/reagents, datum/reagents/source, methods=TOUCH, volume_modifier=1, show_message=TRUE)
 	. = ..()
@@ -681,7 +681,7 @@
 	if(methods & (INGEST | INHALE))
 		taste_list(reagents)
 
-	var/touch_protection = (methods & VAPOR) ? getarmor(null, BIO) * 0.01 : 0
+	var/touch_protection = (methods & (VAPOR | TOUCH)) ? getarmor(null, BIO) * 0.01 : 0
 	SEND_SIGNAL(source, COMSIG_REAGENTS_EXPOSE_MOB, src, reagents, methods, volume_modifier, show_message, touch_protection)
 	for(var/datum/reagent/reagent as anything in reagents)
 		var/reac_volume = reagents[reagent]

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -182,7 +182,7 @@
 	var/burn_damage = ((holder.chem_temp / fry_temperature) * 0.33) //Damage taken per unit
 	if(methods & TOUCH)
 		burn_damage *= max(1 - touch_protection, 0)
-	var/FryLoss = round(min(0, burn_damage * reac_volume))
+	var/FryLoss = round(min(38, burn_damage * reac_volume))
 	if(!HAS_TRAIT(exposed_mob, TRAIT_OIL_FRIED))
 		exposed_mob.visible_message(span_warning("The boiling oil sizzles as it covers [exposed_mob]!"), \
 		span_userdanger("You're covered in boiling oil!"))

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -182,17 +182,16 @@
 	var/burn_damage = ((holder.chem_temp / fry_temperature) * 0.33) //Damage taken per unit
 	if(methods & TOUCH)
 		burn_damage *= max(1 - touch_protection, 0)
-	var/FryLoss = round(min(38, burn_damage * reac_volume))
+	var/FryLoss = round(min(0, burn_damage * reac_volume))
 	if(!HAS_TRAIT(exposed_mob, TRAIT_OIL_FRIED))
 		exposed_mob.visible_message(span_warning("The boiling oil sizzles as it covers [exposed_mob]!"), \
 		span_userdanger("You're covered in boiling oil!"))
 		if(FryLoss)
 			exposed_mob.emote("scream")
+			exposed_mob.adjustFireLoss(FryLoss)
 		playsound(exposed_mob, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
 		ADD_TRAIT(exposed_mob, TRAIT_OIL_FRIED, "cooking_oil_react")
 		addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 0.3 SECONDS)
-	if(FryLoss)
-		exposed_mob.adjustFireLoss(FryLoss)
 
 /datum/reagent/consumable/nutriment/fat/expose_turf(turf/open/exposed_turf, reac_volume)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -183,15 +183,17 @@
 	if(methods & TOUCH)
 		burn_damage *= max(1 - touch_protection, 0)
 	var/FryLoss = round(min(38, burn_damage * reac_volume))
-	if(!HAS_TRAIT(exposed_mob, TRAIT_OIL_FRIED))
-		exposed_mob.visible_message(span_warning("The boiling oil sizzles as it covers [exposed_mob]!"), \
-		span_userdanger("You're covered in boiling oil!"))
-		if(FryLoss)
-			exposed_mob.emote("scream")
-			exposed_mob.adjustFireLoss(FryLoss)
-		playsound(exposed_mob, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
-		ADD_TRAIT(exposed_mob, TRAIT_OIL_FRIED, "cooking_oil_react")
-		addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 0.3 SECONDS)
+	if(HAS_TRAIT(exposed_mob, TRAIT_OIL_FRIED))
+		return
+
+	exposed_mob.visible_message(span_warning("The boiling oil sizzles as it covers [exposed_mob]!"), \
+	span_userdanger("You're covered in boiling oil!"))
+	if(FryLoss)
+		exposed_mob.emote("scream")
+		exposed_mob.adjustFireLoss(FryLoss)
+	playsound(exposed_mob, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
+	ADD_TRAIT(exposed_mob, TRAIT_OIL_FRIED, "cooking_oil_react")
+	addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 0.3 SECONDS)
 
 /datum/reagent/consumable/nutriment/fat/expose_turf(turf/open/exposed_turf, reac_volume)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -193,7 +193,7 @@
 		exposed_mob.adjustFireLoss(FryLoss)
 	playsound(exposed_mob, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
 	ADD_TRAIT(exposed_mob, TRAIT_OIL_FRIED, "cooking_oil_react")
-	addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 0.3 SECONDS)
+	addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 2 SECONDS)
 
 /datum/reagent/consumable/nutriment/fat/expose_turf(turf/open/exposed_turf, reac_volume)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The ``touch_protection`` argument in ``expose_mob()`` would only pass along a value if the exposure method on the mob was from a ``VAPOUR`` source. This would not be passed if it was a ``TOUCH`` source. You wouldn't know that from just the name.

As a consequence, fats in particular wouldn't respect any amount of protective gear you may have against their dangerous frying prowess. And since the damage is mostly a consequence of temperature, not just volume, sufficiently hot fats will cook you through quite a lot. This is true even if you're currently frying.

This may have been, at most, a minor issue if there was only a single kind of oil in existence. Unfortunately, there is about four now since the Foodening. You can't stack all of them as olive oil will mix fat into itself, but three oils of different types can bypass the internal limitation of 38 damage max to reach a pretty decent amount of damage.

So we've sanity checked this. Bio protection is respected by us passing along a value if our mob is exposed by ``TOUCH``. We don't do more damage if we're currently frying (and thus limiting the effectiveness of multiple oils).

## Why It's Good For The Game

I had to learn this the hard way when a bunch of assistants were seemingly trying to splash me with test tubes. I didn't know what exactly it was that they were using, just that it was slippery. I figured it was lube, which, you know, fair enough. No, turns out they were trying to oneshot me with scolding hot fats like I'm an operative shaped french fry. Taking tator tot too literally.

There is a distinct difference between weaponizing mechanics that are working as intended compared to weaponizing an oversight. One of these can be funny. The other is just kind of lame because it bypasses player expectations and I WILL fix them if you come at me with them. I need the GBP.

## Changelog
:cl:
fix: Touch protection actually respects the TOUCH exposure method.
fix: You cannot Fry-Fu someone through bio protective clothing using three drops of essential oils heated to the temperature of the sun.
/:cl:
