### PR TITLE
[NO GBP] Objects on tables no longer get burnt by lava

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -283,6 +283,8 @@
 		return LAVA_BE_IGNORING
 	if(isobj(burn_target))
 		var/obj/burn_obj = burn_target
+		if(HAS_TRAIT(src, TRAIT_ELEVATED_TURF) && !HAS_TRAIT(burn_obj, TRAIT_ELEVATING_OBJECT))
+			return LAVA_BE_PROCESSING
 		if((burn_obj.resistance_flags & immunity_resistance_flags))
 			return LAVA_BE_PROCESSING
 		return LAVA_BE_BURNING


### PR DESCRIPTION

## About The Pull Request

Oversight from #89661, my bad.

## Why It's Good For The Game

You'd expect things on tables to not burn in lava that they're not even touching.

## Changelog
:cl:
fix: Objects on tables no longer get burnt by lava
/:cl:
