### PR TITLE
Moves the crew pinpointer from the premium vendor section to the regular section.

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -95,7 +95,7 @@
 	desc = "A handheld tracking device that points to crew suit sensors."
 	icon_state = "pinpointer_crew"
 	worn_icon_state = "pinpointer_crew"
-	custom_price = PAYCHECK_CREW * 4
+	custom_price = PAYCHECK_CREW * 6
 	custom_premium_price = PAYCHECK_CREW * 6
 	var/has_owner = FALSE
 	var/pinpointer_owner = null

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -20,6 +20,7 @@
 		/obj/item/cane/white = 2,
 		/obj/item/clothing/glasses/eyepatch/medical = 2,
 		/obj/item/storage/box/bandages = 2,
+		/obj/item/pinpointer/crew = 2,
 	)
 	contraband = list(
 		/obj/item/storage/box/gum/happiness = 3,
@@ -29,7 +30,6 @@
 		/obj/item/reagent_containers/hypospray/medipen = 3,
 		/obj/item/storage/belt/medical = 3,
 		/obj/item/sensor_device = 2,
-		/obj/item/pinpointer/crew = 2,
 		/obj/item/storage/medkit/advanced = 2,
 		/obj/item/shears = 1,
 		/obj/item/storage/organbox = 1,


### PR DESCRIPTION

## About The Pull Request
Moves the crew pinpointer from the premium vendor tab to the regular tab while adjusting its price slightly to ensure it is still relatively expensive for non medical crew. Currently with this change it costs 60cr for medical staff and 300cr for everyone else. Ideally I wanted it to be a bit more expensive for medical staff (more around 100-150cr) but vendors are a bit rigid in how their pricing seems to work.
## Why It's Good For The Game
Lifeline on the PDA/Tablet/Whatever they're called is more or less objectively superior to these old things in all situations but one, when the comms go out. The problem is that these being 300cr even for medical staff is quite steep and discourages people from buying them at all. With this change I hope to encourage use of these as a more reliable but less efficient backup tool in the event that shit has hit the fan and comms are likely to be out for an extended period of time.
## Changelog
:cl:
balance: Crew pinpointers have been moved to the regular section of the medivend, and as such now benefit from the department discount.
/:cl:
