### PR TITLE
Consistency pass on spell invocations (punctuation)

### DIFF
--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -88,7 +88,7 @@
 			return
 		gender = targeted_gender
 	else
-		gender = targeted_atom.gender
+		gender = targeted_atom.get_visible_gender()
 	///The pronouns are ordered by their length to avoid %PRONOUN_Theyve being translated to "Heve" instead of "He's", for example
 	var/regex/pronoun_regex = regex("%PRONOUN(_(theirs|Theirs|theyve|Theyve|theyre|Theyre|their|Their|they|They|them|Them|have|were|are|do|es|s))")
 	while(pronoun_regex.Find(target_string))
@@ -300,82 +300,61 @@
 		else
 			return "itself"
 
+/// Reports what gender this atom appears to be
+/atom/proc/get_visible_gender()
+	return gender
+
+/mob/living/carbon/human/get_visible_gender()
+	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
+		return PLURAL
+	var/face_hidden = (wear_mask?.flags_inv & HIDEFACE) || (head?.flags_inv & HIDEFACE)
+	if(face_hidden && (check_obscured_slots() & ITEM_SLOT_ICLOTHING))
+		return PLURAL
+	return gender
+
 //humans need special handling, because they can have their gender hidden
 /mob/living/carbon/human/p_they(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_their(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_theirs(capitalized, temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_them(capitalized, temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_have(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_are(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_were(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_do(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_s(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_es(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 /mob/living/carbon/human/p_themselves(temp_gender)
-	var/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	if((obscured & ITEM_SLOT_ICLOTHING) && skipface)
-		temp_gender = PLURAL
+	temp_gender ||= get_visible_gender()
 	return ..()
 
 //clothing need special handling due to pairs of items, ie gloves vs a singular glove, shoes, ect.

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -486,7 +486,7 @@
 	school = SCHOOL_CONJURATION
 	cooldown_time = 10 SECONDS
 
-	invocation = "JE VES"
+	invocation = "JE VES?"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 	spell_max_level = 0 //cannot be improved

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "A'GRSV SPR'D"
+	invocation = "A'GRSV SPR'D."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -10,7 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 70 SECONDS
 
-	invocation = "FL'MS"
+	invocation = "FL'MS."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -72,7 +72,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "C'SC'DE"
+	invocation = "C'SC'D."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -112,7 +112,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 300
 
-	invocation = "F'RE"
+	invocation = "F'R."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "FL'MS O'ET'RN'ITY."
+	invocation = "FL'MS O' 'T'RN'TY."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 45 SECONDS
 
-	invocation = "C'SM'S 'XP'ND"
+	invocation = "C'SM'S 'XP'ND!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/cosmic_runes.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_runes.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 15 SECONDS
 
-	invocation = "ST'R R'N'"
+	invocation = "ST'R R'N."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/eldritch_blind.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_blind.dm
@@ -5,7 +5,7 @@
 	overlay_icon_state = "bg_heretic_border"
 
 	school = SCHOOL_FORBIDDEN
-	invocation = "E'E'S"
+	invocation = "E'E'S."
 	spell_requirements = NONE
 
 	cast_range = 10

--- a/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
@@ -8,7 +8,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "E'P"
+	invocation = "E'P."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
@@ -7,7 +7,7 @@
 	overlay_icon_state = "bg_heretic_border"
 
 	school = SCHOOL_FORBIDDEN
-	invocation = "SH'PE"
+	invocation = "SH'PE."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/mind_gate.dm
+++ b/code/modules/antagonists/heretic/magic/mind_gate.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 
-	invocation = "Op' 'oY 'Mi'd"
+	invocation = "Op'n y'r m'd."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 	cast_range = 6

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "L'N'R P'RAD"
+	invocation = "L'N'R P'R'D!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
-	invocation = "R''S 'E"
+	invocation = "R'S 'E!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/moon_smile.dm
+++ b/code/modules/antagonists/heretic/magic/moon_smile.dm
@@ -12,7 +12,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 20 SECONDS
 	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
-	invocation = "Mo'N S'M'LE"
+	invocation = "M'N S'M'LE!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	cast_range = 6

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -11,7 +11,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 1 MINUTES
 
-	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER"
+	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_HUMAN
 

--- a/code/modules/antagonists/heretic/magic/rust_construction.dm
+++ b/code/modules/antagonists/heretic/magic/rust_construction.dm
@@ -10,6 +10,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 8 SECONDS
 
+	// Both of these are changed in before_cast
 	invocation = "Someone raises a wall of rust."
 	invocation_self_message = "You raise a wall of rust."
 	invocation_type = INVOCATION_EMOTE

--- a/code/modules/antagonists/heretic/magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_wave.dm
@@ -13,7 +13,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 30 SECONDS
 
-	invocation = "'NTR'P'C PL'M'"
+	invocation = "'NTR'P'C PL'M!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
@@ -78,7 +78,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 35 SECONDS
 
-	invocation = "SPR'D TH' WO'D"
+	invocation = "SPR'D TH' W'D."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/void_prison.dm
+++ b/code/modules/antagonists/heretic/magic/void_prison.dm
@@ -15,7 +15,7 @@
 
 	sound = null
 	school = SCHOOL_FORBIDDEN
-	invocation = "V''D PR'S'N!"
+	invocation = "V'D PR'S'N!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/antagonists/heretic/magic/wolves_among_sheep.dm
+++ b/code/modules/antagonists/heretic/magic/wolves_among_sheep.dm
@@ -16,7 +16,7 @@
 	school = SCHOOL_FORBIDDEN
 	cooldown_time = 5 MINUTES
 
-	invocation = "D`M``N `XP`NS``N!"
+	invocation = "D'M'N XP'NS'N!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	/// Max distance our effect is expected to reach

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -404,7 +404,11 @@
 				invoker.whisper(used_invocation_message, forced = "spell ([src])")
 
 		if(INVOCATION_EMOTE)
-			invoker.visible_message(used_invocation_message, invocation_self_message)
+			invoker.visible_message(
+				capitalize(REPLACE_PRONOUNS(replacetext(used_invocation_message, "%CASTER", invoker.name), invoker)),
+				capitalize(REPLACE_PRONOUNS(replacetext(invocation_self_message, "%CASTER", invoker.name), invoker)),
+				visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
+			)
 
 /// Checks if the current OWNER of the spell is in a valid state to say the spell's invocation
 /datum/action/cooldown/spell/proc/try_invoke(mob/living/invoker, feedback = TRUE)

--- a/code/modules/spells/spell_types/aoe_spell/knock.dm
+++ b/code/modules/spells/spell_types/aoe_spell/knock.dm
@@ -8,7 +8,7 @@
 	cooldown_time = 10 SECONDS
 	cooldown_reduction_per_rank = 2 SECONDS
 
-	invocation = "AULIE OXIN FIERA"
+	invocation = "AULIE OXIN FIERA!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 	aoe_radius = 3

--- a/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
+++ b/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
@@ -8,7 +8,7 @@
 	cooldown_time = 20 SECONDS
 	cooldown_reduction_per_rank = 3.5 SECONDS
 
-	invocation = "FORTI GY AMA"
+	invocation = "FORTI GY AMA!"
 	invocation_type = INVOCATION_SHOUT
 
 	aoe_radius = 7

--- a/code/modules/spells/spell_types/aoe_spell/repulse.dm
+++ b/code/modules/spells/spell_types/aoe_spell/repulse.dm
@@ -76,7 +76,7 @@
 	sound = 'sound/effects/magic/repulse.ogg'
 
 	school = SCHOOL_EVOCATION
-	invocation = "GITTAH WEIGH"
+	invocation = "GITTAH WEIGH!"
 	invocation_type = INVOCATION_SHOUT
 	aoe_radius = 5
 

--- a/code/modules/spells/spell_types/aoe_spell/sacred_flame.dm
+++ b/code/modules/spells/spell_types/aoe_spell/sacred_flame.dm
@@ -7,7 +7,7 @@
 	school = SCHOOL_EVOCATION
 	cooldown_time = 6 SECONDS
 
-	invocation = "FI'RAN DADISKO"
+	invocation = "FI'RAN DADISKO!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 

--- a/code/modules/spells/spell_types/conjure/bees.dm
+++ b/code/modules/spells/spell_types/conjure/bees.dm
@@ -10,7 +10,7 @@
 	cooldown_time = 1 MINUTES
 	cooldown_reduction_per_rank = 10 SECONDS
 
-	invocation = "NOT THE BEES"
+	invocation = "NOT THE BEES!"
 	invocation_type = INVOCATION_SHOUT
 
 	summon_radius = 3

--- a/code/modules/spells/spell_types/conjure/carp.dm
+++ b/code/modules/spells/spell_types/conjure/carp.dm
@@ -6,7 +6,7 @@
 	school = SCHOOL_CONJURATION
 	cooldown_time = 2 MINUTES
 
-	invocation = "NOUK FHUNMM SACP RISSKA"
+	invocation = "NOUK FHUNMM SACP RISSKA!"
 	invocation_type = INVOCATION_SHOUT
 
 	summon_radius = 1

--- a/code/modules/spells/spell_types/conjure/cheese.dm
+++ b/code/modules/spells/spell_types/conjure/cheese.dm
@@ -8,7 +8,7 @@
 	cooldown_time = 1 MINUTES
 	spell_requirements = null
 
-	invocation = "PL`YR DOT PL`CTM` OOO`BEE G" //player.placeatme 00064B33 9
+	invocation = "PL'YR DOT PL'CTM' OOO'BEE G!" //player.placeatme 00064B33 9
 	invocation_type = INVOCATION_SHOUT
 	garbled_invocation_prob = 0 //i'd rather it remain like this
 

--- a/code/modules/spells/spell_types/conjure/creatures.dm
+++ b/code/modules/spells/spell_types/conjure/creatures.dm
@@ -6,7 +6,7 @@
 	school = SCHOOL_CONJURATION
 	cooldown_time = 2 MINUTES
 
-	invocation = "IA IA"
+	invocation = "IA IA!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 

--- a/code/modules/spells/spell_types/conjure/invisible_chair.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_chair.dm
@@ -11,7 +11,7 @@
 
 	school = SCHOOL_MIME
 	cooldown_time = 30 SECONDS
-	invocation = "Someone does a weird gesture." // Overriden in before cast
+	invocation = span_notice("<b>%CASTER</b> pulls out an invisible chair and sits down.")
 	invocation_self_message = span_notice("You conjure an invisible chair and sit down.")
 	invocation_type = INVOCATION_EMOTE
 
@@ -22,10 +22,6 @@
 	summon_radius = 0
 	summon_type = list(/obj/structure/chair/mime)
 	summon_lifespan = 25 SECONDS
-
-/datum/action/cooldown/spell/conjure/invisible_chair/before_cast(atom/cast_on)
-	. = ..()
-	invocation = span_notice("<b>[cast_on]</b> pulls out an invisible chair and sits down.")
 
 /datum/action/cooldown/spell/conjure/invisible_chair/post_summon(atom/summoned_object, mob/living/carbon/human/cast_on)
 	if(!isobj(summoned_object))

--- a/code/modules/spells/spell_types/conjure/invisible_wall.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_wall.dm
@@ -11,7 +11,7 @@
 
 	school = SCHOOL_MIME
 	cooldown_time = 30 SECONDS
-	invocation = "Someone does a weird gesture." // Overriden in before cast
+	invocation = span_notice("<b>%CASTER</b> looks as if a wall is in front of %PRONOUN_them.")
 	invocation_self_message = span_notice("You form a wall in front of yourself.")
 	invocation_type = INVOCATION_EMOTE
 
@@ -22,7 +22,3 @@
 	summon_radius = 0
 	summon_type = list(/obj/effect/forcefield/mime)
 	summon_lifespan = 30 SECONDS
-
-/datum/action/cooldown/spell/conjure/invisible_wall/before_cast(atom/cast_on)
-	. = ..()
-	invocation = span_notice("<b>[cast_on]</b> looks as if a wall is in front of [cast_on.p_them()].")

--- a/code/modules/spells/spell_types/conjure/link_worlds.dm
+++ b/code/modules/spells/spell_types/conjure/link_worlds.dm
@@ -6,7 +6,7 @@
 	button_icon_state = "nether"
 	cooldown_time = 1 MINUTES
 	cooldown_reduction_per_rank = 10 SECONDS
-	invocation = "FL'NT N' ST'L"
+	invocation = "FL'NT N' ST'L!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
 	summon_radius = 1

--- a/code/modules/spells/spell_types/conjure/presents.dm
+++ b/code/modules/spells/spell_types/conjure/presents.dm
@@ -6,7 +6,7 @@
 	cooldown_time = 1 MINUTES
 	cooldown_reduction_per_rank = 13.75 SECONDS
 
-	invocation = "HO HO HO"
+	invocation = "HO HO HO!"
 	invocation_type = INVOCATION_SHOUT
 
 	summon_radius = 3

--- a/code/modules/spells/spell_types/conjure/the_traps.dm
+++ b/code/modules/spells/spell_types/conjure/the_traps.dm
@@ -6,7 +6,7 @@
 	cooldown_time = 25 SECONDS
 	cooldown_reduction_per_rank = 5 SECONDS
 
-	invocation = "CAVERE INSIDIAS"
+	invocation = "CAVERE INSIDIAS!"
 	invocation_type = INVOCATION_SHOUT
 
 	summon_radius = 3

--- a/code/modules/spells/spell_types/conjure_item/invisible_box.dm
+++ b/code/modules/spells/spell_types/conjure_item/invisible_box.dm
@@ -13,7 +13,7 @@
 
 	school = SCHOOL_MIME
 	cooldown_time = 30 SECONDS
-	invocation = "Someone does a weird gesture." // Overriden in before cast
+	invocation = span_notice("<b>%CASTER</b> moves %PRONOUN_their hands in the shape of a box, pressing a box out of the air.")
 	invocation_self_message = span_notice("You conjure up an invisible box, large enough to store a few things.")
 	invocation_type = INVOCATION_EMOTE
 
@@ -25,10 +25,6 @@
 	item_type = /obj/item/storage/box/mime
 	/// How long boxes last before going away
 	var/box_lifespan = 50 SECONDS
-
-/datum/action/cooldown/spell/conjure_item/invisible_box/before_cast(atom/cast_on)
-	. = ..()
-	invocation = span_notice("<b>[cast_on]</b> moves [cast_on.p_their()] hands in the shape of a cube, pressing a box out of the air.")
 
 /datum/action/cooldown/spell/conjure_item/invisible_box/make_item(atom/caster)
 	. = ..()

--- a/code/modules/spells/spell_types/pointed/blind.dm
+++ b/code/modules/spells/spell_types/pointed/blind.dm
@@ -9,7 +9,7 @@
 	cooldown_time = 30 SECONDS
 	cooldown_reduction_per_rank = 6.25 SECONDS
 
-	invocation = "STI KALY"
+	invocation = "STI KALY."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 

--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -13,9 +13,9 @@
 	school = SCHOOL_MIME
 	cooldown_time = 30 SECONDS
 
-	invocation = ""
-	invocation_type = INVOCATION_EMOTE
+	invocation = span_notice("<b>%CASTER</b> fires %PRONOUN_their finger gun!")
 	invocation_self_message = span_danger("You fire your finger gun!")
+	invocation_type = INVOCATION_EMOTE
 
 	spell_requirements = SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_MIME_VOW
 	antimagic_flags = NONE
@@ -43,10 +43,3 @@
 			return FALSE
 
 	return ..()
-
-/datum/action/cooldown/spell/pointed/projectile/finger_guns/before_cast(atom/cast_on)
-	. = ..()
-	if(isnull(owner))
-		invocation = initial(invocation)
-	else
-		invocation = span_notice("<b>[owner]</b> fires [owner.p_their()] finger gun!")

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -11,7 +11,7 @@
 	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_PHASED|AB_CHECK_OPEN_TURF
 
-	invocation = "GIN'YU CAPAN"
+	invocation = "GIN'YU CAPAN."
 	invocation_type = INVOCATION_WHISPER
 	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
 

--- a/code/modules/spells/spell_types/self/charge.dm
+++ b/code/modules/spells/spell_types/self/charge.dm
@@ -10,7 +10,7 @@
 	cooldown_time = 60 SECONDS
 	cooldown_reduction_per_rank = 5 SECONDS
 
-	invocation = "DIRI CEL"
+	invocation = "Diri Cel!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 

--- a/code/modules/spells/spell_types/self/disable_tech.dm
+++ b/code/modules/spells/spell_types/self/disable_tech.dm
@@ -23,7 +23,7 @@
 	cooldown_time = 40 SECONDS
 	cooldown_reduction_per_rank = 5 SECONDS
 
-	invocation = "NEC CANTIO"
+	invocation = "NEC CANTIO!"
 	invocation_type = INVOCATION_SHOUT
 
 	emp_heavy = 6

--- a/code/modules/spells/spell_types/self/forcewall.dm
+++ b/code/modules/spells/spell_types/self/forcewall.dm
@@ -8,7 +8,7 @@
 	cooldown_time = 10 SECONDS
 	cooldown_reduction_per_rank = 1.25 SECONDS
 
-	invocation = "TARCOL MINTI ZHERI"
+	invocation = "TARCOL MINTI ZHERI!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 
@@ -59,13 +59,9 @@
 	spell_requirements = SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_MIME_VOW
 	antimagic_flags = NONE
 
-	invocation = ""
-	invocation_type = INVOCATION_EMOTE
+	invocation = span_notice("<b>%CASTER</b> looks as if a blockade is in front of %PRONOUN_them.")
 	invocation_self_message = span_notice("You form a blockade in front of yourself.")
+	invocation_type = INVOCATION_EMOTE
 	spell_max_level = 1
 
 	wall_type = /obj/effect/forcefield/mime/advanced
-
-/datum/action/cooldown/spell/forcewall/mime/before_cast(atom/cast_on)
-	. = ..()
-	invocation = span_notice("<b>[cast_on]</b> looks as if a blockade is in front of [cast_on.p_them()].")

--- a/code/modules/spells/spell_types/self/mutate.dm
+++ b/code/modules/spells/spell_types/self/mutate.dm
@@ -43,7 +43,7 @@
 	cooldown_reduction_per_rank = 5 SECONDS
 	spell_max_level = 3
 
-	invocation = "BIRUZ BENNAR"
+	invocation = "BIRUZ BENNAR!"
 	invocation_type = INVOCATION_SHOUT
 
 	mutations_to_add = list(/datum/mutation/human/laser_eyes, /datum/mutation/human/hulk/wizardly, /datum/mutation/human/gigantism)

--- a/code/modules/spells/spell_types/self/sanguine_strike.dm
+++ b/code/modules/spells/spell_types/self/sanguine_strike.dm
@@ -15,7 +15,7 @@
 	cooldown_time = 60 SECONDS
 	cooldown_reduction_per_rank = 10 SECONDS
 
-	invocation = "SHAPSDAY"
+	invocation = "SHAPSDAY."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 

--- a/code/modules/spells/spell_types/self/summonitem.dm
+++ b/code/modules/spells/spell_types/self/summonitem.dm
@@ -6,7 +6,7 @@
 	school = SCHOOL_TRANSMUTATION
 	cooldown_time = 10 SECONDS
 
-	invocation = "GAR YOK"
+	invocation = "Gar Yok!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 

--- a/code/modules/spells/spell_types/shapeshift/dragon.dm
+++ b/code/modules/spells/spell_types/shapeshift/dragon.dm
@@ -2,8 +2,9 @@
 /datum/action/cooldown/spell/shapeshift/dragon
 	name = "Dragon Form"
 	desc = "Take on the shape a lesser ash drake."
-	invocation = "RAAAAAAAAWR!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = span_danger("<b>%CASTER</b> lets out a mighty roar!")
+	invocation_self_message = span_danger("You let out a mighty roar!")
+	invocation_type = INVOCATION_EMOTE
 	spell_requirements = NONE
 
 	possible_shapes = list(/mob/living/simple_animal/hostile/megafauna/dragon/lesser)

--- a/code/modules/spells/spell_types/shapeshift/polar_bear.dm
+++ b/code/modules/spells/spell_types/shapeshift/polar_bear.dm
@@ -1,8 +1,9 @@
 /datum/action/cooldown/spell/shapeshift/polar_bear
 	name = "Polar Bear Form"
 	desc = "Take on the shape of a polar bear."
-	invocation = "RAAAAAAAAWR!"
-	invocation_type = INVOCATION_SHOUT
+	invocation = span_danger("<b>%CASTER</b> lets out a mighty roar!")
+	invocation_self_message = span_danger("You let out a mighty roar!")
+	invocation_type = INVOCATION_EMOTE
 	spell_requirements = NONE
 
 	possible_shapes = list(/mob/living/simple_animal/hostile/asteroid/polarbear/lesser)

--- a/code/modules/spells/spell_types/teleport/teleport.dm
+++ b/code/modules/spells/spell_types/teleport/teleport.dm
@@ -10,7 +10,7 @@
 	cooldown_reduction_per_rank = 20 SECONDS
 	spell_max_level = 3
 
-	invocation = "SCYAR NILA"
+	invocation = "SCYAR NILA" // gets punctuation auto applied
 	invocation_type = INVOCATION_SHOUT
 
 	smoke_type = /datum/effect_system/fluid_spread/smoke


### PR DESCRIPTION
## About The Pull Request

Recent events on the station have left me very - unimpressed, as it comes to our spells. 

Some have backticks, most use apostrophes. Some have punctuation, many don't. Some are in all caps, others aren't. 

So I went through and basically just tweaked all the invocations slightly to make them more consistent. They're all punctuated now, with whispered invocations preferring periods and shouting invocations preferring exclamation (though this is not a set rule, as sometimes a period gets the message across stronger than an exclamation point." 

I also made it a bit easier to work with emote invocations. Which in turn involved me touching the human `p_x` procs. 
 
## Why It's Good For The Game

Spell invocations are wildly inconsistent style wise, tightening them up helps towards muh immersions. Makes it feel more like a system and less like stuff thrown together.

## Changelog

:cl: Melbert
qol: All spell invocations have been made a bit more consistent - some have changed slightly, some are now punctuated. "Dragon Form" and "Bear Form" are now emotes invocations.
qol: "Unknown" mobs are now properly referred to as they/them
/:cl:
