### PR TITLE
See abnormal limbs for species in examine_more

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -578,7 +578,37 @@
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN))
 		return
 
-	if((wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE)))
+	var/limbs_text = get_mismatched_limb_text()
+	if(LAZYLEN(limbs_text))
+		. += limbs_text
+
+	var/agetext = get_age_text()
+	if(agetext)
+		. += agetext
+
+/// Reports all body parts which are mismatched with the user's species
+/mob/living/carbon/human/proc/get_mismatched_limb_text()
+	var/list/covered = get_covered_body_zones()
+	var/list/texts = list()
+	for(var/obj/item/bodypart/part as anything in bodyparts)
+		var/part_id = part.limb_id
+		var/obj/item/bodypart/expected_part = dna?.species?.bodypart_overrides[part.body_zone]
+		var/expected_id = initial(expected_part?.limb_id)
+		// only report abnormal bodyparts
+		if(part_id == expected_id)
+			continue
+		// same shape bodyparts are concealed by clothing
+		// this means you can see ex. digitigrade legs through clothes
+		// but you can't see ex. cybernetic legs through clothes
+		if(part.bodyshape == initial(expected_part?.bodyshape) && (part.body_zone in covered))
+			continue
+		texts += span_notice("[p_They()] [p_have()] \a [part].")
+
+	return texts
+
+/// Reports how old the mob appears to be
+/mob/living/carbon/human/proc/get_age_text()
+	if((wear_mask?.flags_inv & HIDEFACE) || (head?.flags_inv & HIDEFACE))
 		return
 
 	var/age_text
@@ -595,7 +625,8 @@
 			age_text = "very old"
 		if(101 to INFINITY)
 			age_text = "withering away"
-	. += list(span_notice("[p_They()] appear[p_s()] to be [age_text]."))
+
+	return span_notice("[p_They()] appear[p_s()] to be [age_text].")
 
 #undef ADD_NEWLINE_IF_NECESSARY
 #undef CARBON_EXAMINE_EMBEDDING_MAX_DIST


### PR DESCRIPTION
## About The Pull Request

I could have SWORN we had this, maybe at some point, but I can't for the life of me find the code for it

When you examine more someone, it will report any limbs their species would not normally have. 
This includes cybernetic limbs and digitigrade limbs. 

If the limb matches the correct bodyshape, clothing will conceal it. So you can hide cyber limbs under your jumpsuit.
(Digitigrade limbs which are squished are also concealed as you'd expect)

![image](https://github.com/user-attachments/assets/3bf5b179-caba-46eb-b1ea-5690ccb8a465)

(The jumpsuit is rolled down in this picture which is why you can see the arm) 

## Why It's Good For The Game

Someone asked about this in #89854

Basically it lets you figure out if you've been fricked up by a bioscrambler, or if someone else is a frakenstein or something

## Changelog

:cl: Melbert
qol: Double-examining a human will tell you if they have any limbs abnormal to their species, assuming said limbs aren't concealed by their clothing.
/:cl:


