### PR TITLE
Allows chemical presses to customize pill duration, chemmasters can now produce instant pills without the need for water

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -15,6 +15,8 @@
 	var/max_volume = 50
 	/// prefix for the product name
 	var/product_name = "factory"
+	/// Selected duration of produced pills, if they're selected
+	var/pill_duration = 3
 	/// All packaging types wrapped up in 1 big list
 	var/static/list/packaging_types = null
 	///The type of packaging to use
@@ -82,6 +84,9 @@
 				suffix = "Bottle"
 		container.name = "[product_name] [suffix]"
 		reagents.trans_to(container, current_volume)
+		if (istype(container, /obj/item/reagent_containers/applicator/pill))
+			var/obj/item/reagent_containers/applicator/pill/pill = container
+			pill.layers_remaining = pill_duration
 		stored_products += container
 
 	//dispense stored products on the floor
@@ -121,7 +126,9 @@
 	var/list/data = list()
 
 	data["current_volume"] = current_volume
+	data["pill_duration"] = pill_duration
 	data["max_volume"] = max_volume
+	data["max_duration"] = PILL_MAX_LAYERS
 	data["product_name"] = product_name
 	data["packaging_type"] = REF(packaging_type)
 	data["packaging_category"] = packaging_category
@@ -144,6 +151,18 @@
 				return FALSE
 
 			current_volume = clamp(value, MIN_VOLUME, max_volume)
+			return TRUE
+
+		if("change_pill_duraton")
+			var/value = params["duration"]
+			if(isnull(value))
+				return FALSE
+
+			value = text2num(value)
+			if(isnull(value))
+				return FALSE
+
+			pill_duration = clamp(value, 0, PILL_MAX_LAYERS)
 			return TRUE
 
 		if("change_product_name")

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -15,12 +15,12 @@ import {
   Table,
   Tooltip,
 } from 'tgui-core/components';
-import { BooleanLike } from 'tgui-core/react';
+import type { BooleanLike } from 'tgui-core/react';
 import { capitalize } from 'tgui-core/string';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
-import { Beaker, BeakerReagent } from './common/BeakerDisplay';
+import type { Beaker, BeakerReagent } from './common/BeakerDisplay';
 
 type Container = {
   icon: string;
@@ -214,10 +214,10 @@ const ChemMasterContent = (props: {
                 />
                 {selectedContainerCategory === 'pills' && (
                   <NumberInput
-                    unit={'s'}
+                    unit="s"
                     step={1}
                     value={selectedPillDuration}
-                    minValue={1}
+                    minValue={0}
                     maxValue={maxPillDuration}
                     onChange={(value) => {
                       act('setPillDuration', {
@@ -437,7 +437,7 @@ const ContainerButton = (props: CategoryButtonProps) => {
         />
       </Button>
     </Tooltip>
-  ) as any;
+  );
 };
 
 const AnalysisResults = (props: {
@@ -517,5 +517,5 @@ const GroupTitle = ({ title }) => {
         <Divider />
       </Stack.Item>
     </Stack>
-  ) as any;
+  );
 };

--- a/tgui/packages/tgui/interfaces/ChemPress.tsx
+++ b/tgui/packages/tgui/interfaces/ChemPress.tsx
@@ -24,9 +24,11 @@ type Category = {
 
 type Data = {
   current_volume: number;
+  pill_duration: number;
   product_name: string;
   min_volume: number;
   max_volume: number;
+  max_duration: number;
   packaging_category: string;
   packaging_types: Category[];
   packaging_type: string;
@@ -36,9 +38,11 @@ export const ChemPress = (props) => {
   const { act, data } = useBackend<Data>();
   const {
     current_volume,
+    pill_duration,
     product_name,
     min_volume,
     max_volume,
+    max_duration,
     packaging_category,
     packaging_types,
     packaging_type,
@@ -78,6 +82,24 @@ export const ChemPress = (props) => {
                 }
               />
             </LabeledList.Item>
+            {shownCategory.cat_name === 'pills' && (
+              <LabeledList.Item label="Duration">
+                <NumberInput
+                  value={pill_duration}
+                  unit="s"
+                  width="43px"
+                  minValue={0}
+                  maxValue={max_duration}
+                  step={1}
+                  stepPixelSize={2}
+                  onChange={(value) =>
+                    act('change_pill_duraton', {
+                      duration: value,
+                    })
+                  }
+                />
+              </LabeledList.Item>
+            )}
             <LabeledList.Item label="Name">
               <Input
                 value={product_name}
@@ -92,7 +114,7 @@ export const ChemPress = (props) => {
             <LabeledList.Item label="Styles">
               {shownCategory.products.map((design, j) => (
                 <Button
-                  key={j}
+                  key={design.ref}
                   selected={design.ref === packaging_type}
                   color="transparent"
                   onClick={() =>


### PR DESCRIPTION

## About The Pull Request

Chemical presses now have a setting to customize pill duration, at 3s by default (like chemmasters). Both presses and chemmasters now have a setting for 0s pills, previously the cap was 1 as allowing to completely dissolve the coating with water was something I only implemented down the line.
Also slightly cleaned up both chemmaster and chem press files so they pass linters now.

- Closes #90427

## Why It's Good For The Game

Presses not being able to customize pill durations is kinda silly and was an oversight on my part, same with 0s pills - you can achieve the same result, and ideally you should be able to produce those with presses, at which point there's no reason to not add them to chemmasters.

## Changelog
:cl:
add: You can now customize pill duration in chemical presses
balance: ChemMasters and chemical presses can now create 0s duration pills.
/:cl:
