### PR TITLE
Do_after cogs inherit mob alpha

### DIFF
--- a/code/datums/cogbar.dm
+++ b/code/datums/cogbar.dm
@@ -53,7 +53,7 @@
 		alpha = 0,
 	)
 	cog.pixel_y = ICON_SIZE_Y + offset_y
-	animate(cog, alpha = 255, time = COGBAR_ANIMATION_TIME)
+	animate(cog, alpha = user.alpha, time = COGBAR_ANIMATION_TIME)
 
 	if(isnull(user_client))
 		return

--- a/code/datums/components/space_dive.dm
+++ b/code/datums/components/space_dive.dm
@@ -32,7 +32,7 @@
 	INVOKE_ASYNC(src, PROC_REF(attempt_dive), parent, bumped)
 
 /datum/component/space_dive/proc/attempt_dive(mob/living/parent, atom/bumped)
-	if(!do_after(parent, dive_time, bumped, hidden = TRUE))
+	if(!do_after(parent, dive_time, bumped))
 		return
 
 	dive(bumped)

--- a/code/datums/components/space_dive.dm
+++ b/code/datums/components/space_dive.dm
@@ -32,7 +32,7 @@
 	INVOKE_ASYNC(src, PROC_REF(attempt_dive), parent, bumped)
 
 /datum/component/space_dive/proc/attempt_dive(mob/living/parent, atom/bumped)
-	if(!do_after(parent, dive_time, bumped))
+	if(!do_after(parent, dive_time, bumped, hidden = TRUE))
 		return
 
 	dive(bumped)


### PR DESCRIPTION
## About The Pull Request

While testing #90173 I noticed that the cogs created by the progress bar in the voidwalker's "space dive" ability are completely visible even while the mob is invisible, meaning you see a very clear pair of gears floating in space which is quite silly.

Initially I just set this progress bar to hidden, but then I thought "well what if you're not invisible while doing it?" as technically voidwalkers can become visible even while in space if engaged in a fight. 
Instead I elected to make the visible effect inherit the alpha that the mob had when it started acting. I haven't _quite_ thought through every case where this would come up, but I'm assuming that if a mob is hard to see then the things it is doing... should probably also generally be hard to see? This is a bit of a buff to various forms of invisibility which also let you act, but do_afters also weren't visible when most of those were added, so I don't know how much of a balance concern it actually is. 
But I'm thinking... it's probably fine!

If this isn't liked then I can do something else specific to my one use case instead I guess.

## Why It's Good For The Game

If you can't see the mob how can you see what it is doing?

## Changelog

:cl:
balance: The action animation indicating someone is performing an action with a progress bar now inherits how visible they are. You won't easily see a pair of gears floating in space if a Voidwalker starts diving under the station.
/:cl:
