### PR TITLE
Adds one more space ruin area type to excluded areas for mapload space verification

### DIFF
--- a/code/modules/unit_tests/mapload_space_verification.dm
+++ b/code/modules/unit_tests/mapload_space_verification.dm
@@ -18,6 +18,7 @@
 		/area/shuttle/transit,
 		// Space Ruins do their own thing (dilapidated lattices over space turfs, for instance). Rather than fuss over it, let's just let it through.
 		/area/ruin/space,
+		/area/ruin/unpowered/no_grav,
 		// Same stipulation as space ruins, but they're (ruined) shuttles instead.
 		/area/shuttle/ruin,
 		/area/shuttle/abandoned,


### PR DESCRIPTION
## About The Pull Request

Tin. This looks like an oversight that this wasn't in here. This is the area type used for hidden space ruins.

## Why It's Good For The Game

Less CI failures for overhanging lattices in space.

## Changelog

N/A