### PR TITLE
Move TitleBar to a separate file & re-make styles

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -14,6 +14,7 @@
 import { perf } from 'common/perf';
 import { createAction } from 'common/redux';
 import { globalEvents } from 'tgui-core/events';
+import { BooleanLike } from 'tgui-core/react';
 
 import { setupDrag } from './drag';
 import { focusMap } from './focus';
@@ -256,12 +257,12 @@ type BackendState<TData> = {
       name: string;
       layout: string;
     };
-    refreshing: boolean;
+    refreshing: BooleanLike;
     window: {
       key: string;
       size: [number, number];
-      fancy: boolean;
-      locked: boolean;
+      fancy: BooleanLike;
+      locked: BooleanLike;
     };
     client: {
       ckey: string;

--- a/tgui/packages/tgui/drag.ts
+++ b/tgui/packages/tgui/drag.ts
@@ -6,6 +6,7 @@
 
 import { storage } from 'common/storage';
 import { vecAdd, vecMultiply, vecScale, vecSubtract } from 'common/vector';
+import { BooleanLike } from 'tgui-core/byond';
 
 import { createLogger } from './logging';
 
@@ -116,10 +117,10 @@ const storeWindowGeometry = async () => {
 // Recall window geometry from local storage and apply it
 export const recallWindowGeometry = async (
   options: {
-    fancy?: boolean;
+    fancy?: BooleanLike;
     pos?: [number, number];
     size?: [number, number];
-    locked?: boolean;
+    locked?: BooleanLike;
   } = {},
 ) => {
   const geometry = options.fancy && (await storage.get(windowKey));

--- a/tgui/packages/tgui/drag.ts
+++ b/tgui/packages/tgui/drag.ts
@@ -6,7 +6,7 @@
 
 import { storage } from 'common/storage';
 import { vecAdd, vecMultiply, vecScale, vecSubtract } from 'common/vector';
-import { BooleanLike } from 'tgui-core/byond';
+import { BooleanLike } from 'tgui-core/react';
 
 import { createLogger } from './logging';
 

--- a/tgui/packages/tgui/layouts/TitleBar.tsx
+++ b/tgui/packages/tgui/layouts/TitleBar.tsx
@@ -11,7 +11,7 @@ type TitleBarProps = Partial<{
   className: string;
   title: string;
   status: number;
-  fancy: boolean;
+  fancy: BooleanLike;
   canClose: BooleanLike;
   onClose: (e) => void;
   onDragStart: (e) => void;

--- a/tgui/packages/tgui/layouts/TitleBar.tsx
+++ b/tgui/packages/tgui/layouts/TitleBar.tsx
@@ -1,0 +1,83 @@
+import { PropsWithChildren } from 'react';
+import { Button, Icon } from 'tgui-core/components';
+import { UI_DISABLED, UI_INTERACTIVE, UI_UPDATE } from 'tgui-core/constants';
+import { classes } from 'tgui-core/react';
+import { toTitleCase } from 'tgui-core/string';
+
+import { globalStore } from '../backend';
+import { toggleKitchenSink } from '../debug/actions';
+
+type TitleBarProps = Partial<{
+  className: string;
+  title: string;
+  status: number;
+  fancy: boolean;
+  canClose: boolean;
+  onClose: (e) => void;
+  onDragStart: (e) => void;
+}> &
+  PropsWithChildren;
+
+const statusToColor = (status) => {
+  switch (status) {
+    case UI_INTERACTIVE:
+      return 'good';
+    case UI_UPDATE:
+      return 'average';
+    case UI_DISABLED:
+    default:
+      return 'bad';
+  }
+};
+
+export function TitleBar(props: TitleBarProps) {
+  const {
+    className,
+    title,
+    status,
+    canClose,
+    fancy,
+    onDragStart,
+    onClose,
+    children,
+  } = props;
+  const dispatch = globalStore.dispatch;
+
+  const finalTitle =
+    (typeof title === 'string' &&
+      title === title.toLowerCase() &&
+      toTitleCase(title)) ||
+    title;
+
+  return (
+    <div className={classes(['TitleBar', className])}>
+      <div
+        className="TitleBar__dragZone"
+        onMouseDown={(e) => fancy && onDragStart && onDragStart(e)}
+      />
+      {status === undefined ? (
+        <Icon className="TitleBar__statusIcon" name="tools" opacity={0.5} />
+      ) : (
+        <Icon
+          className="TitleBar__statusIcon"
+          color={statusToColor(status)}
+          name={status === UI_DISABLED ? 'eye-slash' : 'eye'}
+        />
+      )}
+      <div className="TitleBar__title">{finalTitle}</div>
+      {!!children && <div className="TitleBar__buttons">{children}</div>}
+      {process.env.NODE_ENV !== 'production' && (
+        <Button
+          className="TitleBar__buttons TitleBar__KitchenSink"
+          icon="bug"
+          onClick={() => dispatch(toggleKitchenSink())}
+        />
+      )}
+      {Boolean(fancy && canClose) && (
+        <div className="TitleBar__close" onClick={onClose}>
+          <Icon className="TitleBar__close--icon" name="times" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tgui/packages/tgui/layouts/TitleBar.tsx
+++ b/tgui/packages/tgui/layouts/TitleBar.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { Button, Icon } from 'tgui-core/components';
 import { UI_DISABLED, UI_INTERACTIVE, UI_UPDATE } from 'tgui-core/constants';
-import { classes } from 'tgui-core/react';
+import { BooleanLike, classes } from 'tgui-core/react';
 import { toTitleCase } from 'tgui-core/string';
 
 import { globalStore } from '../backend';
@@ -12,13 +12,13 @@ type TitleBarProps = Partial<{
   title: string;
   status: number;
   fancy: boolean;
-  canClose: boolean;
+  canClose: BooleanLike;
   onClose: (e) => void;
   onDragStart: (e) => void;
 }> &
   PropsWithChildren;
 
-const statusToColor = (status) => {
+function statusToColor(status: number): string {
   switch (status) {
     case UI_INTERACTIVE:
       return 'good';
@@ -28,7 +28,7 @@ const statusToColor = (status) => {
     default:
       return 'bad';
   }
-};
+}
 
 export function TitleBar(props: TitleBarProps) {
   const {

--- a/tgui/packages/tgui/layouts/Window.tsx
+++ b/tgui/packages/tgui/layouts/Window.tsx
@@ -12,14 +12,13 @@ import {
   useLayoutEffect,
   useState,
 } from 'react';
-import { Box, Icon } from 'tgui-core/components';
-import { UI_DISABLED, UI_INTERACTIVE, UI_UPDATE } from 'tgui-core/constants';
+import { Box } from 'tgui-core/components';
+import { UI_DISABLED, UI_INTERACTIVE } from 'tgui-core/constants';
 import { classes } from 'tgui-core/react';
-import { decodeHtmlEntities, toTitleCase } from 'tgui-core/string';
+import { decodeHtmlEntities } from 'tgui-core/string';
 
 import { backendSuspendStart, globalStore, useBackend } from '../backend';
 import { useDebug } from '../debug';
-import { toggleKitchenSink } from '../debug/actions';
 import {
   dragStartHandler,
   recallWindowGeometry,
@@ -28,9 +27,9 @@ import {
 } from '../drag';
 import { createLogger } from '../logging';
 import { Layout } from './Layout';
+import { TitleBar } from './TitleBar';
 
 const logger = createLogger('Window');
-
 const DEFAULT_SIZE: [number, number] = [400, 600];
 
 type Props = Partial<{
@@ -113,7 +112,6 @@ export const Window = (props: Props) => {
   return suspended ? null : (
     <Layout className="Window" theme={theme}>
       <TitleBar
-        className="Window__titleBar"
         title={title || decodeHtmlEntities(config.title)}
         status={config.status}
         fancy={fancy}
@@ -175,81 +173,3 @@ const WindowContent = (props: ContentProps) => {
 };
 
 Window.Content = WindowContent;
-
-const statusToColor = (status) => {
-  switch (status) {
-    case UI_INTERACTIVE:
-      return 'good';
-    case UI_UPDATE:
-      return 'average';
-    case UI_DISABLED:
-    default:
-      return 'bad';
-  }
-};
-
-type TitleBarProps = Partial<{
-  canClose: boolean;
-  className: string;
-  fancy: boolean;
-  onClose: (e) => void;
-  onDragStart: (e) => void;
-  status: number;
-  title: string;
-}> &
-  PropsWithChildren;
-
-const TitleBar = (props: TitleBarProps) => {
-  const {
-    className,
-    title,
-    status,
-    canClose,
-    fancy,
-    onDragStart,
-    onClose,
-    children,
-  } = props;
-  const dispatch = globalStore.dispatch;
-
-  const finalTitle =
-    (typeof title === 'string' &&
-      title === title.toLowerCase() &&
-      toTitleCase(title)) ||
-    title;
-
-  return (
-    <div className={classes(['TitleBar', className])}>
-      {(status === undefined && (
-        <Icon className="TitleBar__statusIcon" name="tools" opacity={0.5} />
-      )) || (
-        <Icon
-          className="TitleBar__statusIcon"
-          color={statusToColor(status)}
-          name="eye"
-        />
-      )}
-      <div
-        className="TitleBar__dragZone"
-        onMouseDown={(e) => fancy && onDragStart && onDragStart(e)}
-      />
-      <div className="TitleBar__title">
-        {finalTitle}
-        {!!children && <div className="TitleBar__buttons">{children}</div>}
-      </div>
-      {process.env.NODE_ENV !== 'production' && (
-        <div
-          className="TitleBar__devBuildIndicator"
-          onClick={() => dispatch(toggleKitchenSink())}
-        >
-          <Icon name="bug" />
-        </div>
-      )}
-      {Boolean(fancy && canClose) && (
-        <div className="TitleBar__close TitleBar__clickable" onClick={onClose}>
-          ×
-        </div>
-      )}
-    </div>
-  );
-};

--- a/tgui/packages/tgui/layouts/Window.tsx
+++ b/tgui/packages/tgui/layouts/Window.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react';
 import { Box } from 'tgui-core/components';
 import { UI_DISABLED, UI_INTERACTIVE } from 'tgui-core/constants';
-import { classes } from 'tgui-core/react';
+import { BooleanLike, classes } from 'tgui-core/react';
 import { decodeHtmlEntities } from 'tgui-core/string';
 
 import { backendSuspendStart, globalStore, useBackend } from '../backend';
@@ -34,7 +34,7 @@ const DEFAULT_SIZE: [number, number] = [400, 600];
 
 type Props = Partial<{
   buttons: ReactNode;
-  canClose: boolean;
+  canClose: BooleanLike;
   height: number;
   theme: string;
   title: string;

--- a/tgui/packages/tgui/styles/layouts/TitleBar.scss
+++ b/tgui/packages/tgui/styles/layouts/TitleBar.scss
@@ -9,103 +9,95 @@
 
 $text-color: hsla(0, 0%, 100%, 0.75) !default;
 $background-color: hsl(0, 0%, 21%) !default;
-$shadow-color-core: hsl(0, 0%, 8.6%) !default;
-$shadow-color: hsla(0, 0%, 0%, 0.1) !default;
+$shadow-color: hsla(0, 0%, 0%, 0.66) !default;
+$shadow-color-core: hsl(0, 0%, 0%, 0.4) !default;
 
 .TitleBar {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  width: 100vw;
+  height: base.rem(32px);
   background-color: $background-color;
   border-bottom: 1px solid $shadow-color-core;
-  box-shadow: 0 2px 2px $shadow-color;
-  box-shadow: 0 base.rem(2px) base.rem(2px) $shadow-color;
+  box-shadow: 0px 0px base.em(6px) base.em(-1px) $shadow-color;
+  z-index: 101; // More than Dimmer
   user-select: none;
+  // Deprecated. Delete after full transition to 516
   -ms-user-select: none;
-}
 
-.TitleBar__clickable {
-  color: color.change($text-color, $alpha: 0.5);
-  background-color: $background-color;
-  transition:
-    color 250ms ease-out,
-    background-color 250ms ease-out;
-
-  &:hover {
-    color: rgba(255, 255, 255, 1);
-    background-color: hsl(0, 100%, 40%);
-    transition:
-      color 0ms,
-      background-color 0ms;
+  &__dragZone {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
   }
-}
 
-.TitleBar__title {
-  position: absolute;
-  display: inline-block;
-  top: 0;
-  left: 46px;
-  left: base.rem(46px);
-  color: $text-color;
-  font-size: 14px;
-  font-size: base.rem(14px);
-  line-height: 31px;
-  line-height: base.rem(31px);
-  white-space: nowrap;
-  pointer-events: none;
-}
+  &__statusIcon {
+    text-align: center;
+    font-size: base.rem(20px);
+    transition: color 0.5s;
+  }
 
-.TitleBar__buttons {
-  pointer-events: initial;
-  display: inline-block;
-  width: 100%;
-  margin-left: 10px;
-}
+  &__title {
+    pointer-events: none;
+    display: inline-block;
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: $text-color;
+    font-size: base.rem(14px);
+  }
 
-.TitleBar__dragZone {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 32px;
-  height: base.rem(32px);
-}
+  &__buttons {
+    overflow: hidden;
+    white-space: nowrap;
+    pointer-events: all;
+    display: inline-block;
+    margin: 0 base.rem(9px);
+    z-index: 102;
+  }
 
-.TitleBar__statusIcon {
-  position: absolute;
-  top: 0;
-  left: 12px;
-  left: base.rem(12px);
-  transition: color 0.5s;
-  font-size: 20px;
-  font-size: base.rem(20px);
-  line-height: 32px !important;
-  line-height: base.rem(32px) !important;
-}
+  &__KitchenSink {
+    width: base.rem(21px);
+    min-width: base.rem(21px);
+    max-width: base.rem(21px);
+    background-color: color.adjust(colors.$good, $lightness: -10%, $space: hsl);
+    color: hsl(120, 100%, 100%);
+    text-align: center;
+    border-radius: 0;
 
-.TitleBar__close {
-  position: absolute;
-  top: -1px;
-  right: 0;
-  width: 45px;
-  width: base.rem(45px);
-  height: 32px;
-  height: base.rem(32px);
-  font-size: 20px;
-  font-size: base.rem(20px);
-  line-height: 31px;
-  line-height: base.rem(31px);
-  text-align: center;
-}
+    &:hover {
+      background-color: colors.$good;
+    }
+  }
 
-.TitleBar__devBuildIndicator {
-  position: absolute;
-  top: 6px;
-  top: base.rem(6px);
-  right: 52px;
-  right: base.rem(52px);
-  min-width: 20px;
-  min-width: base.rem(20px);
-  padding: 2px 4px;
-  padding: base.rem(2px) base.rem(4px);
-  background-color: color.adjust(colors.$good, $lightness: -10%, $space: hsl);
-  color: hsl(120, 100%, 100%);
-  text-align: center;
+  &__close {
+    cursor: pointer;
+    pointer-events: all;
+    align-content: center;
+    text-align: center;
+    font-size: base.rem(16px);
+    height: 100%;
+    color: color.change($text-color, $alpha: 0.5);
+    z-index: 102;
+    transition:
+      background-color 0.2s,
+      color 0.2s;
+
+    &:hover {
+      background-color: hsl(0, 100%, 40%);
+      color: rgba(255, 255, 255, 1);
+      transition-duration: 0s;
+    }
+  }
+
+  &__statusIcon,
+  &__close {
+    width: base.rem(45px);
+    min-width: base.rem(45px);
+    max-width: base.rem(45px);
+  }
 }

--- a/tgui/packages/tgui/styles/layouts/Window.scss
+++ b/tgui/packages/tgui/styles/layouts/Window.scss
@@ -22,16 +22,6 @@
   );
 }
 
-.Window__titleBar {
-  position: fixed;
-  z-index: 1;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 32px;
-  height: base.rem(32px);
-}
-
 // Everything after the title bar
 .Window__rest {
   position: fixed;


### PR DESCRIPTION
## About The Pull Request
Cleans up TitleBar styles and moves it to a separate file
Plus if UI disabled, icon will changes to eye-slash, signaling that your character doesn't even see what information is currently in a particular interface, and info can be old. Red didn't go anywhere

Also, Window buttons now can be used without fear of being eaten by the title (still can be eaten by closing button)

## Why It's Good For The Game
It's easier to show

And don't look on debug button, idk why but SCSS ignores :last-child selector on titlebar buttons
Prob because used local tgui-core

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/920ee385-42f5-43ed-ad12-1f8da6c60b89) | ![image](https://github.com/user-attachments/assets/4f347bfb-3017-4254-9818-1dd7b2250ffb) |

<details> <summary> Before (Video) </summary>

https://github.com/user-attachments/assets/15b54f69-fceb-43f4-8137-b63556b182aa

</details>
<details> <summary> After (Video) </summary>

https://github.com/user-attachments/assets/4818269d-46fa-4cb9-9c5f-ed92d69cc059

</details>
<details> <summary> New icon </summary>

https://github.com/user-attachments/assets/c0cf0d7c-13c2-4b64-832d-ad7525af4a1a

</details>


## Changelog
qol: TGUI titlebar icon, now signals more explicitly that your character can't see the interface and isn't getting up-to-date information. The eye icon will not only be red but also slashed
