### PR TITLE
Fixes orbiting runtimes caused by mind transfers

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -57,7 +57,7 @@
 	newcomp.orbiter_list = null
 
 /datum/component/orbiter/PostTransfer(datum/new_parent)
-	if(!isatom(parent) || isarea(new_parent) || !get_turf(new_parent))
+	if(!isatom(new_parent) || isarea(new_parent) || !get_turf(new_parent))
 		return COMPONENT_INCOMPATIBLE
 	move_react(new_parent)
 


### PR DESCRIPTION

## About The Pull Request
Orbiting component typechecked a knowingly null parent, which errored and caused two runtimes for the price of one when you tried to transfer a mob's mind while it had orbiters.

## Changelog
:cl:
fix: Fixed mind transfers not transferring mob's observers to mind's new mob.
/:cl:
