### PR TITLE
Fixes prototype egun's electrodes instantly detaching

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -14,7 +14,7 @@
 	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
 
 /obj/item/ammo_casing/energy/electrode/old
-	e_cost = LASER_SHOTS(1, STANDARD_CELL_CHARGE)
+	e_cost = LASER_SHOTS(1.5, STANDARD_CELL_CHARGE)
 
 /obj/item/ammo_casing/energy/electrode/ai_turrets
 	projectile_type = /obj/projectile/energy/electrode/ai_turrets


### PR DESCRIPTION

## About The Pull Request

Closes #89828
Gave it a bit of a leeway allowing it to stun the target for a bit, but not enough to fire another one (and you'll be able to fire at most 2 laser with click delays and passive drain from the taser)

## Changelog
:cl:
fix: Fixed prototype egun's electrodes instantly detaching
/:cl:
