### PR TITLE
Prevents selecting wizard finales you can't immediately invoke

### DIFF
--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -342,14 +342,14 @@
 		return
 	var/datum/grand_finale/picked_finale = picks_to_instances[pick]
 	var/round_time_passed = world.time - SSticker.round_start_time
-	if(picked_finale.minimum_time >=round_time_passed)
+	if(picked_finale.minimum_time >= round_time_passed)
 		to_chat(user, span_warning("The chosen grand finale will only be available in <b>[DisplayTimeText(picked_finale.minimum_time - round_time_passed)]</b>!"))
 		to_chat(user, span_warning("Be patient, or select another option."))
 		return
 	chosen_effect = TRUE
 	if (pick == PICK_NOTHING)
 		return
-	finale_effect = picks_to_instances[pick]
+	finale_effect = picked_finale
 	invoke_time = get_invoke_time()
 	if (finale_effect.glow_colour)
 		spell_colour = finale_effect.glow_colour

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -340,6 +340,12 @@
 	var/pick = show_radial_menu(user, user, options, require_near = TRUE, tooltips = TRUE)
 	if (!pick)
 		return
+	var/datum/grand_finale/picked_finale = picks_to_instances[pick]
+	var/round_time_passed = world.time - SSticker.round_start_time
+	if(picked_finale.minimum_time >=round_time_passed)
+		to_chat(user, span_warning("The chosen grand finale will only be available in <b>[DisplayTimeText(picked_finale.minimum_time - round_time_passed)]</b>!"))
+		to_chat(user, span_warning("Be patient, or select another option."))
+		return
 	chosen_effect = TRUE
 	if (pick == PICK_NOTHING)
 		return

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -341,11 +341,12 @@
 	if (!pick)
 		return
 	var/datum/grand_finale/picked_finale = picks_to_instances[pick]
-	var/round_time_passed = world.time - SSticker.round_start_time
-	if(picked_finale.minimum_time >= round_time_passed)
-		to_chat(user, span_warning("The chosen grand finale will only be available in <b>[DisplayTimeText(picked_finale.minimum_time - round_time_passed)]</b>!"))
-		to_chat(user, span_warning("Be patient, or select another option."))
-		return
+	if (istype(picked_finale))
+		var/round_time_passed = world.time - SSticker.round_start_time
+		if(picked_finale.minimum_time >= round_time_passed)
+			to_chat(user, span_warning("The chosen grand finale will only be available in <b>[DisplayTimeText(picked_finale.minimum_time - round_time_passed)]</b>!"))
+			to_chat(user, span_warning("Be patient, or select another option."))
+			return
 	chosen_effect = TRUE
 	if (pick == PICK_NOTHING)
 		return


### PR DESCRIPTION
## About The Pull Request

If you can't immediately invoke a wizard finale, it'll just tell you to wait a bit.

## Why It's Good For The Game

While the radial does tell you that the effect cannot be invoked yet, it's quite small text that you have to quickly read while (assumedly) your ass is public enemy #\1. 

Instead of locking you into something you can't do for another 20 minutes, why not just let them pick another one? Or if they really want to pick that one, they can wait before selecting it?

## Changelog

:cl: Melbert
qol: When reaching the wizard grand finale, you no longer get locked into finale effects that cannot yet be invoked. 
/:cl:


