### PR TITLE
The contents of a piggy bank are now capped, anything exceeding the limit is converted into a single holochip.

### DIFF
--- a/code/game/objects/items/piggy_bank.dm
+++ b/code/game/objects/items/piggy_bank.dm
@@ -59,9 +59,14 @@
 	if(maximum_savings_per_shift)
 		maximum_value = calculate_dosh_amount() + maximum_savings_per_shift
 
-#define MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH 35
-
 /obj/item/piggy_bank/proc/save_cash()
+	sanitize_piggy_bank_contents_len()
+	SSpersistence.save_piggy_bank(src)
+
+#define MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH 38
+
+///This prevents the piggy bank from becoming laggy as hell if broken with hundred upon hundreds of chips inside it.
+/obj/item/piggy_bank/proc/sanitize_piggy_bank_contents_len()
 	var/contents_len = length(contents)
 	if(contents_len <= MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH)
 		return
@@ -76,7 +81,6 @@
 		qdel(money)
 	if(creds_amount)
 		new /obj/item/holochip(src, creds_amount)
-	SSpersistence.save_piggy_bank(src)
 
 #undef MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH
 
@@ -135,6 +139,7 @@
 		balloon_alert(user, "stuck in your hands!")
 	else
 		balloon_alert(user, "inserted [creds_value] creds")
+		sanitize_piggy_bank_contents_len()
 	return TRUE
 
 ///Returns the total amount of credits that its contents amount to.

--- a/code/game/objects/items/piggy_bank.dm
+++ b/code/game/objects/items/piggy_bank.dm
@@ -67,7 +67,7 @@
 
 ///This prevents the piggy bank from becoming laggy as hell if broken with hundred upon hundreds of chips inside it.
 /obj/item/piggy_bank/proc/sanitize_piggy_bank_contents_len()
-var/contents_len = length(contents)
+	var/contents_len = length(contents)
 	if(contents_len <= MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH)
 		return
 	// that +1 is to make space for the holochip with the collected amount

--- a/code/game/objects/items/piggy_bank.dm
+++ b/code/game/objects/items/piggy_bank.dm
@@ -63,11 +63,11 @@
 	sanitize_piggy_bank_contents_len()
 	SSpersistence.save_piggy_bank(src)
 
-#define MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH 38
+#define MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH 35
 
 ///This prevents the piggy bank from becoming laggy as hell if broken with hundred upon hundreds of chips inside it.
 /obj/item/piggy_bank/proc/sanitize_piggy_bank_contents_len()
-	var/contents_len = length(contents)
+var/contents_len = length(contents)
 	if(contents_len <= MAXIMUM_PIGGY_BANK_CONTENTS_LENGTH)
 		return
 	// that +1 is to make space for the holochip with the collected amount


### PR DESCRIPTION
## About The Pull Request
Piggy banks have a hard cap of 35 items. Anything beyond that is crunched down into a single chip.

## Why It's Good For The Game
This prevents Lenald from making lag bombs with piggy banks. :^)

## Changelog

:cl:
fix: The number of coins, chips or bills that can fit inside a piggy bank is now capped, anything exceeding that amount is converted into a single holochip.
/:cl:
