### PR TITLE
Add rare chance of thunder for ash storms on lavaland

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -20,8 +20,9 @@
 	target_trait = ZTRAIT_ASHSTORM
 	immunity_type = TRAIT_ASHSTORM_IMMUNE
 	probability = 90
+	turf_thunder_chance = THUNDER_CHANCE_VERY_RARE
 
-	weather_flags = (WEATHER_MOBS | WEATHER_BAROMETER)
+	weather_flags = (WEATHER_MOBS | WEATHER_BAROMETER | WEATHER_THUNDER)
 
 	var/list/weak_sounds = list()
 	var/list/strong_sounds = list()
@@ -81,6 +82,6 @@
 	end_message = span_notice("The emberfall slows, stops. Another layer of hardened soot to the basalt beneath your feet.")
 	end_sound = null
 
-	weather_flags = parent_type::weather_flags & ~WEATHER_MOBS
+	weather_flags = parent_type::weather_flags & ~(WEATHER_MOBS|WEATHER_THUNDER)
 
 	probability = 10

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -21,6 +21,7 @@
 	immunity_type = TRAIT_ASHSTORM_IMMUNE
 	probability = 90
 	turf_thunder_chance = THUNDER_CHANCE_VERY_RARE
+	thunder_color = "#7a0000"
 
 	weather_flags = (WEATHER_MOBS | WEATHER_BAROMETER | WEATHER_THUNDER)
 


### PR DESCRIPTION
## About The Pull Request
This adds `THUNDER_CHANCE_VERY_RARE` for a thunder strike to occur on lavaland during ash storms. The chance is 1 in 50,000, which is rare enough for it to occur a few times during an ash storm. The emberfalls storm does not have thunder strikes applied. I also went ahead and colored the thunder red, to go with the red color of the mining turf colors as requested by:

![Discord_zBq1WlovrU](https://github.com/user-attachments/assets/11ea9b16-4cea-468d-adae-0607da88edd2)


## Why It's Good For The Game
Fun little rare event to make ash storms cool. 

You might wonder why we don't increase the chance? Since lavaland is really only used by a few players during a round, it is a good idea to minimize the amount of turf processing that is done. By making it very rare, the calculations average about ~`1.18` turfs being processed per tick for the entire z-level.

![Code_HdVqgjWtnN](https://github.com/user-attachments/assets/ec576348-b85f-4db5-97eb-4c6bbb5de118)


## Changelog
:cl:
add: Add rare chance of thunder strikes during ash storms on lavaland
/:cl:
