### PR TITLE
Change bounty console's cooldown message to a balloon alert (+ minor code improvements)

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -176,7 +176,7 @@
  */
 /obj/machinery/computer/piratepad_control/civilian/proc/pick_bounty(datum/bounty/choice)
 	if(!inserted_scan_id?.registered_account?.bounties?[choice])
-		playsound(loc, 'sound/machines/synth/synth_no.ogg', vol = 40, vary = TRUE)
+		playsound(loc, 'sound/machines/synth/synth_no.ogg', 40 , TRUE)
 		return
 	inserted_scan_id.registered_account.civilian_bounty = inserted_scan_id.registered_account.bounties[choice]
 	inserted_scan_id.registered_account.bounties = null

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -152,21 +152,21 @@
 
 ///Here is where cargo bounties are added to the player's bank accounts, then adjusted and scaled into a civilian bounty.
 /obj/machinery/computer/piratepad_control/civilian/proc/add_bounties(mob/user, cooldown_reduction = 0)
-	var/datum/bank_account/pot_acc = inserted_scan_id?.registered_account
-	if(!pot_acc)
+	var/datum/bank_account/id_account = inserted_scan_id?.registered_account
+	if(!id_account)
 		return
-	if((pot_acc.civilian_bounty || pot_acc.bounties) && !COOLDOWN_FINISHED(pot_acc, bounty_timer))
-		var/time_left = DisplayTimeText(COOLDOWN_TIMELEFT(pot_acc, bounty_timer), round_seconds_to = 1)
+	if((id_account.civilian_bounty || id_account.bounties) && !COOLDOWN_FINISHED(id_account, bounty_timer))
+		var/time_left = DisplayTimeText(COOLDOWN_TIMELEFT(id_account, bounty_timer), round_seconds_to = 1)
 		balloon_alert(user, "try again in [time_left]!")
 		return FALSE
-	if(!pot_acc.account_job)
+	if(!id_account.account_job)
 		say("Requesting ID card has no job assignment registered!")
 		return FALSE
-	var/list/datum/bounty/crumbs = list(random_bounty(pot_acc.account_job.bounty_types), // We want to offer 2 bounties from their appropriate job catagories
-										random_bounty(pot_acc.account_job.bounty_types), // and 1 guaranteed assistant bounty if the other 2 suck.
+	var/list/datum/bounty/crumbs = list(random_bounty(id_account.account_job.bounty_types), // We want to offer 2 bounties from their appropriate job catagories
+										random_bounty(id_account.account_job.bounty_types), // and 1 guaranteed assistant bounty if the other 2 suck.
 										random_bounty(CIV_JOB_BASIC))
-	COOLDOWN_START(pot_acc, bounty_timer, (5 MINUTES) - cooldown_reduction)
-	pot_acc.bounties = crumbs
+	COOLDOWN_START(id_account, bounty_timer, (5 MINUTES) - cooldown_reduction)
+	id_account.bounties = crumbs
 
 /**
  * Proc that assigned a civilian bounty to an ID card, from the list of potential bounties that that bank account currently has available.
@@ -175,13 +175,14 @@
  * @param choice The index of the bounty in the list of bounties that the player can choose from.
  */
 /obj/machinery/computer/piratepad_control/civilian/proc/pick_bounty(datum/bounty/choice)
-	if(!inserted_scan_id?.registered_account?.bounties?[choice])
+	var/datum/bank_account/id_account = inserted_scan_id?.registered_account
+	if(!id_account?.bounties?[choice])
 		playsound(loc, 'sound/machines/synth/synth_no.ogg', 40 , TRUE)
 		return
-	inserted_scan_id.registered_account.civilian_bounty = inserted_scan_id.registered_account.bounties[choice]
-	inserted_scan_id.registered_account.bounties = null
-	SSblackbox.record_feedback("tally", "bounties_assigned", 1, inserted_scan_id.registered_account.civilian_bounty.type)
-	return inserted_scan_id.registered_account.civilian_bounty
+	id_account.civilian_bounty = id_account.bounties[choice]
+	id_account.bounties = null
+	SSblackbox.record_feedback("tally", "bounties_assigned", 1, id_account.civilian_bounty.type)
+	return id_account.civilian_bounty
 
 /obj/machinery/computer/piratepad_control/civilian/click_alt(mob/user)
 	id_eject(user, inserted_scan_id)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -156,7 +156,8 @@
 	if(!pot_acc)
 		return
 	if((pot_acc.civilian_bounty || pot_acc.bounties) && !COOLDOWN_FINISHED(pot_acc, bounty_timer))
-		balloon_alert(user, "try again in [DisplayTimeText(COOLDOWN_TIMELEFT(pot_acc, bounty_timer))]!")
+		var/time_left = DisplayTimeText(COOLDOWN_TIMELEFT(pot_acc, bounty_timer), round_seconds_to = 1)
+		balloon_alert(user, "try again in [time_left]!")
 		return FALSE
 	if(!pot_acc.account_job)
 		say("Requesting ID card has no job assignment registered!")


### PR DESCRIPTION
## About The Pull Request

this changes the bounty console's "Internal ID network spools coiling, try again in 1.5 minutes!" out loud alert to a balloon alert like "try again in 1 minute and 30 seconds!"

![image](https://github.com/user-attachments/assets/0cc42461-49b6-44c2-bbb2-ac8b937e656b)

also made minor improvements to the civ bounty console's code (goodbye `usr`)

## Why It's Good For The Game

oh god stop spamming this shit please. also it's nice for time to be slightly more readable.

## Changelog
:cl:
qol: Changed the civilian bounty console's cooldown message to a balloon alert, and it now says like "1 minute and 30 seconds" instead of "1.5 minutes"
code: Minor improvements to civilian bounty console code.
/:cl:
