### PR TITLE
Fix a list qdel in `/datum/mind/Destroy()`

### DIFF
--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -109,7 +109,7 @@
 /datum/mind/Destroy()
 	SSticker.minds -= src
 	QDEL_NULL(antag_hud)
-	QDEL_LIST(memories)
+	QDEL_LIST_ASSOC_VAL(memories)
 	QDEL_NULL(memory_panel)
 	QDEL_LIST(antag_datums)
 	set_current(null)


### PR DESCRIPTION

## About The Pull Request

this changes `QDEL_LIST(memories)` to `QDEL_LIST_ASSOC_VAL(memories)`

## Why It's Good For The Game

proper behavior good

## Changelog
:cl:
fix: Fixed improperly cleaning up memories when a mind is deleted.
/:cl:
