### PR TITLE
Bumps up Nitrium reagent addition on breath so people don't lose sleep immunity

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -553,7 +553,7 @@
 		breather.reagents.add_reagent(/datum/reagent/nitrium_low_metabolization, max(0, 2 - existing))
 	if (nitrium_pp > 10)
 		var/existing = breather.reagents.get_reagent_amount(/datum/reagent/nitrium_high_metabolization)
-		breather.reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, max(0, 1 - existing))
+		breather.reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, max(0, 2 - existing))
 
 /// Radioactive, green gas. Toxin damage, and a radiation chance
 /obj/item/organ/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)


### PR DESCRIPTION
## About The Pull Request
webedit hihi

Nitrium is the anti-sleepy gas (at high pp), however, some effects have negative consequences for how good it is at its job. Lag (occasionally), and crucially, eating will make it so the reagent is metab'd out of the mob for just long enough that they lose the sleep immunity. This creates a frustrating loop where you're falling asleep for just a moment every few seconds when breathing in a mix of nitrium and healium, which are meant to synergize together. To fix this, this bumps up the amount of reagent added to a max of 2, up from 1, bringing it in line with the lower pp version (which already adds 2 of itself, and doesn't have a similar issue).

## Why It's Good For The Game
It's frustrating for players to create a gas mix that arbitrarily doesn't work, especially when caused by eating, often disabling the proper functioning of Nitrium for the full duration of whatever kind of "good food" status that is granted. This fixes that minor frustration.


## Changelog

:cl:

fix: Mobs should no longer fall asleep when breathing in enough Nitrium to provide sleep immunity.

/:cl:

