### PR TITLE
Fixes jittering resetting the wrong pair of visual offsets

### DIFF
--- a/code/datums/status_effects/debuffs/jitteriness.dm
+++ b/code/datums/status_effects/debuffs/jitteriness.dm
@@ -23,8 +23,8 @@
 	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
 	owner.clear_mood_event(id)
 	// juuust in case, reset our x and y's from our jittering
-	owner.pixel_x = 0
-	owner.pixel_y = 0
+	owner.pixel_w = 0
+	owner.pixel_z = 0
 
 /datum/status_effect/jitter/get_examine_text()
 	switch(duration - world.time)

--- a/code/datums/status_effects/debuffs/jitteriness.dm
+++ b/code/datums/status_effects/debuffs/jitteriness.dm
@@ -22,9 +22,7 @@
 /datum/status_effect/jitter/on_remove()
 	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
 	owner.clear_mood_event(id)
-	// juuust in case, reset our x and y's from our jittering
-	owner.pixel_w = 0
-	owner.pixel_z = 0
+	owner.update_offsets()
 
 /datum/status_effect/jitter/get_examine_text()
 	switch(duration - world.time)


### PR DESCRIPTION

## About The Pull Request

Jittering has been transitioned to pixel_w/z, so we should use that instead.

## Changelog
:cl:
fix: Fixed jittering resetting the wrong pair of visual offsets
/:cl:
