### PR TITLE
Cleans up crafting code, fixes multiple bugs

### DIFF
--- a/code/datums/components/crafting/_recipes.dm
+++ b/code/datums/components/crafting/_recipes.dm
@@ -98,13 +98,6 @@
 /datum/crafting_recipe/proc/on_craft_completion(mob/user, atom/result)
 	return
 
-///Check if the pipe used for atmospheric device crafting is the proper one
-/datum/crafting_recipe/proc/atmos_pipe_check(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	return FALSE
-
 /// Additional UI data to be passed to the crafting UI for this recipe
 /datum/crafting_recipe/proc/crafting_ui_data()
 	return list()

--- a/code/datums/components/crafting/atmospheric.dm
+++ b/code/datums/components/crafting/atmospheric.dm
@@ -37,13 +37,17 @@
 		/obj/item/stack/sheet/iron = 1,
 		)
 	blacklist = list(/obj/item/analyzer/ranged)
+	category = CAT_ATMOSPHERIC
 
 ///abstract path for pipe crafting recipes that set the pipe_type of their results and have other checks as well
 /datum/crafting_recipe/spec_pipe
 	var/pipe_type
 
 /datum/crafting_recipe/spec_pipe/check_requirements(mob/user, list/collected_requirements)
-	return atmos_pipe_check(user, collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	return FALSE
 
 /datum/crafting_recipe/spec_pipe/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
@@ -236,17 +240,6 @@
 		/obj/item/stock_parts/water_recycler = 1,
 	)
 	category = CAT_ATMOSPHERIC
-
-/datum/crafting_recipe/elder_atmosian_statue
-	name = "Elder Atmosian Statue"
-	result = /obj/structure/statue/elder_atmosian
-	time = 6 SECONDS
-	reqs = list(
-		/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
-		/obj/item/stack/sheet/mineral/zaukerite = 15,
-		/obj/item/stack/sheet/iron = 30,
-	)
-	category = CAT_STRUCTURE
 
 /datum/crafting_recipe/spec_pipe/airlock_pump
 	name = "External Airlock Pump"

--- a/code/datums/components/crafting/entertainment.dm
+++ b/code/datums/components/crafting/entertainment.dm
@@ -248,7 +248,7 @@
 		/obj/item/clothing/gloves/latex = 1,
 		/obj/item/stack/cable_coil = 2,
 	)
-	category = CAT_EQUIPMENT
+	category = CAT_ENTERTAINMENT
 
 /datum/crafting_recipe/violin
 	name = "Violin"

--- a/code/datums/components/crafting/melee_weapon.dm
+++ b/code/datums/components/crafting/melee_weapon.dm
@@ -55,9 +55,7 @@
 	category = CAT_WEAPON_MELEE
 
 /datum/crafting_recipe/balloon_mallet/check_requirements(mob/user, list/collected_requirements)
-	. = ..()
-	if(HAS_TRAIT(user, TRAIT_BALLOON_SUTRA))
-		return TRUE
+	return HAS_TRAIT(user, TRAIT_BALLOON_SUTRA)
 
 /datum/crafting_recipe/tailwhip
 	name = "Liz O' Nine Tails"

--- a/code/datums/components/crafting/structures.dm
+++ b/code/datums/components/crafting/structures.dm
@@ -94,3 +94,14 @@
 	)
 	time = 120 SECONDS
 	category = CAT_STRUCTURE
+
+/datum/crafting_recipe/elder_atmosian_statue
+	name = "Elder Atmosian Statue"
+	result = /obj/structure/statue/elder_atmosian
+	time = 6 SECONDS
+	reqs = list(
+		/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
+		/obj/item/stack/sheet/mineral/zaukerite = 15,
+		/obj/item/stack/sheet/iron = 30,
+	)
+	category = CAT_STRUCTURE

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -580,9 +580,7 @@
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/balloon_helmet/check_requirements(mob/user, list/collected_requirements)
-	. = ..()
-	if(HAS_TRAIT(user, TRAIT_BALLOON_SUTRA))
-		return TRUE
+	return HAS_TRAIT(user, TRAIT_BALLOON_SUTRA)
 
 /datum/crafting_recipe/balloon_tophat
 	result = /obj/item/clothing/head/hats/tophat/balloon
@@ -593,9 +591,7 @@
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/balloon_tophat/check_requirements(mob/user, list/collected_requirements)
-	. = ..()
-	if(HAS_TRAIT(user, TRAIT_BALLOON_SUTRA))
-		return TRUE
+	return HAS_TRAIT(user, TRAIT_BALLOON_SUTRA)
 
 /datum/crafting_recipe/balloon_vest
 	result = /obj/item/clothing/suit/armor/balloon_vest
@@ -606,9 +602,7 @@
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/balloon_vest/check_requirements(mob/user, list/collected_requirements)
-	. = ..()
-	if(HAS_TRAIT(user, TRAIT_BALLOON_SUTRA))
-		return TRUE
+	return HAS_TRAIT(user, TRAIT_BALLOON_SUTRA)
 
 /datum/crafting_recipe/press_armor
 	name = "press armor vest"

--- a/code/datums/elements/slapcrafting.dm
+++ b/code/datums/elements/slapcrafting.dm
@@ -108,8 +108,8 @@
 
 	var/error_string = craft_sheet.construct_item(user, actual_recipe)
 
-	if(!isatom(error_string))
-		to_chat(user, span_warning("crafting failed" + error_string))
+	if(istext(error_string))
+		to_chat(user, span_warning("Crafting failed[error_string]"))
 
 /// Alerts any examiners to the recipe, if they wish to know more.
 /datum/element/slapcrafting/proc/get_examine_info(atom/source, mob/user, list/examine_list)

--- a/code/modules/manufactorio/machines/crafter.dm
+++ b/code/modules/manufactorio/machines/crafter.dm
@@ -104,7 +104,7 @@
 	var/list/prediff = get_overfloor_objects()
 	var/result = craftsman.construct_item(src, recipe)
 	if(istext(result))
-		say("Crafting failed,[result]")
+		say("Crafting failed[result]")
 		return
 	var/list/diff = get_overfloor_objects() - prediff
 	for(var/atom/movable/diff_result as anything in diff)


### PR DESCRIPTION

## About The Pull Request
Cleaned up an unnecessary proc on base crafting datum, fixed balloon sutra-exclusive items being craftable by anyone, air sensors being only craftable via search, crafters adding a second comma when failing to craft something and missing capitalization in slapcrafting errors.

## Changelog
:cl:
fix: You can no longer craft balloon armor and weapons without knowing Balloon Sutra
fix: Air sensors now show up in atmospherics category
spellcheck: Fixed grammar/capitalization in crafter/slapcrafting error messages
code: Cleaned up some crafting code
/:cl:
