### PR TITLE
Fix the `ispath` SDQL2/Lua wrapper (and add a `is_type_in_typecache` wrapper)

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -66,8 +66,7 @@
 /proc/_ispath(path, type)
 	if(isnull(type))
 		return ispath(path)
-	else
-		return ispath(path, type)
+	return ispath(path, type)
 
 /proc/_length(E)
 	return length(E)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -64,7 +64,10 @@
 	return istype(object, type)
 
 /proc/_ispath(path, type)
-	return ispath(path, type)
+	if(isnull(type))
+		return ispath(path)
+	else
+		return ispath(path, type)
 
 /proc/_length(E)
 	return length(E)
@@ -297,3 +300,6 @@
 	if(!filter_index || filter_index < 1 || filter_index > length(target.filters))
 		return
 	animate(target.filters[filter_index], appearance = set_vars, time, loop, easing, flags)
+
+/proc/_is_type_in_typecache(thing_to_check, typecache)
+	return is_type_in_typecache(thing_to_check, typecache)


### PR DESCRIPTION
## About The Pull Request

This fixes the `_ispath` SDQL2 / Lua wrapper: it always passed two arguments, meaning it couldn't be used to just simply check if something was a path _at all_.

In addition, I just added wrapper around `is_type_in_typecache` (as it's a define), as that's the whole reason I was using `_ispath` anyways, so it can't hurt.

## Why It's Good For The Game

things working properly is nice

## Changelog
:cl:
fix: The _ispath SDQL2/Lua wrapper can now be used to actually check if something is a path.
code: Added the _is_type_in_typecache wrapper, for SDQL2 / Lua scripts.
/:cl:
