### PR TITLE
Makes Toner Cartridges small

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -663,6 +663,7 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 	desc = "A small, lightweight cartridge of Nanotrasen ValueBrand toner. Fits photocopiers and autopainters alike."
 	icon = 'icons/obj/service/bureaucracy.dmi'
 	icon_state = "tonercartridge"
+	w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/iodine = 40, /datum/reagent/iron = 10)
 	var/charges = 5
 	var/max_charges = 5


### PR DESCRIPTION
## About The Pull Request

This pull request makes toner cartridges small-sized items. Normal, large, and extreme toner cartridges are the same size but we can assume it is futuristic printer companies pulling a pricing scheme rather than anything supernatural.

## Why It's Good For The Game

Fixes #89987

## Changelog

:cl:
fix: Toner cartridges are no longer larger than the airlock sprayer.
/:cl:
