### PR TITLE
Fixes wawa sec disposals

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2713,10 +2713,9 @@
 /area/station/security/detectives_office)
 "aSK" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/effect/mapping_helpers/mail_sorting/security/general,
 /turf/open/floor/iron,
 /area/station/security/office)
 "aSM" = (
@@ -12046,6 +12045,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"ehT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/office)
 "ehY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/arrow_ccw,
@@ -12892,6 +12900,9 @@
 /area/station/security/courtroom)
 "exF" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "exQ" = (
@@ -14933,6 +14944,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"fmQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/security/office)
 "fmR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -41446,7 +41466,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "ozr" = (
@@ -50412,6 +50434,16 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
+"rAX" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "rAZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -51274,6 +51306,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "rQO" = (
@@ -59882,7 +59917,7 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -89320,7 +89355,7 @@ igQ
 gIO
 dCi
 hcQ
-cpO
+ehT
 uzh
 kSP
 eDG
@@ -89577,10 +89612,10 @@ lHC
 lar
 bPY
 jMU
-cpO
+fmQ
 exF
 rQK
-iyG
+rAX
 uJO
 azb
 rRK


### PR DESCRIPTION

## About The Pull Request

Reroutes disposals piping in wawa's sec office to avoid disposaled items being turned back because they ran into the straight ahead output of a mail sorter.

Fixes #90121

## Why It's Good For The Game

Badly piped disposals causes garbage to pile up, garbage piling up causes rats.

## Changelog
:cl:
fix: Wawastation: Security disposals has been rerouted to avoid trash being returned to sender.
/:cl:
