### PR TITLE
Fixes AI detector runtiming when it finds machine-users

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -205,7 +205,7 @@
 	var/turf/our_turf = get_turf(src)
 	detect_state = PROXIMITY_NONE
 
-	for(var/mob/eye/camera/ai/AI_eye as anything in GLOB.camera_eyes)
+	for(var/mob/eye/camera/ai/AI_eye in GLOB.camera_eyes)
 		if(!AI_eye.ai_detector_visible)
 			continue
 


### PR DESCRIPTION
## About The Pull Request

Fixes this runtime 

![image](https://github.com/user-attachments/assets/eef1887e-52ae-4db6-8742-ccb66a791482)

That list can contain non-AI cameras which I don't think was the intention at all. So we add typechecking to ensure we aren't trying to check a var that doesn't exist.

## Why It's Good For The Game

More reliable AI detection tools hopefully

## Changelog

:cl:
fix: fixes the AI detector breaking if there is a machinery-camera operating user nearby (like xenobio console or camera console for instance)
/:cl:
