### PR TITLE
Adds missing aquarium props box to goodies and games vending machine.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -312,6 +312,12 @@
 	cost = PAYCHECK_LOWER
 	contains = list(/obj/item/book/manual/fish_catalog)
 
+/datum/supply_pack/goody/aquarium_props
+	name = "Aquarium Props Single-Pack"
+	desc = "A box containing generic aquarium props. You'll still need an aquarium or fish tank for these."
+	cost = PAYCHECK_LOWER
+	contains = list(/obj/item/storage/box/aquarium_props)
+
 /datum/supply_pack/goody/coffee_mug
 	name = "Coffee Mug Single-Pack"
 	desc = "A bog standard coffee mug, for drinking coffee."

--- a/code/modules/fishing/aquarium/aquarium_kit.dm
+++ b/code/modules/fishing/aquarium/aquarium_kit.dm
@@ -188,6 +188,7 @@
 	name = "aquarium props box"
 	desc = "All you need to make your aquarium look good."
 	illustration = "fish"
+	custom_price = PAYCHECK_LOWER
 
 /obj/item/storage/box/aquarium_props/PopulateContents()
 	for(var/prop_type in subtypesof(/obj/item/aquarium_prop))

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -55,6 +55,7 @@
 				/obj/item/storage/box/fishing_lures = 2,
 				/obj/item/book/manual/fish_catalog = 5,
 				/obj/item/reagent_containers/cup/fish_feed = 4,
+				/obj/item/storage/box/aquarium_props = 4,
 				/obj/item/fish_analyzer = 2,
 				/obj/item/storage/bag/fishing = 2,
 				/obj/item/fishing_rod/telescopic = 1,


### PR DESCRIPTION
## About The Pull Request
Title. At some point, they've become unobtainable, likely because they were only found in the now removed aquarium construction kit cargo pack.

## Why It's Good For The Game
This fixes #89713.

## Changelog

:cl:
fix: Adds missing aquarium props box to goodies and games vending machine.
/:cl:
