### PR TITLE
Fixes hat stabilizer overlays rendering behind hats

### DIFF
--- a/code/datums/components/hat_stabilizer.dm
+++ b/code/datums/components/hat_stabilizer.dm
@@ -127,7 +127,7 @@
 		return
 	var/mutable_appearance/worn_overlay = attached_hat.build_worn_icon(default_layer = ABOVE_BODY_FRONT_HEAD_LAYER - 0.1, default_icon_file = 'icons/mob/clothing/head/default.dmi')
 	for (var/mutable_appearance/overlay in worn_overlay.overlays)
-		overlay.layer = ABOVE_BODY_FRONT_HEAD_LAYER - 0.1
+		overlay.layer = -ABOVE_BODY_FRONT_HEAD_LAYER + 0.1
 	// loose hats are slightly angled
 	if(loose_hat)
 		var/matrix/tilt_trix = matrix(worn_overlay.transform)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -827,9 +827,9 @@ generate/load female uniform sprites matching all previously decided variables
 			greyscale_colors = greyscale_colors,
 		)
 	if(building_icon)
-		draw_target = mutable_appearance(building_icon)
+		draw_target = mutable_appearance(building_icon, layer = -layer2use)
 	else
-		draw_target = mutable_appearance(file2use, t_state)
+		draw_target = mutable_appearance(file2use, t_state, layer = -layer2use)
 
 	//Get the overlays for this item when it's being worn
 	//eg: ammo counters, primed grenade flashes, etc.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because we didn't pass layer into sub-overlays they ended up layering ontop of other sub-overlays. This didn't break main layering because BYOND's overlay rendering is actually acting like an ordered tree when layered overlays are concerned, and blood decals (other user of separate overlays) also used FLOAT_LAYER (-1).

And hat stabilizers also just assigned an absolute value to theirs, which also made them not work properly.

Closes #90388

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed hat stabilizer overlays rendering behind hats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
