### PR TITLE
Fixes incorrect offsets on wide items' attack animations

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1583,6 +1583,8 @@
 
 	var/image/attack_image = image(icon = used_item)
 	attack_image.plane = attacked_atom.plane + 1
+	attack_image.pixel_w = used_item.base_pixel_x + used_item.base_pixel_w
+	attack_image.pixel_z = used_item.base_pixel_y + used_item.base_pixel_z
 	// Scale the icon.
 	attack_image.transform *= 0.5
 	// The icon should not rotate.


### PR DESCRIPTION
## About The Pull Request

Looks jank if you hit something with like, a Sakhno, not sure what else to add.

## Changelog
:cl:
fix: Fixed incorrect offsets on wide items' attack animations
/:cl:
