### PR TITLE
Covers an edge case with Cryogelidia possibly still not removing the status effects when it should.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -124,3 +124,9 @@
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/frozenstasis/irresistable)
 	affected_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
+
+/datum/reagent/inverse/cryostylane/on_mob_delete(mob/living/affected_mob, amount)
+	. = ..()
+	affected_mob.remove_status_effect(/datum/status_effect/frozenstasis/irresistable)
+	affected_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
+


### PR DESCRIPTION

## About The Pull Request

We remove the status effects on both on_mob_end_metabolize() and on_mob_delete()

## Why It's Good For The Game

Not sure HOW this happens but this will hopefully cover those potential situations where something removes reagents from a mob, but doesn't necessarily call on_mob_end_metabolize().

## Changelog
:cl:
fix: Makes absolutely sure we're removing Cyrogelidia's status effects if the reagent is out of our mobs system.
/:cl:
