### PR TITLE
Fixes a missing wire under Wawa's Coldroom APC

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -44599,6 +44599,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "pNa" = (


### PR DESCRIPTION

## About The Pull Request

Closes #89937

## Changelog
:cl:
fix: Fixed a missing wire under Wawa's Coldroom APC
/:cl:
