### PR TITLE
Makes hopline on Wawastation a little more feel like a hopline

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -6485,6 +6485,7 @@
 	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/medical/treatment_center)
 "cnm" = (
@@ -50586,6 +50587,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/medical/treatment_center)
 "rCL" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -1698,6 +1698,10 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "aBU" = (
@@ -4004,6 +4008,9 @@
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
@@ -12452,7 +12459,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_blue,
-/obj/effect/landmark/start/hangover,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -21529,6 +21535,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "hvw" = (
@@ -24283,13 +24290,14 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "iwu" = (
@@ -26981,6 +26989,10 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jwI" = (
@@ -27498,7 +27510,11 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/obj/machinery/ticket_machine/directional/west,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jEc" = (
@@ -34977,6 +34993,10 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "mhO" = (
@@ -47218,10 +47238,6 @@
 /obj/item/storage/medkit{
 	pixel_x = -10
 	},
-/obj/item/toy/figure/ian{
-	pixel_x = 5;
-	pixel_y = 12
-	},
 /turf/open/floor/carpet/executive,
 /area/station/command/meeting_room)
 "qwu" = (
@@ -54431,6 +54447,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sPV" = (
@@ -60584,6 +60601,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/item/storage/box/stickers,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "uWj" = (
@@ -66580,6 +66598,16 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/station/asteroid)
+"xcr" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "xcs" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/chair_comfy{
@@ -66760,6 +66788,7 @@
 	dir = 4
 	},
 /obj/machinery/photobooth,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "xgn" = (
@@ -68297,8 +68326,9 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/item/storage/box/stickers{
-	pixel_y = 16
+/obj/item/toy/figure/ian{
+	pixel_y = 15;
+	pixel_x = 7
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
@@ -97048,7 +97078,7 @@ dbJ
 mMH
 sPS
 jww
-btw
+xcr
 btw
 btw
 iow


### PR DESCRIPTION
## About The Pull Request
This makes hopline feel more like a line and places the sticker pack(which is put in the locker instead) that kinda looks weird on the printer for a cute ion toy also adds a missing ticket counter

## Why It's Good For The Game

I think it just looks better that way, adds more flair to the area
![image](https://github.com/user-attachments/assets/843561ba-efa1-4314-9784-45e610e4e07a)

Also fixes some suspicous wiring ig... 
![image](https://github.com/user-attachments/assets/8098727a-b5ab-4fdf-aec5-74c8bdcc8a0e)


## Changelog

:cl: Ezel
map: Hopline looks now more like a line.
fix: medbay grid is wired to eachother again
/:cl:
