### PR TITLE
Converts hot springs to use proper shared particles

### DIFF
--- a/code/game/objects/effects/shared_particle_holder.dm
+++ b/code/game/objects/effects/shared_particle_holder.dm
@@ -39,9 +39,6 @@ GLOBAL_LIST_EMPTY(shared_particles)
  * and don't have vis_contents, so to avoid copypaste code we do this weirdness
  */
 /atom/proc/add_shared_particles(particle_type, custom_key = null, particle_flags = NONE, pool_size = 3)
-	if (isarea(src))
-		CRASH("add_shared_particles was called on an area [src] ([type]) trying to add [particle_type]! Only turfs and movables support shared particles.")
-
 	var/atom/movable/play_pretend = src
 	var/particle_key = custom_key || "[particle_type]"
 	if (!GLOB.shared_particles[particle_key])
@@ -66,13 +63,13 @@ GLOBAL_LIST_EMPTY(shared_particles)
 	GLOB.shared_particles[particle_key][SHARED_PARTICLE_USER_NUM_INDEX] += 1
 	return particle_holder
 
+/area/add_shared_particles(particle_type, custom_key = null, particle_flags = NONE, pool_size = 3)
+	CRASH("add_shared_particles was called on an area [src] ([type]) trying to add [particle_type]! Only turfs and movables support shared particles.")
+
 /* Removes shared particles from object's vis_contents and disposes of it if nothing uses that type/key of particle
  * particle_key can be either a type (if no custom_key was passed) or said custom_key
  */
 /atom/proc/remove_shared_particles(particle_key, delete_on_empty = TRUE)
-	if (isarea(src))
-		CRASH("remove_shared_particles was called on an area [src] ([type]) trying to add [particle_key]! Only turfs and movables support shared particles.")
-
 	if (!particle_key)
 		return
 
@@ -95,6 +92,9 @@ GLOBAL_LIST_EMPTY(shared_particles)
 			QDEL_LIST(type_holders)
 			GLOB.shared_particles -= particle_key
 		return
+
+/area/remove_shared_particles(particle_key, delete_on_empty = TRUE)
+	CRASH("remove_shared_particles was called on an area [src] ([type]) trying to add [particle_key]! Only turfs and movables support shared particles.")
 
 #undef SHARED_PARTICLE_HOLDER_INDEX
 #undef SHARED_PARTICLE_USER_NUM_INDEX

--- a/code/game/objects/effects/shared_particle_holder.dm
+++ b/code/game/objects/effects/shared_particle_holder.dm
@@ -33,36 +33,46 @@ GLOBAL_LIST_EMPTY(shared_particles)
  * for 400 objects using them. This should be prioritized over normal particles when possible if it is known
  * that there will be a lot of objects using certain particles.
  * custom_key can be used to create a new pool of already existing particle type in case you're planning to edit holder's color or properties
- * pool_size controls how many particle holders per type are created. Any objects over this cap will pick an existing holder from the pool
+ * pool_size controls how many particle holders per type are created. Any objects over this cap will pick an existing holder from the pool.
+ *
+ * Now, this code seems fucked up, that's because this is meant to support both objects (and mobs) and turfs, *however* areas are special
+ * and don't have vis_contents, so to avoid copypaste code we do this weirdness
  */
-/atom/movable/proc/add_shared_particles(particle_type, custom_key = null, particle_flags = NONE, pool_size = 3)
+/atom/proc/add_shared_particles(particle_type, custom_key = null, particle_flags = NONE, pool_size = 3)
+	if (isarea(src))
+		CRASH("add_shared_particles was called on an area [src] ([type]) trying to add [particle_type]! Only turfs and movables support shared particles.")
+
+	var/atom/movable/play_pretend = src
 	var/particle_key = custom_key || "[particle_type]"
 	if (!GLOB.shared_particles[particle_key])
 		GLOB.shared_particles[particle_key] = list(list(new /obj/effect/abstract/shared_particle_holder(null, particle_type, particle_flags)), 1)
-		vis_contents += GLOB.shared_particles[particle_key][SHARED_PARTICLE_HOLDER_INDEX][1]
+		play_pretend.vis_contents += GLOB.shared_particles[particle_key][SHARED_PARTICLE_HOLDER_INDEX][1]
 		return GLOB.shared_particles[particle_key][SHARED_PARTICLE_HOLDER_INDEX][1]
 
 	var/list/type_holders = GLOB.shared_particles[particle_key][SHARED_PARTICLE_HOLDER_INDEX]
 	for (var/obj/effect/abstract/shared_particle_holder/particle_holder as anything in type_holders)
-		if (particle_holder in vis_contents)
+		if (particle_holder in play_pretend.vis_contents)
 			return particle_holder
 
 	if (length(type_holders) < pool_size)
 		var/obj/effect/abstract/shared_particle_holder/new_holder = new(null, particle_type, particle_flags)
 		type_holders += new_holder
-		vis_contents += new_holder
+		play_pretend.vis_contents += new_holder
 		GLOB.shared_particles[particle_key][SHARED_PARTICLE_USER_NUM_INDEX] += 1
 		return new_holder
 
 	var/obj/effect/abstract/shared_particle_holder/particle_holder = pick(type_holders)
-	vis_contents += particle_holder
+	play_pretend.vis_contents += particle_holder
 	GLOB.shared_particles[particle_key][SHARED_PARTICLE_USER_NUM_INDEX] += 1
 	return particle_holder
 
 /* Removes shared particles from object's vis_contents and disposes of it if nothing uses that type/key of particle
  * particle_key can be either a type (if no custom_key was passed) or said custom_key
  */
-/atom/movable/proc/remove_shared_particles(particle_key, delete_on_empty = TRUE)
+/atom/proc/remove_shared_particles(particle_key, delete_on_empty = TRUE)
+	if (isarea(src))
+		CRASH("remove_shared_particles was called on an area [src] ([type]) trying to add [particle_key]! Only turfs and movables support shared particles.")
+
 	if (!particle_key)
 		return
 
@@ -72,12 +82,13 @@ GLOBAL_LIST_EMPTY(shared_particles)
 	if (!GLOB.shared_particles[particle_key])
 		return
 
+	var/atom/movable/play_pretend = src
 	var/list/type_holders = GLOB.shared_particles[particle_key][SHARED_PARTICLE_HOLDER_INDEX]
 	for (var/obj/effect/abstract/shared_particle_holder/particle_holder as anything in type_holders)
-		if (!(particle_holder in vis_contents))
+		if (!(particle_holder in play_pretend.vis_contents))
 			continue
 
-		vis_contents -= particle_holder
+		play_pretend.vis_contents -= particle_holder
 		GLOB.shared_particles[particle_key][SHARED_PARTICLE_USER_NUM_INDEX] -= 1
 
 		if (delete_on_empty && GLOB.shared_particles[particle_key][SHARED_PARTICLE_USER_NUM_INDEX] <= 0)

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -109,8 +109,6 @@
 	immerse_overlay_color = "#A0E2DE"
 	immerse_overlay_alpha = 190
 	fishing_datum = /datum/fish_source/hot_spring
-	/// Holder for the steam particles
-	var/obj/effect/abstract/particle_holder/cached/particle_effect
 
 /turf/open/water/hot_spring/Initialize(mapload)
 	. = ..()
@@ -121,18 +119,18 @@
 	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
 	immerse_added = TRUE
 	icon_state = "pool_[rand(1, 4)]"
-	particle_effect = new(src, /particles/hotspring_steam, 4)
-	//render the steam over mobs and objects on the game plane
-	particle_effect.vis_flags &= ~VIS_INHERIT_PLANE
-	//And be unaffected by ambient occlusions, which would render the steam grey
-	particle_effect.plane = MUTATE_PLANE(MASSIVE_OBJ_PLANE, src)
+	var/obj/effect/abstract/shared_particle_holder/holder = add_shared_particles(/particles/hotspring_steam, "hot_springs_[GET_TURF_PLANE_OFFSET(src)]", pool_size = 4)
+	// Render the steam over mobs and objects on the game plane
+	holder.vis_flags &= ~VIS_INHERIT_PLANE
+	// And be unaffected by ambient occlusions, which would render the steam grey
+	holder.plane = MUTATE_PLANE(MASSIVE_OBJ_PLANE, src)
 	add_filter("hot_spring_waves", 1, wave_filter(y = 1, size = 1, offset = 0, flags = WAVE_BOUNDED))
 	var/filter = get_filter("hot_spring_waves")
 	animate(filter, offset = 1, time = 3 SECONDS, loop = -1, easing = SINE_EASING|EASE_IN|EASE_OUT)
 	animate(offset = 0, time = 3 SECONDS, easing = SINE_EASING|EASE_IN|EASE_OUT)
 
 /turf/open/water/hot_spring/Destroy()
-	QDEL_NULL(particle_effect)
+	remove_shared_particles("hot_springs_[GET_TURF_PLANE_OFFSET(src)]")
 	remove_filter("hot_spring_waves")
 	for(var/atom/movable/movable as anything in contents)
 		exit_hot_spring(movable)


### PR DESCRIPTION

## About The Pull Request

Converts hot spring turfs to shared particles instead of pseudo-cached per-turf holders. This does come with some ugliness in add/remove_shared_particles code due to /area not having vis_contents, but that code shouldn't be touched by most developers who don't know what's going on anyways.

I'm not sure if the "cached" particles even worked in practice, and if they had any clientside perf improvements.

## Why It's Good For The Game

Better perf, 

## Changelog
:cl:
code: Converted hot springs to a new shared particles system for better clientside performance.
/:cl:
