### PR TITLE
Removes felinid Tail pulling and Tabling moodlets

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -437,11 +437,6 @@
 	mood_change = -1
 	timeout = 2 MINUTES
 
-/datum/mood_event/rippedtail
-	description = "I ripped their tail right off, what have I done!"
-	mood_change = -5
-	timeout = 30 SECONDS
-
 /datum/mood_event/sabrage_fail
 	description = "Blast it! That stunt didn't go as planned!"
 	mood_change = -2

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -106,13 +106,6 @@
 	mood_change = -2
 	timeout = 2 MINUTES
 
-/datum/mood_event/table/add_effects()
-	if(isfelinid(owner)) //Holy snowflake batman!
-		var/mob/living/carbon/human/feline = owner
-		feline.wag_tail(3 SECONDS)
-		description = "They want to play on the table!"
-		mood_change = 2
-
 /datum/mood_event/table_limbsmash
 	description = "That fucking table, man that hurts..."
 	mood_change = -3

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -29,11 +29,6 @@
 	mood_change = 1
 	timeout = 2 MINUTES
 
-/datum/mood_event/tailpulled
-	description = "I love getting my tail pulled!"
-	mood_change = 1
-	timeout = 2 MINUTES
-
 /datum/mood_event/arcade
 	description = "I beat the arcade game!"
 	mood_change = 3

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -318,27 +318,6 @@
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(helper, span_warning("[src] looks visibly upset as you pat [p_them()] on the head."))
 
-	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.get_organ_by_type(/obj/item/organ/tail)))
-		helper.visible_message(span_notice("[helper] pulls on [src]'s tail!"), \
-					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(helper, src))
-		to_chat(helper, span_notice("You pull on [src]'s tail!"))
-		to_chat(src, span_notice("[helper] pulls on your tail!"))
-		if(HAS_TRAIT(src, TRAIT_BADTOUCH)) //How dare they!
-			to_chat(helper, span_warning("[src] makes a grumbling noise as you pull on [p_their()] tail."))
-		else
-			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
-
-	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && (istype(head, /obj/item/clothing/head/costume/kitty) || istype(head, /obj/item/clothing/head/collectable/kitty)))
-		var/obj/item/clothing/head/faketail = head
-		helper.visible_message(span_danger("[helper] pulls on [src]'s tail... and it rips off!"), \
-					null, span_hear("You hear a ripping sound."), DEFAULT_MESSAGE_RANGE, list(helper, src))
-		to_chat(helper, span_danger("You pull on [src]'s tail... and it rips off!"))
-		to_chat(src, span_userdanger("[helper] pulls on your tail... and it rips off!"))
-		playsound(loc, 'sound/effects/cloth_rip.ogg', 75, TRUE)
-		dropItemToGround(faketail)
-		helper.put_in_hands(faketail)
-		helper.add_mood_event("rippedtail", /datum/mood_event/rippedtail)
-
 	else
 		if (helper.grab_state >= GRAB_AGGRESSIVE)
 			helper.visible_message(span_notice("[helper] embraces [src] in a tight bear hug!"), \


### PR DESCRIPTION

## About The Pull Request
Removes tail pulling and tabling moodlets. This does not change anything about hulks throwing people around by their tails because thats funny. (unless i fucked something up)
I'm bad at github so feel free to smack me with cardboard tubes in case anything is botched.
## Why It's Good For The Game
While I imagine these were originally added because someone thought they were funny, they mostly serve as a way to harass felinids. (and lizards if people remember they can pull lizard tails too) While felinids are certainly lacking in interesting features I don't think these are something that are healthy for the game.
Also there is no animal on earth that even enjoys having its tail pulled anyways???
## Changelog
:cl:
del: You can no longer pull on tails. Felinids as well no longer have any strong feelings regarding tables.
/:cl:
