### PR TITLE
Kheiral Cuffs announce when you are gibbed

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -212,12 +212,12 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 		broadcast(msg, channels, command_span)
 
 /// Returns a random announcement system that is operational, has the specified config entry, signal can reach source and radio supports any channel in list. Config entry, source and channels are optional.
-/proc/get_announcement_system(aas_config_entry_type, source, list/channels)
+/proc/get_announcement_system(aas_config_entry_type, source, list/channels, ignore_z)
 	if (!GLOB.announcement_systems.len)
 		return null
 	var/list/intact_aass = list()
 	for(var/obj/machinery/announcement_system/announce as anything in GLOB.announcement_systems)
-		if(!QDELETED(announce) && announce.is_operational && announce.has_supported_channels(channels) && announce.can_be_reached_from(source))
+		if(!QDELETED(announce) && announce.is_operational && announce.has_supported_channels(channels) && (announce.can_be_reached_from(source) || ignore_z))
 			if(aas_config_entry_type)
 				var/datum/aas_config_entry/entry = locate(aas_config_entry_type) in announce.config_entries
 				if(!entry || !entry.enabled)
@@ -226,9 +226,9 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	return intact_aass.len ? pick(intact_aass) : null
 
 /// Announces the provided message with the provided variables and config entry type. Channels, announcement_line, command_span and source are optional.
-/proc/aas_config_announce(aas_config_entry_type, list/variables_map, source, list/channels, announcement_line, command_span)
-	var/obj/machinery/announcement_system/announcer = get_announcement_system(aas_config_entry_type, source, channels)
-	if (!announcer)
+/proc/aas_config_announce(aas_config_entry_type, list/variables_map, source, list/channels, announcement_line, command_span, ignore_z)
+	var/obj/machinery/announcement_system/announcer = get_announcement_system(aas_config_entry_type, source, channels, ignore_z)
+	if(!announcer)
 		return
 	announcer.announce(aas_config_entry_type, variables_map, channels, announcement_line, command_span)
 

--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -73,6 +73,7 @@
 		return
 	balloon_alert(user, "gps de-activated")
 	REMOVE_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
+	UnregisterSignal(user, COMSIG_LIVING_GIBBED)
 	gps_enabled = FALSE
 
 /// If we're off the Z-level, set far_from_home = TRUE. If being worn, trigger kheiral_network proc


### PR DESCRIPTION

## About The Pull Request
Cargo gets a message saying if you've been gibbed, and whether or not your brain was dropped.

![image](https://github.com/user-attachments/assets/7b474992-680f-4aca-bcb9-201d4decdab3)
## Why It's Good For The Game
One of the larger criticisms I'd seen with the cuffs is that they become relatively useless if your cause of death was from a megafauna, which more or less gibs you immediately.

If your cause of death wasn't a gibbing then it still only connects you to the station's suit sensors, no big announcement there.

Edit: I have been informed megafauna no longer gib you. It should be very clear I'm not a mining main by the fact I made a thing that tells the station when miners die. Even without that, I still think it's a good idea to be able to communicate that you've been gibbed to the station if you're off the Z level.

## Changelog
:cl: Wallem
qol: Kheiral Cuffs now inform Cargo if your body has been gibbed off-station.
/:cl:
