### PR TITLE
Fix edge-cases where clothing icons wouldn't update when equipped

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -98,7 +98,7 @@
 	///How large is the object, used for stuff like whether it can fit in backpacks or not
 	var/w_class = WEIGHT_CLASS_NORMAL
 	///This is used to determine on which slots an item can fit.
-	var/slot_flags = 0
+	var/slot_flags = NONE
 	pass_flags = PASSTABLE
 	pressure_resistance = 4
 	/// This var exists as a weird proxy "owner" ref
@@ -939,31 +939,7 @@
 	if(!ismob(loc))
 		return
 	var/mob/owner = loc
-	var/flags = slot_flags
-	if(flags & ITEM_SLOT_OCLOTHING)
-		owner.update_worn_oversuit()
-	if(flags & ITEM_SLOT_ICLOTHING)
-		owner.update_worn_undersuit()
-	if(flags & ITEM_SLOT_GLOVES)
-		owner.update_worn_gloves()
-	if(flags & ITEM_SLOT_EYES)
-		owner.update_worn_glasses()
-	if(flags & ITEM_SLOT_EARS)
-		owner.update_worn_ears()
-	if(flags & ITEM_SLOT_MASK)
-		owner.update_worn_mask()
-	if(flags & ITEM_SLOT_HEAD)
-		owner.update_worn_head()
-	if(flags & ITEM_SLOT_FEET)
-		owner.update_worn_shoes()
-	if(flags & ITEM_SLOT_ID)
-		owner.update_worn_id()
-	if(flags & ITEM_SLOT_BELT)
-		owner.update_worn_belt()
-	if(flags & ITEM_SLOT_BACK)
-		owner.update_worn_back()
-	if(flags & ITEM_SLOT_NECK)
-		owner.update_worn_neck()
+	owner.update_clothing(slot_flags | owner.get_slot_by_item(src))
 
 ///Returns the temperature of src. If you want to know if an item is hot use this proc.
 /obj/item/proc/get_temperature()


### PR DESCRIPTION
## About The Pull Request

> [I get the feeling I made a mistake somehow but idk what, so fuck it we ball](https://github.com/tgstation/tgstation/pull/89343/commits/905d9fade6aa3d5b340efdf8d76d88b0b78f8124)

_FORESHADOWING IS A LITERARY DEVICE-_

---

`/obj/item/proc/update_slot_icon` was overly complex and didn't work in many edge-cases... such as suit storage. We can literally just do `owner.update_clothing` lol. It both works better, and is much simpler code!

https://github.com/user-attachments/assets/7f949224-e725-4abb-9e7a-30b622f115bc


## Why It's Good For The Game

things working is good

## Changelog
:cl:
fix: Fixed some edge cases where player worn icons wouldn't update properly... such as blades being hidden when equipping to a void cloak.
/:cl:
