### PR TITLE
Adds the Mail Ghoul

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -298,6 +298,18 @@
 		else
 			new_mail.junk_mail()
 
+	if(check_holidays(APRIL_FOOLS))
+		var/static/mail_ghoul = FALSE
+		if(!mail_ghoul && prob(10))
+			var/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/ghoul = new(src)
+			mail_ghoul = TRUE
+			notify_ghosts(
+				"A mail ghoul has spawned!",
+				source = ghoul,
+				header = "Delivery",
+				click_interact = TRUE,
+			)
+
 	update_icon()
 
 /// Crate for mail that automatically depletes the economy subsystem's pending mail counter.

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -303,12 +303,7 @@
 		if(!mail_ghoul && prob(10))
 			var/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/ghoul = new(src)
 			mail_ghoul = TRUE
-			notify_ghosts(
-				"A mail ghoul has spawned!",
-				source = ghoul,
-				header = "Delivery",
-				click_interact = TRUE,
-			)
+			ghoul.do_poll()
 
 	update_icon()
 

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -300,7 +300,7 @@
 
 	if(check_holidays(APRIL_FOOLS))
 		var/static/mail_ghoul = FALSE
-		if(!mail_ghoul && prob(5 * amount))
+		if(!mail_ghoul && prob(3 * mail_count))
 			var/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/ghoul = new(src)
 			mail_ghoul = TRUE
 			ghoul.do_poll()

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -300,7 +300,7 @@
 
 	if(check_holidays(APRIL_FOOLS))
 		var/static/mail_ghoul = FALSE
-		if(!mail_ghoul && prob(10))
+		if(!mail_ghoul && prob(5 * amount))
 			var/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/ghoul = new(src)
 			mail_ghoul = TRUE
 			ghoul.do_poll()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1031,7 +1031,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		AM.relay_container_resist_act(user, src)
 		return
 	if(!welded && !locked)
-		open()
+		open(user)
 		return
 
 	if(DOING_INTERACTION_WITH_TARGET(user, src))

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -413,7 +413,7 @@
 	var/datum/objective/until_it_is_done = new()
 	until_it_is_done.no_failure = TRUE
 	until_it_is_done.explanation_text = "Take over as the station's new mail carrier. \
-		If anyone forgets to pick up their package, remind them... With force if necessary."
+		If anyone forgets to pick up their package, remind them... With force if necessary. But try words first."
 	ghoul.objectives += until_it_is_done
 
 	ADD_TRAIT(spawned_mob, TRAIT_HULK, INNATE_TRAIT)

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -326,3 +326,104 @@
 		/obj/item/gun/ballistic/automatic/pistol/aps,
 		/obj/item/paper/fluff/ruins/forgottenship/password,
 	)
+
+/obj/effect/mob_spawn/ghost_role/human/mail_ghoul
+	name = "ominous package"
+	icon = 'icons/obj/storage/wrapping.dmi'
+	icon_state = "deliverypackage5"
+	prompt_name = "a mail ghoul"
+	you_are_text = "You are the mail ghoul!"
+	flavour_text = "You are the mail ghoul, a former mail carrier who fell into the depths of central command's mailroom. \
+		You have escaped, and now - corrupted by the endless waves of paper, stamps, and spam - you seek to deliver people... to the afterlife!... \
+		If they neglect the four digit code on the destination address or forget to sign for their package. Otherwise you just wanna get back to work."
+	outfit = /datum/outfit/mail_ghoul
+	mob_species = /datum/species/zombie
+	hairstyle = /datum/sprite_accessory/hair/bald::name
+	facial_hairstyle = /datum/sprite_accessory/facial_hair/shaved::name
+
+/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/create(mob/mob_possessor, newname)
+	var/mob/living/spawned_mob = ..()
+	for(var/obj/structure/closet/box in spawned_mob.loc)
+		spawned_mob.set_resting(TRUE, instant = TRUE)
+		spawned_mob.forceMove(box)
+		spawned_mob.set_resting(FALSE, silent = FALSE)
+		break
+	return spawned_mob
+
+/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/special(mob/living/carbon/human/spawned_mob, mob/mob_possessor)
+	. = ..()
+	var/datum/antagonist/ghoul = new()
+	ghoul.name = "Mail Ghoul"
+	var/datum/objective/rip = new()
+	rip.no_failure = TRUE
+	rip.explanation_text = "Maul whoever opens your crate."
+	ghoul.objectives += rip
+	var/datum/objective/tear = new()
+	tear.no_failure = TRUE
+	tear.explanation_text = "Deliver the former mail carrier's body to someone. \
+		Good choices include the coroner, the detective, the quartermaster, or the chaplain."
+	ghoul.objectives += tear
+	var/datum/objective/until_it_is_done = new()
+	until_it_is_done.no_failure = TRUE
+	until_it_is_done.explanation_text = "Take over as the station's new mail carrier. \
+		If anyone refuses to sign for their package, make them... With force."
+	ghoul.objectives += until_it_is_done
+
+	ADD_TRAIT(spawned_mob, TRAIT_HULK, INNATE_TRAIT)
+	ADD_TRAIT(spawned_mob, TRAIT_CHUNKYFINGERS, INNATE_TRAIT)
+	spawned_mob.mind.add_antag_datum(ghoul)
+	spawned_mob.AddComponent(/datum/component/strong_pull)
+	spawned_mob.AddComponent( \
+		/datum/component/mutant_hands, \
+		mutant_hand_path = /obj/item/mutant_hand/mailghoul, \
+		ignored = LEFT_HANDS, \
+	)
+	spawned_mob.AddComponent( \
+		/datum/component/regenerator, \
+		regeneration_delay = 10 SECONDS, \
+		brute_per_second = 0.25, \
+		burn_per_second = 0.25, \
+		tox_per_second = 0.1, \
+		oxy_per_second = 0.5, \
+		heals_wounds = TRUE, \
+	)
+	for(var/obj/item/bodypart/leg in spawned_mob.bodyparts)
+		leg.speed_modifier = 0.95
+	spawned_mob.update_bodypart_speed_modifier()
+	// my antag will have stun immunity and god mode and
+	spawned_mob.physiology.stun_mod *= 0.25
+	spawned_mob.physiology.stamina_mod *= 0.25
+	spawned_mob.physiology.knockdown_mod *= (1.5 * (1 / spawned_mob.physiology.stun_mod)) // stunmod applies to knockdowns
+	spawned_mob.physiology.damage_resistance = 33
+	spawned_mob.set_combat_mode(TRUE)
+
+/datum/outfit/mail_ghoul
+	name = "Mail Ghoul"
+	id = /obj/item/card/id/advanced/mailman
+	uniform = /obj/item/clothing/under/misc/mailman
+	head = /obj/item/clothing/head/costume/mailman
+	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/tank/internals/emergency_oxygen
+	ears = /obj/item/radio/headset
+
+/obj/item/card/id/advanced/mailman
+	name = "mail carrier ID"
+	desc = "An ID card for a mail carrier. Looks quite dated."
+	trim = /datum/id_trim/job/cargo_technician
+
+/obj/item/card/id/advanced/mailman/Initialize(mapload)
+	. = ..()
+	registered_age = rand(40, 80)
+	assignment = "Mail Carrier"
+	update_label()
+
+/obj/item/mutant_hand/mailghoul
+	name = "mail ghoul claw"
+	desc = "A clawed hand, once capable of delivering mail, now capable of delivering death... AND mail."
+	hitsound = 'sound/effects/hallucinations/growl1.ogg'
+	force = 16
+	demolition_mod = 1.5
+	wound_bonus = -30
+	bare_wound_bonus = 30
+	sharpness = SHARP_EDGED
+	obj_flags = CONDUCTS_ELECTRICITY

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -386,8 +386,22 @@
 		spawned_mob.forceMove(box)
 		spawned_mob.AddComponent(/datum/component/block_walking_out_early, box)
 		spawned_mob.set_resting(FALSE, silent = FALSE)
+		var/obj/item/satchel = spawned_mob.get_item_by_slot(ITEM_SLOT_BELT)
+		for(var/obj/item/mail/mail in box)
+			if(prob(50) && length(satchel?.contents) < 7)
+				mail.forceMove(satchel)
 		break
 	return spawned_mob
+
+/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/equip(mob/living/spawned_mob)
+	. = ..()
+	for(var/obj/item/equipment in spawned_mob.get_equipped_items())
+		ADD_TRAIT(equipment, TRAIT_NODROP, INNATE_TRAIT)
+	var/obj/item/clothing/under/mailsuit = spawned_mob.get_item_by_slot(ITEM_SLOT_ICLOTHING)
+	if(istype(mailsuit))
+		mailsuit.has_sensor = BROKEN_SENSORS
+		mailsuit.sensor_mode = SENSOR_OFF
+		mailsuit.update_wearer_status()
 
 /obj/effect/mob_spawn/ghost_role/human/mail_ghoul/special(mob/living/carbon/human/spawned_mob, mob/mob_possessor)
 	. = ..()
@@ -412,6 +426,7 @@
 	ADD_TRAIT(spawned_mob, TRAIT_HULK, INNATE_TRAIT)
 	ADD_TRAIT(spawned_mob, TRAIT_STRONG_GRABBER, INNATE_TRAIT)
 	ADD_TRAIT(spawned_mob, TRAIT_CHUNKYFINGERS, INNATE_TRAIT)
+	spawned_mob.add_movespeed_mod_immunities(INNATE_TRAIT, /datum/movespeed_modifier/damage_slowdown)
 	spawned_mob.mind.add_antag_datum(ghoul)
 	spawned_mob.AddComponent(/datum/component/strong_pull)
 	spawned_mob.AddComponent( \
@@ -421,7 +436,7 @@
 	)
 	spawned_mob.AddComponent( \
 		/datum/component/regenerator, \
-		regeneration_delay = 10 SECONDS, \
+		regeneration_delay = 4 SECONDS, \
 		brute_per_second = 0.25, \
 		burn_per_second = 0.25, \
 		tox_per_second = 0.1, \
@@ -452,6 +467,8 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/tank/internals/emergency_oxygen
 	ears = /obj/item/radio/headset
+	belt = /obj/item/storage/bag/mail
+	back = /obj/item/storage/backpack/satchel/leather
 
 /obj/item/card/id/advanced/mailman
 	name = "mail carrier ID"

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -501,7 +501,7 @@
 
 /datum/component/block_walking_out_early
 	COOLDOWN_DECLARE(spam_cd)
-	var/obj/structure/closet/box
+	VAR_PRIVATE/obj/structure/closet/box
 
 /datum/component/block_walking_out_early/Initialize(obj/structure/closet/box)
 	. = ..()
@@ -524,7 +524,7 @@
 	SIGNAL_HANDLER
 	if(user != parent)
 		return NONE
-	if(!COOLDOWN_FINISHED(src, spam_cd))
+	if(COOLDOWN_FINISHED(src, spam_cd))
 		to_chat(user, span_warning("I don't want to get up yet. It's comfy in here. 5 more minutes..."))
 		COOLDOWN_START(src, spam_cd, 5 SECONDS)
 	return BLOCK_OPEN

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -379,13 +379,6 @@
 	to_chat(user, span_warning("You feel an ominous aura from [source], but there's nothing out of the ordinary inside."))
 	qdel(src)
 
-/obj/effect/mob_spawn/ghost_role/human/mail_ghoul/proc/block_walking_out_early(datum/source, mob/user)
-	SIGNAL_HANDLER
-	if(!polling)
-		return
-	to_chat(user, span_warning("The mail ghoul is being polled for."))
-	qdel(src)
-
 /obj/effect/mob_spawn/ghost_role/human/mail_ghoul/create(mob/mob_possessor, newname)
 	var/mob/living/spawned_mob = ..()
 	for(var/obj/structure/closet/box in spawned_mob.loc)

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -410,6 +410,7 @@
 	ghoul.objectives += until_it_is_done
 
 	ADD_TRAIT(spawned_mob, TRAIT_HULK, INNATE_TRAIT)
+	ADD_TRAIT(spawned_mob, TRAIT_STRONG_GRABBER, INNATE_TRAIT)
 	ADD_TRAIT(spawned_mob, TRAIT_CHUNKYFINGERS, INNATE_TRAIT)
 	spawned_mob.mind.add_antag_datum(ghoul)
 	spawned_mob.AddComponent(/datum/component/strong_pull)

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -413,7 +413,7 @@
 	var/datum/objective/until_it_is_done = new()
 	until_it_is_done.no_failure = TRUE
 	until_it_is_done.explanation_text = "Take over as the station's new mail carrier. \
-		If anyone refuses to sign for their package, make them... With force."
+		If anyone forgets to pick up their package, remind them... With force if necessary."
 	ghoul.objectives += until_it_is_done
 
 	ADD_TRAIT(spawned_mob, TRAIT_HULK, INNATE_TRAIT)


### PR DESCRIPTION
## About The Pull Request

Item #: SCP-████

Object Class: Euclid

Special Containment Procedures: SCP-████ is to be contained within a mail crate at Station-██. All incoming and outgoing mail within a 5 km radius of Station-██ is to be screened for anomalous activity. 

Description: SCP-████, designated "The Mail Ghoul," is a ghoulish humanoid entity measuring approximately 6 feet in height. It manifests sporadically in locations with high volumes of undelivered or misdirected mail. The entity appears in a tattered ████-era postal uniform, though all attempts to identify its insignia or origin have been unsuccessful. 

When "activated", SCP-████ will relentlessly pursue any individuals who forgot to pick up their mail. In particular, SCP-████ seems to target the mail carrier who is neglecting their duties. Upon contact with their target individual, SCP-████ is shown to brutally and effectively maul them to death.

Personnel are advised to avoid contact with SCP-████ if they are sighted on the premises. It is suggested in the event of a containment breach, all personnel check cargo for any missing envelopes. Under no circumstances should attempts to be made to "return to sender".

## Why It's Good For The Game

The mail ghoul has no progression mechanics. 

## Changelog

:cl: Melbert
add: Mail Ghoul
/:cl:
