### PR TITLE
Relocates a test tube rack in Metastation Perma

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31748,7 +31748,6 @@
 "liL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/item/storage/test_tube_rack/full,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "liO" = (
@@ -60332,6 +60331,7 @@
 /area/station/medical/pharmacy)
 "vjZ" = (
 /obj/structure/table,
+/obj/item/storage/test_tube_rack/full,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "vkb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31748,6 +31748,7 @@
 "liL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/item/storage/test_tube_rack/full,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "liO" = (
@@ -46979,10 +46980,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"qHW" = (
-/obj/item/storage/test_tube_rack/full,
-/turf/closed/wall/r_wall,
-/area/station/security/prison/safe)
 "qHY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -91767,7 +91764,7 @@ hDE
 wZz
 wZz
 wZz
-qHW
+sjP
 iPb
 iPb
 uza


### PR DESCRIPTION

## About The Pull Request

So, there's this test tube. It's stuck in a wall within Metastation perma.

![image](https://github.com/user-attachments/assets/85a9fbb5-2c00-4f0a-b50b-6a52bdf589d3)

It sure doesn't look like it should be there.

Now, I'm not gonna say this test tube was an unintended addition to perma and remove it. *Clearly* it was *intended* to be in perma, but was simply *misplaced* in that wall. It has been moved to a more *sensible* location in the rec area.

![image](https://github.com/user-attachments/assets/17c6cf55-c6b6-4faf-a19a-e8f9021e5b9d)
## Why It's Good For The Game

Moves a thing out of a wall where it shouldn't be.

By moving it, rather than *re*moving it, it codifies the addition of a little something extra to the permabrig mini-sandbox.

C'mon what's the worst that could happen if the prisoners get a measly set of test tubes. It can't be that bad, right?
## Changelog
:cl: Rhials
fix: A test tube rack, which was (definitely) intentionally placed in Metastation Perma, has been moved out of a wall and onto a table.
/:cl:
