### PR TITLE
Nugget Boxes can now be placed into paper sacks

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -511,6 +511,7 @@
 	icon_state = "nuggetbox"
 	base_icon_state = "nuggetbox"
 	contents_tag = "nugget"
+	w_class = WEIGHT_CLASS_SMALL
 	spawn_type = /obj/item/food/nugget
 	spawn_count = 6
 


### PR DESCRIPTION

## About The Pull Request
Nugget Boxes can now be placed into paper sacks.
## Why It's Good For The Game
You can now live out your minimum wage dreams as a fast food worker a Chick'fil'a. To quote someone that wanted this "I can now fastfoodmax as a chef".
## Changelog
:cl:
add: Makes Nuggetboxes small items so they can fit inside paper sacks.
/:cl:
