### PR TITLE
Combat shotgun changes

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com
 	name = "combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/com/compact

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -61,7 +61,7 @@
 	var/projectile_wound_bonus = 0
 
 	/// The most reasonable way to modify projectile speed values for projectile fired from this gun. Honest.
-	/// Lower values are better, higher values are worse.
+	/// Lower values are worse, higher values are better.
 	var/projectile_speed_multiplier = 1
 
 	var/spread = 0 //Spread induced by the gun itself.

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -62,16 +62,17 @@
 	desc = "A semi automatic shotgun with tactical furniture and a six-shell capacity underneath."
 	icon_state = "cshotgun"
 	inhand_icon_state = "shotgun_combat"
-	fire_delay = 5
+	projectile_damage_multiplier = 1.5
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
-	name = "compact shotgun"
-	desc = "A compact version of the semi automatic combat shotgun. For close encounters."
+	name = "compact combat shotgun"
+	desc = "A compact version of the semi automatic combat shotgun. Lower magazine capacity, but more easily carried."
 	icon_state = "cshotgunc"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_MEDIUM
 
 //Dual Feed Shotgun
 


### PR DESCRIPTION

## About The Pull Request

Combat shotguns have a x1.5 damage bonus compared to riot shotguns. (For comparisons sake, riot shotguns firing buckshot at point blank have a max damage of 30, while this version of the combat shotgun would do 45)

Combat shotguns come pre-loaded with rubbershot, rather than beanbags.

The compact combat shotgun is now able to be fired while wielding something else in your other hand. This doesn't allow dual-wielding, but does allow pairing it with a shield or baton.

You may also notice I've removed the fire delay variable. Ranged click cooldown is 0.5 deciseconds, which is the same value as this variable.

## Why It's Good For The Game

Combat shotguns are quite terrible. Their immense bulk makes them difficult to carry around, and they lack any meaningful upsides to riot shotguns in most cases. They're also often pretty expensive. For the inconvenience of their size and price, you maybe squeeze out one more shot per second over a riot shotgun, which can add up, but usually not quite enough compared to using alternative equipment in this range (the baton, for instance, does about as much damage and comes with a disabling effect to boot). 

In actual play, having a weapon in your hands at all times is a significantly disadvantageous position to be in unless you are somehow incapable of being knocked down or slipped.

If people must use combat shotguns, I think the risks and cumbersomeness of the weapon should have a comparable upside; raw force.

The compact combat shotgun meanwhile actually earns its status as a rare high value weapon. Getting it is not just a matter of increased damage, but also convenience over even the riot shotgun. Too often I'm seeing a lot of wardens use the riot shotguns in the armory over this because of the higher capacity. Higher fire rate is not enough of an upgrade.

## Changelog
:cl:
balance: Combat shotguns have a x1.5 damage increase over riot shotguns. This extends to the compact combat shotgun.
balance: The combat shotgun comes pre-loaded with rubbershot, rather than benabags.
balance: Compact combat shotguns can be used while wielding something in your off-hand (but still cannot be dual-wielded).
/:cl:
