### PR TITLE
bloodless species now take damage from bone chiller (chilling green)

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -110,9 +110,13 @@ Slimecrossing Weapons
 		return FALSE
 	charge_timer = 0
 	var/mob/living/M = loc
-	if(istype(M) && M.blood_volume >= 20)
-		charges++
-		M.blood_volume -= 20
+	if(istype(M) && HAS_TRAIT(M, TRAIT_NOBLOOD) && M.stat == CONSCIOUS)
+		charges ++
+		M.apply_damage(10, BRUTE)
+	else
+		if(istype(M) && M.blood_volume >= 20)
+			charges++
+			M.blood_volume -= 20
 	if(charges == 1)
 		recharge_newshot()
 	return TRUE

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -112,7 +112,7 @@ Slimecrossing Weapons
 	var/mob/living/M = loc
 	if(istype(M) && HAS_TRAIT(M, TRAIT_NOBLOOD) && M.stat == CONSCIOUS)
 		charges ++
-		M.apply_damage(10, BRUTE)
+		M.apply_damage(5, BRUTE)
 	else
 		if(istype(M) && M.blood_volume >= 20)
 			charges++

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -255,6 +255,9 @@ Chilling extracts:
 	var/mob/living/L = user
 	if(!istype(user))
 		return
+	if(HAS_TRAIT(user, TRAIT_NOBLOOD))
+		to_chat(user, span_warning("You have no blood with which to use this weapon!"))
+		return
 	var/obj/item/held = L.get_active_held_item() //This should be itself, but just in case...
 	L.dropItemToGround(held)
 	var/obj/item/gun/magic/bloodchill/gun = new(user)

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -255,9 +255,6 @@ Chilling extracts:
 	var/mob/living/L = user
 	if(!istype(user))
 		return
-	if(HAS_TRAIT(user, TRAIT_NOBLOOD))
-		to_chat(user, span_warning("You have no blood with which to use this weapon!"))
-		return
 	var/obj/item/held = L.get_active_held_item() //This should be itself, but just in case...
 	L.dropItemToGround(held)
 	var/obj/item/gun/magic/bloodchill/gun = new(user)


### PR DESCRIPTION
## About The Pull Request
Bloodless species now take brute damage from using the bone chiller (chilling green)
## Why It's Good For The Game
they don't have blood, which makes the weapon infinite use for them (unintended afaik) fixes #90118
## Changelog
:cl:
fix: bloodless species no longer have a free bonechiller
/:cl:
