### PR TITLE
Fix storage whitelists / blacklists being ignored in some contexts

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -441,7 +441,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 					stack_trace("[parent.type]:[to_insert.type] has TRAIT_NO_STORAGE_INSERT")
 			else if(user)
 				user.balloon_alert(user, "can't hold!")
-			return FALSE
+		return FALSE
 
 	if(HAS_TRAIT(to_insert, TRAIT_NODROP))
 		if(messages)

--- a/code/modules/unit_tests/storage.dm
+++ b/code/modules/unit_tests/storage.dm
@@ -41,3 +41,57 @@
 		var/obj/item/item = allocate(item_type, run_loc_floor_bottom_left)
 		item.melee_attack_chain(dummy, bag)
 		TEST_ASSERT_EQUAL(item.loc, bag, "[item_type] was unable to be inserted into a backpack on click while off combat mode")
+
+// Tests that equip equip works
+/datum/unit_test/quick_equip
+
+/datum/unit_test/quick_equip/Run()
+	var/mob/living/carbon/human/consistent/dummy = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+	var/obj/item/clothing/under/pants/jeans = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	dummy.equip_to_appropriate_slot(jeans)
+
+	var/obj/item/assembly/flash/handheld/flash_one = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	dummy.put_in_active_hand(flash_one)
+	dummy.execute_quick_equip()
+
+	TEST_ASSERT_EQUAL(dummy.l_store, flash_one, "Quick equip failed to equip the first flash to the left pocket")
+
+	var/obj/item/assembly/flash/handheld/flash_two = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	dummy.put_in_active_hand(flash_two)
+	dummy.execute_quick_equip()
+
+	TEST_ASSERT_EQUAL(dummy.r_store, flash_two, "Quick equip failed to equip the second flash to the right pocket")
+
+	var/obj/item/assembly/flash/handheld/flash_three = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	dummy.put_in_active_hand(flash_three)
+	dummy.execute_quick_equip()
+
+	TEST_ASSERT_EQUAL(dummy.get_active_held_item(), flash_three, "Quick equip should have left the third flash in the active hand")
+
+/// Tests that quick equip respects storage blacklists
+/datum/unit_test/quick_equip_respects_storage
+
+/datum/unit_test/quick_equip_respects_storage
+	var/obj/item/storage/backpack/storage_item =  allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+	var/mob/living/carbon/human/consistent/dummy = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	dummy.equip_to_appropriate_slot(storage_item)
+
+	var/obj/item/assembly/flash/handheld/flash_one = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	dummy.put_in_active_hand(flash_one)
+	dummy.execute_quick_equip()
+
+	TEST_ASSERT_EQUAL(flash_one.loc, storage_item, "Quick equip failed to equip the first flash to the storage item")
+
+	var/obj/item/assembly/flash/handheld/flash_two = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
+
+	storage_item.atom_storage.cant_hold = typecacheof(list(/obj/item/assembly/flash/handheld))
+	dummy.put_in_active_hand(flash_two)
+	dummy.execute_quick_equip()
+
+	TEST_ASSERT_EQUAL(dummy.get_active_held_item(), flash_two, "Quick equip should have left the second flash in the active hand")

--- a/code/modules/unit_tests/storage.dm
+++ b/code/modules/unit_tests/storage.dm
@@ -75,7 +75,7 @@
 /// Tests that quick equip respects storage blacklists
 /datum/unit_test/quick_equip_respects_storage
 
-/datum/unit_test/quick_equip_respects_storage
+/datum/unit_test/quick_equip_respects_storage/Run()
 	var/obj/item/storage/backpack/storage_item =  allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
 	var/mob/living/carbon/human/consistent/dummy = allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left)
 


### PR DESCRIPTION
## About The Pull Request

It did not return FALSE unless it was set to print messages.

Fixes #90226

## Changelog

:cl: Melbert
fix: Fix storage whitelists / blacklists being ignored in some contexts (hotkeys)
/:cl:
