### PR TITLE
Fixes tool_act returns on reflectors

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -96,7 +96,7 @@
 		return ITEM_INTERACT_SUCCESS
 	user.visible_message(span_notice("[user] starts to dismantle [src]."), span_notice("You start to dismantle [src]..."))
 	if(!tool.use_tool(src, user, 8 SECONDS, volume=50))
-		return
+		return ITEM_INTERACT_BLOCKING
 	to_chat(user, span_notice("You dismantle [src]."))
 	new framebuildstacktype(drop_location(), framebuildstackamount)
 	if(buildstackamount)
@@ -106,7 +106,7 @@
 
 /obj/structure/reflector/welder_act(mob/living/user, obj/item/tool)
 	if(!tool.tool_start_check(user, amount=1))
-		return
+		return ITEM_INTERACT_BLOCKING
 	if(atom_integrity < max_integrity)
 		user.visible_message(span_notice("[user] starts to repair [src]."),
 							span_notice("You begin repairing [src]..."),


### PR DESCRIPTION

## About The Pull Request

These two should be ITEM_INTERACT_BLOCKING to prevent accidentally bashing them when failing to use the tool for whatever reason

## Changelog
:cl:
fix: Fixed failed wrench/welder interaction attempts resulting in you attacking reflectors
/:cl:
