### PR TITLE
Fix Donk Pocket spawns

### DIFF
--- a/code/game/objects/items/storage/boxes/food_boxes.dm
+++ b/code/game/objects/items/storage/boxes/food_boxes.dm
@@ -9,7 +9,9 @@
 	var/donktype = /obj/item/food/donkpocket
 
 /obj/item/storage/box/donkpockets/PopulateContents()
-	return donktype
+	. = list()
+	for(var/_ in 1 to 6)
+		. += donktype
 
 /obj/item/storage/box/donkpockets/donkpocketspicy
 	name = "box of spicy-flavoured donk-pockets"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/90294. Donk pockets should spawn in multitudes, not singular.

## Why It's Good For The Game

Bugfix, restoring previous functionality.

## Changelog

:cl:
fix: Donk pocket boxes start with more than one donk pocket again.
/:cl:
