### PR TITLE
Fixes runtimes caused by energy bolas

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -232,6 +232,9 @@ SUBSYSTEM_DEF(throwing)
 
 	if (callback)
 		callback.Invoke()
+		// Same can happen in the callback
+		if(QDELETED(thrownthing))
+			return
 
 	if(!thrownthing.currently_z_moving) // I don't think you can zfall while thrown but hey, just in case.
 		var/turf/T = get_turf(thrownthing)


### PR DESCRIPTION

## About The Pull Request

Certain throw impact callbacks, like those on energy bolas, could cause the object to get deleted, which would make throwing datums runtime because they didn't account for it.

## Changelog
:cl:
fix: Fixed runtimes caused by energy bolas
/:cl:
