### PR TITLE
Removes Access restrictions from Mail sorter

### DIFF
--- a/code/modules/vending/mail.dm
+++ b/code/modules/vending/mail.dm
@@ -14,7 +14,6 @@
 	density = TRUE
 	max_integrity = 300
 	integrity_failure = 0.33
-	req_access = list(ACCESS_CARGO)
 	circuit = /obj/item/circuitboard/machine/mailsorter
 
 	var/light_mask = "mailsorter-light-mask"
@@ -101,9 +100,6 @@
 	return is_type_in_list(weapon, accepted_items)
 
 /obj/machinery/mailsorter/interact(mob/user)
-	if (!allowed(user))
-		to_chat(user, span_warning("Access denied."))
-		return
 	if (currentstate != STATE_IDLE)
 		return
 	if (length(mail_list) == 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the cargo only access restrictions from the mail sorter.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There is no reason to implement access restrictions as stealing other people’s mail is useless outside of griefing which is against the rules, since there is no way to hack it you can’t set it up outside of cargo for people to take their mail from it.

and I don’t think anyone in cargo would be upset if someone took their own mail from the mail sorter.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Removed the access restrictions from mail sorter vending machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
