### PR TITLE
Robotact is now at the top of Borg PDA screens

### DIFF
--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -5,7 +5,7 @@
 	extended_desc = "A built-in app for cyborg self-management and diagnostics."
 	ui_header = "robotact.gif" //DEBUG -- new icon before PR
 	program_open_overlay = "command"
-	program_flags = NONE
+	program_flags = PROGRAM_HEADER
 	undeletable = TRUE
 	can_run_on_flags = PROGRAM_PDA
 	size = 5


### PR DESCRIPTION
## About The Pull Request
Robotact is now at the top of borg PDAs' main screen. Same as Messenger for crew PDAs.
![image](https://github.com/user-attachments/assets/8426371f-3d16-47f2-8ec3-52d7006158da)
## Why It's Good For The Game
Robotact is just as important to borgs as Messenger is to carbons, so we should make it easier to find at a glance.
## Changelog
:cl:
qol: Cyborg PDAs' home screens now have Robotact at the top of the screen.
/:cl:
