### PR TITLE
Simplifies fish traits inheritability a little

### DIFF
--- a/code/modules/autowiki/pages/fishing.dm
+++ b/code/modules/autowiki/pages/fishing.dm
@@ -118,7 +118,6 @@
 			"name" = escape_value(trait.name),
 			"description" = escape_value(trait.catalog_description),
 			"inheritability" = trait.inheritability,
-			"inheritability_diff" = trait.diff_traits_inheritability,
 
 		))
 

--- a/code/modules/fishing/aquarium/fish_analyzer.dm
+++ b/code/modules/fishing/aquarium/fish_analyzer.dm
@@ -112,7 +112,7 @@
 
 	for(var/trait_type in fishie.fish_traits)
 		var/datum/fish_trait/trait = GLOB.fish_traits[trait_type]
-		fish_traits += list(list("trait_name" = trait.name, "trait_desc" = trait.catalog_description, "trait_inherit" = trait.diff_traits_inheritability))
+		fish_traits += list(list("trait_name" = trait.name, "trait_desc" = trait.catalog_description, "trait_inherit" = trait.inheritability))
 
 	data["fish_list"] += list(list(
 		"fish_name" = fishie.name,

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -823,8 +823,8 @@
 		if(length(fish_traits & trait.incompatible_traits))
 			continue
 		// If there's no partner, we've been reated through parthenogenesis or growth, therefore, traits are copied
-		// Otherwise, we do some probability checks.
-		if(!y_traits || ((trait_type in same_traits) ? prob(trait.inheritability) : prob(trait.diff_traits_inheritability)))
+		// Otherwise, we check if both have the trait or perform a probability check.
+		if(!y_traits || (trait_type in same_traits) || prob(trait.inheritability))
 			fish_traits |= trait_type
 			incompatible_traits |= trait.incompatible_traits
 

--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -28,9 +28,7 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 	///A list of traits fish cannot have in conjunction with this trait.
 	var/list/incompatible_traits
 	/// The probability this trait can be inherited by offsprings when both mates have it
-	var/inheritability = 100
-	/// Same as above, but for when only one has it.
-	var/diff_traits_inheritability = 50
+	var/inheritability = 50
 	/// A list of fish types and traits that they can spontaneously manifest with associated probabilities
 	var/list/spontaneous_manifest_types
 	/// An optional whitelist of fish that can get this trait
@@ -356,8 +354,7 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/parthenogenesis
 	name = "Parthenogenesis"
 	catalog_description = "This fish can reproduce asexually, without the need of a mate."
-	inheritability = 80
-	diff_traits_inheritability = 25
+	inheritability = 40
 
 /datum/fish_trait/parthenogenesis/apply_to_fish(obj/item/fish/fish)
 	. = ..()
@@ -386,14 +383,13 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/recessive
 	name = "Recessive"
 	catalog_description = "If crossbred, offsprings will always be of the mate species, unless it also possess the trait."
-	diff_traits_inheritability = 0
+	inheritability = 0
 
 /datum/fish_trait/no_mating/apply_to_fish(obj/item/fish/fish)
 	. = ..()
 	ADD_TRAIT(fish, TRAIT_FISH_RECESSIVE, FISH_TRAIT_DATUM)
 
 /datum/fish_trait/revival
-	diff_traits_inheritability = 15
 	name = "Self-Revival"
 	catalog_description = "This fish shows a peculiar ability of reviving itself a minute or two after death."
 	spontaneous_manifest_types = list(/obj/item/fish/boned = 100, /obj/item/fish/mastodon = 100)
@@ -460,7 +456,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/toxic
 	name = "Toxic"
 	catalog_description = "This fish contains toxins. Feeding it to predatory fishes or people is not recommended."
-	diff_traits_inheritability = 25
 	reagents_to_add = list(/datum/reagent/toxin/tetrodotoxin = 1)
 	infusion_entry = /datum/infuser_entry/ttx_healing
 	///The amount of venom injected if the fish has a stinger is multiplied by this value.
@@ -506,7 +501,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/toxic/carpotoxin
 	name = "Carpotoxic"
 	catalog_description = "This fish contains carpotoxin. Definitely not safe for consumption."
-	diff_traits_inheritability = 50
 	reagents_to_add = list(/datum/reagent/toxin/carpotoxin = 4)
 	infusion_entry = null
 	venom_mult = 6
@@ -514,7 +508,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/toxin_immunity
 	name = "Toxin Immunity"
 	catalog_description = "This fish has developed an ample-spected immunity to toxins."
-	diff_traits_inheritability = 40
 
 /datum/fish_trait/toxin_immunity/apply_to_fish(obj/item/fish/fish)
 	. = ..()
@@ -523,8 +516,7 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/crossbreeder
 	name = "Crossbreeder"
 	catalog_description = "This fish's adaptive genetics allows it to crossbreed with other fish species."
-	inheritability = 80
-	diff_traits_inheritability = 20
+	inheritability = 40
 	incompatible_traits = list(/datum/fish_trait/no_mating)
 
 /datum/fish_trait/crossbreeder/apply_to_fish(obj/item/fish/fish)
@@ -533,8 +525,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/territorial
 	name = "Territorial"
-	inheritability = 80
-	diff_traits_inheritability = 40
 	catalog_description = "This fish will start attacking other fish if the aquarium has five or more."
 
 /datum/fish_trait/territorial/apply_to_fish(obj/item/fish/fish)
@@ -558,8 +548,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/lubed
 	name = "Lubed"
-	inheritability = 90
-	diff_traits_inheritability = 45
 	spontaneous_manifest_types = list(/obj/item/fish/clownfish/lube = 100)
 	catalog_description = "This fish exudes a viscous, slippery lubrificant. It's recommended not to step on it."
 	added_difficulty = 5
@@ -584,8 +572,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/amphibious
 	name = "Amphibious"
-	inheritability = 80
-	diff_traits_inheritability = 40
 	catalog_description = "This fish has developed a primitive adaptation to life on both land and water."
 	infusion_entry = /datum/infuser_entry/amphibious
 
@@ -597,8 +583,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/mixotroph
 	name = "Mixotroph"
-	inheritability = 75
-	diff_traits_inheritability = 25
 	catalog_description = "This fish is capable of substaining itself by producing its own sources of energy (food)."
 	incompatible_traits = list(/datum/fish_trait/predator, /datum/fish_trait/necrophage)
 
@@ -608,8 +592,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/antigrav
 	name = "Anti-Gravity"
-	inheritability = 75
-	diff_traits_inheritability = 25
 	catalog_description = "This fish will invert the gravity of the bait at random. May fall upward outside after being caught."
 	added_difficulty = 20
 	reagents_to_add = list(/datum/reagent/gravitum = 2.3)
@@ -630,8 +612,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 ///This is just barely enough to crossbreed out of anxiety, but it severely limits the potential of
 /datum/fish_trait/anxiety
 	name = "Anxiety"
-	inheritability = 100
-	diff_traits_inheritability = 70
 	catalog_description = "This fish tends to die of stress when forced to be around too many other fish."
 
 /datum/fish_trait/anxiety/apply_to_fish(obj/item/fish/fish)
@@ -653,8 +633,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/electrogenesis
 	name = "Electrogenesis"
-	inheritability = 60
-	diff_traits_inheritability = 30
 	catalog_description = "This fish is electroreceptive, and will generate electric fields. Can be harnessed inside a bioelectric generator."
 	reagents_to_add = list(/datum/reagent/consumable/liquidelectricity = 1.5)
 
@@ -701,7 +679,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 	catalog_description = "This chrab's development is stunted, and will not properly reach adulthood."
 	spontaneous_manifest_types = list(/obj/item/fish/chasm_crab = 12)
 	fish_whitelist = list(/obj/item/fish/chasm_crab, /obj/item/fish/chasm_crab/ice)
-	diff_traits_inheritability = 40
 
 /datum/fish_trait/stunted/apply_to_mob(mob/living/basic/mob)
 	. = ..()
@@ -709,8 +686,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 
 /datum/fish_trait/stinger
 	name = "Stinger"
-	inheritability = 80
-	diff_traits_inheritability = 35
 	catalog_description = "This fish is equipped with a sharp stringer or bill capable of delivering damage and toxins."
 	spontaneous_manifest_types = list(
 		/obj/item/fish/stingray = 100,
@@ -785,7 +760,6 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 /datum/fish_trait/ink
 	name = "Ink Production"
 	catalog_description = "This fish possess a sac that produces ink."
-	diff_traits_inheritability = 70
 	spontaneous_manifest_types = list(/obj/item/fish/squid = 35)
 	infusion_entry = /datum/infuser_entry/squid
 

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -149,7 +149,6 @@
 /datum/fish_trait/dummy
 	incompatible_traits = list(/datum/fish_trait/dummy/two)
 	inheritability = 100
-	diff_traits_inheritability = 100
 	reagents_to_add = list(/datum/reagent/fishdummy = FISH_REAGENT_AMOUNT)
 
 /datum/fish_trait/dummy/apply_to_fish(obj/item/fish/fish)

--- a/tgui/packages/tgui/interfaces/FishAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/FishAnalyzer.tsx
@@ -183,7 +183,7 @@ const FishItem = (props) => {
                           tooltip={
                             <Stack vertical>
                               <Stack.Item>
-                                Inheritance: {trait.trait_inherit}
+                                Inheritance: {trait.trait_inherit}%
                               </Stack.Item>
                               <Stack.Item>{trait.trait_desc}</Stack.Item>
                             </Stack>


### PR DESCRIPTION
## About The Pull Request
I'm thinking of removing some of the redundant or unnecessary bad design from fishing, especially aquariums, which are definitely a bit fringe and difficult to attend to on top of other stuff. However I don't have all time of the world so I'd rather start small, even if it isn't the main obstacle (which is keeping fish alive and getting them to reproduce in the first place).

Thinking about it, the fact that some traits have a chance not to be passed down to the offspring even if both parents have them is plain bad and it's led situations where I couldn' tell if it was a bug or a feature. The solution? Forgo the probability check for traits shared by both parents.

## Why It's Good For The Game
Clearly that was bad design. 

## Changelog

:cl:
balance: Made fish traits inheritability easier. They're now guaranteed to be passed down to offsprings if both parents have them.
/:cl:
