### PR TITLE
Fixes sanity hallucinations not working after 3 years

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -549,7 +549,7 @@
 			sanity_level = SANITY_LEVEL_GREAT
 
 	// Crazy or insane = add some uncommon hallucinations
-	if(sanity_level >= SANITY_CRAZY)
+	if(sanity_level >= SANITY_LEVEL_CRAZY)
 		mob_parent.apply_status_effect(/datum/status_effect/hallucination/sanity)
 	else
 		mob_parent.remove_status_effect(/datum/status_effect/hallucination/sanity)


### PR DESCRIPTION

## About The Pull Request

So #70311 never actually did anything because it used SANITY_CRAZY and not SANITY_LEVEL_CRAZY, and sanity_level only goes up to 6 (SANITY_CRAZY is 25).

Yeeeah.

## Why It's Good For The Game

Its supposed to be a rare cool low sanity effect but because of an oversight it never worked, so see original PR's justification?

## Changelog
:cl:
fix: Being at low sanity will actually give your hallucinations as intended.
/:cl:
