### PR TITLE
Buffs Borg Factory Spawned Cyborg Cells

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -20,7 +20,7 @@
 	/// How long until the next mob can be processed
 	var/cooldown_timer
 	/// The created cyborg's cell chage
-	var/robot_cell_charge = STANDARD_CELL_CHARGE * 5
+	var/robot_cell_charge = STANDARD_CELL_CHARGE * 20 //Tier 2 cells
 	/// The visual countdown effect
 	var/obj/effect/countdown/transformer/countdown
 	/// Who the master AI is that created this factory

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -19,8 +19,6 @@
 	var/cooldown = FALSE
 	/// How long until the next mob can be processed
 	var/cooldown_timer
-	/// The created cyborg's cell chage
-	var/robot_cell_charge = STANDARD_CELL_CHARGE * 20 //Tier 2 cells
 	/// The visual countdown effect
 	var/obj/effect/countdown/transformer/countdown
 	/// Who the master AI is that created this factory
@@ -101,7 +99,7 @@
 
 	use_energy(active_power_usage) // Use a lot of power.
 	var/mob/living/silicon/robot/new_borg = victim.Robotize()
-	new_borg.cell = new /obj/item/stock_parts/power_store/cell/upgraded/plus(new_borg, robot_cell_charge)
+	new_borg.cell = new /obj/item/stock_parts/power_store/cell/super(new_borg)
 
 	// So he can't jump out the gate right away.
 	new_borg.SetLockdown()


### PR DESCRIPTION
## About The Pull Request
Atomization of #89810 incase it doesn't go through/while I work on rebalancing it.
Buffs the cells cyborgs spawns with to T2 cells (the same level as rounstart cyborgs) instead of their potato battery they currently have
## Why It's Good For The Game
Hopefully this makes the very cool borg factory module be more used, It used to be that this endgame module was onpar with doomsday, but people just stopped using it I guess. my wish is that, by increasing the cell charge the borgs spawns with it would incentivize AIs to actually do something else than just doomsdaying for once
## Changelog
:cl:
balance: Buffs the energy cells borg factory-spawned cyborgs spawn with (They are now T2 cells)
/:cl:
