### PR TITLE
HACK: Fixes 516 small character creator bug by shaking screen_loc.

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -22,14 +22,14 @@
 		ASYNC
 			// HACK: This fixes the character creator in 516 being small and relying on other byondui things (like cameras) to open in order to update and refresh.
 			// This also will fix the camera console screen being offset, Gateway, and admin pod panel.
-			// Adding 100 then setting it back seemed to do the trick!
+			// Setting the alpha value to 254 then back to fixes it
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
 			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
-			sleep(0.2 SECONDS)
-			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
-			sleep(0.2 SECONDS)
-			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
+			sleep(world.tick_lag)
+			alpha = 254
+			sleep(world.tick_lag)
+			alpha = 255
 	else
 		screen_loc = "[x]:[px],[y]:[py]"
 

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -26,9 +26,9 @@
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
 			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
-			sleep(0.2 SECONDS)
+			sleep(world.tick_lag)
 			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
-			sleep(0.2 SECONDS)
+			sleep(world.tick_lag)
 			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -26,7 +26,7 @@
 			// I don't think plane master will be effected, I hope.
 			// We're stuck in the belly of this awful machine.
 			sleep(0.2 SECONDS)
-			screen_loc = "[assigned_map]:[x+3]:[px],[y+3]:[py]"
+			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
 			sleep(0.2 SECONDS)
 			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -26,9 +26,9 @@
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
 			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
-			sleep(world.tick_lag)
+			sleep(0.2 SECONDS) // If it's too fast, it has a chance to fail? Idk. This seems like a good number.
 			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
-			sleep(world.tick_lag)
+			sleep(0.2 SECONDS)
 			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -22,14 +22,14 @@
 		ASYNC
 			// HACK: This fixes the character creator in 516 being small and relying on other byondui things (like cameras) to open in order to update and refresh.
 			// This also will fix the camera console screen being offset, Gateway, and admin pod panel.
-			// Setting the alpha value to 254 then back to fixes it
+			// Adding 100 then setting it back seemed to do the trick!
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
 			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
-			sleep(world.tick_lag)
-			alpha = 254
-			sleep(world.tick_lag)
-			alpha = 255
+			sleep(0.2 SECONDS)
+			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
+			sleep(0.2 SECONDS)
+			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"
 

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -19,6 +19,16 @@
 /atom/movable/screen/proc/set_position(x, y, px = 0, py = 0)
 	if(assigned_map)
 		screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
+		ASYNC
+			// HACK: This fixes the character creator in 516 being small and relying on other byondui things (like cameras) to update and refresh. This fixes them to.
+			// Adding three then setting it back seemed to do the trick!
+			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
+			// I don't think plane master will be effected, I hope.
+			// We're stuck in the belly of this awful machine.
+			sleep(0.2 SECONDS)
+			screen_loc = "[assigned_map]:[x+3]:[px],[y+3]:[py]"
+			sleep(0.2 SECONDS)
+			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"
 

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -26,9 +26,9 @@
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
 			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
-			sleep(0.2 SECONDS) // If it's too fast, it has a chance to fail? Idk. This seems like a good number.
+			sleep(0.1 SECONDS) // If it's too fast, it has a chance to fail? Idk. This seems like a good number.
 			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
-			sleep(0.2 SECONDS)
+			sleep(0.1 SECONDS)
 			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -20,10 +20,11 @@
 	if(assigned_map)
 		screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 		ASYNC
-			// HACK: This fixes the character creator in 516 being small and relying on other byondui things (like cameras) to update and refresh. This fixes them to.
-			// Adding three then setting it back seemed to do the trick!
+			// HACK: This fixes the character creator in 516 being small and relying on other byondui things (like cameras) to open in order to update and refresh.
+			// This also will fix the camera console screen being offset, Gateway, and admin pod panel.
+			// Adding 100 then setting it back seemed to do the trick!
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
-			// I don't think plane master will be effected, I hope.
+			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
 			sleep(0.2 SECONDS)
 			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -143,13 +143,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		ui.set_autoupdate(FALSE)
 		ui.open()
 
-		// HACK: Without this the character starts out really tiny because of some BYOND bug.
-		// You can fix it by changing a preference, so let's just forcably update the body to emulate this.
-		// Lemon from the future: this issue appears to replicate if the byond map (what we're relaying here)
-		// Is shown while the client's mouse is on the screen. As soon as their mouse enters the main map, it's properly scaled
-		// I hate this place
-		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS)
-
 /datum/preferences/ui_state(mob/user)
 	return GLOB.always_state
 


### PR DESCRIPTION
## About The Pull Request

So basically there's some byond bug that has made character previews small and things like cameras offset for the longest time when you open them. 

Basically when ``/atom/movable/screen/proc/set_position`` is called and it has an ``assigned_map``, sleep, add three to the x and y offset, sleep, then reset it. Sorry @Mothblocks but your original code to update the character after a second doesn't seem to work anymore.

![dreamseeker_a1EDRWfgDA](https://github.com/user-attachments/assets/b7940fa9-ef92-40cd-a700-b22aefdfa286)



## Why It's Good For The Game

This is not good for the game

## Changelog


:cl:
fix: Character creator preview being miniature
/:cl:

