### PR TITLE
the admin audio player is a little more resilient against crashes

### DIFF
--- a/tgui/packages/tgui-panel/audio/player.ts
+++ b/tgui/packages/tgui-panel/audio/player.ts
@@ -67,7 +67,7 @@ export class AudioPlayer {
       });
     }
 
-    audio.play();
+    audio.play()?.catch((error) => logger.log('playback error', error));
 
     this.onPlaySubscribers.forEach((subscriber) => subscriber());
   }


### PR DESCRIPTION

## About The Pull Request

if we try to play something and end up not being able to play it for whatever reason, we should not crash the whole chat

## Why It's Good For The Game

less chat crash = more good

## Changelog

:cl:
fix: admins trying to play certain songs would crash the chat, it no longer does
/:cl:

