### PR TITLE
Makes pistol whipping work properly for guns that have hold at gunpoint disabled

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -291,11 +291,11 @@
 	return NONE
 
 /obj/item/gun/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	if(!can_hold_up || !isliving(interacting_with))
-		return interact_with_atom(interacting_with, user, modifiers)
-
 	if(user.combat_mode && isliving(interacting_with))
 		return ITEM_INTERACT_SKIP_TO_ATTACK // Gun bash / bayonet attack
+
+	if(!can_hold_up || !isliving(interacting_with))
+		return interact_with_atom(interacting_with, user, modifiers)
 
 	var/datum/component/gunpoint/gunpoint_component = user.GetComponent(/datum/component/gunpoint)
 	if (gunpoint_component)


### PR DESCRIPTION
## About The Pull Request

Just shifts some logic around so that hold gunpoint being disabled on a gun does not cause it to fire when pistol whipping.

## Why It's Good For The Game

Fixes an unintended interaction

## Changelog

:cl:
fix: combat rmb will no longer fire the gun at the same time as pistol whipping for certain guns
/:cl:

