### PR TITLE
Fixes ai multicam room being pitch dark on multiz maps

### DIFF
--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -91,7 +91,6 @@
 /turf/open/ai_visible/Initialize(mapload)
 	. = ..()
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(multiz_offset_increase))
-	multiz_offset_increase(SSmapping)
 
 /turf/open/ai_visible/proc/multiz_offset_increase(datum/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Title.
## Why It's Good For The Game
Actually working multicam room
## Changelog
:cl:

fix: fixed AI multicam room on multiz maps not showing anything

/:cl:
