### PR TITLE
Keyboard presses (and thus keybindings) will now report the turf the mouse was over when a player presses or releases a key

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -294,7 +294,7 @@ Turf and target are separate in case you want to teleport some distance from a t
  * @return The turf at the calculated map position, or the closest one if out of bounds, as well as the residual x and y map offsets
  *
  * Important Notes:
-  * - This WILL be incorrect when client pixel_wxyz is animating, and it WILL be incorrect if the user is gliding, because we don't have a good way to compensate this on the serverside. Yay!!!
+ * - This WILL be incorrect when client pixel_wxyz is animating, and it WILL be incorrect if the user is gliding, because we don't have a good way to compensate this on the serverside. Yay!!!
  * - Mouse coordinates originate from the top-left corner because we can't have consistency in this engine
  * - Coordinate systems are inconsistent between control pixels and screen pixels
  * - Something on the byond side (icon size likely? needs debugging) affects the control pixels

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -280,11 +280,26 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return click_turf
 
 /**
- * Takes mousepos_x and mousepos_y and the client that provided them and returns the turf clicked on
- * reminder, mouseposx and mouseposy start from the top left corner because we can't have consistency or nice things
- * they also ignore sizes, so we need to compensate for that
- * sizex and sizey are the size of the map for this purpose
- * also keep in mind that the screen size is the worlds pixel size, while mousepos and size are the completely unrelated control size
+ * Converts mouse-pos control coordinates to a specific turf location on the map.
+ *
+ * Handles the conversion between control-space mouse coordinates and screen-space map coordinates,
+ * accounting for various BYOND quirks and display scaling factors.
+ *
+ * @param mousepos_x	The x-coordinate of the mouse click (in control pixels, top-left origin)
+ * @param mousepos_y	The y-coordinate of the mouse click (in control pixels, top-left origin)
+ * @param sizex			x control width of the map
+ * @param sizey			y control width of the map
+ * @param viewing_client The client whose view perspective to use for the conversion
+ *
+ * @return The turf at the calculated map position, or the closest one if out of bounds, as well as the residual x and y map offsets
+ *
+ * Important Notes:
+ * - Mouse coordinates originate from the top-left corner because we can't have consistency in this engine
+ * - Coordinate systems are inconsistent between control pixels and screen pixels
+ * - Something on the byond side (icon size likely? needs debugging) affects the control pixels
+ * - This uses the ratios between them rather than absolute values for reliable results
+ * - For absolute value comparisons, dividing by 2 may work as a temporary hack,
+ *   but using ratios (as implemented in the proc) is the recommended approach
  */
 /proc/get_loc_from_mousepos(mousepos_x, mousepos_y, sizex, sizey, client/viewing_client)
 	var/turf/baseloc = get_turf(viewing_client.eye)

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -294,6 +294,7 @@ Turf and target are separate in case you want to teleport some distance from a t
  * @return The turf at the calculated map position, or the closest one if out of bounds, as well as the residual x and y map offsets
  *
  * Important Notes:
+  * - This WILL be incorrect when client pixel_wxyz is animating, and it WILL be incorrect if the user is gliding, because we don't have a good way to compensate this on the serverside. Yay!!!
  * - Mouse coordinates originate from the top-left corner because we can't have consistency in this engine
  * - Coordinate systems are inconsistent between control pixels and screen pixels
  * - Something on the byond side (icon size likely? needs debugging) affects the control pixels

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -287,13 +287,6 @@ Turf and target are separate in case you want to teleport some distance from a t
  * also keep in mind that the screen size is the worlds pixel size, while mousepos and size are the completely unrelated control size
  */
 /proc/get_loc_from_mousepos(mousepos_x, mousepos_y, sizex, sizey, client/viewing_client)
-	//hack because we can't have shit with this engine!!!!!!
-	// https://discord.com/channels/725444629172060262/1063155296052191373/1357460149836451960
-	mousepos_x = mousepos_x / 2
-	mousepos_y = mousepos_y / 2
-	sizex = sizex / 2
-	sizey = sizey / 2
-
 	var/turf/baseloc = get_turf(viewing_client.eye)
 	var/list/actual_view = getviewsize(viewing_client ? viewing_client.view : world.view)
 

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -333,8 +333,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	mousepos_y /= y_ratio
 
 	//relative to bottom left corner of turf in the middle of the screen
-	var/relative_x = mousepos_x - (screen_width / 2) + (ICON_SIZE_X/2)
-	var/relative_y = -(mousepos_y - (screen_height / 2))+ (ICON_SIZE_Y/2) - 1
+	var/relative_x = mousepos_x - (screen_width / 2) + (ICON_SIZE_X/2) + viewing_client.pixel_x + viewing_client.pixel_w
+	var/relative_y = -(mousepos_y - (screen_height / 2))+ (ICON_SIZE_Y/2) - 1 + viewing_client.pixel_y + viewing_client.pixel_z
 	var/turf_x_diff = FLOOR(relative_x / ICON_SIZE_X, 1)
 	var/turf_y_diff = FLOOR(relative_y / ICON_SIZE_Y, 1)
 

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -33,11 +33,11 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 // This is for when macro sets are eventually datumized
 /datum/controller/subsystem/verb_manager/input/proc/setup_default_macro_sets()
 	macro_set = list(
-	"Any" = "\"KeyDown \[\[*\]\]\"",
-	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
-	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
-	"Tab" = "\".winset \\\"input.focus=true?map.focus=true:input.focus=true\\\"\"",
-	"Escape" = "Open-Escape-Menu",
+		"Any" = "\"KeyDown \[\[*\]\] \[\[map.mouse-pos\]\] \[\[map.size\]\]\"",
+		"Any+UP" = "\"KeyUp \[\[*\]\] \[\[map.mouse-pos\]\] \[\[map.size\]\]\"",
+		"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
+		"Tab" = "\".winset \\\"input.focus=true?map.focus=true:input.focus=true\\\"\"",
+		"Escape" = "Open-Escape-Menu",
 	)
 
 // Badmins just wanna have fun ♪

--- a/code/datums/keybinding/_keybindings.dm
+++ b/code/datums/keybinding/_keybindings.dm
@@ -16,13 +16,13 @@
 	if(LAZYLEN(hotkey_keys) && !LAZYLEN(classic_keys))
 		classic_keys = hotkey_keys.Copy()
 
-/datum/keybinding/proc/down(client/user)
+/datum/keybinding/proc/down(client/user, turf/target)
 	SHOULD_CALL_PARENT(TRUE)
-	return SEND_SIGNAL(user.mob, keybind_signal) & COMSIG_KB_ACTIVATED
+	return SEND_SIGNAL(user.mob, keybind_signal, target) & COMSIG_KB_ACTIVATED
 
-/datum/keybinding/proc/up(client/user)
+/datum/keybinding/proc/up(client/user, turf/target)
 	SHOULD_CALL_PARENT(TRUE)
-	SEND_SIGNAL(user.mob, DEACTIVATE_KEYBIND(keybind_signal))
+	SEND_SIGNAL(user.mob, DEACTIVATE_KEYBIND(keybind_signal), target)
 	return FALSE
 
 /datum/keybinding/proc/can_use(client/user)

--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -19,7 +19,7 @@
 	description = "Go ghost"
 	keybind_signal = COMSIG_KB_ADMIN_AGHOST_DOWN
 
-/datum/keybinding/admin/admin_ghost/down(client/user)
+/datum/keybinding/admin/admin_ghost/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -33,7 +33,7 @@
 	description = "Opens up the new player panel"
 	keybind_signal = COMSIG_KB_ADMIN_PLAYERPANELNEW_DOWN
 
-/datum/keybinding/admin/player_panel_new/down(client/user)
+/datum/keybinding/admin/player_panel_new/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -47,7 +47,7 @@
 	description = "Toggles buildmode"
 	keybind_signal = COMSIG_KB_ADMIN_TOGGLEBUILDMODE_DOWN
 
-/datum/keybinding/admin/toggle_buildmode_self/down(client/user)
+/datum/keybinding/admin/toggle_buildmode_self/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -61,7 +61,7 @@
 	description = "Enters stealth mode"
 	keybind_signal = COMSIG_KB_ADMIN_STEALTHMODETOGGLE_DOWN
 
-/datum/keybinding/admin/stealthmode/down(client/user)
+/datum/keybinding/admin/stealthmode/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -75,7 +75,7 @@
 	description = "Toggles ghost-like invisibility (Don't abuse this)"
 	keybind_signal = COMSIG_KB_ADMIN_INVISIMINTOGGLE_DOWN
 
-/datum/keybinding/admin/invisimin/down(client/user)
+/datum/keybinding/admin/invisimin/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -89,7 +89,7 @@
 	description = "Allows you to send a message to dead chat"
 	keybind_signal = COMSIG_KB_ADMIN_DSAY_DOWN
 
-/datum/keybinding/admin/deadsay/down(client/user)
+/datum/keybinding/admin/deadsay/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -103,7 +103,7 @@
 	description = "Shed your admin powers"
 	keybind_signal = COMSIG_KB_ADMIN_DEADMIN_DOWN
 
-/datum/keybinding/admin/deadmin/down(client/user)
+/datum/keybinding/admin/deadmin/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -117,7 +117,7 @@
 	description = "Regain your admin powers"
 	keybind_signal = COMSIG_KB_ADMIN_READMIN_DOWN
 
-/datum/keybinding/admin/readmin/down(client/user)
+/datum/keybinding/admin/readmin/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -131,7 +131,7 @@
 	description = "Open the View-Tags menu"
 	keybind_signal = COMSIG_KB_ADMIN_VIEWTAGS_DOWN
 
-/datum/keybinding/admin/view_tags/down(client/user)
+/datum/keybinding/admin/view_tags/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/artificial_intelligence.dm
+++ b/code/datums/keybinding/artificial_intelligence.dm
@@ -12,7 +12,7 @@
 	description = "Reconnects you to your most recently used AI shell"
 	keybind_signal = COMSIG_KB_SILICON_RECONNECT_DOWN
 
-/datum/keybinding/artificial_intelligence/reconnect/down(client/user)
+/datum/keybinding/artificial_intelligence/reconnect/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -13,7 +13,7 @@
 	category = CATEGORY_CARBON
 	keybind_signal = COMSIG_KB_CARBON_TOGGLETHROWMODE_DOWN
 
-/datum/keybinding/carbon/toggle_throw_mode/down(client/user)
+/datum/keybinding/carbon/toggle_throw_mode/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -29,14 +29,14 @@
 	category = CATEGORY_CARBON
 	keybind_signal = COMSIG_KB_CARBON_HOLDTHROWMODE_DOWN
 
-/datum/keybinding/carbon/hold_throw_mode/down(client/user)
+/datum/keybinding/carbon/hold_throw_mode/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
 	var/mob/living/carbon/carbon_user = user.mob
 	carbon_user.throw_mode_on(THROW_MODE_HOLD)
 
-/datum/keybinding/carbon/hold_throw_mode/up(client/user)
+/datum/keybinding/carbon/hold_throw_mode/up(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -49,7 +49,7 @@
 	description = "Give the item you're currently holding"
 	keybind_signal = COMSIG_KB_CARBON_GIVEITEM_DOWN
 
-/datum/keybinding/carbon/give/down(client/user)
+/datum/keybinding/carbon/give/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -10,7 +10,7 @@
 	description = "Ask an admin for help."
 	keybind_signal = COMSIG_KB_CLIENT_GETHELP_DOWN
 
-/datum/keybinding/client/admin_help/down(client/user)
+/datum/keybinding/client/admin_help/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -25,7 +25,7 @@
 	description = "Take a screenshot."
 	keybind_signal = COMSIG_KB_CLIENT_SCREENSHOT_DOWN
 
-/datum/keybinding/client/screenshot/down(client/user)
+/datum/keybinding/client/screenshot/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -39,7 +39,7 @@
 	description = "Makes the game window fullscreen."
 	keybind_signal = COMSIG_KB_CLIENT_FULLSCREEN_DOWN
 
-/datum/keybinding/client/toggle_fullscreen/down(client/user)
+/datum/keybinding/client/toggle_fullscreen/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -53,7 +53,7 @@
 	description = "Hide most HUD features"
 	keybind_signal = COMSIG_KB_CLIENT_MINIMALHUD_DOWN
 
-/datum/keybinding/client/minimal_hud/down(client/user)
+/datum/keybinding/client/minimal_hud/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -7,7 +7,7 @@
 	full_name = "IC Say"
 	keybind_signal = COMSIG_KB_CLIENT_SAY_DOWN
 
-/datum/keybinding/client/communication/say/down(client/user)
+/datum/keybinding/client/communication/say/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -20,7 +20,7 @@
 	full_name = "IC Radio (;)"
 	keybind_signal = COMSIG_KB_CLIENT_RADIO_DOWN
 
-/datum/keybinding/client/communication/radio/down(client/user)
+/datum/keybinding/client/communication/radio/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -33,7 +33,7 @@
 	full_name = "Out Of Character Say (OOC)"
 	keybind_signal = COMSIG_KB_CLIENT_OOC_DOWN
 
-/datum/keybinding/client/communication/ooc/down(client/user)
+/datum/keybinding/client/communication/ooc/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -46,7 +46,7 @@
 	full_name = "Custom Emote (/Me)"
 	keybind_signal = COMSIG_KB_CLIENT_ME_DOWN
 
-/datum/keybinding/client/communication/me/down(client/user)
+/datum/keybinding/client/communication/me/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/emote.dm
+++ b/code/datums/keybinding/emote.dm
@@ -11,7 +11,7 @@
 	name = initial(faketype.key)
 	full_name = capitalize(initial(faketype.key))
 
-/datum/keybinding/emote/down(client/user)
+/datum/keybinding/emote/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -12,7 +12,7 @@
 	description = "Quickly puts an item in the best slot available"
 	keybind_signal = COMSIG_KB_HUMAN_QUICKEQUIP_DOWN
 
-/datum/keybinding/human/quick_equip/down(client/user)
+/datum/keybinding/human/quick_equip/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -31,7 +31,7 @@
 	var/slot_item_name = "belt"
 	keybind_signal = COMSIG_KB_HUMAN_QUICKEQUIPBELT_DOWN
 
-/datum/keybinding/human/quick_equip_belt/down(client/user)
+/datum/keybinding/human/quick_equip_belt/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -12,7 +12,7 @@
 	description = "Break free of your current state. Handcuffed? on fire? Resist!"
 	keybind_signal = COMSIG_KB_LIVING_RESIST_DOWN
 
-/datum/keybinding/living/resist/down(client/user)
+/datum/keybinding/living/resist/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -22,7 +22,7 @@
 		owner.hud_used.resist_icon.icon_state = "[owner.hud_used.resist_icon.base_icon_state]_on"
 	return TRUE
 
-/datum/keybinding/living/resist/up(client/user)
+/datum/keybinding/living/resist/up(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -37,7 +37,7 @@
 	description = "Look up at the next z-level.  Only works if directly below open space."
 	keybind_signal = COMSIG_KB_LIVING_LOOKUP_DOWN
 
-/datum/keybinding/living/look_up/down(client/user)
+/datum/keybinding/living/look_up/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -45,7 +45,7 @@
 	L.look_up()
 	return TRUE
 
-/datum/keybinding/living/look_up/up(client/user)
+/datum/keybinding/living/look_up/up(client/user, turf/target)
 	. = ..()
 	var/mob/living/L = user.mob
 	L.end_look_up()
@@ -58,7 +58,7 @@
 	description = "Look down at the previous z-level.  Only works if directly above open space."
 	keybind_signal = COMSIG_KB_LIVING_LOOKDOWN_DOWN
 
-/datum/keybinding/living/look_down/down(client/user)
+/datum/keybinding/living/look_down/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -66,7 +66,7 @@
 	L.look_down()
 	return TRUE
 
-/datum/keybinding/living/look_down/up(client/user)
+/datum/keybinding/living/look_down/up(client/user, turf/target)
 	. = ..()
 	var/mob/living/L = user.mob
 	L.end_look_down()
@@ -79,7 +79,7 @@
 	description = "Lay down, or get up."
 	keybind_signal = COMSIG_KB_LIVING_REST_DOWN
 
-/datum/keybinding/living/rest/down(client/user)
+/datum/keybinding/living/rest/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -95,7 +95,7 @@
 	keybind_signal = COMSIG_KB_LIVING_TOGGLE_COMBAT_DOWN
 
 
-/datum/keybinding/living/toggle_combat_mode/down(client/user)
+/datum/keybinding/living/toggle_combat_mode/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -109,7 +109,7 @@
 	description = "Enable combat mode."
 	keybind_signal = COMSIG_KB_LIVING_ENABLE_COMBAT_DOWN
 
-/datum/keybinding/living/enable_combat_mode/down(client/user)
+/datum/keybinding/living/enable_combat_mode/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -123,7 +123,7 @@
 	description = "Disable combat mode."
 	keybind_signal = COMSIG_KB_LIVING_DISABLE_COMBAT_DOWN
 
-/datum/keybinding/living/disable_combat_mode/down(client/user)
+/datum/keybinding/living/disable_combat_mode/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -137,7 +137,7 @@
 	description = "Held down to cycle to the other move intent, release to cycle back"
 	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENT_DOWN
 
-/datum/keybinding/living/toggle_move_intent/down(client/user)
+/datum/keybinding/living/toggle_move_intent/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -145,7 +145,7 @@
 	M.toggle_move_intent()
 	return TRUE
 
-/datum/keybinding/living/toggle_move_intent/up(client/user)
+/datum/keybinding/living/toggle_move_intent/up(client/user, turf/target)
 	. = ..()
 	var/mob/living/M = user.mob
 	M.toggle_move_intent()
@@ -158,7 +158,7 @@
 	description = "Pressing this cycle to the opposite move intent, does not cycle back"
 	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENTALT_DOWN
 
-/datum/keybinding/living/toggle_move_intent_alternative/down(client/user)
+/datum/keybinding/living/toggle_move_intent_alternative/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -9,7 +9,7 @@
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_STOPPULLING_DOWN
 
-/datum/keybinding/mob/stop_pulling/down(client/user)
+/datum/keybinding/mob/stop_pulling/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -27,7 +27,7 @@
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_SWAPHANDS_DOWN
 
-/datum/keybinding/mob/swap_hands/down(client/user)
+/datum/keybinding/mob/swap_hands/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -42,7 +42,7 @@
 	description = "Uses whatever item you have inhand"
 	keybind_signal = COMSIG_KB_MOB_ACTIVATEINHAND_DOWN
 
-/datum/keybinding/mob/activate_inhand/down(client/user)
+/datum/keybinding/mob/activate_inhand/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -57,7 +57,7 @@
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_DROPITEM_DOWN
 
-/datum/keybinding/mob/drop_item/down(client/user)
+/datum/keybinding/mob/drop_item/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -71,7 +71,7 @@
 		user.mob.dropItemToGround(I)
 	return TRUE
 
-/datum/keybinding/mob/target/down(client/user)
+/datum/keybinding/mob/target/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return .
@@ -180,13 +180,13 @@
 	description = "Prevents you from moving"
 	keybind_signal = COMSIG_KB_MOB_BLOCKMOVEMENT_DOWN
 
-/datum/keybinding/mob/prevent_movement/down(client/user)
+/datum/keybinding/mob/prevent_movement/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
 	user.movement_locked = TRUE
 
-/datum/keybinding/mob/prevent_movement/up(client/user)
+/datum/keybinding/mob/prevent_movement/up(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/movement.dm
+++ b/code/datums/keybinding/movement.dm
@@ -37,7 +37,7 @@
 	description = "Moves your character up a z-level if possible"
 	keybind_signal = COMSIG_KB_MOVEMENT_ZLEVEL_MOVEUP_DOWN
 
-/datum/keybinding/movement/zlevel_upwards/down(client/user)
+/datum/keybinding/movement/zlevel_upwards/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -51,7 +51,7 @@
 	description = "Moves your character down a z-level if possible"
 	keybind_signal = COMSIG_KB_MOVEMENT_ZLEVEL_MOVEDOWN_DOWN
 
-/datum/keybinding/movement/zlevel_downwards/down(client/user)
+/datum/keybinding/movement/zlevel_downwards/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/robot.dm
+++ b/code/datums/keybinding/robot.dm
@@ -12,7 +12,7 @@
 	description = "Equips or unequips the first module"
 	keybind_signal = COMSIG_KB_SILICON_TOGGLEMODULEONE_DOWN
 
-/datum/keybinding/robot/moduleone/down(client/user)
+/datum/keybinding/robot/moduleone/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -27,7 +27,7 @@
 	description = "Equips or unequips the second module"
 	keybind_signal = COMSIG_KB_SILICON_TOGGLEMODULETWO_DOWN
 
-/datum/keybinding/robot/moduletwo/down(client/user)
+/datum/keybinding/robot/moduletwo/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -42,7 +42,7 @@
 	description = "Equips or unequips the third module"
 	keybind_signal = COMSIG_KB_SILICON_TOGGLEMODULETHREE_DOWN
 
-/datum/keybinding/robot/modulethree/down(client/user)
+/datum/keybinding/robot/modulethree/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -57,7 +57,7 @@
 	description = "Unequips the active module"
 	keybind_signal = COMSIG_KB_SILICON_UNEQUIPMODULE_DOWN
 
-/datum/keybinding/robot/unequip_module/down(client/user)
+/datum/keybinding/robot/unequip_module/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return
@@ -73,7 +73,7 @@
 	description = "Returns you to your AI core"
 	keybind_signal = COMSIG_KB_SILION_UNDEPLOY_DOWN
 
-/datum/keybinding/robot/undeploy/down(client/user)
+/datum/keybinding/robot/undeploy/down(client/user, turf/target)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -1,6 +1,6 @@
 // Clients aren't datums so we have to define these procs indpendently.
 // These verbs are called for all key press and release events
-/client/verb/keyDown(_key as text)
+/client/verb/keyDown(_key as text, mousepos_x as num, mousepos_y as num, sizex as num, sizey as num)
 	set instant = TRUE
 	set hidden = TRUE
 
@@ -43,7 +43,7 @@
 		return
 
 	if(length(keys_held) >= HELD_KEY_BUFFER_LENGTH && !keys_held[_key])
-		keyUp(keys_held[1]) //We are going over the number of possible held keys, so let's remove the first one.
+		keyUp(keys_held[1], mousepos_x, mousepos_y, sizex, sizey) //We are going over the number of possible held keys, so let's remove the first one.
 
 	//the time a key was pressed isn't actually used anywhere (as of 2019-9-10) but this allows easier access usage/checking
 	keys_held[_key] = world.time
@@ -68,25 +68,31 @@
 				key_combos_held[_key] = full_key
 			else
 				full_key = _key
+
+	var/list/click_data = get_loc_from_mousepos(mousepos_x, mousepos_y, sizex, sizey, src)
+
+	var/turf/test = click_data[1]
+	test.add_atom_colour(COLOR_RED, ADMIN_COLOUR_PRIORITY)
+
 	var/keycount = 0
 	for(var/kb_name in prefs.key_bindings_by_key[full_key])
 		keycount++
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
-		if(kb.can_use(src) && kb.down(src) && keycount >= MAX_COMMANDS_PER_KEY)
+		if(kb.can_use(src) && kb.down(src, click_data[1]) && keycount >= MAX_COMMANDS_PER_KEY)
 			break
 
 	holder?.key_down(_key, src, full_key)
 	mob.focus?.key_down(_key, src, full_key)
 	mob.update_mouse_pointer()
 
-/client/verb/keyUp(_key as text)
+/client/verb/keyUp(_key as text, mousepos_x as num, mousepos_y as num, sizex as num, sizey as num)
 	set instant = TRUE
 	set hidden = TRUE
 
 	var/key_combo = key_combos_held[_key]
 	if(key_combo)
 		key_combos_held -= _key
-		keyUp(key_combo)
+		keyUp(key_combo, mousepos_x, mousepos_y, sizex, sizey)
 
 	if(!keys_held[_key])
 		return
@@ -99,11 +105,12 @@
 		if(!movement_locked && !(next_move_dir_add & movement))
 			next_move_dir_sub |= movement
 
+	var/list/click_data = get_loc_from_mousepos(mousepos_x, mousepos_y, sizex, sizey, src)
 	// We don't do full key for release, because for mod keys you
 	// can hold different keys and releasing any should be handled by the key binding specifically
 	for (var/kb_name in prefs.key_bindings_by_key[_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
-		if(kb.can_use(src) && kb.up(src))
+		if(kb.can_use(src) && kb.up(src, click_data[1]))
 			break
 	holder?.key_up(_key, src)
 	mob.focus?.key_up(_key, src)


### PR DESCRIPTION

## About The Pull Request

Semi WIP cus I need to probably make an issue report for lummox, but apart from that ready for review

Uses the new mouse-pos so we can combine it with screen size and size to estimate very accurately the mouse position in turf terms. In future also will need to add a way to continously poll the users mouse pos but this alone is very useful

## Why It's Good For The Game

This isnt used yet, but the benefits are pretty damn obvious (hitting E and dashing towards where your mouse??? 1990s features?????)

## Changelog
:cl:
refactor: Added the possibility for keybindings to report the turf they clicked on.
/:cl:
