### PR TITLE
Add a cooldown to wiremod MMI messages

### DIFF
--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -1,3 +1,5 @@
+#define MMI_MESSAGE_COOLDOWN (1 SECONDS)
+
 /**
  * # Man-Machine Interface Component
  *
@@ -38,6 +40,9 @@
 	/// Maximum length of the message that can be sent to the MMI
 	var/max_length = 300
 
+	/// Cooldown for when the next message can be sent to the MMI.
+	COOLDOWN_DECLARE(message_cooldown)
+
 /obj/item/circuit_component/mmi/populate_ports()
 	message = add_input_port("Message", PORT_TYPE_STRING)
 	send = add_input_port("Send Message", PORT_TYPE_SIGNAL)
@@ -64,7 +69,7 @@
 	if(COMPONENT_TRIGGERED_BY(eject, port))
 		remove_current_brain()
 	if(COMPONENT_TRIGGERED_BY(send, port))
-		if(!message.value)
+		if(!message.value || !COOLDOWN_FINISHED(src, message_cooldown))
 			return
 
 		var/msg_str = copytext(html_encode(message.value), 1, max_length)
@@ -74,6 +79,7 @@
 			return
 
 		to_chat(target, "[span_bold("You hear a message in your ear: ")][msg_str]")
+		COOLDOWN_START(src, message_cooldown, MMI_MESSAGE_COOLDOWN)
 
 
 /obj/item/circuit_component/mmi/register_shell(atom/movable/shell)
@@ -170,3 +176,5 @@
 	REMOVE_TRAIT(removed_from, TRAIT_COMPONENT_MMI, REF(src))
 	remove_current_brain()
 	return ..()
+
+#undef MMI_MESSAGE_COOLDOWN


### PR DESCRIPTION

## About The Pull Request

turns out there's _zero_ cooldown on sending messages to MMI. which can. uh. lead to an unpleasant experience.

![image](https://github.com/user-attachments/assets/0e0319e3-92bf-4d64-ae15-df8bfe800be6)

so i added a 1 second cooldown. simple enough.

## Why It's Good For The Game

this shit nearly crashes my game

## Changelog
:cl:
fix: Messages sent to MMIs in wiremod components now have a 1 second cooldown, to prevent massive spam.
/:cl:
