### PR TITLE
Fix an edge-case that could result in heretic mark effects not being removed

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -31,6 +31,10 @@
 	owner.update_icon(UPDATE_OVERLAYS)
 	return ..()
 
+// We WANT to call on_remove when replaced, else effects might not be cleaned up in the case where a mark is applied while a different mark is active.
+/datum/status_effect/eldritch/be_replaced()
+	qdel(src)
+
 /**
  * Signal proc for [COMSIG_ATOM_UPDATE_OVERLAYS].
  *


### PR DESCRIPTION
## About The Pull Request

So, last night, I discovered an interesting edge-case after being attacked by two heretics: if you have a mark applied, then a heretic on a different path also applies a mark, the second mark will replace the first _without the effects from said mark being cleaned up_. This could lead to, for example, permanent pacifism if the first mark was the moon path mark.

This makes it so heretic mark status effects are _properly_ removed before being replaced.

## Why It's Good For The Game

bugged permanent pacifism sucks

## Changelog
:cl:
fix: Fixed an edge-case where, if two heretics of different paths applied a mark to the same person, the effects from the first mark (i.e moon path's pacifism) would likely be permanent.
/:cl:
