### PR TITLE
Fixes seethrough mob offsetting on 516

### DIFF
--- a/code/datums/components/seethrough_mob.dm
+++ b/code/datums/components/seethrough_mob.dm
@@ -55,8 +55,7 @@
 	for(var/atom/movable/screen/plane_master/seethrough as anything in our_hud.get_true_plane_masters(SEETHROUGH_PLANE))
 		seethrough.unhide_plane(fool)
 
-	render_source_atom.pixel_x = -fool.pixel_x
-	render_source_atom.pixel_y = ((fool.get_cached_height() - ICON_SIZE_Y) * 0.5)
+	render_source_atom.name = "seethrough" //So our name is not just "movable" when looking at VVs
 
 	initial_render_target_value = fool.render_target
 	fool.render_target = "*transparent_bigmob[personal_uid]"


### PR DESCRIPTION
## About The Pull Request

Some of the pixel_x/y changes in 516 broke this i think (Lemon update: this was an intentional change in 516 to remove the need to dumb offsetting like this)

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/4f9b1ba5-82d7-4569-98b1-69635a6b17f1)

## Changelog
:cl:
fix: fixed seethrough mob offsetting your sprite
/:cl:
