### PR TITLE
Cleanup redundant NOT `!` operator in `CALCULATE_ADJACENT_TURFS`

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -246,7 +246,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		if(ispath(oldType, /turf/closed) && isopenturf(src))
 			SSair.add_to_active(src)
 	else //In effect, I want closed turfs to make their tile active when sheered, but we need to queue it since they have no adjacent turfs
-		CALCULATE_ADJACENT_TURFS(src, (!(ispath(oldType, /turf/closed) && isopenturf(src)) ? NORMAL_TURF : MAKE_ACTIVE))
+		CALCULATE_ADJACENT_TURFS(src, (ispath(oldType, /turf/closed) && isopenturf(src) ? MAKE_ACTIVE : NORMAL_TURF))
 
 /turf/open/AfterChange(flags, oldType)
 	..()


### PR DESCRIPTION

## About The Pull Request
Small code tweak for better readability.

```
if(thing)
  var = foo
else
  var = bar
```
is slightly easier to read than
```
if(!thing)
  var = bar
else
  var = foo
```
Especially when `thing` is a grouped set of operations like `(thing1 == meow && thing2 >= blah || thing3 & CATFISH)`

## Why It's Good For The Game
N/A

## Changelog
:cl:
code: Remove redundant NOT operator from CALCULATE_ADJACENT_TURFS
/:cl:
