### PR TITLE
If you are upside down, you ignore elevation

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -192,9 +192,10 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PHASING (1<<4)
 /// The mob is walking on the ceiling. Or is generally just, upside down.
 #define UPSIDE_DOWN (1<<5)
-
 /// Combination flag for movetypes which, for all intents and purposes, mean the mob is not touching the ground
 #define MOVETYPES_NOT_TOUCHING_GROUND (FLYING|FLOATING|UPSIDE_DOWN)
+/// Trait source for stuff movetypes applies
+#define SOURCE_MOVETYPES "movetypes"
 
 //Fire and Acid stuff, for resistance_flags
 #define LAVA_PROOF (1<<0)

--- a/code/datums/elements/movetype_handler.dm
+++ b/code/datums/elements/movetype_handler.dm
@@ -49,6 +49,8 @@
 	source.movement_type |= flag
 	if(!(old_state & (FLOATING|FLYING)) && (source.movement_type & (FLOATING|FLYING)) && !HAS_TRAIT(source, TRAIT_NO_FLOATING_ANIM))
 		DO_FLOATING_ANIM(source)
+	if(source.movement_type & UPSIDE_DOWN)
+		ADD_TRAIT(source, TRAIT_IGNORE_ELEVATION, SOURCE_MOVETYPES)
 	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_ENABLED, flag, old_state)
 
 /// Called when a movement type trait is removed from the movable. Disables the relative bitflag if it wasn't there in the compile-time bitfield.
@@ -64,6 +66,8 @@
 		var/turf/pitfall = source.loc //Things that don't fly fall in open space.
 		if(istype(pitfall))
 			pitfall.zFall(source)
+	if((old_state & UPSIDE_DOWN) && !(source.movement_type & UPSIDE_DOWN))
+		REMOVE_TRAIT(source, TRAIT_IGNORE_ELEVATION, SOURCE_MOVETYPES)
 	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_DISABLED, flag, old_state)
 
 /// Called when the TRAIT_NO_FLOATING_ANIM trait is added to the movable. Stops it from bobbing up and down.


### PR DESCRIPTION
## About The Pull Request

If you have the `UPSIDE_DOWN` movetype, you ignore elevation changes. Cuz yknow, you're on the roof.

## Changelog

:cl: Melbert
fix: Being atrocinated ignores elevation from tables and such
/:cl:

