### PR TITLE
Introduces a variable to the /obj/machinery type which allows for controlling what size mob may enter

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -152,6 +152,8 @@
 	///What was our power state the last time we updated its appearance?
 	///TRUE for on, FALSE for off, -1 for never checked
 	var/appearance_power_state = -1
+	///variable controlling the size of carbon mobs allowed to occupy our machine, defaults to large
+	var/max_mob_size_allowed = MOB_SIZE_LARGE
 
 /datum/armor/obj_machinery
 	melee = 25
@@ -434,7 +436,7 @@
 				continue
 			if(isliving(current_atom))
 				var/mob/living/current_mob = atom
-				if(current_mob.buckled || current_mob.mob_size >= MOB_SIZE_LARGE)
+				if(current_mob.buckled || current_mob.mob_size >= max_mob_size_allowed)
 					continue
 			target = atom
 


### PR DESCRIPTION
## About The Pull Request
Gives a variable that allows for custom mob size requirements for closing a machine, defaults to current settings
## Why It's Good For The Game
Rather than it just being a flat denial on everyone greater than or equal to MOB_SIZE_LARGE, now you will be able to give specific machines a more curated choice for what size mob can enter them.
## Changelog
:cl:
code: introduces a variable to machines allowing for customization on what mob size is allowed to enter
/:cl:
