### PR TITLE
Deshittifies looking up/down

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -48,7 +48,7 @@
 /datum/keybinding/living/look_up/up(client/user)
 	. = ..()
 	var/mob/living/L = user.mob
-	L.end_look_up()
+	L.end_look()
 	return TRUE
 
 /datum/keybinding/living/look_down
@@ -69,7 +69,7 @@
 /datum/keybinding/living/look_down/up(client/user)
 	. = ..()
 	var/mob/living/L = user.mob
-	L.end_look_down()
+	L.end_look()
 	return TRUE
 
 /datum/keybinding/living/rest

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2293,6 +2293,32 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 /mob/living/proc/get_body_temp_cold_damage_limit()
 	return BODYTEMP_COLD_DAMAGE_LIMIT
 
+/atom/movable/looking_holder
+	invisibility = INVISIBILITY_MAXIMUM
+	///the direction we are operating in
+	var/look_direction
+	///owner we are showing this view to
+	var/mob/living/owner
+
+/atom/movable/looking_holder/Initialize(mapload, mob/living/owner, direction)
+	. = ..()
+	look_direction = direction
+	src.owner = owner
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(mirror_move))
+
+/atom/movable/looking_holder/Destroy()
+	owner = null
+	return ..()
+
+/atom/movable/looking_holder/proc/mirror_move(mob/living/source, atom/oldloc, direction, Forced, old_locs)
+	SIGNAL_HANDLER
+	set_glide_size(source.glide_size)
+	var/turf/looking_turf = owner.get_looking_turf(look_direction)
+	if(!looking_turf)
+		owner.end_look()
+		return
+	abstract_move(looking_turf)
+
 ///Checks if the user is incapacitated or on cooldown.
 /mob/living/proc/can_look_up()
 	if(next_move > world.time)
@@ -2300,6 +2326,13 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(INCAPACITATED_IGNORING(src, INCAPABLE_RESTRAINTS))
 		return FALSE
 	return TRUE
+
+/mob/living/proc/end_look()
+	reset_perspective()
+	looking_vertically = NONE
+	QDEL_NULL(looking_holder)
+
+
 /**
  * look_up Changes the perspective of the mob to any openspace turf above the mob
  *
@@ -2307,61 +2340,40 @@ GLOBAL_LIST_EMPTY(fire_appearances)
  *
  */
 /mob/living/proc/look_up()
-	if(client.perspective != MOB_PERSPECTIVE) //We are already looking up.
-		stop_look_up()
+	if(looking_vertically == UP)
+		return
+	if(looking_vertically == DOWN)
+		end_look()
+		return
 	if(!can_look_up())
 		return
 	changeNext_move(CLICK_CD_LOOK_UP)
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(stop_look_up)) //We stop looking up if we move.
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(start_look_up)) //We start looking again after we move.
-	start_look_up()
-
-/mob/living/proc/start_look_up()
-	SIGNAL_HANDLER
-
-	looking_vertically = TRUE
-
-	var/turf/current_turf = get_turf(src)
-	var/turf/above_turf = GET_TURF_ABOVE(current_turf)
-
-	//Check if turf above exists
+	var/turf/above_turf = get_looking_turf(UP)
 	if(!above_turf)
-		to_chat(src, span_warning("There's nothing interesting above."))
-		to_chat(src, "You set your head straight again.")
-		end_look_up()
 		return
+	looking_vertically = UP
+	looking_holder = new(above_turf, src, UP)
+	reset_perspective(looking_holder)
 
-	var/turf/ceiling = get_step_multiz(src, UP)
-	if(!ceiling) //We are at the highest z-level.
-		if (prob(0.1))
-			to_chat(src, span_warning("You gaze out into the infinite vastness of deep space, for a moment, you have the impulse to continue travelling, out there, out into the deep beyond, before your consciousness reasserts itself and you decide to stay within travelling distance of the station."))
-			return
-		to_chat(src, span_warning("There's nothing interesting up there."))
+/mob/living/proc/get_looking_turf(direction)
+	//down needs to check this floor
+	var/turf/check_turf = get_step_multiz(src, direction == DOWN ? NONE : direction)
+	if(!get_step_multiz(src, direction)) //We are at the edge z-level.
+		to_chat(src, span_warning("There's nothing interesting there."))
 		return
-	else if(!istransparentturf(ceiling)) //There is no turf we can look through above us
-		var/turf/front_hole = get_step(ceiling, dir)
+	else if(!istransparentturf(check_turf)) //There is no turf we can look through above us
+		var/turf/front_hole = get_step(check_turf, dir)
 		if(istransparentturf(front_hole))
-			ceiling = front_hole
+			check_turf = front_hole
 		else
-			for(var/turf/checkhole in TURF_NEIGHBORS(ceiling))
+			for(var/turf/checkhole in TURF_NEIGHBORS(check_turf))
 				if(istransparentturf(checkhole))
-					ceiling = checkhole
+					check_turf = checkhole
 					break
-		if(!istransparentturf(ceiling))
-			to_chat(src, span_warning("You can't see through the floor above you."))
+		if(!istransparentturf(check_turf))
+			to_chat(src, span_warning("You can't see through the floor [direction == DOWN ? "below" : "above"] you."))
 			return
-
-	reset_perspective(ceiling)
-
-/mob/living/proc/stop_look_up()
-	SIGNAL_HANDLER
-	reset_perspective()
-
-/mob/living/proc/end_look_up()
-	stop_look_up()
-	looking_vertically = FALSE
-	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
-	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	return direction == DOWN ? get_step_multiz(check_turf, DOWN) : check_turf
 
 /**
  * look_down Changes the perspective of the mob to any openspace turf below the mob
@@ -2370,63 +2382,20 @@ GLOBAL_LIST_EMPTY(fire_appearances)
  *
  */
 /mob/living/proc/look_down()
-	if(client.perspective != MOB_PERSPECTIVE) //We are already looking down.
-		stop_look_down()
+	if(looking_vertically == UP)
+		end_look()
+		return
+	if(looking_vertically == DOWN)
+		return
 	if(!can_look_up()) //if we cant look up, we cant look down.
 		return
 	changeNext_move(CLICK_CD_LOOK_UP)
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(stop_look_down)) //We stop looking down if we move.
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(start_look_down)) //We start looking again after we move.
-	start_look_down()
-
-/mob/living/proc/start_look_down()
-	SIGNAL_HANDLER
-
-	looking_vertically = TRUE
-
-	var/turf/current_turf = get_turf(src)
-	var/turf/below_turf = GET_TURF_BELOW(current_turf)
-
-	//Check if turf below exists
+	var/turf/below_turf = get_looking_turf(DOWN)
 	if(!below_turf)
-		to_chat(src, span_warning("There's nothing interesting below."))
-		to_chat(src, "You set your head straight again.")
-		end_look_up()
 		return
-
-	var/turf/floor = get_turf(src)
-	var/turf/lower_level = get_step_multiz(floor, DOWN)
-	if(!lower_level) //We are at the lowest z-level.
-		to_chat(src, span_warning("You can't see through the floor below you."))
-		return
-	else if(!istransparentturf(floor)) //There is no turf we can look through below us
-		var/turf/front_hole = get_step(floor, dir)
-		if(istransparentturf(front_hole))
-			floor = front_hole
-			lower_level = get_step_multiz(front_hole, DOWN)
-		else
-			// Try to find a hole near us
-			for(var/turf/checkhole in TURF_NEIGHBORS(floor))
-				if(istransparentturf(checkhole))
-					floor = checkhole
-					lower_level = get_step_multiz(checkhole, DOWN)
-					break
-		if(!istransparentturf(floor))
-			to_chat(src, span_warning("You can't see through the floor below you."))
-			return
-
-	reset_perspective(lower_level)
-
-/mob/living/proc/stop_look_down()
-	SIGNAL_HANDLER
-	reset_perspective()
-
-/mob/living/proc/end_look_down()
-	stop_look_down()
-	looking_vertically = FALSE
-	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
-	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
-
+	looking_vertically = DOWN
+	looking_holder = new(get_looking_turf(DOWN), src, DOWN)
+	reset_perspective(looking_holder)
 
 /mob/living/set_stat(new_stat)
 	. = ..()
@@ -2958,7 +2927,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 	if(looking_vertically)
 		to_chat(src, "You set your head straight again.")
-		end_look_up()
+		end_look()
 		return
 
 	var/turf/current_turf = get_turf(src)
@@ -2978,7 +2947,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 	if(looking_vertically)
 		to_chat(src, "You set your head straight again.")
-		end_look_down()
+		end_look()
 		return
 
 	var/turf/current_turf = get_turf(src)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -214,8 +214,10 @@
 	///what multiplicative slowdown we get from turfs currently.
 	var/current_turf_slowdown = 0
 
-	/// Is the mob looking vertically
-	var/looking_vertically = FALSE
+	/// Direction that this mob is looking at, used for the look_up and look_down procs
+	var/looking_vertically = NONE
+	///looking holder we use for look_up and look_down. we use this over resetting to the turf because we want to glide
+	var/atom/movable/looking_holder/looking_holder
 
 	/// Living mob's mood datum
 	var/datum/mood/mob_mood


### PR DESCRIPTION

## About The Pull Request
Looking down code was kinda messy for like, no reason?
This simplifies it, makes it track the direction you're looking, and uses a holder so the movement isn't extremely jittery

See
https://github.com/tgstation/TerraGov-Marine-Corps/pull/17631
https://github.com/tgstation/TerraGov-Marine-Corps/pull/17463

## Why It's Good For The Game

https://streamable.com/qj0zed

## Changelog
:cl:
refactor: Overhauled how looking up and looking down function. they should now not jitter, and trying to look up/down while already doing so will cancel the previous look up/down in the opposite direction
/:cl:
