### PR TITLE
Blacklists certain RNG-dependant crates from testing

### DIFF
--- a/code/modules/bitrunning/objects/vendor.dm
+++ b/code/modules/bitrunning/objects/vendor.dm
@@ -77,7 +77,7 @@
 	hidden = TRUE
 	crate_name = "bitrunning delivery crate"
 	access = list(ACCESS_BIT_DEN)
-	abstract = TRUE
+	test_ignored = TRUE
 
 /datum/supply_pack/bitrunning/New(purchaser, cost, list/contains)
 	. = ..()

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -42,7 +42,7 @@
 	/// Can coupons target this pack? If so, how rarely?
 	var/discountable = SUPPLY_PACK_NOT_DISCOUNTABLE
 	/// Is this supply pack considered unpredictable for the purposes of testing unit testing? Examples include the stock market, or miner supply crates. If true, exempts from unit testing
-	var/abstract = FALSE
+	var/test_ignored = FALSE
 
 /datum/supply_pack/New()
 	id = type
@@ -129,7 +129,7 @@
 	hidden = TRUE
 	crate_name = "shaft mining delivery crate"
 	access = ACCESS_MINING
-	abstract = TRUE
+	test_ignored = TRUE
 
 /datum/supply_pack/custom/New(purchaser, cost, list/contains)
 	. = ..()

--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -31,6 +31,13 @@
 	crate_name = "collectable hats crate"
 	crate_type = /obj/structure/closet/crate/wooden
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE
+	test_ignored = TRUE
+
+/datum/supply_pack/costumes_toys/randomised/fill(obj/structure/closet/crate/C)
+	var/list/L = contains.Copy()
+	for(var/i in 1 to num_contained)
+		var/item = pick_n_take(L)
+		new item(C)
 
 /datum/supply_pack/costumes_toys/formalwear
 	name = "Formalwear Crate"
@@ -198,12 +205,6 @@
 				)
 	crate_name = "wizard costume crate"
 	crate_type = /obj/structure/closet/crate/wooden
-
-/datum/supply_pack/costumes_toys/randomised/fill(obj/structure/closet/crate/C)
-	var/list/L = contains.Copy()
-	for(var/i in 1 to num_contained)
-		var/item = pick_n_take(L)
-		new item(C)
 
 /datum/supply_pack/costumes_toys/trekkie
 	name = "Trekkie Costume Crate"

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -214,7 +214,7 @@
 	contains = list()
 	crate_name = "syndicate gear crate"
 	crate_type = /obj/structure/closet/crate
-	abstract = TRUE // Not 
+	test_ignored = TRUE
 	///Total TC worth of contained uplink items
 	var/crate_value = 30
 	///What uplink the contents are pulled from

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -96,6 +96,7 @@
 	)
 	crate_name = "putrid dumpster"
 	crate_type = /obj/structure/closet/crate/trashcart
+	test_ignored = TRUE
 
 /datum/supply_pack/imports/shells
 	name = "Lethal Shotgun Shell Box Crate"
@@ -145,6 +146,7 @@
 		/obj/effect/spawner/random/contraband = 5,
 	)
 	crate_name = "crate"
+	test_ignored = TRUE
 
 /datum/supply_pack/imports/wt550
 	name = "Smuggled WT-550 Autorifle Crate"
@@ -289,6 +291,7 @@
 	cost = CARGO_CRATE_VALUE * 30
 	contains = list(/obj/effect/spawner/random/animalhide = 5)
 	crate_name = "animal hide crate"
+	test_ignored = TRUE
 
 /datum/supply_pack/imports/dreadnog
 	name = "Dreadnog Carton Crate"

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -230,8 +230,7 @@
 		new /mob/living/basic/garden_gnome(.)
 
 /datum/supply_pack/critter/fish
-	crate_type = /obj/structure/closet/crate
-	abstract = ABSTRACT // However, we should be wary of how possible it is to get more valuable fish out of this on average, depending on sample size.
+	test_ignored = TRUE // However, we should be wary of how possible it is to get more valuable fish out of this on average, depending on sample size.
 
 /datum/supply_pack/critter/fish/aquarium_fish
 	name = "Aquarium Fish Case"

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -75,7 +75,7 @@
 	cost = CARGO_CRATE_VALUE * 0.05
 	contains = list(/obj/machinery/portable_atmospherics/canister)
 	crate_type = /obj/structure/closet/crate/large
-	abstract = TRUE
+	test_ignored = TRUE
 
 /datum/supply_pack/materials/gas_canisters/generate_supply_packs()
 	var/list/canister_packs = list()
@@ -101,7 +101,7 @@
 		pack.cost = cost + moleCount * initial(gas.base_value) * 1.6
 		pack.cost = CEILING(pack.cost, 10)
 
-		pack.abstract = FALSE
+		pack.test_ignored = FALSE
 
 		pack.contains = list(GLOB.gas_id_to_canister[initial(gas.id)])
 

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -114,6 +114,7 @@
 				)
 	crate_name = "medical supplies crate"
 	crate_type = /obj/structure/closet/crate/medical
+	test_ignored = TRUE
 
 /datum/supply_pack/medical/supplies/fill(obj/structure/closet/crate/C)
 	for(var/i in 1 to 10)

--- a/code/modules/unit_tests/cargo_crate_sanity.dm
+++ b/code/modules/unit_tests/cargo_crate_sanity.dm
@@ -9,8 +9,8 @@
 
 	for(var/crate in subtypesof(/datum/supply_pack))
 		var/datum/supply_pack/new_crate = allocate(crate)
-		if(new_crate.abstract)
-			continue // We can safely ignore custom supply packs like the stock market or mining supply crates.
+		if(new_crate.test_ignored)
+			continue // We can safely ignore custom supply packs like the stock market or mining supply crates, or packs that have innate randomness.
 		if(!new_crate?.crate_type)
 			continue
 		var/obj/crate_type = allocate(new_crate.crate_type)


### PR DESCRIPTION

## About The Pull Request

Blacklists dumpster, hide, random toys, contraband and random medical equipment crates from the cargo_crate_sanity unit test. These crates are innately random, and while we have to be aware of potentially having their average be over their price, we cannot (sanely) test for that (without spawning a thousand crates, and even then we're affected by random). The whole point of these crates is gambling on their value.

Closes #90328 
Closes #90314
Closes #90298
Closes #90253
Closes #90216
Closes #90181
Closes #90178

## Changelog

Not player facing
