### PR TITLE
Prevent duplicated objects in important_recursive_contents

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -990,8 +990,9 @@
 
 ///allows this movable to hear and adds itself to the important_recursive_contents list of itself and every movable loc its in
 /atom/movable/proc/become_hearing_sensitive(trait_source = TRAIT_GENERIC)
+	var/already_hearing_sensitive = HAS_TRAIT(src, TRAIT_HEARING_SENSITIVE)
 	ADD_TRAIT(src, TRAIT_HEARING_SENSITIVE, trait_source)
-	if(!HAS_TRAIT(src, TRAIT_HEARING_SENSITIVE))
+	if(already_hearing_sensitive) // If we were already hearing sensitive, we don't wanna be in important_recursive_contents twice, else we'll have potential issues like one radio sending the same message multiple times
 		return
 
 	for(var/atom/movable/location as anything in get_nested_locs(src) + src)


### PR DESCRIPTION

## About The Pull Request

This fixes a bug introduced back in https://github.com/tgstation/tgstation/pull/66709 that could cause the same object to appear in `important_recursive_contents` multiple times if `become_hearing_sensitive` was called multiple times, most commonly with the broadcast camera's entertainment channel microphone.

<details>
<summary><h3>Before</h3></summary>

![2025-03-04 (1741121218) ~ dreamseeker](https://github.com/user-attachments/assets/237de847-6bb9-40ac-8efb-fb1d9c1e8048)

</details>

<details>
<summary><h3>After</h3></summary>

![2025-03-04 (1741121797) ~ dreamseeker](https://github.com/user-attachments/assets/dd954ae4-8f65-4d84-b462-f91664979d0c)

</details>

## Why It's Good For The Game

because hearing every message twice when the curator is streaming is annoying

## Changelog
:cl:
fix: Fixed some hearing sensitive objects hearing the same thing multiple times, such as the broadcast camera sending everything to the entertainment channel twice.
/:cl:
