### PR TITLE
Being sufficiently drunk gives you fearlessness

### DIFF
--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -126,6 +126,7 @@
 		owner.sound_environment_override = SOUND_ENVIRONMENT_NONE
 
 	UnregisterSignal(owner, COMSIG_MOB_FIRED_GUN)
+	REMOVE_TRAIT(owner, TRAIT_FEARLESS, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/inebriated/drunk/proc/drunk_gun_fired(datum/source, obj/item/gun/gun, atom/firing_at, params, zone, bonus_spread_values)
 	SIGNAL_HANDLER
@@ -182,6 +183,9 @@
 			if(iscarbon(owner))
 				var/mob/living/carbon/carbon_owner = owner
 				carbon_owner.vomit(VOMIT_CATEGORY_DEFAULT) // Vomiting clears toxloss - consider this a blessing
+		ADD_TRAIT(owner, TRAIT_FEARLESS, TRAIT_STATUS_EFFECT(id))
+	else
+		REMOVE_TRAIT(owner, TRAIT_FEARLESS, TRAIT_STATUS_EFFECT(id))
 
 	// Over 71, we will constantly have blurry eyes
 	if(drunk_value >= 71)


### PR DESCRIPTION
## About The Pull Request

Drunkness > 50 gives you `TRAIT_FEARLESS`, which helps with phobias and social anxiety

## Why It's Good For The Game

Liquid courage

## Changelog

:cl: Melbert
add: If you are sufficiently drunk, you can resist your phobias and social anxiety. 
/:cl:

