### PR TITLE
Genetic mutation injectors will not use a charge when spent on incompatible mobs

### DIFF
--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -94,6 +94,7 @@
 
 	if(!inject(target, user)) //Now we actually do the heavy lifting.
 		to_chat(user, span_notice("It appears that [target] does not have compatible DNA."))
+		return
 
 	used = TRUE
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

This makes it so incompatible DNA injectors do not expend a charge when used on an incompatible mob.
## Why It's Good For The Game

This shouldn't burn a charge. It should be a warning message.
## Changelog
:cl: Rhials
fix: Mutation injectors used on incompatible mobs will no longer burn a charge.
/:cl:
