### PR TITLE
Fix Tiziran supply boxes not having the proper contents

### DIFF
--- a/code/datums/storage/subtypes/boxes.dm
+++ b/code/datums/storage/subtypes/boxes.dm
@@ -303,6 +303,11 @@
 	max_slots = 15
 	max_total_storage = 15 * WEIGHT_CLASS_SMALL
 
+///Tiziran goods box
+/datumn/storage/box/tiziran_goods
+	max_slots = 8
+	max_total_storage = 8 * WEIGHT_CLASS_NORMAL
+
 ///Tiziran cans box
 /datum/storage/box/tiziran_cans
 	max_slots = 8

--- a/code/datums/storage/subtypes/boxes.dm
+++ b/code/datums/storage/subtypes/boxes.dm
@@ -304,7 +304,7 @@
 	max_total_storage = 15 * WEIGHT_CLASS_SMALL
 
 ///Tiziran goods box
-/datumn/storage/box/tiziran_goods
+/datum/storage/box/tiziran_goods
 	max_slots = 8
 	max_total_storage = 8 * WEIGHT_CLASS_NORMAL
 

--- a/code/game/objects/items/storage/boxes/food_boxes.dm
+++ b/code/game/objects/items/storage/boxes/food_boxes.dm
@@ -449,7 +449,7 @@
 	)
 
 	var/list/obj/item/insert = list()
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 8)
 		insert += pick_weight(food)
 
 	return insert
@@ -463,16 +463,9 @@
 
 /obj/item/storage/box/tiziran_cans/PopulateContents()
 	var/static/list/obj/item/food = list(
-		/obj/item/food/bread/root = 2,
-		/obj/item/food/grown/ash_flora/seraka = 2,
-		/obj/item/food/grown/korta_nut = 10,
-		/obj/item/food/grown/korta_nut/sweet = 2,
-		/obj/item/food/liver_pate = 5,
-		/obj/item/food/lizard_dumplings = 5,
-		/obj/item/food/moonfish_caviar = 5,
-		/obj/item/food/root_flatbread = 5,
-		/obj/item/food/rootroll = 5,
-		/obj/item/food/spaghetti/nizaya = 5,
+		/obj/item/food/canned/jellyfish = 5,
+		/obj/item/food/canned/desert_snails = 5,
+		/obj/item/food/canned/larvae = 5,
 	)
 
 	var/list/obj/item/insert = list()

--- a/code/game/objects/items/storage/boxes/food_boxes.dm
+++ b/code/game/objects/items/storage/boxes/food_boxes.dm
@@ -433,6 +433,7 @@
 	desc = "A box containing an assortment of fresh Tiziran goods- perfect for making the foods of the Lizard Empire."
 	icon_state = "lizard_package"
 	illustration = null
+	storage_type = /datumn/storage/box/tiziran_goods
 
 /obj/item/storage/box/tiziran_goods/PopulateContents()
 	var/static/list/obj/item/food = list(

--- a/code/game/objects/items/storage/boxes/food_boxes.dm
+++ b/code/game/objects/items/storage/boxes/food_boxes.dm
@@ -433,7 +433,7 @@
 	desc = "A box containing an assortment of fresh Tiziran goods- perfect for making the foods of the Lizard Empire."
 	icon_state = "lizard_package"
 	illustration = null
-	storage_type = /datumn/storage/box/tiziran_goods
+	storage_type = /datum/storage/box/tiziran_goods
 
 /obj/item/storage/box/tiziran_goods/PopulateContents()
 	var/static/list/obj/item/food = list(


### PR DESCRIPTION
## About The Pull Request
Tiziran canned goods boxes used the farm fresh list while the farm fresh box only gave three items. The farm fresh box now gives eight food items and the canned goods now actually give canned goods. Adds a storage type for tiziran goods.

## Why It's Good For The Game
Canned goods should have canned goods. Farm fresh should provide plenty of items due to the amount of different things it can roll. (It's also how it used to be) 

## Changelog
:cl: Goat
fix: The Tiziran Empire has now actually puts canned goods in their canned good exports along with putting more food in their farm fresh boxes.
/:cl:
