### PR TITLE
wild raptors no are no longer automatically hostile to other mining level fauna

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	attack_verb_continuous = "pecks"
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/items/weapons/punch1.ogg'
-	faction = list(FACTION_RAPTOR, FACTION_NEUTRAL)
+	faction = list(FACTION_RAPTOR, FACTION_NEUTRAL, FACTION_MINING)
 	speak_emote = list("screeches")
 	ai_controller = /datum/ai_controller/basic_controller/raptor
 	///can this mob breed


### PR DESCRIPTION

## About The Pull Request
gives raptors the mining faction so they won't attack lavaland fauna for ??

I did some testing in local host and it seems to work just fine, though I'm not very familiar with how factions and basic mob AI handle things, deleting the faction in VV didn't seem to make it start targetting fauna, but without the faction in the code spawning a raptor near the tendril would have it start attacking everything, and with the faction it wasn't so - correct me if I did this incorrectly but I believe its fixed :)
## Why It's Good For The Game
closes #89975
## Changelog
:cl:
fix: wild raptors no longer attack lavaland fauna for no reason
/:cl:
