### PR TITLE
Fixes delam hallucinations

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -25,7 +25,7 @@
 			continue
 
 		//Hilariously enough, running into a closet should make you get hit the hardest.
-		var/hallucination_amount = max(100 SECONDS, min(600 SECONDS, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(victim, src) + 1))))
+		var/hallucination_amount = max(100 SECONDS, min(600 SECONDS, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(victim, sm) + 1))))
 		victim.adjust_hallucinations(hallucination_amount)
 
 	for(var/mob/victim as anything in GLOB.player_list)


### PR DESCRIPTION
## About The Pull Request

Fixes the delam hallucination proc to actually calculate based on distance from the supermatter.

## Why It's Good For The Game

Fixes 2.5 year old bug.

## Changelog

:cl: LT3
fix: Supermatter delamination now applies hallucinations based on distance
/:cl: