### PR TITLE
Prosopagnosia now uses ID card names (if present) instead of always Unknown

### DIFF
--- a/code/datums/quirks/negative_quirks/prosopagnosia.dm
+++ b/code/datums/quirks/negative_quirks/prosopagnosia.dm
@@ -15,20 +15,22 @@
 /datum/quirk/prosopagnosia/remove()
 	UnregisterSignal(quirk_holder, list(COMSIG_MOB_REQUESTING_SCREENTIP_NAME_FROM_USER, COMSIG_LIVING_PERCEIVE_EXAMINE_NAME))
 
-/datum/quirk/prosopagnosia/proc/examine_name_override(datum/source, mob/living/examined, visible_name, list/name_override)
+/datum/quirk/prosopagnosia/proc/examine_name_override(datum/source, mob/living/carbon/human/examined, visible_name, list/name_override)
 	SIGNAL_HANDLER
 
-	if(!ishuman(examined))
+	if(!ishuman(examined) || source == examined)
 		return NONE
 
-	name_override[1] = "Unknown"
+	var/id_name = examined.get_id_name("")
+	name_override[1] = id_name ? "[id_name]?" : "Unknown"
 	return COMPONENT_EXAMINE_NAME_OVERRIDEN
 
-/datum/quirk/prosopagnosia/proc/screentip_name_override(datum/source, list/returned_name, obj/item/held_item, atom/hovered)
+/datum/quirk/prosopagnosia/proc/screentip_name_override(datum/source, list/returned_name, obj/item/held_item, mob/living/carbon/human/hovered)
 	SIGNAL_HANDLER
 
-	if(!ishuman(hovered))
+	if(!ishuman(hovered) || source == hovered)
 		return NONE
 
-	returned_name[1] = "Unknown"
+	var/id_name = hovered.get_id_name("")
+	returned_name[1] = id_name ? "[id_name]?" : "Unknown"
 	return SCREENTIP_NAME_SET


### PR DESCRIPTION
## About The Pull Request

This changes Prosopagnosia a bit - instead of people _always_ appearing as Unknown, if they have an ID, they'll appear as the name's ID, albeit with a question mark next to it, i.e "Captain?" or "John Doe?"

![2025-03-23 (1742707863) ~ dreamseeker](https://github.com/user-attachments/assets/34f2b636-a4e7-4acc-9b80-6a3e3e9b6804)
![2025-03-23 (1742707875) ~ dreamseeker](https://github.com/user-attachments/assets/ffb660ac-70a9-46b3-919a-1e33a16f01ed)

Also, this lets you see your _own_ name when self-examining / hovering over yourself, 'cuz it's not like you can see your own face anyways, you kinda just know you are you.

## Why It's Good For The Game

you can see the ID card while examining anyways - nothing says you can't recognize IDs, just faces.

## Changelog
:cl:
qol: Players with the Prosopagnosia quirk will now see the ID name (if there is one) examining someone, instead of ALWAYS Unknown, altho it'll have a question mark, i.e "John Doe?"
qol: Prosopagnosia no longer makes you see yourself as Unknown.
/:cl:
