### PR TITLE
Adds a Megacell to the Russian Derelict

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -3340,11 +3340,9 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "zP" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/item/shard,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/table,
+/obj/item/stock_parts/power_store/battery/high,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/tech_storage)
 "zR" = (

--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -1356,9 +1356,6 @@
 "pn" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/shard{
-	icon_state = "medium"
-	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/tech_storage)
 "pp" = (
@@ -3343,9 +3340,11 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "zP" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/item/shard,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/table,
-/obj/item/stock_parts/power_store/battery/high,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/tech_storage)
 "zR" = (
@@ -5272,15 +5271,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/ks13/hallway/central)
-"JP" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/ks13/engineering/tech_storage)
 "JQ" = (
 /obj/structure/frame/machine{
 	anchored = 1
@@ -11460,7 +11450,7 @@ sU
 Dy
 Us
 Rt
-JP
+iy
 iy
 zP
 QG

--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -1356,6 +1356,9 @@
 "pn" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/shard{
+	icon_state = "medium"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/tech_storage)
 "pp" = (
@@ -5269,6 +5272,15 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/ks13/hallway/central)
+"JP" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
 "JQ" = (
 /obj/structure/frame/machine{
 	anchored = 1
@@ -11448,7 +11460,7 @@ sU
 Dy
 Us
 Rt
-iy
+JP
 iy
 zP
 QG

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -57915,7 +57915,7 @@ ZS
 sK
 GX
 wl
-iu
+io
 vR
 Ab
 Ab

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -57915,7 +57915,7 @@ ZS
 sK
 GX
 wl
-io
+iu
 vR
 Ab
 Ab


### PR DESCRIPTION
## About The Pull Request

Fixes #89030 about the Russian derelict being overlooked and not having a megacell available in the engine room.

## Why It's Good For The Game

Drone gaming.

## Changelog


:cl:
fix: Added a Megacell to the Russian Derelict engine room. Rejoice, drones!
/:cl:
