### PR TITLE
Fixes cult target selection

### DIFF
--- a/code/modules/antagonists/cult/cult_objectives.dm
+++ b/code/modules/antagonists/cult/cult_objectives.dm
@@ -20,12 +20,12 @@
 	var/datum/team/cult/cult = team
 	var/list/target_candidates = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD)
+		if(player.mind && !IS_CULTIST(player) && !is_convertable_to_cult(player) && player.stat != DEAD && is_station_level(player.loc.z))
 			target_candidates += player.mind
 	if(target_candidates.len == 0)
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
+			if(player.mind && !IS_CULTIST(player) && player.stat != DEAD && is_station_level(player.loc.z))
 				target_candidates += player.mind
 	list_clear_nulls(target_candidates)
 	if(LAZYLEN(target_candidates))

--- a/html/changelogs/AutoChangeLog-pr-89621.yml
+++ b/html/changelogs/AutoChangeLog-pr-89621.yml
@@ -1,4 +1,0 @@
-author: "possiblepossibility"
-delete-after: True
-changes:
-  - rscadd: "you may now take out individual slices of pizza"

--- a/html/changelogs/AutoChangeLog-pr-89621.yml
+++ b/html/changelogs/AutoChangeLog-pr-89621.yml
@@ -1,0 +1,4 @@
+author: "possiblepossibility"
+delete-after: True
+changes:
+  - rscadd: "you may now take out individual slices of pizza"


### PR DESCRIPTION

## About The Pull Request
Cult target now must be on station zlevel
## Why It's Good For The Game
Cultist shouldn't explore space to find their target, since they can't draw runes there.
## Changelog
:cl:
fix: fixed offstation humans being able to be cult target
/:cl:
