### PR TITLE
[no GBP] Wheelchair Bomb Fixes

### DIFF
--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -185,7 +185,7 @@
 /obj/vehicle/ridden/wheelchair/motorized/Bump(atom/bumped_atom)
 	. = ..()
 	// Here is the shitty emag functionality.
-	if(obj_flags & EMAGGED && (isclosedturf(bumped_atom) || isliving(bumped_atom)))
+	if((obj_flags & EMAGGED) && (isclosedturf(bumped_atom) || isliving(bumped_atom)))
 		detonate_bomb()
 		return
 	// If the speed is higher than delay_multiplier throw the person on the wheelchair away

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -61,7 +61,7 @@
 /// When you ring your bell and are armed try to explode
 /obj/vehicle/ridden/wheelchair/proc/on_bell_rang()
 	SIGNAL_HANDLER
-	if (!prob(20))
+	if (prob(80))
 		return
 	detonate_bomb()
 
@@ -71,7 +71,7 @@
 	if(!tool.use_tool(src, user, 4 SECONDS, volume=50))
 		return ITEM_INTERACT_SUCCESS
 	to_chat(user, span_notice("You detach the wheels and deconstruct the chair."))
-	deconstruct(TRUE)
+	deconstruct(disassembled = TRUE)
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 
@@ -99,6 +99,8 @@
 		return FALSE
 	if(has_buckled_mobs())
 		return FALSE
+	remove_bell()
+	remove_bomb()
 	user.visible_message(span_notice("[user] collapses [src]."), span_notice("You collapse [src]."))
 	var/obj/vehicle/ridden/wheelchair/wheelchair_folded = new foldabletype(get_turf(src))
 	user.put_in_hands(wheelchair_folded)
@@ -133,6 +135,7 @@
 	visible_message(span_notice("[bell_attached] falls off!"))
 	bell_attached = null
 	update_appearance()
+	return
 
 /obj/vehicle/ridden/wheelchair/proc/remove_bomb()
 	if (!bomb_attached)
@@ -141,6 +144,7 @@
 	visible_message(span_notice("[bomb_attached] falls off!"))
 	bomb_attached = null
 	update_appearance()
+	return
 
 /// A reward item for obtaining 5K hardcore random points. Do not use for anything else
 /obj/vehicle/ridden/wheelchair/gold

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -135,7 +135,6 @@
 	visible_message(span_notice("[bell_attached] falls off!"))
 	bell_attached = null
 	update_appearance()
-	return
 
 /obj/vehicle/ridden/wheelchair/proc/remove_bomb()
 	if (!bomb_attached)
@@ -144,7 +143,6 @@
 	visible_message(span_notice("[bomb_attached] falls off!"))
 	bomb_attached = null
 	update_appearance()
-	return
 
 /// A reward item for obtaining 5K hardcore random points. Do not use for anything else
 /obj/vehicle/ridden/wheelchair/gold


### PR DESCRIPTION
## About The Pull Request

Two nitpicks and one fix from #90176 which were posted post-merge.
Main thing is that the wheelchair will no longer delete bells/TTVs when folded, other things are just code cleanup.

## Changelog

:cl:
fix: Folding a wheelchair will no longer destroy attached bells or bombs.
/:cl:
