### PR TITLE
Use volcanic tiles

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -196,7 +196,7 @@
 /turf/open/indestructible/white,
 /area/ruin/powered/clownplanet)
 "bp" = (
-/turf/closed/mineral/bananium,
+/turf/closed/mineral/bananium/volcanic,
 /area/ruin/powered/clownplanet)
 "bq" = (
 /obj/item/pickaxe,


### PR DESCRIPTION

## About The Pull Request
Tiles on lavaland should use the volcanic turf type so they spawn with atmos and don't crush miners with low pressure when they mine them out

## Why It's Good For The Game
I like not being crushed

## Changelog
:cl: Goat
fix: Clown biodome on lavaland uses lavaland turf now for the bananium ore. 
/:cl:
