### PR TITLE
Small autoreel (and cloaked?) fishing line(s) buff

### DIFF
--- a/code/modules/fishing/fish/fish_traits.dm
+++ b/code/modules/fishing/fish/fish_traits.dm
@@ -634,6 +634,12 @@ GLOBAL_LIST_INIT(spontaneous_fish_traits, populate_spontaneous_fish_traits())
 	diff_traits_inheritability = 70
 	catalog_description = "This fish tends to die of stress when forced to be around too many other fish."
 
+/datum/fish_trait/anxiety/difficulty_mod(obj/item/fishing_rod/rod, mob/fisherman)
+	. = ..()
+	// Anxious fish are easier with a cloaked line.
+	if(rod.line && (rod.line.fishing_line_traits & FISHING_LINE_CLOAKED))
+		.[ADDITIVE_FISHING_MOD] -= FISH_TRAIT_MINOR_DIFFICULTY_BOOST
+
 /datum/fish_trait/anxiety/apply_to_fish(obj/item/fish/fish)
 	. = ..()
 	RegisterSignal(fish, COMSIG_FISH_LIFE, PROC_REF(on_fish_life))

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -44,7 +44,7 @@
 	desc = "Even harder to notice than the common variety."
 	icon_state = "reel_white"
 	fishing_line_traits = FISHING_LINE_CLOAKED
-	line_color = "#82cfdd"
+	line_color = "#82cfdd20" //low alpha channel value, harder to see.
 	wiki_desc = "Fishing anxious and wary fish will be easier with this equipped."
 
 /obj/item/fishing_line/bouncy
@@ -87,8 +87,8 @@
 	icon_state = "reel_auto"
 	fishing_line_traits = FISHING_LINE_AUTOREEL
 	line_color = "#F88414"
-	wiki_desc = "Automatically starts the minigame once the fish bites the bait. It also spin fishing lures for you without needing an input. \
-		It can also be used to snag in objects from a distance more rapidly.<br>\
+	wiki_desc = "Automatically starts the minigame and helps guide the bait a little. It also spin fishing lures for you without need of an input. \
+		It can also be used to snag in objects from a distance and throw them in your direction.<br>\
 		<b>It requires the Advanced Fishing Technology Node to be researched to be printed.</b>"
 
 /obj/item/fishing_line/auto_reel/Initialize(mapload)

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -746,9 +746,9 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	if(current_active_effect == FISHING_MINIGAME_RULE_ANTIGRAV)
 		velocity_change = -velocity_change
 
-	if(special_effects & FISHING_MINIGAME_AUTOREEL)
+	if(reeling_state == REELING_STATE_IDLE && special_effects & FISHING_MINIGAME_AUTOREEL)
 		var/bait_center = bait_position + bait_height / 2
-		var/auto_adjustment = reeling_velocity * 0.2
+		var/auto_adjustment = reeling_velocity * 0.25
 		if(fish_position > bait_center)
 			velocity_change += auto_adjustment
 		else

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -748,7 +748,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 
 	if(reeling_state == REELING_STATE_IDLE && special_effects & FISHING_MINIGAME_AUTOREEL)
 		var/bait_center = bait_position + bait_height / 2
-		var/auto_adjustment = reeling_velocity * 0.25
+		var/auto_adjustment = reeling_velocity * 0.2
 		if(fish_position > bait_center)
 			velocity_change += auto_adjustment
 		else

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -746,6 +746,14 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	if(current_active_effect == FISHING_MINIGAME_RULE_ANTIGRAV)
 		velocity_change = -velocity_change
 
+	if(special_effects & FISHING_MINIGAME_AUTOREEL)
+		var/bait_center = bait_position + bait_height / 2
+		var/auto_adjustment = reeling_velocity * 0.2
+		if(fish_position > bait_center)
+			velocity_change += auto_adjustment
+		else
+			velocity_change -= auto_adjustment
+
 	/**
 	 * Pull the brake on the velocity if the current velocity and the acceleration
 	 * have different directions, making the bait less slippery, thus easier to control

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -746,7 +746,7 @@ GLOBAL_LIST_EMPTY(fishing_challenges_by_user)
 	if(current_active_effect == FISHING_MINIGAME_RULE_ANTIGRAV)
 		velocity_change = -velocity_change
 
-	if(reeling_state == REELING_STATE_IDLE && special_effects & FISHING_MINIGAME_AUTOREEL)
+	if(reeling_state == REELING_STATE_IDLE && (special_effects & FISHING_MINIGAME_AUTOREEL))
 		var/bait_center = bait_position + bait_height / 2
 		var/auto_adjustment = reeling_velocity * 0.2
 		if(fish_position > bait_center)


### PR DESCRIPTION
## About The Pull Request
The autoreel fishing line now nudges the bait up/down lightly towards the fish position at 20% of the reeling velocity when idle, which is most likely not enough to defeat gravity but enough to help with control unless for maybe a couple of ultra-light material for fishing rods like snow. May or may not trivialize the minigame a bit when tied with a gyroscopic hook. We'll see if that's even a problem.

The cloaked fishing line is actually way more transparent now, and a smidge better at catching fish with the anxiety trait (only the zappy fish so far...) and not only those with the wary trait.

## Why It's Good For The Game
I feel disappointment knowing I had it called "autoreel" yet it doesn't do that muh during the actual minigame, only affecting the portion before it. Also cloaked lines aren't that hard to notice rn smh.

## Changelog

:cl:
balance: Autoreel fishing lines do what their name implies and nudges the bait towards the fish a little during the minigame when you're not pressing the mouse button. Also cloaked lines are more transparent, and better at catching a certain fish...
/:cl:
