### PR TITLE
Fixes the powerfist not considering temperature in its calculation

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -28,8 +28,8 @@
 	var/click_delay = 0.15 SECONDS
 	/// Pressure level on the fist
 	var/fist_pressure_setting = LOW_PRESSURE
-	/// Amount of moles per punch
-	var/gas_per_fist = 3
+	/// Volume released per punch
+	var/gas_per_fist = 7
 	/// Tank used for the gauntlet's piston-ram.
 	var/obj/item/tank/internals/tank
 
@@ -114,7 +114,8 @@
 	if(!our_turf)
 		return
 
-	var/datum/gas_mixture/gas_used = tank.remove_air(gas_per_fist * fist_pressure_setting)
+	var/moles_to_remove = PUMP_MAX_PRESSURE * (gas_per_fist * fist_pressure_setting)/(R_IDEAL_GAS_EQUATION * tank.air_contents.temperature)
+	var/datum/gas_mixture/gas_used = tank.remove_air(moles_to_remove)
 	if(!gas_used)
 		to_chat(user, span_warning("\The [src]'s tank is empty!"))
 		target.apply_damage((force / 5), BRUTE)
@@ -123,7 +124,7 @@
 			span_userdanger("[user]'s punches you!"))
 		return
 
-	if(!molar_cmp_equals(gas_used.total_moles(), gas_per_fist * fist_pressure_setting))
+	if(gas_used.total_moles() < moles_to_remove)
 		our_turf.assume_air(gas_used)
 		to_chat(user, span_warning("\The [src]'s piston-ram lets out a weak hiss, it needs more gas!"))
 		playsound(loc, 'sound/items/weapons/punch4.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request

So, a little while back, a silly little item known as the powerfist was added. Overall a pretty powerful thing, limited only by its 3 uses on high pressure.

Or so I thought.

Turns out, it has been using a set amount of moles. Yeah. This means that you end up in funny situations where supercooling the tank gets you way more punches (If you go to 3K, almost 100x more if I didn't fail elementary school level math too hard)

If you want more proof this is unintentional, look at the original PR [here](https://github.com/tgstation/tgstation/pull/19013), which says:

> A full large-tank will get exactly 4 level-3 punches in before needing to replace the external tank. This thing is incredibly lethal for taking out singular targets at a time but very poor against crowds as odds are you're going to exhaust your supply before fending off everyone.

## Why It's Good For The Game

This is an oversight that was never fixed. And it wouldnt make sense for a low pressure gust of supercooled gas to produce a gut wrenching punch either.

fixes #90007

## Changelog

:cl:
fix: The powerfist now correctly adjusts the amount of moles it uses according to the temperature.
/:cl:
