### PR TITLE
[NO GBP] Going through lava while buckled to an object no longer explodes the server

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -300,13 +300,9 @@
 
 	var/mob/living/burn_living = burn_target
 	var/atom/movable/burn_buckled = burn_living.buckled
-	while(burn_buckled)
-		if (cache_burn_check(burn_buckled) == LAVA_BE_PROCESSING)
+	if(burn_buckled)
+		if(cache_burn_check(burn_buckled) != LAVA_BE_BURNING)
 			return LAVA_BE_PROCESSING
-
-		if (isliving(burn_buckled))
-			var/mob/living/living_buckled = burn_buckled
-			burn_buckled = living_buckled.buckled
 
 	if(iscarbon(burn_living))
 		var/mob/living/carbon/burn_carbon = burn_living

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -300,9 +300,8 @@
 
 	var/mob/living/burn_living = burn_target
 	var/atom/movable/burn_buckled = burn_living.buckled
-	if(burn_buckled)
-		if(cache_burn_check(burn_buckled) != LAVA_BE_BURNING)
-			return LAVA_BE_PROCESSING
+	if(burn_buckled && cache_burn_check(burn_buckled) != LAVA_BE_BURNING)
+		return LAVA_BE_PROCESSING
 
 	if(iscarbon(burn_living))
 		var/mob/living/carbon/burn_carbon = burn_living


### PR DESCRIPTION


## About The Pull Request

Closes #89963
I fucked up and didn't remove the while loop after switching to recursive checks

## Changelog
:cl:
fix: Going through lava while buckled to an object no longer explodes the server
/:cl:
