### PR TITLE
Smartfridge/Vending machine layouts auto-update rather than be a setting

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -80,8 +80,6 @@
 #define DEFAULT_CYBORG_NAME "Default Cyborg Name"
 
 // Choose grid or list TGUI layouts for UI's, when possible.
-/// Default layout will be used. It can be either a grid or a list
-#define TGUI_LAYOUT_DEFAULT "default"
 /// Force grid layout, even if default is a list.
 #define TGUI_LAYOUT_GRID "grid"
 /// Force list layout, even if default is a grid.

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -79,6 +79,8 @@
 #ifdef DATUMVAR_DEBUGGING_MODE
 	var/list/cached_vars
 #endif
+	///The layout pref we take from the player looking at this datum's UI to know what layout to give.
+	var/datum/preference/choiced/layout_prefs_used = /datum/preference/choiced/tgui_layout
 
 /**
  * Called when a href for this datum is clicked

--- a/code/modules/client/preferences/tgui.dm
+++ b/code/modules/client/preferences/tgui.dm
@@ -39,24 +39,28 @@
 
 /// Changes layout in some UI's, like Vending, Smartfridge etc. Making it list or grid
 /datum/preference/choiced/tgui_layout
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "tgui_layout"
 	savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/choiced/tgui_layout/init_possible_values()
 	return list(
-		TGUI_LAYOUT_DEFAULT,
 		TGUI_LAYOUT_GRID,
 		TGUI_LAYOUT_LIST,
 	)
 
 /datum/preference/choiced/tgui_layout/create_default_value()
-	return TGUI_LAYOUT_DEFAULT
+	return TGUI_LAYOUT_LIST
 
 /datum/preference/choiced/tgui_layout/apply_to_client(client/client, value)
 	for (var/datum/tgui/tgui as anything in client.mob?.tgui_open_uis)
 		// Force it to reload either way
 		tgui.update_static_data(client.mob)
+
+/datum/preference/choiced/tgui_layout/smartfridge
+	savefile_key = "tgui_layout_smartfridge"
+
+/datum/preference/choiced/tgui_layout/create_default_value()
+	return TGUI_LAYOUT_GRID
 
 /datum/preference/toggle/tgui_lock
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -32,8 +32,7 @@
 	var/welded_down = FALSE
 	/// The sound of item retrieval
 	var/vend_sound = 'sound/machines/machine_vend.ogg'
-	/// Whether the UI should be set to list view by default
-	var/default_list_view = FALSE
+	layout_prefs_used = /datum/preference/choiced/tgui_layout/smartfridge
 
 /obj/machinery/smartfridge/Initialize(mapload)
 	. = ..()
@@ -385,7 +384,6 @@
 	.["contents"] = sort_list(listofitems)
 	.["name"] = name
 	.["isdryer"] = FALSE
-	.["default_list_view"] = default_list_view
 
 /obj/machinery/smartfridge/Exited(atom/movable/gone, direction) // Update the UIs in case something inside is removed
 	. = ..()
@@ -729,7 +727,6 @@
 	desc = "A refrigerated storage unit for medicine storage."
 	base_build_path = /obj/machinery/smartfridge/chemistry
 	contents_overlay_icon = "chem"
-	default_list_view = TRUE
 
 /obj/machinery/smartfridge/chemistry/accept_check(obj/item/weapon)
 	// not an item or reagent container
@@ -780,7 +777,6 @@
 	desc = "A refrigerated storage unit for volatile sample storage."
 	base_build_path = /obj/machinery/smartfridge/chemistry/virology
 	contents_overlay_icon = "viro"
-	default_list_view = TRUE
 
 /obj/machinery/smartfridge/chemistry/virology/preloaded
 	initial_contents = list(

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -90,6 +90,10 @@
 	// If UI is not interactive or usr calling Topic is not the UI user, bail.
 	if(!ui || ui.status != UI_INTERACTIVE)
 		return TRUE
+	if(action == "change_ui_state")
+		var/mob/living/user = ui.user
+		//write_preferences will make sure it's valid for href exploits.
+		user.client.prefs.write_preference(GLOB.preference_entries[layout_prefs_used], params["new_state"])
 
 /**
  * public

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -248,7 +248,7 @@
 		"status" = status,
 		"interface" = list(
 			"name" = interface,
-			"layout" = user.client.prefs.read_preference(/datum/preference/choiced/tgui_layout),
+			"layout" = user.client.prefs.read_preference(src_object.layout_prefs_used),
 		),
 		"refreshing" = refreshing,
 		"window" = list(

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/tgui.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/tgui.tsx
@@ -1,5 +1,4 @@
-import { CheckboxInput, Feature, FeatureToggle } from '../base';
-import { FeatureDropdownInput } from '../dropdowns';
+import { CheckboxInput, FeatureToggle } from '../base';
 
 export const tgui_fancy: FeatureToggle = {
   name: 'Enable fancy TGUI',
@@ -27,14 +26,6 @@ export const tgui_input_swapped: FeatureToggle = {
   category: 'UI',
   description: 'Makes TGUI buttons less traditional, more functional.',
   component: CheckboxInput,
-};
-
-export const tgui_layout: Feature<string> = {
-  name: 'Default TGUI Layout',
-  category: 'UI',
-  description:
-    'Applies the selected layout type to all interfaces where it possible. Like on Smartfridge.',
-  component: FeatureDropdownInput,
 };
 
 export const tgui_lock: FeatureToggle = {

--- a/tgui/packages/tgui/interfaces/SmartVend.tsx
+++ b/tgui/packages/tgui/interfaces/SmartVend.tsx
@@ -28,19 +28,12 @@ type Data = {
   name: string;
   isdryer: BooleanLike;
   drying: BooleanLike;
-  default_list_view: BooleanLike;
 };
 
 export const SmartVend = (props) => {
   const { act, data } = useBackend<Data>();
   const [searchText, setSearchText] = useState('');
-  const [displayMode, setDisplayMode] = useState(
-    getLayoutState() === LAYOUT.Default
-      ? data.default_list_view
-        ? LAYOUT.List
-        : LAYOUT.Grid
-      : getLayoutState(),
-  );
+  const [displayMode, setDisplayMode] = useState(getLayoutState());
   const search = createSearch(searchText, (item: Item) => item.name);
   const contents =
     searchText.length > 0

--- a/tgui/packages/tgui/interfaces/common/LayoutToggle.tsx
+++ b/tgui/packages/tgui/interfaces/common/LayoutToggle.tsx
@@ -10,16 +10,12 @@ type Props = {
 };
 
 export enum LAYOUT {
-  Default = 'default',
   Grid = 'grid',
   List = 'list',
 }
 
 export function getLayoutState(defaultState?: LAYOUT) {
   const { config } = useBackend();
-  if (config.interface.layout === LAYOUT.Default) {
-    return defaultState || LAYOUT.Default;
-  }
   return config.interface.layout;
 }
 
@@ -29,22 +25,24 @@ export function getLayoutState(defaultState?: LAYOUT) {
  */
 export function LayoutToggle(props: Props) {
   const { setState, state } = props;
+  const { act } = useBackend();
 
   const handleClick = () => {
     const newState = state === LAYOUT.Grid ? LAYOUT.List : LAYOUT.Grid;
     setState(newState);
+    act('change_ui_state', {
+      new_state: newState,
+    });
   };
 
-  if (getLayoutState() === LAYOUT.Default) {
-    return (
-      <Stack.Item>
-        <Button
-          icon={state === LAYOUT.Grid ? 'list' : 'border-all'}
-          tooltip={state === LAYOUT.Grid ? 'View as List' : 'View as Grid'}
-          tooltipPosition={'bottom-end'}
-          onClick={handleClick}
-        />
-      </Stack.Item>
-    );
-  }
+  return (
+    <Stack.Item>
+      <Button
+        icon={state === LAYOUT.Grid ? 'list' : 'border-all'}
+        tooltip={state === LAYOUT.Grid ? 'View as List' : 'View as Grid'}
+        tooltipPosition={'bottom-end'}
+        onClick={handleClick}
+      />
+    </Stack.Item>
+  );
 }


### PR DESCRIPTION
## About The Pull Request

Sorry for my incompetence with TGUI.

This comes from a comment I made here https://github.com/tgstation/tgstation/pull/89137#issuecomment-2601185587 & https://github.com/tgstation/tgstation/pull/89160#pullrequestreview-2566047191

Instead of having to go to your game settings, find the option of layout style you want your vending/fridge machines to be, and change it without having a UI to show you the difference, now the preference is tied to the in-game UI; Clicking to swap to the other layout mode will automatically update your prefs and stay until you change it again.

I also separated smartfridges and vending machines as 2 separate prefs so players can have grid on one and list on the other.

I couldn't figure out a way to implement this without adding a new var on base ``/datum``, if you got other possible solutions I'd be happy to try. I thought of making 'layouts' limited to smartfridge/vending machines, taking it out of backend for all UIs, but thought I should avoid that if possible in case future UIs want to make use of it. If it's better than a var on datum I'm fine taking that path instead.

https://github.com/user-attachments/assets/921586fa-1ec1-49c0-87ca-ec4bbb6aaa98

## Why It's Good For The Game

The settings list having these small options that you can't even see the effects of until you find the machine in-game is a little lame, now players don't even have to think about it, they simply set it to the mode they want as they use the machine and it'll update itself for the player.

Currently using the button to swap to list/grid mode instantly reverts itself as soon as you close the UI, which is a little lame.

## Changelog

:cl:
qol: Smartfridges and Vending machines no longer have a setting to change the list/grid mode, it instead updates automatically as you swap the mode in-game.
/:cl: