### PR TITLE
Emp flashlight cost reduction

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -62,7 +62,7 @@
 			Useful for disrupting headsets, cameras, doors, lockers and borgs during stealth operations. \
 			Attacking a target with this flashlight will direct an EM pulse at it and consumes a charge."
 	item = /obj/item/flashlight/emp
-	cost = 4
+	cost = 2
 	surplus = 30
 
 /datum/uplink_item/stealthy_tools/emplight/New()


### PR DESCRIPTION

## About The Pull Request
4 tc -> 2 tc
Since radio jammer now costs 1 tc I don't see a reason why emp flashlight should cost this much.
Also I would like to see it used more.
## Why It's Good For The Game
Present traitors with a dilemma to solve: how to render their target unable to scream for help. Right now the obvious choices are radio jammer (1 tc), emp kit (2 tc) or sleepy pen (4 tc). Lowering costs presents a new option for stealth traitors.
## Changelog
:cl:
balance: emp flashlight costs 4 -> 2 tc
/:cl:
