### PR TITLE
fixes being able to pull mobs while riding them

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -207,6 +207,7 @@
 		human_parent.buckle_lying = 90
 
 /datum/component/riding/creature/handle_buckle(mob/living/rider)
+	. = ..()
 	var/mob/living/ridden = parent
 	if(!require_minigame || ridden.faction.Find(REF(rider)))
 		return


### PR DESCRIPTION
## About The Pull Request
u werent supposed to be able to pull these while riding them, since it causes lots of weird behavior with their offsets permenantly for the whole ride, even after u stop pulling them.

## Changelog
:cl:
fix: fixes being able to pull mobs while riding them
/:cl:
