### PR TITLE
partially reverses the giga-nerf to exosuit PKAs

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -264,8 +264,6 @@
 /obj/projectile/kinetic/mech
 	range = 5
 	damage = 50
-	//the multiplier we apply to our PKa's AOE effect.
-	var/aoe_damage_multiplier = 0.3
 
 /obj/projectile/kinetic/mech/strike_thing(atom/target)
 	. = ..()
@@ -277,7 +275,7 @@
 			continue
 
 		var/armor = living_mob.run_armor_check(def_zone, armor_flag, armour_penetration = armour_penetration)
-		living_mob.apply_damage(damage*aoe_damage_multiplier, damage_type, def_zone, armor)
+		living_mob.apply_damage(damage, damage_type, def_zone, armor)
 		to_chat(living_mob, span_userdanger("You're struck by a [name]!"))
 
 //Modkits

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -172,7 +172,6 @@
 	icon_state = "mecha_kineticgun"
 	energy_drain = 30
 	projectile = /obj/projectile/kinetic/mech
-	equip_cooldown = 1.6 SECONDS
 	fire_sound = 'sound/items/weapons/kinetic_accel.ogg'
 	harmful = TRUE
 	mech_flags = EXOSUIT_MODULE_COMBAT | EXOSUIT_MODULE_WORKING


### PR DESCRIPTION
## About The Pull Request

as it turns out having a PKA that is worse and cannot be upgraded strapped to a machine that requires departmental cooperation with robotics to build, which is also harder to maintain and easier to lose (due to things like motors breaking and lobstrosities flattening them instantly) was not a very good deal. As a result, the clarke went from a powerful machine that was worth the material and research point investment, to Bad. (One quarter DPS on direct hits, one eighth on indirect hits, as aoe dealt a grand total of 15 damage)

the double cooldown has been removed, and so has the aoe falloff, though it still only works against mining mobs

## Why It's Good For The Game

clarke mechs were a tool designed to help facilitate the collection of materials, especially on lowpop with no miners. because of arcmining, these materials are stored in ore veins, which require a combat encounter to harvest, which became significantly impossible to downright impossible to perform due to the nerfs. if you're going to go through the effort of researching and constructing an exosuit from robotics, it probably shouldn't be a sidegrade to a guy with roundstart equipment

## Changelog
:cl:
balance: exosuit proto-kinetic accelerator cooldown halved, damage falloff on aoe removed.
/:cl:
