### PR TITLE
Makes tgui_input_list() candystripe

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
@@ -181,6 +181,7 @@ const ListDisplay = (props) => {
       {filteredItems.map((item, index) => {
         return (
           <Button
+            className="candystripe"
             color="transparent"
             fluid
             id={index}


### PR DESCRIPTION

## About The Pull Request
What it says on the tin
## Why It's Good For The Game
Makes it a little less disorienting if you need to scroll through a long list
## Changelog
:cl: Wallem
qol: some tgui lists that use the same simple function--Navigation menu, Fulton navbeacon selection, Ghost teleportation, etc.--have been given a candystripe.
/:cl:
