### PR TITLE
Immortal pyro anomalies no longer (unsuccessfully) attempt to spawn pyro slimes

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
+++ b/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
@@ -23,7 +23,7 @@
 
 /obj/effect/anomaly/pyro/anomalyEffect(seconds_per_tick)
 	..()
-	if(!already_polling && death_time < (world.time - poll_time))
+	if(!immortal && !already_polling && death_time < (world.time - poll_time))
 		start_poll()
 	ticks += seconds_per_tick
 	if(ticks < releasedelay)


### PR DESCRIPTION

## About The Pull Request

Closes #89910

## Changelog
:cl:
fix: Immortal pyro anomalies no longer (unsuccessfully) attempt to spawn pyro slimes
/:cl:
