### PR TITLE
Fixes Soybean Grinding/Juicing

### DIFF
--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -24,7 +24,7 @@
 	gender = PLURAL
 	icon_state = "soybeans"
 	foodtypes = VEGETABLES
-	grind_results = list(/datum/reagent/consumable/soymilk = 0)
+	juice_typepath = /datum/reagent/consumable/soymilk
 	tastes = list("soy" = 1)
 	distill_reagent = /datum/reagent/consumable/soysauce
 


### PR DESCRIPTION
## About The Pull Request

Noticed on downstream. You can't grind soybeans into veggie oil despite it being in the seed reagents as the `grind_results` overwrites it. Swaps that to `juice_typepath`.

## Why It's Good For The Game

Lets you grind soybeans down for vegetable oil, and juice them for soy milk.

## Changelog
:cl:
fix: soybeans now grind into the proper reagents and juice into soymilk.
/:cl:
