### PR TITLE
Improves crate mimics' disguise

### DIFF
--- a/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
+++ b/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 // Aggro when you try to open them. Will also pickup loot when spawns and drop it when dies.
 /mob/living/basic/mimic/crate
 	name = "crate"
-	desc = "A rectangular steel crate."
+	desc = "A very hostile rectangular steel crate."
 	icon = 'icons/obj/storage/crates.dmi'
 	icon_state = "crate"
 	icon_living = "crate"
@@ -70,12 +70,15 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 	var/storage_capacity = 50
 	///A cap for mobs. Mobs count towards the item cap. Same purpose as above.
 	var/mob_storage_capacity = 10
+	///Nullspaced crate that we are pretending to be
+	var/atom/movable/crate = /obj/structure/closet/crate
 
 // Pickup loot
 /mob/living/basic/mimic/crate/Initialize(mapload)
 	. = ..()
 	lock = new
 	lock.Grant(src)
+	crate = new crate(null) // Nullspaced so we don't accidentally spew it out when opening
 	ADD_TRAIT(src, TRAIT_AI_PAUSED, INNATE_TRAIT)
 	ai_controller?.set_ai_status(AI_STATUS_OFF) //start inert, let gullible people pull us into cargo or something and then go nuts when opened
 	if(mapload) //eat shit
@@ -83,6 +86,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 			item.forceMove(src)
 
 /mob/living/basic/mimic/crate/Destroy()
+	QDEL_NULL(crate)
 	lock = null
 	return ..()
 
@@ -133,6 +137,11 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 	. = ..()
 	if(istype(mover, /obj/structure/closet))
 		return FALSE
+
+/mob/living/basic/mimic/crate/examine(mob/user)
+	if(ai_controller?.ai_status == AI_STATUS_OFF && !client)
+		return crate.examine(user)
+	return ..()
 
 /**
 * Used to open and close the mimic

--- a/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
+++ b/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
@@ -52,6 +52,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 	desc = "A very hostile rectangular steel crate."
 	icon = 'icons/obj/storage/crates.dmi'
 	icon_state = "crate"
+	base_icon_state = "crate"
 	icon_living = "crate"
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
@@ -78,12 +79,17 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 	. = ..()
 	lock = new
 	lock.Grant(src)
-	crate = new crate(null) // Nullspaced so we don't accidentally spew it out when opening
 	ADD_TRAIT(src, TRAIT_AI_PAUSED, INNATE_TRAIT)
 	ai_controller?.set_ai_status(AI_STATUS_OFF) //start inert, let gullible people pull us into cargo or something and then go nuts when opened
 	if(mapload) //eat shit
 		for(var/obj/item/item in loc)
 			item.forceMove(src)
+
+	crate = new crate(null) // Nullspaced so we don't accidentally spew it out when opening
+	icon = crate.icon
+	icon_state = crate.icon_state
+	base_icon_state = crate.base_icon_state
+	icon_living = icon_state
 
 /mob/living/basic/mimic/crate/Destroy()
 	QDEL_NULL(crate)
@@ -158,14 +164,14 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 	if(!opened)
 		ADD_TRAIT(src, TRAIT_UNDENSE, MIMIC_TRAIT)
 		opened = TRUE
-		icon_state = "crateopen"
+		icon_state = "[base_icon_state]open"
 		playsound(src, 'sound/machines/crate/crate_open.ogg', 50, TRUE)
 		for(var/atom/movable/movable as anything in src)
 			movable.forceMove(loc)
 	else
 		REMOVE_TRAIT(src, TRAIT_UNDENSE, MIMIC_TRAIT)
 		opened = FALSE
-		icon_state = "crate"
+		icon_state = base_icon_state
 		playsound(src, 'sound/machines/crate/crate_close.ogg', 50, TRUE)
 		for(var/atom/movable/movable as anything in get_turf(src))
 			if(movable != src && insert(movable) == CANT_INSERT_FULL)


### PR DESCRIPTION

## About The Pull Request

Crate mimics now spawn a nullspaced crate which they base their disguise off - examining them will examine the crate instead. This also gives us (or mappers) the ability to edit their crate's type to a different one, in case we want a mimic that looks like a wooden crate or a necropolis chest.

Closes #90033

## Why It's Good For The Game

For mimics they're disappointingly easy to distinguish from normal crates.

## Changelog
:cl:
balance: Improved crate mimics' disguise
/:cl:
