### PR TITLE
[NO GBP] Fix preferences layout for Byond 515

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -398,7 +398,7 @@ export function QuirksPage(props) {
   }
 
   return (
-    <Stack align="center" fill>
+    <Stack fill>
       <Stack.Item basis="50%">
         <Stack vertical fill align="center">
           <Stack.Item>
@@ -467,7 +467,7 @@ export function QuirksPage(props) {
         </Stack>
       </Stack.Item>
 
-      <Stack.Item>
+      <Stack.Item align="center">
         <Icon name="exchange-alt" size={1.5} ml={2} mr={2} />
       </Stack.Item>
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -69,9 +69,8 @@ function QuirkList(props: QuirkProps & QuirkListProps) {
   return (
     <Stack vertical>
       {quirks.map(([quirkKey, quirk]) => (
-        <Stack.Item m={0}>
+        <Stack.Item key={quirkKey} m={0}>
           <QuirkDisplay
-            key={quirkKey}
             onClick={onClick}
             quirk={quirk}
             quirkKey={quirkKey}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -67,20 +67,21 @@ function QuirkList(props: QuirkProps & QuirkListProps) {
   } = props;
 
   return (
-    // Stack is not used here for a variety of IE flex bugs
-    <Box className="PreferencesMenu__Quirks__QuirkList">
+    <Stack vertical>
       {quirks.map(([quirkKey, quirk]) => (
-        <QuirkDisplay
-          key={quirkKey}
-          onClick={onClick}
-          quirk={quirk}
-          quirkKey={quirkKey}
-          randomBodyEnabled={randomBodyEnabled}
-          selected={selected}
-          serverData={serverData}
-        />
+        <Stack.Item m={0}>
+          <QuirkDisplay
+            key={quirkKey}
+            onClick={onClick}
+            quirk={quirk}
+            quirkKey={quirkKey}
+            randomBodyEnabled={randomBodyEnabled}
+            selected={selected}
+            serverData={serverData}
+          />
+        </Stack.Item>
       ))}
-    </Box>
+    </Stack>
   );
 }
 
@@ -432,7 +433,7 @@ export function QuirksPage(props) {
               onInput={(text, value) => setSearchQuery(value)}
             />
           </Stack.Item>
-          <Stack.Item grow width="100%">
+          <Stack.Item grow className="PreferencesMenu__Quirks__QuirkList">
             <QuirkList
               selected={false}
               onClick={(quirkName, quirk) => {
@@ -492,8 +493,8 @@ export function QuirksPage(props) {
               Current Quirks
             </Box>
           </Stack.Item>
-          &nbsp; {/* Filler to better align the menu*/}
-          <Stack.Item grow width="100%">
+          <Stack.Item p={1.5} /> {/* Filler to better align the menu*/}
+          <Stack.Item grow className="PreferencesMenu__Quirks__QuirkList">
             <QuirkList
               selected
               onClick={(quirkName, quirk) => {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/index.tsx
@@ -165,7 +165,7 @@ export function CharacterPreferenceWindow(props) {
         </Stack>
       </Stack.Item>
       <Stack.Divider />
-      <Stack.Item grow position="relative" overflow="hidden auto">
+      <Stack.Item grow position="relative" overflowX="hidden" overflowY="auto">
         {pageContents}
       </Stack.Item>
     </Stack>

--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -201,8 +201,8 @@ $department_map: (
   &__Quirks {
     &__QuirkList {
       background-color: colors.$light-grey;
-      height: 100%;
-      min-height: 100%;
+      width: 100%;
+      overflow-x: hidden;
       overflow-y: scroll;
 
       &__quirk {

--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -201,7 +201,7 @@ $department_map: (
   &__Quirks {
     &__QuirkList {
       background-color: colors.$light-grey;
-      height: calc(90vh - 170px);
+      height: 100%;
       min-height: 100%;
       overflow-y: scroll;
 


### PR DESCRIPTION
## About The Pull Request
Fixes preferences layout in Byond 515 after fixing it for Byond 516

## Why It's Good For The Game
Support for what is soon to be dropped

![image](https://github.com/user-attachments/assets/8651aeb5-17f6-4a36-a3cf-f0676ee18592)


## Changelog

:cl:
fix: Fixed preferences layout for Byond 515 after fixing it for Byond 516
/:cl:
