### PR TITLE
Nooatrium can no longer revive suicided mobs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -496,6 +496,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 /datum/reagent/inverse/penthrite/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick)
 	. = ..()
+	if (HAS_TRAIT(affected_mob, TRAIT_SUICIDED))
+		return
+	if (affected_mob.mind && HAS_TRAIT(affected_mob.mind, TRAIT_SUICIDED))
+		return
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -498,8 +498,6 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	if (HAS_TRAIT(affected_mob, TRAIT_SUICIDED))
 		return
-	if (affected_mob.mind && HAS_TRAIT(affected_mob.mind, TRAIT_SUICIDED))
-		return
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return


### PR DESCRIPTION

## About The Pull Request

I'd wrap the suicide check around grab_ghost but we generally don't want to revive suicided mobs, and strange reagent also simply refuses to act on suicide victims, so I just prevent revival from running altogether.

Closes #89944

## Changelog
:cl:
fix: Nooatrium can no longer revive suicided mobs
/:cl:
