### PR TITLE
Fixes some stupid stuff going on with food export.

### DIFF
--- a/code/modules/cargo/exports/food_and_drink.dm
+++ b/code/modules/cargo/exports/food_and_drink.dm
@@ -9,16 +9,14 @@
 	export_types = list(/obj/item/food)
 	include_subtypes = TRUE
 	exclude_types = list(/obj/item/food/grown)
-	/// Have we already set the cost of this export? Necessary to avoid the cost being constantly reset.
-	var/cost_obtained_from_venue_value = FALSE
 
-/datum/export/food/get_cost(obj/object, allowed_categories, apply_elastic)
+/datum/export/food/get_cost(obj/item/food/object, allowed_categories, apply_elastic)
 	if(HAS_TRAIT(object, TRAIT_FOOD_SILVER))
 		return FOOD_PRICE_WORTHLESS
 
-	var/obj/item/food/sold_food = object
-	if(!cost_obtained_from_venue_value)
-		cost = sold_food.venue_value
-		cost_obtained_from_venue_value = TRUE
+	var/elastic_cost = ..()
+	if(object.venue_value)
+		var/elastic_percent = elastic_cost / init_cost
+		return round(object.venue_value * elastic_percent)
 
-	return ..()
+	return elastic_cost


### PR DESCRIPTION
## About The Pull Request
The way this is implemented right now is stupid as fuck. Basically, if you export a well-priced dish, all other food servings after it will sell for the same price, provided exports are kept as singletons. This makes me want to ping the author of the PR that did this and yell at them, but whatever.

## Why It's Good For The Game
Fixing an issue that's also causing the cargo_crate_sanity unit test to fail so many times.

Closes #90075
Closes #90073
Closes #90087
Closes #90091

At least until they pop up again.

## Changelog

:cl:
fix: Fixing an issue with food exports.
/:cl:
