### PR TITLE
Reword the Pushover quirk's description to be more accurate

### DIFF
--- a/code/datums/quirks/negative_quirks/pushover.dm
+++ b/code/datums/quirks/negative_quirks/pushover.dm
@@ -1,6 +1,6 @@
 /datum/quirk/pushover
 	name = "Pushover"
-	desc = "Your first instinct is always to let people push you around. Resisting out of grabs will take conscious effort."
+	desc = "Your first instinct is always to let people push you around. Resisting out of grabs is noticeably more difficult."
 	icon = FA_ICON_HANDSHAKE
 	value = -8
 	mob_trait = TRAIT_GRABWEAKNESS


### PR DESCRIPTION

## About The Pull Request

Exactly what it says on the tin.

`TRAIT_GRABWEAKNESS` doesn't care if you're resisting via the verb/button, or by trying to move while grabbed, it acts the same regardless.

"Resisting out of grabs will take conscious effort" can easily be interpreted as "you have to use the resist verb/button to escape like normal", when this is not the case.

I've reworded that part to "Resisting out of grabs is noticeably more difficult.", to make it clear that resisting out of grabs _in general_ is more difficult.

## Why It's Good For The Game

makes things clearer for players

## Changelog
:cl:
qol: Reword the Pushover quirk's description to be more accurate to how it actually works.
/:cl:
