### PR TITLE
Slightly refactors the Cortex Imprint bioware

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -84,8 +84,10 @@
 #define COMSIG_CARBON_GAIN_ADDICTION "carbon_gain_addiction"
 ///Called when a carbon is no longer addicted (source = what addiction datum was lost, addicted_mind = mind of the freed carbon)
 #define COMSIG_CARBON_LOSE_ADDICTION "carbon_lose_addiction"
-///Called when a carbon gets a brain trauma (source = carbon, trauma = what trauma was added) - this is before on_gain()
+///Called when a carbon gets a brain trauma (source = carbon, trauma = what trauma was added, resilience = the resilience of the trauma given, if set differently from the default) - this is before on_gain()
 #define COMSIG_CARBON_GAIN_TRAUMA "carbon_gain_trauma"
+	/// Return if you want to prevent the carbon from gaining the brain trauma.
+	#define COMSIG_CARBON_BLOCK_TRAUMA (1 << 0)
 ///Called when a carbon loses a brain trauma (source = carbon, trauma = what trauma was removed)
 #define COMSIG_CARBON_LOSE_TRAUMA "carbon_lose_trauma"
 ///Called when a carbon's health hud is updated. (source = carbon, shown_health_amount)

--- a/code/datums/status_effects/buffs/bioware/cortex.dm
+++ b/code/datums/status_effects/buffs/bioware/cortex.dm
@@ -15,11 +15,9 @@
 /datum/status_effect/bioware/cortex/imprinted
 
 /datum/status_effect/bioware/cortex/imprinted/bioware_gained()
-	if(!iscarbon(owner))
-		return
-	var/mob/living/carbon/carbon_owner = owner
-	carbon_owner.cure_all_traumas(resilience = TRAUMA_RESILIENCE_BASIC)
-	RegisterSignal(carbon_owner, COMSIG_CARBON_GAIN_TRAUMA, PROC_REF(on_gain_trauma))
+	var/mob/living/carbon/human/human_owner = owner
+	human_owner.cure_all_traumas(resilience = TRAUMA_RESILIENCE_BASIC)
+	RegisterSignal(human_owner, COMSIG_CARBON_GAIN_TRAUMA, PROC_REF(on_gain_trauma))
 
 /datum/status_effect/bioware/cortex/imprinted/bioware_lost()
 	UnregisterSignal(owner, COMSIG_CARBON_GAIN_TRAUMA)

--- a/code/datums/status_effects/buffs/bioware/cortex.dm
+++ b/code/datums/status_effects/buffs/bioware/cortex.dm
@@ -13,8 +13,20 @@
 
 // Imprinted brain - Cures basic traumas continuously
 /datum/status_effect/bioware/cortex/imprinted
-	tick_interval = 2 SECONDS
 
-/datum/status_effect/bioware/cortex/imprinted/tick(seconds_between_ticks)
-	var/mob/living/carbon/human/human_owner = owner
-	human_owner.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
+/datum/status_effect/bioware/cortex/imprinted/bioware_gained()
+	if(!iscarbon(owner))
+		return
+	var/mob/living/carbon/carbon_owner = owner
+	carbon_owner.cure_all_traumas(resilience = TRAUMA_RESILIENCE_BASIC)
+	RegisterSignal(carbon_owner, COMSIG_CARBON_GAIN_TRAUMA, PROC_REF(on_gain_trauma))
+
+/datum/status_effect/bioware/cortex/imprinted/bioware_lost()
+	UnregisterSignal(owner, COMSIG_CARBON_GAIN_TRAUMA)
+
+/datum/status_effect/bioware/cortex/imprinted/proc/on_gain_trauma(datum/source, datum/brain_trauma/trauma, resilience)
+	SIGNAL_HANDLER
+	if(isnull(resilience))
+		resilience = trauma.resilience
+	if(resilience <= TRAUMA_RESILIENCE_BASIC) // there SHOULD be nothing lower than TRAUMA_RESILIENCE_BASIC, but I'd prefer to not make assumptions in case this ever gets some sort of refactor
+		return COMSIG_CARBON_BLOCK_TRAUMA

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -575,7 +575,9 @@
 	add_trauma_to_traumas(actual_trauma)
 	if(owner)
 		actual_trauma.owner = owner
-		SEND_SIGNAL(owner, COMSIG_CARBON_GAIN_TRAUMA, trauma)
+		if(SEND_SIGNAL(owner, COMSIG_CARBON_GAIN_TRAUMA, trauma, resilience) & COMSIG_CARBON_BLOCK_TRAUMA)
+			qdel(actual_trauma)
+			return FALSE
 		actual_trauma.on_gain()
 		log_game("[key_name_and_tag(owner)] has gained the following brain trauma: [trauma.type]")
 	if(resilience)


### PR DESCRIPTION

## About The Pull Request

I slightly refactored the Cortex Imprint bioware - instead of ticking every 2 seconds, it now just registers `COMSIG_CARBON_GAIN_TRAUMA`, and blocks any basic resilience trauma from even being added - in addition to curing all basic resilience traumas upon being gained.

I also added a `COMSIG_CARBON_BLOCK_TRAUMA` value, which is exactly what it says on the tin, and also pass the resilience arg to `COMSIG_CARBON_GAIN_TRAUMA`.

## Why It's Good For The Game

this doesn't need to tick i dont think, so, like, why not just use a signal?

## Changelog
:cl:
code: Slightly improved the code for the Cortex Imprint bioware.
/:cl:
