### PR TITLE
Adds a message that reminds AIs how to speak through Holopads during ionospheric anomalies

### DIFF
--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -21,6 +21,7 @@
 
 	for(var/mob/living/silicon/ai/A in GLOB.ai_list) //AIs are always aware of communication blackouts.
 		to_chat(A, "<br>[span_warning("<b>[alert]</b>")]<br>")
+		to_chat(A, span_notice("Remember, you can transmit over holopads by right clicking on them, and can speak through them with \".[/datum/saymode/holopad::key]\"."))
 
 	if(prob(30) || fake) //most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
 		priority_announce(alert, "Anomaly Alert")


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/tgstation/pull/89666 but it compiles, and has a proper changelog.

## Why It's Good For The Game

It's good to teach players how to use mechanics like this when it's appropriate and unobtrusive. 

## Changelog

:cl:
qol: Added a reminder message for AIs about how to use holopads during communication blackouts. 
/:cl:
