### PR TITLE
Fixes weather from Z levels above rendering over players' UI

### DIFF
--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -248,6 +248,7 @@
 	documentation = "Holds the main tiling 32x32 sprites of weather. We mask against walls that are on the edge of weather effects."
 	plane = WEATHER_PLANE
 	start_hidden = TRUE
+	critical = PLANE_CRITICAL_DISPLAY
 
 /atom/movable/screen/plane_master/weather/set_home(datum/plane_master_group/home)
 	. = ..()
@@ -314,6 +315,7 @@
 	documentation = "Holds the glowing parts of the main tiling 32x32 sprites of weather."
 	plane = WEATHER_GLOW_PLANE
 	start_hidden = TRUE
+	critical = PLANE_CRITICAL_DISPLAY
 
 /atom/movable/screen/plane_master/weather_glow/set_home(datum/plane_master_group/home)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_performance.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_performance.tsx
@@ -1,11 +1,12 @@
 import { createDropdownInput, Feature } from '../base';
 
 export const multiz_performance: Feature<number> = {
-  name: 'Multi-Z Detail',
+  name: 'Multi-Z Depth',
   category: 'GAMEPLAY',
-  description: 'How detailed multi-z is. Lower this to improve performance',
+  description:
+    'How many Multi-Z levels are rendered before they start getting culled. Decrease this to improve performance in case of lag on multi-z maps.',
   component: createDropdownInput({
-    [-1]: 'Standard',
+    [-1]: 'No Culling',
     2: 'High',
     1: 'Medium',
     0: 'Low',


### PR DESCRIPTION

## About The Pull Request

Because these didn't have PLANE_CRITICAL_DISPLAY they got cut off if you had multiz culling enabled, which resulted in weather from planes above getting rendered ontop of your UI.

Also renamed "Multi-Z Detail" to "Multi-Z Depth" and elaborated on what it does, as "Standard" is a very confusing setting (it actually disables multi-z culling)

## Why It's Good For The Game

I had no idea what this setting did until like 2 months ago when I dove into planecube code, I bet none of our players (or even most maintainers) know what it does.

## Changelog
:cl:
fix: Fixed weather from Z levels above rendering over players' UI
qol: Multi-Z Detail setting has been renamed to Multi-Z Depth with an explanation on what it does. "Standard" setting has been renamed to "No Culling"
/:cl:
