### PR TITLE
`TRAIT_TOXIMMUNE` prevents liver damage from toxins

### DIFF
--- a/code/modules/reagents/chemistry/holder/mob_life.dm
+++ b/code/modules/reagents/chemistry/holder/mob_life.dm
@@ -49,7 +49,7 @@
 		// If applicable, calculate any toxin-related liver damage
 		// Note: we have to do this AFTER metabolize_reagent, because we want handle_reagent to run before we make the determination.
 		// The order is really important unfortunately.
-		if(toxin && !liverless && liver && liver.filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
+		if(toxin && !liverless && liver && liver.filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER) && !HAS_TRAIT(owner, TRAIT_TOXIMMUNE))
 			if(toxin.affected_organ_flags && !(liver.organ_flags & toxin.affected_organ_flags)) //this particular toxin does not affect this type of organ
 				continue
 


### PR DESCRIPTION

## About The Pull Request

for some reason, toxin liver damage only checked `TRAIT_TOXINLOVER` and not also `TRAIT_TOXIMMUNE` - which doesn't make sense. so let's check that here

## Why It's Good For The Game

it makes sense lol

## Changelog
:cl:
fix: Toxins no longer damage your liver if you are immune to toxins anyways.
/:cl:
