### PR TITLE
ERT leaders now have a headset with high-volume mode

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -391,10 +391,12 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
+/obj/item/radio/headset/headset_cent/alt/leader
+	command = TRUE
+
 /obj/item/radio/headset/silicon/pai
 	name = "\proper mini Integrated Subspace Transceiver"
 	subspace_transmission = FALSE
-
 
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver"

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -122,7 +122,7 @@
 
 /datum/antagonist/ert/deathsquad/leader
 	name = "Deathsquad Officer"
-	outfit = /datum/outfit/centcom/death_commando
+	outfit = /datum/outfit/centcom/death_commando/officer
 	role = "Officer"
 
 /datum/antagonist/ert/medic/inquisitor

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -46,6 +46,7 @@
 		/obj/item/melee/baton/security/loaded = 1,
 	)
 	belt = /obj/item/storage/belt/security/full
+	ears = /obj/item/radio/headset/headset_cent/alt/leader
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	l_pocket = /obj/item/switchblade
 	additional_radio = /obj/item/encryptionkey/heads/captain
@@ -261,6 +262,7 @@
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/storage/box/lights/mixed = 1,
 	)
+	ears = /obj/item/radio/headset/headset_cent/alt/leader
 	r_hand = /obj/item/reagent_containers/spray/chemsprayer/janitor
 
 /datum/outfit/centcom/ert/clown
@@ -471,6 +473,7 @@
 	name = "Death Commando Officer"
 
 	back = /obj/item/mod/control/pre_equipped/apocryphal/officer
+	ears = /obj/item/radio/headset/headset_cent/alt/leader
 
 /datum/outfit/centcom/death_commando/officer/post_equip(mob/living/carbon/human/squaddie, visuals_only = FALSE)
 	. = ..()
@@ -491,6 +494,7 @@
 	suit_store = /obj/item/gun/ballistic/automatic/wt550
 	back = /obj/item/shield/riot
 	belt = /obj/item/storage/belt/military/assault/full
+	ears = /obj/item/radio/headset/headset_cent/alt/leader
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch
 	l_pocket = /obj/item/knife/combat
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
@@ -504,6 +508,7 @@
 
 	id = /obj/item/card/id/advanced/centcom/ert/security
 	suit = /obj/item/clothing/suit/armor/vest/marine/security
+	ears = /obj/item/radio/headset/headset_cent/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	head = /obj/item/clothing/head/helmet/marine/security
 	additional_radio = /obj/item/encryptionkey/heads/hos
@@ -523,9 +528,9 @@
 		/obj/item/storage/medkit/advanced = 1,
 	)
 	belt = /obj/item/storage/belt/medical/paramedic
+	ears = /obj/item/radio/headset/headset_cent/alt
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
 	additional_radio = /obj/item/encryptionkey/heads/cmo
-
 
 	skillchips = list(/obj/item/skillchip/entrails_reader)
 
@@ -539,6 +544,7 @@
 	back = /obj/item/deployable_turret_folded
 	uniform = /obj/item/clothing/under/rank/centcom/military/eng
 	belt = /obj/item/storage/belt/utility/full/powertools/rcd
+	ears = /obj/item/radio/headset/headset_cent/alt
 	glasses = /obj/item/clothing/glasses/hud/diagnostic/sunglasses
 	additional_radio = /obj/item/encryptionkey/heads/ce
 
@@ -561,9 +567,9 @@
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/salacid
 	ears = /obj/item/radio/headset
 	backpack_contents = list(
-			/obj/item/storage/medkit/emergency = 1,
-			/obj/item/crowbar = 1,
-			/obj/item/restraints/handcuffs = 1,
+		/obj/item/storage/medkit/emergency = 1,
+		/obj/item/crowbar = 1,
+		/obj/item/restraints/handcuffs = 1,
 	)
 
 /datum/outfit/centcom/militia/general
@@ -590,6 +596,7 @@
 		/obj/item/stack/medical/poultice = 1, //These stacks contain 15 by default. Great for getting corpses to defib range without surgery.
 	)
 	belt = /obj/item/storage/belt/medical/ert
+	ears = /obj/item/radio/headset/headset_cent/alt
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
 	additional_radio = /obj/item/encryptionkey/heads/cmo
 	mask = /obj/item/clothing/mask/surgical


### PR DESCRIPTION
## About The Pull Request

Added an headset subtype for ERT leaders. The only difference is the high-volume mode
Also fixed the fact that Deathsquad Officer spawns with `/datum/outfit/centcom/death_commando` instead of `/datum/outfit/centcom/death_commando/officer`
## Why It's Good For The Game

The messages of ERT leaders will have better visibility in chat
## Changelog
:cl:
qol: ERT leaders now have a headset with high-volume mode
fix: Deathsquad Officer will now have proper outfit
/:cl:
