### PR TITLE
Part 1: Storage Improvements

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -161,11 +161,7 @@
 /datum/storage/proc/on_deconstruct()
 	SIGNAL_HANDLER
 
-	var/atom/drop_location = real_location.drop_location()
-	for(var/obj/thing in real_location)
-		thing.forceMove(drop_location)
-		thing.pixel_x = thing.base_pixel_x + rand(-8, 8)
-		thing.pixel_y = thing.base_pixel_y + rand(-8, 8)
+	remove_all()
 
 /// Automatically ran on all object insertions: flag marking and view refreshing.
 /datum/storage/proc/handle_enter(datum/source, obj/item/arrived)
@@ -576,11 +572,12 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	else
 		thing.moveToNullspace()
 
-	if(animated)
-		animate_parent()
+	if(!silent)
+		if(animated)
+			animate_parent()
 
-	refresh_views()
-	parent.update_appearance()
+		refresh_views()
+		parent.update_appearance()
 
 	SEND_SIGNAL(parent, COMSIG_ATOM_REMOVED_ITEM, thing, remove_to_loc, silent)
 	SEND_SIGNAL(src, COMSIG_STORAGE_REMOVED_ITEM, thing, remove_to_loc, silent)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -162,8 +162,10 @@
 	SIGNAL_HANDLER
 
 	var/atom/drop_location = real_location.drop_location()
-	for(var/obj/important_thing in real_location)
-		important_thing.forceMove(drop_location)
+	for(var/obj/thing in real_location)
+		thing.forceMove(drop_location)
+		thing.pixel_x = thing.base_pixel_x + rand(-8, 8)
+		thing.pixel_y = thing.base_pixel_y + rand(-8, 8)
 
 /// Automatically ran on all object insertions: flag marking and view refreshing.
 /datum/storage/proc/handle_enter(datum/source, obj/item/arrived)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -161,7 +161,9 @@
 /datum/storage/proc/on_deconstruct()
 	SIGNAL_HANDLER
 
-	remove_all()
+	var/atom/drop_location = real_location.drop_location()
+	for(var/obj/important_thing in real_location)
+		important_thing.forceMove(drop_location)
 
 /// Automatically ran on all object insertions: flag marking and view refreshing.
 /datum/storage/proc/handle_enter(datum/source, obj/item/arrived)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -161,7 +161,7 @@
 /datum/storage/proc/on_deconstruct()
 	SIGNAL_HANDLER
 
-	remove_all()
+	remove_all(update_storage = FALSE)
 
 /// Automatically ran on all object insertions: flag marking and view refreshing.
 /datum/storage/proc/handle_enter(datum/source, obj/item/arrived)
@@ -552,8 +552,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  * * obj/item/thing - the object we're removing
  * * atom/remove_to_loc - where we're placing the item
  * * silent - if TRUE, we won't play any exit sounds
+ * * visual_updates - if TRUE we update storage views & animate parent appearance
  */
-/datum/storage/proc/attempt_remove(obj/item/thing, atom/remove_to_loc, silent = FALSE)
+/datum/storage/proc/attempt_remove(obj/item/thing, atom/remove_to_loc, silent = FALSE, visual_updates = TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 
 	if(istype(thing) && ismob(parent.loc))
@@ -564,7 +565,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		reset_item(thing)
 		thing.forceMove(remove_to_loc)
 
-		if(do_rustle && !silent)
+		if(!silent && do_rustle)
 			if(remove_rustle_sound)
 				playsound(parent, remove_rustle_sound, 50, TRUE, -5)
 			else if(rustle_sound)
@@ -572,7 +573,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	else
 		thing.moveToNullspace()
 
-	if(!silent)
+	if(visual_updates)
 		if(animated)
 			animate_parent()
 
@@ -588,10 +589,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  *
  * Arguments
  * * atom/drop_loc - where we're placing the item
+ * * update_storage - should we update the parent to show visual effects
  */
-/datum/storage/proc/remove_all(atom/drop_loc = parent.drop_location())
+/datum/storage/proc/remove_all(atom/drop_loc = parent.drop_location(), update_storage = TRUE)
 	for(var/obj/item/thing in real_location)
-		if(!attempt_remove(thing, drop_loc, silent = TRUE))
+		if(!attempt_remove(thing, drop_loc, silent = TRUE, visual_updates = update_storage))
 			continue
 		thing.pixel_x = thing.base_pixel_x + rand(-8, 8)
 		thing.pixel_y = thing.base_pixel_y + rand(-8, 8)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -2,44 +2,14 @@
 	name = "storage"
 	icon = 'icons/obj/storage/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
-	interaction_flags_click = ALLOW_RESTING|FORBID_TELEKINESIS_REACH
+	interaction_flags_click = ALLOW_RESTING | FORBID_TELEKINESIS_REACH
 	action_slots = ALL
-	var/rummage_if_nodrop = TRUE
 	/// Should we preload the contents of this type?
 	/// BE CAREFUL, THERE'S SOME REALLY NASTY SHIT IN THIS TYPEPATH
 	/// SANTA IS EVIL
 	var/preload = FALSE
 	/// What storage type to use for this item
 	var/datum/storage/storage_type = /datum/storage
-
-/obj/item/storage/apply_fantasy_bonuses(bonus)
-	. = ..()
-	if(isnull(atom_storage)) // some abstract types of storage (yes i know) don't get a datum
-		return
-
-	atom_storage.max_slots = modify_fantasy_variable("max_slots", atom_storage.max_slots, round(bonus/2))
-	atom_storage.max_total_storage = modify_fantasy_variable("max_total_storage", atom_storage.max_total_storage, round(bonus/2))
-	LAZYSET(fantasy_modifications, "max_specific_storage", atom_storage.max_specific_storage)
-	if(bonus >= 15)
-		atom_storage.max_specific_storage = max(WEIGHT_CLASS_HUGE, atom_storage.max_specific_storage)
-	else if(bonus >= 10)
-		atom_storage.max_specific_storage = max(WEIGHT_CLASS_BULKY, atom_storage.max_specific_storage)
-	else if(bonus <= -10)
-		atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	else if(bonus <= -15)
-		atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
-
-/obj/item/storage/remove_fantasy_bonuses(bonus)
-	if(isnull(atom_storage)) // some abstract types of storage (yes i know) don't get a datum
-		return ..()
-
-	atom_storage.max_slots = reset_fantasy_variable("max_slots", atom_storage.max_slots)
-	atom_storage.max_total_storage = reset_fantasy_variable("max_total_storage", atom_storage.max_total_storage)
-	var/previous_max_storage = LAZYACCESS(fantasy_modifications, "max_specific_storage")
-	LAZYREMOVE(fantasy_modifications, "max_specific_storage")
-	if(previous_max_storage)
-		atom_storage.max_specific_storage = previous_max_storage
-	return ..()
 
 /obj/item/storage/Initialize(mapload)
 	. = ..()
@@ -63,9 +33,9 @@
 	storage_type ||= src.storage_type
 	return ..()
 
-
-/obj/item/storage/AllowDrop()
-	return FALSE
+///Use this to populate the contents of the storage
+/obj/item/storage/proc/PopulateContents()
+	PROTECTED_PROC(TRUE)
 
 /obj/item/storage/contents_explosion(severity, target)
 	switch(severity)
@@ -77,30 +47,51 @@
 			SSexplosions.low_mov_atom += contents
 
 /obj/item/storage/canStrip(mob/who)
-	. = ..()
-	if(!. && rummage_if_nodrop)
-		return TRUE
+	return TRUE
 
 /obj/item/storage/doStrip(mob/who)
-	if(HAS_TRAIT(src, TRAIT_NODROP) && rummage_if_nodrop)
+	if(HAS_TRAIT(src, TRAIT_NODROP))
 		atom_storage.remove_all()
 		return TRUE
 	return ..()
 
-/obj/item/storage/contents_explosion(severity, target)
-//Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
+/obj/item/storage/AllowDrop()
+	return FALSE
 
-/obj/item/storage/proc/PopulateContents()
-
+///Drops all contents of this storage on the turf of its parent
 /obj/item/storage/proc/emptyStorage()
+	SHOULD_NOT_OVERRIDE(TRUE)
+
 	atom_storage.remove_all()
 
-/obj/item/storage/Destroy()
-	for(var/obj/important_thing in contents)
-		if(!(important_thing.resistance_flags & INDESTRUCTIBLE))
-			continue
-		important_thing.forceMove(drop_location())
-	return ..()
+/obj/item/storage/apply_fantasy_bonuses(bonus)
+	. = ..()
+	if(isnull(atom_storage)) // some abstract types of storage (yes i know) don't get a datum
+		return
+
+	atom_storage.max_slots = modify_fantasy_variable("max_slots", atom_storage.max_slots, round(bonus/2))
+	atom_storage.max_total_storage = modify_fantasy_variable("max_total_storage", atom_storage.max_total_storage, round(bonus/2))
+	LAZYSET(fantasy_modifications, "max_specific_storage", atom_storage.max_specific_storage)
+	if(bonus >= 15)
+		atom_storage.max_specific_storage = max(WEIGHT_CLASS_HUGE, atom_storage.max_specific_storage)
+	else if(bonus >= 10)
+		atom_storage.max_specific_storage = max(WEIGHT_CLASS_BULKY, atom_storage.max_specific_storage)
+	else if(bonus <= -10)
+		atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
+	else if(bonus <= -15)
+		atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
+
+/obj/item/storage/remove_fantasy_bonuses(bonus)
+	. = ..()
+	if(isnull(atom_storage)) // some abstract types of storage (yes i know) don't get a datum
+		return
+
+	atom_storage.max_slots = reset_fantasy_variable("max_slots", atom_storage.max_slots)
+	atom_storage.max_total_storage = reset_fantasy_variable("max_total_storage", atom_storage.max_total_storage)
+	var/previous_max_storage = LAZYACCESS(fantasy_modifications, "max_specific_storage")
+	LAZYREMOVE(fantasy_modifications, "max_specific_storage")
+	if(previous_max_storage)
+		atom_storage.max_specific_storage = previous_max_storage
 
 /// Returns a list of object types to be preloaded by our code
 /// I'll say it again, be very careful with this. We only need it for a few things


### PR DESCRIPTION
## About The Pull Request
- Removed duplicate definition of `/obj/item/storage/contents_explosion()`
- Removed var `rummage_if_nodrop`. It's always `TRUE` and nowhere in game is it modified so we implement its value directly
- Autodoc for procs `PopulateContents()` & `emptyStorage()`
- Deconstructing storages is faster as it drops the contents directly on the turf instead of refreshing views, animating parent, updating appearance & other stuff done in `removeAll()`. It also has no side effects as presently indestructible contents is moved to the turf inside `Destroy()`

## Changelog
:cl:
code: improved storage code
/:cl:

