### PR TITLE
[NO GBP]Fixes some storages doing stuff in init

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -101,7 +101,6 @@
 	base_icon_state = "donutbox"
 	spawn_type = /obj/item/food/donut/plain
 	spawn_count = 6
-	open_status = TRUE
 	appearance_flags = KEEP_TOGETHER|LONG_GLIDE
 	custom_premium_price = PAYCHECK_COMMAND * 1.75
 	contents_tag = "donut"

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -80,6 +80,9 @@
 
 /obj/item/storage/fancy/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
+	if(!(flags_1 & INITIALIZED_1))
+		return
+
 	if(open_status == FANCY_CONTAINER_CLOSED)
 		open_status = FANCY_CONTAINER_OPEN
 	update_appearance()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -93,6 +93,9 @@
 
 /obj/item/storage/lockbox/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
+	if(!(flags_1 & INITIALIZED_1))
+		return
+
 	open = TRUE
 	update_appearance()
 

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -58,7 +58,7 @@
 	pre_compute |= !isnull(type_paths)
 
 	//we now begin inserting these items the right way
-	flags_1 &= ~INITIALIZED_1 ///Used inside Entered() to decide if this object is being moved inside during init
+	flags_1 &= ~INITIALIZED_1 //Used inside Entered() to know if this object was moved inside during init
 	for(var/obj/item/insert as anything in items)
 		if(ispath(insert))
 			insert = new insert(null)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -58,6 +58,7 @@
 	pre_compute |= !isnull(type_paths)
 
 	//we now begin inserting these items the right way
+	flags_1 &= ~INITIALIZED_1 ///Used inside Entered() to decide if this object is being moved inside during init
 	for(var/obj/item/insert as anything in items)
 		if(ispath(insert))
 			insert = new insert(null)
@@ -74,6 +75,7 @@
 		if(!atom_storage.can_insert(insert, messages = STORAGE_ERROR_INSERT))
 			. = INITIALIZE_HINT_QDEL //this thing was shoved inside & destroyed us. Fix your storage caps and try again
 		insert.forceMove(src)
+	flags_1 |= INITIALIZED_1
 
 	if(!pre_compute || . == INITIALIZE_HINT_QDEL)
 		return


### PR DESCRIPTION
## About The Pull Request
- Fixes #90315

Only the 2 items listed in the issue had the problem

## Changelog
:cl:
fix: lockboxes & fancy storages spawned at round start with items in them don't have issues anymore
/:cl:

