### PR TITLE
tg chat settings export and import

### DIFF
--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -53,6 +53,7 @@
 	// Other setup
 	request_telemetry()
 	addtimer(CALLBACK(src, PROC_REF(on_initialize_timed_out)), 5 SECONDS)
+	window.send_message("testTelemetryCommand")
 
 /**
  * private

--- a/tgui/package.json
+++ b/tgui/package.json
@@ -27,6 +27,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.9.0",
     "@types/webpack-env": "^1.18.5",
+    "@types/wicg-file-system-access": "^2023.10.5",
     "@typescript-eslint/parser": "^8.13.0",
     "@typescript-eslint/utils": "^8.13.0",
     "css-loader": "^7.1.2",

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -183,9 +183,10 @@ export const chatMiddleware = (store) => {
       type === importSettings.type
     ) {
       next(action);
+      const nextSettings = selectSettings(store.getState());
       chatRenderer.setHighlight(
-        settings.highlightSettings,
-        settings.highlightSettingById,
+        nextSettings.highlightSettings,
+        nextSettings.highlightSettingById,
       );
 
       return;

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -9,6 +9,7 @@ import DOMPurify from 'dompurify';
 
 import {
   addHighlightSetting,
+  importSettings,
   loadSettings,
   removeHighlightSetting,
   updateHighlightSetting,
@@ -97,12 +98,14 @@ export const chatMiddleware = (store) => {
   chatRenderer.events.on('scrollTrackingChanged', (scrollTracking) => {
     store.dispatch(changeScrollTracking(scrollTracking));
   });
-  setInterval(() => {
-    saveChatToStorage(store);
-  }, MESSAGE_SAVE_INTERVAL);
   return (next) => (action) => {
     const { type, payload } = action;
-    if (!initialized) {
+    const settings = selectSettings(store.getState());
+    // Load the chat once settings are loaded
+    if (!initialized && settings.initialized) {
+      setInterval(() => {
+        saveChatToStorage(store);
+      }, MESSAGE_SAVE_INTERVAL);
       initialized = true;
       loadChatFromStorage(store);
     }
@@ -176,10 +179,10 @@ export const chatMiddleware = (store) => {
       type === loadSettings.type ||
       type === addHighlightSetting.type ||
       type === removeHighlightSetting.type ||
-      type === updateHighlightSetting.type
+      type === updateHighlightSetting.type ||
+      type === importSettings.type
     ) {
       next(action);
-      const settings = selectSettings(store.getState());
       chatRenderer.setHighlight(
         settings.highlightSettings,
         settings.highlightSettingById,

--- a/tgui/packages/tgui-panel/chat/reducer.ts
+++ b/tgui/packages/tgui-panel/chat/reducer.ts
@@ -4,6 +4,7 @@
  * @license MIT
  */
 
+import { importSettings } from '../settings/actions';
 import {
   addChatPage,
   changeChatPage,
@@ -17,6 +18,7 @@ import {
   updateMessageCount,
 } from './actions';
 import { canPageAcceptType, createMainPage } from './model';
+import { Page } from './types';
 
 const mainPage = createMainPage();
 
@@ -126,6 +128,24 @@ export const chatReducer = (state = initialState, action) => {
         [payload.id]: payload,
       },
     };
+  }
+  if (type === importSettings.type) {
+    const pagesById: Record<string, Page>[] = payload.newPages;
+    if (!pagesById) {
+      return state;
+    }
+    const newPageIds: string[] = Object.keys(pagesById);
+    if (!newPageIds) {
+      return state;
+    }
+
+    const nextState = {
+      ...state,
+      currentPageId: newPageIds[0],
+      pages: [...newPageIds],
+      pageById: { ...pagesById },
+    };
+    return nextState;
   }
   if (type === changeChatPage.type) {
     const { pageId } = payload;

--- a/tgui/packages/tgui-panel/chat/types.ts
+++ b/tgui/packages/tgui-panel/chat/types.ts
@@ -1,0 +1,9 @@
+export type Page = {
+  isMain: boolean;
+  id: string;
+  name: string;
+  acceptedTypes: Record<string, boolean>;
+  unreadCount: number;
+  hideUnreadCount: boolean;
+  createdAt: number;
+};

--- a/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
@@ -15,9 +15,10 @@ import { capitalize } from 'tgui-core/string';
 
 import { clearChat, saveChatToDisk } from '../chat/actions';
 import { THEMES } from '../themes';
-import { updateSettings } from './actions';
+import { exportSettings, updateSettings } from './actions';
 import { FONTS } from './constants';
 import { selectSettings } from './selectors';
+import { importChatSettings } from './settingsImExport';
 
 export function SettingsGeneral(props) {
   const { theme, fontFamily, fontSize, lineHeight } =
@@ -148,6 +149,25 @@ export function SettingsGeneral(props) {
       </LabeledList>
       <Divider />
       <Stack fill>
+        <Stack.Item mt={0.15}>
+          <Button
+            icon="compact-disc"
+            tooltip="Export chat settings"
+            onClick={() => dispatch(exportSettings())}
+          >
+            Export settings
+          </Button>
+        </Stack.Item>
+        <Stack.Item mt={0.15}>
+          <Button.File
+            accept=".json"
+            tooltip="Import chat settings"
+            icon="arrow-up-from-bracket"
+            onSelectFiles={(files) => importChatSettings(files)}
+          >
+            Import settings
+          </Button.File>
+        </Stack.Item>
         <Stack.Item grow mt={0.15}>
           <Button
             icon="save"

--- a/tgui/packages/tgui-panel/settings/actions.ts
+++ b/tgui/packages/tgui-panel/settings/actions.ts
@@ -25,3 +25,10 @@ export const removeHighlightSetting = createAction(
 export const updateHighlightSetting = createAction(
   'settings/updateHighlightSetting',
 );
+export const exportSettings = createAction('settings/export');
+export const importSettings = createAction(
+  'settings/import',
+  (settings, pages) => ({
+    payload: { newSettings: settings, newPages: pages },
+  }),
+);

--- a/tgui/packages/tgui-panel/settings/middleware.ts
+++ b/tgui/packages/tgui-panel/settings/middleware.ts
@@ -93,8 +93,8 @@ export function settingsMiddleware(store) {
       });
     }
     if (type === exportSettings.type) {
-      const settings = selectSettings(store.getState());
       const state = store.getState();
+      const settings = selectSettings(state);
       exportChatSettings(settings, state.chat.pageById);
       return;
     }

--- a/tgui/packages/tgui-panel/settings/middleware.ts
+++ b/tgui/packages/tgui-panel/settings/middleware.ts
@@ -9,6 +9,8 @@ import { storage } from 'common/storage';
 import { setClientTheme } from '../themes';
 import {
   addHighlightSetting,
+  exportSettings,
+  importSettings,
   loadSettings,
   removeHighlightSetting,
   updateHighlightSetting,
@@ -16,6 +18,7 @@ import {
 } from './actions';
 import { FONTS_DISABLED } from './constants';
 import { selectSettings } from './selectors';
+import { exportChatSettings } from './settingsImExport';
 
 let statFontTimer: NodeJS.Timeout;
 let statTabsTimer: NodeJS.Timeout;
@@ -89,12 +92,19 @@ export function settingsMiddleware(store) {
         store.dispatch(loadSettings(settings));
       });
     }
+    if (type === exportSettings.type) {
+      const settings = selectSettings(store.getState());
+      const state = store.getState();
+      exportChatSettings(settings, state.chat.pageById);
+      return;
+    }
     if (
       type !== updateSettings.type &&
       type !== loadSettings.type &&
       type !== addHighlightSetting.type &&
       type !== removeHighlightSetting.type &&
-      type !== updateHighlightSetting.type
+      type !== updateHighlightSetting.type &&
+      type !== importSettings.type
     ) {
       return next(action);
     }
@@ -109,6 +119,10 @@ export function settingsMiddleware(store) {
     next(action);
 
     const settings = selectSettings(store.getState());
+
+    if (importSettings.type) {
+      setClientTheme(settings.theme);
+    }
 
     // Update stat panel settings
     setStatTabsStyle(settings.statTabsStyle);

--- a/tgui/packages/tgui-panel/settings/reducer.ts
+++ b/tgui/packages/tgui-panel/settings/reducer.ts
@@ -7,6 +7,7 @@
 import {
   addHighlightSetting,
   changeSettingsTab,
+  importSettings,
   loadSettings,
   openChatSettings,
   removeHighlightSetting,
@@ -38,6 +39,7 @@ const initialState = {
     visible: false,
     activeTab: SETTINGS_TABS[0].id,
   },
+  initialized: false,
   statLinked: true,
   statFontSize: 12,
   statTabsStyle: 'default',
@@ -60,7 +62,12 @@ export function settingsReducer(
       {
         // Validate version and/or migrate state
         if (!payload?.version) {
-          return state;
+          const nextState = {
+            ...state,
+            ...payload,
+          };
+          nextState.initialized = true;
+          return nextState;
         }
 
         delete payload.view;
@@ -68,6 +75,7 @@ export function settingsReducer(
           ...state,
           ...payload,
         };
+        nextState.initialized = true;
         // Lazy init the list for compatibility reasons
         if (!nextState.highlightSettings) {
           nextState.highlightSettings = [defaultHighlightSetting.id];
@@ -93,6 +101,18 @@ export function settingsReducer(
 
         return nextState;
       }
+    }
+
+    case importSettings.type: {
+      const newSettings = payload.newSettings;
+      if (!newSettings) {
+        return state;
+      }
+      const nextState = {
+        ...state,
+        ...newSettings,
+      };
+      return nextState;
     }
 
     case toggleSettings.type: {

--- a/tgui/packages/tgui-panel/settings/settingsImExport.ts
+++ b/tgui/packages/tgui-panel/settings/settingsImExport.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from 'tgui/backend';
 
-import { Page } from '../chat/types';
+import type { Page } from '../chat/types';
 import { importSettings } from './actions';
 
 export function exportChatSettings(
@@ -26,14 +26,10 @@ export function exportChatSettings(
   window
     .showSaveFilePicker(opts)
     .then((fileHandle) => {
-      try {
-        fileHandle.createWritable().then((writableHandle) => {
-          writableHandle.write(JSON.stringify(exportObject));
-          writableHandle.close();
-        });
-      } catch (e) {
-        console.error(e);
-      }
+      fileHandle.createWritable().then((writableHandle) => {
+        writableHandle.write(JSON.stringify(exportObject));
+        writableHandle.close();
+      });
     })
     .catch((e) => {
       // Log the error if the error has nothing to do with the user aborting the download

--- a/tgui/packages/tgui-panel/settings/settingsImExport.ts
+++ b/tgui/packages/tgui-panel/settings/settingsImExport.ts
@@ -1,0 +1,59 @@
+import { useDispatch } from 'tgui/backend';
+
+import { Page } from '../chat/types';
+import { importSettings } from './actions';
+
+export function exportChatSettings(
+  settings: Record<string, any>,
+  pages: Record<string, Page>[],
+) {
+  const opts: SaveFilePickerOptions = {
+    id: `ss13-chatprefs-${Date.now()}`,
+    suggestedName: `ss13-chatsettings-${new Date().toJSON().slice(0, 10)}.json`,
+    types: [
+      {
+        description: 'SS13 file',
+        accept: { 'application/json': ['.json'] },
+      },
+    ],
+  };
+
+  const pagesEntry: Record<string, Page>[] = [];
+  pagesEntry['chatPages'] = pages;
+
+  const exportObject = Object.assign(settings, pagesEntry);
+
+  window
+    .showSaveFilePicker(opts)
+    .then((fileHandle) => {
+      try {
+        fileHandle.createWritable().then((writableHandle) => {
+          writableHandle.write(JSON.stringify(exportObject));
+          writableHandle.close();
+        });
+      } catch (e) {
+        console.error(e);
+      }
+    })
+    .catch((e) => {
+      // Log the error if the error has nothing to do with the user aborting the download
+      if (e.name !== 'AbortError') {
+        console.error(e);
+      }
+    });
+}
+
+export function importChatSettings(settings: string | string[]) {
+  if (Array.isArray(settings)) {
+    return;
+  }
+  const dispatch = useDispatch();
+  const ourImport = JSON.parse(settings);
+  if (!ourImport?.version) {
+    return;
+  }
+  const pageRecord = ourImport['chatPages'];
+  delete ourImport['chatPages'];
+
+  dispatch(importSettings(ourImport, pageRecord));
+}

--- a/tgui/packages/tgui-panel/telemetry.js
+++ b/tgui/packages/tgui-panel/telemetry.js
@@ -36,6 +36,14 @@ export const telemetryMiddleware = (store) => {
       Byond.sendMessage('telemetry', { connections });
       return;
     }
+    // For whatever reason we didn't get the telemetry, re-request
+    if (type === 'testTelemetryCommand') {
+      setTimeout(() => {
+        if (!telemetry) {
+          Byond.sendMessage('ready');
+        }
+      }, 500);
+    }
     // Keep telemetry up to date
     if (type === 'backend/update') {
       next(action);

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -3641,6 +3641,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/wicg-file-system-access@npm:^2023.10.5":
+  version: 2023.10.5
+  resolution: "@types/wicg-file-system-access@npm:2023.10.5"
+  checksum: 10c0/3c6099320a2517ab405bd65712eb19ba2c1f7f0c30f952744102b76809ed9ad5205f881c79ebe6f92ac7af7a13667df8c23dd59b0a5182119c74afa17335bfd3
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.5.13":
   version: 8.5.13
   resolution: "@types/ws@npm:8.5.13"
@@ -18802,6 +18809,7 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.9.0"
     "@types/webpack-env": "npm:^1.18.5"
+    "@types/wicg-file-system-access": "npm:^2023.10.5"
     "@typescript-eslint/parser": "npm:^8.13.0"
     "@typescript-eslint/utils": "npm:^8.13.0"
     css-loader: "npm:^7.1.2"


### PR DESCRIPTION
In rare cases, we could lose the telemetry or ready message. We'll now have a check to re-request once if we did not receive any telemetry.

Also the chat was able to init before the setting were loaded, even though a rare condition, this could lead to the setting wiped.

Recommending to TM, as our chat differs heavily from the original and I only gave it a short test.

## About The Pull Request
## Why It's Good For The Game
## Changelog
:cl:
fix: TG chat can no longer initialize before the settings loading was called
qol: chat settings can be exported and imported
/:cl:
