### PR TITLE
Fix some new sound runtimes

### DIFF
--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -139,7 +139,7 @@
 	mid_length = 1.8 SECONDS
 	end_sound = 'sound/machines/computer/computer_end.ogg'
 	end_volume = 1 SECONDS
-	volume = 2
+	volume = SOUND_AUDIBLE_VOLUME_MIN
 	falloff_exponent = 5 //Ultra quiet very fast
 	extra_range = -12
 	falloff_distance = 1 //Instant falloff after initial tile

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -533,7 +533,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(silent)
 		return
 
-	if(do_rustle)
+	if(do_rustle && rustle_sound)
 		playsound(parent, rustle_sound, 50, rustle_vary, -5)
 
 	if(!silent_for_user)
@@ -567,7 +567,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		if(do_rustle && !silent)
 			if(remove_rustle_sound)
 				playsound(parent, remove_rustle_sound, 50, TRUE, -5)
-			else
+			else if(rustle_sound)
 				playsound(parent, rustle_sound, 50, TRUE, -5)
 	else
 		thing.moveToNullspace()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -353,7 +353,7 @@
 	))
 	atom_storage.open_sound = 'sound/items/handling/holster_open.ogg'
 	atom_storage.open_sound_vary = TRUE
-	atom_storage.rustle_sound = FALSE
+	atom_storage.rustle_sound = null
 
 /obj/item/storage/belt/security/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -202,8 +202,6 @@
 	)
 
 /datum/surgery_step/proc/play_preop_sound(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(!preop_sound)
-		return
 	var/sound_file_use
 	if(islist(preop_sound))
 		for(var/typepath in preop_sound)//iterate and assign subtype to a list, works best if list is arranged from subtype first and parent last
@@ -212,7 +210,9 @@
 				break
 	else
 		sound_file_use = preop_sound
-	playsound(get_turf(target), sound_file_use, 75, TRUE, falloff_exponent = 12, falloff_distance = 1)
+	if(!sound_file_use)
+		return
+	playsound(target, sound_file_use, 75, TRUE, falloff_exponent = 12, falloff_distance = 1)
 
 /datum/surgery_step/proc/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = TRUE)
 	SEND_SIGNAL(user, COMSIG_MOB_SURGERY_STEP_SUCCESS, src, target, target_zone, tool, surgery, default_display_results)


### PR DESCRIPTION
## About The Pull Request

- This sound was lower than the min

![image](https://github.com/user-attachments/assets/4447ac03-33ea-41f9-9ea6-99e3e0c9725d)

- Mechanical surgery seemed to cause a `null` preop sound runtime. This fix might be silencing a runtime, I'll have to look closer.

- And `rustle_sound` could be `null`. I think this is actually a mistake, and the correct way to mute rustling is `do_rustle = FALSE`, but I feel like we could just delete that var and let people dictate it by setting it to `null` or not? For a follow up PR nevertheless

## Changelog

:cl: Melbert
fix: You can hear looping computer sounds again
/:cl:
