### PR TITLE
Fixes watcher crusher trophies not applying their effects on basicmobs

### DIFF
--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -89,7 +89,7 @@
 	SEND_SIGNAL(parent, COMSIG_BASICMOB_POST_ATTACK_RANGED, target, modifiers)
 	return
 
-/datum/component/ranged_attacks/proc/disable_attack(obj/item/crusher_trophy/used_trophy, mob/living/user)
+/datum/component/ranged_attacks/proc/disable_attack(mob/source, obj/item/crusher_trophy/used_trophy, mob/living/user)
 	SIGNAL_HANDLER
 	var/stun_duration = (used_trophy.bonus_value * 0.1) SECONDS
 	COOLDOWN_INCREMENT(src, fire_cooldown, stun_duration)


### PR DESCRIPTION

## About The Pull Request

Was missing a source arg, thus trying to get mob's bonus_value var and runtiming.

## Changelog
:cl:
fix: Fixed watcher crusher trophies not applying their effects on basicmobs
/:cl:
