### PR TITLE
Spraypaint is now age-restricted, requiring you to be 20 or older to purchase. Say no to huffing paint!

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -803,6 +803,8 @@
 		/obj/item/fish, // Used for aquarium sprites
 		/obj/structure/window, // Does not play nice with window tint
 	))
+	// The Spinward Stellar Coalition's D.A.R.E. campaign was effective in persuading NT to stop selling spraypaint cans to people who can't be trusted to not get high off of it.
+	age_restricted = TRUE
 
 /obj/item/toy/crayon/spraycan/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The Spinward Stellar Coalition's D.A.R.E. campaign was effective in persuading NT to stop selling spraypaint to people who can't be trusted to not get high off of it, and spraypaint now requires you to be 20 or older to purchase. Say no to huffing paint!

## Why It's Good For The Game

![Logo_of_Drug_Abuse_Resistance_Education_(DARE)](https://github.com/user-attachments/assets/e652c09e-e2bb-4af3-a03f-ba6e705e76f4)


## Changelog

:cl:
balance: The Spinward Stellar Coalition's D.A.R.E. campaign was effective in persuading NT to stop selling spraypaint to people who can't be trusted to not get high off of it, and spraypaint now requires you to be 20 or older to purchase. Say no to huffing paint!
/:cl:
