### PR TITLE
Removes 516 warning from the statpanel

### DIFF
--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -18,5 +18,5 @@
 #endif
 
 #if DM_VERSION >= 517
-	#error "Remove all 516 experiments"
+	#error "Remove all 517 experiments"
 #endif

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -101,14 +101,10 @@ SUBSYSTEM_DEF(statpanels)
 			return
 
 /datum/controller/subsystem/statpanels/proc/set_status_tab(client/target)
-#if MIN_COMPILER_VERSION > 515
-	#warn 516 is most certainly out of beta, remove this beta notice if you haven't already
-#endif
-	var/static/list/beta_notice = list("", "You are on BYOND 516, some visual glitches with UIs may be present!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
 	if(!global_data)//statbrowser hasnt fired yet and we were called from immediate_send_stat_data()
 		return
 	target.stat_panel.send_message("update_stat", list(
-		"global_data" = (target.byond_version < 516) ? global_data : (global_data + beta_notice),
+		"global_data" = global_data,
 		"ping_str" = "Ping: [round(target.lastping, 1)]ms (Average: [round(target.avgping, 1)]ms)",
 		"other_str" = target.mob?.get_status_tab_items(),
 	))


### PR DESCRIPTION

## About The Pull Request

Removed the 516 warning from the statpanel, and updated incorrect compiler warning note about 517 experiments.

## Why It's Good For The Game

Our servers now nag you to update to 516, makes no sense to have a warning saying that you should downgrade.

## Changelog
:cl:
code: Removed the 516 beta warning entirely
/:cl:
