### PR TITLE
emagging a handheld flash will now turn it into a 1 use light EMP

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -239,7 +239,7 @@
 	. = TRUE
 
 	if(obj_flags & EMAGGED)
-		M.emp_act(2)
+		M.emp_act(EMP_LIGHT)
 		burn_out(src)
 
 	if(iscarbon(M))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -237,6 +237,11 @@
 		return FALSE
 
 	. = TRUE
+
+	if(obj_flags & EMAGGED)
+		M.emp_act(2)
+		burn_out(src)
+
 	if(iscarbon(M))
 		flash_carbon(M, user, confusion_duration = 5 SECONDS, targeted = TRUE)
 		return
@@ -303,6 +308,18 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 
 /obj/item/assembly/flash/handheld //this is now the regular pocket flashes
+
+///Emagging a handheld flash will turn it into a 1 use EMP
+/obj/item/assembly/flash/handheld/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		balloon_alert(user, "already emagged!")
+		return FALSE
+	if(burnt_out)
+		balloon_alert(user, "the flash too broken to supercharge")
+		return FALSE
+	balloon_alert(user, "sparks fly as the flash is supercharged")
+	obj_flags |= EMAGGED
+	return TRUE
 
 /obj/item/assembly/flash/armimplant
 	name = "photon projector"


### PR DESCRIPTION

## About The Pull Request
using an emag on a handheld flash will now turn it into a single use light EMP
## Why It's Good For The Game
More uses for an emag, offers a slight alternative for the EMP flashlight that's significantly worse (doesn't recharge, single use so it needs to be tossed after, though you could stock up on them at the cost of inventory space)
Dunks on silicons
## Changelog
:cl:
add: Emag functionality on a handheld flash assembly
balance: Emagging a handheld flash assembly turns it into a single use light EMP
/:cl:
