### PR TITLE
Fixes basic mobs not idling due to nearby ghosts

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -203,7 +203,7 @@ multiple modular subtrees with behaviors
 	if(!can_idle || isnull(our_cells))
 		return FALSE
 	for(var/datum/spatial_grid_cell/grid as anything in our_cells.member_cells)
-		if(length(grid.client_contents))
+		if(locate(/mob/living) in grid.client_contents)
 			return FALSE
 	return TRUE
 
@@ -227,6 +227,9 @@ multiple modular subtrees with behaviors
 
 /datum/ai_controller/proc/on_client_enter(datum/source, atom/target)
 	SIGNAL_HANDLER
+
+	if (!isliving(target))
+		return
 
 	if(ai_status == AI_STATUS_IDLE)
 		set_ai_status(AI_STATUS_ON)


### PR DESCRIPTION
## About The Pull Request

``client_contents`` contains all mobs with clients, just like you'd expect. This includes observers, which results in any observer going over lavaland at full speed disturbing all the mobs on it. locate() is only marginally more expensive than length on a (most likely) 0-1 length list, so potential perf impact shouldn't be of any concern.

Closes #90003

## Changelog
:cl:
fix: Fixed basic mobs not idling due to nearby ghosts
/:cl:
