### PR TITLE
Fixes constant runtimes caused by large internals boxes station trait

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -19,7 +19,7 @@
 	/// Do we get to benefit from Nanotrasen's largesse?
 	var/give_premium_goods = TRUE
 
-/obj/item/storage/box/survival/Initialize(mapload)
+/obj/item/storage/box/survival/create_storage(max_slots, max_specific_storage, max_total_storage, list/canhold, list/canthold, storage_type)
 	. = ..()
 	if(crafted || !HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		return


### PR DESCRIPTION

## About The Pull Request

Not sure if any outfits except admin-ones runtimed? Happened because box size was increased after init and not after creating storage but before populating it. The combat-ready box constantly runtimed due to The Wardrobe trying to create it for an outfit and repeatedly failing, which got annoying in testing real fast.

## Changelog
:cl:
fix: Large internals station trait no longer prevents admin-specific internals boxes from spawning
/:cl:
