### PR TITLE
byond-tracy forces a hard reboot

### DIFF
--- a/code/modules/debugging/tracy.dm
+++ b/code/modules/debugging/tracy.dm
@@ -57,6 +57,18 @@ GLOBAL_REAL(Tracy, /datum/tracy)
 	return FALSE
 #endif
 
+/// Flushes the byond-tracy file, if the Paradise version of byond-tracy which outputs a file is used.
+/datum/tracy/proc/flush()
+	// if trace_path is set, that means we're using para-tracy, which should have this.
+	if(!enabled || !trace_path)
+		return
+	SEND_TEXT(world.log, "Flushing byond-tracy log")
+	var/flush_result = call_ext(TRACY_DLL_PATH, "flush")()
+	if(flush_result != "0")
+		SEND_TEXT(world.log, "Error flushing byond-tracy log: [flush_result]")
+		CRASH("Error flushing byond-tracy log: [flush_result]")
+	SEND_TEXT(world.log, "Flushed byond-tracy log")
+
 /datum/tracy/vv_edit_var(var_name, var_value)
 	return FALSE // no.
 

--- a/code/modules/debugging/tracy.dm
+++ b/code/modules/debugging/tracy.dm
@@ -57,18 +57,6 @@ GLOBAL_REAL(Tracy, /datum/tracy)
 	return FALSE
 #endif
 
-/// Flushes the byond-tracy file, if the Paradise version of byond-tracy which outputs a file is used.
-/datum/tracy/proc/flush()
-	// if trace_path is set, that means we're using para-tracy, which should have this.
-	if(!enabled || !trace_path)
-		return
-	SEND_TEXT(world.log, "Flushing byond-tracy log")
-	var/flush_result = call_ext(TRACY_DLL_PATH, "flush")()
-	if(flush_result != "0")
-		SEND_TEXT(world.log, "Error flushing byond-tracy log: [flush_result]")
-		CRASH("Error flushing byond-tracy log: [flush_result]")
-	SEND_TEXT(world.log, "Flushed byond-tracy log")
-
 /datum/tracy/vv_edit_var(var_name, var_value)
 	return FALSE // no.
 


### PR DESCRIPTION

## About The Pull Request

byond-tracy lacks the ability to clean up its hooks, so it will error if it tries to initialize again after a normal reboot.

This forces a hard reboot (regardless of the `rounds_until_hard_restart` config) if byond-tracy is enabled.

I also folded the hard reboot checks into a new proc, `/world/proc/check_hard_reboot()`, for the sake of cleanliness, and added a `flush()` function to `/datum/tracy`, although currently it's not called (it also gets flushed by the `destroy` call) - this is just for the sake of documenting that it exists in case anyone wants to use it in the future, altho if anyone knows good places to call it, let me know.

## Why It's Good For The Game

Less likely to cause problems.

## Changelog

No player-facing changes.
