### PR TITLE
Add neutral faction to basic bots

### DIFF
--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -37,7 +37,7 @@ GLOBAL_LIST_INIT(command_strings, list(
 	bubble_icon = "machine"
 
 	speech_span = SPAN_ROBOT
-	faction = list(FACTION_SILICON, FACTION_TURRET)
+	faction = list(FACTION_SILICON, FACTION_NEUTRAL, FACTION_TURRET)
 	light_system = OVERLAY_LIGHT
 	light_range = 3
 	light_power = 0.6


### PR DESCRIPTION
## About The Pull Request

Fixes #89940
This seems like a simple oversight made when making the bot basetype.
Simple Animal bots have this faction but Basic ones don't for some reason, this causes them to be read as hostile by mobs that are supposed to be passive towards station-aligned targets.

## Changelog

:cl:
fix: Random supposedly-friendly mobs will no longer aggro onto and kill medbots and cleanbots
/:cl:
