### PR TITLE
Removes a rogue fire alarm from DeltaStation's freezer

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -96057,7 +96057,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)


### PR DESCRIPTION

## About The Pull Request

Closes #89898

## Changelog
:cl:
fix: Removed a rogue fire alarm from DeltaStation's freezer
/:cl:
