### PR TITLE
Fix Eye Chart being unobtainable

### DIFF
--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -275,6 +275,10 @@
 		var/obj/structure/sign/potential_sign = s
 		if(!initial(potential_sign.is_editable))
 			continue
-		output[initial(potential_sign.sign_change_name)] = potential_sign
+		var/shown_name = initial(potential_sign.sign_change_name) || capitalize(format_text(initial(potential_sign.name)))
+		if(output[shown_name])
+			stack_trace("Two signs share the same sign_change_name: [output[shown_name]] and [potential_sign]")
+			continue
+		output[shown_name] = potential_sign
 	output = sort_list(output) //Alphabetizes the results.
 	return output

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -277,7 +277,8 @@
 			continue
 		var/shown_name = initial(potential_sign.sign_change_name) || capitalize(format_text(initial(potential_sign.name)))
 		if(output[shown_name])
-			stack_trace("Two signs share the same sign_change_name: [output[shown_name]] and [potential_sign]")
+			if(!ispath(potential_sign, output[shown_name]))
+				stack_trace("Two signs share the same sign_change_name: [output[shown_name]] and [potential_sign]")
 			continue
 		output[shown_name] = potential_sign
 	output = sort_list(output) //Alphabetizes the results.

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -191,7 +191,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/holy, 32)
 
 /obj/structure/sign/departments/holy_alt
 	name = "\improper Chapel sign"
-	sign_change_name = "Department - Chapel"
+	sign_change_name = "Department - Chapel Alt"
 	desc = "A sign labelling a religious area."
 	icon_state = "chapel"
 


### PR DESCRIPTION
## About The Pull Request

Turns out you need to set sign change name for it to be selectable on blank signs

I thought this was a big footgun so I just added logic to have signs default to their name if they are editable but don't have a change_name set. 

## Changelog

:cl: Melbert
fix: You can make eye charts out of blank signs
/:cl:

