### PR TITLE
Add qdeleted check to /datum/quirk/remove_from_current_holder

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -125,7 +125,7 @@
 	if(!quirk_transfer && lose_text)
 		to_chat(quirk_holder, lose_text)
 
-	if(mob_trait)
+	if(mob_trait && !QDELETED(quirk_holder))
 		REMOVE_TRAIT(quirk_holder, mob_trait, QUIRK_TRAIT)
 
 	if(quirk_flags & QUIRK_PROCESSES)


### PR DESCRIPTION
## About The Pull Request

Check that the quirk_holder hasn't been qdeleted before we try to remove any quirk traits from them.

## Why It's Good For The Game

Fixes #90043 

## Changelog

N/A
