### PR TITLE
Fixes balloon alert positioning on wide mobs

### DIFF
--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -44,17 +44,12 @@
 	if (isnull(viewer_client))
 		return
 
-	var/bound_width = ICON_SIZE_X
-	if (ismovable(src))
-		var/atom/movable/movable_source = src
-		bound_width = movable_source.bound_width
-
 	var/image/balloon_alert = image(loc = isturf(src) ? src : get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
 	SET_PLANE_EXPLICIT(balloon_alert, BALLOON_CHAT_PLANE, src)
 	balloon_alert.alpha = 0
 	balloon_alert.appearance_flags = RESET_ALPHA|RESET_COLOR|RESET_TRANSFORM
 	balloon_alert.maptext = MAPTEXT("<span style='text-align: center; -dm-text-outline: 1px #0005'>[text]</span>")
-	balloon_alert.maptext_x = (BALLOON_TEXT_WIDTH - bound_width) * -0.5
+	balloon_alert.maptext_x = (BALLOON_TEXT_WIDTH - ICON_SIZE_X) * -0.5 - base_pixel_x
 	WXH_TO_HEIGHT(viewer_client?.MeasureText(text, null, BALLOON_TEXT_WIDTH), balloon_alert.maptext_height)
 	balloon_alert.maptext_width = BALLOON_TEXT_WIDTH
 


### PR DESCRIPTION

## About The Pull Request

We don't care about bound_width, only about base offset. If a mob wants to be offset, let them be offset.

![image](https://github.com/user-attachments/assets/961aaece-1379-4e32-9703-6f5385cf4efd)
![image](https://github.com/user-attachments/assets/c763f10e-d802-4506-b7f4-a9eba2524b11)

Been bugging me for ages.

## Changelog
:cl:
fix: Fixed balloon alert positioning on wide mobs
/:cl:
