### PR TITLE
Fixes `to_chat` never actually queuing

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -487,7 +487,8 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 		SS_INIT_NO_MESSAGE,
 	)
 
-	if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
+	if ((subsystem.flags & SS_NO_INIT) || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
+		subsystem.initialized = TRUE // set initialized to TRUE, because the value of initialized may still be checked on SS_NO_INIT subsystems as an "is this ready" check
 		return
 
 	current_initializing_subsystem = subsystem


### PR DESCRIPTION

## About The Pull Request

Look at this check:
```dm
if(isnull(Master) || !SSchat?.initialized || !MC_RUNNING(SSchat.init_stage))
	to_chat_immediate(target, html, type, text, avoid_highlighting)
	return
```

`SSchat` has the `SS_NO_INIT` flag. Therefore, it would never get the `initialized` var set.
Thus, it would ALWAYS do `to_chat_immediate` anyways.

So, instead of just changing this specific check, at the suggestion of potato, I've made it so `SS_NO_INIT` subsystems also get `initialized` set to `TRUE` - as it's reasonable to expect such a var to be used for an "is this subsystem _ready_" check.

## Why It's Good For The Game

I'm pretty sure this is meant to queue for a reason. AND IT NEVER. DID.

## Changelog
:cl:
fix: Chat messages now actually queue as intended.
/:cl:
