### PR TITLE
Modifies Space Crawl Criteria

### DIFF
--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -7,7 +7,7 @@
  */
 /datum/action/cooldown/spell/jaunt/space_crawl
 	name = "Space Phase"
-	desc = "Allows you to phase in and out of existence while in space or misc tiles."
+	desc = "Allows you to phase in and out of existence while in space or a low-pressure, outdoor area."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 
@@ -33,10 +33,14 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(isspaceturf(get_turf(owner)) || ismiscturf(get_turf(owner)))
+	var/turf/my_turf = get_turf(owner)
+	if(isspaceturf(my_turf))
+		return TRUE
+	var/area/my_area = get_area(owner)
+	if (isopenturf(my_turf) && my_area.outdoors && lavaland_equipment_pressure_check(my_turf))
 		return TRUE
 	if(feedback)
-		to_chat(owner, span_warning("You must stand on a space or misc turf!"))
+		to_chat(owner, span_warning("You must stand in space, or an outdoor area with low pressure!"))
 	return FALSE
 
 /datum/action/cooldown/spell/jaunt/space_crawl/cast(mob/living/cast_on)


### PR DESCRIPTION
## About The Pull Request

Closes #90163
Space Crawl previously decided if you were in space by identifying your location as either a space turf or a "misc" turf, an arbitrary typepath that coincidentally is often but not exclusively used for turfs that are outside.   
This is only coincidentally accurate and fails, for instance, in the tram underpass specifically if you are stood on the sandy asteroid tiles but _not_ if you are stood on the grass tiles, which is a pretty weird inconsistency. It really shouldn't work there at all. Additionally, there are often _non_-misc turfs outside too, meaning that you can space crawl on exterior asteroid tiles but not exterior plating tiles for some reason.   

_Now_ it will function under the following criteria:
- You're on a space tile.
- You're in an outdoor area with low pressure, 

This preserves the existing behaviour where this ability functions on icebox and lavaland, but closes the weird outliers both in and outside.  
Unfortunately as the tram underpass is classified as outside for some reason (it shares the area as exterior asteroid) then venting it will let you spacecrawl there... but then again, if it's vented then arguably it is in fact in space?

This would be easier if this ability was just dogshit on Icebox so I could also check if there is gravity but unfortunately players probably wouldn't like that.

## Why It's Good For The Game

Hopefully makes the ability work in a more consistently understandable way.

## Changelog

:cl:
balance: Space Crawl now functions if you are on a space tile, or if you are in an outdoor area with low air pressure.
/:cl:
