### PR TITLE
Make a craftable version of the radio jammers, and make the traitor radio jammer cost 1 TC instead of 5

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -110,9 +110,9 @@
 		if(crayon.use_charges(user, 10))
 			return
 
-/datum/crafting_recipe/radio_jammer
-	name = "Radio Jammer"
-	result = /obj/item/jammer
+/datum/crafting_recipe/makeshift_radio_jammer
+	name = "Makeshift Radio Jammer"
+	result = /obj/item/jammer/makeshift
 	reqs = list(
 		/obj/item/universal_scanner = 1,
 		/obj/item/encryptionkey = 1,

--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -109,3 +109,13 @@
 			continue
 		if(crayon.use_charges(user, 10))
 			return
+
+/datum/crafting_recipe/radio_jammer
+	name = "Radio Jammer"
+	result = /obj/item/jammer
+	reqs = list(
+		/obj/item/universal_scanner = 1,
+		/obj/item/encryptionkey = 1,
+		/obj/item/stack/cable_coil = 5,
+	)
+	category = CAT_TOOLS

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -327,8 +327,14 @@ effective or pretty fucking useless.
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
 	icon_state = "jammer"
 	var/active = FALSE
+
+	/// The range of devices to disable while active
 	var/range = 12
+
+	/// The range of the disruptor wave, disabling radios
 	var/disruptor_range = 7
+
+	/// The delay between using the disruptor wave
 	var/jam_cooldown_duration = 15 SECONDS
 	COOLDOWN_DECLARE(jam_cooldown)
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -328,6 +328,7 @@ effective or pretty fucking useless.
 	icon_state = "jammer"
 	var/active = FALSE
 	var/range = 12
+	var/disruptor_range = 7
 	var/jam_cooldown_duration = 15 SECONDS
 	COOLDOWN_DECLARE(jam_cooldown)
 
@@ -348,7 +349,7 @@ effective or pretty fucking useless.
 
 	user.balloon_alert(user, "disruptor wave released!")
 	to_chat(user, span_notice("You release a disruptor wave, disabling all nearby radio devices."))
-	for (var/atom/potential_owner in view(7, user))
+	for (var/atom/potential_owner in view(disruptor_range, user))
 		disable_radios_on(potential_owner, ignore_syndie = TRUE)
 	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
 
@@ -372,7 +373,7 @@ effective or pretty fucking useless.
 	if(. & ITEM_INTERACT_ANY_BLOCKER)
 		return
 
-	if (!(interacting_with in view(7, user)))
+	if (!(interacting_with in view(disruptor_range, user)))
 		user.balloon_alert(user, "out of reach!")
 		return
 
@@ -391,6 +392,12 @@ effective or pretty fucking useless.
 /obj/item/jammer/Destroy()
 	GLOB.active_jammers -= src
 	return ..()
+
+/obj/item/jammer/makeshift
+	name = "makeshift radio jammer"
+	desc = "A jury-rigged device that disrupts nearby radio communication. Its crude construction provides a significantly smaller area of effect compared to its Syndicate counterpart."
+	range = 5
+	disruptor_range = 3
 
 /obj/item/storage/toolbox/emergency/turret
 	desc = "You feel a strange urge to hit this with a wrench."

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -405,6 +405,10 @@ effective or pretty fucking useless.
 	range = 5
 	disruptor_range = 3
 
+/obj/item/jammer/makeshift/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_CONTRABAND, INNATE_TRAIT)
+
 /obj/item/storage/toolbox/emergency/turret
 	desc = "You feel a strange urge to hit this with a wrench."
 

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -83,7 +83,7 @@
 	name = "Radio Jammer"
 	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."
 	item = /obj/item/jammer
-	cost = 5
+	cost = 1
 
 /datum/uplink_item/stealthy_tools/smugglersatchel
 	name = "Smuggler's Satchel"


### PR DESCRIPTION
## About The Pull Request
Makes makeshift radio jammers craftable with:
1. Universal scanner
2. Headset encryption key (it doesn't steal the one from your headset don't worry)
3. Cable coil

Makeshift radio jammers are the same as Syndicate ones, except with a smaller active range (12 -> 5) and smaller disruptor range (7 -> 3)

Lowers the cost of radio jammers from 5 TC to 1 TC.

## Why It's Good For The Game

This is intended as a potentially overkill solution to the problem of people shouting that they are being killed right away. Common is not going away, but we need to do something to aide this style of gameplay over going loud etc. By making radio jammers craftable, we allow all antagonists to use this instead of just traitors.

## Changelog
:cl:
add: You can now craft radio jammers.
balance: Radio jammers have had their cost lowered from 5 TC to 1 TC.
/:cl:
