### PR TITLE
Fix del loop in modsuit devices

### DIFF
--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -330,6 +330,7 @@
 	SIGNAL_HANDLER
 
 	if(source == device)
+		device.moveToNullspace()
 		device = null
 		qdel(src)
 


### PR DESCRIPTION

## About The Pull Request
When the device of a modsuit module (eg foam mister) is the first thing to be deleted, it causes a del loop runtime. Chain is:
- device qdel, hasn't yet run destroy() which would normally move the device to nullspace
- signal runs on_device_deletion, destroys the module
- module destroy(), calls parent which deletes contents, including the still-deleting device

Fixed by moving device to nullspace in on_device_deletion
## Changelog
N/A
