### PR TITLE
Wawa Station Atmospherics Redesign

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2070,6 +2070,15 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
+"aId" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "aIo" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -3936,6 +3945,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "btl" = (
@@ -3958,6 +3968,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"btK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "btM" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/south,
@@ -4939,6 +4959,17 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"bLt" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "bLI" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/stripes/line,
@@ -5180,6 +5211,13 @@
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"bQa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "bQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5402,6 +5440,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"bUI" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "bUJ" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/structure/cable,
@@ -5550,6 +5597,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/xenobiology)
+"bXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "bXx" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/airalarm/directional/south,
@@ -5994,6 +6046,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"cfN" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "cfO" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -7127,6 +7191,14 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"cDy" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "cDD" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -8258,6 +8330,8 @@
 "cYa" = (
 /obj/effect/landmark/navigate_destination,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cYs" = (
@@ -8787,11 +8861,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "dhH" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/glass/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "dhN" = (
 /obj/structure/rack,
@@ -10371,6 +10443,14 @@
 /obj/machinery/light/small/dim/directional/north,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/cargo)
+"dGS" = (
+/obj/machinery/shower/directional/south{
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/fluff/shower_drain,
+/turf/open/floor/iron/dark/small,
+/area/station/engineering/atmos/project)
 "dHa" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -10987,6 +11067,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "dSQ" = (
@@ -11194,9 +11275,14 @@
 /obj/machinery/light/small/dim/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/checker{
+	dir = 4
+	},
+/area/station/engineering/atmos/project)
 "dVX" = (
 /obj/structure/table,
 /obj/item/storage/box/mousetraps{
@@ -13190,8 +13276,8 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/storage)
 "eES" = (
-/turf/open/openspace,
-/area/station/engineering/atmospherics_engine)
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/atmos/project)
 "eEV" = (
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","rd","xeno")
@@ -13593,6 +13679,13 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"eOt" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "eOx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -14340,6 +14433,9 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"ffb" = (
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "ffk" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
@@ -14811,9 +14907,6 @@
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/ladder{
-	icon_state = "ladder10"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "fpi" = (
@@ -15281,8 +15374,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
 "fwz" = (
@@ -15395,6 +15486,15 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"fym" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "fyn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21059,12 +21159,13 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/theater)
 "hrS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/project)
 "hsb" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/item/assembly/mousetrap/armed,
@@ -22312,6 +22413,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/space/basic,
 /area/space/nearstation)
+"hQG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "hQH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/textured_large,
@@ -22366,6 +22474,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hRv" = (
@@ -22378,13 +22488,10 @@
 /turf/closed/wall,
 /area/station/service/bar)
 "hRE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/ladder,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/openspace,
-/area/station/engineering/atmospherics_engine)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "hRH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/arrow_ccw,
@@ -22548,6 +22655,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hUw" = (
@@ -23525,6 +23634,15 @@
 	dir = 8
 	},
 /area/station/medical/pharmacy)
+"inS" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "ioa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -24274,6 +24392,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"iCx" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "iCD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26445,6 +26569,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"jsA" = (
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "jsC" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/central)
@@ -26499,6 +26629,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jtW" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "juf" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/spawner/random/structure/table,
@@ -26897,12 +27035,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "jAE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/station/engineering/atmospherics_engine)
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "jAG" = (
 /turf/closed/wall,
 /area/station/service/lawoffice)
@@ -28439,6 +28574,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"kbr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "kbv" = (
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
@@ -29162,6 +29303,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/cargo/boutique)
+"kmm" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/openspace,
+/area/space)
 "kmu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30255,11 +30400,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "kDI" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 5
-	},
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/glass/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "kDJ" = (
 /obj/effect/turf_decal/sand/plating,
@@ -30302,6 +30445,13 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"kEs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "kEt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31156,6 +31306,13 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"kUc" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/space/openspace,
+/area/space)
 "kUd" = (
 /obj/machinery/door/poddoor/lift{
 	transport_linked_id = "cargo"
@@ -34723,12 +34880,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "mkX" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/openspace,
-/area/station/engineering/atmospherics_engine)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "mkZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -36202,10 +36364,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "mKJ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/openspace,
-/area/station/engineering/atmospherics_engine)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "mKM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
@@ -36941,6 +37105,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"mYZ" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "mZc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -38039,8 +38209,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
 "nrp" = (
@@ -42322,12 +42490,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "oYM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oYX" = (
@@ -43077,6 +43243,15 @@
 /obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
+"pmB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "pmC" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
@@ -45901,6 +46076,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"qjz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "qjW" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/siding/brown{
@@ -47369,6 +47552,33 @@
 "qNo" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
+"qNu" = (
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "qNz" = (
 /obj/structure/railing{
 	dir = 1
@@ -51442,6 +51652,30 @@
 	},
 /turf/open/floor/engine,
 /area/station/hallway/secondary/entry)
+"sbE" = (
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/multitool{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/holosign_creator/atmos{
+	pixel_y = 11;
+	pixel_x = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "sbL" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Aft Port Solar Access"
@@ -51694,10 +51928,8 @@
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
 "sgw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "sgz" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -52310,7 +52542,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/project)
 "sqJ" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -53579,12 +53811,15 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "sNc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "sNi" = (
 /obj/machinery/light/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
@@ -54757,6 +54992,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"tkd" = (
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "tkh" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -57285,6 +57523,10 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/textured,
 /area/station/security/processing)
+"ubY" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "uca" = (
 /obj/machinery/modular_computer/preset/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -58216,6 +58458,7 @@
 "usm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "usq" = (
@@ -58344,7 +58587,6 @@
 "uuq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "uuu" = (
@@ -58954,8 +59196,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
 "uFN" = (
@@ -59602,6 +59842,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"uRY" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "uSd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -59784,6 +60035,13 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
+"uVR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "uVU" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -60236,6 +60494,13 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
+"veF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/space/openspace,
+/area/space)
 "veW" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/closed/wall,
@@ -60306,6 +60571,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"vgg" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "vgh" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "secentrylock";
@@ -60889,6 +61161,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/closed/wall,
 /area/station/maintenance/department/medical/central)
+"vqG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/checker{
+	dir = 4
+	},
+/area/station/engineering/atmos/project)
 "vqH" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/turf_decal/tile/neutral,
@@ -62567,9 +62850,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "vWh" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/engineering/atmospherics_engine)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/project)
 "vWo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -64038,6 +64323,15 @@
 /obj/item/pai_card,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"wyR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "wyZ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -64205,8 +64499,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wBV" = (
@@ -64267,6 +64559,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"wCI" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Overlook"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "wCO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65936,6 +66236,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
+"xhp" = (
+/obj/machinery/light/small/dim/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "xhu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67825,6 +68130,17 @@
 "xQH" = (
 /turf/closed/wall,
 /area/station/commons/locker)
+"xQK" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "xQN" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
@@ -68515,9 +68831,16 @@
 "ydX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "yec" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -68599,6 +68922,17 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"yfR" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "ygb" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -109489,7 +109823,7 @@ rpS
 rpS
 wGZ
 dow
-sgw
+bzC
 bzC
 oAO
 rhB
@@ -176314,8 +176648,8 @@ ovD
 ovD
 ovD
 iZa
+nmr
 lMj
-ksR
 ksR
 kIx
 nAa
@@ -176572,7 +176906,7 @@ muw
 dLW
 iZa
 dhH
-pMG
+ixY
 pMG
 grb
 peW
@@ -176820,7 +177154,7 @@ qpt
 rbw
 rbw
 cZf
-bDk
+bXq
 ovD
 mio
 jgs
@@ -176829,7 +177163,7 @@ pMG
 pCF
 iZa
 kDI
-xIh
+lMj
 xIh
 rsd
 cti
@@ -177085,9 +177419,9 @@ rlH
 uIj
 jgs
 adP
-aaY
-aaY
-aaY
+vgg
+vgg
+vgg
 aaY
 cCQ
 iZa
@@ -177334,20 +177668,20 @@ diZ
 fvq
 psi
 smn
-nUS
+qjz
 qhG
 sqA
-kUX
-mRu
-mRu
-mRu
-kUX
-mRu
-mRu
-mRu
-mRu
-mRu
-kUX
+sgw
+ubY
+ubY
+ubY
+sgw
+sgw
+ubY
+wCI
+ubY
+sgw
+sgw
 vxX
 vxX
 uFC
@@ -177595,16 +177929,16 @@ usm
 qhG
 ydX
 hrS
+aId
+aId
+aId
+btK
+bLt
+aId
+aId
+hrS
 vWh
-eES
-eES
-eES
-eES
-eES
-eES
-eES
-vWh
-kUX
+sgw
 vxX
 vxX
 uFC
@@ -177848,20 +178182,20 @@ tNK
 vkp
 qgD
 smn
-rbw
+bQa
 btj
 dVW
 sNc
-vWh
+pmB
+fym
+ffb
 eES
 eES
 eES
-eES
-eES
-eES
-eES
-vWh
-kUX
+ffb
+ffb
+iCx
+sgw
 vxX
 vxX
 uFC
@@ -178109,16 +178443,16 @@ xmZ
 qhG
 qhG
 qhG
-vWh
+bUI
+uRY
 eES
 eES
 eES
 eES
 eES
-eES
-eES
-vWh
-kUX
+ffb
+kEs
+sgw
 vxX
 vxX
 uFC
@@ -178366,16 +178700,16 @@ keJ
 keJ
 qdl
 qhG
-vWh
+cDy
+uRY
 eES
 eES
 eES
 eES
 eES
-eES
-eES
+ffb
 mKJ
-kUX
+sgw
 fYe
 vxX
 uFC
@@ -178623,16 +178957,16 @@ bDk
 bqz
 tXf
 qhG
-vWh
+sbE
+uRY
 eES
 eES
 eES
 eES
 eES
-eES
-eES
-vWh
-kUX
+ffb
+hQG
+sgw
 fYe
 fYe
 uFC
@@ -178880,16 +179214,16 @@ rhi
 bDk
 eju
 qhG
-vWh
+qNu
+uRY
+ffb
 eES
 eES
 eES
-eES
-eES
-eES
-eES
-vWh
-kUX
+ffb
+ffb
+iCx
+sgw
 fYe
 fYe
 uFC
@@ -179137,16 +179471,16 @@ nUS
 bDk
 eJi
 qhG
-vWh
-eES
-eES
-eES
-eES
-eES
-eES
-eES
+xQK
+uRY
+tkd
+uVR
+kbr
+eOt
+inS
+inS
 mkX
-kUX
+sgw
 hen
 hen
 uFC
@@ -179394,16 +179728,16 @@ tEu
 bDk
 eJi
 qhG
-vWh
-vWh
-vWh
-vWh
-vWh
-vWh
-vWh
+dGS
+vqG
+wyR
+sgw
+yfR
+sgw
+jtW
 jAE
 hRE
-kUX
+sgw
 hen
 hen
 uFC
@@ -179651,16 +179985,16 @@ llW
 llW
 feQ
 qhG
-kUX
-kUX
-kUX
-kUX
-kUX
-kUX
-kUX
-kUX
-kUX
-kUX
+sgw
+sgw
+sgw
+sgw
+xhp
+sgw
+sgw
+sgw
+sgw
+sgw
 hen
 fYe
 uFC
@@ -179910,11 +180244,11 @@ vbd
 fYe
 vxX
 vxX
-vxX
-vxX
-vxX
-vxX
-vxX
+hhX
+mYZ
+cfN
+jsA
+hhX
 vxX
 vxX
 vxX
@@ -180167,11 +180501,11 @@ uLR
 tAo
 vxX
 vxX
-vxX
-vxX
-vxX
-vxX
-vxX
+hhX
+veF
+kmm
+kUc
+hhX
 vxX
 vxX
 vxX
@@ -180425,8 +180759,8 @@ fYe
 fYe
 vxX
 vxX
-vxX
-vxX
+hhX
+kmm
 hhX
 hhX
 vxX
@@ -180683,7 +181017,7 @@ uVI
 mUQ
 hhX
 hhX
-hhX
+kmm
 hhX
 hhX
 vxX

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2070,15 +2070,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
-"aId" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/project)
 "aIo" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -2134,6 +2125,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"aJd" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "aJr" = (
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
@@ -2610,6 +2608,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"aRc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "aRf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3968,16 +3973,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"btK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/project)
 "btM" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/south,
@@ -4959,17 +4954,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"bLt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/project)
 "bLI" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/stripes/line,
@@ -5211,13 +5195,6 @@
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"bQa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "bQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5440,15 +5417,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"bUI" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/project)
 "bUJ" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/structure/cable,
@@ -5597,11 +5565,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/xenobiology)
-"bXq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "bXx" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/airalarm/directional/south,
@@ -6046,18 +6009,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
-"cfN" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/project)
 "cfO" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -6846,6 +6797,9 @@
 "cwq" = (
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
+"cws" = (
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "cwt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -7191,14 +7145,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
-"cDy" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/project)
 "cDD" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -9848,6 +9794,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/interrogation)
+"dzf" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "dzm" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4
@@ -10443,14 +10400,6 @@
 /obj/machinery/light/small/dim/directional/north,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/cargo)
-"dGS" = (
-/obj/machinery/shower/directional/south{
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/fluff/shower_drain,
-/turf/open/floor/iron/dark/small,
-/area/station/engineering/atmos/project)
 "dHa" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -13276,7 +13225,7 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/storage)
 "eES" = (
-/turf/open/floor/glass/reinforced,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "eEV" = (
 /obj/machinery/camera/autoname/directional/north{
@@ -13679,13 +13628,6 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"eOt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "eOx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -14433,9 +14375,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"ffb" = (
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "ffk" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
@@ -15312,6 +15251,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"fuQ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "fuZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -15486,15 +15429,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"fym" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "fyn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19189,6 +19123,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"gKU" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/space/openspace,
+/area/space)
 "gLp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -20334,6 +20275,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"heM" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "heO" = (
 /obj/structure/falsewall/reinforced,
 /turf/open/floor/plating,
@@ -21915,6 +21862,12 @@
 /obj/structure/railing,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"hGY" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "hGZ" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/machinery/light/small/dim/directional/west,
@@ -22413,13 +22366,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/space/basic,
 /area/space/nearstation)
-"hQG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "hQH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/textured_large,
@@ -23634,15 +23580,6 @@
 	dir = 8
 	},
 /area/station/medical/pharmacy)
-"inS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "ioa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -23956,6 +23893,18 @@
 "isT" = (
 /turf/open/openspace,
 /area/station/engineering/break_room)
+"isV" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "ita" = (
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
 /obj/machinery/light_switch/directional/east,
@@ -24392,12 +24341,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"iCx" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "iCD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24819,6 +24762,17 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"iJv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/checker{
+	dir = 4
+	},
+/area/station/engineering/atmos/project)
 "iJB" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psychology Bedroom"
@@ -25392,6 +25346,12 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/science)
+"iXa" = (
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "iXj" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -25646,6 +25606,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"jcl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "jco" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -26569,12 +26536,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"jsA" = (
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/project)
 "jsC" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/central)
@@ -26629,14 +26590,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"jtW" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/project)
 "juf" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/spawner/random/structure/table,
@@ -28574,11 +28527,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"kbr" = (
+"kbi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/corner,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "kbv" = (
 /obj/machinery/turretid{
@@ -29303,10 +29259,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/cargo/boutique)
-"kmm" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/openspace,
-/area/space)
 "kmu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30360,6 +30312,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/theater)
+"kCK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/project)
 "kDb" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/cable,
@@ -30445,13 +30403,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"kEs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "kEt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30633,6 +30584,13 @@
 	},
 /turf/open/openspace,
 /area/station/engineering/atmos)
+"kIh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "kIl" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -31306,13 +31264,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"kUc" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/space/openspace,
-/area/space)
 "kUd" = (
 /obj/machinery/door/poddoor/lift{
 	transport_linked_id = "cargo"
@@ -31842,6 +31793,30 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"lfk" = (
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/multitool{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/holosign_creator/atmos{
+	pixel_y = 11;
+	pixel_x = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "lfn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
@@ -32245,6 +32220,17 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
+"lnr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "lnt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -32398,6 +32384,9 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"lqt" = (
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/atmos/project)
 "lqv" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -32458,6 +32447,17 @@
 	},
 /turf/open/floor/circuit,
 /area/station/science/robotics/lab)
+"lrK" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "lrV" = (
 /obj/structure/sign/poster/official/enlist/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -32613,6 +32613,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"lvi" = (
+/obj/machinery/light/small/dim/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "lvj" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole{
@@ -32752,6 +32757,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"lxE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "lxI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/parquet,
@@ -35235,6 +35248,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"mqV" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/openspace,
+/area/space)
 "mra" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_y = 24
@@ -36212,6 +36229,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
+"mIz" = (
+/obj/machinery/shower/directional/south{
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/fluff/shower_drain,
+/turf/open/floor/iron/dark/small,
+/area/station/engineering/atmos/project)
 "mIA" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -37105,12 +37130,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"mYZ" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/project)
 "mZc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -39329,6 +39348,12 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"nOd" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "nOx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -39765,6 +39790,11 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/storage/gas)
+"nZL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "nZW" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/components/binary/pump/on/green/visible{
@@ -40066,6 +40096,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"ofh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "oft" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -42991,6 +43030,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"pir" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Overlook"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "piu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -43243,15 +43291,6 @@
 /obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
-"pmB" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "pmC" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
@@ -45561,6 +45600,13 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/station/science/xenobiology)
+"qav" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "qaz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -46076,14 +46122,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"qjz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "qjW" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/siding/brown{
@@ -47552,33 +47590,6 @@
 "qNo" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
-"qNu" = (
-/obj/structure/table,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = -9;
-	pixel_y = 8
-	},
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = -9;
-	pixel_y = 0
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/stack/sheet/plasteel/twenty{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/project)
 "qNz" = (
 /obj/structure/railing{
 	dir = 1
@@ -51652,30 +51663,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/hallway/secondary/entry)
-"sbE" = (
-/obj/structure/table,
-/obj/item/multitool{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/multitool{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/holosign_creator/atmos{
-	pixel_y = 11;
-	pixel_x = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/project)
 "sbL" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Aft Port Solar Access"
@@ -52542,6 +52529,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
+/area/station/engineering/atmos/project)
+"sqE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/project)
 "sqJ" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -54992,9 +54988,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"tkd" = (
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "tkh" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -55038,6 +55031,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"tkX" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "tla" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -57523,10 +57524,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/textured,
 /area/station/security/processing)
-"ubY" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/project)
 "uca" = (
 /obj/machinery/modular_computer/preset/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -58244,6 +58241,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"upe" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "upj" = (
 /obj/effect/landmark/navigate_destination/hydro,
 /obj/machinery/door/airlock/hydroponics/glass{
@@ -58259,6 +58267,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"upp" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "ups" = (
 /obj/docking_port/stationary/escape_pod,
 /turf/open/space/basic,
@@ -59842,17 +59859,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"uRY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/project)
 "uSd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -60035,13 +60041,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
-"uVR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "uVU" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -60494,13 +60493,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
-"veF" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/space/openspace,
-/area/space)
 "veW" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/closed/wall,
@@ -60571,13 +60563,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"vgg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/upper)
 "vgh" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "secentrylock";
@@ -60650,6 +60635,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
+"vhI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "vhT" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -61161,17 +61153,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/closed/wall,
 /area/station/maintenance/department/medical/central)
-"vqG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/checker{
-	dir = 4
-	},
-/area/station/engineering/atmos/project)
 "vqH" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/turf_decal/tile/neutral,
@@ -62850,10 +62831,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "vWh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/checker,
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/large,
 /area/station/engineering/atmos/project)
 "vWo" = (
 /obj/structure/disposalpipe/segment,
@@ -64323,15 +64306,6 @@
 /obj/item/pai_card,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"wyR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/project)
 "wyZ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -64559,14 +64533,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"wCI" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Overlook"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/project)
 "wCO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65179,6 +65145,16 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"wNG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "wNK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes,
@@ -66236,11 +66212,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"xhp" = (
-/obj/machinery/light/small/dim/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/project)
 "xhu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66819,6 +66790,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"xsf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/space/openspace,
+/area/space)
 "xsj" = (
 /obj/machinery/netpod,
 /obj/structure/cable,
@@ -67025,6 +67003,33 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/hos)
+"xvu" = (
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "xvH" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Quiet Room"
@@ -67131,6 +67136,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/corporate_dock)
+"xxB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "xxH" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -68130,17 +68144,6 @@
 "xQH" = (
 /turf/closed/wall,
 /area/station/commons/locker)
-"xQK" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/project)
 "xQN" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
@@ -68690,6 +68693,15 @@
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/main)
+"ybV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/project)
 "yca" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Chemistry Lab"
@@ -68922,17 +68934,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
-"yfR" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/project)
 "ygb" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -177154,7 +177155,7 @@ qpt
 rbw
 rbw
 cZf
-bXq
+nZL
 ovD
 mio
 jgs
@@ -177419,9 +177420,9 @@ rlH
 uIj
 jgs
 adP
-vgg
-vgg
-vgg
+jcl
+jcl
+jcl
 aaY
 cCQ
 iZa
@@ -177668,18 +177669,18 @@ diZ
 fvq
 psi
 smn
-qjz
+lxE
 qhG
 sqA
 sgw
-ubY
-ubY
-ubY
+fuQ
+fuQ
+fuQ
 sgw
 sgw
-ubY
-wCI
-ubY
+fuQ
+pir
+fuQ
 sgw
 sgw
 vxX
@@ -177929,15 +177930,15 @@ usm
 qhG
 ydX
 hrS
-aId
-aId
-aId
-btK
-bLt
-aId
-aId
+xxB
+xxB
+xxB
+wNG
+upe
+xxB
+xxB
 hrS
-vWh
+kCK
 sgw
 vxX
 vxX
@@ -178182,19 +178183,19 @@ tNK
 vkp
 qgD
 smn
-bQa
+qav
 btj
 dVW
 sNc
-pmB
-fym
-ffb
+ybV
+kbi
+eES
+lqt
+lqt
+lqt
 eES
 eES
-eES
-ffb
-ffb
-iCx
+nOd
 sgw
 vxX
 vxX
@@ -178443,15 +178444,15 @@ xmZ
 qhG
 qhG
 qhG
-bUI
-uRY
+upp
+lnr
+lqt
+lqt
+lqt
+lqt
+lqt
 eES
-eES
-eES
-eES
-eES
-ffb
-kEs
+aRc
 sgw
 vxX
 vxX
@@ -178700,14 +178701,14 @@ keJ
 keJ
 qdl
 qhG
-cDy
-uRY
+vWh
+lnr
+lqt
+lqt
+lqt
+lqt
+lqt
 eES
-eES
-eES
-eES
-eES
-ffb
 mKJ
 sgw
 fYe
@@ -178957,15 +178958,15 @@ bDk
 bqz
 tXf
 qhG
-sbE
-uRY
+lfk
+lnr
+lqt
+lqt
+lqt
+lqt
+lqt
 eES
-eES
-eES
-eES
-eES
-ffb
-hQG
+vhI
 sgw
 fYe
 fYe
@@ -179214,15 +179215,15 @@ rhi
 bDk
 eju
 qhG
-qNu
-uRY
-ffb
+xvu
+lnr
+eES
+lqt
+lqt
+lqt
 eES
 eES
-eES
-ffb
-ffb
-iCx
+nOd
 sgw
 fYe
 fYe
@@ -179471,14 +179472,14 @@ nUS
 bDk
 eJi
 qhG
-xQK
-uRY
-tkd
-uVR
-kbr
-eOt
-inS
-inS
+lrK
+lnr
+cws
+kIh
+hGY
+aJd
+ofh
+ofh
 mkX
 sgw
 hen
@@ -179728,13 +179729,13 @@ tEu
 bDk
 eJi
 qhG
-dGS
-vqG
-wyR
+mIz
+iJv
+sqE
 sgw
-yfR
+dzf
 sgw
-jtW
+tkX
 jAE
 hRE
 sgw
@@ -179989,7 +179990,7 @@ sgw
 sgw
 sgw
 sgw
-xhp
+lvi
 sgw
 sgw
 sgw
@@ -180245,9 +180246,9 @@ fYe
 vxX
 vxX
 hhX
-mYZ
-cfN
-jsA
+heM
+isV
+iXa
 hhX
 vxX
 vxX
@@ -180502,9 +180503,9 @@ tAo
 vxX
 vxX
 hhX
-veF
-kmm
-kUc
+gKU
+mqV
+xsf
 hhX
 vxX
 vxX
@@ -180760,7 +180761,7 @@ fYe
 vxX
 vxX
 hhX
-kmm
+mqV
 hhX
 hhX
 vxX
@@ -181017,7 +181018,7 @@ uVI
 mUQ
 hhX
 hhX
-kmm
+mqV
 hhX
 hhX
 vxX

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -39,6 +39,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/upper)
 "abb" = (
@@ -224,7 +226,7 @@
 /area/station/maintenance/port/greater)
 "adP" = (
 /obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Overlook"
+	name = "Atmospherics Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
@@ -288,6 +290,9 @@
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -713,7 +718,8 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/disposal/incinerator)
 "alv" = (
-/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "alx" = (
@@ -983,13 +989,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "apK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/mix)
 "apQ" = (
 /turf/closed/wall,
 /area/station/service/library)
@@ -1443,11 +1455,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "axv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner,
-/obj/structure/cable/layer3,
-/turf/open/openspace,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "axB" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	req_access = list("xenobiology")
@@ -1570,12 +1587,11 @@
 /area/station/asteroid)
 "azs" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
 "azt" = (
@@ -1797,12 +1813,18 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/minisat)
 "aDJ" = (
-/obj/machinery/shower/directional/south{
-	name = "emergency shower"
-	},
+/obj/item/circuitboard/machine/thermomachine,
+/obj/item/circuitboard/machine/thermomachine,
+/obj/item/storage/bag/construction,
+/obj/item/storage/bag/construction,
+/obj/item/storage/bag/construction,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/dark_blue/end,
-/turf/open/floor/iron/textured,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/large,
 /area/station/engineering/atmos)
 "aDW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2153,19 +2175,11 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aJz" = (
-/obj/structure/railing,
-/obj/structure/table,
-/obj/item/plate,
-/obj/item/food/spaghetti/mac_n_cheese{
-	pixel_y = 3
-	},
-/obj/item/flashlight/flare/candle{
-	icon_state = "candle1_lit";
-	pixel_x = 12;
-	start_on = 1
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "aJA" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	req_access = list("xenobiology")
@@ -2232,12 +2246,16 @@
 	},
 /area/station/maintenance/radshelter/medical)
 "aKA" = (
-/obj/structure/stairs/south,
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "aKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -2470,13 +2488,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aOb" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/engineering/atmos/mix)
 "aOi" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -2867,9 +2883,15 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "aWF" = (
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "aWJ" = (
 /turf/open/misc/asteroid,
 /area/station/maintenance/central/greater)
@@ -3162,17 +3184,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "bcA" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "Engineering"
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/trunk/multiz/down,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/upper)
 "bcX" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -3588,6 +3610,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
+"bkC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "blh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -3942,17 +3978,23 @@
 /obj/item/pai_card,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"bta" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/engineering/atmos)
 "btj" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Incinerator"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
+/area/station/engineering/atmos/project)
 "btl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4912,6 +4954,17 @@
 	dir = 1
 	},
 /area/station/service/chapel)
+"bJU" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "bJX" = (
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -4961,12 +5014,14 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "bLS" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/cable/multilayer/multiz,
-/obj/item/assembly/mousetrap/armed,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "bMb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ladder,
@@ -5003,13 +5058,21 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/meter,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "bMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5151,18 +5214,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "bPH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
 	},
 /area/station/engineering/atmos/upper)
 "bPP" = (
@@ -5697,6 +5759,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
+"bZJ" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "caq" = (
 /obj/effect/spawner/surgery_tray/full/deployed,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -5989,6 +6059,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"cfD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cfG" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -6094,6 +6170,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"chA" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/upper)
 "chF" = (
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6171,14 +6257,52 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ciF" = (
-/obj/machinery/shower/directional/south{
-	name = "emergency shower"
+/obj/structure/table,
+/obj/item/electronics/airalarm{
+	pixel_x = -5;
+	pixel_y = -5
 	},
+/obj/item/electronics/airalarm{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/electronics/firealarm{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/electronics/firealarm{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/electronics/firealarm{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/multitool{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/item/multitool{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/item/multitool{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_blue/end,
-/turf/open/floor/iron/textured,
+/turf/open/floor/iron/large,
 /area/station/engineering/atmos)
 "ciR" = (
 /obj/structure/transport/linear/public{
@@ -6222,6 +6346,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
+"ckf" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "ckn" = (
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/grass,
@@ -6427,6 +6558,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"coV" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4;
+	pixel_x = -15
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/atmos/mix)
 "cpw" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -6636,26 +6777,20 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "csH" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/mix)
 "csW" = (
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
 "cti" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/upper)
 "cts" = (
 /turf/closed/wall/rock/porous,
@@ -6760,8 +6895,8 @@
 /area/station/maintenance/aft/upper)
 "cvX" = (
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "cvZ" = (
@@ -6821,6 +6956,18 @@
 "cxg" = (
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
+"cxq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "cxr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -7131,12 +7278,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cCQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/space_heater,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/upper)
 "cDl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -7539,6 +7689,13 @@
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"cLO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "cLS" = (
 /obj/item/stack/cable_coil/five,
 /turf/open/floor/plating/airless,
@@ -7591,16 +7748,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
 /turf/open/floor/iron/checker{
 	dir = 4
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "cMZ" = (
 /turf/closed/wall/r_wall,
 /area/station/science/auxlab/firing_range)
@@ -7756,13 +7907,7 @@
 /turf/closed/wall/r_wall,
 /area/station/science/lab)
 "cPx" = (
-/obj/structure/table,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "cPE" = (
@@ -8095,6 +8240,8 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cVs" = (
@@ -8219,16 +8366,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine)
 "cXn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "cXo" = (
 /obj/structure/barricade/wooden/crude,
 /obj/structure/holosign/barrier/atmos,
@@ -8275,7 +8421,6 @@
 /area/station/maintenance/department/medical/central)
 "cYa" = (
 /obj/effect/landmark/navigate_destination,
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -8291,13 +8436,10 @@
 /turf/open/openspace,
 /area/station/engineering/main)
 "cYB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
 "cYC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -8623,12 +8765,14 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "deX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/left/directional/east,
-/turf/open/floor/engine/airless,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "deY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm/directional/east,
@@ -8809,7 +8953,18 @@
 "dhH" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/station/engineering/atmos/upper)
 "dhN" = (
 /obj/structure/rack,
@@ -8870,6 +9025,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/department/engine)
+"diH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "diI" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/computer/security,
@@ -8877,12 +9043,22 @@
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "diM" = (
-/obj/structure/sign/poster/official/random/directional/south,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "diZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
@@ -9147,8 +9323,9 @@
 /area/station/medical/storage)
 "dmW" = (
 /obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "dni" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -9417,8 +9594,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "drK" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/multiz/dark/visible/layer5{
 	name = "Port To Turbine"
 	},
@@ -9925,52 +10100,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "dAo" = (
-/obj/structure/table,
-/obj/item/electronics/airalarm{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/structure/railing/corner/end{
+	dir = 8
 	},
-/obj/item/electronics/airalarm{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/effect/turf_decal/arrows{
+	dir = 8
 	},
-/obj/item/electronics/airalarm{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/item/electronics/firealarm{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/electronics/firealarm{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/electronics/firealarm{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/multitool{
-	pixel_x = 11;
-	pixel_y = 10
-	},
-/obj/item/multitool{
-	pixel_x = 11;
-	pixel_y = 10
-	},
-/obj/item/multitool{
-	pixel_x = 11;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "dAq" = (
 /obj/machinery/door/airlock/security/glass{
@@ -10042,16 +10181,14 @@
 	name = "Atmospherics Lockdown";
 	req_access = list("atmospherics")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/iron/dark/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
 	},
 /area/station/engineering/atmos/upper)
 "dBu" = (
@@ -10100,14 +10237,13 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "dBX" = (
-/obj/structure/railing,
-/obj/machinery/camera/autoname/directional/west,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics"
 	},
-/obj/item/kirbyplants/random,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "dCh" = (
 /obj/machinery/gibber,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -10611,7 +10747,7 @@
 "dKI" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/textured,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "dLf" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics Tank - Plasma"
@@ -11011,12 +11147,10 @@
 	},
 /area/station/command/corporate_showroom)
 "dSN" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "dSQ" = (
@@ -11082,12 +11216,15 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/central/greater)
 "dTz" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "dTA" = (
 /obj/item/wrench,
@@ -11124,6 +11261,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"dTR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/upper)
 "dTU" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11142,6 +11287,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dUf" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "dUi" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
@@ -11222,12 +11371,12 @@
 /area/space/nearstation)
 "dVW" = (
 /obj/machinery/light/small/dim/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker{
 	dir = 4
 	},
@@ -11264,14 +11413,14 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "dWB" = (
-/obj/machinery/atmospherics/components/binary/pump/off/orange/visible{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer5{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "dWI" = (
 /obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
@@ -11511,6 +11660,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ebi" = (
@@ -11665,6 +11817,9 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/multiz/dark/visible/layer5{
 	name = "Port To Turbine"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -12114,9 +12269,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "elz" = (
-/obj/structure/window/spawner,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "elE" = (
 /obj/structure/door_assembly,
 /turf/open/misc/asteroid,
@@ -12177,10 +12333,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "enL" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -12365,7 +12518,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "eqX" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -12576,12 +12728,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "eus" = (
-/obj/structure/stairs/east,
-/obj/structure/railing{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "euF" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/landmark/start/hangover/closet,
@@ -12905,6 +13059,20 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"eAG" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Crystallizer Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "eAJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12988,6 +13156,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"eBF" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "eBH" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/white/smooth_large,
@@ -13283,17 +13458,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "eFM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "eFP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -14066,11 +14235,12 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office/private_investigators_office)
 "eYM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/project)
 "eYO" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
@@ -14841,6 +15011,15 @@
 /obj/structure/grille,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/science)
+"fpd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "fpg" = (
 /obj/effect/turf_decal/stripes{
 	dir = 6
@@ -15059,45 +15238,25 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "fst" = (
-/obj/machinery/light/dim/directional/west,
-/obj/structure/cable,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/item/holosign_creator/atmos{
-	pixel_y = 5
-	},
-/obj/structure/table,
-/obj/item/holosign_creator/atmos{
-	pixel_y = 7
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/corner{
-	dir = 8
+	dir = 1
 	},
 /area/station/engineering/atmos/upper)
 "fsu" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Mixing Room"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "fsx" = (
 /obj/machinery/door/airlock/security/glass,
@@ -15365,11 +15524,13 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "fwV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "fxg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
@@ -15479,11 +15640,14 @@
 	},
 /area/station/science/xenobiology)
 "fze" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "fzg" = (
 /obj/structure/cable,
@@ -15837,10 +16001,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/requests_console/auto_name/directional/east,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "fEI" = (
@@ -15879,13 +16039,10 @@
 /turf/open/floor/iron,
 /area/station/command/corporate_showroom)
 "fFb" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fFg" = (
@@ -16133,14 +16290,15 @@
 	},
 /area/station/command/bridge)
 "fIG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/disposalpipe/trunk/multiz,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "fIW" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
@@ -16304,12 +16462,9 @@
 /turf/open/floor/plating,
 /area/station/medical/patients_rooms/room_a)
 "fMW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos/mix)
 "fMY" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -16473,6 +16628,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"fPo" = (
+/obj/machinery/light/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/upper)
 "fPp" = (
 /obj/item/storage/toolbox/emergency,
 /obj/structure/rack,
@@ -16648,7 +16812,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "fRC" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
@@ -17448,18 +17612,25 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "ggP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos/project)
 "ggQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/mix)
 "ggY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -17735,8 +17906,13 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "glH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17966,8 +18142,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "grb" = (
-/obj/effect/turf_decal/siding/thinplating_new,
-/turf/open/floor/glass/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "grl" = (
 /obj/structure/cable,
@@ -18407,6 +18585,26 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"gym" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/firealarm/directional/west,
+/obj/item/analyzer{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/analyzer{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/wrench{
+	pixel_x = 6;
+	pixel_y = 15
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "gyq" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -18671,6 +18869,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"gCk" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/upper)
 "gCL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -18710,17 +18916,14 @@
 /area/station/science/xenobiology)
 "gCY" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/engineering/atmospherics,
-/turf/open/floor/iron/dark/corner{
-	dir = 8
-	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gDl" = (
 /obj/structure/sign/xenobio_guide/directional/south,
 /obj/structure/tank_holder/extinguisher,
@@ -19181,13 +19384,12 @@
 /area/station/service/chapel/funeral)
 "gLQ" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "gLZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19261,6 +19463,14 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
+"gNG" = (
+/obj/item/flashlight/flare/candle{
+	pixel_x = -18;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "gNP" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -19605,7 +19815,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "gUl" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/button/door/directional/north{
@@ -20169,14 +20379,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "hcU" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Incinerator"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable/multilayer/connected,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "hdd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -20282,9 +20491,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/project)
 "heO" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "heP" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -20921,19 +21132,12 @@
 /turf/open/floor/engine,
 /area/station/command/corporate_dock)
 "hqj" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Crystallizer Room"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/checker{
-	dir = 1
-	},
-/area/station/engineering/atmos/upper)
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "hqk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -20980,6 +21184,19 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"hqW" = (
+/obj/structure/table,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
 "hrg" = (
 /obj/structure/broken_flooring/singular{
 	dir = 4
@@ -21078,12 +21295,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hrA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hrI" = (
@@ -21187,15 +21399,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "htx" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/shower/directional/south{
-	name = "emergency shower"
-	},
+/obj/structure/tank_holder/extinguisher/advanced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/dark_blue/end,
-/turf/open/floor/iron/textured,
+/turf/open/floor/iron/large,
 /area/station/engineering/atmos)
 "htJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -21263,13 +21471,16 @@
 /turf/open/floor/wood/parquet,
 /area/station/cargo/boutique)
 "huP" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "huX" = (
 /obj/structure/closet,
@@ -21474,12 +21685,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "hzg" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/obj/structure/cable/layer3,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/openspace,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "hzh" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/newscaster/directional/south,
@@ -23165,9 +23381,14 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
 "ifc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/requests_console/auto_name/directional/east,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ifd" = (
@@ -23522,17 +23743,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "ine" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "ini" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -23742,6 +23958,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"iqx" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "iqE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -24131,10 +24357,13 @@
 /turf/closed/wall/r_wall,
 /area/station/science/research)
 "ixY" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "ixZ" = (
 /obj/effect/turf_decal/sand/plating,
@@ -24302,6 +24531,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "iBK" = (
@@ -24462,10 +24692,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iEB" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/thinplating_new,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "iEK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24890,6 +25121,15 @@
 /obj/machinery/recharger,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/hop)
+"iLL" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "iLZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -25611,7 +25851,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/corner,
+/turf/open/floor/iron/checker{
+	dir = 4
+	},
 /area/station/engineering/atmos/upper)
 "jco" = (
 /obj/machinery/vending/tool,
@@ -26039,7 +26281,7 @@
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "jka" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -26585,9 +26827,6 @@
 "jtS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "juf" = (
@@ -26657,7 +26896,7 @@
 "jvn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "jvt" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/stripes/line{
@@ -26723,7 +26962,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "jww" = (
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/effect/mapping_helpers/mail_sorting/service/hop_office,
@@ -26828,6 +27067,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"jyK" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "jyM" = (
 /obj/structure/ladder{
 	icon_state = "ladder10"
@@ -27299,13 +27546,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "jFf" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "jFP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -27580,10 +27826,10 @@
 	},
 /area/station/maintenance/radshelter/medical)
 "jJp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
 /obj/machinery/incident_display/delam/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jJv" = (
@@ -28528,11 +28774,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "kbi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
@@ -29056,9 +29302,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "kjv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "kjx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/broken_flooring/singular,
@@ -29266,10 +29517,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kmB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
 "kmL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -29326,8 +29578,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/checker,
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "knX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -29688,17 +29940,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "ksg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/upper)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/atmos/mix)
 "ksl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29729,11 +29975,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "ksR" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/upper)
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ksU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30045,11 +30292,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "kyE" = (
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "kyP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30225,11 +30475,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "kBN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/main)
 "kBX" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -30360,7 +30616,12 @@
 "kDI" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/station/engineering/atmos/upper)
 "kDJ" = (
 /obj/effect/turf_decal/sand/plating,
@@ -30574,16 +30835,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "kHU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/cable/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/mix)
 "kIh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -30609,11 +30867,17 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
 "kIx" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 10
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Engineering"
 	},
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/upper)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "kIB" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -30635,6 +30899,9 @@
 "kIS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kIY" = (
@@ -30831,13 +31098,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "kNb" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/storage/gas)
+/turf/closed/wall,
+/area/station/engineering/atmos)
 "kNk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30989,12 +31251,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kQz" = (
-/obj/effect/spawner/random/trash/graffiti,
-/obj/item/instrument/musicalmoth,
-/obj/effect/spawner/random/entertainment/musical_instrument,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "kQF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
@@ -31337,14 +31601,14 @@
 /turf/open/floor/plating,
 /area/station/science/breakroom)
 "kVV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "kVX" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -31709,6 +31973,13 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/lobby)
+"lcL" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "lcM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -31896,11 +32167,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "lfR" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/large,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "lgh" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32685,10 +32957,17 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lww" = (
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "lwB" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/sign/picture_frame/portrait/bar{
@@ -32758,11 +33037,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "lxE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "lxI" = (
@@ -32799,14 +33077,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "lyy" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
+/obj/structure/stairs/east,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "lyF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32989,13 +33262,20 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "lBB" = (
-/obj/machinery/suit_storage_unit/radsuit,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/structure/table,
+/obj/item/storage/toolbox/drone{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/storage/toolbox/drone{
+	pixel_x = -1;
+	pixel_y = 11
+	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "lBC" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /obj/structure/sign/poster/random/directional/south,
@@ -33007,6 +33287,13 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/research)
+"lBQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "lCk" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
@@ -33154,8 +33441,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -33216,10 +33503,17 @@
 /turf/open/floor/glass,
 /area/station/command/meeting_room)
 "lFJ" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/upper)
 "lFK" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -33495,9 +33789,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "lKF" = (
@@ -33577,10 +33868,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "lMj" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 9
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
-/turf/open/floor/glass/reinforced,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "lMx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33632,6 +33923,9 @@
 /area/station/engineering/supermatter/room)
 "lNr" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lNu" = (
@@ -33767,6 +34061,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
+"lPO" = (
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "lPV" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
@@ -33875,16 +34172,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "lSm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/checker{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "lSz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -34090,6 +34383,9 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
+"lWT" = (
+/turf/open/openspace,
+/area/station/engineering/atmos/mix)
 "lWW" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -34206,6 +34502,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -34449,16 +34748,21 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "mdw" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/shower/directional/south{
+	name = "emergency shower"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/dark/corner{
-	dir = 8
+/obj/effect/turf_decal/box,
+/obj/structure/fluff/shower_drain,
+/turf/open/floor/iron/dark/small,
+/area/station/engineering/atmos)
+"mec" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mee" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -34604,8 +34908,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "mhh" = (
-/turf/open/openspace,
-/area/station/engineering/atmos)
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/atmos/mix)
 "mhi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34634,10 +34938,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mhA" = (
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mhD" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/contraband/narcotics,
@@ -34862,13 +35170,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "mkL" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos/mix)
 "mkN" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Tactical Shower"
@@ -35170,6 +35476,10 @@
 "moU" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mpc" = (
@@ -35207,6 +35517,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"mpX" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mpZ" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -35427,6 +35745,15 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/research)
+"mtP" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "mtS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -35663,17 +35990,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mxL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
-	},
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/upper)
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/atmos/mix)
 "myg" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
@@ -35726,9 +36048,12 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "mzb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/upper)
 "mzB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/closet/firecloset/full,
@@ -35745,11 +36070,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "mzJ" = (
-/obj/structure/stairs/south,
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
 "mzU" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35888,7 +36212,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -35975,6 +36299,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"mDE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "mDF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -36720,14 +37058,26 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"mRD" = (
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
 "mRI" = (
 /obj/effect/mob_spawn/corpse/human/clown,
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "mRU" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos/upper)
 "mSe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
@@ -37078,6 +37428,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "mYd" = (
@@ -37547,10 +37898,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "neM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "neT" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/reinforced/airless,
@@ -37719,10 +38073,8 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "nhS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer5{
+/obj/structure/stairs/east,
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -37941,8 +38293,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nmr" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/station/engineering/atmos/upper)
 "nmD" = (
 /obj/structure/cable/multilayer/multiz,
@@ -38128,6 +38484,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"npo" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "npw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -38245,6 +38608,13 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"nrV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "nrW" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/camera/autoname/directional/south{
@@ -38604,13 +38974,17 @@
 /area/station/ai_monitored/turret_protected/ai)
 "nAa" = (
 /obj/machinery/door/firedoor/border_only{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/sign/poster/contraband/singletank_bomb/directional/south,
-/turf/open/floor/iron/dark/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "nAb" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -38936,6 +39310,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/medical)
+"nGB" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "nGO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -39178,9 +39562,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nKO" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "nLb" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/landmark/start/hangover/closet,
@@ -39482,6 +39868,12 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"nSb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "nSn" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
@@ -39770,29 +40162,31 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/command/corporate_dock)
 "nZw" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 5
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/box,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/upper)
 "nZH" = (
-/obj/effect/spawner/structure/window/hollow/directional{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/mix)
 "nZI" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/corner{
-	dir = 8
-	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nZL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "nZW" = (
@@ -40501,9 +40895,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oow" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/upper)
 "ooy" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/machinery/newscaster/directional/south,
@@ -40527,7 +40928,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "opG" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -40749,17 +41150,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ost" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/upper)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/atmos/mix)
 "osK" = (
 /obj/machinery/light/cold/dim/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40836,22 +41231,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "ouG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/cable/multilayer/connected,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/checker{
-	dir = 1
-	},
-/area/station/engineering/atmos/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "ouH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -41096,27 +41479,18 @@
 /area/station/security/lockers)
 "oAc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oAn" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/atmos)
 "oAo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41550,6 +41924,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oHC" = (
@@ -41893,6 +42269,12 @@
 /obj/item/surgery_tray/deployed,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
+"oOG" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "oOI" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -42191,14 +42573,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "oUb" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/mix)
 "oUd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42536,12 +42917,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oYX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "oZb" = (
 /obj/machinery/light/dim/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -42625,9 +43010,11 @@
 /area/station/hallway/primary/central)
 "pah" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -42838,9 +43225,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "peW" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/upper)
@@ -43031,18 +43422,21 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pir" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Overlook"
-	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Project Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "piu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "piE" = (
@@ -43135,12 +43529,12 @@
 	pixel_x = -35
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/engineering/atmos)
 "pkl" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/fore)
@@ -43782,7 +44176,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "pvo" = (
@@ -44428,6 +44824,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pFP" = (
@@ -44437,8 +44834,16 @@
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "pFZ" = (
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "pGf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45116,11 +45521,9 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "pSH" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/right/directional/east,
-/turf/open/floor/engine/airless,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "pSK" = (
 /obj/machinery/door/airlock/external{
@@ -45602,9 +46005,8 @@
 /area/station/science/xenobiology)
 "qav" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "qaz" = (
@@ -45665,6 +46067,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"qbb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "qbd" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
@@ -45860,6 +46271,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"qeV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/station/engineering/atmos/mix)
 "qeW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47306,11 +47723,10 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/closet/radiation,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "qHp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -47534,9 +47950,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "qMw" = (
-/obj/structure/chair/plastic,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "qMA" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
@@ -47570,23 +47991,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qMX" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
-/area/station/engineering/atmos/upper)
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "qNo" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
@@ -47766,7 +48177,7 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "qQW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qRb" = (
@@ -48277,8 +48688,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
 "rat" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "ray" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -48774,9 +49188,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
 "rhB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rhK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -49148,14 +49567,20 @@
 /area/station/science/xenobiology/hallway)
 "rlH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "rlU" = (
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/upper)
 "rmi" = (
 /obj/structure/table,
@@ -49240,12 +49665,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "roc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "rox" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Port"
@@ -49428,14 +49852,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "rry" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "rrz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -49459,10 +49886,13 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "rsd" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 6
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/box,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/upper)
 "rsk" = (
 /obj/effect/turf_decal/siding/wood{
@@ -49784,8 +50214,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "rxW" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -49983,24 +50416,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "rAW" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/electrolyzer{
-	anchored = 1
-	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/engine/airless,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "rAZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "rBb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50142,17 +50577,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "rCT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/openspace,
-/area/station/engineering/atmos)
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
+/obj/item/analyzer,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/mix)
 "rCW" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -50519,10 +50948,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rJy" = (
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
 "rJz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -50799,10 +51228,12 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "rQb" = (
-/obj/effect/turf_decal/siding/thinplating_new/end,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/glass,
-/area/station/engineering/main)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "rQg" = (
 /obj/structure/chair{
 	dir = 1
@@ -51403,7 +51834,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "rXZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -51556,9 +51987,18 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "rZX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/light/dim/directional/north,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/station/engineering/atmos/upper)
 "sab" = (
 /obj/effect/landmark/start/research_director,
@@ -51717,8 +52157,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/checker,
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "scg" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass/reinforced,
@@ -51878,6 +52318,16 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"sfV" = (
+/obj/machinery/light/small/dim/directional/south,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "sfY" = (
 /obj/structure/stairs/east,
 /obj/structure/railing{
@@ -51957,11 +52407,15 @@
 /turf/open/floor/plating,
 /area/station/cargo/boutique)
 "shb" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "shc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
@@ -52520,14 +52974,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
 "sqA" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Hypertorus Fusion Reactor"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Office"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "sqE" = (
@@ -53135,6 +53589,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"sAW" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/disposal/incinerator)
 "sBb" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
@@ -53204,12 +53667,17 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/command/corporate_dock)
 "sCf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"sCg" = (
+/obj/machinery/suit_storage_unit/radsuit,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "sCp" = (
 /obj/structure/lattice,
 /turf/open/openspace,
@@ -53625,10 +54093,18 @@
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "sJh" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmospherics_engine)
+"sJi" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "sJo" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -53660,9 +54136,7 @@
 /area/station/cargo/storage)
 "sKn" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "sKs" = (
@@ -53808,12 +54282,12 @@
 /area/station/service/hydroponics/garden)
 "sNc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/project)
 "sNi" = (
@@ -53910,6 +54384,10 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central)
+"sPt" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "sPv" = (
 /obj/structure/table/wood,
 /obj/item/stamp/head/hop,
@@ -54606,6 +55084,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "tbH" = (
@@ -54838,6 +55317,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "thT" = (
@@ -55032,11 +55512,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tkX" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/camera/autoname/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos/project)
 "tla" = (
@@ -55079,9 +55559,15 @@
 /turf/open/floor/catwalk_floor/iron_dark/telecomms,
 /area/station/ai_monitored/turret_protected/ai)
 "tlY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "tmk" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Prison Workshop"
@@ -55581,6 +56067,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tuB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "tuE" = (
 /obj/effect/spawner/structure/window/hollow/middle{
 	dir = 4
@@ -55879,6 +56373,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
+"tAF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "tAL" = (
 /obj/item/exodrone,
 /obj/machinery/exodrone_launcher,
@@ -56470,14 +56970,16 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "tLa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/area/station/engineering/atmos/upper)
 "tLg" = (
 /turf/closed/indestructible/reinforced,
 /area/space/nearstation)
@@ -56848,11 +57350,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "tQC" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tQF" = (
@@ -57118,7 +57619,7 @@
 "tUV" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/station/maintenance/department/engine)
+/area/station/engineering/main)
 "tVF" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/structure/cable,
@@ -57334,7 +57835,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "tZt" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
@@ -57669,12 +58170,12 @@
 "ueK" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "ueX" = (
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/iron/dark,
@@ -57744,7 +58245,7 @@
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "ugs" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -57855,7 +58356,7 @@
 /turf/open/floor/iron/checker{
 	dir = 4
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "uif" = (
 /obj/structure/flora/rock/style_random,
 /turf/open/misc/asteroid/airless,
@@ -58168,6 +58669,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"und" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "unk" = (
 /turf/closed/wall/rock/porous,
 /area/station/asteroid)
@@ -58196,9 +58706,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "unH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer5{
 	dir = 5
 	},
@@ -58473,9 +58981,7 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "usm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "usq" = (
@@ -58602,8 +59108,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/theater)
 "uuq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "uuu" = (
@@ -58681,7 +59187,7 @@
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "uvN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -59532,8 +60038,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "uMq" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "uMz" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -59786,7 +60295,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "uQl" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_x = 16;
@@ -59918,11 +60427,10 @@
 /turf/open/floor/iron,
 /area/station/security)
 "uTU" = (
-/obj/structure/tank_holder/extinguisher/advanced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/railing/corner/end{
+	dir = 1
 	},
-/turf/open/floor/iron/large,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "uUj" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -60109,8 +60617,9 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "uXe" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -60290,9 +60799,8 @@
 /turf/open/floor/iron,
 /area/station/security)
 "vas" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -60404,20 +60912,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "vcZ" = (
-/obj/item/circuitboard/machine/thermomachine,
-/obj/item/circuitboard/machine/thermomachine,
-/obj/item/storage/bag/construction,
-/obj/item/storage/bag/construction,
-/obj/item/storage/bag/construction,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/stairs/west,
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "vdb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -60699,16 +61198,15 @@
 /area/station/science/research)
 "vji" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/trunk/multiz,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "vjm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -60825,10 +61323,13 @@
 /turf/open/floor/iron/textured,
 /area/station/commons/storage/art)
 "vkN" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "vkO" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/tank_dispenser/oxygen,
@@ -60895,16 +61396,16 @@
 /area/station/maintenance/department/medical/central)
 "vlX" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "vmf" = (
 /obj/structure/closet/wardrobe/orange,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -60977,6 +61478,10 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"vnQ" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/atmos/project)
 "vnV" = (
 /obj/structure/sign/warning/directional/east,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -61049,12 +61554,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "vpf" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vpn" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -61145,10 +61650,8 @@
 	},
 /area/station/science/research)
 "vqB" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "vqC" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/closed/wall,
@@ -61201,6 +61704,14 @@
 /obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"vrP" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/corner,
+/area/station/engineering/atmos/upper)
 "vrR" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/wood,
@@ -61310,6 +61821,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"vvy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/engineering/atmos)
 "vvC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -62274,21 +62796,21 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark/corner,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "vNg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/uppernorth)
 "vNk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "vNB" = (
@@ -62685,10 +63207,13 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "vUb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/large,
-/area/station/engineering/atmos/storage/gas)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	dir = 8;
+	id = "atmoshfr"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "vUh" = (
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
@@ -62728,8 +63253,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/railing/corner,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "vUJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62908,7 +63437,7 @@
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/area/station/engineering/atmos/upper)
+/area/station/engineering/atmos/mix)
 "vXS" = (
 /obj/structure/broken_flooring/side,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62936,6 +63465,10 @@
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
+/area/station/engineering/atmos)
+"vYO" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vYQ" = (
 /obj/structure/bodycontainer/morgue,
@@ -63247,15 +63780,11 @@
 /turf/open/space/basic,
 /area/station/solars/port/aft)
 "wex" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/light/small/dim/directional/south,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "weB" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -63325,6 +63854,12 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/engineering/atmos)
+"wfO" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/mix)
 "wfW" = (
 /obj/structure/lattice/catwalk,
 /obj/item/food/pie/cream,
@@ -63360,6 +63895,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "whn" = (
@@ -63653,10 +64191,11 @@
 /area/station/security/brig)
 "wmj" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wmr" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
@@ -63727,7 +64266,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "woo" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/portable_atmospherics/canister,
@@ -63893,6 +64432,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "wrU" = (
@@ -64653,9 +65193,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "wDP" = (
-/obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/glass/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "wDW" = (
 /obj/machinery/modular_computer/preset/id{
@@ -64790,9 +65332,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "wFG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/stripes{
@@ -64911,6 +65452,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"wIS" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/upper)
 "wIT" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -64953,12 +65508,27 @@
 /obj/machinery/space_heater/improvised_chem_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"wJW" = (
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "wKo" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/deck,
 /obj/effect/spawner/random/entertainment/deck,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"wKp" = (
+/obj/item/instrument/musicalmoth,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/item/flashlight/flare/candle{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "wKE" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -65173,12 +65743,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/iron/dark/corner{
-	dir = 8
-	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wNZ" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -65456,6 +66024,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "wUH" = (
@@ -65464,18 +66033,15 @@
 /area/station/medical/chemistry/minisat)
 "wUK" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/engineering/atmos)
 "wUM" = (
 /obj/machinery/nuclearbomb/beer,
 /obj/machinery/airalarm/directional/north,
@@ -65954,6 +66520,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/research)
+"xbW" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xcb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66212,6 +66782,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
+"xhc" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "xhu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66504,11 +67082,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xmH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/trunk/multiz/down{
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "xmM" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -66620,15 +67201,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xoR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/stack/rods/twentyfive,
-/obj/item/stack/cable_coil,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/project)
 "xoT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66968,10 +67550,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/atmos)
 "xvg" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
@@ -67673,6 +68258,16 @@
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
+"xGT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "xGX" = (
 /obj/machinery/pdapainter{
 	pixel_y = 2
@@ -67724,11 +68319,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xIh" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 4
+/obj/machinery/electrolyzer{
+	anchored = 1
 	},
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/mix)
 "xIl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
@@ -68255,11 +68852,19 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xTP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/mix)
 "xTZ" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/tile,
@@ -68324,12 +68929,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/research)
 "xVk" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "xVt" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -68571,6 +69174,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"xZl" = (
+/obj/structure/stairs/east,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xZL" = (
 /obj/machinery/camera/autoname/directional/east{
 	network = list("ss13","tcomms")
@@ -68698,8 +69306,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/project)
 "yca" = (
@@ -68841,7 +69449,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "ydX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -68849,6 +69456,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -69250,12 +69858,9 @@
 	},
 /area/station/command/meeting_room)
 "ylQ" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 10
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/upper)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "ylR" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -107781,8 +108386,8 @@ eyg
 dUi
 myg
 sCf
-svf
-svf
+jxd
+jxd
 svf
 svf
 pTJ
@@ -108037,9 +108642,9 @@ gTV
 eyg
 wpn
 cFc
-tlY
-vEZ
-nPM
+svf
+svf
+aJz
 tQC
 fQO
 eqp
@@ -108293,11 +108898,11 @@ lKE
 gsM
 tFW
 mZc
-cFc
+npo
 ifc
-ruZ
-ruZ
-ruZ
+rQb
+lww
+jyK
 ruZ
 ruZ
 ruZ
@@ -108546,17 +109151,17 @@ dHL
 dpU
 bnK
 lED
-tLa
 ocB
 ocB
 hrA
+hrA
 enL
-aOb
-ruZ
+aWD
+aWD
+xDn
+aWD
+aWD
 heP
-apK
-apK
-apK
 bTt
 svK
 ulc
@@ -108806,21 +109411,21 @@ oss
 vEZ
 fEu
 vEZ
-ine
+vEZ
 hmz
-bLS
-ruZ
-bcA
-ruZ
-ruZ
-ruZ
+aWD
+sCg
+qcQ
+gpJ
+aWD
+tAF
 ruZ
 ugJ
 mIY
 eLk
-ruZ
-ruZ
-ruZ
+aWD
+aWD
+aWD
 ykG
 oUw
 ece
@@ -109056,26 +109661,26 @@ eLV
 sbf
 cbJ
 giD
-uMq
-uMq
-uMq
+fTX
+fTX
+fTX
 scd
-uMq
-uMq
+fTX
+fTX
+hfp
+fTX
+fTX
 aWD
-xDn
+epE
+hnu
+dUf
+aWD
+tAF
 aWD
 aWD
-aWD
-wuS
-aWD
-chV
-rDD
-ruZ
-ruZ
 tUV
-ruZ
-ruZ
+aWD
+aWD
 chV
 rDD
 ykG
@@ -109313,21 +109918,21 @@ arB
 pvX
 pvX
 rJD
-rhB
+hfp
 woe
 pjY
 xuZ
 jFf
-uMq
+fwV
 lBB
-qcQ
-gpJ
+gym
+eFM
 aWD
-xoR
+tMD
 huP
-dBX
-ahl
-hQm
+cCj
+aWD
+kIx
 aWD
 rZb
 rJb
@@ -109570,28 +110175,28 @@ jak
 tnp
 mSN
 oQp
-rhB
+hfp
 rXU
 gLQ
-xuZ
-vpf
-uMq
-epE
-hnu
+vvy
+tlY
+tlY
+tlY
+iLL
 neM
-kmB
-roc
-btl
-lyy
-rhS
-sqw
+aWD
+aWD
+diM
+aWD
+aWD
+wuS
 aWD
 iTa
 wWy
 jzJ
 aWD
-cNM
-rhS
+nSb
+ugV
 jeY
 dCM
 btl
@@ -109827,29 +110432,29 @@ dow
 bzC
 bzC
 oAO
-rhB
+hfp
 gUe
 ueK
-xuZ
+nZI
 vpf
-uMq
-tMD
+cfD
+und
 lSm
-cCj
+oAn
 aWD
 jJp
-btl
+kBN
 oAc
 moU
-ggP
+oAc
 eaX
-kVV
+xfi
 mjf
 sNU
 aer
 xfi
 wBH
-ggQ
+rhS
 mLN
 btl
 kIS
@@ -110084,15 +110689,15 @@ bND
 cYa
 bND
 fvW
-uMq
+fTX
 wUK
 wmj
 gCY
 kNb
-uMq
-aWD
-oAn
-aWD
+mdw
+bJU
+fTX
+fTX
 aWD
 cNM
 mCb
@@ -110345,13 +110950,13 @@ knK
 vji
 wFC
 wNN
-nZI
+kNb
 mdw
-aWD
+bJU
 cXn
 vNk
 oHA
-xfi
+qMX
 jtS
 rhS
 rhS
@@ -110363,9 +110968,9 @@ dAe
 rhS
 rhS
 rhS
-rhS
-gaN
 nHr
+gaN
+rhS
 sqw
 ryC
 kqC
@@ -110597,19 +111202,19 @@ fTX
 htx
 hUr
 wBU
-aKA
-uMq
+mzJ
+fTX
 fIG
 dmW
 rxU
 rat
 wex
-aWD
-eFM
-xCf
-xCf
-xCf
-cYB
+sfV
+fTX
+ksR
+rhS
+rhS
+jtS
 rhS
 rhS
 rhS
@@ -110844,7 +111449,7 @@ oEZ
 rFZ
 bND
 mjR
-bND
+elz
 vcZ
 fTX
 fTX
@@ -110855,18 +111460,18 @@ aDJ
 hUr
 wBU
 mzJ
-uMq
+fTX
 vlX
-vUr
-vUr
+rry
+fpd
 vUr
 eus
-aWD
-qWG
+bta
+dBX
 vas
-fMW
-cfJ
 ybD
+cfJ
+mhA
 ybD
 ybD
 ybD
@@ -111101,10 +111706,10 @@ jSu
 cnS
 gvR
 bND
-bND
+vYO
 dAo
 fTX
-deX
+pSH
 rAW
 pSH
 fTX
@@ -111112,15 +111717,15 @@ ciF
 hUr
 wBU
 dYx
-uMq
-vqB
-sJh
-rJy
-vUb
-uMq
-aWD
-mkL
-qHp
+fTX
+fTX
+nhS
+lyy
+xZl
+fTX
+fTX
+fTX
+uFC
 uFC
 uFC
 jnY
@@ -111359,25 +111964,25 @@ cnS
 bND
 bND
 lNr
-bND
+wex
 ecF
-dWB
 vck
-nhS
+vck
+vck
 vck
 flQ
 hRp
 wBU
-diM
+mzJ
 uMq
-vqB
-sJh
-rJy
+fTX
 vUb
-nZH
+vUb
+vUb
+fTX
+wKp
 uFC
-jnY
-oUb
+uFC
 uFC
 lNk
 sJG
@@ -111618,24 +112223,24 @@ bND
 bND
 gvR
 bND
-eYM
+bND
 fIZ
-oYX
+fIZ
 umT
 mjP
 jZN
 uFL
 azs
-uMq
-vqB
+mRD
+kUX
 sJh
 rJy
-vUb
-uMq
+cYB
+kUX
+gNG
 uFC
 boT
 djU
-wFG
 lLU
 utV
 cPG
@@ -111876,23 +112481,23 @@ trz
 bND
 bND
 qQW
-mzb
-kBN
+bND
+bND
 mVf
 kUX
 lXI
 mRu
 eeo
 kUX
-mRu
-mRu
-mRu
-mRu
 kUX
+sJh
+rJy
+cYB
+kUX
+uFC
 uFC
 jsL
 kpn
-nPW
 nPW
 auj
 cPG
@@ -112145,11 +112750,11 @@ jfo
 jfo
 jfo
 jfo
+kmB
 xxi
 uFC
 eBZ
 kpn
-pxu
 pxu
 pxu
 oyV
@@ -112402,11 +113007,11 @@ kGZ
 kGZ
 kGZ
 tbk
+kGZ
 rkp
 uFC
 boT
 kAh
-wCm
 qWs
 utV
 gea
@@ -112660,7 +113265,7 @@ kzk
 qRF
 kGZ
 cPx
-uFC
+hqW
 uFC
 uFC
 uFC
@@ -112918,7 +113523,7 @@ cEh
 kGZ
 woo
 kUX
-vxX
+uFC
 vxX
 uFC
 cUD
@@ -173308,7 +173913,7 @@ jjX
 ugo
 uvH
 uhW
-eyg
+nZH
 eyg
 isT
 isT
@@ -173559,13 +174164,13 @@ xKo
 joo
 bkk
 ksg
-ktL
-ktL
+bkC
+vqB
 dKI
-anN
+nKO
 fRB
 opq
-iZa
+nZH
 dUi
 dUi
 dUi
@@ -173817,12 +174422,12 @@ joo
 bkk
 mxL
 xTP
-jgs
+hqj
 jws
-anN
+nKO
 uPR
 uWX
-iZa
+nZH
 lyN
 lyN
 lyN
@@ -174074,12 +174679,12 @@ lVx
 bkk
 rAZ
 glC
-ktL
+mkL
 jvn
-anN
-anN
+nKO
+vqB
 vNd
-iZa
+nZH
 dRs
 lyN
 lyN
@@ -174331,12 +174936,12 @@ cie
 bkk
 cMW
 tZp
-aaY
-aaY
-aaY
-aaY
+tZp
+iEB
+kVV
+iEB
 qHl
-iZa
+nZH
 pSb
 qJs
 jHn
@@ -174350,13 +174955,13 @@ wCG
 alv
 guO
 rhS
-kyE
+rhS
 rhS
 bWl
-rhS
-alv
-rhS
-nHr
+guO
+wJW
+ybD
+rhB
 lYp
 pah
 aWD
@@ -174586,27 +175191,27 @@ bkk
 bkk
 bkk
 bkk
-ewM
-ewM
-ewM
-ewM
-ewM
-ewM
-hqj
+nZH
+nZH
+ylQ
+ylQ
+eAG
+ylQ
+iZa
 iZa
 iZa
 uyj
-dUi
-dUi
-heO
-dUi
+iZa
+iZa
+iZa
+iZa
+iZa
+iZa
 aWD
-aWD
-aWD
-vzC
-aWD
-mog
-mog
+cNM
+alv
+rhS
+xbW
 fFb
 ybD
 cSd
@@ -174840,30 +175445,30 @@ cIN
 lVx
 bkk
 axv
-kHU
+vkN
 kHU
 rCT
-kHU
-kHU
-kHU
-kHU
-kHU
-kHU
-ouG
+xIh
+wfO
+csH
+mDE
+vkN
+qeV
+iZa
 fst
 dBp
 bPH
-dUi
+tLa
 lFJ
 oow
-lFJ
-aWD
+chA
+dTR
 mRU
-sCp
-sCp
-aWD
-mog
-iNj
+mec
+mpX
+alv
+xbW
+qHp
 wtH
 wtH
 jNL
@@ -175095,31 +175700,31 @@ vxX
 gMk
 vWx
 dor
-bkk
-hzg
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-fsu
+ckf
+xGT
+aOb
+deX
+oYX
+oYX
+oYX
+oYX
+sJi
+fMW
+nrV
+ovD
 fze
 lMj
-ylQ
-dUi
-oow
-kQz
-oow
-aWD
-rQb
-mog
-sCp
-aWD
-aWD
+anN
+ktL
+ktL
+ktL
+ktL
+vrP
+iZa
+qWG
+nHr
+rhS
+sqw
 wtH
 wtH
 rsw
@@ -175353,31 +175958,31 @@ gMk
 cIN
 lVx
 bkk
-hzg
+aKA
+vqB
+vqB
 mhh
 mhh
 mhh
 mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-fsu
+vqB
+vqB
+bLS
+iZa
 nmr
-ixY
-mhA
-dUi
-lFJ
-oow
-lFJ
-aWD
-mRU
-mog
-sCp
-sCp
-sCp
-wje
+cLO
+anN
+uuq
+uuq
+uIj
+lPO
+kyE
+xhc
+vas
+lcL
+ybD
+qHp
+wtH
 anX
 mGP
 jjI
@@ -175611,30 +176216,30 @@ xKo
 bjy
 bkk
 hzg
+vqB
 mhh
 mhh
 mhh
 mhh
 mhh
 mhh
-mhh
-mhh
-mhh
+vqB
+hcU
 fsu
 shb
 ixY
-iEB
-dUi
-dUi
-dUi
+anN
+ktL
+uuq
+sPt
+lBQ
+iZa
 aWD
 aWD
-lww
-mog
-mog
-mog
-sCp
-wje
+aWD
+aWD
+aWD
+wtH
 uca
 eVA
 mYb
@@ -175867,30 +176472,30 @@ wlR
 lNe
 lVx
 bkk
-hzg
+apK
+nGB
 mhh
 mhh
 mhh
 mhh
 mhh
 mhh
-mhh
-mhh
-mhh
-qMX
+vqB
+oUb
+iZa
 xmH
-ixY
+qbb
 wDP
 xVk
 lfR
-iZa
+mzb
 aWF
-elz
-mog
-mog
-mog
+ewM
 mog
 sCp
+sCp
+sCp
+mog
 wje
 cSC
 jPb
@@ -176124,29 +176729,29 @@ jBG
 oEN
 aCL
 bkk
-hzg
+coV
+cxq
+vqB
 mhh
 mhh
 mhh
 mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-csH
-nmr
+vqB
+jvn
+ine
+ovD
+bcA
 nZw
 rsd
 rlU
 dTz
-iZa
+bZJ
 pFZ
-nKO
+ewM
+sCp
+sCp
 mog
-mog
-mog
-mog
+sCp
 sCp
 wje
 vno
@@ -176381,30 +176986,30 @@ iNv
 xKo
 tpz
 bkk
-hzg
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-mhh
-rry
-rZX
+lWT
+ggQ
+iEB
+iEB
 kjv
-fwV
-vkN
-qdV
+eBF
+mtP
+iEB
+iEB
+dWB
 iZa
+rZX
+qdV
+qdV
+qdV
+nAa
+oOG
 qMw
-aJz
+ewM
 mog
 mog
 mog
 mog
-sCp
+mog
 wje
 wtH
 kjR
@@ -176638,25 +177243,25 @@ uab
 qhG
 qhG
 qhG
-hcU
+qhG
+sAW
 qhG
 qhG
-qhG
+iZa
 iZa
 ovD
 ovD
 ovD
-ovD
-ovD
 iZa
-nmr
-lMj
-ksR
-kIx
+iZa
+wIS
+qdV
+qdV
+qdV
 nAa
+roc
+iqx
 iZa
-aWD
-aWD
 uFC
 uFC
 tel
@@ -176895,7 +177500,7 @@ uab
 qhG
 awM
 eqX
-efQ
+bDk
 drK
 unH
 sKn
@@ -176907,13 +177512,13 @@ muw
 dLW
 iZa
 dhH
-ixY
-pMG
+grb
+grb
 grb
 peW
+diH
 iZa
-vxX
-vxX
+iZa
 uFC
 xlG
 tGb
@@ -177164,12 +177769,12 @@ pMG
 pCF
 iZa
 kDI
-lMj
-xIh
-rsd
+pMG
+pMG
+pMG
 cti
+fPo
 iZa
-vxX
 vxX
 uFC
 xlG
@@ -177421,12 +178026,12 @@ uIj
 jgs
 adP
 jcl
-jcl
-jcl
+tuB
+kQz
 aaY
 cCQ
+gCk
 iZa
-vxX
 vxX
 uFC
 xlG
@@ -177670,7 +178275,7 @@ fvq
 psi
 smn
 lxE
-qhG
+sgw
 sqA
 sgw
 fuQ
@@ -177683,7 +178288,7 @@ pir
 fuQ
 sgw
 sgw
-vxX
+sgw
 vxX
 uFC
 xlG
@@ -177927,7 +178532,7 @@ qhG
 evO
 sIQ
 usm
-qhG
+sgw
 ydX
 hrS
 xxB
@@ -177936,7 +178541,7 @@ xxB
 wNG
 upe
 xxB
-xxB
+xoR
 hrS
 kCK
 sgw
@@ -178193,8 +178798,8 @@ eES
 lqt
 lqt
 lqt
-eES
-eES
+ouG
+eYM
 nOd
 sgw
 vxX
@@ -178441,9 +179046,9 @@ qhG
 qhG
 sjR
 xmZ
-qhG
-qhG
-qhG
+sgw
+sgw
+sgw
 upp
 lnr
 lqt
@@ -178451,7 +179056,7 @@ lqt
 lqt
 lqt
 lqt
-eES
+ggP
 aRc
 sgw
 vxX
@@ -178700,15 +179305,15 @@ smn
 keJ
 keJ
 qdl
-qhG
+sgw
 vWh
 lnr
 lqt
 lqt
+vnQ
 lqt
 lqt
-lqt
-eES
+ggP
 mKJ
 sgw
 fYe
@@ -178957,7 +179562,7 @@ stS
 bDk
 bqz
 tXf
-qhG
+sgw
 lfk
 lnr
 lqt
@@ -178965,7 +179570,7 @@ lqt
 lqt
 lqt
 lqt
-eES
+ggP
 vhI
 sgw
 fYe
@@ -179214,7 +179819,7 @@ mra
 rhi
 bDk
 eju
-qhG
+sgw
 xvu
 lnr
 eES
@@ -179222,7 +179827,7 @@ lqt
 lqt
 lqt
 eES
-eES
+heO
 nOd
 sgw
 fYe
@@ -179471,7 +180076,7 @@ vwh
 nUS
 bDk
 eJi
-qhG
+sgw
 lrK
 lnr
 cws
@@ -179728,7 +180333,7 @@ ofx
 tEu
 bDk
 eJi
-qhG
+sgw
 mIz
 iJv
 sqE
@@ -179985,7 +180590,7 @@ llW
 llW
 llW
 feQ
-qhG
+sgw
 sgw
 sgw
 sgw
@@ -182820,10 +183425,10 @@ hhX
 hhX
 hhX
 hhX
-hhX
-hhX
-hhX
-hhX
+cLf
+cLf
+cLf
+cLf
 hhX
 hhX
 hhX
@@ -183077,10 +183682,10 @@ hhX
 hhX
 hhX
 hhX
-hhX
-hhX
-hhX
-hhX
+cLf
+cLf
+cLf
+cLf
 hhX
 hhX
 hhX
@@ -183334,10 +183939,10 @@ hhX
 hhX
 hhX
 hhX
-hhX
-hhX
-hhX
-hhX
+cLf
+cLf
+cLf
+cLf
 hhX
 hhX
 hhX

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -7051,6 +7051,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"czw" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "czC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door/directional/east{
@@ -110446,7 +110455,7 @@ jJp
 kBN
 oAc
 moU
-oAc
+czw
 eaX
 xfi
 mjf

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -19343,7 +19343,7 @@
 	dir = 5
 	},
 /turf/open/space/openspace,
-/area/space)
+/area/space/nearstation)
 "gLp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -35577,10 +35577,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"mqV" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/openspace,
-/area/space)
 "mra" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_y = 24
@@ -67394,7 +67390,7 @@
 	dir = 6
 	},
 /turf/open/space/openspace,
-/area/space)
+/area/space/nearstation)
 "xsj" = (
 /obj/machinery/netpod,
 /obj/structure/cable,
@@ -181125,7 +181121,7 @@ vxX
 vxX
 hhX
 gKU
-mqV
+mxt
 xsf
 hhX
 vxX
@@ -181382,7 +181378,7 @@ fYe
 vxX
 vxX
 hhX
-mqV
+mxt
 hhX
 hhX
 vxX
@@ -181639,7 +181635,7 @@ uVI
 mUQ
 hhX
 hhX
-mqV
+mxt
 hhX
 hhX
 vxX

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -997,9 +997,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/mix)
 "apQ" = (
@@ -1461,6 +1459,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -5020,6 +5019,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/mix)
 "bMb" = (
@@ -6566,6 +6566,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/mix)
 "cpw" = (
@@ -6779,6 +6780,7 @@
 "csH" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos/mix)
 "csW" = (
@@ -6964,6 +6966,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -15255,6 +15260,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -15267,6 +15273,7 @@
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Mixing Room"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "fsx" = (
@@ -20395,6 +20402,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/mix)
 "hdd" = (
@@ -30851,6 +30859,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/mix)
 "kIh" = (
@@ -36316,6 +36325,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -38620,6 +38630,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/mix)
 "nrW" = (
@@ -46014,6 +46025,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "qaz" = (
@@ -46282,6 +46294,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/mix)
 "qeW" = (
@@ -50592,6 +50605,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
 /obj/item/analyzer,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos/mix)
 "rCW" = (
@@ -61338,6 +61352,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -63870,6 +63885,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light_switch/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos/mix)
 "wfW" = (
@@ -68276,6 +68292,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -68336,6 +68353,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos/mix)
 "xIl" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -9608,6 +9608,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "drO" = (
@@ -12529,6 +12530,7 @@
 "eqX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "era" = (
@@ -47946,6 +47948,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"qLS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "qMd" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/effect/landmark/start/bartender,
@@ -177509,7 +177516,7 @@ uab
 qhG
 awM
 eqX
-bDk
+qLS
 drK
 unH
 sKn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wawas atmospherics sucks and was severely undersized and had practically 0 room to do any projects, exacerbated by the fact the Z-level above was open making a single plasma fire near completely unfixable. I did slightly adjust the entrance of engineering to accommodate

Anyways, Here's some pictures of the new redesign. Mostly removing the open air spots and turning them into project rooms.

![image](https://github.com/user-attachments/assets/f91ceb33-9cc3-468f-a512-b6ec92b7fb7f)

![image](https://github.com/user-attachments/assets/8223835c-3884-4b4b-b05b-edfaf85c9b4a)

![image](https://github.com/user-attachments/assets/31db13f2-08ee-415f-b261-cada6111fc3d)

![image](https://github.com/user-attachments/assets/5488f720-7049-48e6-9248-61ba2d74c0bc)

![image](https://github.com/user-attachments/assets/6b197820-b2d7-4a46-8114-ce5eeaffed83)

![image](https://github.com/user-attachments/assets/0220d139-0514-4f90-bb8d-853d8e5b63ab)

![image](https://github.com/user-attachments/assets/93f175b0-9b29-4737-aac4-baddd0e320c3)




## Why It's Good For The Game

It makes wawa atmospherics actually usable by adding space.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

map: redesigned wawa station's atmospherics 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
