### PR TITLE
Part 2:  Storage Improvements

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -503,7 +503,10 @@
 /obj/item/storage/box/stickers/skub/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 3
-	atom_storage.exception_hold = typecacheof(list(/obj/item/skub, /obj/item/clothing/suit/costume/wellworn_shirt/skub))
+	atom_storage.set_holdable(exception_hold_list = list(
+		/obj/item/skub,
+		/obj/item/clothing/suit/costume/wellworn_shirt/skub,
+	))
 
 /obj/item/storage/box/stickers/skub/PopulateContents()
 	new /obj/item/skub(src)
@@ -518,7 +521,7 @@
 
 /obj/item/storage/box/stickers/anti_skub/Initialize(mapload)
 	. = ..()
-	atom_storage.exception_hold = typecacheof(list(/obj/item/clothing/suit/costume/wellworn_shirt/skub))
+	atom_storage.set_holdable(exception_hold_list = /obj/item/clothing/suit/costume/wellworn_shirt/skub)
 
 /obj/item/storage/box/stickers/anti_skub/PopulateContents()
 	for(var/i in 1 to 4)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -334,15 +334,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			desc += "\a [initial(valid_item.name)]"
 		can_hold_description = "\n\t[span_notice("[desc.Join("\n\t")]")]"
 
-/// Generates a description, primarily for clothing storage.
-/datum/storage/proc/generate_hold_desc(can_hold_list)
-	var/list/desc = list()
-
-	for(var/obj/item/valid_item as anything in can_hold_list)
-		desc += "\a [initial(valid_item.name)]"
-
-	return "\n\t[span_notice("[desc.Join("\n\t")]")]"
-
 /// Updates the action button for toggling collectmode.
 /datum/storage/proc/update_actions(atom/source, mob/equipper, slot)
 	SIGNAL_HANDLER

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -35,6 +35,7 @@
 	/// Do not set directly, use set_holdable
 	VAR_FINAL/list/obj/item/cant_hold
 	/// Typecache of items that can always be inserted into this storage, regardless of size.
+	///Do not set directly, use set_holdable
 	VAR_FINAL/list/obj/item/exception_hold
 	/// For use with an exception typecache:
 	/// The maximum amount of items of the exception type that can be inserted into this storage.
@@ -287,26 +288,51 @@
 /// ~Lemon
 GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
-/datum/storage/proc/set_holdable(list/can_hold_list, list/cant_hold_list)
-	if(!isnull(can_hold_list) && !islist(can_hold_list))
-		can_hold_list = list(can_hold_list)
-	if(!isnull(cant_hold_list) && !islist(cant_hold_list))
-		cant_hold_list = list(cant_hold_list)
-
+/**
+ * Sets what type of contents this storage supports
+ * Arguments
+ *
+ * * list/can_hold_list - The list of item types whitelisted in this storage rejecting everything else
+ * * list/cant_hold_list - The list of item types blacklisted in this storage accepting everything else
+ * * list/exception_hold_list - The list of items that can exceed `max_specific_storage`. It can only fit `exception_count` of such items
+ */
+/datum/storage/proc/set_holdable(list/can_hold_list, list/cant_hold_list, list/exception_hold_list)
+	can_hold = null
 	if (!isnull(can_hold_list))
-		if(isnull(can_hold_description))
-			can_hold_description = generate_hold_desc(can_hold_list)
+		if(!islist(can_hold_list))
+			can_hold_list = list(can_hold_list)
 
 		var/unique_key = can_hold_list.Join("-")
 		if(!GLOB.cached_storage_typecaches[unique_key])
 			GLOB.cached_storage_typecaches[unique_key] = typecacheof(can_hold_list)
 		can_hold = GLOB.cached_storage_typecaches[unique_key]
 
+	cant_hold = null
 	if (!isnull(cant_hold_list))
+		if(!islist(cant_hold_list))
+			cant_hold_list = list(cant_hold_list)
+
 		var/unique_key = cant_hold_list.Join("-")
 		if(!GLOB.cached_storage_typecaches[unique_key])
 			GLOB.cached_storage_typecaches[unique_key] = typecacheof(cant_hold_list)
 		cant_hold = GLOB.cached_storage_typecaches[unique_key]
+
+	exception_hold = null
+	if (!isnull(exception_hold_list))
+		if(!islist(exception_hold_list))
+			exception_hold_list = list(exception_hold_list)
+
+		var/unique_key = exception_hold_list.Join("-")
+		if(!GLOB.cached_storage_typecaches[unique_key])
+			GLOB.cached_storage_typecaches[unique_key] = typecacheof(exception_hold_list)
+		exception_hold = GLOB.cached_storage_typecaches[unique_key]
+
+	can_hold_description = null
+	if(length(can_hold_list))
+		var/list/desc = list()
+		for(var/obj/item/valid_item as anything in can_hold_list)
+			desc += "\a [initial(valid_item.name)]"
+		can_hold_description = "\n\t[span_notice("[desc.Join("\n\t")]")]"
 
 /// Generates a description, primarily for clothing storage.
 /datum/storage/proc/generate_hold_desc(can_hold_list)

--- a/code/datums/storage/subtypes/backpack.dm
+++ b/code/datums/storage/subtypes/backpack.dm
@@ -9,8 +9,8 @@
 	max_total_storage,
 )
 	. = ..()
-	var/static/list/exception_cache = typecacheof(list(/obj/item/fish_tank))
-	exception_hold = exception_cache
+
+	set_holdable(exception_hold_list = /obj/item/fish_tank)
 
 /datum/storage/backpack/santabag
 	max_total_storage = 60

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -10,7 +10,7 @@
 )
 	. = ..()
 
-	set_holdable(/obj/item/fish_tank)
+	set_holdable(exception_hold_list = /obj/item/fish_tank)
 
 // Syndi bags get some FUN extras
 // You can fit any 2 bulky objects (assuming they're in the whitelist)

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -76,3 +76,6 @@
 	)
 
 	set_holdable(exception_hold_list = exception_type_list)
+
+	//...So we can run this without it generating a line for every subtype.
+	can_hold_description = generate_hold_desc(exception_type_list)

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -9,8 +9,8 @@
 	max_total_storage,
 )
 	. = ..()
-	var/static/list/exception_cache = typecacheof(list(/obj/item/fish_tank))
-	exception_hold = exception_cache
+
+	set_holdable(/obj/item/fish_tank)
 
 // Syndi bags get some FUN extras
 // You can fit any 2 bulky objects (assuming they're in the whitelist)
@@ -75,9 +75,4 @@
 		/obj/item/fish_tank,
 	)
 
-	// We keep the type list and the typecache list separate...
-	var/static/list/exception_cache = typecacheof(exception_type_list)
-	exception_hold = exception_cache
-
-	//...So we can run this without it generating a line for every subtype.
-	can_hold_description = generate_hold_desc(exception_type_list)
+	set_holdable(exception_hold_list = exception_type_list)

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -78,4 +78,7 @@
 	set_holdable(exception_hold_list = exception_type_list)
 
 	//...So we can run this without it generating a line for every subtype.
-	can_hold_description = generate_hold_desc(exception_type_list)
+	var/list/desc = list()
+	for(var/obj/item/valid_item as anything in exception_type_list)
+		desc += "\a [initial(valid_item.name)]"
+	can_hold_description = "\n\t[span_notice("[desc.Join("\n\t")]")]"

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -34,14 +34,14 @@
 	max_total_storage,
 )
 	. = ..()
-	var/static/list/exception_cache = typecacheof(list(
+
+	set_holdable(exception_hold_list = list(
 		/obj/item/katana,
 		/obj/item/toy/katana,
 		/obj/item/nullrod/claymore/katana,
 		/obj/item/energy_katana,
 		/obj/item/gun/ballistic/automatic/tommygun,
 	))
-	exception_hold = exception_cache
 
 /datum/storage/pockets/small/fedora/detective
 	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
@@ -85,40 +85,44 @@
 	max_total_storage,
 )
 	. = ..()
-	set_holdable(list(
-		/obj/item/knife,
-		/obj/item/spess_knife,
-		/obj/item/switchblade,
-		/obj/item/boxcutter,
-		/obj/item/pen,
-		/obj/item/scalpel,
-		/obj/item/dnainjector,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/reagent_containers/applicator/pill,
-		/obj/item/reagent_containers/hypospray/medipen,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/implanter,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool/mini,
-		/obj/item/firing_pin,
-		/obj/item/suppressor,
-		/obj/item/ammo_box/magazine/m9mm,
-		/obj/item/ammo_box/magazine/m10mm,
-		/obj/item/ammo_box/magazine/m45,
-		/obj/item/ammo_box/magazine/toy/pistol,
-		/obj/item/ammo_casing,
-		/obj/item/lipstick,
-		/obj/item/cigarette,
-		/obj/item/lighter,
-		/obj/item/match,
-		/obj/item/holochip,
-		/obj/item/toy/crayon,
-		/obj/item/reagent_containers/cup/glass/flask),
-		list(/obj/item/screwdriver/power,
-		/obj/item/ammo_casing/rocket,
-		/obj/item/cigarette/pipe,
-		/obj/item/toy/crayon/spraycan)
+	set_holdable(
+		can_hold_list = list(
+			/obj/item/knife,
+			/obj/item/spess_knife,
+			/obj/item/switchblade,
+			/obj/item/boxcutter,
+			/obj/item/pen,
+			/obj/item/scalpel,
+			/obj/item/dnainjector,
+			/obj/item/reagent_containers/syringe,
+			/obj/item/reagent_containers/applicator/pill,
+			/obj/item/reagent_containers/hypospray/medipen,
+			/obj/item/reagent_containers/dropper,
+			/obj/item/implanter,
+			/obj/item/screwdriver,
+			/obj/item/weldingtool/mini,
+			/obj/item/firing_pin,
+			/obj/item/suppressor,
+			/obj/item/ammo_box/magazine/m9mm,
+			/obj/item/ammo_box/magazine/m10mm,
+			/obj/item/ammo_box/magazine/m45,
+			/obj/item/ammo_box/magazine/toy/pistol,
+			/obj/item/ammo_casing,
+			/obj/item/lipstick,
+			/obj/item/cigarette,
+			/obj/item/lighter,
+			/obj/item/match,
+			/obj/item/holochip,
+			/obj/item/toy/crayon,
+			/obj/item/reagent_containers/cup/glass/flask
+		),
+		cant_hold_list = list(
+			/obj/item/screwdriver/power,
+			/obj/item/ammo_casing/rocket,
+			/obj/item/cigarette/pipe,
+			/obj/item/toy/crayon/spraycan
 		)
+	)
 
 /datum/storage/pockets/shoes/clown/New(
 	atom/parent,
@@ -195,10 +199,12 @@
 	max_total_storage,
 )
 	. = ..()
-	set_holdable(list(/obj/item/reagent_containers/cup/glass/bottle/vodka,
-					  /obj/item/reagent_containers/cup/glass/bottle/molotov,
-					  /obj/item/reagent_containers/cup/glass/drinkingglass,
-					  /obj/item/ammo_box/strilka310))
+	set_holdable(list(
+		/obj/item/reagent_containers/cup/glass/bottle/vodka,
+		/obj/item/reagent_containers/cup/glass/bottle/molotov,
+		/obj/item/reagent_containers/cup/glass/drinkingglass,
+		/obj/item/ammo_box/strilka310
+	))
 
 
 /datum/storage/pockets/void_cloak
@@ -213,19 +219,22 @@
 	max_total_storage,
 )
 	. = ..()
-	set_holdable(list(
-		/obj/item/ammo_box/strilka310/lionhunter,
-		/obj/item/bodypart, // Bodyparts are often used in rituals. They're also often normal sized, so you can only fit one.
-		/obj/item/clothing/neck/eldritch_amulet,
-		/obj/item/clothing/neck/heretic_focus,
-		/obj/item/codex_cicatrix,
-		/obj/item/eldritch_potion,
-		/obj/item/food/grown/poppy, // Used to regain a Living Heart.
-		/obj/item/melee/rune_carver,
-		/obj/item/melee/sickly_blade, // Normal sized, so you can only fit one.
-		/obj/item/organ, // Organs are also often used in rituals.
-		/obj/item/reagent_containers/cup/beaker/eldritch,
-	))
-
-	var/static/list/exception_cache = typecacheof(list(/obj/item/bodypart, /obj/item/melee/sickly_blade))
-	exception_hold = exception_cache
+	set_holdable(
+		can_hold_list = list(
+			/obj/item/ammo_box/strilka310/lionhunter,
+			/obj/item/bodypart, // Bodyparts are often used in rituals. They're also often normal sized, so you can only fit one.
+			/obj/item/clothing/neck/eldritch_amulet,
+			/obj/item/clothing/neck/heretic_focus,
+			/obj/item/codex_cicatrix,
+			/obj/item/eldritch_potion,
+			/obj/item/food/grown/poppy, // Used to regain a Living Heart.
+			/obj/item/melee/rune_carver,
+			/obj/item/melee/sickly_blade, // Normal sized, so you can only fit one.
+			/obj/item/organ, // Organs are also often used in rituals.
+			/obj/item/reagent_containers/cup/beaker/eldritch,
+		),
+		exception_hold_list = list(
+			/obj/item/bodypart,
+			/obj/item/melee/sickly_blade,
+		)
+	)

--- a/code/datums/storage/subtypes/portable_chem_mixer.dm
+++ b/code/datums/storage/subtypes/portable_chem_mixer.dm
@@ -5,12 +5,10 @@
 /datum/storage/portable_chem_mixer/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
 	. = ..()
 
-	var/static/list/obj/item/reagent_containers/containers = list(
+	set_holdable(list(
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/cup/glass/waterbottle,
 		/obj/item/reagent_containers/condiment,
-	)
-
-	set_holdable(containers)
+	))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -372,13 +372,11 @@
 /obj/item/storage/bag/sheetsnatcher/debug/Initialize(mapload)
 	. = ..()
 	// Overrides so it can hold all possible sheets
-	atom_storage.set_holdable(
-		can_hold_list = list(
-			/obj/item/stack/sheet,
-			/obj/item/stack/sheet/mineral/sandstone,
-			/obj/item/stack/sheet/mineral/wood,
-		)
-	)
+	atom_storage.set_holdable(list(
+		/obj/item/stack/sheet,
+		/obj/item/stack/sheet/mineral/sandstone,
+		/obj/item/stack/sheet/mineral/wood,
+	))
 
 // -----------------------------
 //           Book bag
@@ -659,7 +657,7 @@
 		/obj/item/ammo_casing/rebar/hydrogen,
 		/obj/item/ammo_casing/rebar/zaukerite,
 		/obj/item/ammo_casing/rebar/paperball,
-		))
+	))
 
 /obj/item/storage/bag/rebar_quiver/syndicate
 	icon_state = "syndie_quiver_0"

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -271,7 +271,10 @@
 
 /obj/item/storage/box/miner_modkits/Initialize(mapload)
 	. = ..()
-	atom_storage.set_holdable(list(/obj/item/borg/upgrade/modkit, /obj/item/crusher_trophy))
+	atom_storage.set_holdable(list(
+		/obj/item/borg/upgrade/modkit,
+		/obj/item/crusher_trophy
+	))
 	atom_storage.numerical_stacking = TRUE
 
 /obj/item/storage/box/miner_modkits/PopulateContents()

--- a/code/game/objects/items/storage/boxes/science_boxes.dm
+++ b/code/game/objects/items/storage/boxes/science_boxes.dm
@@ -44,7 +44,7 @@
 /obj/item/storage/box/monkeycubes/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 7
-	atom_storage.set_holdable(/obj/item/food/monkeycube)
+	atom_storage.set_holdable(/obj/item/food/monkeycube, /obj/item/food/monkeycube/gorilla)
 
 /obj/item/storage/box/monkeycubes/PopulateContents()
 	for(var/i in 1 to 5)
@@ -63,7 +63,7 @@
 /obj/item/storage/box/gorillacubes/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 3
-	atom_storage.set_holdable(/obj/item/food/monkeycube)
+	atom_storage.set_holdable(/obj/item/food/monkeycube/gorilla)
 
 /obj/item/storage/box/gorillacubes/PopulateContents()
 	for(var/i in 1 to 3)

--- a/code/game/objects/items/storage/boxes/science_boxes.dm
+++ b/code/game/objects/items/storage/boxes/science_boxes.dm
@@ -44,7 +44,10 @@
 /obj/item/storage/box/monkeycubes/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 7
-	atom_storage.set_holdable(/obj/item/food/monkeycube, /obj/item/food/monkeycube/gorilla)
+	atom_storage.set_holdable(
+		can_hold_list = /obj/item/food/monkeycube,
+		cant_hold_list = /obj/item/food/monkeycube/gorilla,
+	)
 
 /obj/item/storage/box/monkeycubes/PopulateContents()
 	for(var/i in 1 to 5)

--- a/code/game/objects/items/storage/boxes/service_boxes.dm
+++ b/code/game/objects/items/storage/boxes/service_boxes.dm
@@ -121,7 +121,10 @@
 /obj/item/storage/box/lights/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 21
-	atom_storage.set_holdable(list(/obj/item/light/tube, /obj/item/light/bulb))
+	atom_storage.set_holdable(list(
+		/obj/item/light/tube,
+		/obj/item/light/bulb
+	))
 	atom_storage.max_total_storage = 21
 	atom_storage.allow_quick_gather = FALSE //temp workaround to re-enable filling the light replacer with the box
 
@@ -209,7 +212,7 @@
 /obj/item/storage/box/balloons/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 24
-	atom_storage.set_holdable(list(/obj/item/toy/balloon/long))
+	atom_storage.set_holdable(/obj/item/toy/balloon/long)
 	atom_storage.max_total_storage = 24
 	atom_storage.allow_quick_gather = FALSE
 
@@ -236,7 +239,7 @@
 /obj/item/storage/box/stickers/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 8
-	atom_storage.set_holdable(list(/obj/item/sticker))
+	atom_storage.set_holdable(/obj/item/sticker)
 	atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
 	if(isnull(illustration))
 		illustration = pick(pack_labels)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -441,7 +441,10 @@
 /obj/item/storage/box/syndie_kit/space/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
-	atom_storage.set_holdable(list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate))
+	atom_storage.set_holdable(list(
+		/obj/item/clothing/suit/space/syndicate,
+		/obj/item/clothing/head/helmet/space/syndicate
+	))
 
 /obj/item/storage/box/syndie_kit/space/PopulateContents()
 	var/obj/item/clothing/suit/space/syndicate/spess_suit = pick(GLOB.syndicate_space_suits_to_helmets)

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -15,37 +15,40 @@
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 4
-	atom_storage.set_holdable(list(
-		/obj/item/stack/spacecash,
-		/obj/item/holochip,
-		/obj/item/card,
-		/obj/item/cigarette,
-		/obj/item/clothing/accessory/dogtag,
-		/obj/item/coin,
-		/obj/item/coupon,
-		/obj/item/dice,
-		/obj/item/disk,
-		/obj/item/flashlight/pen,
-		/obj/item/folder/biscuit,
-		/obj/item/food/chococoin,
-		/obj/item/implanter,
-		/obj/item/laser_pointer,
-		/obj/item/lighter,
-		/obj/item/lipstick,
-		/obj/item/match,
-		/obj/item/paper,
-		/obj/item/pen,
-		/obj/item/photo,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/reagent_containers/applicator,
-		/obj/item/screwdriver,
-		/obj/item/seeds,
-		/obj/item/spess_knife,
-		/obj/item/stack/medical,
-		/obj/item/stamp,
-		/obj/item/toy/crayon),
-		list(/obj/item/screwdriver/power))
+	atom_storage.set_holdable(
+		can_hold_list = list(
+			/obj/item/stack/spacecash,
+			/obj/item/holochip,
+			/obj/item/card,
+			/obj/item/cigarette,
+			/obj/item/clothing/accessory/dogtag,
+			/obj/item/coin,
+			/obj/item/coupon,
+			/obj/item/dice,
+			/obj/item/disk,
+			/obj/item/flashlight/pen,
+			/obj/item/folder/biscuit,
+			/obj/item/food/chococoin,
+			/obj/item/implanter,
+			/obj/item/laser_pointer,
+			/obj/item/lighter,
+			/obj/item/lipstick,
+			/obj/item/match,
+			/obj/item/paper,
+			/obj/item/pen,
+			/obj/item/photo,
+			/obj/item/reagent_containers/dropper,
+			/obj/item/reagent_containers/syringe,
+			/obj/item/reagent_containers/applicator,
+			/obj/item/screwdriver,
+			/obj/item/seeds,
+			/obj/item/spess_knife,
+			/obj/item/stack/medical,
+			/obj/item/stamp,
+			/obj/item/toy/crayon
+		),
+		cant_hold_list = /obj/item/screwdriver/power
+	)
 
 /obj/item/storage/wallet/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/code/modules/events/holiday/easter.dm
+++ b/code/modules/events/holiday/easter.dm
@@ -49,7 +49,12 @@
 
 /obj/item/storage/basket/easter/Initialize(mapload)
 	. = ..()
-	atom_storage.set_holdable(list(/obj/item/food/egg, /obj/item/food/chocolateegg, /obj/item/food/boiledegg, /obj/item/surprise_egg))
+	atom_storage.set_holdable(list(
+		/obj/item/food/egg,
+		/obj/item/food/chocolateegg,
+		/obj/item/food/boiledegg,
+		/obj/item/surprise_egg
+	))
 
 /obj/item/storage/basket/easter/proc/countEggs()
 	cut_overlays()

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -335,10 +335,8 @@
 /obj/item/storage/toolbox/fishing/Initialize(mapload)
 	. = ..()
 	// Can hold fishing rod despite the size
-	var/static/list/exception_cache = typecacheof(list(
-		/obj/item/fishing_rod,
-	))
-	atom_storage.exception_hold = exception_cache
+	atom_storage.set_holdable(exception_hold_list = /obj/item/fishing_rod)
+
 	AddComponent(/datum/component/adjust_fishing_difficulty, fishing_modifier, ITEM_SLOT_HANDS)
 
 /obj/item/storage/toolbox/fishing/PopulateContents()

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -17,7 +17,11 @@
 		icon_state = "moneybagalt"
 	atom_storage.max_slots = 40
 	atom_storage.max_specific_storage = 40
-	atom_storage.set_holdable(list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/holochip))
+	atom_storage.set_holdable(list(
+		/obj/item/coin,
+		/obj/item/stack/spacecash,
+		/obj/item/holochip
+	))
 
 /obj/item/storage/bag/money/vault/PopulateContents()
 	new /obj/item/coin/silver(src)

--- a/code/modules/shuttle/mobile_port/variants/emergency/pods.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/pods.dm
@@ -145,12 +145,11 @@
 	// (IE all space suits instead of just the emergency ones)
 	// because an enterprising traitor might be able to hide things,
 	// like their syndicate toolbox or softsuit. may be fun?
-	var/static/list/exception_cache = typecacheof(list(
+	set_holdable(exception_hold_list = list(
 		/obj/item/clothing/suit/space,
 		/obj/item/pickaxe,
 		/obj/item/storage/toolbox,
 	))
-	src.exception_hold = exception_cache
 	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(update_lock))
 	update_lock(new_level = SSsecurity_level.get_current_level_as_number())
 


### PR DESCRIPTION
## About The Pull Request
Continuation of #90365

- Formatted some usages of `set_holdable()` to be more readable
- `exception_hold` list now stores its values inside ` GLOB.cached_storage_typecaches`. This means we don't have to manage a static typecache list per storage but can share the value across all storages making memory management slightly more efficient
- Monkey cube boxes now cannot hold gorilla cubes cause that would make gorilla cube boxes obsolete also now gorilla cube boxes can now only hold gorilla cubes & not general monkey cubes(which gorilla cubes is a subtype of) cause that would make monkey cube boxes obsolete. We are specializing each box for that specific use case

## Changelog
:cl:
code: further improved storage code
fix: monkey cube boxes can no longer hold gorilla cubes & vice versa
/:cl:

