### PR TITLE
makes `get_mob_by_ckey` not horrifically inefficient

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -601,8 +601,6 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 		return persistent_mob
 	// hopefully the above will always handle it, but any time a coder thinks "no way this will happen", murphy's law guarantees it somehow will
 	for(var/mob/mob as anything in GLOB.mob_list)
-		if(QDELETED(mob))
-			continue
 		if(mob.ckey == key)
 			return mob
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -596,8 +596,13 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 /proc/get_mob_by_ckey(key)
 	if(!key)
 		return
-	var/list/mobs = sort_mobs()
-	for(var/mob/mob in mobs)
+	var/mob/persistent_mob = GLOB.persistent_clients_by_ckey[key]?.mob
+	if(persistent_mob)
+		return persistent_mob
+	// hopefully the above will always handle it, but any time a coder thinks "no way this will happen", murphy's law guarantees it somehow will
+	for(var/mob/mob as anything in GLOB.mob_list)
+		if(QDELETED(mob))
+			continue
 		if(mob.ckey == key)
 			return mob
 


### PR DESCRIPTION

## About The Pull Request

why the hell did this need to do `sort_mobs`???

also we have persistent clients now, and they track mobs, so yeah let's just. always check that first.

## Why It's Good For The Game

because _this_ is bad:

![2025-04-02 (1743602147) ~ tracy-profiler](https://github.com/user-attachments/assets/a598d159-1369-42c1-92a4-34c7875640f5)

## Changelog
:cl:
code: Optimized a proc related to getting a specific player's mob FAR less inefficient.
/:cl:
