### PR TITLE
Change hardcoded ice/snow temperatures values to use `ICEBOX_MIN_TEMPERATURE` define

### DIFF
--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -287,7 +287,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 
 //Used in SnowCabin.dm
 /turf/open/misc/asteroid/snow/snow_cabin
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 
 /turf/open/misc/asteroid/snow/atmosphere
 	initial_gas_mix = FROZEN_ATMOS

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -69,7 +69,7 @@
 
 //Used in Snowcabin.dm
 /turf/open/floor/wood/freezing
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 
 /turf/open/floor/wood/airless
 	initial_gas_mix = AIRLESS_ATMOS

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -178,7 +178,7 @@
 
 //Used in SnowCabin.dm
 /turf/open/floor/mineral/plastitanium/red/snow_cabin
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 
 //BANANIUM
 

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -52,7 +52,7 @@
 	icon_state = "snowplating"
 	base_icon_state = "snowplating"
 	initial_gas_mix = FROZEN_ATMOS
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 	attachment_holes = FALSE
 	planetary_atmos = TRUE
 	footstep = FOOTSTEP_SAND
@@ -91,7 +91,7 @@
 
 //Used in SnowCabin.dm
 /turf/open/floor/plating/snowed/snow_cabin
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 
 /turf/open/floor/plating/snowed/smoothed/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS

--- a/code/game/turfs/open/ice.dm
+++ b/code/game/turfs/open/ice.dm
@@ -5,7 +5,7 @@
 	icon_state = "ice_turf-0"
 	base_icon_state = "ice_turf-0"
 	initial_gas_mix = FROZEN_ATMOS
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 	planetary_atmos = TRUE
 	baseturfs = /turf/open/misc/ice
 	slowdown = 1

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -156,7 +156,7 @@
 /turf/open/floor/iron/dark/snowdin
 	initial_gas_mix = FROZEN_ATMOS
 	planetary_atmos = TRUE
-	temperature = 180
+	temperature = ICEBOX_MIN_TEMPERATURE
 
 /////////// papers
 


### PR DESCRIPTION

## About The Pull Request
Several variables in the code had hardcoded temperature vars set to 180 when it should just use the `ICEBOX_MIN_TEMPERATURE` define that is used to indicate a 180 temp.

## Why It's Good For The Game
No hardcoded values.

## Changelog
:cl:
code: Change some hardcoded ice/snow temperature variables that were set to 180 to use `ICEBOX_MIN_TEMPERATURE` instead.
/:cl:
