### PR TITLE
Disable basketball minigame temporarily 

### DIFF
--- a/code/datums/minigames_menu.dm
+++ b/code/datums/minigames_menu.dm
@@ -34,8 +34,10 @@
 			ctf()
 			return TRUE
 		if("basketball")
-			ui.close()
-			basketball()
+			var/mob/user = ui.user
+			to_chat(user, span_warning("The basketball minigame has been temporarily disabled."))
+			// ui.close()
+			// basketball()
 			return TRUE
 		if("deathmatch")
 			ui.close()


### PR DESCRIPTION

## About The Pull Request
Anytime the basketball minigame is activated on the live server it ends up crashing and causing a massive lagspike.

![dreamseeker_OP5a40TxoE](https://github.com/user-attachments/assets/2a61cb9d-f34a-42df-9930-56de5a6ccb8c)

See also:
- #89537
- #89649
- #89856
- #81708

Strangely, this only affects the basketball minigame and not the others, despite it using the same code as mafia. Also strange was when I tested this on my local dev server, I had no issues loading the minigame and playing. 

The temp fix is to just disable the minigame from being played in the menu. The real solution is to transition the minigame to use the lazyloader templates but that will take me longer to do. (maybe a week?)

## Why It's Good For The Game
No more server crashing.

## Changelog
:cl:
del: Disable basketball minigame temporarily
/:cl:
