### PR TITLE
Adds a step_trigger what forces on outfits for event maps

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -235,7 +235,7 @@
 	var/happens_once = 0
 
 /obj/effect/step_trigger/outfitter/Trigger(atom/movable/A)
-	if(!iscarbon(A))
+	if(!ishuman(A))
 		return
 
 	var/mob/living/carbon/human/fellow = A

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -202,7 +202,7 @@
 	var/volume = 100
 	var/freq_vary = 1 //Should the frequency of the sound vary?
 	var/extra_range = 0 // eg World.view = 7, extra_range = 1, 7+1 = 8, 8 turfs radius
-	var/happens_once = 0
+	var/happens_once = FALSE
 	var/triggerer_only = 0 //Whether the triggerer is the only person who hears this
 
 
@@ -232,7 +232,7 @@
 	mobs_only = TRUE
 	///outfit to equip
 	var/datum/outfit/dresscode
-	var/happens_once = 0
+	var/happens_once = FALSE
 
 /obj/effect/step_trigger/outfitter/Trigger(atom/movable/A)
 	if(!ishuman(A))

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -231,7 +231,7 @@
 /obj/effect/step_trigger/outfitter
 	mobs_only = TRUE
 	///outfit to equip
-	var/datum/outfit/dress_code
+	var/datum/outfit/dresscode
 	var/happens_once = 0
 
 /obj/effect/step_trigger/outfitter/Trigger(atom/movable/A)
@@ -239,8 +239,8 @@
 		return
 
 	var/mob/living/carbon/human/fellow = A
-	A.delete_equipment()
-	A.equipOutfit(dresscode,FALSE)
+	fellow.delete_equipment()
+	fellow.equipOutfit(dresscode,FALSE)
 
 	if(happens_once)
 		qdel(src)

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -226,3 +226,21 @@
 	name = "a grave mistake";
 	sound = 'sound/effects/hallucinations/i_see_you1.ogg'
 	triggerer_only = 1
+
+/// Forces a given outfit onto any carbon which crosses it, for event maps
+/obj/effect/step_trigger/outfitter
+	mobs_only = TRUE
+	///outfit to equip
+	var/datum/outfit/dress_code
+	var/happens_once = 0
+
+/obj/effect/step_trigger/outfitter/Trigger(atom/movable/A)
+	if(!iscarbon(A))
+		return
+
+	var/mob/living/carbon/human/fellow = A
+	A.delete_equipment()
+	A.equipOutfit(dresscode,FALSE)
+
+	if(happens_once)
+		qdel(src)

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -222,7 +222,7 @@
 		qdel(src)
 
 /obj/effect/step_trigger/sound_effect/lavaland_cult_altar
-	happens_once = 1
+	happens_once = TRUE
 	name = "a grave mistake";
 	sound = 'sound/effects/hallucinations/i_see_you1.ogg'
 	triggerer_only = 1
@@ -231,7 +231,7 @@
 /obj/effect/step_trigger/outfitter
 	mobs_only = TRUE
 	///outfit to equip
-	var/datum/outfit/dresscode
+	var/datum/outfit/outfit_to_equip
 	var/happens_once = FALSE
 
 /obj/effect/step_trigger/outfitter/Trigger(atom/movable/A)
@@ -240,7 +240,7 @@
 
 	var/mob/living/carbon/human/fellow = A
 	fellow.delete_equipment()
-	fellow.equipOutfit(dresscode,FALSE)
+	fellow.equipOutfit(outfit_to_equip,FALSE)
 
 	if(happens_once)
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request

/obj/effect/step_trigger/outfitter
it deletes existing equipment and forces on an outfit for any human
intended for event maps wherein you want location-dependent loadouts(like what im working on now)

code is tested btw

## Why It's Good For The Game
Events are good for the game(I think), and administrative overhead is bad for events

## Changelog
not player facing
