### PR TITLE
Wallout Loadout equips itself / Lipstick Loadout comes applies itself (and is customizable) 

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -173,3 +173,7 @@
 #define COMSIG_MUTATION_GAINED "mutation_gained"
 ///Called from on_losing(mob/living/carbon/human/owner)
 #define COMSIG_MUTATION_LOST "mutation_lost"
+
+/// Called at the very end of human character setup
+/// At this point all quirks are assigned and the mob has a mind / client
+#define COMSIG_HUMAN_CHARACTER_SETUP_FINISHED "human_character_setup_finished"

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -165,3 +165,8 @@
 #define INFO_RESKIN "reskin"
 /// Handles which layer the item will be on, for accessories
 #define INFO_LAYER "layer"
+
+// Lipstick styles
+#define UPPER_LIP "Upper"
+#define MIDDLE_LIP "Middle"
+#define LOWER_LIP "Lower"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -430,6 +430,8 @@ SUBSYSTEM_DEF(ticker)
 			if(new_player_mob.client?.prefs?.should_be_random_hardcore(player_assigned_role, new_player_living.mind))
 				new_player_mob.client.prefs.hardcore_random_setup(new_player_living)
 			SSquirks.AssignQuirks(new_player_living, new_player_mob.client)
+		if(ishuman(new_player_living))
+			SEND_SIGNAL(new_player_living, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED)
 		CHECK_TICK
 
 	if(captainless)

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -1,7 +1,3 @@
-#define UPPER_LIP "Upper"
-#define MIDDLE_LIP "Middle"
-#define LOWER_LIP "Lower"
-
 /obj/item/lipstick
 	gender = PLURAL
 	name = "red lipstick"
@@ -343,7 +339,3 @@
 
 /obj/item/razor/surgery/get_surgery_tool_overlay(tray_extended)
 	return "razor"
-
-#undef UPPER_LIP
-#undef MIDDLE_LIP
-#undef LOWER_LIP

--- a/code/modules/loadout/categories/pocket.dm
+++ b/code/modules/loadout/categories/pocket.dm
@@ -258,7 +258,7 @@
 	name = "Wallet"
 	item_path = /obj/item/storage/wallet
 
-/datum/loadout_item/pocket_items/wallet/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE, job_equipping_step = FALSE)
+/datum/loadout_item/pocket_items/wallet/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	return
 
 /datum/loadout_item/pocket_items/wallet/on_equip_item(

--- a/code/modules/loadout/categories/pocket.dm
+++ b/code/modules/loadout/categories/pocket.dm
@@ -269,7 +269,7 @@
 	visuals_only = FALSE,
 )
 	// Do this at the very end of the setup process so we can insert quirk items and such
-	if(!visuals_only || isdummy(equipper))
+	if(!visuals_only && !isdummy(equipper))
 		RegisterSignal(equipper, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED, PROC_REF(apply_after_setup), override = TRUE)
 	return NONE
 

--- a/code/modules/loadout/categories/pocket.dm
+++ b/code/modules/loadout/categories/pocket.dm
@@ -43,40 +43,73 @@
 
 	return ..()
 
-/datum/loadout_item/pocket_items/lipstick_black
-	name = "Lipstick (Black)"
-	item_path = /obj/item/lipstick/black
-	additional_displayed_text = list("Black")
-
-/datum/loadout_item/pocket_items/lipstick_blue
-	name = "Lipstick (Blue)"
-	item_path = /obj/item/lipstick/blue
-	additional_displayed_text = list("Blue")
-
-/datum/loadout_item/pocket_items/lipstick_green
-	name = "Lipstick (Green)"
-	item_path = /obj/item/lipstick/green
-	additional_displayed_text = list("Green")
-
-/datum/loadout_item/pocket_items/lipstick_jade
-	name = "Lipstick (Jade)"
-	item_path = /obj/item/lipstick/jade
-	additional_displayed_text = list("Jade")
-
-/datum/loadout_item/pocket_items/lipstick_purple
-	name = "Lipstick (Purple)"
-	item_path = /obj/item/lipstick/purple
-	additional_displayed_text = list("Purple")
-
-/datum/loadout_item/pocket_items/lipstick_red
-	name = "Lipstick (Red)"
+/datum/loadout_item/pocket_items/lipstick
+	name = "Lipstick"
 	item_path = /obj/item/lipstick
-	additional_displayed_text = list("Red")
+	additional_displayed_text = list("Recolorable")
 
-/datum/loadout_item/pocket_items/lipstick_white
-	name = "Lipstick (White)"
-	item_path = /obj/item/lipstick/white
-	additional_displayed_text = list("White")
+/datum/loadout_item/pocket_items/lipstick/on_equip_item(
+	obj/item/lipstick/equipped_item,
+	datum/preferences/preference_source,
+	list/preference_list,
+	mob/living/carbon/human/equipper,
+	visuals_only,
+)
+	. = ..()
+	var/picked_style = style_to_style(preference_list[item_path]?[INFO_LAYER])
+	var/picked_color = preference_list[item_path]?[INFO_GREYSCALE] || /obj/item/lipstick::lipstick_color
+	if(istype(equipped_item)) // can be null for visuals_only
+		equipped_item.style = picked_style
+		equipped_item.lipstick_color = picked_color
+	equipper.update_lips(picked_style, picked_color)
+
+/// Converts style (readable) to style (internal)
+/datum/loadout_item/pocket_items/lipstick/proc/style_to_style(style)
+	switch(style)
+		if(UPPER_LIP)
+			return "lipstick_upper"
+		if(LOWER_LIP)
+			return "lipstick_lower"
+	return "lipstick"
+
+/datum/loadout_item/pocket_items/lipstick/get_ui_buttons()
+	. = ..()
+	UNTYPED_LIST_ADD(., list(
+		"label" = "Style",
+		"act_key" = "select_lipstick_style",
+		"button_icon" = FA_ICON_ARROWS_ROTATE,
+		"active_key" = INFO_LAYER,
+	))
+	UNTYPED_LIST_ADD(., list(
+		"label" = "Color",
+		"act_key" = "select_lipstick_color",
+		"button_icon" = FA_ICON_PALETTE,
+		"active_key" = INFO_GREYSCALE,
+	))
+
+/datum/loadout_item/pocket_items/lipstick/handle_loadout_action(datum/preference_middleware/loadout/manager, mob/user, action, params)
+	switch(action)
+		if("select_lipstick_style")
+			var/list/their_loadout = manager.preferences.read_preference(/datum/preference/loadout)
+			var/old_style = their_loadout?[item_path]?[INFO_LAYER] || MIDDLE_LIP
+			var/chosen = tgui_input_list(user, "Pick a lipstick style. (This determines where it sits on your sprite.)", "Pick a style", list(UPPER_LIP, MIDDLE_LIP, LOWER_LIP), old_style)
+			their_loadout = manager.preferences.read_preference(/datum/preference/loadout) // after sleep: sanity check
+			if(their_loadout?[item_path]) // Validate they still have it equipped
+				their_loadout[item_path][INFO_LAYER] = chosen
+				manager.preferences.update_preference(/datum/preference/loadout, their_loadout)
+			return TRUE // Update UI
+
+		if("select_lipstick_color")
+			var/list/their_loadout = manager.preferences.read_preference(/datum/preference/loadout)
+			var/old_color = their_loadout?[item_path]?[INFO_GREYSCALE] || /obj/item/lipstick::lipstick_color
+			var/chosen = input(user, "Pick a lipstick color.", "Pick a color", old_color) as color|null
+			their_loadout = manager.preferences.read_preference(/datum/preference/loadout) // after sleep: sanity check
+			if(their_loadout?[item_path]) // Validate they still have it equipped
+				their_loadout[item_path][INFO_GREYSCALE] = chosen
+				manager.preferences.update_preference(/datum/preference/loadout, their_loadout)
+			return TRUE // Update UI
+
+	return ..()
 
 /datum/loadout_item/pocket_items/plush
 	abstract_type = /datum/loadout_item/pocket_items/plush
@@ -220,6 +253,51 @@
 	name = "Poster (Pinup)"
 	item_path = /obj/item/poster/random_contraband/pinup
 
+// The wallet loadout item is special, and puts the player's ID and other small items into it on initialize (fancy!)
 /datum/loadout_item/pocket_items/wallet
 	name = "Wallet"
 	item_path = /obj/item/storage/wallet
+
+/datum/loadout_item/pocket_items/wallet/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE, job_equipping_step = FALSE)
+	return
+
+/datum/loadout_item/pocket_items/wallet/on_equip_item(
+	obj/item/equipped_item,
+	datum/preferences/preference_source,
+	list/preference_list,
+	mob/living/carbon/human/equipper,
+	visuals_only = FALSE,
+)
+	// Do this at the very end of the setup process so we can insert quirk items and such
+	if(!visuals_only || isdummy(equipper))
+		RegisterSignal(equipper, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED, PROC_REF(apply_after_setup), override = TRUE)
+	return NONE
+
+/datum/loadout_item/pocket_items/wallet/proc/apply_after_setup(mob/living/carbon/human/source, ...)
+	SIGNAL_HANDLER
+	equip_wallet(source)
+	UnregisterSignal(source, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED)
+
+/datum/loadout_item/pocket_items/wallet/proc/equip_wallet(mob/living/carbon/human/equipper)
+	var/obj/item/card/id/advanced/id_card = equipper.get_item_by_slot(ITEM_SLOT_ID)
+	if(istype(id_card, /obj/item/storage/wallet)) // Wallets station trait guard
+		return
+
+	var/obj/item/storage/wallet/wallet = new(equipper)
+	if(istype(id_card))
+		equipper.temporarilyRemoveItemFromInventory(id_card, force = TRUE)
+		equipper.equip_to_slot_if_possible(wallet, ITEM_SLOT_ID, initial = TRUE)
+		id_card.forceMove(wallet)
+
+		for(var/obj/item/thing in equipper?.back)
+			// leaves a slot free for whatever they may want
+			if(length(wallet.contents) >= wallet.atom_storage.max_slots - 1)
+				break
+			if(thing.w_class > wallet.atom_storage.max_specific_storage)
+				continue
+			wallet.atom_storage.attempt_insert(thing, override = TRUE, force = STORAGE_FULLY_LOCKED, messages = FALSE)
+
+	else
+		// They must have a PDA or some other thing in their ID slot, abort
+		if(!equipper.equip_to_slot_if_possible(wallet, slot = ITEM_SLOT_BACKPACK, initial = TRUE))
+			wallet.forceMove(equipper.drop_location())

--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -39,17 +39,13 @@
 	var/list/new_contents = get_all_gear()
 	var/update = NONE
 	for(var/datum/loadout_item/item as anything in loadout_datums)
-		var/obj/item/equipped = locate(item.item_path) in new_contents
-		if(isnull(equipped))
-			continue
 		update |= item.on_equip_item(
-			equipped_item = equipped,
+			equipped_item = locate(item.item_path) in new_contents,
 			preference_source = preference_source,
 			preference_list = preference_list,
 			equipper = src,
 			visuals_only = visuals_only,
 		)
-
 	if(update)
 		update_clothing(update)
 

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
  *
  * Arguments:
  * * preference_source - the datum/preferences our loadout item originated from - cannot be null
- * * equipper - the mob we're equipping this item onto - cannot be null
+ * * equipper - the mob we're equipping this item onto
  * * visuals_only - whether or not this is only concerned with visual things (not backpack, not renaming, etc)
  * * preference_list - what the raw loadout list looks like in the preferences
  *
@@ -240,7 +240,8 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	mob/living/carbon/human/equipper,
 	visuals_only = FALSE,
 )
-	ASSERT(!isnull(equipped_item))
+	if(isnull(equipped_item))
+		return NONE
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, "Loadout")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -246,7 +246,7 @@
 
 	if(humanc) // Quirks may change manifest datapoints, so inject only after assigning quirks
 		GLOB.manifest.inject(humanc)
-
+		SEND_SIGNAL(humanc, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED)
 	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
 	if(humanc && arrivals && !arrivals.power_environ) //arrivals depowered
 		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(get_turf(humanc))) //if hands full then just drops on the floor


### PR DESCRIPTION
## About The Pull Request

- Selecting Wallet in the loadout, will equip the wallet when you load into the game. It will auto-fill the wallet with small items from your roundstart kit like quirk items or other loadout items.

- Selecting Lipstick in the loadout will automatically apply it to your character. You still get the lipstick item at game start. 

- Deletes all the preset lipstick colors, now you can just pick what color you want. You can also pick what layer the lipstick starts at (high, middle, low).

## Why It's Good For The Game

- Makes it work like the station trait (except the money part) 

- Convenience

- Extra customization

## Changelog

:cl: Melbert
qol: Wallet loadout item comes pre-equipped
qol: Lipstick loadout item comes pre-applied
qol: You can choose your lipstick color from any color now. You can also choose what layer it defaults to.
/:cl:


