### PR TITLE
Fixes constant modular computer runtimes

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -997,7 +997,7 @@
 		if(SEC_LEVEL_RED) // all-hands-on-deck situations, everyone is responsible for combatting a threat
 			return ALERT_RELEVANCY_PERTINENT
 		if(SEC_LEVEL_BLUE) // suspected threat. security needs to be alert and possibly preparing for it, no further concerns
-			if(ACCESS_SECURITY in computer_id_slot.access)
+			if(ACCESS_SECURITY in computer_id_slot?.access)
 				return ALERT_RELEVANCY_PERTINENT
 			else
 				return ALERT_RELEVANCY_WARN


### PR DESCRIPTION

## About The Pull Request

Caused constant runtimes because modular computers, be it PDAs, laptops, or whatever, can not have an ID.

## Changelog
:cl:
fix: Fixed constant runtimes caused by modular computers without IDs
/:cl:
