### PR TITLE
[NO GBP] Fixes felinid ears' weird rendering behavior

### DIFF
--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -187,6 +187,7 @@
 
 /datum/bodypart_overlay/mutant/cat_ears/get_image(image_layer, obj/item/bodypart/limb)
 	var/mutable_appearance/base_ears = ..()
+	base_ears.color = (dye_color || draw_color)
 
 	// Only add inner ears on the inner layer
 	if(image_layer != bitflag_to_layer(inner_layer))
@@ -195,19 +196,14 @@
 	// Construct image of inner ears, apply to base ears as an overlay
 	feature_key += "inner"
 	var/mutable_appearance/inner_ears = ..()
-	inner_ears.appearance_flags = RESET_COLOR|KEEP_APART
-	if(limb.cached_color_filter)
-		inner_ears.color = limb.color
-		inner_ears = filter_appearance_recursive(inner_ears, limb.cached_color_filter)
-	if(limb.owner)
-		if(limb.owner.color)
-			inner_ears.color = limb.owner.color
-		if(limb.owner.cached_color_filter)
-			inner_ears = filter_appearance_recursive(inner_ears, limb.owner.cached_color_filter)
 	feature_key = initial(feature_key)
+	var/mutable_appearance/ear_holder = mutable_appearance(layer = image_layer)
+	ear_holder.overlays += base_ears
+	ear_holder.overlays += inner_ears
+	return ear_holder
 
-	base_ears.overlays += inner_ears
-	return base_ears
+/datum/bodypart_overlay/mutant/cat_ears/color_image(image/overlay, layer, obj/item/bodypart/limb)
+	return // We color base ears manually above in get_image
 
 /obj/item/organ/ears/penguin
 	name = "penguin ears"


### PR DESCRIPTION
## About The Pull Request

Kudos to Ephe (00-Steven) for finding this, human overlays should almost never have KEEP_APART on them

![image](https://github.com/user-attachments/assets/6b1bcb6a-fa60-4897-9fc7-beebe48fb62f)

Closes #90491

## Changelog
:cl:
fix: Fixed felinid ears' weird rendering behavior
/:cl:
