### PR TITLE
completely removes player access to technology disks (not design disks, like BEPIS tech disks, they're different)

### DIFF
--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2229,7 +2229,6 @@
 "jr" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /turf/open/floor/iron/white,
 /area/awaymission/undergroundoutpost45/research)

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -68165,15 +68165,6 @@
 /obj/structure/table,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
 /obj/item/stack/cable_coil,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white/small,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6375,15 +6375,6 @@
 /area/station/hallway/primary/starboard)
 "bBL" = (
 /obj/structure/table/reinforced,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -59312,14 +59312,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_y = 4
 	},
-/obj/item/disk/tech_disk{
-	pixel_x = -2;
-	pixel_y = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = -4;
-	pixel_y = -7
-	},
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6483,10 +6483,6 @@
 	pixel_x = 9;
 	pixel_y = -1
 	},
-/obj/item/disk/tech_disk{
-	pixel_x = -2;
-	pixel_y = -3
-	},
 /obj/item/disk/design_disk{
 	name = "component design disk";
 	pixel_y = 6
@@ -55891,15 +55887,6 @@
 "tLH" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -13630,10 +13630,6 @@
 	name = "component design disk";
 	pixel_y = 6
 	},
-/obj/item/disk/tech_disk{
-	pixel_x = -2;
-	pixel_y = -3
-	},
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -44419,9 +44419,6 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/clothing/glasses/welding,
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
 /obj/item/reagent_containers/dropper,
 /obj/structure/table,
 /obj/machinery/requests_console/auto_name/directional/north,

--- a/_maps/virtual_domains/meta_central.dmm
+++ b/_maps/virtual_domains/meta_central.dmm
@@ -2832,10 +2832,6 @@
 	pixel_x = 9;
 	pixel_y = -1
 	},
-/obj/item/disk/tech_disk{
-	pixel_x = -2;
-	pixel_y = -3
-	},
 /obj/item/disk/design_disk{
 	name = "component design disk";
 	pixel_y = 6

--- a/code/modules/research/designs/electronics_designs.dm
+++ b/code/modules/research/designs/electronics_designs.dm
@@ -50,18 +50,3 @@
 		RND_CATEGORY_AI + RND_SUBCATEGORY_AI_UPGRADES
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
-
-////////////////////////////////////////
-//////////Disk Construction Disks///////
-////////////////////////////////////////
-/datum/design/tech_disk
-	name = "Technology Data Storage Disk"
-	desc = "Produce additional disks for storing technology data."
-	id = "tech_disk"
-	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
-	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 3, /datum/material/glass =SMALL_MATERIAL_AMOUNT)
-	build_path = /obj/item/disk/tech_disk
-	category = list(
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE

--- a/code/modules/research/techweb/nodes/research_nodes.dm
+++ b/code/modules/research/techweb/nodes/research_nodes.dm
@@ -7,7 +7,6 @@
 		"rdserver",
 		"rdservercontrol",
 		"rdconsole",
-		"tech_disk",
 		"doppler_array",
 		"experimentor",
 		"destructive_analyzer",


### PR DESCRIPTION

## About The Pull Request

There is almost zero use cases for technology disks as of the moment. Since they are currently exploitable, removing access at the very least prevents them from being used to cause server problems until at some point someone does something about the related procs + how technology disks handle techweb copying (like not completely copying the entire techweb datum, for starters)

## Why It's Good For The Game

This does not fix the underlying issue. But there is also zero reason for these to exist in player hands, as there is no player facing usecase for them. They are used for debugging purposes.

## Changelog
:cl:
del: Removes player access to technology disks. (Not design disks, like BEPIS tech disks. These are different and almost entirely useless)
/:cl:
