### PR TITLE
516: Fix TGUI Asset Loading

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -320,6 +320,18 @@
       if (!sync) {
         node.media = 'only x';
       }
+      var removeNodeAndRetry = function () {
+        node.parentNode.removeChild(node);
+        node = null;
+        retry();
+      }
+      // 516: Chromium won't call onload() if there is a 404 error
+      // Legacy IE doesn't use onerror, so we retain that
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#stylesheet_load_events
+      node.onerror = function () {
+        node.onerror = null;
+        removeNodeAndRetry();
+      }
       node.onload = function () {
         node.onload = null;
         if (isStyleSheetLoaded(node, url)) {
@@ -327,10 +339,7 @@
           node.media = 'all';
           return;
         }
-        // Try again
-        node.parentNode.removeChild(node);
-        node = null;
-        retry();
+        removeNodeAndRetry();
       };
       injectNode(node);
       return;


### PR DESCRIPTION
## About The Pull Request

Soooo, Chromium/Webview2 broke TGUI's asset loading retries, but nobody can catch it on local! After copious investigation, I bring you the solution: `onerror`.

This should fix assets not showing up until you forcibly refresh TGUI windows, especially if you have higher latency to the sending server.

![image](https://github.com/user-attachments/assets/16d87699-3a47-406a-82a9-464b02ddd545)

Here you can see evidence of my fix. "1" is `removeNodeAndRetry`, "2" is `onerror` and "3" is `onload`. The chain of events occurs exactly as expected. You can see that `onload` doesn't run if there's a 404, thus breaking retries!

## Why It's Good For The Game

Asset loading correctly good

Fixes #89986 

## Changelog

:cl:
fix: Fixed TGUI assets and icons sometimes not showing up until you refreshed the page on 516 clients
/:cl: