### PR TITLE
April fools station traits

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -339,9 +339,10 @@ SUBSYSTEM_DEF(dynamic)
 
 	var/list/trait_list_strings = list()
 	for(var/datum/station_trait/station_trait as anything in SSstation.station_traits)
-		if(!station_trait.show_in_report)
+		var/report_message = station_trait.get_report()
+		if(!report_message)
 			continue
-		trait_list_strings += "[station_trait.get_report()]<BR>"
+		trait_list_strings += "[report_message]<BR>"
 	if(trait_list_strings.len > 0)
 		. += "<hr><b>Identified shift divergencies:</b><BR>" + trait_list_strings.Join()
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -159,22 +159,10 @@ GLOBAL_LIST(holidays)
 	GLOB.holidays = list()
 	for(var/holiday_type in subtypesof(/datum/holiday))
 		var/datum/holiday/holiday = new holiday_type()
-		var/delete_holiday = TRUE
-		for(var/timezone in holiday.timezones)
-			var/time_in_timezone = world.realtime + timezone HOURS
-
-			var/YYYY = text2num(time2text(time_in_timezone, "YYYY")) // get the current year
-			var/MM = text2num(time2text(time_in_timezone, "MM")) // get the current month
-			var/DD = text2num(time2text(time_in_timezone, "DD")) // get the current day
-			var/DDD = time2text(time_in_timezone, "DDD") // get the current weekday
-
-			if(holiday.shouldCelebrate(DD, MM, YYYY, DDD))
-				holiday.celebrate()
-				GLOB.holidays[holiday.name] = holiday
-				delete_holiday = FALSE
-				break
-		if(delete_holiday)
+		if(!holiday.should_be_celebrated)
 			qdel(holiday)
+		else
+			holiday.celebrate()
 
 	if(GLOB.holidays.len)
 		shuffle_inplace(GLOB.holidays)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -158,7 +158,6 @@ PROCESSING_SUBSYSTEM_DEF(station)
 			return
 		//Rolls from the table for the specific trait type
 		var/datum/station_trait/trait_type = pick_weight(selectable_traits)
-		selectable_traits -= trait_type
 		budget -= initial(trait_type.cost)
 		setup_trait(trait_type)
 
@@ -166,6 +165,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /datum/controller/subsystem/processing/station/proc/setup_trait(datum/station_trait/trait_type)
 	if(locate(trait_type) in station_traits)
 		return
+	selectable_traits_by_types[initial(trait_type.trait_type)] -= trait_type
 	var/datum/station_trait/trait_instance = new trait_type()
 	station_traits += trait_instance
 	log_game("Station Trait: [trait_instance.name] chosen for this round.")

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	///Whether this trait is always enabled; generally used for debugging
 	var/force = FALSE
 	///Does this trait show in the centcom report?
-	var/show_in_report = FALSE
+	var/show_in_report = TRUE
 	///What message to show in the centcom report?
 	var/report_message
 	///What code-trait does this station trait give? gives none if null

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -15,8 +15,6 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	var/cost = STATION_TRAIT_COST_FULL
 	///Whether this trait is always enabled; generally used for debugging
 	var/force = FALSE
-	///Does this trait show in the centcom report?
-	var/show_in_report = TRUE
 	///What message to show in the centcom report?
 	var/report_message
 	///What code-trait does this station trait give? gives none if null
@@ -68,7 +66,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 
 /// Returns the type of info the centcom report has on this trait, if any.
 /datum/station_trait/proc/get_report()
-	return "<i>[name]</i> - [report_message]"
+	return report_message ? "<i>[name]</i> - [report_message]" : null
 
 /// Will attempt to revert the station trait, used by admins.
 /datum/station_trait/proc/revert()

--- a/code/datums/station_traits/april_fools_traits.dm
+++ b/code/datums/station_traits/april_fools_traits.dm
@@ -1,0 +1,110 @@
+///This file contains station traits that typically roll on every other round during april fools.
+/datum/station_trait/april_fools
+	weight = 0 //Prevent the station traits from being picked by SSstation.SetupTraits.
+	abstract_type = /datum/station_trait/april_fools
+	trait_type = STATION_TRAIT_NEUTRAL //They should all be treated as neutral traits, it's easier to pick them that way.
+	//By default, they don't. Some of them just add more station traits, while it doesn't take much to understand others are pranks.
+	show_in_report = FALSE
+	can_revert = FALSE //I'm pretty sure these won't be easy to revert a trait that adds more unrevertable traits.
+
+///Enables all job traits
+/datum/station_trait/april_fools/all_jobs
+	name = "All Job Traits Enabled (April Fools)"
+
+/datum/station_trait/april_fools/all_jobs/New()
+	. = ..()
+	for(var/datum/station_trait/job/job_trait as anything in subtypesof(/datum/station_trait/job))
+		if(job_trait in SSstation.selectable_traits_by_types[job_trait::trait_type]) //Not blacklisted or abstract
+			SSstation.setup_trait(job_trait)
+
+///Enable a bunch of traits regardless of weight. Yes, it can pick other april fools trait as well.
+/datum/station_trait/april_fools/random_traits
+	name = "A Bunch Of Random Traits (April Fools)"
+
+/datum/station_trait/april_fools/random_traits/New()
+	. = ..()
+	var/traits_left = rand(10, 20)
+	var/list/available_types = SSstation.selectable_traits_by_types.Copy()
+	while(traits_left > 0)
+		if(!length(available_types))
+			break
+		var/picked_type = pick(available_types)
+		var/list_to_pick_from = SSstation.selectable_traits_by_types[picked_type]
+		if(!length(list_to_pick_from))
+			available_types -= picked_type
+			continue
+		SSstation.setup_trait(pick(list_to_pick_from))
+		traits_left--
+
+///Shuffle job landmarks around. Might get some people stuck, which is why we also give them a mini welding tool.
+/datum/station_trait/april_fools/shuffe_job_landmarks
+	name = "Shuffle Job Landmarks (April Fools)"
+	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/random_spawns, /datum/station_trait/hangover)
+
+/datum/station_trait/april_fools/shuffe_job_landmarks/New()
+	. = ..()
+	RegisterSignal(SSminor_mapping, , PROC_REF(shuffe_job_landmarks))
+	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(give_emergency_welding_tool))
+
+/datum/station_trait/april_fools/proc/shuffe_job_landmarks()
+	SIGNAL_HANDLER
+	var/list/stored_locations = list()
+	var/list/stored_landmarks = list()
+	//While it'll be hella funny, I'm sure we should leave non-crew landmarks untouched.
+	var/list/skipped_landmark_types = typecacheof(list(
+		/obj/effect/landmark/start/nukeop,
+		/obj/effect/landmark/start/nukeop_leader,
+		/obj/effect/landmark/start/nukeop_overwatch,
+		/obj/effect/landmark/start/new_player,
+		/obj/effect/landmark/start/hangover,
+	))
+	for(var/obj/effect/landmark/start/landmark as anything in GLOB.start_landmarks_list)
+		if(is_type_in_typecache(landmark, skipped_landmark_types))
+			continue
+		stored_locations += landmark.loc
+		stored_landmarks += landmark
+
+	stored_landmarks = shuffle(stored_landmarks)
+	for(var/obj/effect/landmark/start/landmark as anything in stored_landmarks)
+		var/picked_location = pick_n_take(stored_locations)
+		landmark.forceMove(picked_location)
+
+//Make it a little harder to be completely stuck in a room with no other way out. I'm that kind...
+/datum/station_trait/april_fools/proc/give_emergency_welding_tool(datum/source, datum/job/job, mob/living/spawned, joined_late)
+	SIGNAL_HANDLER
+	if(joined_late || issilicon(spawned)) //You already have all access, borgos.
+		return
+	var/obj/item/weldingtool/mini/i_may_be_stuck = new(get_turf(spawned))
+	var/list/slot_list = list(ITEM_SLOT_HANDS, ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET, ITEM_SLOT_BACKPACK)
+	spawned.equip_in_one_of_slots(i_may_be_stuck, slot_list, qdel_on_fail = FALSE, indirect_action = TRUE)
+
+/datum/station_trait/april_fools/another_holiday
+	name = "Pick Random Holiday (April Fools)"
+
+/datum/station_trait/april_fools/another_holiday/New()
+	. = ..()
+	var/holiday_type = pick(subtypesof(/datum/holiday))
+	var/datum/holiday/holiday = new holiday_type()
+	holiday.celebrate()
+	if(!holiday.holiday_colors)
+		return
+	var/datum/holiday/april_fools/fools = GLOB.holidays[APRIL_FOOLS]
+	fools.holiday_colors = FALSE
+
+/datum/station_trait/april_fools/super_maintenance_loot
+	name = "Super Maintenance Loot (April Fools)"
+	can_revert = TRUE
+
+/datum/station_trait/aprol_fools/super_maintenance_loot/New()
+	. = ..()
+	GLOB.maintenance_loot -= GLOB.trash_loot
+	GLOB.maintenance_loot -= GLOB.common_loot
+	GLOB.maintenance_loot[GLOB.uncommon_loot] /= 5
+	GLOB.maintenance_loot[GLOB.oddity_loot] *= 2
+
+/datum/station_trait/aprol_fools/super_maintenance_loot/revert()
+	GLOB.maintenance_loot[GLOB.trash_loot] = maint_trash_weight
+	GLOB.maintenance_loot[GLOB.common_loot] = maint_common_weight
+	GLOB.maintenance_loot[GLOB.uncommon_loot] *= 5
+	GLOB.maintenance_loot[GLOB.oddity_loot] /= 2
+	return ..()

--- a/code/datums/station_traits/april_fools_traits.dm
+++ b/code/datums/station_traits/april_fools_traits.dm
@@ -42,7 +42,7 @@
 
 /datum/station_trait/april_fools/shuffe_job_landmarks/New()
 	. = ..()
-	RegisterSignal(SSminor_mapping, , PROC_REF(shuffle))
+	RegisterSignal(SSminor_mapping, COMSIG_SUBSYSTEM_POST_INITIALIZE, PROC_REF(shuffle))
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(give_emergency_welding_tool))
 
 /datum/station_trait/april_fools/shuffe_job_landmarks/proc/shuffle()

--- a/code/datums/station_traits/april_fools_traits.dm
+++ b/code/datums/station_traits/april_fools_traits.dm
@@ -4,7 +4,6 @@
 	abstract_type = /datum/station_trait/april_fools
 	trait_type = STATION_TRAIT_NEUTRAL //They should all be treated as neutral traits, it's easier to pick them that way.
 	//By default, they don't. Some of them just add more station traits, while it doesn't take much to understand others are pranks.
-	show_in_report = FALSE
 	can_revert = FALSE //I'm pretty sure these won't be easy to revert a trait that adds more unrevertable traits.
 
 ///Enables all job traits

--- a/code/datums/station_traits/april_fools_traits.dm
+++ b/code/datums/station_traits/april_fools_traits.dm
@@ -43,10 +43,10 @@
 
 /datum/station_trait/april_fools/shuffe_job_landmarks/New()
 	. = ..()
-	RegisterSignal(SSminor_mapping, , PROC_REF(shuffe_job_landmarks))
+	RegisterSignal(SSminor_mapping, , PROC_REF(shuffle))
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(give_emergency_welding_tool))
 
-/datum/station_trait/april_fools/proc/shuffe_job_landmarks()
+/datum/station_trait/april_fools/shuffe_job_landmarks/proc/shuffle()
 	SIGNAL_HANDLER
 	var/list/stored_locations = list()
 	var/list/stored_landmarks = list()

--- a/code/datums/station_traits/job_traits.dm
+++ b/code/datums/station_traits/job_traits.dm
@@ -118,7 +118,6 @@
 	button_desc = "Sign up to become the Bridge Assistant and watch over the Bridge."
 	weight = 2
 	report_message = "We have installed a Bridge Assistant on your station."
-	show_in_report = TRUE
 	can_roll_antag = CAN_ROLL_PROTECTED
 	job_to_add = /datum/job/bridge_assistant
 
@@ -172,7 +171,6 @@
 	button_desc = "Sign up to become a DISABLED but hard boiled Veteran Advisor of Nanotrasen Security Force. Advise HoS and Captain, train Officers, all while fighting your PTSD."
 	weight = 2
 	report_message = "Veteran Security Advisor has been assigned to your station to help with Security matters."
-	show_in_report = TRUE
 	can_roll_antag = CAN_ROLL_PROTECTED
 	job_to_add = /datum/job/veteran_advisor
 
@@ -186,7 +184,6 @@
 	weight = 1
 	trait_flags = parent_type::trait_flags | STATION_TRAIT_REQUIRES_AI
 	report_message = "Our recent technological advancements in machine Artificial Intelligence has proven futile. In the meantime, we're sending an Intern to help out."
-	show_in_report = TRUE
 	can_roll_antag = CAN_ROLL_PROTECTED
 	job_to_add = /datum/job/human_ai
 	trait_to_give = STATION_TRAIT_HUMAN_AI
@@ -252,7 +249,6 @@
 	button_desc = "Ook ook ah ah, sign up to play as the bartender's monkey."
 	weight = 0 //Unrollable by default, available all day during monkey day.
 	report_message = "We've evaluated the bartender's monkey to have the mental capacity of the average crewmember. As such, we made them one."
-	show_in_report = TRUE
 	can_roll_antag = CAN_ROLL_ALWAYS
 	job_to_add = /datum/job/pun_pun
 

--- a/code/datums/station_traits/job_traits.dm
+++ b/code/datums/station_traits/job_traits.dm
@@ -85,7 +85,6 @@
 	name = "Cargo Gorilla"
 	button_desc = "Sign up to become the Cargo Gorilla, a peaceful shepherd of boxes."
 	weight = 0
-	show_in_report = FALSE // Selective attention test. Did you spot the gorilla?
 	can_roll_antag = CAN_ROLL_NEVER
 	job_to_add = /datum/job/cargo_gorilla
 

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -2,7 +2,6 @@
 	name = "Carp infestation"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Dangerous fauna is present in the area of this station."
 	trait_to_give = STATION_TRAIT_CARP_INFESTATION
 
@@ -10,7 +9,6 @@
 	name = "Distant supply lines"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 3
-	show_in_report = TRUE
 	report_message = "Due to the distance to our normal supply lines, cargo orders are more expensive."
 	blacklist = list(/datum/station_trait/strong_supply_lines)
 
@@ -22,7 +20,6 @@
 	name = "Postal workers strike"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
-	show_in_report = TRUE
 	report_message = "Due to an ongoing strike announced by the postal workers union, mail won't be delivered this shift."
 
 /datum/station_trait/mail_blocked/on_round_start()
@@ -35,7 +32,7 @@
 		our_event.unavailable_situations -= /datum/shuttle_loan_situation/mail_strike
 	SSeconomy.mail_blocked = !SSeconomy.mail_blocked
 
-/datum/station_trait/mail_blocked/hangover/revert()
+/datum/station_trait/mail_blocked/revert()
 	var/datum/round_event_control/shuttle_loan/our_event = locate() in SSevents.control
 	our_event.unavailable_situations |= /datum/shuttle_loan_situation/mail_strike
 	SSeconomy.mail_blocked = !SSeconomy.mail_blocked
@@ -45,28 +42,25 @@
 	name = "Late Arrivals"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
-	show_in_report = TRUE
 	report_message = "Sorry for that, we didn't expect to fly into that vomiting goose while bringing you to your new station."
 	trait_to_give = STATION_TRAIT_LATE_ARRIVALS
-	blacklist = list(/datum/station_trait/random_spawns, /datum/station_trait/hangover)
+	blacklist = list(/datum/station_trait/random_spawns, /datum/station_trait/hangover, /datum/station_trait/april_fools/shuffe_job_landmarks)
 
 /datum/station_trait/random_spawns
 	name = "Drive-by landing"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
-	show_in_report = TRUE
 	report_message = "Sorry for that, we missed your station by a few miles, so we just launched you towards your station in pods. Hope you don't mind!"
 	trait_to_give = STATION_TRAIT_RANDOM_ARRIVALS
-	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/hangover)
+	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/hangover, /datum/station_trait/april_fools/shuffe_job_landmarks)
 
 /datum/station_trait/hangover
 	name = "Hangover"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
-	show_in_report = TRUE
 	report_message = "Ohh....Man....That mandatory office party from last shift...God that was awesome..I woke up in some random toilet 3 sectors away..."
 	trait_to_give = STATION_TRAIT_HANGOVER
-	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/random_spawns)
+	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/random_spawns, /datum/station_trait/april_fools/shuffe_job_landmarks)
 
 /datum/station_trait/hangover/New()
 	. = ..()
@@ -95,12 +89,10 @@
 	hat = new hat(spawned_mob)
 	spawned_mob.equip_to_slot_or_del(hat, ITEM_SLOT_HEAD)
 
-
 /datum/station_trait/blackout
 	name = "Blackout"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 3
-	show_in_report = TRUE
 	report_message = "Station lights seem to be damaged, be safe when starting your shift today."
 
 /datum/station_trait/blackout/on_round_start()
@@ -114,7 +106,6 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
 	cost = STATION_TRAIT_COST_LOW //Most of maints is literal trash anyway
-	show_in_report = TRUE
 	report_message = "Our workers cleaned out most of the junk in the maintenace areas."
 	blacklist = list(/datum/station_trait/filled_maint)
 	trait_to_give = STATION_TRAIT_EMPTY_MAINT
@@ -126,7 +117,6 @@
 	name = "Overflow bureaucracy mistake"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
-	show_in_report = TRUE
 	var/chosen_job_name
 
 /datum/station_trait/overflow_job_bureaucracy/New()
@@ -146,7 +136,6 @@
 	name = "Slow Shuttle"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Due to distance to our supply station, the cargo shuttle will have a slower flight time to your cargo department."
 	blacklist = list(/datum/station_trait/quick_shuttle)
 
@@ -159,7 +148,6 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 4
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "Your station's friendly bots have had their language matrix fried due to an event, resulting in some strange and unfamiliar speech patterns."
 	trait_to_give = STATION_TRAIT_BOTS_GLITCHED
 
@@ -180,7 +168,6 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
 	cost = STATION_TRAIT_COST_FULL
-	show_in_report = TRUE
 	report_message = "Your station's machines have had their language matrix fried due to an event, \
 		resulting in some strange and unfamiliar speech patterns."
 	trait_to_give = STATION_TRAIT_MACHINES_GLITCHED
@@ -289,7 +276,6 @@
 /datum/station_trait/random_event_weight_modifier
 	name = "Random Event Modifier"
 	report_message = "A random event has been modified this shift! Someone forgot to set this!"
-	show_in_report = TRUE
 	abstract_type = /datum/station_trait/random_event_weight_modifier
 	weight = 0
 
@@ -345,14 +331,12 @@
 	name = "Cramped Escape Pods"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Due to budget cuts, we have downsized your escape pods."
 	trait_to_give = STATION_TRAIT_SMALLER_PODS
 	blacklist = list(/datum/station_trait/luxury_escape_pods)
 
 /datum/station_trait/revolutionary_trashing
 	name = "Post-Revolutionary Fervor"
-	show_in_report = TRUE
 	report_message = "Your station was recently reclaimed from a revolutionary commune. We couldn't clean up after them in time."
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_to_give = STATION_TRAIT_REVOLUTIONARY_TRASHING
@@ -466,8 +450,6 @@
 	abstract_type = /datum/station_trait/nebula
 	weight = 0
 
-	show_in_report = TRUE
-
 	///The parallax layer of the nebula
 	var/nebula_layer = /atom/movable/screen/parallax_layer/random/space_gas
 	///If set, gives the basic carp different colors
@@ -554,7 +536,6 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_flags = STATION_TRAIT_SPACE_BOUND //maybe when we can LOOK UP
 	weight = 1
-	show_in_report = TRUE
 	report_message = "This station is located inside a radioactive nebula. Setting up nebula shielding is top-priority."
 	trait_to_give = STATION_TRAIT_RADIOACTIVE_NEBULA
 
@@ -737,7 +718,6 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_flags = STATION_TRAIT_PLANETARY
 	weight = 3
-	show_in_report = TRUE
 	report_message = "It looks like the storm is not gonna calm down anytime soon, stay safe out there."
 	storm_type = /datum/weather/snow_storm/forever_storm
 
@@ -751,7 +731,6 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 3
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "Due to a mishap at the Robust Softdrinks Megafactory, some drinks may contain traces of ethanol or psychoactive chemicals."
 	trait_to_give = STATION_TRAIT_SPIKED_DRINKS
 

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -48,7 +48,6 @@
 	name = "Ian's Adventure"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	show_in_report = FALSE
 	cost = STATION_TRAIT_COST_LOW
 
 /datum/station_trait/ian_adventure/on_round_start()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -17,7 +17,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "System's local planet has irregular atmospherical properties."
 	trait_to_give = STATION_TRAIT_UNNATURAL_ATMOSPHERE
 
@@ -36,7 +35,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	trait_flags = parent_type::trait_flags | STATION_TRAIT_REQUIRES_AI
 	weight = 5
-	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment, we've removed \
 		access to your set of alternative upload modules because we know you're already thinking about meddling with this experiment."
 	trait_to_give = STATION_TRAIT_UNIQUE_AI
@@ -52,7 +50,6 @@
 	weight = 5
 	show_in_report = FALSE
 	cost = STATION_TRAIT_COST_LOW
-	report_message = "Ian has gone exploring somewhere in the station."
 
 /datum/station_trait/ian_adventure/on_round_start()
 	for(var/mob/living/basic/pet/dog/corgi/dog in GLOB.mob_list)
@@ -110,7 +107,6 @@
 	name = "PDA glitch"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	show_in_report = TRUE
 	cost = STATION_TRAIT_COST_MINIMAL
 	report_message = "Something seems to be wrong with the PDAs issued to you all this shift. Nothing too bad though."
 	trait_to_give = STATION_TRAIT_PDA_GLITCHED
@@ -119,7 +115,6 @@
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 1
-	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot, /datum/station_trait/birthday)
 
@@ -136,7 +131,6 @@
 	name = "Announcement \"System\""
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 1
-	show_in_report = TRUE
 	report_message = "Our announcement system is under scheduled maintanance at the moment. Thankfully, we have a backup."
 	blacklist = list(/datum/station_trait/announcement_intern, /datum/station_trait/birthday)
 
@@ -148,7 +142,6 @@
 	name = "Colored Assistants"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 10
-	show_in_report = TRUE
 	cost = STATION_TRAIT_COST_MINIMAL
 	report_message = "Due to a shortage in standard issue jumpsuits, we have provided your assistants with one of our backup supplies."
 	blacklist = list(/datum/station_trait/assistant_gimmicks)
@@ -163,7 +156,6 @@
 	name = "Employee Birthday"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 2
-	show_in_report = TRUE
 	report_message = "We here at Nanotrasen would all like to wish Employee Name a very happy birthday"
 	trait_to_give = STATION_TRAIT_BIRTHDAY
 	blacklist = list(/datum/station_trait/announcement_intern, /datum/station_trait/announcement_medbot) //Overiding the annoucer hides the birthday person in the annoucement message.
@@ -296,7 +288,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 2
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "Nanotrasen has chosen your station for an experiment - everyone has free scryers! Use these to talk to other people easily and privately."
 
 /datum/station_trait/scryers/New()
@@ -324,7 +315,6 @@
 /datum/station_trait/wallets
 	name = "Wallets!"
 	trait_type = STATION_TRAIT_NEUTRAL
-	show_in_report = TRUE
 	weight = 5
 	cost = STATION_TRAIT_COST_MINIMAL
 	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
@@ -368,13 +358,11 @@
 	trait_to_give = STATION_TRAIT_FORESTED
 	trait_flags = STATION_TRAIT_PLANETARY
 	weight = 10
-	show_in_report = TRUE
 	report_message = "There sure are a lot of trees out there."
 
 /datum/station_trait/linked_closets
 	name = "Closet Anomaly"
 	trait_type = STATION_TRAIT_NEUTRAL
-	show_in_report = TRUE
 	weight = 1
 	report_message = "We've reports of high amount of trace eigenstasium on your station. Ensure that your closets are working correctly."
 
@@ -403,7 +391,6 @@
 /datum/station_trait/skub
 	name = "The Great Skub Contention"
 	trait_type = STATION_TRAIT_NEUTRAL
-	show_in_report = FALSE
 	weight = 2
 	sign_up_button = TRUE
 	/// List of people signed up to be either pro_skub or anti_skub
@@ -535,7 +522,6 @@
 	report_message = "We replaced the intern doing your crew's background checks with a trained screener for this shift! That said, our enemies may just find another way to infiltrate the station, so be careful."
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 1
-	show_in_report = TRUE
 	can_revert = FALSE
 
 	dynamic_category = RULESET_CATEGORY_NO_WITTING_CREW_ANTAGONISTS
@@ -546,7 +532,6 @@
 /datum/station_trait/pet_day
 	name = "Bring Your Pet To Work Day"
 	trait_type = STATION_TRAIT_NEUTRAL
-	show_in_report = FALSE
 	weight = 2
 	sign_up_button = TRUE
 
@@ -594,6 +579,5 @@
 	trait_to_give = STATION_TRAIT_ECONOMY_ALERTS
 	weight = 2
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 
 	dynamic_threat_id = "GMM Econ Spotlight"

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -5,7 +5,6 @@
 	name = "Lucky winner"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 1
-	show_in_report = TRUE
 	report_message = "Your station has won the grand prize of the annual station charity event. Free snacks will be delivered to the bar every now and then."
 	trait_processes = TRUE
 	COOLDOWN_DECLARE(party_cooldown)
@@ -45,7 +44,6 @@
 	name = "Galactic grant"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Your station has been selected for a special grant. Some extra funds has been made available to your cargo department."
 
 /datum/station_trait/galactic_grant/on_round_start()
@@ -56,7 +54,6 @@
 	name = "Premium internals boxes"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "The internals boxes for your crew have been upsized and filled with bonus equipment."
 	trait_to_give = STATION_TRAIT_PREMIUM_INTERNALS
 
@@ -65,7 +62,6 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "It seems collectors in this system are extra keen to on bounties, and will pay more to see their completion."
 
 /datum/station_trait/bountiful_bounties/on_round_start()
@@ -76,7 +72,6 @@
 	name = "Glowsticks party"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 2
-	show_in_report = TRUE
 	report_message = "We've glowsticks upon glowsticks to spare, so we scattered some around maintenance (plus a couple floor lights)."
 
 /datum/station_trait/glowsticks/New()
@@ -123,7 +118,6 @@
 	name = "Strong supply lines"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Prices are low in this system, BUY BUY BUY!"
 	blacklist = list(/datum/station_trait/distant_supply_lines)
 
@@ -135,7 +129,6 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "Our workers accidentally forgot more of their personal belongings in the maintenace areas."
 	blacklist = list(/datum/station_trait/empty_maint)
 	trait_to_give = STATION_TRAIT_FILLED_MAINT
@@ -147,7 +140,6 @@
 	name = "Quick Shuttle"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Due to proximity to our supply station, the cargo shuttle will have a quicker flight time to your cargo department."
 	blacklist = list(/datum/station_trait/slow_shuttle)
 
@@ -158,7 +150,6 @@
 /datum/station_trait/deathrattle_department
 	name = "deathrattled department"
 	trait_type = STATION_TRAIT_POSITIVE
-	show_in_report = TRUE
 	abstract_type = /datum/station_trait/deathrattle_department
 	blacklist = list(/datum/station_trait/deathrattle_all)
 
@@ -230,7 +221,6 @@
 /datum/station_trait/deathrattle_all
 	name = "Deathrattled Station"
 	trait_type = STATION_TRAIT_POSITIVE
-	show_in_report = TRUE
 	weight = 1
 	report_message = "All members of the station have received an implant to notify each other if one of them dies. This should help improve job-safety!"
 	var/datum/deathrattle_group/deathrattle_group
@@ -251,7 +241,6 @@
 /datum/station_trait/cybernetic_revolution
 	name = "Cybernetic Revolution"
 	trait_type = STATION_TRAIT_POSITIVE
-	show_in_report = TRUE
 	weight = 1
 	report_message = "The new trends in cybernetics have come to the station! Everyone has some form of cybernetic implant."
 	trait_to_give = STATION_TRAIT_CYBERNETIC_REVOLUTION
@@ -318,7 +307,6 @@
 	name = "Luxury Escape Pods"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	show_in_report = TRUE
 	report_message = "Due to good performance, we've provided your station with luxury escape pods."
 	trait_to_give = STATION_TRAIT_BIGGER_PODS
 	blacklist = list(/datum/station_trait/cramped_escape_pods)
@@ -328,7 +316,6 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 	report_message = "Your station's medibots have received a hardware upgrade, enabling expanded healing capabilities."
 	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
 
@@ -361,7 +348,6 @@
 	report_message = "The stars shine bright and the clouds are scarcer than usual. It's a bright day here on the Ice Moon's surface."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	show_in_report = TRUE
 	trait_flags = STATION_TRAIT_PLANETARY
 	trait_to_give = STATION_TRAIT_BRIGHT_DAY
 
@@ -371,7 +357,6 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 4
 	trait_to_give = STATION_TRAIT_SHUTTLE_SALE
-	show_in_report = TRUE
 
 /datum/station_trait/missing_wallet
 	name = "Misplaced Wallet"
@@ -379,7 +364,6 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	cost = STATION_TRAIT_COST_LOW
-	show_in_report = TRUE
 
 /datum/station_trait/missing_wallet/on_round_start()
 	. = ..()
@@ -420,7 +404,6 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 3
 	trait_to_give = STATION_TRAIT_ASSISTANT_GIMMICKS
-	show_in_report = TRUE
 	blacklist = list(/datum/station_trait/colored_assistants)
 
 /datum/station_trait/random_event_weight_modifier/assistant_gimmicks/get_pulsar_message()

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -30,7 +30,9 @@
 	/// The default pattern of the holiday, if the requested pattern is null.
 	var/holiday_pattern = PATTERN_DEFAULT
 
-/datum/holiday/New()
+/datum/holiday/New(calculate_timezones = TRUE)
+	if(!calculate_timezones)
+		return
 	for(var/timezone in timezones)
 		var/time_in_timezone = world.realtime + timezone HOURS
 
@@ -943,7 +945,7 @@
 	for(var/year in min_year to max_year)
 		for(var/month in min_month to max_month)
 			for(var/day in 1 to max_day)
-				var/datum/holiday/new_day = new path()
+				var/datum/holiday/new_day = new path(FALSE)
 				if(new_day.shouldCelebrate(day, month, year, iso_to_weekday(day_of_month(year, month, day))))
 					deets += "[year]/[month]/[day]"
 	return deets

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -45,6 +45,7 @@
 
 // This proc gets run before the game starts when the holiday is activated. Do festive shit here.
 /datum/holiday/proc/celebrate()
+	SHOULD_CALL_PARENT(TRUE)
 	if(mail_holiday)
 		SSeconomy.mail_blocked = TRUE
 	GLOB.holidays[name] = src

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -11,7 +11,7 @@
 	/// What month does the holiday end on?
 	var/end_month = 0
 	/// Set on New by ShouldCelebrate()
-	var/should_be_celebrated = TRUE
+	var/should_be_celebrated = FALSE
 	/// Held variable to better calculate when certain holidays may fall on, like easter.
 	var/current_year = 0
 	/// How many years are you offsetting your calculations for begin_day and end_day on. Used for holidays like easter.

--- a/code/modules/holiday/nth_week.dm
+++ b/code/modules/holiday/nth_week.dm
@@ -78,8 +78,8 @@
 //National Moth Week falls on the last full week of July, including the saturday and sunday before. See http://nationalmothweek.org/ for precise tracking.
 /datum/holiday/nth_week/moth/shouldCelebrate(dd, mm, yyyy, ddd)
 	if(first_day_of_month(yyyy, mm) >= 5) //Friday or later start of the month means week 5 is a full week.
-		begin_week += 1
-		end_week += 1
+		begin_week = 4
+		end_week = 5
 	return ..(dd, mm, yyyy, ddd)
 
 /datum/holiday/nth_week/moth/getStationPrefix()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -465,6 +465,7 @@
 	if(qdel_on_fail)
 		qdel(equipping)
 	return null
+
 /**
  * Actually equips an item to a slot (UNSAFE)
  *

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -457,6 +457,14 @@
 	equip_to_slot(W, slot, initial, redraw_mob, indirect_action = indirect_action) //This proc should not ever fail.
 	return TRUE
 
+///A proc that calls equip_to_slot_if_possible() for each slot in a list until it succeeds for one of them.
+/mob/proc/equip_in_one_of_slots(obj/item/equipping, list/slots, qdel_on_fail = TRUE, indirect_action = FALSE)
+	for(var/slot in slots)
+		if(equip_to_slot_if_possible(equipping, slots[slot], disable_warning = TRUE, indirect_action = indirect_action))
+			return slot
+	if(qdel_on_fail)
+		qdel(equipping)
+	return null
 /**
  * Actually equips an item to a slot (UNSAFE)
  *

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -104,14 +104,6 @@
 		visible_items += held
 	return visible_items
 
-/mob/living/carbon/proc/equip_in_one_of_slots(obj/item/equipping, list/slots, qdel_on_fail = TRUE, indirect_action = FALSE)
-	for(var/slot in slots)
-		if(equip_to_slot_if_possible(equipping, slots[slot], disable_warning = TRUE, indirect_action = indirect_action))
-			return slot
-	if(qdel_on_fail)
-		qdel(equipping)
-	return null
-
 //This is an UNSAFE proc. Use mob_can_equip() before calling this one! Or rather use equip_to_slot_if_possible() or advanced_equip_to_slot_if_possible()
 /mob/living/carbon/equip_to_slot(obj/item/equipping, slot, initial = FALSE, redraw_mob = FALSE, indirect_action = FALSE)
 	if(!slot)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1909,6 +1909,7 @@
 #include "code\datums\skills\mining.dm"
 #include "code\datums\station_traits\_station_trait.dm"
 #include "code\datums\station_traits\admin_panel.dm"
+#include "code\datums\station_traits\april_fools_traits.dm"
 #include "code\datums\station_traits\job_traits.dm"
 #include "code\datums\station_traits\negative_traits.dm"
 #include "code\datums\station_traits\neutral_traits.dm"


### PR DESCRIPTION
## About The Pull Request
April fools is upon us, unfortunately I did not have the time to cook anything bizzarre, but the thing is I also wanted to do something that could be merged for future April Fools (and admin shenanigans)  and that also don't require a lot of maintenance, which means I'm just adding mainly small april-fools-only station traits.

So, each round on april fools, there is a 40% chance for one of these traits to be setup. There are five so far, and they're the following:
- Enable all Station job traits
- Pick anywhere from 10 to 20 other traits (can pick other april fools traits)
- Shuffle all job start landmarks around (mini welding tool included if you're stuck)
- Enable a random holiday
- Remove trash and common loot from maintenance, while altering the remaining tiers to favor rarer loot.

I had to adjust some of the code to make it work. Also `show_in_report` was false by default despite the majority of station traits setting it to true, so I changed that.

## Why It's Good For The Game
April Fools is in da house.

## Changelog

:cl:
add: A set of small, april fools exclusive station traits.
/:cl:
