### PR TITLE
Fixes certain mobs runtiming when dusted

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -481,7 +481,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 			if(user.stat != DEAD)
 				user.investigate_log("has died from being cremated.", INVESTIGATE_DEATHS)
 			M.death(TRUE)
-			if(M) //some animals get automatically deleted on death.
+			if(!QDELETED(M)) //some animals get automatically deleted on death.
 				M.ghostize()
 				qdel(M)
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -92,7 +92,6 @@
 	if(body_position == STANDING_UP)
 		// keep us upright so the animation fits.
 		ADD_TRAIT(src, TRAIT_FORCED_STANDING, TRAIT_GENERIC)
-	death(TRUE)
 
 	if(drop_items)
 		unequip_everything()
@@ -100,8 +99,11 @@
 	if(buckled)
 		buckled.unbuckle_mob(src, force = TRUE)
 
-	addtimer(CALLBACK(src, PROC_REF(spawn_dust), just_ash), DUST_ANIMATION_TIME - 0.3 SECONDS)
-	ghostize()
+	death(TRUE)
+	// Some mobs get qdeleted on death
+	if (!QDELETED(src))
+		addtimer(CALLBACK(src, PROC_REF(spawn_dust), just_ash), DUST_ANIMATION_TIME - 0.3 SECONDS)
+		ghostize()
 
 /// Animates turning into dust.
 /// Does not delete src afterwards, BUT it will become invisible (and grey), so ensure you handle that yourself


### PR DESCRIPTION

## About The Pull Request

Certain mobs, like bots, delete on death. Also fixed an incorrect deletion check in crematorium code.

## Changelog
:cl:
fix: Fixed certain mobs runtiming when dusted
/:cl:
