### PR TITLE
Adds sidewalks to Wawa Supermatter

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -14604,6 +14604,11 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/uppersouth)
+"fgd" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "fgi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24785,6 +24790,11 @@
 "iFN" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
+"iFQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/open/openspace,
+/area/station/engineering/main)
 "iFU" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
@@ -25865,6 +25875,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"jcB" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "jcG" = (
 /obj/machinery/light/warm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -28769,6 +28786,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/breakroom)
+"kaX" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "kbg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -30773,6 +30797,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"kGt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "kGu" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/command/corporate_showroom)
@@ -31513,6 +31544,13 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
+"kTT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "kTV" = (
 /obj/item/circuitboard/machine/engine/propulsion,
 /turf/open/misc/asteroid,
@@ -49259,6 +49297,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"riF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "riJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -61773,6 +61818,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
+"vtC" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner,
+/turf/open/openspace,
+/area/station/engineering/main)
 "vtN" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
@@ -64653,6 +64703,13 @@
 /obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
+"wvr" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "wvs" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/landmark/start/prisoner,
@@ -65329,6 +65386,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
+"wFx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/engineering/main)
 "wFy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -175490,7 +175554,7 @@ wtH
 iNj
 mog
 aWD
-sCp
+iFQ
 sCp
 sCp
 aWD
@@ -175747,7 +175811,7 @@ wtH
 wtH
 aWD
 aWD
-sCp
+iFQ
 mog
 mog
 aWD
@@ -176002,9 +176066,9 @@ jjI
 mee
 uqM
 wje
-sCp
-sCp
-sCp
+vtC
+jcB
+kaX
 mog
 mog
 aWD
@@ -176251,7 +176315,7 @@ aWD
 aWD
 aWD
 aWD
-aWD
+vzC
 wtH
 uca
 eVA
@@ -176259,7 +176323,7 @@ mYb
 oZC
 aKj
 wje
-sCp
+iFQ
 mog
 mog
 mog
@@ -176504,11 +176568,11 @@ lfR
 mzb
 aWF
 ewM
-mog
-sCp
-sCp
 sCp
 mog
+mog
+mog
+kGt
 wje
 cSC
 jPb
@@ -176516,7 +176580,7 @@ iBH
 eVA
 qqh
 wje
-sCp
+iFQ
 mog
 mog
 mog
@@ -176762,10 +176826,10 @@ bZJ
 pFZ
 ewM
 sCp
-sCp
 mog
-sCp
-sCp
+mog
+mog
+kGt
 wje
 vno
 lAE
@@ -176773,7 +176837,7 @@ afp
 wsW
 hYP
 wje
-sCp
+iFQ
 mog
 mog
 mog
@@ -177018,11 +177082,11 @@ nAa
 oOG
 qMw
 ewM
-mog
-mog
-mog
-mog
-mog
+sCp
+wvr
+wFx
+wFx
+riF
 wje
 wtH
 kjR
@@ -177030,11 +177094,11 @@ buk
 ygJ
 wtH
 wje
-sCp
-mog
-mog
-mog
-mog
+kTT
+wFx
+wFx
+wFx
+wFx
 aWD
 vxX
 vxX
@@ -177276,7 +177340,7 @@ roc
 iqx
 iZa
 uFC
-uFC
+fgd
 tel
 tel
 tel
@@ -177291,7 +177355,7 @@ tel
 tel
 tel
 tel
-uFC
+fgd
 uFC
 vxX
 vxX


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/5edd7ef1-35f8-4751-9331-e5462d670464)
## Why It's Good For The Game

Gas leaks there can be annoying to fix. also connects it to the supermatter for alternate ways to sneak in

## Changelog
:cl: Ezel
map: Wawastation supermatter upperfloor has extra entrances and is easier to fix for gas leaks
/:cl:

