### PR TITLE
Implements cross-server newscaster channels

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -302,6 +302,17 @@
 	var/msg = input["msg"]
 	var/author = input["author"]
 	var/author_key = input["author_ckey"]
-	var/channel = input["message"]
-	message_admins(span_adminnotice("Incoming cross-sector newscaster article by [author_key] in channel [channel]."))
-	GLOB.news_network.submit_article(msg, author, channel)
+	var/channel_name = input["message"]
+
+	var/found_channel = FALSE
+	for(var/datum/feed_channel/channel in network_channels)
+		if(channel.channel_name == channel_name)
+			found_channel = TRUE
+			break
+
+	// No channel with a matching name, abort
+	if (!found_channel)
+		return
+
+	message_admins(span_adminnotice("Incoming cross-sector newscaster article by [author_key] in channel [channel_name]."))
+	GLOB.news_network.submit_article(msg, author, channel_name)

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -305,7 +305,7 @@
 	var/channel_name = input["message"]
 
 	var/found_channel = FALSE
-	for(var/datum/feed_channel/channel in network_channels)
+	for(var/datum/feed_channel/channel in GLOB.news_network.network_channels)
 		if(channel.channel_name == channel_name)
 			found_channel = TRUE
 			break

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -250,7 +250,7 @@
 
 /datum/world_topic/create_news_channel
 	keyword = "create_news_channel"
-	/// List of timers for actually creating the channel to give admins some time
+	/// Lazylist of timers for actually creating the channel to give admins some time
 	var/list/timers
 
 /datum/world_topic/create_news_channel/Run(list/input)
@@ -305,7 +305,7 @@
 	var/channel_name = input["message"]
 
 	var/found_channel = FALSE
-	for(var/datum/feed_channel/channel in GLOB.news_network.network_channels)
+	for(var/datum/feed_channel/channel as anything in GLOB.news_network.network_channels)
 		if(channel.channel_name == channel_name)
 			found_channel = TRUE
 			break

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -259,12 +259,11 @@
 	input["timer_id"] = timer_id
 	LAZYADD(timers, timer_id)
 
-	var/message = "<b color='orange'>Cross-sector channel creation (Incoming):</b> [input["author_ckey"]] is about to create a cross-sector\
+	var/message = "<b color='orange'>Cross-sector channel creation (Incoming):</b> [input["author_ckey"]] is about to create a cross-sector \
 			newscaster channel \"[input["message"]]\" (will autoapprove in [DisplayTimeText(message_delay)]): \
 			<b><a href='byond://?src=[REF(src)];reject_channel_creation=[timer_id]'>REJECT</a></b>"
 
 	message_admins(span_adminnotice(message))
-
 
 /datum/world_topic/create_news_channel/Topic(href, list/href_list)
 	. = ..()
@@ -294,4 +293,15 @@
 /datum/world_topic/create_news_channel/proc/create_channel(list/input)
 	LAZYREMOVE(timers, input["timer_id"])
 	message_admins("[input["author_ckey"]] has crated a cross-sector newscaster channel titled \"[input["message"]]\"")
-	GLOB.news_network.create_feed_channel(input["message"], input["author"], input["desc"], locked = TRUE, receiving_cross_sector = TRUE)
+	GLOB.news_network.create_feed_channel("[input["message"]]-cross", input["author"], input["desc"], locked = TRUE, receiving_cross_sector = TRUE)
+
+/datum/world_topic/create_news_article
+	keyword = "create_news_article"
+
+/datum/world_topic/create_news_article/Run(list/input)
+	var/msg = input["msg"]
+	var/author = input["author"]
+	var/author_key = input["author_ckey"]
+	var/channel = input["message"]
+	message_admins(span_adminnotice("Incoming cross-sector newscaster article by [author_key] in channel [channel]."))
+	GLOB.news_network.submit_article(msg, author, channel)

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -293,7 +293,7 @@
 /datum/world_topic/create_news_channel/proc/create_channel(list/input)
 	LAZYREMOVE(timers, input["timer_id"])
 	message_admins("[input["author_ckey"]] has crated a cross-sector newscaster channel titled \"[input["message"]]\"")
-	GLOB.news_network.create_feed_channel("[input["message"]]-cross", input["author"], input["desc"], locked = TRUE, receiving_cross_sector = TRUE)
+	GLOB.news_network.create_feed_channel(input["message"], input["author"], input["desc"], locked = TRUE, receiving_cross_sector = TRUE)
 
 /datum/world_topic/create_news_article
 	keyword = "create_news_article"

--- a/code/game/machinery/newscaster/newscaster_data.dm
+++ b/code/game/machinery/newscaster/newscaster_data.dm
@@ -101,6 +101,10 @@ GLOBAL_LIST_EMPTY(request_list)
 	var/is_admin_channel = FALSE
 	/// Channel ID is a random number sequence similar to account ID number that allows for us to link messages to the proper channels through the UI backend.
 	var/channel_ID
+	/// Should this channel send cross-server messages?
+	var/cross_sector = FALSE
+	/// Is this a cross-sector channel? If so, this channel can only receive messages via topics
+	var/receiving_cross_sector = FALSE
 
 /datum/feed_channel/New()
 	. = ..()
@@ -184,16 +188,27 @@ GLOBAL_LIST_EMPTY(request_list)
 	create_feed_channel("Station Announcements", "SS13", "Company news, staff announcements, and all the latest information. Have a secure shift!", locked = TRUE, hardset_channel = 1000)
 	wanted_issue = new /datum/wanted_message
 
-/datum/feed_network/proc/create_feed_channel(channel_name, author, desc, locked, adminChannel = FALSE, hardset_channel)
+/datum/feed_network/proc/create_feed_channel(channel_name, author, desc, locked, adminChannel = FALSE, hardset_channel = null, author_ckey = null, cross_sector = FALSE, cross_sector_delay = null, receiving_cross_sector = FALSE)
 	var/datum/feed_channel/newChannel = new /datum/feed_channel
 	newChannel.channel_name = channel_name
 	newChannel.author = author
 	newChannel.channel_desc = desc
 	newChannel.locked = locked
 	newChannel.is_admin_channel = adminChannel
+	newChannel.receiving_cross_sector = receiving_cross_sector
 	if(hardset_channel)
 		newChannel.channel_ID = hardset_channel
 	network_channels += newChannel
+	if(!cross_sector)
+		return
+	newChannel.cross_sector = TRUE
+	var/list/payload = list(
+		"author" = author,
+		"author_ckey" = author_ckey,
+		"desc" = desc,
+		"delay" = cross_sector_delay,
+	)
+	send2otherserver(html_decode(station_name()), channel_name, "create_news_channel", additional_data = payload)
 
 /datum/feed_network/proc/submit_article(msg, author, channel_name, datum/picture/picture, adminMessage = FALSE, allow_comments = TRUE, update_alert = TRUE)
 	var/datum/feed_message/newMsg = new /datum/feed_message

--- a/code/game/machinery/newscaster/newscaster_data.dm
+++ b/code/game/machinery/newscaster/newscaster_data.dm
@@ -210,28 +210,44 @@ GLOBAL_LIST_EMPTY(request_list)
 	)
 	send2otherserver(html_decode(station_name()), channel_name, "create_news_channel", additional_data = payload)
 
-/datum/feed_network/proc/submit_article(msg, author, channel_name, datum/picture/picture, adminMessage = FALSE, allow_comments = TRUE, update_alert = TRUE)
+/datum/feed_network/proc/submit_article(msg, author, channel_name, datum/picture/picture, adminMessage = FALSE, allow_comments = TRUE, update_alert = TRUE, mob/author_mob = null)
 	var/datum/feed_message/newMsg = new /datum/feed_message
 	newMsg.author = author
 	newMsg.body = msg
 	newMsg.time_stamp = "[station_time_timestamp()]"
 	newMsg.is_admin_message = adminMessage
 	newMsg.locked = !allow_comments
+
+	message_count++
+	last_action++
+	newMsg.creation_time = last_action
+	newMsg.message_ID = message_count
+
 	if(picture)
 		newMsg.img = picture.picture_image
 		newMsg.caption = picture.caption
 		newMsg.photo_file = save_photo(picture.picture_image)
-	for(var/datum/feed_channel/FC in network_channels)
-		if(FC.channel_name == channel_name)
-			FC.messages += newMsg
-			newMsg.parent_ID = FC.channel_ID
+
+	for(var/datum/feed_channel/channel in network_channels)
+		if(channel.channel_name != channel_name)
+			continue
+		channel.messages += newMsg
+		newMsg.parent_ID = channel.channel_ID
+		if (!channel.cross_sector)
 			break
-	for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
-		NEWSCASTER.news_alert(channel_name, update_alert)
-	last_action ++
-	newMsg.creation_time = last_action
-	message_count ++
-	newMsg.message_ID = message_count
+
+		// Newscaster articles could be huge, and usefulness of first 50 symbols is dubious
+		message_admins(span_adminnotice("Outgoing cross-sector newscaster article by [key_name(author_mob) || author] in channel [channel_name]."))
+		var/list/payload = list(
+			"author" = author,
+			"author_ckey" = author_mob?.ckey,
+			"msg" = msg,
+		)
+		send2otherserver(html_decode(station_name()), channel_name, "create_news_article", additional_data = payload)
+		break
+
+	for(var/obj/machinery/newscaster/caster in GLOB.allCasters)
+		caster.news_alert(channel_name, update_alert)
 
 /datum/feed_network/proc/submit_wanted(criminal, body, scanned_user, datum/picture/picture, adminMsg = FALSE, newMessage = FALSE)
 	wanted_issue.active = TRUE

--- a/code/game/machinery/newscaster/newscaster_data.dm
+++ b/code/game/machinery/newscaster/newscaster_data.dm
@@ -231,6 +231,7 @@ GLOBAL_LIST_EMPTY(request_list)
 	for(var/datum/feed_channel/channel in network_channels)
 		if(channel.channel_name != channel_name)
 			continue
+
 		channel.messages += newMsg
 		newMsg.parent_ID = channel.channel_ID
 		if (!channel.cross_sector)

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -40,6 +40,8 @@
 	var/creating_channel = FALSE
 	///Is the current user creating a new comment at the moment?
 	var/creating_comment = FALSE
+	///Are we currently locked and awaiting approval for the new cross-sector channel?
+	var/awaiting_approval = FALSE
 	///What is the user submitted, criminal name for the new wanted issue?
 	var/criminal_name
 	///What is the user submitted, crime description for the new wanted issue?
@@ -50,6 +52,8 @@
 	var/channel_desc
 	///What is the current, in-creation comment's body going to be?
 	var/comment_text
+	///Timer ID for creation of cross-sector channels
+	var/channel_approval_timer
 
 	///The station request datum being affected by UI actions.
 	var/datum/station_request/active_request
@@ -167,6 +171,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	data["security_mode"] = (security_access in card?.GetAccess())
 	data["photo_data"] = !isnull(current_image)
 	data["creating_channel"] = creating_channel
+	data["awaiting_approval"] = awaiting_approval
 	data["creating_comment"] = creating_comment
 	data["viewing_wanted"] = viewing_wanted
 
@@ -225,10 +230,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 		data["channelAuthor"] = "Nanotrasen Inc"
 		data["channelDesc"] = "Welcome to Newscaster Net. Interface & News networks Operational."
 		data["channelLocked"] = TRUE
+		data["receivingCrossSector"] = FALSE
 	else
 		data["channelDesc"] = current_channel.channel_desc
 		data["channelLocked"] = current_channel.locked
 		data["channelCensored"] = current_channel.censored
+		data["receivingCrossSector"] = current_channel.receiving_cross_sector
 
 	//We send all the information about all messages in existence.
 	data["messages"] = message_list
@@ -268,6 +275,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	. = ..()
 	if(.)
 		return
+
+	var/mob/user = ui.user
 	var/current_ref_num = params["request"]
 	var/current_app_num = params["applicant"]
 	var/datum/bank_account/request_target
@@ -293,17 +302,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 		if("createStory")
 			if(!current_channel)
-				balloon_alert(usr, "select a channel first!")
+				balloon_alert(user, "select a channel first!")
 				return TRUE
 			var/prototype_channel = params["current"]
-			create_story(channel_name = prototype_channel)
+			create_story(user, channel_name = prototype_channel)
 
 		if("togglePhoto")
-			toggle_photo()
+			toggle_photo(user)
 			return TRUE
 
 		if("startCreateChannel")
-			start_create_channel()
+			start_create_channel(user)
 			return TRUE
 
 		if("setChannelName")
@@ -320,12 +329,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 		if("createChannel")
 			var/locked = params["lockedmode"]
-			create_channel(locked)
+			var/cross_sector = params["cross_sector"]
+			create_channel(user, locked, cross_sector)
 			return TRUE
 
 		if("cancelCreation")
 			creating_channel = FALSE
 			creating_comment = FALSE
+			awaiting_approval = FALSE
 			viewing_wanted = FALSE
 			criminal_name = null
 			crime_description = null
@@ -333,8 +344,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 		if("storyCensor")
 			var/obj/item/card/id/id_card
-			if(isliving(usr))
-				var/mob/living/living_user = usr
+			if(isliving(user))
+				var/mob/living/living_user = user
 				id_card = living_user.get_idcard(hand_first = TRUE)
 			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
@@ -347,8 +358,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 		if("authorCensor")
 			var/obj/item/card/id/id_card
-			if(isliving(usr))
-				var/mob/living/living_user = usr
+			if(isliving(user))
+				var/mob/living/living_user = user
 				id_card = living_user.get_idcard(hand_first = TRUE)
 			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
@@ -361,8 +372,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 		if("channelDNotice")
 			var/obj/item/card/id/id_card
-			if(isliving(usr))
-				var/mob/living/living_user = usr
+			if(isliving(user))
+				var/mob/living/living_user = user
 				id_card = living_user.get_idcard(hand_first = TRUE)
 			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
@@ -395,7 +406,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			return TRUE
 
 		if("createComment")
-			create_comment()
+			create_comment(user)
 			return TRUE
 
 		if("toggleWanted")
@@ -405,14 +416,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			return TRUE
 
 		if("setCriminalName")
-			var/temp_name = tgui_input_text(usr, "Write the Criminal's Name", "Warrent Alert Handler", "John Doe", max_length = MAX_NAME_LEN, multiline = FALSE)
+			var/temp_name = tgui_input_text(user, "Write the Criminal's Name", "Warrent Alert Handler", "John Doe", max_length = MAX_NAME_LEN, multiline = FALSE)
 			if(!temp_name)
 				return TRUE
 			criminal_name = temp_name
 			return TRUE
 
 		if("setCrimeData")
-			var/temp_desc = tgui_input_text(usr, "Write the Criminal's Crimes", "Warrent Alert Handler", "Unknown", max_length = MAX_BROADCAST_LEN, multiline = TRUE)
+			var/temp_desc = tgui_input_text(user, "Write the Criminal's Crimes", "Warrent Alert Handler", "Unknown", max_length = MAX_BROADCAST_LEN, multiline = TRUE)
 			if(!temp_desc)
 				return TRUE
 			crime_description = temp_desc
@@ -426,13 +437,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			return TRUE
 
 		if("clearWantedIssue")
-			clear_wanted_issue(user = usr)
+			clear_wanted_issue(user)
 			for(var/obj/machinery/newscaster/other_newscaster in GLOB.allCasters)
 				other_newscaster.update_appearance()
 				return TRUE
 
 		if("printNewspaper")
-			print_paper(usr)
+			print_paper(user)
 			return TRUE
 
 		if("createBounty")
@@ -589,7 +600,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 		else
 			to_chat(user, span_warning("You cannot interface with silicon photo uploading!"))
 		if(!targetcam.stored.len)
-			to_chat(usr, span_bolddanger("No images saved."))
+			to_chat(user, span_bolddanger("No images saved."))
 			return
 		var/datum/picture/selection = targetcam.selectpicture(user)
 		if(selection)
@@ -635,29 +646,95 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 /**
  * Performs a series of sanity checks before giving the user confirmation to create a new feed_channel using channel_name, and channel_desc.
  * *channel_locked: This variable determines if other users than the author can make comments and new feed_stories on this channel.
+ *
  */
-/obj/machinery/newscaster/proc/create_channel(channel_locked)
+/obj/machinery/newscaster/proc/create_channel(mob/user, channel_locked, cross_sector)
 	if(!channel_name)
 		return
-	for(var/datum/feed_channel/iterated_feed_channel as anything in GLOB.news_network.network_channels)
-		if(iterated_feed_channel.channel_name == channel_name)
-			tgui_alert(usr, "ERROR: Feed channel with that name already exists on the Network.", list("Okay"))
-			return TRUE
+	if(cross_sector)
+		channel_locked = TRUE
+
 	if(!channel_desc)
 		return TRUE
+
 	if(isnull(channel_locked))
 		return TRUE
-	var/choice = tgui_alert(usr, "Please confirm feed channel creation","Network Channel Handler", list("Confirm","Cancel"))
-	if(choice == "Confirm")
-		GLOB.news_network.create_feed_channel(channel_name, newscaster_username, channel_desc, locked = channel_locked)
-		SSblackbox.record_feedback("text", "newscaster_channels", 1, "[channel_name]")
+
+	for(var/datum/feed_channel/iterated_feed_channel as anything in GLOB.news_network.network_channels)
+		if(iterated_feed_channel.channel_name == channel_name)
+			tgui_alert(user, "ERROR: Feed channel with that name already exists on the Network.", list("Okay"))
+			return TRUE
+
+	var/list/hard_filter_result = is_ic_filtered(channel_name)
+	if(hard_filter_result)
+		tgui_alert(user, "Your channel name contains: (\"[hard_filter_result[CHAT_FILTER_INDEX_WORD]]\"), which is not allowed on this server.")
+		return TRUE
+
+	var/choice = tgui_alert(user, "Please confirm feed channel creation","Network Channel Handler", list("Confirm", "Cancel"))
 	creating_channel = FALSE
-	update_static_data(usr)
+	if(choice != "Confirm")
+		update_static_data(user)
+		return
+
+	var/approval_time = CROSS_SECTOR_CANCEL_TIME
+	var/list/soft_filter_result = is_soft_ooc_filtered(channel_name)
+	if(soft_filter_result)
+		if(tgui_alert(user,"Your channel name contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to use it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
+			return
+		message_admins("[ADMIN_LOOKUPFLW(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \
+			They may be using a disallowed term for a cross-station newscaster channel. Increasing delay time to reject.\n\n Channel name: \"[channel_name]\"")
+		log_admin_private("[key_name(user)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \
+			They may be using a disallowed term for a cross-station newscaster channel. Increasing delay time to reject.\n\n Channel name: \"[channel_name]\"")
+		approval_time = EXTENDED_CROSS_SECTOR_CANCEL_TIME
+
+	if(!cross_sector)
+		finish_channel_creation(user, channel_locked, FALSE)
+		return
+
+	awaiting_approval = TRUE
+	update_static_data(user)
+	user.log_message("is about to create a cross-sector newscaster channel with the following name: [channel_name]", LOG_GAME)
+	to_chat(
+		GLOB.admins,
+		span_adminnotice( \
+			"<b color='orange'>Cross-sector channel creation (OUTGOING):</b> [ADMIN_LOOKUPFLW(user)] is about to create a cross-sector\
+			newscaster channel \"[channel_name]\" (will autoapprove in [DisplayTimeText(approval_time)]): \
+			<b><a href='byond://?src=[REF(src)];reject_channel_creation=1'>REJECT</a></b>"\
+		)
+	)
+	channel_approval_timer = addtimer(CALLBACK(src, PROC_REF(finish_channel_creation), user, channel_locked, TRUE, approval_time), approval_time, TIMER_STOPPABLE)
+
+/obj/machinery/newscaster/proc/finish_channel_creation(mob/user, channel_locked, cross_sector, cross_sector_delay)
+	channel_approval_timer = null
+	awaiting_approval = FALSE
+	GLOB.news_network.create_feed_channel(channel_name, newscaster_username, channel_desc, locked = channel_locked, author_ckey = user.ckey, cross_sector = cross_sector, cross_sector_delay = cross_sector_delay)
+	SSblackbox.record_feedback("text", "newscaster_channels", 1, "[channel_name]")
+	update_static_data(user)
+
+/obj/machinery/newscaster/Topic(href, href_list)
+	if (!href_list["reject_channel_creation"])
+		return ..()
+
+	if (!usr.client?.holder)
+		usr.log_message("tried to reject the creation of a cross-sector newscaster channel without being an admin.", LOG_ADMIN)
+		message_admins("[key_name(usr)] tried to reject the creation of a cross-sector newscaster channel without being an admin.")
+		return
+
+	if (isnull(channel_approval_timer))
+		to_chat(usr, span_warning("It's too late!"))
+		return
+
+	deltimer(channel_approval_timer)
+	channel_approval_timer = null
+
+	log_admin("[key_name(usr)] has cancelled the creation of a cross-sector newscaster channel.")
+	message_admins("[key_name(usr)] has cancelled the creation of a cross-sector newscaster channel.")
+	return TRUE
 
 /**
  * Constructs a comment to attach to the currently selected feed_message of choice, assuming that a user can be found and that a message body has been written.
  */
-/obj/machinery/newscaster/proc/create_comment()
+/obj/machinery/newscaster/proc/create_comment(mob/user)
 	if(!comment_text)
 		creating_comment = FALSE
 		return TRUE
@@ -670,7 +747,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	new_feed_comment.time_stamp = station_time_timestamp()
 	GLOB.news_network.last_action ++
 	current_message.comments += new_feed_comment
-	usr.log_message("(as [newscaster_username]) commented on message [current_message.return_body(-1)] -- [current_message.body]", LOG_COMMENT)
+	user.log_message("(as [newscaster_username]) commented on message [current_message.return_body(-1)] -- [current_message.body]", LOG_COMMENT)
 	creating_comment = FALSE
 
 /**
@@ -678,7 +755,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  * preventing an un-ID'd user from making a channel, and preventing censored authors from making a channel.
  * Otherwise, sets creating_channel to TRUE.
  */
-/obj/machinery/newscaster/proc/start_create_channel()
+/obj/machinery/newscaster/proc/start_create_channel(mob/user)
 	//This first block checks for pre-existing reasons to prevent you from making a new channel, like being censored, or if you have a channel already.
 	var/list/existing_authors = list()
 	for(var/datum/feed_channel/iterated_feed_channel as anything in GLOB.news_network.network_channels)
@@ -688,7 +765,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			existing_authors += iterated_feed_channel.author
 	if(!newscaster_username || (newscaster_username in existing_authors))
 		creating_channel = FALSE
-		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel.", list("Okay"))
+		tgui_alert(user, "ERROR: User cannot be found or already has an owned feed channel.", list("Okay"))
 		return TRUE
 	creating_channel = TRUE
 	return TRUE
@@ -698,19 +775,23 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  * Verifies that the message is being written to a real feed_channel, then provides a text input for the feed story to be written into.
  * Finally, it submits the message to the network, is logged globally, and clears all message-specific variables from the machine.
  */
-/obj/machinery/newscaster/proc/create_story(channel_name)
-	var/temp_message = tgui_input_text(usr, "Write your Feed story", "Network Channel Handler", feed_channel_message, max_length = MAX_BROADCAST_LEN, multiline = TRUE)
-	if(length(temp_message) <= 1)
-		return TRUE
-	if(temp_message)
-		feed_channel_message = temp_message
-
+/obj/machinery/newscaster/proc/create_story(mob/user, channel_name)
 	for(var/datum/feed_channel/potential_channel as anything in GLOB.news_network.network_channels)
 		if(channel_name == potential_channel.channel_ID)
 			current_channel = potential_channel
 			break
 
-	GLOB.news_network.submit_article("<font face=\"[PEN_FONT]\">[parsemarkdown(feed_channel_message, usr)]</font>", newscaster_username, current_channel.channel_name, send_photo_data(), adminMessage = FALSE, allow_comments = TRUE)
+	if (current_channel.receiving_cross_sector)
+		return
+
+	var/temp_message = tgui_input_text(user, "Write your Feed story", "Network Channel Handler", feed_channel_message, max_length = MAX_BROADCAST_LEN, multiline = TRUE)
+	if(length(temp_message) <= 1)
+		return TRUE
+
+	if(temp_message)
+		feed_channel_message = temp_message
+
+	GLOB.news_network.submit_article("<font face=\"[PEN_FONT]\">[parsemarkdown(feed_channel_message, user)]</font>", newscaster_username, current_channel.channel_name, send_photo_data(), adminMessage = FALSE, allow_comments = TRUE)
 	SSblackbox.record_feedback("amount", "newscaster_stories", 1)
 	feed_channel_message = ""
 	current_image = null
@@ -719,22 +800,22 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  * Selects a currently held photo from the user's hand and makes it the current_image held by the newscaster.
  * If a photo is still held in the newscaster, it will otherwise clear it from the machine.
  */
-/obj/machinery/newscaster/proc/toggle_photo()
+/obj/machinery/newscaster/proc/toggle_photo(mob/user)
 	if(current_image)
-		balloon_alert(usr, "current photo cleared.")
+		balloon_alert(user, "current photo cleared.")
 		current_image = null
 		return TRUE
+
+	attach_photo(user)
+	if(current_image)
+		balloon_alert(user, "photo selected.")
 	else
-		attach_photo(usr)
-		if(current_image)
-			balloon_alert(usr, "photo selected.")
-		else
-			balloon_alert(usr, "no photo identified.")
+		balloon_alert(user, "no photo identified.")
 
 /obj/machinery/newscaster/proc/clear_wanted_issue(user)
 	var/obj/item/card/id/id_card
-	if(isliving(usr))
-		var/mob/living/living_user = usr
+	if(isliving(user))
+		var/mob/living/living_user = user
 		id_card = living_user.get_idcard(hand_first = TRUE)
 	if(!(security_access in id_card?.GetAccess()))
 		say("Clearance not found.")

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -697,7 +697,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	to_chat(
 		GLOB.admins,
 		span_adminnotice( \
-			"<b color='orange'>Cross-sector channel creation (OUTGOING):</b> [ADMIN_LOOKUPFLW(user)] is about to create a cross-sector\
+			"<b color='orange'>Cross-sector channel creation (OUTGOING):</b> [ADMIN_LOOKUPFLW(user)] is about to create a cross-sector \
 			newscaster channel \"[channel_name]\" (will autoapprove in [DisplayTimeText(approval_time)]): \
 			<b><a href='byond://?src=[REF(src)];reject_channel_creation=1'>REJECT</a></b>"\
 		)
@@ -791,7 +791,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	if(temp_message)
 		feed_channel_message = temp_message
 
-	GLOB.news_network.submit_article("<font face=\"[PEN_FONT]\">[parsemarkdown(feed_channel_message, user)]</font>", newscaster_username, current_channel.channel_name, send_photo_data(), adminMessage = FALSE, allow_comments = TRUE)
+	GLOB.news_network.submit_article("<font face=\"[PEN_FONT]\">[parsemarkdown(feed_channel_message, user)]</font>", newscaster_username, current_channel.channel_name, send_photo_data(), adminMessage = FALSE, allow_comments = TRUE, author_mob = user)
 	SSblackbox.record_feedback("amount", "newscaster_stories", 1)
 	feed_channel_message = ""
 	current_image = null

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -812,7 +812,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	else
 		balloon_alert(user, "no photo identified.")
 
-/obj/machinery/newscaster/proc/clear_wanted_issue(user)
+/obj/machinery/newscaster/proc/clear_wanted_issue(mob/user)
 	var/obj/item/card/id/id_card
 	if(isliving(user))
 		var/mob/living/living_user = user

--- a/tgui/packages/tgui/interfaces/Newscaster.jsx
+++ b/tgui/packages/tgui/interfaces/Newscaster.jsx
@@ -403,6 +403,7 @@ const NewscasterChannelBox = (props) => {
     channelLocked,
     channelAuthor,
     channelCensored,
+    receivingCrossSector,
     viewing_channel,
     admin_mode,
     photo_data,
@@ -446,7 +447,8 @@ const NewscasterChannelBox = (props) => {
               selected={photo_data}
               disabled={
                 (channelLocked && channelAuthor !== user.name) ||
-                channelCensored
+                channelCensored ||
+                receivingCrossSector
               }
               onClick={() => act('togglePhoto')}
             >

--- a/tgui/packages/tgui/interfaces/common/LoadingScreen.tsx
+++ b/tgui/packages/tgui/interfaces/common/LoadingScreen.tsx
@@ -18,13 +18,18 @@ import { Icon, Stack } from 'tgui-core/components';
  * )
  * ```
  */
-export function LoadingScreen(props) {
+
+type LoadingScreenProps = {
+  label?: string;
+};
+
+export function LoadingScreen(props: LoadingScreenProps) {
   return (
     <Stack align="center" fill justify="center" vertical>
       <Stack.Item>
         <Icon color="blue" name="toolbox" spin size={4} />
       </Stack.Item>
-      <Stack.Item>Please wait...</Stack.Item>
+      <Stack.Item>{props.label || 'Please wait...'}</Stack.Item>
     </Stack>
   );
 }


### PR DESCRIPTION

## About The Pull Request

Implements cross-server newscaster channel support, allowing players to send their articles to other sectors. When creating a channel, you can mark it as "cross-sector", which will forcefully set it to private and give admins 10 (30 if it triggered the soft filter) seconds to deny its creation (similarly to how cross-sector comms messages are done). After the delay, the channel will be created, and admins on other servers will have the same delay to deny it on their side. All articles posted in the channel (excluding photos) will be mirrored to other servers and posted in their respective channels. "Receiver" channels cannot be posted in, and operate in read-only mode.

This is a commission by @RaveRadbury

## Why It's Good For The Game

Allowing players to post their news stories to other sectors is a good way to make the world feel slightly more alive and gives curators, assistants and HoP more things to do. Only major concern is moderation of these channels, is this gets abused far too often for admins' comfort, be it metacomms, spam or rulebreaking messages, it could be locked behind curator/HoP access to reduce ease of access for griefers.

## Changelog
:cl:
add: You can now mark newscaster channels as cross-sector to send messages to other servers.
/:cl:
