### PR TITLE
Fixes aquarium fish overlays

### DIFF
--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -27,13 +27,13 @@
 	var/list/used_layers = list()
 
 	///The minimum pixel x of the area where vis overlays should be displayed
-	var/aquarium_zone_min_px
+	var/aquarium_zone_min_pw
 	///The maximum pixel x of the area where vis overlays should be displayed
-	var/aquarium_zone_max_px
+	var/aquarium_zone_max_pw
 	///The minimum pixel y of the area where vis overlays should be displayed
-	var/aquarium_zone_min_py
+	var/aquarium_zone_min_pz
 	///The maximum pixel y of the area where vis overlays should be displayed
-	var/aquarium_zone_max_py
+	var/aquarium_zone_max_pz
 
 	///While the feed (reagent) storage is not empty, this is the interval which the fish are fed.
 	var/feeding_interval = 3 MINUTES
@@ -73,10 +73,10 @@
 	src.default_beauty = default_beauty
 	src.reagents_size = reagents_size
 
-	aquarium_zone_min_px = min_px
-	aquarium_zone_max_px = max_px
-	aquarium_zone_min_py = min_py
-	aquarium_zone_max_py = max_py
+	aquarium_zone_min_pw = min_px
+	aquarium_zone_max_pw = max_px
+	aquarium_zone_min_pz = min_py
+	aquarium_zone_max_pz = max_py
 
 	src.min_fluid_temp = min_fluid_temp
 	src.max_fluid_temp = max_fluid_temp
@@ -424,10 +424,10 @@
 	SIGNAL_HANDLER
 	used_layers -= visual.layer
 	visual.layer = request_layer(visual.layer_mode)
-	visual.aquarium_zone_min_px = aquarium_zone_min_px
-	visual.aquarium_zone_max_px = aquarium_zone_max_px
-	visual.aquarium_zone_min_py = aquarium_zone_min_py
-	visual.aquarium_zone_max_py = aquarium_zone_max_py
+	visual.aquarium_zone_min_pw = aquarium_zone_min_pw
+	visual.aquarium_zone_max_pw = aquarium_zone_max_pw
+	visual.aquarium_zone_min_pz = aquarium_zone_min_pz
+	visual.aquarium_zone_max_pz = aquarium_zone_max_pz
 	visual.fluid_type = fluid_type
 
 /datum/component/aquarium/proc/request_layer(layer_type)

--- a/code/datums/components/aquarium_content.dm
+++ b/code/datums/components/aquarium_content.dm
@@ -110,12 +110,12 @@
 	/// How the visual will be layered
 	var/layer_mode = AQUARIUM_LAYER_MODE_AUTO
 	///minimum pixel x, inherited from the aquarium
-	var/aquarium_zone_min_px
+	var/aquarium_zone_min_pw
 	///maximum pixel x, inherited from the aquarium
-	var/aquarium_zone_max_px
+	var/aquarium_zone_max_pw
 	///minimum pixel y, inherited from the aquarium
-	var/aquarium_zone_min_py
+	var/aquarium_zone_min_pz
 	///maximum pixel y, inherited from the aquarium
-	var/aquarium_zone_max_py
+	var/aquarium_zone_max_pz
 	///The current fluid type, inherited fom the aquarium
 	var/fluid_type

--- a/code/game/objects/items/food/lizard.dm
+++ b/code/game/objects/items/food/lizard.dm
@@ -156,12 +156,12 @@
 	SIGNAL_HANDLER
 	var/sprite_width = 5
 	var/sprite_height = 4
-	var/px_min = visual.aquarium_zone_min_px
-	var/px_max = visual.aquarium_zone_max_px - sprite_width
-	var/py_min = visual.aquarium_zone_min_py - sprite_height
+	var/pw_min = visual.aquarium_zone_min_pw
+	var/pw_max = visual.aquarium_zone_max_pw - sprite_width
+	var/pz_min = visual.aquarium_zone_min_pz - sprite_height
 
-	visual.pixel_x = rand(px_min, px_max)
-	visual.pixel_y = py_min + rand(-1, 1)
+	visual.pixel_w = rand(pw_min, pw_max)
+	visual.pixel_z = pz_min + rand(-1, 1)
 
 /obj/item/food/moonfish_eggs/proc/get_aquarium_beauty(datum/source, list/beauty_holder)
 	SIGNAL_HANDLER

--- a/code/modules/fishing/aquarium/aquarium.dm
+++ b/code/modules/fishing/aquarium/aquarium.dm
@@ -11,10 +11,10 @@
 	integrity_failure = 0.3
 
 	//This is the area where fish can swim
-	var/aquarium_zone_min_px = 2
-	var/aquarium_zone_max_px = 31
-	var/aquarium_zone_min_py = 10
-	var/aquarium_zone_max_py = 28
+	var/aquarium_zone_min_pw = 2
+	var/aquarium_zone_max_pw = 31
+	var/aquarium_zone_min_pz = 10
+	var/aquarium_zone_max_pz = 28
 
 	/// Default beauty of the aquarium, without anything inside it
 	var/default_beauty = 150
@@ -24,7 +24,7 @@
 
 /obj/structure/aquarium/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/aquarium, aquarium_zone_min_px, aquarium_zone_max_px, aquarium_zone_min_py, aquarium_zone_max_py, default_beauty)
+	AddComponent(/datum/component/aquarium, aquarium_zone_min_pw, aquarium_zone_max_pw, aquarium_zone_min_pz, aquarium_zone_max_pz, default_beauty)
 	AddComponent(/datum/component/plumbing/aquarium, start = anchored)
 	RegisterSignal(src, COMSIG_AQUARIUM_FLUID_CHANGED, PROC_REF(on_aquarium_liquid_changed))
 	update_appearance()

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1114,8 +1114,8 @@
 	var/move_number = rand(3, 5) //maybe unhardcode this
 	for(var/i in 1 to move_number)
 		//If it's last movement, move back to start otherwise move to some random point
-		var/target_x = i == move_number ? origin_w : rand(pw_min,pw_max) //could do with enforcing minimal delta for prettier zigzags
-		var/target_y = i == move_number ? origin_z : rand(pz_min,pz_max)
+		var/target_w = i == move_number ? origin_w : rand(pw_min,pw_max) //could do with enforcing minimal delta for prettier zigzags
+		var/target_z = i == move_number ? origin_z : rand(pz_min,pz_max)
 		var/dist_w = prev_w - target_w
 		var/dist_z = prev_z - target_z
 		prev_w = target_w

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1071,13 +1071,13 @@
 	SIGNAL_HANDLER
 	var/avg_width = round(sprite_width * 0.5)
 	var/avg_height = round(sprite_height * 0.5)
-	var/px_min = visual.aquarium_zone_min_px + avg_width - 16
-	var/px_max = visual.aquarium_zone_max_px - avg_width - 16
-	var/py_min = visual.aquarium_zone_min_py + avg_height - 16
-	var/py_max = visual.aquarium_zone_max_py - avg_height - 16
+	var/pw_min = visual.aquarium_zone_min_pw + avg_width - 16
+	var/pw_max = visual.aquarium_zone_max_pw - avg_width - 16
+	var/pz_min = visual.aquarium_zone_min_pz + avg_height - 16
+	var/pz_max = visual.aquarium_zone_max_pz - avg_height - 16
 
-	visual.pixel_x = visual.base_pixel_x = rand(px_min,px_max)
-	visual.pixel_y = visual.base_pixel_y = rand(py_min,py_max)
+	visual.pixel_w = visual.base_pixel_w = rand(pw_min,pw_max)
+	visual.pixel_z = visual.base_pixel_z = rand(pz_min,pz_max)
 
 /obj/item/fish/proc/update_aquarium_animation(datum/source, current_animation, obj/effect/visual, fluid_type)
 	SIGNAL_HANDLER
@@ -1101,40 +1101,40 @@
 	var/avg_width = round(sprite_width / 2)
 	var/avg_height = round(sprite_height / 2)
 
-	var/px_min = visual.aquarium_zone_min_px + avg_width - 16
-	var/px_max = visual.aquarium_zone_max_px - avg_width - 16
-	var/py_min = visual.aquarium_zone_min_py + avg_height - 16
-	var/py_max = visual.aquarium_zone_max_py - avg_width - 16
+	var/pw_min = visual.aquarium_zone_min_pw + avg_width - 16
+	var/pw_max = visual.aquarium_zone_max_pw - avg_width - 16
+	var/pz_min = visual.aquarium_zone_min_pz + avg_height - 16
+	var/pz_max = visual.aquarium_zone_max_pz - avg_width - 16
 
-	var/origin_x = visual.base_pixel_x
-	var/origin_y = visual.base_pixel_y
-	var/prev_x = origin_x
-	var/prev_y = origin_y
-	animate(visual, pixel_x = origin_x, time = 0, loop = -1) //Just to start the animation
+	var/origin_w = visual.base_pixel_w
+	var/origin_z = visual.base_pixel_z
+	var/prev_w = origin_w
+	var/prev_z = origin_z
+	animate(visual, pixel_w = origin_w, time = 0, loop = -1) //Just to start the animation
 	var/move_number = rand(3, 5) //maybe unhardcode this
 	for(var/i in 1 to move_number)
 		//If it's last movement, move back to start otherwise move to some random point
-		var/target_x = i == move_number ? origin_x : rand(px_min,px_max) //could do with enforcing minimal delta for prettier zigzags
-		var/target_y = i == move_number ? origin_y : rand(py_min,py_max)
-		var/dx = prev_x - target_x
-		var/dy = prev_y - target_y
-		prev_x = target_x
-		prev_y = target_y
-		var/dist = abs(dx) + abs(dy)
+		var/target_x = i == move_number ? origin_w : rand(pw_min,pw_max) //could do with enforcing minimal delta for prettier zigzags
+		var/target_y = i == move_number ? origin_z : rand(pz_min,pz_max)
+		var/dist_w = prev_w - target_w
+		var/dist_z = prev_z - target_z
+		prev_w = target_w
+		prev_z = target_z
+		var/dist = abs(dist_w) + abs(dist_z)
 		var/eyeballed_time = dist * 2 //2ds per px
 		//Face the direction we're going
 		var/matrix/dir_mx = matrix(visual.transform)
-		if(dx <= 0) //assuming default sprite is facing left here
+		if(dist_w <= 0) //assuming default sprite is facing left here
 			dir_mx.Scale(-1, 1)
 		animate(transform = dir_mx, time = 0, loop = -1)
-		animate(pixel_x = target_x, pixel_y = target_y, time = eyeballed_time, loop = -1)
+		animate(pixel_w = target_w, pixel_z = target_z, time = eyeballed_time, loop = -1)
 
 /obj/item/fish/proc/dead_animation(obj/effect/aquarium/visual)
 	//Set base_pixel_y to lowest possible value
 	var/avg_height = round(sprite_height / 2)
-	var/py_min = visual.aquarium_zone_min_py + avg_height - 16
-	visual.base_pixel_y = py_min
-	animate(visual, pixel_y = py_min, time = 1) //flop to bottom and end current animation.
+	var/pz_min = visual.aquarium_zone_min_pz + avg_height - 16
+	visual.base_pixel_z = pz_min
+	animate(visual, pixel_z = pz_min, time = 1) //flop to bottom and end current animation.
 
 ///Malus to the beauty value if the fish content is dead
 #define DEAD_FISH_BEAUTY -500


### PR DESCRIPTION
## About The Pull Request
I don't know if it's 516 or some of the latter updates 515 (EDIT: definitely 516), but fish visual overlays are now rendered under other overlays composing the aquarium when past a certain pixel offset, since they are using the pixel x/y vars to do it. All we have to do is to change it to pixel w/z

## Why It's Good For The Game
Small layering issue.

## Changelog

:cl:
fix: fixed a small rendering issue with fishes inside an aquarium.
/:cl:
