### PR TITLE
Don't initialize the sheet snatcher box in a horribly slow and inefficient way

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -335,36 +335,39 @@
 // Copy-pasted from the former /obj/item/storage/box/material, w/ small additions like rods, cardboard, plastic.
 // "Only 20 uranium 'cause of radiation"
 /obj/item/storage/bag/sheetsnatcher/debug/PopulateContents()
+	// amount should be null if it should spawn with the type's default amount
 	var/static/items_inside = list(
-		/obj/item/stack/sheet/iron/fifty=1,
-		/obj/item/stack/sheet/glass/fifty=1,
-		/obj/item/stack/sheet/rglass/fifty=1,
-		/obj/item/stack/sheet/plasmaglass/fifty=1,
-		/obj/item/stack/sheet/titaniumglass/fifty=1,
-		/obj/item/stack/sheet/plastitaniumglass/fifty=1,
-		/obj/item/stack/sheet/plasteel/fifty=1,
-		/obj/item/stack/sheet/mineral/titanium/fifty=1,
-		/obj/item/stack/sheet/mineral/gold=50,
-		/obj/item/stack/sheet/mineral/silver=50,
-		/obj/item/stack/sheet/mineral/plasma=50,
-		/obj/item/stack/sheet/mineral/uranium=20,
-		/obj/item/stack/sheet/mineral/diamond=50,
-		/obj/item/stack/sheet/bluespace_crystal=50,
-		/obj/item/stack/sheet/mineral/bananium=50,
-		/obj/item/stack/sheet/mineral/wood/fifty=1,
-		/obj/item/stack/sheet/plastic/fifty=1,
-		/obj/item/stack/sheet/runed_metal/fifty=1,
-		/obj/item/stack/rods/fifty=1,
-		/obj/item/stack/sheet/mineral/plastitanium=50,
-		/obj/item/stack/sheet/mineral/abductor=50,
-		/obj/item/stack/sheet/cardboard/fifty=1,
-		)
+		/obj/item/stack/sheet/iron/fifty = null,
+		/obj/item/stack/sheet/glass/fifty = null,
+		/obj/item/stack/sheet/rglass/fifty = null,
+		/obj/item/stack/sheet/plasmaglass/fifty = null,
+		/obj/item/stack/sheet/titaniumglass/fifty = null,
+		/obj/item/stack/sheet/plastitaniumglass/fifty = null,
+		/obj/item/stack/sheet/plasteel/fifty = null,
+		/obj/item/stack/sheet/mineral/titanium/fifty = null,
+		/obj/item/stack/sheet/mineral/gold = 50,
+		/obj/item/stack/sheet/mineral/silver = 50,
+		/obj/item/stack/sheet/mineral/plasma = 50,
+		/obj/item/stack/sheet/mineral/uranium = 20,
+		/obj/item/stack/sheet/mineral/diamond = 50,
+		/obj/item/stack/sheet/bluespace_crystal = 50,
+		/obj/item/stack/sheet/mineral/bananium = 50,
+		/obj/item/stack/sheet/mineral/wood/fifty = null,
+		/obj/item/stack/sheet/plastic/fifty = null,
+		/obj/item/stack/sheet/runed_metal/fifty = null,
+		/obj/item/stack/rods/fifty = null,
+		/obj/item/stack/sheet/mineral/plastitanium = 50,
+		/obj/item/stack/sheet/mineral/abductor = 50,
+		/obj/item/stack/sheet/cardboard/fifty = null,
+	)
 	//This needs to be done here and not in Initialize() because the stacks get merged and fall out when their weight updates if this is set after PopulateContents()
 	atom_storage.allow_big_nesting = TRUE
 	atom_storage.max_slots = 99
 	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
 	atom_storage.max_total_storage = capacity
-	generate_items_inside(items_inside,src)
+	for(var/obj/item/stack/stack_type as anything in items_inside)
+		var/amt = items_inside[stack_type]
+		new stack_type(src, amt, FALSE)
 
 /obj/item/storage/bag/sheetsnatcher/debug/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

while optimizing things downstream, I discovered that the materials/sheetsnatcher box's `PopulateContents` is _HORRIBLY_ inefficient.

it will spawn several different types of stacks 50 times (i.e `/obj/item/stack/sheet/mineral/gold`) - instead of initializing it once with the amount set to 50.

i've changed `/obj/item/storage/bag/sheetsnatcher/debug/PopulateContents()` to instead just pass the amount directly to the stack new (and dont try to merge)

## Why It's Good For The Game

we do not need to try to merge 400 or so times to initialize a box with a pre-set amount of materials

## Changelog
:cl:
code: Spawning the debug "sheet snatcher" box will no longer try to do ~400 stack merges.
/:cl:
