### PR TITLE
You can pick up desk bells

### DIFF
--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -10,6 +10,7 @@
 	pass_flags = PASSTABLE // Able to place on tables
 	max_integrity = 5000 // To make attacking it not instantly break it
 	throwforce = 2
+	interaction_flags_mouse_drop = NEED_HANDS
 
 	/// The amount of times this bell has been rang, used to check the chance it breaks
 	var/times_rang = 0
@@ -113,8 +114,8 @@
 	times_rang++
 	return TRUE
 
-/obj/structure/desk_bell/mouse_drop_dragged(atom/over_object, mob/living/user)
-	if(!isliving(user) || over_object != user || !length(user.held_items))
+/obj/structure/desk_bell/mouse_drop_dragged(atom/over_object, mob/user)
+	if(over_object != user)
 		return FALSE
 	var/obj/item/inhand_desk_bell/held_bell = new (user, src)
 	user.put_in_hands(held_bell, del_on_fail = FALSE)
@@ -141,6 +142,7 @@
 		stack_trace("You shouldn't map in this item, use /obj/structure/desk_bell")
 	if (!bell)
 		return INITIALIZE_HINT_QDEL
+	register_item_context()
 	src.bell = bell
 	bell.forceMove(src)
 	appearance = bell.appearance
@@ -153,6 +155,14 @@
 	UnregisterSignal(bell, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
 	bell = null
 	qdel(src)
+
+/obj/item/inhand_desk_bell/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
+	. = NONE
+	if(istype(target, /obj/vehicle/ridden/wheelchair))
+		var/obj/vehicle/ridden/wheelchair/chair = target
+		if(!chair.bell_attached)
+			context[SCREENTIP_CONTEXT_LMB] = "Attach bell to wheelchair."
+			return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/inhand_desk_bell/examine(mob/user)
 	return bell.examine(user)

--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -9,6 +9,7 @@
 	anchored = FALSE
 	pass_flags = PASSTABLE // Able to place on tables
 	max_integrity = 5000 // To make attacking it not instantly break it
+	throwforce = 2
 
 	/// The amount of times this bell has been rang, used to check the chance it breaks
 	var/times_rang = 0
@@ -60,6 +61,10 @@
 	times_rang += weapon.force
 	ring_bell(user)
 
+/obj/structure/desk_bell/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	ring_bell()
+
 // Fix the clapper
 /obj/structure/desk_bell/screwdriver_act(mob/living/user, obj/item/tool)
 	if(broken_ringer)
@@ -91,7 +96,10 @@
 /// Check if the clapper breaks, and if it does, break it
 /obj/structure/desk_bell/proc/check_clapper(mob/living/user)
 	if(((times_rang >= 10000) || prob(times_rang/100)) && ring_cooldown_length)
-		to_chat(user, span_notice("You hear [src]'s clapper fall off of its hinge. Nice job, you broke it."))
+		if (user)
+			to_chat(user, span_notice("You hear [src]'s clapper fall off of its hinge. Nice job, you broke it."))
+		else
+			audible_message(span_notice("You hear [src]'s clapper fall off of its hinge. Nice job, you broke it."))
 		broken_ringer = TRUE
 
 /// Ring the bell
@@ -105,20 +113,84 @@
 	times_rang++
 	return TRUE
 
+/obj/structure/desk_bell/mouse_drop_dragged(atom/over_object, mob/living/user)
+	if(!isliving(user) || over_object != user || !length(user.held_items))
+		return FALSE
+	var/obj/item/inhand_desk_bell/held_bell = new (user, src)
+	user.put_in_hands(held_bell, del_on_fail = FALSE)
+
 // A warning to all who enter; the ringing sound STACKS. It won't be deafening because it only goes every decisecond,
 // but I did feel like my ears were going to start bleeding when I tested it with my autoclicker.
 /obj/structure/desk_bell/speed_demon
 	desc = "The cornerstone of any customer service job. This one's been modified for hyper-performance."
 	ring_cooldown_length = 0
 
-/obj/structure/desk_bell/mouse_drop_dragged(atom/over_object, mob/user)
-	if(!istype(over_object, /obj/vehicle/ridden/wheelchair))
+/// Handheld bell
+/obj/item/inhand_desk_bell
+	name = "held desk bell"
+	force = 1
+	w_class = WEIGHT_CLASS_SMALL
+	obj_flags = CONDUCTS_ELECTRICITY
+	force = 1
+	throwforce = 2
+	/// Our contained bell
+	var/obj/structure/desk_bell/bell
+
+/obj/item/inhand_desk_bell/Initialize(mapload, obj/structure/desk_bell/bell)
+	if (mapload)
+		stack_trace("You shouldn't map in this item, use /obj/structure/desk_bell")
+	if (!bell)
+		return INITIALIZE_HINT_QDEL
+	src.bell = bell
+	bell.forceMove(src)
+	appearance = bell.appearance
+	RegisterSignals(bell, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(on_bell_gone))
+	return ..()
+
+/// If we don't have a bell we're nothing
+/obj/item/inhand_desk_bell/proc/on_bell_gone()
+	SIGNAL_HANDLER
+	UnregisterSignal(bell, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
+	bell = null
+	qdel(src)
+
+/obj/item/inhand_desk_bell/examine(mob/user)
+	return bell.examine(user)
+
+/obj/item/inhand_desk_bell/on_thrown(mob/living/carbon/user, atom/target)
+	var/obj/throwing_bell = bell // We are about to null this variable but also want to return it
+	bell.forceMove(user.drop_location())
+	return throwing_bell
+
+/obj/item/inhand_desk_bell/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
+	. = ..()
+	if (isturf(loc))
+		bell.forceMove(loc)
+
+/obj/item/inhand_desk_bell/attack(mob/living/target_mob, mob/living/user, params)
+	. = ..()
+	if (.)
 		return
-	var/obj/vehicle/ridden/wheelchair/target = over_object
-	if(target.bell_attached)
+	bell.ring_bell(user)
+
+/obj/item/inhand_desk_bell/attack_self(mob/user, modifiers)
+	. = ..()
+	if (.)
+		return
+	bell.ring_bell(user)
+
+/obj/item/inhand_desk_bell/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ..()
+	if (!istype(interacting_with, /obj/vehicle/ridden/wheelchair))
+		return NONE
+	var/obj/vehicle/ridden/wheelchair/chair = interacting_with
+
+	if (chair.bell_attached)
 		user.balloon_alert(user, "already has a bell!")
-		return
+		return ITEM_INTERACT_FAILURE
 	user.balloon_alert(user, "attaching bell...")
-	if(!do_after(user, 0.5 SECONDS))
-		return
-	target.attach_bell(src)
+	if (!do_after(user, 0.5 SECONDS, chair))
+		return ITEM_INTERACT_FAILURE
+
+	chair.attach_bell(bell)
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -132,6 +132,9 @@
 	user.visible_message(span_notice("[user] collapses [src]."), span_notice("You collapse [src]."))
 	var/obj/vehicle/ridden/wheelchair/wheelchair_folded = new foldabletype(get_turf(src))
 	user.put_in_hands(wheelchair_folded)
+	if (bell_attached)
+		visible_message(span_notice("The bell attached to [src] falls to the ground."))
+		bell_attached.forceMove(drop_location())
 	qdel(src)
 
 /obj/item/wheelchair/attack_self(mob/user)  //Deploys wheelchair on in-hand use


### PR DESCRIPTION
## About The Pull Request

2 years and 9 months ago it was suggested that the UX for attaching a bell to a wheelchair was unintuitive.
![image](https://github.com/user-attachments/assets/e4818ac4-0ba9-4d73-b13e-3e240ad2e8c5)
Today I am finally implementing that feature request.

This PR lets you pick up desk bells by dragging them onto yourself. 
After picking up a desk bell you can ring it by using it in your hand, hit someone with it (which also rings the bell), attach it to a wheelchair, or throw it at someone (which also rings the bell).

_Also_ now if you fold up your wheelchair the bell falls off, instead of being deleted forever.

## Why It's Good For The Game

If ringing the bell repeatedly doesn't get someone's attention you can now physically hurl the desk bell at their head, which should be more effective.
Also people were saying on my other PR that they had no idea that you even could attach desk bells to wheelchairs, this will hopefully make it more intuitive.

## Changelog

:cl:
add: You can pick up desk bells by dragging them onto yourself. This is now how you attach them to wheelchairs, instead of dragging it onto the wheelchair.
fix: Folding a wheelchair with attached bell will drop the bell to the ground instead of deleting it forever.
/:cl:
