### PR TITLE
You can now disable hair_mask for clothes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -2045,7 +2045,7 @@
 	if(!hair_mask)
 		return
 
-	if(toggle != null)
+	if(!isnull(toggle))
 		if(toggle != hair_mask_enabled)
 			hair_mask_enabled = toggle
 		else

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -2046,9 +2046,6 @@
 		return
 
 	if(!isnull(toggle))
-		if(toggle != hair_mask_enabled)
-			hair_mask_enabled = toggle
-		else
-			return
+		hair_mask_enabled = toggle
 	else
 		hair_mask_enabled = !hair_mask_enabled

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -132,6 +132,8 @@
 	///Name of a mask in icons\mob\human\hair_masks.dmi to apply to hair when this item is worn
 	///Used by certain hats to give the appearance of squishing down tall hairstyles without hiding the hair completely
 	var/hair_mask = ""
+	///Variable that indicates if hair_mask should be applied
+	var/hair_mask_enabled = TRUE
 
 	///flags for what should be done when you click on the item, default is picking it up
 	var/interaction_flags_item = INTERACT_ITEM_ATTACK_HAND_PICKUP
@@ -2037,3 +2039,16 @@
 		target_limb = victim.get_bodypart(target_limb) || victim.bodyparts[1]
 
 	return get_embed()?.embed_into(victim, target_limb)
+
+/// Toggles whether hair_mask should be applied to the character
+/obj/item/proc/toggle_hair_mask(toggle = null)
+	if(!hair_mask)
+		return
+
+	if(toggle != null)
+		if(toggle != hair_mask_enabled)
+			hair_mask_enabled = toggle
+		else
+			return
+	else
+		hair_mask_enabled = !hair_mask_enabled

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -2041,7 +2041,7 @@
 	return get_embed()?.embed_into(victim, target_limb)
 
 /// Toggles whether hair_mask should be applied to the character
-/obj/item/proc/toggle_hair_mask(toggle = null)
+/obj/item/proc/toggle_hair_mask(toggle = null, need_update = TRUE)
 	if(!hair_mask)
 		return
 
@@ -2049,3 +2049,6 @@
 		hair_mask_enabled = toggle
 	else
 		hair_mask_enabled = !hair_mask_enabled
+
+	if(need_update)
+		update_slot_icon()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -236,6 +236,12 @@
 	QDEL_NULL(moth_snack)
 	return ..()
 
+/obj/item/clothing/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(hair_mask)
+		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = hair_mask_enabled ? "Hide hair" : "Show hair"
+
 /obj/item/clothing/dropped(mob/living/user)
 	..()
 	if(!istype(user))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -228,7 +228,6 @@
 		if(3 to INFINITY) // take better care of your shit, dude
 			name = "tattered [initial(name)]"
 
-	register_context()
 	update_clothes_damaged_state(CLOTHING_DAMAGED)
 	update_appearance()
 
@@ -236,14 +235,6 @@
 	user_vars_remembered = null //Oh god somebody put REFERENCES in here? not to worry, we'll clean it up
 	QDEL_NULL(moth_snack)
 	return ..()
-
-/obj/item/clothing/add_context(atom/source, list/context, obj/item/held_item, mob/user)
-	. = ..()
-
-	if(hair_mask)
-		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = hair_mask_enabled ? "Hide hair" : "Show hair"
-
-	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/clothing/dropped(mob/living/user)
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -112,6 +112,9 @@
 		create_moth_snack()
 	moth_snack.attack(target, user, params)
 
+/obj/item/clothing/click_ctrl_shift(mob/user)
+	toggle_hair_mask()
+
 /// Creates a food object in null space which we can eat and imagine we're eating this pair of shoes
 /obj/item/clothing/proc/create_moth_snack()
 	moth_snack = new
@@ -349,6 +352,9 @@
 			how_cool_are_your_threads += "Adding or removing items from [src] makes no noise.\n"
 		how_cool_are_your_threads += "</span>"
 		. += how_cool_are_your_threads.Join()
+
+	if(hair_mask)
+		. += span_notice("Ctrl-Shift-click to toggle hiding hair on the character.")
 
 	if(get_armor().has_any_armor() || (flags_cover & (HEADCOVERSMOUTH|PEPPERPROOF)) || (clothing_flags & STOPSPRESSUREDAMAGE) || (visor_flags & STOPSPRESSUREDAMAGE))
 		. += span_notice("It has a <a href='byond://?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -228,6 +228,7 @@
 		if(3 to INFINITY) // take better care of your shit, dude
 			name = "tattered [initial(name)]"
 
+	register_context()
 	update_clothes_damaged_state(CLOTHING_DAMAGED)
 	update_appearance()
 
@@ -241,6 +242,8 @@
 
 	if(hair_mask)
 		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = hair_mask_enabled ? "Hide hair" : "Show hair"
+
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/clothing/dropped(mob/living/user)
 	..()

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -15,7 +15,7 @@
 				hair_hidden = TRUE
 			if(worn_item.flags_inv & HIDEFACIALHAIR)
 				facial_hair_hidden = TRUE
-			if(worn_item.hair_mask)
+			if(worn_item.hair_mask && worn_item.hair_mask_enabled)
 				LAZYSET(hair_masks, worn_item.hair_mask, TRUE)
 		//invisibility and husk stuff
 		if(HAS_TRAIT(human_head_owner, TRAIT_INVISIBLE_MAN) || HAS_TRAIT(human_head_owner, TRAIT_HUSK))


### PR DESCRIPTION
## About The Pull Request

Added ability to disable hair_mask overlay on clothes. To toggle it you need to click on it with ctrl and shift keys held down

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/1faddaf4-38ad-4780-a978-9cd92086a28e)

![image](https://github.com/user-attachments/assets/85a5c46e-aabb-43a0-a789-7699f97d33e1) ![image](https://github.com/user-attachments/assets/f6646dbf-8112-4788-b797-4192bce655ae)

![image](https://github.com/user-attachments/assets/681b9e1a-9c47-42e8-9c66-2c75af037835) ![image](https://github.com/user-attachments/assets/13a9f946-d9f2-42a7-b193-ca4fabaa99ff)


</details>

## Why It's Good For The Game

With certain hairstyles this mask looks terrible. It will now be possible to turn it off
## Changelog
:cl:
add: You can now disable hair_mask for clothes
/:cl:
