### PR TITLE
Hotfix for IRV votes not submitting on 516

### DIFF
--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -295,7 +295,7 @@ GLOBAL_PROTECT(poll_options)
 		output += "<font size='2'>Revoting is enabled.</font>"
 	output += "Please sort the options in the order of <b>most preferred</b> to <b>least preferred</b><br></div>"
 	if(!length(voted_for) || poll.allow_revoting)
-		output += {"<form action='?src=[REF(src)]' method='POST'>
+		output += {"<form action='?src=[REF(src)]' method='get'>
 		<input type='hidden' name='src' value='[REF(src)]'>
 		<input type='hidden' name='votepollref' value='[REF(poll)]'>
 		<input type='hidden' name='IRVdata' id='IRVdata'>


### PR DESCRIPTION
## About The Pull Request

Fixes #90273

we relied on the post request sending the form data over the url, apparently this was the default behavior in ie11 but edge changed the form data to be sent in the http body, because browser standards i guess

this is bad for us though because it breaks voting since the form data does not appear in the topic anymore. this PR changes the form submission method to get, which correctly submits form data again.

proof of testing on localhost:
![dreamseeker_M8gllkPAnx](https://github.com/user-attachments/assets/d140043a-3912-4e4f-8cf3-805829e7345c)
(the long line on the bottom of the log is me suibmitting my result to the form, also note how the "Vote successful." message shows up in the chat)

## Changelog

:cl:
fix: Players on 516 can submit votes for IRV again.
/:cl:
