### PR TITLE
Fixes 'Alternate Names' menu being squished on 516

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
@@ -68,9 +68,9 @@ export function MultiNameInput(props: MultiNameProps) {
 
   return (
     <Modal
+      width={30}
       style={{
         margin: '0 auto',
-        width: '40%',
       }}
     >
       <TrackOutsideClicks onOutsideClick={props.handleClose}>


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/90301
Fixes https://github.com/NovaSector/NovaSector/issues/5122

<details><summary>Before</summary>

![QQnLx0cQ6w](https://github.com/user-attachments/assets/8010494e-2ac1-416b-84ab-e3c010d0e2fa)

</details>

<details><summary>After</summary>

![image](https://github.com/user-attachments/assets/f20506d5-9013-40fe-b04a-f62101af562c)

</details>

Hopefully this looks close to how it was before

## Why It's Good For The Game

Unsquish the ui.

## Changelog

:cl:
fix: 'Alternate Names' menu has been unsquished
/:cl:
