### PR TITLE
[NO GBP] Generalizes `semicd` to `fire_cd` and applies it to burst fire

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -275,7 +275,7 @@
 // Gun procs.
 
 /obj/item/gun/proc/on_autofire_start(mob/living/shooter)
-	if(semicd || shooter.incapacitated || !can_trigger_gun(shooter))
+	if(fire_cd || shooter.incapacitated || !can_trigger_gun(shooter))
 		return FALSE
 	if(!can_shoot())
 		shoot_with_empty_chamber(shooter)
@@ -295,7 +295,7 @@
 
 /obj/item/gun/proc/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
 	SIGNAL_HANDLER
-	if(semicd || shooter.incapacitated)
+	if(fire_cd || shooter.incapacitated)
 		return NONE
 	if(!can_shoot())
 		shoot_with_empty_chamber(shooter)

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -445,7 +445,7 @@
 	. = ..()
 	AddComponent(/datum/component/scope, range_modifier = 4) //enough range to at least make extremely good use of the penetrator rounds
 
-/obj/item/gun/ballistic/rifle/sniper_rifle/reset_semicd()
+/obj/item/gun/ballistic/rifle/sniper_rifle/reset_fire_cd()
 	. = ..()
 	if(suppressed)
 		playsound(src, 'sound/machines/eject.ogg', 25, TRUE, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -341,7 +341,7 @@
 		times_dry_fired = 0
 	var/turf/target_turf = get_offset_target_turf(get_ranged_target_turf(owner, owner.dir, 7), dx = rand(-1, 1), dy = rand(-1, 1))
 	held_gun.process_fire(target_turf, owner, TRUE, null, pick(GLOB.all_body_zones))
-	held_gun.semicd = FALSE
+	held_gun.fire_cd = FALSE
 
 /datum/action/cooldown/spell/charged/psychic_booster
 	name = "Psychic Booster"


### PR DESCRIPTION
## About The Pull Request
Title. Firing a weapon in burst now triggers fire delay based off the fire cooldown variable, which was reused from the now-renamed `semicd`. This shouldn't affect anything, but if this does, uh, my bad.

## Why It's Good For The Game
My previous PR, tgstation/tgstation#89634, separated fire delay and burst delay for a possible avenue of balance for gun design (e.g. fast burst gun with long delays between bursts). I didn't realize burst didn't set the cooldown, though, so... now it's here. My bad.

## Changelog

:cl:
fix: Burst-firing weapons now respect their fire delay, in the event that their fire delay is longer than click cooldown. If your local burst-fire weapon starts to feel weird because of this, please submit an issue report.
/:cl:
