### PR TITLE
Stops spurious ruins lattice CI runtimes

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -49,7 +49,7 @@
 	for(var/obj/structure/lattice/LAT in loc)
 		if(LAT == src)
 			continue
-		if(mapload)
+		if(is_station_level(loc.z) || is_mining_level(loc.z))
 			stack_trace("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
 		else
 			log_mapping("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -52,7 +52,7 @@
 		if(is_station_level(loc.z) || is_mining_level(loc.z))
 			stack_trace("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
 		else
-			log_mapping("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
+			log_mapping("multiple lattices found in non-station/non-mining area: [get_area(LAT)]")
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/lattice/blob_act(obj/structure/blob/B)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -49,7 +49,10 @@
 	for(var/obj/structure/lattice/LAT in loc)
 		if(LAT == src)
 			continue
-		stack_trace("multiple lattices found in ([loc.x], [loc.y], [loc.z])")
+		if(mapload)
+			stack_trace("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
+		else
+			log_mapping("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/lattice/blob_act(obj/structure/blob/B)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -49,10 +49,7 @@
 	for(var/obj/structure/lattice/LAT in loc)
 		if(LAT == src)
 			continue
-		if(is_station_level(loc.z) || is_mining_level(loc.z))
-			stack_trace("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
-		else
-			log_mapping("multiple lattices found in non-station/non-mining area: [get_area(LAT)]")
+		log_mapping("multiple lattices found in ([loc.x], [loc.y], [loc.z], [get_area(LAT)])")
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/lattice/blob_act(obj/structure/blob/B)


### PR DESCRIPTION
## About The Pull Request

Simply stops this from `stack_trace()`'ing in ruins, opting to `log_mapping()` instead. By changing it to use `log_mapping()` it will only cause CI failures if they occur on mining or station z levels, which should stop ruins weirdness from causing garbage outputs/failures in tests.

As well as improving the debug logging by adding the area to the printout. 

## Why It's Good For The Game

There's really no point to complaining about a ruin spawning overlapping lattices after mapload when one of them just gets deleted anyway. Stops unhelpful stack_trace messages from blocking CI from passing.

## Changelog

Not player facing.

