### PR TITLE
Makes fishing rods with higher (or lower) bait speed a smidge easier to control in the minigame

### DIFF
--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -5,8 +5,6 @@
 // UI minigame phase
 #define MINIGAME_PHASE 3
 
-// Acceleration mod when bait is over fish
-#define FISH_ON_BAIT_ACCELERATION_MULT 0.6
 /// The minimum velocity required for the bait to bounce
 #define BAIT_MIN_VELOCITY_BOUNCE 150
 
@@ -109,10 +107,12 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	var/gravity_velocity = -800
 	/// The acceleration of the bait while reeling
 	var/reeling_velocity = 1200
-	/// By how much the bait recoils back when hitting the bounds of the slider while idle
+	/// By how much the bait recoils back when hitting the bounds of the slider while idle. Should be never above 1
 	var/bait_bounce_mult = 0.6
 	/// The multiplier of deceleration of velocity that happens when the bait switches direction
 	var/deceleration_mult = 1.8
+	/// Multiplier of the velocity applied when the bait is overlapping the fish
+	var/overlap_velocity_mult = 0.6
 
 	///The background as shown in the minigame, and the holder of the other visual overlays
 	var/atom/movable/screen/fishing_hud/fishing_hud
@@ -170,6 +170,11 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	bait_bounce_mult *= rod.bounciness_mult
 	deceleration_mult *= rod.deceleration_mult
 	gravity_velocity *= rod.gravity_mult
+	/**
+	 * The overlap multiplier is lower than 1 by default and exponentiation will make it even lower,
+	 * to offset the harder control however a bait velocity higher (or lower) than normal.
+	 */
+	overlap_velocity_mult = overlap_velocity_mult ** rod.bait_speed_mult
 
 /datum/fishing_challenge/Destroy(force)
 	GLOB.fishing_challenges_by_user -= user
@@ -739,7 +744,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 				velocity_change = gravity_velocity
 			else
 				velocity_change = -gravity_velocity
-	velocity_change *= (fish_on_bait ? FISH_ON_BAIT_ACCELERATION_MULT : 1) * seconds_per_tick
+	velocity_change *= (fish_on_bait ? overlap_velocity_mult : 1) * seconds_per_tick
 
 	velocity_change = round(velocity_change)
 
@@ -765,7 +770,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 		bait_velocity += velocity_change
 
 	//check that the fish area is still intersecting the bait now that it has moved
-	if(is_fish_on_bait())
+	if(fish_on_bait)
 		completion += completion_gain * seconds_per_tick
 		if(completion >= 100)
 			complete(TRUE)
@@ -776,10 +781,6 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 			complete(FALSE)
 
 	completion = clamp(completion, 0, 100)
-
-///Returns TRUE if the fish and the bait are intersecting
-/datum/fishing_challenge/proc/is_fish_on_bait()
-	return (fish_position + fish_height >= bait_position) && (bait_position + bait_height >= fish_position)
 
 ///update the vertical pixel position of both fish and bait, and the icon state of the completion bar
 /datum/fishing_challenge/proc/update_visuals(seconds_per_tick)
@@ -935,7 +936,6 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 #undef REELING_STATE_UP
 #undef REELING_STATE_DOWN
 
-#undef FISH_ON_BAIT_ACCELERATION_MULT
 #undef BAIT_MIN_VELOCITY_BOUNCE
 
 #undef MAX_FISH_COMPLETION_MALUS


### PR DESCRIPTION
## About The Pull Request
While the bait overlaps the fish during the minigame, the change in velocity will be further cut down or amplified for fishing rods that have higher or lower speed multiplier than the identity (1).

## Why It's Good For The Game
Fishing rods that are supposed to be better are also made slighly more annoying or finnicky by their speed multiplier.

## Changelog

:cl:
balance: Makes fishing rods with higher (or lower) bait speed a smidge easier to control during the minigame
/:cl:
