### PR TITLE
Changing the description of the red stable slimecore effect

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -110,7 +110,7 @@ Stabilized extracts:
 
 /obj/item/slimecross/stabilized/red
 	colour = SLIME_TYPE_RED
-	effect_desc = "Nullifies all equipment based slowdowns."
+	effect_desc = "Nullifies all equipment based speed change."
 
 /obj/item/slimecross/stabilized/green
 	colour = SLIME_TYPE_GREEN


### PR DESCRIPTION
## About The Pull Request
changes the description of the stable red extract from "Nullifies all equipment based slowdowns." to "Nullifies all equipment based speed change." Because that's what it does.
## Why It's Good For The Game
The description of the effects in the game must match what their code does.
## Changelog
:cl:
spellcheck: changes the description of the stable red extract from "Nullifies all equipment based slowdowns." to "Nullifies all equipment based speed change."
/:cl:
