### PR TITLE
Fixes emp flashlight not emping cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -173,6 +173,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/flashlight))
+		if(user.combat_mode)
+			return NONE
 		if(!opened)
 			balloon_alert(user, "open the chassis cover first!")
 			return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION

## About The Pull Request
Title. Now user must be in combat mode to emp a borg
## Why It's Good For The Game
Actually working tool to disable borgs
## Changelog
:cl:

fix: fixed emp flashlight not working on cyborgs

/:cl:
