### PR TITLE
Hotfix for Stock Market Exploit.

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	amount = 25
 
 /obj/item/stack/sheet/mineral/uranium/fifty
-	amount = 25
+	amount = 50
 
 /*
  * Plasma

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -119,14 +119,15 @@
 		if(block.export_mat != material_id)
 			return 0
 
-	var/market_price = SSstock_market.materials_prices[material_id]
 	var/material_value = 0
 	if(block)
-		material_value = block.export_value
-		market_price = material_value / amount
+		if(block.fluid)
+			material_value = SSstock_market.materials_prices[block.export_mat] * amount
+		else
+			material_value = block.export_value
 	else
-		material_value = market_price * amount
-	return cost * material_value
+		material_value = SSstock_market.materials_prices[material_id] * amount
+	return cost * material_value // Cost in this case is only serving as the elastic modifier, where material value is the raw value of the sheets sold.
 
 /datum/export/material/market/sell_object(obj/sold_item, datum/export_report/report, dry_run, apply_elastic)
 	. = ..()

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -87,7 +87,7 @@
 		var/obj/item/stock_block/new_block = new /obj/item/stock_block(drop_location())
 		new_block.export_value = price
 		new_block.export_mat = material_to_export
-		new_block.quantity = amount
+		new_block.quantity = amount / SHEET_MATERIAL_AMOUNT
 		to_chat(user, span_notice("You have created a stock block worth [new_block.export_value] cr! Sell it before it becomes liquid!"))
 		playsound(src, 'sound/machines/synth/synth_yes.ogg', 50, FALSE)
 		return TRUE
@@ -393,6 +393,7 @@
 	icon_state = "stock_block_liquid"
 	update_appearance(UPDATE_ICON_STATE)
 	visible_message(span_warning("\The [src] becomes liquid!"))
+	fluid = TRUE
 
 #undef MAX_STACK_LIMIT
 #undef GALATIC_MATERIAL_ORDER


### PR DESCRIPTION
## About The Pull Request

So when I made #89674, I made a miiiinor slight basic error when it came to the quantity assigned to sheets of materials when they're sold, using the quantity as referenced by an export report. That quantity was then brought over to the export value, for gathering the cost.

Cost when sold in an export report is reported as the units of material in those sheets, while stock blocks actually care about the sheet quantity, making the value actually 100x larger than it should be. I caught this super fast while playing a round last night, but I needed to just quality check to make sure there's no other weird inconsistencies.

Such as the stack of 50 uranium I added for debug and testing purposes actually only holding 25 sheets. Things like that.

Stock blocks will now actually fluidly recalc their market price after going fluid, because as it turns out, the fluid var isn't used in price calculation, which was an easy fix.

## Why It's Good For The Game

🐛 💥  Killing some fairly egregious oversights on the stock market sales side of things. Thank you for your patience.

## Changelog

:cl:
fix: Stock blocks that have gone liquid should properly recalculate their cost when possible.
fix: Spawned sheets of uranium now actually hold 50 sheets.
/:cl:
