### PR TITLE
Airlock prying from `/datum/element/door_pryer` does damage to the door like jaws of life prying

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -55,6 +55,9 @@
 /// We are getting this door open if it has not been physically held shut somehow. Play a special sound to signify this level of opening.
 #define BYPASS_DOOR_CHECKS 2
 
+/// Damage dealth to an airlock when prie
+#define AIRLOCK_PRY_DAMAGE 25
+
 //used in design to specify which machine can build it
 //Note: More than one of these can be added to a design but imprinter and lathe designs are incompatible.
 #define IMPRINTER (1<<0) //For circuits. Uses glass/chemicals.

--- a/code/datums/elements/door_pryer.dm
+++ b/code/datums/elements/door_pryer.dm
@@ -69,3 +69,4 @@
 		return
 	attacker.visible_message(span_warning("[attacker] forces the [airlock_target] to open."))
 	airlock_target.open(BYPASS_DOOR_CHECKS)
+	airlock_target.take_damage(AIRLOCK_PRY_DAMAGE, BRUTE, sound_effect = FALSE)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1232,7 +1232,7 @@
 		return
 
 	open(BYPASS_DOOR_CHECKS)
-	take_damage(25, BRUTE, 0, 0) // Enough to sometimes spark
+	take_damage(AIRLOCK_PRY_DAMAGE, BRUTE, 0, 0) // Enough to sometimes spark
 	if(density && !open(BYPASS_DOOR_CHECKS))
 		to_chat(user, span_warning("Despite your attempts, [src] refuses to open."))
 


### PR DESCRIPTION
## About The Pull Request

`/datum/element/door_pryer` (regal rats, space dragons, strong arms) (wait why the fuck don't xenos use this they also door pry AHHH-) now cause damage to the door like prying them via jaws of life does

## Why It's Good For The Game

Consistency (leaves a trace, gives people a reason to frown at it, engineer job content :tm:, etc) 

## Changelog

:cl: Melbert
balance: Mobs that pry open doors (regal rats, space dragons, strong arms) now deal damage to the doors, similar to how jaws of life damage the doors
/:cl:
