### PR TITLE
Adds holodisk to the photography camera's description

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -58,6 +58,11 @@
 	. += span_notice("It has [pictures_left] photos left.")
 	. += span_notice("Alt-click to change its focusing, allowing you to set how big of an area it will capture.")
 
+	if(!disk)
+		. += span_notice("It has a slot for a holographic disk.")
+	else
+		. += span_notice("It has \an [disk.name] inserted.")
+
 /obj/item/camera/proc/adjust_zoom(mob/user)
 	if(loc != user)
 		to_chat(user, span_warning("You must be holding the camera to continue!"))


### PR DESCRIPTION


## About The Pull Request

A few weeks ago, someone asked me which vendors have holodisks in them. I didn't remember it, so I have searched for it in the code. To my surprise, I have learned you can put holodisks in cameras, which allows you to record a holographic image of them.

As nothing indicated in game that this is possible, I have decided to extend the camera's description. If it has no disk in it, it mentions that it has an empty holodisk slot, otherwise, it will print out that it is holding a [name of the disk].

## Why It's Good For The Game

Mechanics shouldn't be only learnable via code diving, especially if it is a harmless fun feature.

## Changelog

:cl:
qol: Extends the examine description of cameras with the fact that they can hold holodisks.
/:cl:

