### PR TITLE
Autholathes and some misc material containers no longer gluttonously consume players' tools

### DIFF
--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -493,6 +493,11 @@
 	if(!(mat_container_flags & MATCONTAINER_ANY_INTENT) && user.combat_mode)
 		return
 
+	if(ismachinery(source))
+		var/obj/machinery/machine = source
+		if(machine.machine_stat || machine.panel_open)
+			return
+
 	user_insert(weapon, user)
 
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -92,7 +92,7 @@
 	if(default_deconstruction_crowbar(tool))
 		return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/autolathe/screwdriver_act_secondary(mob/living/user, obj/item/tool)
+/obj/machinery/autolathe/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_BLOCKING
 	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", tool))
 		return ITEM_INTERACT_SUCCESS
@@ -419,47 +419,55 @@
 	drop_direction = 0
 	return CLICK_ACTION_SUCCESS
 
-/obj/machinery/autolathe/attackby(obj/item/attacking_item, mob/living/user, params)
-	if(user.combat_mode) //so we can hit the machine
+/obj/machinery/autolathe/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
 		return ..()
 
 	if(busy)
 		balloon_alert(user, "it's busy!")
-		return TRUE
+		return ITEM_INTERACT_BLOCKING
 
-	if(panel_open && is_wire_tool(attacking_item))
+	if(panel_open && is_wire_tool(tool))
 		wires.interact(user)
-		return TRUE
+		return ITEM_INTERACT_SUCCESS
 
 	if(machine_stat)
-		return TRUE
+		return ..()
 
-	if(istype(attacking_item, /obj/item/disk/design_disk))
-		user.visible_message(span_notice("[user] begins to load \the [attacking_item] in \the [src]..."),
-			balloon_alert(user, "uploading design..."),
-			span_hear("You hear the chatter of a floppy drive."))
-		busy = TRUE
-		if(do_after(user, 14.4, target = src))
-			var/obj/item/disk/design_disk/disky = attacking_item
-			var/list/not_imported
-			for(var/datum/design/blueprint as anything in disky.blueprints)
-				if(!blueprint)
-					continue
-				if(blueprint.build_type & AUTOLATHE)
-					imported_designs[blueprint.id] = TRUE
-				else
-					LAZYADD(not_imported, blueprint.name)
-			if(not_imported)
-				to_chat(user, span_warning("The following design[length(not_imported) > 1 ? "s" : ""] couldn't be imported: [english_list(not_imported)]"))
-		busy = FALSE
-		update_static_data_for_all_viewers()
-		return TRUE
+	if(!istype(tool, /obj/item/disk/design_disk))
+		return ..()
 
 	if(panel_open)
 		balloon_alert(user, "close the panel first!")
-		return FALSE
+		return ITEM_INTERACT_BLOCKING
 
-	return ..()
+	user.visible_message(span_notice("[user] begins to load \the [tool] in \the [src]..."),
+		balloon_alert(user, "uploading design..."),
+		span_hear("You hear the chatter of a floppy drive."))
+	busy = TRUE
+
+	if(do_after(user, 1.5 SECONDS, target = src))
+		busy = FALSE
+		update_static_data_for_all_viewers()
+		balloon_alert(user, "interrupted!")
+		return ITEM_INTERACT_BLOCKING
+
+	var/obj/item/disk/design_disk/disky = tool
+	var/list/not_imported
+	for(var/datum/design/blueprint as anything in disky.blueprints)
+		if(!blueprint)
+			continue
+		if(blueprint.build_type & AUTOLATHE)
+			imported_designs[blueprint.id] = TRUE
+		else
+			LAZYADD(not_imported, blueprint.name)
+
+	if(not_imported)
+		to_chat(user, span_warning("The following design[length(not_imported) > 1 ? "s" : ""] couldn't be imported: [english_list(not_imported)]"))
+
+	busy = FALSE
+	update_static_data_for_all_viewers()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/autolathe/RefreshParts()
 	. = ..()

--- a/code/game/machinery/drone_dispenser.dm
+++ b/code/game/machinery/drone_dispenser.dm
@@ -105,7 +105,7 @@
 	dispense_type = list(/obj/effect/mob_spawn/ghost_role/drone/syndrone/badass)
 	end_create_message = "dispenses an ominous suspicious drone shell."
 
-// tool don't need your forgiveness, this is awesome.
+// I don't need your forgiveness, this is awesome.
 /obj/machinery/drone_dispenser/snowflake
 	name = "snowflake drone shell dispenser"
 	desc = "A hefty machine that, when supplied with iron and glass, will periodically create a snowflake drone shell. Does not need to be manually operated."

--- a/code/game/machinery/drone_dispenser.dm
+++ b/code/game/machinery/drone_dispenser.dm
@@ -105,7 +105,7 @@
 	dispense_type = list(/obj/effect/mob_spawn/ghost_role/drone/syndrone/badass)
 	end_create_message = "dispenses an ominous suspicious drone shell."
 
-// I don't need your forgiveness, this is awesome.
+// tool don't need your forgiveness, this is awesome.
 /obj/machinery/drone_dispenser/snowflake
 	name = "snowflake drone shell dispenser"
 	desc = "A hefty machine that, when supplied with iron and glass, will periodically create a snowflake drone shell. Does not need to be manually operated."
@@ -254,36 +254,35 @@
 	icon_state = icon_on
 	return ..()
 
-/obj/machinery/drone_dispenser/attackby(obj/item/I, mob/living/user)
-	if(I.tool_behaviour == TOOL_CROWBAR)
-		materials.retrieve_all()
-		I.play_tool_sound(src)
-		to_chat(user, span_notice("You retrieve the materials from [src]."))
+/obj/machinery/drone_dispenser/crowbar_act(mob/living/user, obj/item/tool)
+	materials.retrieve_all()
+	tool.play_tool_sound(src)
+	to_chat(user, span_notice("You retrieve the materials from [src]."))
+	return ITEM_INTERACT_SUCCESS
 
-	else if(I.tool_behaviour == TOOL_WELDER)
-		if(!(machine_stat & BROKEN))
-			to_chat(user, span_warning("[src] doesn't need repairs."))
-			return
+/obj/machinery/drone_dispenser/welder_act(mob/living/user, obj/item/tool)
+	if(!(machine_stat & BROKEN))
+		to_chat(user, span_warning("[src] doesn't need repairs."))
+		return ITEM_INTERACT_BLOCKING
 
-		if(!I.tool_start_check(user, amount=1))
-			return
+	if(!tool.tool_start_check(user, amount=1))
+		return ITEM_INTERACT_BLOCKING
 
-		user.visible_message(
-			span_notice("[user] begins patching up [src] with [I]."),
-			span_notice("You begin restoring the damage to [src]..."))
+	user.visible_message(
+		span_notice("[user] begins patching up [src] with [tool]."),
+		span_notice("You begin restoring the damage to [src]..."))
 
-		if(!I.use_tool(src, user, 40, volume=50))
-			return
+	if(!tool.use_tool(src, user, 40, volume=50))
+		return ITEM_INTERACT_BLOCKING
 
-		user.visible_message(
-			span_notice("[user] fixes [src]!"),
-			span_notice("You restore [src] to operation."))
+	user.visible_message(
+		span_notice("[user] fixes [src]!"),
+		span_notice("You restore [src] to operation."))
 
-		set_machine_stat(machine_stat & ~BROKEN)
-		atom_integrity = max_integrity
-		update_appearance()
-	else
-		return ..()
+	set_machine_stat(machine_stat & ~BROKEN)
+	atom_integrity = max_integrity
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/drone_dispenser/atom_break(damage_flag)
 	. = ..()

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -66,7 +66,6 @@
 	The safety-sensors status light is [obj_flags & EMAGGED ? "off" : "on"]."}
 
 /obj/machinery/recycler/wrench_act(mob/living/user, obj/item/tool)
-	. = ..()
 	default_unfasten_wrench(user, tool)
 	return ITEM_INTERACT_SUCCESS
 
@@ -76,16 +75,15 @@
 		return FAILED_UNFASTEN
 	return SUCCESSFUL_UNFASTEN
 
-/obj/machinery/recycler/attackby(obj/item/I, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "grinder-oOpen", "grinder-o0", I))
-		return
+/obj/machinery/recycler/crowbar_act(mob/living/user, obj/item/tool)
+	if(default_pry_open(tool, close_after_pry = TRUE))
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING
 
-	if(default_pry_open(I, close_after_pry = TRUE))
-		return
-
-	if(default_deconstruction_crowbar(I))
-		return
-	return ..()
+/obj/machinery/recycler/screwdriver_act(mob/living/user, obj/item/tool)
+	if(default_deconstruction_screwdriver(user, "grinder-oOpen", "grinder-o0", tool))
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING
 
 /obj/machinery/recycler/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/sheetifier.dm
+++ b/code/game/machinery/sheetifier.dm
@@ -63,10 +63,13 @@
 	default_unfasten_wrench(user, tool)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/sheetifier/attackby(obj/item/I, mob/user, params)
-	if(default_deconstruction_screwdriver(user, initial(icon_state), initial(icon_state), I))
+/obj/machinery/sheetifier/screwdriver_act(mob/living/user, obj/item/tool)
+	if(default_deconstruction_screwdriver(user, initial(icon_state), initial(icon_state), tool))
 		update_appearance()
-		return
-	if(default_deconstruction_crowbar(I))
-		return
-	return ..()
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
+
+/obj/machinery/sheetifier/crowbar_act(mob/living/user, obj/item/tool)
+	if(default_deconstruction_crowbar(tool))
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION

## About The Pull Request
Converted autolathes, drone dispensers, sheetifiers and recyclers to tool_acts, and autolathes now use base_item_interaction similarly to flatpackers to avoid the ire of material containers. Material containers also now refuse to accept materials if the owner is a machine which is broken or has an open panel.

## Why It's Good For The Game

Autolathe ate my multitool one too many times, can't have shit in space detroit.

There's been a ton of feedback on autolathes having bad UX and #89859 kinda pushed me over the edge, its just far too confusing to deal with - now they should be up to parity with protolathes (tools don't get eaten on left click anymore)

## Changelog
:cl:
fix: You no longer can insert sheets into unpowered, broken or opened autolathes.
qol: Screwdriver/crowbar/multitool interactions on autolathes now work with left click instead of right click.
/:cl:
