### PR TITLE
Table frame interaction refactor

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/glass
 	grind_results = list(/datum/reagent/silicon = 20)
 	material_type = /datum/material/glass
-	tableVariant = /obj/structure/table/glass
+	table_type = /obj/structure/table/glass
 	matter_amount = 4
 	cost = SHEET_MATERIAL_AMOUNT
 	source = /datum/robot_energy_storage/material/glass
@@ -103,7 +103,7 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/plasmaglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10)
 	material_flags = NONE
-	tableVariant = /obj/structure/table/glass/plasmaglass
+	table_type = /obj/structure/table/glass/plasmaglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
 
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/rglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/iron = 10)
 	matter_amount = 6
-	tableVariant = /obj/structure/table/reinforced/rglass
+	table_type = /obj/structure/table/reinforced/rglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
 
@@ -203,7 +203,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10, /datum/reagent/iron = 10)
 	gulag_valid = TRUE
 	matter_amount = 8
-	tableVariant = /obj/structure/table/reinforced/plasmarglass
+	table_type = /obj/structure/table/reinforced/plasmarglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
 
@@ -235,7 +235,7 @@ GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 	armor_type = /datum/armor/sheet_titaniumglass
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/titaniumglass
-	tableVariant = /obj/structure/table/reinforced/titaniumglass
+	table_type = /obj/structure/table/reinforced/titaniumglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
 
@@ -267,7 +267,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	material_flags = NONE
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/plastitaniumglass
-	tableVariant = /obj/structure/table/reinforced/plastitaniumglass
+	table_type = /obj/structure/table/reinforced/plastitaniumglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/silver
 	material_type = /datum/material/silver
-	tableVariant = /obj/structure/table/optable
+	table_type = /obj/structure/table/optable
 	walltype = /turf/closed/wall/mineral/silver
 
 GLOBAL_LIST_INIT(silver_recipes, list ( \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/iron
 	grind_results = list(/datum/reagent/iron = 20)
 	gulag_valid = TRUE
-	tableVariant = /obj/structure/table
+	table_type = /obj/structure/table
 	material_type = /datum/material/iron
 	matter_amount = 4
 	cost = SHEET_MATERIAL_AMOUNT
@@ -293,7 +293,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/plasteel
 	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
 	gulag_valid = TRUE
-	tableVariant = /obj/structure/table/reinforced
+	table_type = /obj/structure/table/reinforced
 	material_flags = NONE
 	matter_amount = 12
 
@@ -763,7 +763,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	novariants = FALSE
 	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/copper = 12) //we have no "tin" reagent so this is the closest thing
 	merge_type = /obj/item/stack/sheet/bronze
-	tableVariant = /obj/structure/table/bronze
+	table_type = /obj/structure/table/bronze
 	material_type = /datum/material/bronze
 	walltype = /turf/closed/wall/mineral/bronze
 	has_unique_girder = TRUE

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -13,6 +13,7 @@
 	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "smash")
 	novariants = FALSE
 	material_flags = MATERIAL_EFFECTS
+	tableVariant = /obj/structure/table/greyscale
 	pickup_sound = 'sound/items/handling/materials/metal_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/metal_drop.ogg'
 	var/sheettype = null //this is used for girders in the creation of walls/false walls

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -13,7 +13,7 @@
 	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "smash")
 	novariants = FALSE
 	material_flags = MATERIAL_EFFECTS
-	tableVariant = /obj/structure/table/greyscale
+	table_type = /obj/structure/table/greyscale
 	pickup_sound = 'sound/items/handling/materials/metal_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/metal_drop.ogg'
 	var/sheettype = null //this is used for girders in the creation of walls/false walls

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -47,7 +47,7 @@
 	/// Does this stack require a unique girder in order to make a wall?
 	var/has_unique_girder = FALSE
 	/// What typepath table we create from this stack
-	var/obj/structure/table/tableVariant
+	var/obj/structure/table/table_type
 	/// What typepath stairs do we create from this stack
 	var/obj/structure/stairs/stairs_type
 	/// If TRUE, we'll use a radial instead when displaying recipes
@@ -217,9 +217,9 @@
 
 /// Gets the table type we make, accounting for potential exceptions.
 /obj/item/stack/proc/get_table_type()
-	if(ispath(tableVariant, /obj/structure/table/greyscale) && isnull(material_type))
+	if(ispath(table_type, /obj/structure/table/greyscale) && isnull(material_type))
 		return // This table type breaks without a material type.
-	return tableVariant
+	return table_type
 
 /**
  * Builds all recipes in a given recipe list and returns an association list containing them

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -215,6 +215,12 @@
 	else
 		. = (amount)
 
+/// Gets the table type we make, accounting for potential exceptions.
+/obj/item/stack/proc/get_table_type()
+	if(ispath(tableVariant, /obj/structure/table/greyscale) && isnull(material_type))
+		return // This table type breaks without a material type.
+	return tableVariant
+
 /**
  * Builds all recipes in a given recipe list and returns an association list containing them
  *

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -217,7 +217,7 @@
 	inhand_icon_state = "tile-carpet"
 	turf_type = /turf/open/floor/carpet
 	resistance_flags = FLAMMABLE
-	tableVariant = /obj/structure/table/wood/fancy
+	table_type = /obj/structure/table/wood/fancy
 	merge_type = /obj/item/stack/tile/carpet
 	tile_reskin_types = list(
 		/obj/item/stack/tile/carpet,
@@ -247,7 +247,7 @@
 	icon_state = "tile-carpet-black"
 	inhand_icon_state = "tile-carpet-black"
 	turf_type = /turf/open/floor/carpet/black
-	tableVariant = /obj/structure/table/wood/fancy/black
+	table_type = /obj/structure/table/wood/fancy/black
 	merge_type = /obj/item/stack/tile/carpet/black
 	tile_reskin_types = null
 
@@ -256,7 +256,7 @@
 	icon_state = "tile-carpet-blue"
 	inhand_icon_state = "tile-carpet-blue"
 	turf_type = /turf/open/floor/carpet/blue
-	tableVariant = /obj/structure/table/wood/fancy/blue
+	table_type = /obj/structure/table/wood/fancy/blue
 	merge_type = /obj/item/stack/tile/carpet/blue
 	tile_reskin_types = null
 
@@ -265,7 +265,7 @@
 	icon_state = "tile-carpet-cyan"
 	inhand_icon_state = "tile-carpet-cyan"
 	turf_type = /turf/open/floor/carpet/cyan
-	tableVariant = /obj/structure/table/wood/fancy/cyan
+	table_type = /obj/structure/table/wood/fancy/cyan
 	merge_type = /obj/item/stack/tile/carpet/cyan
 	tile_reskin_types = null
 
@@ -274,7 +274,7 @@
 	icon_state = "tile-carpet-green"
 	inhand_icon_state = "tile-carpet-green"
 	turf_type = /turf/open/floor/carpet/green
-	tableVariant = /obj/structure/table/wood/fancy/green
+	table_type = /obj/structure/table/wood/fancy/green
 	merge_type = /obj/item/stack/tile/carpet/green
 	tile_reskin_types = null
 
@@ -283,7 +283,7 @@
 	icon_state = "tile-carpet-orange"
 	inhand_icon_state = "tile-carpet-orange"
 	turf_type = /turf/open/floor/carpet/orange
-	tableVariant = /obj/structure/table/wood/fancy/orange
+	table_type = /obj/structure/table/wood/fancy/orange
 	merge_type = /obj/item/stack/tile/carpet/orange
 	tile_reskin_types = null
 
@@ -292,7 +292,7 @@
 	icon_state = "tile-carpet-purple"
 	inhand_icon_state = "tile-carpet-purple"
 	turf_type = /turf/open/floor/carpet/purple
-	tableVariant = /obj/structure/table/wood/fancy/purple
+	table_type = /obj/structure/table/wood/fancy/purple
 	merge_type = /obj/item/stack/tile/carpet/purple
 	tile_reskin_types = null
 
@@ -301,7 +301,7 @@
 	icon_state = "tile-carpet-red"
 	inhand_icon_state = "tile-carpet-red"
 	turf_type = /turf/open/floor/carpet/red
-	tableVariant = /obj/structure/table/wood/fancy/red
+	table_type = /obj/structure/table/wood/fancy/red
 	merge_type = /obj/item/stack/tile/carpet/red
 	tile_reskin_types = null
 
@@ -310,7 +310,7 @@
 	icon_state = "tile-carpet-royalblack"
 	inhand_icon_state = "tile-carpet-royalblack"
 	turf_type = /turf/open/floor/carpet/royalblack
-	tableVariant = /obj/structure/table/wood/fancy/royalblack
+	table_type = /obj/structure/table/wood/fancy/royalblack
 	merge_type = /obj/item/stack/tile/carpet/royalblack
 	tile_reskin_types = null
 
@@ -319,7 +319,7 @@
 	icon_state = "tile-carpet-royalblue"
 	inhand_icon_state = "tile-carpet-royalblue"
 	turf_type = /turf/open/floor/carpet/royalblue
-	tableVariant = /obj/structure/table/wood/fancy/royalblue
+	table_type = /obj/structure/table/wood/fancy/royalblue
 	merge_type = /obj/item/stack/tile/carpet/royalblue
 	tile_reskin_types = null
 

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -39,7 +39,7 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/structure/table_frame/wrench_act(mob/living/user, obj/item/tool)
-	to_chat(user, span_notice("You start disassembling [src]..."))
+	balloon_alert(user, "deconstructing...")
 	tool.play_tool_sound(src)
 	if(!tool.use_tool(src, user, 3 SECONDS))
 		return ITEM_INTERACT_BLOCKING
@@ -59,12 +59,13 @@
 		return NONE
 
 	if(our_stack.get_amount() < 1)
-		to_chat(user, span_warning("You need one [our_stack.name] sheet to do this!"))
+		balloon_alert(user, "need more material!")
 		return ITEM_INTERACT_BLOCKING
 	if(locate(/obj/structure/table) in loc)
-		to_chat(user, span_warning("There's already a table built here!"))
+		balloon_alert(user, "can't stack tables!")
 		return ITEM_INTERACT_BLOCKING
 
+	balloon_alert(user, "constructing table...")
 	if(!do_after(user, 2 SECONDS, target = src))
 		return ITEM_INTERACT_BLOCKING
 	if((locate(/obj/structure/table) in loc) || !our_stack.use(1))

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -21,59 +21,62 @@
 	var/framestack = /obj/item/stack/rods
 	var/framestackamount = 2
 
+/obj/structure/table_frame/Initialize(mapload)
+	. = ..()
+	register_context()
 
-/obj/structure/table_frame/wrench_act(mob/living/user, obj/item/I)
+/obj/structure/table_frame/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		return NONE
+
+	if(held_item.tool_behaviour == TOOL_WRENCH)
+		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
+		context[SCREENTIP_CONTEXT_RMB] = "Deconstruct"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(isstack(held_item) && get_table_type(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Construct table"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/structure/table_frame/wrench_act(mob/living/user, obj/item/tool)
 	to_chat(user, span_notice("You start disassembling [src]..."))
-	I.play_tool_sound(src)
-	if(!I.use_tool(src, user, 3 SECONDS))
-		return TRUE
+	tool.play_tool_sound(src)
+	if(!tool.use_tool(src, user, 3 SECONDS))
+		return ITEM_INTERACT_BLOCKING
 	playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 	deconstruct(TRUE)
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
+/obj/structure/table_frame/wrench_act_secondary(mob/living/user, obj/item/tool)
+	return wrench_act(user, tool)
 
-/obj/structure/table_frame/attackby(obj/item/I, mob/user, params)
-	if(isstack(I))
-		var/obj/item/stack/material = I
-		if(material.tableVariant)
-			if(material.get_amount() < 1)
-				to_chat(user, span_warning("You need one [material.name] sheet to do this!"))
-				return
-			if(locate(/obj/structure/table) in loc)
-				to_chat(user, span_warning("There's already a table built here!"))
-				return
-			to_chat(user, span_notice("You start adding [material] to [src]..."))
-			if(!do_after(user, 2 SECONDS, target = src) || !material.use(1) || (locate(/obj/structure/table) in loc))
-				return
-			make_new_table(material.tableVariant)
-		else if(istype(material, /obj/item/stack/sheet))
-			if(material.get_amount() < 1)
-				to_chat(user, span_warning("You need one sheet to do this!"))
-				return
-			if(locate(/obj/structure/table) in loc)
-				to_chat(user, span_warning("There's already a table built here!"))
-				return
-			to_chat(user, span_notice("You start adding [material] to [src]..."))
-			if(!do_after(user, 2 SECONDS, target = src) || !material.use(1) || (locate(/obj/structure/table) in loc))
-				return
-			var/list/material_list = list()
-			if(material.material_type)
-				material_list[material.material_type] = SHEET_MATERIAL_AMOUNT
-			make_new_table(/obj/structure/table/greyscale, material_list)
-		return
-	return ..()
+/obj/structure/table_frame/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!isstack(tool))
+		return NONE
+	var/obj/item/stack/our_stack = tool
+	var/table_type = get_table_type(our_stack)
+	if(isnull(table_type))
+		return NONE
 
+	if(our_stack.get_amount() < 1)
+		to_chat(user, span_warning("You need one [our_stack.name] sheet to do this!"))
+		return ITEM_INTERACT_BLOCKING
+	if(locate(/obj/structure/table) in loc)
+		to_chat(user, span_warning("There's already a table built here!"))
+		return ITEM_INTERACT_BLOCKING
 
-/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials, carpet_type) //makes sure the new table made retains what we had as a frame
-	var/obj/structure/table/T = new table_type(loc)
-	T.frame = type
-	T.framestack = framestack
-	T.framestackamount = framestackamount
-	if (carpet_type)
-		T.buildstack = carpet_type
-	if(custom_materials)
-		T.set_custom_materials(custom_materials)
+	if(!do_after(user, 2 SECONDS, target = src))
+		return ITEM_INTERACT_BLOCKING
+	if((locate(/obj/structure/table) in loc) || !our_stack.use(1))
+		return ITEM_INTERACT_BLOCKING
+
+	new table_type(loc, src, our_stack)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
+
+/// Gets the table type we make with our given stack.
+/obj/structure/table_frame/proc/get_table_type(obj/item/stack/our_stack)
+	return our_stack.get_table_type()
 
 /obj/structure/table_frame/atom_deconstruct(disassembled = TRUE)
 	new framestack(get_turf(src), framestackamount)
@@ -94,22 +97,8 @@
 	framestackamount = 2
 	resistance_flags = FLAMMABLE
 
-/obj/structure/table_frame/wood/attackby(obj/item/I, mob/user, params)
-	if (isstack(I))
-		var/obj/item/stack/material = I
-		var/toConstruct // stores the table variant
-		var/carpet_type // stores the carpet type used for construction in case of poker tables
-		if(istype(I, /obj/item/stack/sheet/mineral/wood))
-			toConstruct = /obj/structure/table/wood
-		else if(istype(I, /obj/item/stack/tile/carpet))
-			toConstruct = /obj/structure/table/wood/poker
-			carpet_type = I.type
-		if (toConstruct)
-			if(material.get_amount() < 1)
-				to_chat(user, span_warning("You need one [material.name] sheet to do this!"))
-				return
-			to_chat(user, span_notice("You start adding [material] to [src]..."))
-			if(do_after(user, 2 SECONDS, target = src) && material.use(1))
-				make_new_table(toConstruct, null, carpet_type)
-	else
-		return ..()
+/obj/structure/table_frame/wood/get_table_type(obj/item/stack/our_stack)
+	if(istype(our_stack, /obj/item/stack/sheet/mineral/wood))
+		return /obj/structure/table/wood
+	if(istype(our_stack, /obj/item/stack/tile/carpet))
+		return /obj/structure/table/wood/poker

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -38,10 +38,13 @@
 	var/framestackamount = 2
 	var/deconstruction_ready = TRUE
 
-/obj/structure/table/Initialize(mapload, _buildstack)
+/obj/structure/table/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
-	if(_buildstack)
-		buildstack = _buildstack
+	if(frame_used)
+		apply_frame_properties(frame_used)
+	if(stack_used)
+		apply_stack_properties(stack_used)
+
 	AddElement(/datum/element/footstep_override, priority = STEP_SOUND_TABLE_PRIORITY)
 
 	make_climbable()
@@ -56,6 +59,16 @@
 	register_context()
 
 	ADD_TRAIT(src, TRAIT_COMBAT_MODE_SKIP_INTERACTION, INNATE_TRAIT)
+
+/// Applies additional properties based on the frame used to construct this table.
+/obj/structure/table/proc/apply_frame_properties(obj/structure/table_frame/frame_used)
+	frame = frame_used.type
+	framestack = frame_used.framestack
+	framestackamount = frame_used.framestackamount
+
+/// Applies additional properties based on the stack used to construct this table.
+/obj/structure/table/proc/apply_stack_properties(obj/item/stack/stack_used)
+	return
 
 ///Adds the element used to make the object climbable, and also the one that shift the mob buckled to it up.
 /obj/structure/table/proc/make_climbable()
@@ -360,6 +373,11 @@
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstack = null //No buildstack, so generate from mat datums
 
+/obj/structure/table/greyscale/apply_stack_properties(obj/item/stack/stack_used)
+	if(!stack_used.material_type)
+		return
+	set_custom_materials(list(stack_used.material_type = SHEET_MATERIAL_AMOUNT))
+
 /obj/structure/table/greyscale/finalize_material_effects(list/materials)
 	. = ..()
 	var/english_list = get_material_english_list(materials)
@@ -378,7 +396,7 @@
 	/// Lazylist of the items that we have on our surface.
 	var/list/attached_items = null
 
-/obj/structure/table/rolling/Initialize(mapload)
+/obj/structure/table/rolling/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	AddElement(/datum/element/noisy_movement)
 
@@ -461,7 +479,7 @@
 	fire = 80
 	acid = 100
 
-/obj/structure/table/glass/Initialize(mapload)
+/obj/structure/table/glass/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
@@ -556,6 +574,9 @@
 	base_icon_state = "poker_table"
 	buildstack = /obj/item/stack/tile/carpet
 
+/obj/structure/table/wood/poker/apply_stack_properties(obj/item/stack/stack_used)
+	buildstack = stack_used.type
+
 /obj/structure/table/wood/poker/narsie_act()
 	..(FALSE)
 
@@ -572,13 +593,16 @@
 	canSmoothWith = SMOOTH_GROUP_FANCY_WOOD_TABLES
 	var/smooth_icon = 'icons/obj/smooth_structures/fancy_table.dmi' // see Initialize()
 
-/obj/structure/table/wood/fancy/Initialize(mapload)
+/obj/structure/table/wood/fancy/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	// Needs to be set dynamically because table smooth sprites are 32x34,
 	// which the editor treats as a two-tile-tall object. The sprites are that
 	// size so that the north/south corners look nice - examine the detail on
 	// the sprites in the editor to see why.
 	icon = smooth_icon
+
+/obj/structure/table/wood/fancy/apply_stack_properties(obj/item/stack/stack_used)
+	buildstack = stack_used.type
 
 /obj/structure/table/wood/fancy/black
 	icon_state = "fancy_table_black"
@@ -808,7 +832,7 @@
 	var/mob/living/carbon/patient = null
 	var/obj/machinery/computer/operating/computer = null
 
-/obj/structure/table/optable/Initialize(mapload)
+/obj/structure/table/optable/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	for(var/direction in GLOB.alldirs)
 		computer = locate(/obj/machinery/computer/operating) in get_step(src, direction)

--- a/code/modules/antagonists/abductor/abductor_structures.dm
+++ b/code/modules/antagonists/abductor/abductor_structures.dm
@@ -15,37 +15,11 @@
 	framestack = /obj/item/stack/sheet/mineral/abductor
 	framestackamount = 1
 
-/obj/structure/table_frame/abductor/attackby(obj/item/attacking_item, mob/user, params)
-	if(attacking_item.tool_behaviour == TOOL_WRENCH)
-		to_chat(user, span_notice("You start disassembling [src]..."))
-		attacking_item.play_tool_sound(src)
-		if(attacking_item.use_tool(src, user, 30))
-			playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-			for(var/i in 0 to framestackamount)
-				new framestack(get_turf(src))
-			qdel(src)
-			return
-	if(istype(attacking_item, /obj/item/stack/sheet/mineral/abductor))
-		var/obj/item/stack/sheet/stacked_sheets = attacking_item
-		if(stacked_sheets.get_amount() < 1)
-			to_chat(user, span_warning("You need one alien alloy sheet to do this!"))
-			return
-		to_chat(user, span_notice("You start adding [stacked_sheets] to [src]..."))
-		if(do_after(user, 5 SECONDS, target = src))
-			stacked_sheets.use(1)
-			new /obj/structure/table/abductor(src.loc)
-			qdel(src)
-		return
-	if(istype(attacking_item, /obj/item/stack/sheet/mineral/silver))
-		var/obj/item/stack/sheet/stacked_sheets = attacking_item
-		if(stacked_sheets.get_amount() < 1)
-			to_chat(user, span_warning("You need one sheet of silver to do this!"))
-			return
-		to_chat(user, span_notice("You start adding [stacked_sheets] to [src]..."))
-		if(do_after(user, 5 SECONDS, target = src))
-			stacked_sheets.use(1)
-			new /obj/structure/table/optable/abductor(src.loc)
-			qdel(src)
+/obj/structure/table_frame/abductor/get_table_type(obj/item/stack/our_stack)
+	if(istype(our_stack, /obj/item/stack/sheet/mineral/abductor))
+		return /obj/structure/table/abductor
+	if(istype(our_stack, /obj/item/stack/sheet/mineral/silver))
+		return /obj/structure/table/optable/abductor
 
 /obj/structure/table/abductor
 	name = "alien table"
@@ -79,7 +53,7 @@
 
 	var/static/list/injected_reagents = list(/datum/reagent/medicine/cordiolis_hepatico)
 
-/obj/structure/table/optable/abductor/Initialize(mapload)
+/obj/structure/table/optable/abductor/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/shuttle/misc/special.dm
+++ b/code/modules/shuttle/misc/special.dm
@@ -80,7 +80,7 @@
 	var/list/mob/living/sleepers = list()
 	var/never_spoken = TRUE
 
-/obj/structure/table/abductor/wabbajack/Initialize(mapload)
+/obj/structure/table/abductor/wabbajack/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	START_PROCESSING(SSobj, src)
 
@@ -182,7 +182,7 @@
 	max_integrity = 1000
 	var/boot_dir = 1
 
-/obj/structure/table/wood/shuttle_bar/Initialize(mapload, _buildstack)
+/obj/structure/table/wood/shuttle_bar/Initialize(mapload, obj/structure/table_frame/frame_used, obj/item/stack/stack_used)
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),


### PR DESCRIPTION

## About The Pull Request

So I was looking for `attackby(...)` instances to kill and, hey look, table frames- oh what the fuck is this.
Oh why does this have the same checks like five times, across the parent type and subtypes.

So this pr's primary point is to refactor the table frame `attackby(...)` into `item_interaction(...)`, and by extension lower the amount of weird `attackby(...)` override jank going on with them.
Instead of having all of the subtypes define their own almost exactly the same table construction interactions, we use a single generic interaction chain and add a new `get_table_type(...)` proc to let subtypes override what tables to construct for what stacks.

We also move the assigning of frame-and-stack-related things to the actual table types themselves, instead of specifying all these interactions on the frame.

We also add screentips for deconstruction and table construction, again using the `get_table_type(...)` proc so screentips can differentiate between which stacks can and can't make a table for our table without needing to change the screentips manually for the subtypes.

Beyond that is mostly generic clean-up.

I'm a bit icky on my implementation of `/obj/item/stack/proc/get_table_type()`, because of hardcoding for `/obj/structure/table/greyscale`, but I think it's better than the alternatives.
This lets us use the old method of letting all `/obj/item/stack/sheet` subtypes use the generic material table, but limit it to working as long as they define a `material_type`. I feel it's better than letting broken tables exist, needing to hardcode it on the table frame, or needing to expect people to add the generic material table `table_type` whenever they add a `material_type` (no one would do this).
## Why It's Good For The Game

Screentips good :+1:
Less jank encountered good.
Specifically the inability to deconstruct table frames on right click when tables can be deconstructed on right click has thrown me off so many times it's wild.
## Changelog
:cl:
refactor: Refactored table frame interactions, please report any issues.
fix: You can no longer make material-less material tables out of certain items.
fix: Fancy tables remember which carpet was used to make them, and no longer magically transmute carpets into simpler types.
fix: You can no longer stack abductor table frame-using tables specifically.
qol: Added screentips for deconstructing table frames and constructing tables out of them if the material you're holding can do so.
qol: Table frames can now also be deconstructed on right click for parity with tables, in addition to left click.
qol: Table frame interactions use balloon alerts.
/:cl:
