### PR TITLE
fix inverted autolathe check

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -446,7 +446,7 @@
 		span_hear("You hear the chatter of a floppy drive."))
 	busy = TRUE
 
-	if(do_after(user, 1.5 SECONDS, target = src))
+	if(!do_after(user, 1.5 SECONDS, target = src))
 		busy = FALSE
 		update_static_data_for_all_viewers()
 		balloon_alert(user, "interrupted!")


### PR DESCRIPTION
## About The Pull Request

Inserting disks into the autolathe would only work if you interrupted the do_after, because the check was inverted.
Now it isn't.

## Changelog

:cl:
fix: Disks will now be inserted into the autolathe if you successfully insert them, rather than if you do not succeed in inserting them.
/:cl: