### PR TITLE
Fixes alien pistols

### DIFF
--- a/code/modules/projectiles/projectile/energy/radiation.dm
+++ b/code/modules/projectiles/projectile/energy/radiation.dm
@@ -9,10 +9,11 @@
 	var/radiation_chance = 30
 
 /obj/projectile/energy/radiation/on_hit(atom/target, blocked, pierce_hit)
+	. = ..()
 	if (ishuman(target) && prob(radiation_chance))
 		radiation_pulse(target, max_range = 0, threshold = RAD_FULL_INSULATION)
 
-	..()
+	return BULLET_ACT_HIT
 
 /obj/projectile/energy/radiation/weak
 	damage = 9

--- a/code/modules/projectiles/projectile/energy/radiation.dm
+++ b/code/modules/projectiles/projectile/energy/radiation.dm
@@ -13,8 +13,6 @@
 	if (ishuman(target) && prob(radiation_chance))
 		radiation_pulse(target, max_range = 0, threshold = RAD_FULL_INSULATION)
 
-	return BULLET_ACT_HIT
-
 /obj/projectile/energy/radiation/weak
 	damage = 9
 	radiation_chance = 10


### PR DESCRIPTION

## About The Pull Request

Decloner projectiles do their 20 damage again, a badly written on_hit() was breaking everything by not returning.

## Why It's Good For The Game

Fixing bugs etc

## Changelog
:cl:
fix: Alien pistols do damage again
/:cl:
