### PR TITLE
Fixes broken drone UI on 516

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(statpanels)
 #if MIN_COMPILER_VERSION > 515
 	#warn 516 is most certainly out of beta, remove this beta notice if you haven't already
 #endif
-	var/static/list/beta_notice = list("", "You are on the BYOND 516, some visual glitches with UIs may be present!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
+	var/static/list/beta_notice = list("", "You are on BYOND 516, some visual glitches with UIs may be present!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
 	if(!global_data)//statbrowser hasnt fired yet and we were called from immediate_send_stat_data()
 		return
 	target.stat_panel.send_message("update_stat", list(

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(statpanels)
 #if MIN_COMPILER_VERSION > 515
 	#warn 516 is most certainly out of beta, remove this beta notice if you haven't already
 #endif
-	var/static/list/beta_notice = list("", "You are on the BYOND 516 beta, various UIs and such may be broken!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
+	var/static/list/beta_notice = list("", "You are on the BYOND 516, some visual glitches with UIs may be present!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
 	if(!global_data)//statbrowser hasnt fired yet and we were called from immediate_send_stat_data()
 		return
 	target.stat_panel.send_message("update_stat", list(

--- a/code/datums/elements/dextrous.dm
+++ b/code/datums/elements/dextrous.dm
@@ -11,8 +11,10 @@
 
 	var/mob/living/mob_parent = target
 	set_available_hands(mob_parent, hands_count)
-	mob_parent.set_hud_used(new hud_type(target))
-	mob_parent.hud_used.show_hud(mob_parent.hud_used.hud_version)
+	mob_parent.hud_type = hud_type
+	if (mob_parent.hud_used)
+		mob_parent.set_hud_used(new hud_type(target))
+		mob_parent.hud_used.show_hud(mob_parent.hud_used.hud_version)
 	ADD_TRAIT(target, TRAIT_CAN_HOLD_ITEMS, REF(src))
 	RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(on_death))
 	RegisterSignal(target, COMSIG_LIVING_UNARMED_ATTACK, PROC_REF(on_hand_clicked))
@@ -23,8 +25,10 @@
 	var/mob/living/mob_parent = source
 	set_available_hands(mob_parent, initial(mob_parent.default_num_hands))
 	var/initial_hud = initial(mob_parent.hud_type)
-	mob_parent.set_hud_used(new initial_hud(source))
-	mob_parent.hud_used.show_hud(mob_parent.hud_used.hud_version)
+	mob_parent.hud_type = initial_hud
+	if (mob_parent.hud_used)
+		mob_parent.set_hud_used(new initial_hud(source))
+		mob_parent.hud_used.show_hud(mob_parent.hud_used.hud_version)
 	REMOVE_TRAIT(source, TRAIT_CAN_HOLD_ITEMS, REF(src))
 	UnregisterSignal(source, list(
 		COMSIG_ATOM_EXAMINE,


### PR DESCRIPTION

## About The Pull Request

Ironically enough, not a 516 issue but rather a fuckup on our part revealed by a 516 plane switch.
Also adjusted the warning, as 516 is outside of beta and we're (supposed to) have almost complete support at this point. 

Closes #89877

## Changelog
:cl:
fix: Fixes black vision for dextrous mobs using 516 version of BYOND
/:cl:
