### PR TITLE
Tech storage now includes a small kit of relevant supplies for custom shuttles

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -67709,6 +67709,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
+"qVt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "qVv" = (
 /obj/machinery/power/shieldwallgen,
 /obj/effect/decal/cleanable/dirt,
@@ -126951,7 +126960,7 @@ sUQ
 bpt
 bpt
 bpt
-kNC
+qVt
 kNC
 kNC
 kNC

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16504,6 +16504,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
 /area/station/command/heads_quarters/hos)
+"eEm" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/storage/tech)
 "eEO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78891,8 +78896,8 @@
 "wzC" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/bot,
-/obj/effect/landmark/event_spawn,
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/large,
 /area/station/engineering/storage/tech)
 "wzH" = (
@@ -245101,7 +245106,7 @@ umu
 umu
 fyK
 oIr
-oIr
+eEm
 wzC
 oIr
 oIr

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18192,6 +18192,16 @@
 /obj/structure/table,
 /obj/item/aicard,
 /obj/item/ai_module/reset,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "gBe" = (
@@ -48635,18 +48645,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "rjZ" = (
-/obj/structure/table,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "rke" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6302,7 +6302,7 @@
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
-/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bde" = (
@@ -50612,9 +50612,10 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "qRn" = (
-/obj/machinery/vending/assist,
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/structure/sign/clock/directional/north,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
+/obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "qRp" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -45343,6 +45343,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage/tech)
 "pQl" = (

--- a/code/game/objects/effects/spawners/random/techstorage.dm
+++ b/code/game/objects/effects/spawners/random/techstorage.dm
@@ -24,6 +24,19 @@
 		/obj/item/circuitboard/computer/arcade/orion_trail,
 	)
 
+/obj/effect/spawner/random/techstorage/custom_shuttle
+	name = "custom shuttle circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/computer/shuttle/docker,
+		/obj/item/circuitboard/computer/shuttle/flight_control,
+		/obj/item/circuitboard/machine/engine/propulsion,
+		/obj/item/circuitboard/machine/engine/propulsion,
+		/obj/item/circuitboard/machine/engine/propulsion,
+		/obj/item/circuitboard/machine/engine/propulsion,
+		/obj/item/shuttle_blueprints,
+		/obj/item/stack/rods/shuttle/fifty,
+	)
+
 /obj/effect/spawner/random/techstorage/service_all
 	name = "service circuit board spawner"
 	loot = list(

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -61,4 +61,5 @@ map multiz_debug
 endmap
 
 map runtimestation
+	#default
 endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -61,5 +61,4 @@ map multiz_debug
 endmap
 
 map runtimestation
-	#default
 endmap


### PR DESCRIPTION

## About The Pull Request

This adds a techstorage spawner for a set of custom shuttle supplies consisting of:

The shuttle navigation and shuttle docking boards
50 shuttle lattice rods
Four boards for propulsion engines
A blank shuttle blueprint

As well, each tech storage has had a rack with this spawner added to it.
## Why It's Good For The Game

As tech storage includes many boards that aren't available otherwise without research or cargo, the same applies to custom shuttle boards and supplies. This makes one set of these supplies available roundstart to anyone who can manage to get tech storage access.
## Changelog
:cl: Bisar
add: NanoTrasen reminds all employees that it assumes no liability for any activities carried out when not on the premises of a Nanotrasen colony, station, or bluespace pocket. Any employees electing to leave the premises during their break are reminded that it is imperative that they clock out, as per their contract.
add: Tech storage now includes a small set of custom shuttle supplies.
/:cl:
