### PR TITLE
Bucket tool for the painting/canvas UI (plus other improvements and fixes)

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -194,12 +194,10 @@
 					return FALSE
 			else
 				var/list/data = params["data"]
-				//could maybe validate continuity but eh
 				for(var/point in data)
 					var/x = text2num(point["x"])
 					var/y = text2num(point["y"])
-					if(action == "paint")
-						grid[x][y] = tool_color
+					grid[x][y] = tool_color
 			var/medium = get_paint_tool_medium(I)
 			if(medium && painting_metadata.medium && painting_metadata.medium != medium)
 				painting_metadata.medium = "Mixed medium"

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -464,7 +464,7 @@
 	}
 
 /**
- * A proc that adopts a scan-based, 4-dir (correct me if I'm wrong) flood fill algorithm used
+ * A proc that adopts a span-based, 4-dir (correct me if I'm wrong) flood fill algorithm used
  * by the bucked tool in the UI, to facilitate coloring larger portions of the canvas.
  * If you have never used the bucket/flood tool on an image editor, I suggest you do it
  * now so you know what I'm basically talking about.

--- a/code/modules/tgui/states/hold_or_view.dm
+++ b/code/modules/tgui/states/hold_or_view.dm
@@ -1,0 +1,12 @@
+/**
+ * tgui state: view
+ *
+ * Checks if the object is in view or the mob is holding it, otherwise close the UI
+ */
+
+GLOBAL_DATUM_INIT(hold_or_view_state, /datum/ui_state/hold_or_view_state, new)
+
+/datum/ui_state/hold_or_view_state/can_use_topic(src_object, mob/user)
+	if((user in viewers(user.client?.view, src_object)) || user.is_holding(src_object))
+		return UI_INTERACTIVE
+	return UI_CLOSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6256,6 +6256,7 @@
 #include "code\modules\tgui\states\default.dm"
 #include "code\modules\tgui\states\greyscale_menu.dm"
 #include "code\modules\tgui\states\hands.dm"
+#include "code\modules\tgui\states\hold_or_view.dm"
 #include "code\modules\tgui\states\human_adjacent.dm"
 #include "code\modules\tgui\states\inventory.dm"
 #include "code\modules\tgui\states\language_menu.dm"

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -46,6 +46,10 @@ const toMassPaintFormat = (data: PointData[]) => {
   return data.map((p) => ({ x: p.x + 1, y: p.y + 1 })); // 1-based index dm side
 };
 
+const checkPointCoords = (x: number, y: number, p: PointData) => {
+  return p.x === x && p.y === y;
+};
+
 class PaintCanvas extends Component<PaintCanvasProps> {
   canvasRef: RefObject<HTMLCanvasElement>;
   baseImageData: Color[][];
@@ -172,9 +176,8 @@ class PaintCanvas extends Component<PaintCanvasProps> {
   }
 
   drawPoint(x: number, y: number, color: any) {
-    // Checks whether an element is even
-    const isDupe = (p: PointData) => p.x === x && p.y === y;
-    if (this.modifiedElements.some(isDupe)) {
+    // check if modifiedElements already contains a point with same x and y
+    if (this.modifiedElements.some(checkPointCoords.bind(null, x, y))) {
       return;
     }
     let p: PointData = { x, y };
@@ -346,7 +349,7 @@ export const Canvas = (props) => {
                   tooltip="Bucket Tool (F)"
                   icon="bucket"
                   backgroundColor={fillmode ? 'green' : 'red'}
-                  onClick={() => setFillMode(!fillmode)}
+                  onClick={() => setFillMode((prevFill) => !prevFill)}
                   m={0.5}
                 />
               </Flex.Item>

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -322,7 +322,7 @@ export const Canvas = (props) => {
                   \n Left-Click the palette at the
                   bottom of the UI to select a color,
                   or input a new one with Right-Click. \n
-		          Tools may have key shortcuts.
+                  Tools may have key shortcuts.
                 `
                     : '')
                 }

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -173,6 +173,11 @@ class PaintCanvas extends Component<PaintCanvasProps> {
   }
 
   drawPoint(x: number, y: number, color: any) {
+    // Checks whether an element is even
+    const isDupe = (p: PointData) => p.x === x && p.y === y;
+    if (this.modifiedElements.some(isDupe)) {
+      return;
+    }
     let p: PointData = { x, y, color: Color.fromHex(color) };
     this.modifiedElements.push(p);
     const canvas = this.canvasRef.current!;
@@ -295,7 +300,7 @@ export const Canvas = (props) => {
 
             switch (keyCode) {
               case KEY_F:
-                setFillMode(fillmode ? false : true);
+                setFillMode((prevFill) => !prevFill);
                 break;
 
               case KEY_G:
@@ -317,7 +322,7 @@ export const Canvas = (props) => {
                   \n Left-Click the palette at the
                   bottom of the UI to select a color,
                   or input a new one with Right-Click. \n
-		          Some tools have key shortcuts.
+		          Tools may have key shortcuts.
                 `
                     : '')
                 }

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -1,6 +1,14 @@
-import { Component, createRef, RefObject } from 'react';
+import { Component, createRef, RefObject, useState } from 'react';
 import { Color } from 'tgui-core/color';
-import { Box, Button, Flex, Icon, Tooltip } from 'tgui-core/components';
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  KeyListener,
+  Tooltip,
+} from 'tgui-core/components';
+import { KEY_F, KEY_G } from 'tgui-core/keycodes';
 import { decodeHtmlEntities } from 'tgui-core/string';
 
 import { useBackend } from '../backend';
@@ -11,6 +19,7 @@ const LEFT_CLICK = 0;
 type PaintCanvasProps = Partial<{
   onCanvasModifiedHandler: (data: PointData[]) => void;
   onCanvasDropperHandler: (x: number, y: number) => void;
+  onCanvasFillHandler: (x: number, y: number) => void;
   value: string[][];
   width: number;
   height: number;
@@ -21,6 +30,7 @@ type PaintCanvasProps = Partial<{
   has_palette: boolean;
   show_grid: boolean;
   zoom: number;
+  fillmode: boolean;
 }>;
 
 type PointData = {
@@ -44,6 +54,7 @@ class PaintCanvas extends Component<PaintCanvasProps> {
   modifiedElements: PointData[];
   onCanvasModified: (data: PointData[]) => void;
   onCanvasDropper: (x: number, y: number) => void;
+  onCanvasFill: (x: number, y: number) => void;
   drawing: boolean;
   drawing_color: string;
   zoom: number;
@@ -55,8 +66,10 @@ class PaintCanvas extends Component<PaintCanvasProps> {
     this.is_grid_shown = false;
     this.drawing = false;
     this.zoom = props.zoom;
+
     this.onCanvasModified = props.onCanvasModifiedHandler;
     this.onCanvasDropper = props.onCanvasDropperHandler;
+    this.onCanvasFill = props.onCanvasFillHandler;
 
     this.handleStartDrawing = this.handleStartDrawing.bind(this);
     this.handleDrawing = this.handleDrawing.bind(this);
@@ -148,10 +161,14 @@ class PaintCanvas extends Component<PaintCanvasProps> {
     ) {
       return;
     }
+    const coords = this.eventToCoords(event);
+    if (this.props.fillmode) {
+      this.onCanvasFill(coords.x + 1, coords.y + 1); // 1-based index dm side
+      return;
+    }
     this.modifiedElements = [];
     this.drawing = true;
     this.drawing_color = this.props.drawing_color;
-    const coords = this.eventToCoords(event);
     this.drawPoint(coords.x, coords.y, this.drawing_color);
   }
 
@@ -182,8 +199,6 @@ class PaintCanvas extends Component<PaintCanvasProps> {
       return;
     }
     this.drawing = false;
-    const canvas = this.canvasRef.current!;
-    const ctx = canvas.getContext('2d')!;
     if (this.onCanvasModified !== undefined) {
       this.onCanvasModified(this.modifiedElements);
     }
@@ -262,6 +277,7 @@ export const Canvas = (props) => {
   const average_plaque_height = 90;
   const palette_height = 38;
   const griddy = !!data.show_grid && !!data.editable && !!data.paint_tool_color;
+  const [fillmode, setFillMode] = useState(false);
   return (
     <Window
       width={Math.max(scaled_width + 72, 280)}
@@ -273,6 +289,21 @@ export const Canvas = (props) => {
       }
     >
       <Window.Content>
+        <KeyListener
+          onKeyDown={(event) => {
+            const keyCode = event.code;
+
+            switch (keyCode) {
+              case KEY_F:
+                setFillMode(fillmode ? false : true);
+                break;
+
+              case KEY_G:
+                act('toggle_grid');
+                break;
+            }
+          }}
+        />
         <Flex align="start" direction="row">
           {!!data.paint_tool_palette && (
             <Flex.Item>
@@ -285,7 +316,8 @@ export const Canvas = (props) => {
                     ? `
                   \n Left-Click the palette at the
                   bottom of the UI to select a color,
-                  or input a new one with Right-Click.
+                  or input a new one with Right-Click. \n
+		          Some tools have key shortcuts.
                 `
                     : '')
                 }
@@ -295,15 +327,26 @@ export const Canvas = (props) => {
             </Flex.Item>
           )}
           {!!data.editable && !!data.paint_tool_color && (
-            <Flex.Item>
-              <Button
-                tooltip="Grid Toggle"
-                icon="th-large"
-                backgroundColor={data.show_grid ? 'green' : 'red'}
-                onClick={() => act('toggle_grid')}
-                m={0.5}
-              />
-            </Flex.Item>
+            <>
+              <Flex.Item>
+                <Button
+                  tooltip="Grid Toggle (G)"
+                  icon="th-large"
+                  backgroundColor={data.show_grid ? 'green' : 'red'}
+                  onClick={() => act('toggle_grid')}
+                  m={0.5}
+                />
+              </Flex.Item>
+              <Flex.Item>
+                <Button
+                  tooltip="Bucket Tool (F)"
+                  icon="bucket"
+                  backgroundColor={fillmode ? 'green' : 'red'}
+                  onClick={() => setFillMode(!fillmode)}
+                  m={0.5}
+                />
+              </Flex.Item>
+            </>
           )}
           <Flex.Item>
             <Button
@@ -336,12 +379,14 @@ export const Canvas = (props) => {
                 drawing_color={data.paint_tool_color}
                 show_grid={griddy}
                 zoom={data.zoom}
+                fillmode={fillmode}
                 onCanvasModifiedHandler={(changed) =>
                   act('paint', { data: toMassPaintFormat(changed) })
                 }
                 onCanvasDropperHandler={(x, y) =>
-                  act('select_color_from_coords', { px: x, py: y })
+                  act('select_color_from_coords', { x: x, y: y })
                 }
+                onCanvasFillHandler={(x, y) => act('fill', { x: x, y: y })}
                 editable={data.editable}
                 has_palette={!!data.paint_tool_palette}
               />

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -36,7 +36,6 @@ type PaintCanvasProps = Partial<{
 type PointData = {
   x: number;
   y: number;
-  color: Color;
 };
 
 const fromDM = (data: string[][]) => {
@@ -178,7 +177,7 @@ class PaintCanvas extends Component<PaintCanvasProps> {
     if (this.modifiedElements.some(isDupe)) {
       return;
     }
-    let p: PointData = { x, y, color: Color.fromHex(color) };
+    let p: PointData = { x, y };
     this.modifiedElements.push(p);
     const canvas = this.canvasRef.current!;
     const ctx = canvas.getContext('2d')!;


### PR DESCRIPTION
## About The Pull Request
First update to the crappy paintings UI I've done in over a year, that I wanted to do it since then, but then I got caught up with the fishing feature.

<details>
  <summary> verbosely explained data size related issue fixed</summary>
First and foremost, this PR fixes an issue with the size of the data sent to topic when drawing. For those who don't know it yet, 516 has introduced a size limit of 2kb for topics, which means anything hitting that limit is fucked. Thankfully, Y0SH1M4S73R is working on a way to split the data in chunks.
However, what does this have to do with drawing on a canvas? For starters, everytime onmousemove is called while the drawing prop is set to true, point data is pushed in the modifiedElements array, BUT it doesn't check if a point data object with the same x and y values is already there, meaning you can move the mouse back and forth two points of the raster/canvas/whateveryouwannacallit or even inside one point and the array will grow until it reaches the aforementioned limit. Furthermore, there's also an unused prop in the PointData type which only makes this worse.
Thankfully, all I had to do Implementing the some() method in a conditional check that prevents point data from being instantiated and pushed if there's an instance with same x and y.
</details>


Moving on, this PR adds a bucket tool to the UI. By enabling it you can click on a point/square/pixel and it'll fill a same-colored area with a new color, much like how it's done in actual painting softwares.
<details>
  <summary> verbose pseudo-technical rant</summary>
The algorithm for it is based on the DM side of the code, although I reckon this is a suboptimal decision, just because there can be a small 1-2 seconds delay between clicking, topic stuff and re-rendering. It is not a major problem but it could be as well scoffed at.
The dm proc employs a span filling algorithm, which works with constant x to reduce time spent accessing each position of the array, at the cost of code complexity. The algorithm uses queues, meaning sections on the same x will be handled first, then move to the next x. This is kinda my first time wrapping my head around this sort of things, so apologies if some of the code or comments are nighttime-coding levels of bad.
</details>

Both bucket mode and grid can now be toggled by key shortcuts with F and G respectively. This will cause some conficts with key bindings on those places if you have them however. If there's a way to prevent standard keybind functions through signals or whatsnot while the UI is open, please tell me. I can perhaps search for a solution to it myself later but I've already done so much. Also I don't want to assign keybinds to them, thank you. The canvas UI is still quite primitive frankly, so it'd be overdoing it.

This PR also fixes observers/viewers not being able to zoom in/out regardless of distance, because it didn't work to begin with! My fault!

## Why It's Good For The Game
Fixing issues with painting UI/UX.

## Changelog

:cl:
fix: Fixed an issue with paintings related to 516. You should now be able to paint larger strokes again.
fix: Fixed ghosts and other non-adjacent viewers not being able to zoom the canvas in and out.
add: Added a bucket tool to the canvas UI to fill larger areas. You can find the button for it beside the one for the grid.
qol: You can toggle the canvas grid and bucket tool with the G and F key respectively.
/:cl:
