### PR TITLE
Fixes the prefs dummy not updating for species features / Bald quirk prefs QoL

### DIFF
--- a/code/datums/quirks/neutral_quirks/bald.dm
+++ b/code/datums/quirks/neutral_quirks/bald.dm
@@ -4,6 +4,7 @@
 	icon = FA_ICON_EGG
 	value = 0
 	mob_trait = TRAIT_BALD
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_CHANGES_APPEARANCE
 	gain_text = span_notice("Your head is as smooth as can be, it's terrible.")
 	lose_text = span_notice("Your head itches, could it be... growing hair?!")
 	medical_record_text = "Patient starkly refused to take off headwear during examination."
@@ -19,7 +20,7 @@
 	RegisterSignal(human_holder, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(unequip_hat))
 
 /datum/quirk/item_quirk/bald/add_unique(client/client_source)
-	var/obj/item/clothing/head/wig/natural/baldie_wig = new(get_turf(quirk_holder))
+	var/obj/item/clothing/head/wig/natural/baldie_wig = SSwardrobe.provide_type(__IMPLIED_TYPE__)
 	if(old_hair == "Bald")
 		baldie_wig.hairstyle = pick(SSaccessories.hairstyles_list - "Bald")
 	else
@@ -27,13 +28,47 @@
 
 	baldie_wig.update_appearance()
 
-	give_item_to_holder(baldie_wig, list(LOCATION_HEAD = ITEM_SLOT_HEAD, LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
+	give_item_to_holder(baldie_wig, list(LOCATION_HEAD = ITEM_SLOT_HEAD, LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS), notify_player = FALSE)
+
+/datum/quirk/item_quirk/bald/give_item_to_holder(obj/item/quirk_item, list/valid_slots, flavour_text = null, default_location = "at your feet", notify_player = TRUE)
+	var/any_head = FALSE
+	for(var/place_loc in valid_slots)
+		if(valid_slots[place_loc] & ITEM_SLOT_HEAD)
+			any_head = TRUE
+			break
+
+	// guess we don't care
+	if(!any_head)
+		return ..()
+
+	if(ispath(quirk_item, /obj/item))
+		quirk_item = new quirk_item(get_turf(quirk_holder))
+
+	// check if their job / loadout has a hat
+	var/obj/item/existing = quirk_holder.get_item_by_slot(ITEM_SLOT_HEAD)
+	// no hat -> try equipping like normal (via parent)
+	if(isnull(existing))
+		return ..()
+	// try removing the existing hat. if fail -> try equipping like normal
+	if(!quirk_holder.temporarilyRemoveItemFromInventory(existing))
+		return ..()
+	// try to place the wig. if fail -> try equipping like normal
+	if(!quirk_holder.equip_to_slot_if_possible(quirk_item, ITEM_SLOT_HEAD, qdel_on_fail = FALSE, indirect_action = TRUE))
+		return ..()
+
+	// now that the wig is properly equipped, try attaching the old job / loadout hat via the component
+	var/datum/component/hat_stabilizer/comp = quirk_item.GetComponent(/datum/component/hat_stabilizer)
+	// nvm i guess someone removed that feature (futureproofed comment)
+	if(!isnull(comp))
+		return ..()
+
+	comp.attach_hat(existing)
 
 /datum/quirk/item_quirk/bald/remove()
 	. = ..()
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.hairstyle = old_hair
-	human_holder.update_body_parts()
+	if(human_holder.hairstyle == "Bald" && old_hair != "Bald")
+		human_holder.set_hairstyle(old_hair, update = TRUE)
 	UnregisterSignal(human_holder, list(COMSIG_CARBON_EQUIP_HAT, COMSIG_CARBON_UNEQUIP_HAT))
 	human_holder.clear_mood_event("bad_hair_day")
 

--- a/code/datums/quirks/neutral_quirks/bald.dm
+++ b/code/datums/quirks/neutral_quirks/bald.dm
@@ -45,9 +45,9 @@
 		quirk_item = new quirk_item(get_turf(quirk_holder))
 
 	// check if their job / loadout has a hat
-	var/obj/item/existing = quirk_holder.get_item_by_slot(ITEM_SLOT_HEAD)
+	var/obj/item/clothing/existing = quirk_holder.get_item_by_slot(ITEM_SLOT_HEAD)
 	// no hat -> try equipping like normal (via parent)
-	if(isnull(existing) || (existing.clothing_flags & STACKABLE_HELMET_EXEMPT))
+	if(!istype(existing) || (existing.clothing_flags & STACKABLE_HELMET_EXEMPT))
 		return ..()
 	// try removing the existing hat. if fail -> try equipping like normal
 	if(!quirk_holder.temporarilyRemoveItemFromInventory(existing))

--- a/code/datums/quirks/neutral_quirks/bald.dm
+++ b/code/datums/quirks/neutral_quirks/bald.dm
@@ -47,7 +47,7 @@
 	// check if their job / loadout has a hat
 	var/obj/item/existing = quirk_holder.get_item_by_slot(ITEM_SLOT_HEAD)
 	// no hat -> try equipping like normal (via parent)
-	if(isnull(existing) || (existing.item_flags & STACKABLE_HELMET_EXEMPT))
+	if(isnull(existing) || (existing.clothing_flags & STACKABLE_HELMET_EXEMPT))
 		return ..()
 	// try removing the existing hat. if fail -> try equipping like normal
 	if(!quirk_holder.temporarilyRemoveItemFromInventory(existing))

--- a/code/datums/quirks/neutral_quirks/bald.dm
+++ b/code/datums/quirks/neutral_quirks/bald.dm
@@ -20,7 +20,7 @@
 	RegisterSignal(human_holder, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(unequip_hat))
 
 /datum/quirk/item_quirk/bald/add_unique(client/client_source)
-	var/obj/item/clothing/head/wig/natural/baldie_wig = SSwardrobe.provide_type(__IMPLIED_TYPE__)
+	var/obj/item/clothing/head/wig/natural/baldie_wig = new(get_turf(quirk_holder))
 	if(old_hair == "Bald")
 		baldie_wig.hairstyle = pick(SSaccessories.hairstyles_list - "Bald")
 	else
@@ -47,7 +47,7 @@
 	// check if their job / loadout has a hat
 	var/obj/item/existing = quirk_holder.get_item_by_slot(ITEM_SLOT_HEAD)
 	// no hat -> try equipping like normal (via parent)
-	if(isnull(existing))
+	if(isnull(existing) || (existing.item_flags & STACKABLE_HELMET_EXEMPT))
 		return ..()
 	// try removing the existing hat. if fail -> try equipping like normal
 	if(!quirk_holder.temporarilyRemoveItemFromInventory(existing))
@@ -59,7 +59,7 @@
 	// now that the wig is properly equipped, try attaching the old job / loadout hat via the component
 	var/datum/component/hat_stabilizer/comp = quirk_item.GetComponent(/datum/component/hat_stabilizer)
 	// nvm i guess someone removed that feature (futureproofed comment)
-	if(!isnull(comp))
+	if(isnull(comp))
 		return ..()
 
 	comp.attach_hat(existing)

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -325,23 +325,27 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 	return null
 
+/// Checks the species currently selected by the passed preferences object to see if it has this preference's key as a feature.
+/datum/preference/proc/current_species_has_savekey(datum/preferences/preferences)
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = GLOB.species_prototypes[species_type]
+	return (savefile_key in species.get_features())
+
+/// Checks if this preference is relevant and thus visible to the passed preferences object.
+/datum/preference/proc/has_relevant_feature(datum/preferences/preferences)
+	if(isnull(relevant_inherent_trait) && isnull(relevant_external_organ) && isnull(relevant_head_flag) && isnull(relevant_body_markings))
+		return TRUE
+
+	return current_species_has_savekey(preferences)
+
 /// Returns whether or not this preference is accessible.
 /// If FALSE, will not show in the UI and will not be editable (by update_preference).
 /datum/preference/proc/is_accessible(datum/preferences/preferences)
 	SHOULD_CALL_PARENT(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 
-	if ( \
-		!isnull(relevant_inherent_trait) \
-		|| !isnull(relevant_external_organ) \
-		|| !isnull(relevant_head_flag) \
-		|| !isnull(relevant_body_markings) \
-	)
-		var/species_type = preferences.read_preference(/datum/preference/choiced/species)
-
-		var/datum/species/species = GLOB.species_prototypes[species_type]
-		if (!(savefile_key in species.get_features()))
-			return FALSE
+	if (!has_relevant_feature(preferences))
+		return FALSE
 
 	if (!should_show_on_page(preferences.current_window))
 		return FALSE

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -144,9 +144,7 @@
 	relevant_head_flag = HEAD_HAIR
 
 /datum/preference/color/hair_color/has_relevant_feature(datum/preferences/preferences)
-	if("[/datum/quirk/item_quirk/bald::name]" in preferences.all_quirks)
-		return TRUE
-	return ..()
+	return ..() || /datum/quirk/item_quirk/bald::name in preferences.all_quirks
 
 /datum/preference/color/hair_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_haircolor(value, update = FALSE)
@@ -164,9 +162,7 @@
 	relevant_head_flag = HEAD_HAIR
 
 /datum/preference/choiced/hairstyle/has_relevant_feature(datum/preferences/preferences)
-	if(/datum/quirk/item_quirk/bald::name in preferences.all_quirks)
-		return TRUE
-	return ..()
+	return ..() || /datum/quirk/item_quirk/bald::name in preferences.all_quirks
 
 /datum/preference/choiced/hairstyle/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.hairstyles_list)

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -144,7 +144,7 @@
 	relevant_head_flag = HEAD_HAIR
 
 /datum/preference/color/hair_color/has_relevant_feature(datum/preferences/preferences)
-	return ..() || /datum/quirk/item_quirk/bald::name in preferences.all_quirks
+	return ..() || (/datum/quirk/item_quirk/bald::name in preferences.all_quirks)
 
 /datum/preference/color/hair_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_haircolor(value, update = FALSE)
@@ -162,7 +162,7 @@
 	relevant_head_flag = HEAD_HAIR
 
 /datum/preference/choiced/hairstyle/has_relevant_feature(datum/preferences/preferences)
-	return ..() || /datum/quirk/item_quirk/bald::name in preferences.all_quirks
+	return ..() || (/datum/quirk/item_quirk/bald::name in preferences.all_quirks)
 
 /datum/preference/choiced/hairstyle/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.hairstyles_list)

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -143,6 +143,11 @@
 	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
 	relevant_head_flag = HEAD_HAIR
 
+/datum/preference/color/hair_color/has_relevant_feature(datum/preferences/preferences)
+	if("[/datum/quirk/item_quirk/bald::name]" in preferences.all_quirks)
+		return TRUE
+	return ..()
+
 /datum/preference/color/hair_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_haircolor(value, update = FALSE)
 
@@ -157,6 +162,11 @@
 	main_feature_name = "Hairstyle"
 	should_generate_icons = TRUE
 	relevant_head_flag = HEAD_HAIR
+
+/datum/preference/choiced/hairstyle/has_relevant_feature(datum/preferences/preferences)
+	if(/datum/quirk/item_quirk/bald::name in preferences.all_quirks)
+		return TRUE
+	return ..()
 
 /datum/preference/choiced/hairstyle/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.hairstyles_list)

--- a/code/modules/client/preferences/species_features/ethereal.dm
+++ b/code/modules/client/preferences/species_features/ethereal.dm
@@ -5,6 +5,10 @@
 	main_feature_name = "Ethereal color"
 	should_generate_icons = TRUE
 
+/datum/preference/choiced/ethereal_color/has_relevant_feature(datum/preferences/preferences)
+	// Skips checks for relevant_organ, relevant trait etc. because ethereal color is tied directly to species (atm)
+	return current_species_has_savekey(preferences)
+
 /datum/preference/choiced/ethereal_color/init_possible_values()
 	return assoc_to_keys(GLOB.color_list_ethereal)
 

--- a/code/modules/client/preferences/species_features/lizard.dm
+++ b/code/modules/client/preferences/species_features/lizard.dm
@@ -63,6 +63,7 @@
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Frills"
 	should_generate_icons = TRUE
+	relevant_external_organ = /obj/item/organ/frills
 
 /datum/preference/choiced/lizard_frills/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.frills_list)
@@ -79,6 +80,7 @@
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Horns"
 	should_generate_icons = TRUE
+	relevant_external_organ = /obj/item/organ/horns
 
 /datum/preference/choiced/lizard_horns/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.horns_list)
@@ -134,6 +136,7 @@
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Snout"
 	should_generate_icons = TRUE
+	relevant_external_organ = /obj/item/organ/snout
 
 /datum/preference/choiced/lizard_snout/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.snouts_list)

--- a/code/modules/client/preferences/species_features/moth.dm
+++ b/code/modules/client/preferences/species_features/moth.dm
@@ -4,6 +4,7 @@
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Antennae"
 	should_generate_icons = TRUE
+	relevant_external_organ = /obj/item/organ/antennae
 
 /datum/preference/choiced/moth_antennae/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.moth_antennae_list)
@@ -86,6 +87,7 @@
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Moth wings"
 	should_generate_icons = TRUE
+	relevant_external_organ = /obj/item/organ/wings/moth
 
 /datum/preference/choiced/moth_wings/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.moth_wings_list)

--- a/code/modules/client/preferences/species_features/pod.dm
+++ b/code/modules/client/preferences/species_features/pod.dm
@@ -4,6 +4,7 @@
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Hairstyle"
 	should_generate_icons = TRUE
+	relevant_external_organ = /obj/item/organ/pod_hair
 
 /datum/preference/choiced/pod_hair/init_possible_values()
 	return assoc_to_keys_features(SSaccessories.pod_hair_list)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -201,6 +201,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 ///Used as callbacks by object pooling
 /obj/item/organ/proc/exit_wardrobe()
 	START_PROCESSING(SSobj, src)
+	bodypart_overlay?.imprint_on_next_insertion = TRUE
 
 //See above
 /obj/item/organ/proc/enter_wardrobe()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -512,15 +512,7 @@ export function MainPage(props: MainPageProps) {
 
   const mainFeatures = [
     ...Object.entries(data.character_preferences.clothing),
-    ...Object.entries(data.character_preferences.features).filter(
-      ([featureName]) => {
-        if (!currentSpeciesData) {
-          return false;
-        }
-
-        return currentSpeciesData.enabled_features.indexOf(featureName) !== -1;
-      },
-    ),
+    ...Object.entries(data.character_preferences.features),
   ];
 
   const randomBodyEnabled =


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/b03901a2-1c2d-4793-9591-abe824a90fd5)

Fixes #89768
Fixes #89769

- Fixes the prefs menu not updating mobs

Organs are imprinted on insert, and SSwardrobe didn't reset this imprinting status when taking out items.

Weirdly in the past (testing old commits) items withdrawn DID reset imprinting status - or maybe they never set it in the first place?

- Lots of prefs now respect features

`is_accessible` is used when checking many features rather than the prefs menu checking itself in the UI

- Bald quirk QOL

Just handy stuff like showing the wig in the prefs preview, pre-starting with your hat attached

## Changelog

:cl: Melbert
fix: Preference dummy now properly updates when changing some species features
qol: If you have the bald quirk selected, the wig shows up on the preference dummy
qol: If you have the bald quirk selected, and your role starts with a hat, the hat will start attached to your wig
/:cl: