### PR TITLE
Fixes the _winget SDQL2/Lua wrapper

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -272,7 +272,7 @@
 	winset(player, control_id, params)
 
 /proc/_winget(player, control_id, params)
-	winget(player, control_id, params)
+	return winget(player, control_id, params)
 
 /proc/_text2path(text)
 	return text2path(text)


### PR DESCRIPTION

## About The Pull Request

this makes it so the `_winget` wrapper actually _returns_ what `winget` returns.

## Why It's Good For The Game

this wrapper is literally useless otherwise

## Changelog
:cl:
fix: Fixed the _winget SDQL2/Lua wrapper, so it actually returns the return value of winget.
/:cl:
