### PR TITLE
Partially reverts #89619, where I partially reverted #87936; Puts back the mining and damage AOE damage on Mech PKA, but improves the standard modkits as well

### DIFF
--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -341,7 +341,7 @@
 
 	add_action(ACTION_MELEED, 50 * (ismegafauna(attacked) ? 1.5 : 1))
 
-/datum/component/style/proc/on_mine(datum/source, turf/closed/mineral/rock, exo_multiplier)
+/datum/component/style/proc/on_mine(datum/source, turf/closed/mineral/rock, exp_multiplier)
 	SIGNAL_HANDLER
 
 	if(istype(rock, /turf/closed/mineral/gibtonite))

--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -341,7 +341,7 @@
 
 	add_action(ACTION_MELEED, 50 * (ismegafauna(attacked) ? 1.5 : 1))
 
-/datum/component/style/proc/on_mine(datum/source, turf/closed/mineral/rock, give_exp)
+/datum/component/style/proc/on_mine(datum/source, turf/closed/mineral/rock, exo_multiplier)
 	SIGNAL_HANDLER
 
 	if(istype(rock, /turf/closed/mineral/gibtonite))
@@ -360,11 +360,11 @@
 				return
 
 	if(rock.mineralType)
-		if(give_exp)
+		if(exp_multiplier)
 			add_action(ACTION_ORE_MINED, 40)
 		rock.mineralAmt = ROUND_UP(rock.mineralAmt * (1 + ((rank * 0.1) - 0.3))) // You start out getting 20% less ore, but it goes up to 20% more at S-tier
 
-	else if(give_exp)
+	else if(exp_multiplier)
 		add_action(ACTION_ROCK_MINED, 25)
 
 /datum/component/style/proc/on_resonator_burst(datum/source, mob/creator, mob/living/hit_living)

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -230,7 +230,7 @@
 			if(istype(rock, /turf/open/misc/asteroid) && prob(35)) // so it's too common
 				new /obj/effect/decal/cleanable/rubble(rock)
 			if(prob(100 - (i * 15)))
-				rock.gets_drilled(user, FALSE)
+				rock.gets_drilled(user)
 				if(prob(50))
 					new /obj/effect/decal/cleanable/rubble(rock)
 		sleep(0.6 SECONDS)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -182,7 +182,7 @@
 		TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 		return
 	if(ismineralturf(src))
-		gets_drilled(user, TRUE)
+		gets_drilled(user, 1)
 		SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
 
 /turf/closed/mineral/attack_hand(mob/user)
@@ -208,9 +208,9 @@
 	if(user.Adjacent(src))
 		attack_hand(user)
 
-/turf/closed/mineral/proc/gets_drilled(mob/user, give_exp = FALSE)
+/turf/closed/mineral/proc/gets_drilled(mob/user, exp_multiplier = 0)
 	if(istype(user))
-		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, give_exp)
+		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, exp_multiplier)
 	if(mineralType && (mineralAmt > 0))
 		new mineralType(src, mineralAmt)
 		SSblackbox.record_feedback("tally", "ore_mined", mineralAmt, mineralType)
@@ -218,11 +218,11 @@
 		new spawned_boulder(src)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(give_exp)
+		if(exp_multiplier)
 			if (mineralType && (mineralAmt > 0))
-				H.mind.adjust_experience(/datum/skill/mining, initial(mineralType.mine_experience) * mineralAmt)
+				H.mind.adjust_experience(/datum/skill/mining, initial(mineralType.mine_experience) * mineralAmt * exp_multiplier)
 			else
-				H.mind.adjust_experience(/datum/skill/mining, 4)
+				H.mind.adjust_experience(/datum/skill/mining, 4 * exp_multiplier)
 
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)
 		qdel(M)
@@ -255,23 +255,23 @@
 /turf/closed/mineral/ex_act(severity, target)
 	. = ..()
 	if(target == src)
-		gets_drilled(null, FALSE)
+		gets_drilled()
 		return TRUE
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			gets_drilled(null, FALSE)
+			gets_drilled()
 		if(EXPLODE_HEAVY)
 			if(prob(90))
-				gets_drilled(null, FALSE)
+				gets_drilled()
 		if(EXPLODE_LIGHT)
 			if(prob(75))
-				gets_drilled(null, FALSE)
+				gets_drilled()
 
 	return TRUE
 
 /turf/closed/mineral/blob_act(obj/structure/blob/B)
 	if(prob(50))
-		gets_drilled(give_exp = FALSE)
+		gets_drilled()
 
 /turf/closed/mineral/random
 	/// What are the base odds that this turf spawns a mineral in the wall on initialize?
@@ -834,9 +834,9 @@
 		if(defuser)
 			SEND_SIGNAL(defuser, COMSIG_LIVING_DEFUSED_GIBTONITE, det_time)
 
-/turf/closed/mineral/gibtonite/gets_drilled(mob/user, give_exp = FALSE, triggered_by_explosion = FALSE)
+/turf/closed/mineral/gibtonite/gets_drilled(mob/user, exp_multiplier = 0, triggered_by_explosion = FALSE)
 	if(istype(user))
-		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, give_exp)
+		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, exp_multiplier)
 
 	if(stage == GIBTONITE_UNSTRUCK && mineralAmt >= 1) //Gibtonite deposit is activated
 		playsound(src,'sound/effects/hit_on_shattered_glass.ogg',50,TRUE)
@@ -906,9 +906,9 @@
 		to_chat(usr, span_warning("The rock seems to be too strong to destroy. Maybe I can break it once I become a master miner."))
 
 
-/turf/closed/mineral/strong/gets_drilled(mob/user, give_exp = FALSE)
+/turf/closed/mineral/strong/gets_drilled(mob/user, exp_multiplier = 0)
 	if(istype(user))
-		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, give_exp)
+		SEND_SIGNAL(user, COMSIG_MOB_MINED, src, exp_multiplier)
 
 	if(!ishuman(user))
 		return // see attackby

--- a/code/modules/events/earthquake.dm
+++ b/code/modules/events/earthquake.dm
@@ -144,7 +144,7 @@
 		for(var/turf/turf_to_clear in underbelly)
 			if(ismineralturf(turf_to_clear))
 				var/turf/closed/mineral/rock_to_clear = turf_to_clear
-				rock_to_clear.gets_drilled(give_exp = FALSE)
+				rock_to_clear.gets_drilled()
 		for(var/turf/turf_to_quake in edges)
 			turf_to_quake.Shake(pixelshiftx = 0.5, pixelshifty = 0.5, duration = 1 SECONDS)
 		playsound(epicenter, 'sound/misc/metal_creak.ogg', 125, TRUE)

--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
@@ -317,7 +317,7 @@
 		if(QDELETED(hit_mineral))
 			return ..()
 		new /obj/effect/temp_visual/kinetic_blast(hit_mineral)
-		hit_mineral.gets_drilled(firer, TRUE)
+		hit_mineral.gets_drilled(firer, 1)
 		if(!iscarbon(firer))
 			return ..()
 		var/mob/living/carbon/carbon_firer = firer

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -171,7 +171,7 @@
 
 /obj/item/crusher_trophy/bileworm_spewlet/on_projectile_hit_mineral(turf/closed/mineral, mob/living/user)
 	for(var/turf/closed/mineral/mineral_turf in RANGE_TURFS(1, mineral) - mineral)
-		mineral_turf.gets_drilled(user, TRUE)
+		mineral_turf.gets_drilled(user, 1)
 
 //yes this is a /mob_cooldown subtype being added to an item. I can't recommend you do what I'm doing
 /datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/spewlet

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -484,7 +484,7 @@
 		target_turf = get_turf(src)
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/mineral_turf = target_turf
-		mineral_turf.gets_drilled(firer, TRUE)
+		mineral_turf.gets_drilled(firer, 1)
 
 /obj/item/pen/destroyer
 	name = "Fine Tipped Pen"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -264,18 +264,19 @@
 /obj/projectile/kinetic/mech
 	range = 5
 	damage = 50
-	//the multiplier we apply to our PKa's AOE effect.
-	var/aoe_damage_multiplier = 0.3
 
 /obj/projectile/kinetic/mech/strike_thing(atom/target)
 	. = ..()
 	new /obj/effect/temp_visual/explosion/fast(get_turf(target))
 
-	for(var/mob/living/living_mob in range(1, target) - firer - target)
+	for(var/turf/closed/mineral/mineral_turf in RANGE_TURFS(2, target) - target)
+		mineral_turf.gets_drilled(firer, TRUE)
+
+	for(var/mob/living/living_mob in range(2, target) - firer - target)
 		if(!ismining(living_mob))
 			continue
 		var/armor = living_mob.run_armor_check(def_zone, armor_flag, armour_penetration = armour_penetration)
-		living_mob.apply_damage(damage*aoe_damage_multiplier, damage_type, def_zone, armor)
+		living_mob.apply_damage(damage, damage_type, def_zone, armor)
 		to_chat(living_mob, span_userdanger("You're struck by a [name]!"))
 
 //Modkits
@@ -426,6 +427,8 @@
 //AoE blasts
 /obj/item/borg/upgrade/modkit/aoe
 	modifier = 0
+	cost = 10
+	maximum_of_type = 1
 	var/turf_aoe = FALSE
 	var/stats_stolen = FALSE
 
@@ -450,20 +453,25 @@
 /obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/projectile/kinetic/K)
 	K.name = "kinetic explosion"
 
-/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/recharge/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/projectile/kinetic/kinetic_blast, turf/target_turf, atom/target, obj/item/gun/energy/recharge/kinetic_accelerator/KA)
 	if(stats_stolen)
 		return
 	new /obj/effect/temp_visual/explosion/fast(target_turf)
 	if(turf_aoe)
-		for(var/T in RANGE_TURFS(1, target_turf) - target_turf)
+		for(var/T in RANGE_TURFS(2, target_turf) - target_turf)
 			if(ismineralturf(T))
 				var/turf/closed/mineral/M = T
-				M.gets_drilled(K.firer, TRUE)
+				M.gets_drilled(kinetic_blast.firer, TRUE)
+
 	if(modifier)
-		for(var/mob/living/L in range(1, target_turf) - K.firer - target)
-			var/armor = L.run_armor_check(K.def_zone, K.armor_flag, "", "", K.armour_penetration)
-			L.apply_damage(K.damage*modifier, K.damage_type, K.def_zone, armor)
-			to_chat(L, span_userdanger("You're struck by a [K.name]!"))
+		for(var/mob/living/living_mob in range(2, target) - kinetic_blast.firer - target)
+
+			if(!ismining(living_mob))
+				continue
+
+			var/armor = living_mob.run_armor_check(kinetic_blast.def_zone, kinetic_blast.armor_flag, armour_penetration = kinetic_blast.armour_penetration)
+			living_mob.apply_damage(kinetic_blast.damage*modifier, kinetic_blast.damage_type, kinetic_blast.def_zone, armor)
+			to_chat(living_mob, span_userdanger("You're struck by a [kinetic_blast.name]!"))
 
 /obj/item/borg/upgrade/modkit/aoe/turfs
 	name = "mining explosion"
@@ -471,16 +479,14 @@
 	denied_type = /obj/item/borg/upgrade/modkit/aoe/turfs
 	turf_aoe = TRUE
 
-/obj/item/borg/upgrade/modkit/aoe/turfs/andmobs
-	name = "offensive mining explosion"
-	desc = "Causes the kinetic accelerator to destroy rock and damage mobs in an AoE."
-	maximum_of_type = 3
-	modifier = 0.25
-
 /obj/item/borg/upgrade/modkit/aoe/mobs
 	name = "offensive explosion"
 	desc = "Causes the kinetic accelerator to damage mobs in an AoE."
-	modifier = 0.2
+	modifier = 1
+
+/obj/item/borg/upgrade/modkit/aoe/mobs/andturfs
+	name = "offensive mining explosion"
+	desc = "Causes the kinetic accelerator to destroy rock and damage mobs in an AoE."
 
 //Minebot passthrough
 /obj/item/borg/upgrade/modkit/minebot_passthrough

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -487,6 +487,7 @@
 /obj/item/borg/upgrade/modkit/aoe/mobs/andturfs
 	name = "offensive mining explosion"
 	desc = "Causes the kinetic accelerator to destroy rock and damage mobs in an AoE."
+	turf_aoe = TRUE
 
 //Minebot passthrough
 /obj/item/borg/upgrade/modkit/minebot_passthrough

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -249,7 +249,7 @@
 			modkit_upgrade.projectile_strike(src, target_turf, target, kinetic_gun)
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
-		M.gets_drilled(firer, TRUE)
+		M.gets_drilled(firer, 1)
 		if(iscarbon(firer))
 			var/mob/living/carbon/carbon_firer = firer
 			var/skill_modifier = 1
@@ -270,7 +270,7 @@
 	new /obj/effect/temp_visual/explosion/fast(get_turf(target))
 
 	for(var/turf/closed/mineral/mineral_turf in RANGE_TURFS(2, target) - target)
-		mineral_turf.gets_drilled(firer, TRUE)
+		mineral_turf.gets_drilled(firer, 0.1)
 
 	for(var/mob/living/living_mob in range(2, target) - firer - target)
 		if(!ismining(living_mob))
@@ -461,7 +461,7 @@
 		for(var/T in RANGE_TURFS(2, target_turf) - target_turf)
 			if(ismineralturf(T))
 				var/turf/closed/mineral/M = T
-				M.gets_drilled(kinetic_blast.firer, TRUE)
+				M.gets_drilled(kinetic_blast.firer, 0.1)
 
 	if(modifier)
 		for(var/mob/living/living_mob in range(2, target) - kinetic_blast.firer - target)

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -15,7 +15,7 @@
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
-		M.gets_drilled(firer, FALSE)
+		M.gets_drilled(firer)
 		if(mine_range)
 			mine_range--
 			range++

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -267,7 +267,7 @@
 	desc = "A device which causes kinetic accelerators to fire AoE blasts that destroy rock and damage creatures."
 	id = "hyperaoemod"
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*3.5, /datum/material/glass = SHEET_MATERIAL_AMOUNT*1.5, /datum/material/silver =SHEET_MATERIAL_AMOUNT*1.5, /datum/material/gold =SHEET_MATERIAL_AMOUNT*1.5, /datum/material/diamond = SHEET_MATERIAL_AMOUNT*2)
-	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs/andmobs
+	build_path = /obj/item/borg/upgrade/modkit/aoe/mobs/andturfs
 
 /datum/design/unique_modkit/rapid_repeater
 	name = "Kinetic Accelerator Rapid Repeater Mod"

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -381,7 +381,7 @@
 				var/turf/closed/mineral/dest_mineral_turf = dest_turf
 				for(var/mob/client_mob in SSspatial_grid.orthogonal_range_search(dest_mineral_turf, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS, 8))
 					shake_camera(client_mob, duration = 2, strength = 3)
-				dest_mineral_turf.gets_drilled(give_exp = FALSE)
+				dest_mineral_turf.gets_drilled()
 
 			for(var/obj/structure/victim_structure in dest_turf.contents)
 				if(QDELING(victim_structure))

--- a/tools/UpdatePaths/Scripts/89993_tufsandmobs_to_mobsandturfs.txt
+++ b/tools/UpdatePaths/Scripts/89993_tufsandmobs_to_mobsandturfs.txt
@@ -1,0 +1,3 @@
+#comment This repaths AOE Offensive Mining modkit from being a child of the turf aoe mining kit to the mob aoe mining kit
+
+/obj/item/borg/upgrade/modkit/aoe/turfs/andmobs : /obj/item/borg/upgrade/modkit/aoe/mobs/andturfs{@OLD}


### PR DESCRIPTION

## About The Pull Request

In #89619, I removed the mech PKA's mining AOE and reduced the damaging AOE to a fraction of the damage.

I have restored both of these aspects, but I have also applied this change to the standard PKA's mining and damage AOE. I have also included the mob biotype limitations as well.

AOE modkits take 10% capacity, now allowing miners to use them in more setups. However, they conflict with one another. You can only have one AOE mod until you can get the dual AOE mod from tendrils.

The AOE damage/mining effect is now a 2 tile effect rather than 1 tile effect.

## Why It's Good For The Game

My intent in the previous PR was to bring mech PKA's down to standard mining limitations. So, why not improve those standards for everyone instead? The new state of mining expects you to be dealing with a lot of mobs at once. Even small vents can, on occasion, decide to spit out several goliaths back to back. That's a lot of mobs with a lot of health.

Miners need AOE options more than ever. They have very little that are actually meaningful, sadly. So my intent here is that this should be an expectation for our miners to be seeking out and can fit into their current, standard gameplay.

Certainly I've only felt like shit having to sacrifice a damage or cooldown mod for an AOE mod, only to get a very minor amount of damage splash for my efforts. That, and the radius doesn't usually impact most mobs as they spawn and attack from awkward angles or distances from one another where they are JUST out of reach of one another. Trying to use the splash to hit multiple enemies is often not worth it compared to just hitting one enemy at a time with a lot of damage.

So, let's just go with the standard of 'Good AOE is fundamentally needed now' and worth from that premise.

## Changelog
:cl:
balance: Mech PKA now once again mines turfs and does full damage on its AOE explosion (still only hitting mining mobs).
balance: The standard PKA AOE mods are now by default 10% capacity. But they cannot be used with one another.
balance: The standard PKA offensive AOE mod now does the PKA's full damage in its AOE.
balance: Mining AOEs will affect everything within a 2 tile radius around the point of impact, up from a 1 tile radius.
/:cl:
