### PR TITLE
Mappers can disable bookshelf randomization, Non-adult shelves can no longer random into adult books

### DIFF
--- a/code/__DEFINES/library.dm
+++ b/code/__DEFINES/library.dm
@@ -7,3 +7,10 @@
 #define CHECKOUTS_PER_PAGE 17
 ///How many inventory items should we load per page?
 #define INVENTORY_PER_PAGE 19
+
+#define BOOK_CATEGORY_FICTION "Fiction"
+#define BOOK_CATEGORY_NONFICTION "Non-fiction"
+#define BOOK_CATEGORY_RELIGION "Religion"
+#define BOOK_CATEGORY_ADULT "Adult"
+#define BOOK_CATEGORY_REFERENCE "Reference"
+#define BOOK_CATEGORY_RANDOM "Random"

--- a/code/__DEFINES/library.dm
+++ b/code/__DEFINES/library.dm
@@ -8,9 +8,11 @@
 ///How many inventory items should we load per page?
 #define INVENTORY_PER_PAGE 19
 
+// Book categories, used in SQL so don't change randomly
 #define BOOK_CATEGORY_FICTION "Fiction"
 #define BOOK_CATEGORY_NONFICTION "Non-fiction"
 #define BOOK_CATEGORY_RELIGION "Religion"
 #define BOOK_CATEGORY_ADULT "Adult"
 #define BOOK_CATEGORY_REFERENCE "Reference"
+/// If making a book of this category it will be randomly selected from all categories
 #define BOOK_CATEGORY_RANDOM "Random"

--- a/code/modules/library/bookcase.dm
+++ b/code/modules/library/bookcase.dm
@@ -74,7 +74,7 @@
 				create_random_books(amount = cat_amount, location = src, category = pick_n_take(category_pool))
 		// Otherwise we can just let the proc handle everything, it will even do randomization for us
 		else
-			create_random_books(amount = books_to_load, location = src, category = random_category)
+			create_random_books(amount = books_to_load, location = src, category = randomizing_categories ? BOOK_CATEGORY_RANDOM : random_category)
 
 		after_random_load()
 		update_appearance() //Make sure you look proper

--- a/code/modules/library/bookcase.dm
+++ b/code/modules/library/bookcase.dm
@@ -17,7 +17,9 @@
 	/// When enabled, books_to_load number of random books will be generated for this bookcase
 	var/load_random_books = FALSE
 	/// The category of books to pick from when populating random books.
-	var/random_category = null
+	var/random_category = BOOK_CATEGORY_RANDOM
+	/// Probability that a category will be changed to random regardless of what it was set to.
+	var/category_prob = 25
 	/// How many random books to generate.
 	var/books_to_load = 0
 
@@ -51,7 +53,10 @@
 	//Loads a random selection of books in from the db, adds a copy of their info to a global list
 	//To send to library consoles as a starting inventory
 	if(load_random_books)
-		create_random_books(books_to_load, src, FALSE, random_category)
+		// When randomizing category we manually pick a new category
+		// This is done so we can exclude the adult category from randomizing on any bookcase that isn't already marked as adult
+		var/loaded_category = prob(category_prob) ? pick(BOOK_CATEGORY_FICTION, BOOK_CATEGORY_NONFICTION, BOOK_CATEGORY_RELIGION, BOOK_CATEGORY_REFERENCE, random_category) : random_category
+		create_random_books(amount = books_to_load, location = src, category = loaded_category)
 		after_random_load()
 		update_appearance() //Make sure you look proper
 

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -44,7 +44,8 @@
  * * amount: How many books to create.
  * * location: Where to create the books.
  * * fail_loud: If TRUE, will create a book with an error message if the database fails.
- * * category: The category of books to pick from. If null or BOOK_CATEGORY_RANDOM, will pick from any category.
+ * * category: The category of books to pick from.
+ * If null or BOOK_CATEGORY_RANDOM, will pick from any category on a per-book basis.
  * * existing_book: If set, will use this book object instead of creating a new one.
  * Note passing any amount above 1 with an existing_book will still only create one book.
  */

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -11,7 +11,7 @@
 /obj/item/book/random
 	icon_state = "random_book"
 	/// The category of books to pick from when creating this book.
-	var/random_category = null
+	var/random_category = BOOK_CATEGORY_RANDOM
 	/// If this book has already been 'generated' yet.
 	var/random_loaded = FALSE
 
@@ -21,7 +21,9 @@
 
 /obj/item/book/random/attack_self()
 	if(!random_loaded)
-		create_random_books(1, loc, TRUE, random_category, src)
+		// Adult books are excluded unless explicitly set
+		var/loaded_category = random_category == BOOK_CATEGORY_RANDOM ? pick(BOOK_CATEGORY_FICTION, BOOK_CATEGORY_NONFICTION, BOOK_CATEGORY_RELIGION, BOOK_CATEGORY_REFERENCE) : random_category
+		create_random_books(amount = 1, location = loc, fail_loud = TRUE,  category = loaded_category, existing_book = src)
 		random_loaded = TRUE
 	return ..()
 
@@ -36,7 +38,17 @@
 		books_to_load += pick(-1,-1,0,1,1)
 	update_appearance()
 
-/proc/create_random_books(amount, location, fail_loud = FALSE, category = null, obj/item/book/existing_book)
+/**
+ * Create a random book or books.
+ *
+ * * amount: How many books to create.
+ * * location: Where to create the books.
+ * * fail_loud: If TRUE, will create a book with an error message if the database fails.
+ * * category: The category of books to pick from. If null or BOOK_CATEGORY_RANDOM, will pick from any category.
+ * * existing_book: If set, will use this book object instead of creating a new one.
+ * Note passing any amount above 1 with an existing_book will still only create one book.
+ */
+/proc/create_random_books(amount = 1, atom/location, fail_loud = FALSE, category = BOOK_CATEGORY_RANDOM, obj/item/book/existing_book)
 	. = list()
 	if(!isnum(amount) || amount<1)
 		return
@@ -45,7 +57,7 @@
 			var/error_text = "There once was a book from Nantucket<br>But the database failed us, so f*$! it.<br>I tried to be good to you<br>Now this is an I.O.U<br>If you're feeling entitled, well, stuff it!<br><br><font color='gray'>~</font>"
 			existing_book.book_data = new("Strange Book", "???", error_text)
 		return
-	if(prob(25))
+	if(category == BOOK_CATEGORY_RANDOM)
 		category = null
 	var/datum/db_query/query_get_random_books = SSdbcore.NewQuery({"
 		SELECT title, author, content
@@ -70,7 +82,7 @@
 
 /obj/structure/bookcase/random/fiction
 	name = "bookcase (Fiction)"
-	random_category = "Fiction"
+	random_category = BOOK_CATEGORY_FICTION
 	///have we spawned the chuuni granter
 	var/static/chuuni_book_spawned = FALSE
 
@@ -81,19 +93,19 @@
 
 /obj/structure/bookcase/random/nonfiction
 	name = "bookcase (Non-Fiction)"
-	random_category = "Non-fiction"
+	random_category = BOOK_CATEGORY_NONFICTION
 
 /obj/structure/bookcase/random/religion
 	name = "bookcase (Religion)"
-	random_category = "Religion"
+	random_category = BOOK_CATEGORY_RELIGION
 
 /obj/structure/bookcase/random/adult
 	name = "bookcase (Adult)"
-	random_category = "Adult"
+	random_category = BOOK_CATEGORY_ADULT
 
 /obj/structure/bookcase/random/reference
 	name = "bookcase (Reference)"
-	random_category = "Reference"
+	random_category = BOOK_CATEGORY_REFERENCE
 	///Chance to spawn a random manual book
 	var/ref_book_prob = 20
 


### PR DESCRIPTION
## About The Pull Request

1. Mappers can disable bookshelf randomization


2. Bookshelves which are not explicitly marked as "adult bookshelves" can no longer randomly load "adult" books


3. Random books can no longer random into "adult" books

## Why It's Good For The Game

1. If a mapper is placing a bookshelf with the express attention only x type books will be in that bookshelf, they can guarantee that by changing `category_prob`. 

2. If the intention behind bookshelves are that "you have to go out of your way to find the adult category to read an adult book", we probably shouldn't add flat 25% chance for all bookshelves to be unmarked adult bookshelves?

3. Similar logic - if you get a random book in the mail and crack it open and it's an adult book, you can't really say you were "asking" for it

## Changelog

:cl: Melbert
qol: Mappers can now disable bookshelf randomization
qol: Random books found via mail or in maint will no longer random into books from the "adult" section
qol: Bookshelf randomization will now exclude adult books unless marked as adult
/:cl:

