### PR TITLE
Fix Plasmamen Prefs Issues Due To Plasmamen Lacking Content

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -511,8 +511,8 @@ export function MainPage(props: MainPageProps) {
     data.character_preferences.secondary_features || [];
 
   const mainFeatures = [
-    ...Object.entries(data.character_preferences.clothing),
-    ...Object.entries(data.character_preferences.features),
+    ...Object.entries(data.character_preferences.clothing ?? {}),
+    ...Object.entries(data.character_preferences.features ?? {}),
   ];
 
   const randomBodyEnabled =


### PR DESCRIPTION
## About The Pull Request

Fixes #90019

This would error on species without any features. It only affects plasmamen due to lacking any features.


## Changelog

:cl: Melbert
fix: Plaslamen can see prefs again
/:cl:

