### PR TITLE
Autolathes now accept alloys without disassembling them into their components

### DIFF
--- a/code/__DEFINES/construction/material.dm
+++ b/code/__DEFINES/construction/material.dm
@@ -47,6 +47,8 @@
 #define MATCONTAINER_ANY_INTENT (1<<2)
 ///If the user won't receive a warning when attacking the container with an unallowed item.
 #define MATCONTAINER_SILENT (1<<3)
+///Alloys won't be disassembled in its components when inserted.
+#define MATCONTAINER_ACCEPT_ALLOYS (1<<4)
 
 /// Whether a material's mechanical effects should apply to the atom. This is necessary for other flags to work.
 #define MATERIAL_EFFECTS (1<<0)

--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -23,7 +23,7 @@
 	var/list/allowed_item_typecache
 	/// Whether or not this material container allows specific amounts from sheets to be inserted
 	var/precise_insertion = FALSE
-	/// The material container flags. See __DEFINES/materials.dm.
+	/// The material container flags. See __DEFINES/construction/materials.dm.
 	var/mat_container_flags
 	/// Signals that are registered with this contained
 	var/list/registered_signals
@@ -164,7 +164,7 @@
 	var/max_mat_value = 0
 	var/material_amount = 0
 
-	var/list/item_materials = source.get_material_composition()
+	var/list/item_materials = source.get_material_composition(mat_container_flags)
 	var/list/mats_consumed = list()
 	for(var/MAT in item_materials)
 		if(!can_hold_material(MAT))
@@ -557,11 +557,11 @@
  * Arguments:
  * - [I][obj/item]: the item whos materials must be retrieved
  */
-/datum/component/material_container/proc/get_item_material_amount(obj/item/I)
-	if(!istype(I) || !I.custom_materials)
+/datum/component/material_container/proc/get_item_material_amount(obj/item/item)
+	if(!istype(item) || !item.custom_materials)
 		return 0
 	var/material_amount = 0
-	var/list/item_materials = I.get_material_composition()
+	var/list/item_materials = item.get_material_composition(mat_container_flags)
 	for(var/MAT in item_materials)
 		if(!can_hold_material(MAT))
 			continue
@@ -769,7 +769,7 @@
 		return NONE
 	if((held_item.flags_1 & HOLOGRAM_1) || (held_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(held_item, allowed_item_typecache)))
 		return NONE
-	var/list/item_materials = held_item.get_material_composition()
+	var/list/item_materials = held_item.get_material_composition(mat_container_flags)
 	if(!length(item_materials))
 		return NONE
 	for(var/material in item_materials)

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -168,7 +168,7 @@ Simple datum which is instanced once per type and is used for every object of sa
  * Arguments:
  * - amount: The amount of the material to break down.
  */
-/datum/material/proc/return_composition(amount = 1)
+/datum/material/proc/return_composition(amount = 1, flags)
 	// Yes we need the parenthesis, without them BYOND stringifies src into "src" and things break.
 	return list((src) = amount)
 

--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -7,13 +7,16 @@
 	/// The materials this alloy is made from weighted by their ratios.
 	var/list/composition = null
 
-/datum/material/alloy/return_composition(amount = 1)
+/datum/material/alloy/return_composition(amount = 1, flags)
+	if(flags & MATCONTAINER_ACCEPT_ALLOYS)
+		return ..()
+
 	. = list()
 
 	var/list/cached_comp = composition
 	for(var/comp_mat in cached_comp)
 		var/datum/material/component_material = GET_MATERIAL_REF(comp_mat)
-		var/list/component_composition = component_material.return_composition(cached_comp[comp_mat])
+		var/list/component_composition = component_material.return_composition(cached_comp[comp_mat], flags)
 		for(var/comp_comp_mat in component_composition)
 			.[comp_comp_mat] += component_composition[comp_comp_mat] * amount
 

--- a/code/game/atom/atom_materials.dm
+++ b/code/game/atom/atom_materials.dm
@@ -292,13 +292,13 @@
  * Arguments:
  * - flags: A set of flags determining how exactly the materials are broken down.
  */
-/atom/proc/get_material_composition()
+/atom/proc/get_material_composition(flags)
 	. = list()
 
 	var/list/cached_materials = custom_materials
 	for(var/mat in cached_materials)
 		var/datum/material/material = GET_MATERIAL_REF(mat)
-		var/list/material_comp = material.return_composition(cached_materials[mat])
+		var/list/material_comp = material.return_composition(cached_materials[mat], flags)
 		for(var/comp_mat in material_comp)
 			.[comp_mat] += material_comp[comp_mat]
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -38,7 +38,7 @@
 		/datum/component/material_container, \
 		SSmaterials.materials_by_category[MAT_CATEGORY_ITEM_MATERIAL], \
 		0, \
-		MATCONTAINER_EXAMINE, \
+		MATCONTAINER_EXAMINE|MATCONTAINER_ACCEPT_ALLOYS, \
 		container_signals = list(COMSIG_MATCONTAINER_ITEM_CONSUMED = TYPE_PROC_REF(/obj/machinery/autolathe, AfterMaterialInsert)) \
 	)
 	. = ..()

--- a/code/modules/wiremod/components/atom/matscanner.dm
+++ b/code/modules/wiremod/components/atom/matscanner.dm
@@ -34,7 +34,7 @@
 	if(!istype(entity) || !IN_GIVEN_RANGE(location, entity, max_range))
 		result.set_output(null)
 		return
-	var/list/composition = entity.get_material_composition()
+	var/list/composition = entity.get_material_composition(break_down_alloys ? NONE : MATCONTAINER_ACCEPT_ALLOYS)
 	var/list/composition_but_with_string_keys = list()
 	for(var/datum/material/material as anything in composition)
 		composition_but_with_string_keys[material.name] = composition[material]


### PR DESCRIPTION
## About The Pull Request
Custom material designs cannot be printed with plasteel and other alloys because of this small issue. This should fix it.

## Why It's Good For The Game
See above.

## Changelog

:cl:
fix: Custom material toolboxes and fishing rods can now be printed with alloys such a plasteel and plasmaglass.
/:cl:
