### PR TITLE
Add some more lua helpers (and fix one)

### DIFF
--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -40,11 +40,7 @@ end
 function SS13.typecacheof(string_types)
 	local types = {}
 	for _, path in string_types do
-		if path == nil then
-			continue
-		elseif SS13.ispath(path) == 1 then
-			table.insert(types, path)
-		else
+		if path ~= nil then
 			table.insert(types, SS13.type(path))
 		end
 	end

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -19,8 +19,19 @@ function SS13.get_runner_client()
 	return dm.global_vars.GLOB.directory[SS13.get_runner_ckey()]
 end
 
-SS13.ispath = dm.global_procs._ispath
-SS13.type = dm.global_procs._text2path
+function SS13.ispath(thing, path)
+	return dm.global_procs._ispath(thing, path) == 1
+end
+
+function SS13.type(typepath)
+	if type(typepath) == "string" then
+		return dm.global_procs._text2path(typepath)
+	elseif SS13.ispath(typepath) then
+		return typepath
+	else
+		return nil
+	end
+end
 
 function SS13.istype(thing, type)
 	return dm.global_procs._istype(thing, SS13.type(type)) == 1
@@ -28,7 +39,7 @@ end
 
 function SS13.typecacheof(string_types)
 	local types = {}
-	for _, path in pairs(string_types) do
+	for _, path in string_types do
 		if path == nil then
 			continue
 		elseif SS13.ispath(path) == 1 then
@@ -40,7 +51,9 @@ function SS13.typecacheof(string_types)
 	return dm.global_procs.typecacheof(types)
 end
 
-SS13.is_type_in_typecache = dm.global_procs._is_type_in_typecache
+function SS13.is_type_in_typecache(thing, typecache)
+	return dm.global_procs._is_type_in_typecache(thing, typecache) == 1
+end
 
 function SS13.get_turf(thing)
 	return dm.global_procs._get_step(thing, 0)

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -19,10 +19,44 @@ function SS13.get_runner_client()
 	return dm.global_vars.GLOB.directory[SS13.get_runner_ckey()]
 end
 
+SS13.ispath = dm.global_procs._ispath
 SS13.type = dm.global_procs._text2path
 
 function SS13.istype(thing, type)
 	return dm.global_procs._istype(thing, SS13.type(type)) == 1
+end
+
+function SS13.typecacheof(string_types)
+	local types = {}
+	for _, path in pairs(string_types) do
+		if path == nil then
+			continue
+		elseif SS13.ispath(path) == 1 then
+			table.insert(types, path)
+		else
+			table.insert(types, SS13.type(path))
+		end
+	end
+	return dm.global_procs.typecacheof(types)
+end
+
+SS13.is_type_in_typecache = dm.global_procs._is_type_in_typecache
+
+function SS13.get_turf(thing)
+	return dm.global_procs._get_step(thing, 0)
+end
+
+function SS13.get_area(thing)
+	if SS13.istype(thing, "/area") then
+		return thing
+	else
+		local turf = SS13.get_turf(thing)
+		-- don't bother with SS13.is_valid, turfs don't get destroyed
+		if dm.is_valid_ref(turf) then
+			return turf.loc
+		end
+	end
+	return nil
 end
 
 SS13.new = dm.new
@@ -94,7 +128,7 @@ local function create_qdeleting_callback(datum)
 end
 
 function SS13.register_signal(datum, signal, func)
-	if not type(func) == "function" then
+	if type(func) ~= "function" then
 		return
 	end
 	if not SS13.istype(datum, "/datum") then


### PR DESCRIPTION

## About The Pull Request

I added new helpers to the default SS13 lua library: `SS13.ispath`, `SS13.typecacheof`, `SS13.is_type_in_typecache`, `SS13.get_turf`, and `SS13.get_area`, which pretty much behave like their actual DM counterparts (albeit `SS13.typecacheof` lets you just input string typepaths, instead of needing to manually `SS13.type` each one)

In addition, I discovered an issue with `SS13.register_signal`: `not type(func) == "function"` is the same as `(not type(func)) == "function"` - so the proper check is `type(func) ~= "function"`.

## Why It's Good For The Game
## Changelog
:cl:
admin: Added some new Lua functions: SS13.ispath, SS13.typecacheof, SS13.is_type_in_typecache, SS13.get_turf, and SS13.get_area
fix: Fixed a broken check in the SS13.register_signal Lua function.
/:cl:
