### PR TITLE
The strongarm set bonus no longer requires a specific biotype to function

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -539,6 +539,7 @@
 	organs_needed = 2
 	bonus_activate_text = span_notice("Your improved arms allow you to open airlocks by force with your bare hands!")
 	bonus_deactivate_text = span_notice("You can no longer force open airlocks with your bare hands.")
+	required_biotype = null
 
 /datum/status_effect/organ_set_bonus/strongarm/enable_bonus()
 	. = ..()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -539,7 +539,7 @@
 	organs_needed = 2
 	bonus_activate_text = span_notice("Your improved arms allow you to open airlocks by force with your bare hands!")
 	bonus_deactivate_text = span_notice("You can no longer force open airlocks with your bare hands.")
-	required_biotype = null
+	required_biotype = NONE
 
 /datum/status_effect/organ_set_bonus/strongarm/enable_bonus()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/89860

## Why It's Good For The Game

I didn't realize this was a variable. The intent was for this to be used by anyone able to have the implants.

## Changelog
:cl:
fix: The strongarm set bonus no longer requires a specific biotype to function. You can now get the set bonus as an android.
/:cl:
