### PR TITLE
makes genetics data disks infinitely reskinnable

### DIFF
--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -168,6 +168,17 @@
 	var/list/mutations = list()
 	var/max_mutations = 6
 	var/read_only = FALSE //Well,it's still a floppy disk
+	obj_flags = parent_type::obj_flags | INFINITE_RESKIN
+	unique_reskin = list(
+			"Red" = "datadisk0",
+			"Dark Blue" = "datadisk1",
+			"Yellow" = "datadisk2",
+			"Black" = "datadisk3",
+			"Green" = "datadisk4",
+			"Purple" = "datadisk5",
+			"Grey" = "datadisk6",
+			"Light Blue" = "datadisk7",
+	)
 
 /obj/item/disk/data/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/user-attachments/assets/92c841d2-c5c8-4116-b9c8-aef004c97230)
Adds a unique_reskin variable and INFINITE_RESKIN to the genetics data disk.

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/140b9561-48b0-49c1-a796-2a8c3c78cb6d)
unfortunately for my friend who suggested the idea i only made it work for genetics data disks. but this could probably be extended out for any other disks if someone else thinks they should be recolorable?

## Changelog

:cl:
qol: Genetics data disks are now infinitely recolorable/reskinnable via alt-click.
/:cl: