### PR TITLE
Clear detached holder before moving assembly

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -54,9 +54,10 @@
 		connected = null
 	if(!holder)
 		return FALSE
-	forceMove(holder.drop_location())
-	SEND_SIGNAL(src, COMSIG_ASSEMBLY_DETACHED, holder)
+	var/atom/was_holder = holder
 	holder = null
+	forceMove(was_holder.drop_location())
+	SEND_SIGNAL(src, COMSIG_ASSEMBLY_DETACHED, was_holder)
 	return TRUE
 
 /**


### PR DESCRIPTION
## About The Pull Request

If you attached a proximity sensor to a wire and then detached it again, it would cause a runtime.
This is because when the proximity sensor moved into your tile it would trigger and attempt to pulse, despite not being attached to anything
To prevent this, we clear its `holder` variable before moving it so that it knows that there actually isn't anything for it to pulse

## Changelog

Not sure this actually had any player facing effect other than creating a runtime error