### PR TITLE
Fixes photo blurring and tall photos taking up too much space.

### DIFF
--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -98,10 +98,14 @@
 	if(!istype(picture) || !picture.picture_image)
 		to_chat(user, span_warning("[src] seems to be blank..."))
 		return
+	var/width_height = "width"
+	if(picture.psize_y > picture.psize_x)
+		// if we're a tall picture, swap our focus to height to stay in frame
+		width_height = "height"
 	user << browse_rsc(picture.picture_image, "tmp_photo.png")
 	user << browse("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>[name]</title></head>" \
 		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
-		+ "<img src='tmp_photo.png' width='480' style='-ms-interpolation-mode:nearest-neighbor' />" \
+		+ "<img src='tmp_photo.png' [width_height]='480' style='-ms-interpolation-mode:nearest-neighbor; image-rendering:pixelated' />" \
 		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]"\
 		+ "</body></html>", "window=photo_showing;size=480x608")
 	onclose(user, "[name]")

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -105,7 +105,7 @@
 	user << browse_rsc(picture.picture_image, "tmp_photo.png")
 	user << browse("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>[name]</title></head>" \
 		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
-		+ "<img src='tmp_photo.png' [width_height]='480' style='-ms-interpolation-mode:nearest-neighbor; image-rendering:pixelated' />" \
+		+ "<img src='tmp_photo.png' [width_height]='480' style='image-rendering:pixelated' />" \
 		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]"\
 		+ "</body></html>", "window=photo_showing;size=480x608")
 	onclose(user, "[name]")


### PR DESCRIPTION

## About The Pull Request

Because we default the picture to a width of 480 in the html, photos with a `psize_y` greater than their `psize_x` would auto-calculate their height such that they extend further than the window reaches.
We fix this by making it so in that case we instead set the *height* to 480 and let it auto-calculate width.
Setting both height and width to 480 just makes the image inflate to fill the box, which isn't desirable.

Then, on 516 images were now blurred. We fix this by adding `image-rendering:pixelated` to the style such that the new browser stuff actually does what we want it to.
## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/f2697f9a-f627-4035-984f-7a29a83dcb16)
## Changelog
:cl:
fix: Pictures are no longer blurry.
fix: Tall pictures no longer get cut off and are actually the right height.
/:cl:
