### PR TITLE
Fixes runtimes caused by get_atom_on_turf and reverts an unintentional balance change to stabilized crossbreeds

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 			data["x"] = disk_turf.x
 			data["y"] = disk_turf.y
 			data["z"] = disk_turf.z
-		var/atom/outer = get_atom_on_turf(nuke_disk, /mob/living)
+		var/atom/outer = get_atom_on_turf(nuke_disk, /mob/living, TRUE)
 		if(outer != nuke_disk)
 			if(isliving(outer))
 				var/mob/living/disk_holder = outer

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -121,9 +121,10 @@ Turf and target are separate in case you want to teleport some distance from a t
 	while(topmost_thing?.loc && !isturf(topmost_thing.loc))
 		topmost_thing = topmost_thing.loc
 		if(stop_type && istype(topmost_thing, stop_type))
-			break
+			return topmost_thing
 
-	return topmost_thing
+	if (!stop_type)
+		return topmost_thing
 
 ///Returns the turf located at the map edge in the specified direction relative to target_atom used for mass driver
 /proc/get_edge_target_turf(atom/target_atom, direction)

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -110,9 +110,10 @@ Turf and target are separate in case you want to teleport some distance from a t
  *
  * Arguments
  * * something_in_turf - a movable within the turf, somewhere.
- * * stop_type - optional - stops looking if stop_type is found in the turf, returning that type (if found).
+ * * stop_type - stops looking if stop_type is found in the turf, returning that type (if found).
+ * * return_any - if set to TRUE, will return last movable found even if its not of the passed type
  **/
-/proc/get_atom_on_turf(atom/movable/something_in_turf, stop_type)
+/proc/get_atom_on_turf(atom/movable/something_in_turf, stop_type = null, return_any = FALSE)
 	if(!istype(something_in_turf))
 		CRASH("get_atom_on_turf was not passed an /atom/movable! Got [isnull(something_in_turf) ? "null":"type: [something_in_turf.type]"]")
 
@@ -123,7 +124,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if(stop_type && istype(topmost_thing, stop_type))
 			return topmost_thing
 
-	if (!stop_type)
+	if (!stop_type || return_any)
 		return topmost_thing
 
 ///Returns the turf located at the map edge in the specified direction relative to target_atom used for mass driver

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -102,7 +102,7 @@
 	else
 		adjust_bloodthirst(1 * seconds_per_tick) //don't cool off rapidly once we're at the point where His Grace consumes all.
 	var/mob/living/master = get_atom_on_turf(src, /mob/living)
-	if(istype(master) && (src in master.held_items))
+	if(!isnull(master) && (src in master.held_items))
 		switch(bloodthirst)
 			if(HIS_GRACE_CONSUME_OWNER to HIS_GRACE_FALL_ASLEEP)
 				master.visible_message(span_boldwarning("[src] turns on [master]!"), "<span class='his_grace big bold'>[src] turns on you!</span>")
@@ -216,6 +216,8 @@
 /obj/item/his_grace/proc/update_stats()
 	REMOVE_TRAIT(src, TRAIT_NODROP, HIS_GRACE_TRAIT)
 	var/mob/living/master = get_atom_on_turf(src, /mob/living)
+	if (isnull(master))
+		return
 	switch(bloodthirst)
 		if(HIS_GRACE_CONSUME_OWNER to HIS_GRACE_FALL_ASLEEP)
 			if(HIS_GRACE_CONSUME_OWNER > prev_bloodthirst)

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -76,7 +76,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		to_chat(target, span_warning("You aren't able to activate \the [src] anymore!"))
 
 	// Has the user thrown it away or otherwise disposed of it such that it's no longer in their hands or in some storage connected to them?
-	if(!(get_atom_on_turf(src, /mob) == user))
+	if(get_atom_on_turf(src, /mob) != user)
 		if(user == target)
 			to_chat(user, span_warning("\The [src] is no longer in your possession!"))
 		else

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -463,7 +463,7 @@
 	if(isnull(linked_extract))
 		qdel(src)
 		return
-	if(get_atom_on_turf(linked_extract, /mob/living) == owner)
+	if(linked_extract.get_held_mob() == owner)
 		return
 	owner.balloon_alert(owner, "[colour] extract faded!")
 	if(!QDELETED(linked_extract))

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -22,8 +22,25 @@ Stabilized extracts:
 	qdel(linked_effect)
 	return ..()
 
+/// Returns the mob that is currently holding us if we are either in their inventory or a backpack analogue.
+/// Returns null if it's in an invalid location, so that we can check explicitly for null later.
+/obj/item/slimecross/stabilized/proc/get_held_mob()
+	if(isnull(loc))
+		return null
+	if(isliving(loc))
+		return loc
+	// Snowflake check for modsuit backpacks, which should be valid but are 3 rather than 2 steps from the owner
+	if(istype(loc, /obj/item/mod/module/storage))
+		var/obj/item/mod/module/storage/mod_backpack = loc
+		var/mob/living/modsuit_wearer = mod_backpack.mod?.wearer
+		return modsuit_wearer ? modsuit_wearer : null
+	var/nested_loc = loc.loc
+	if (isliving(nested_loc))
+		return nested_loc
+	return null
+
 /obj/item/slimecross/stabilized/process()
-	var/mob/living/holder = get_atom_on_turf(src, /mob/living)
+	var/mob/living/holder = get_held_mob()
 	if(isnull(holder))
 		return
 	var/effectpath = /datum/status_effect/stabilized


### PR DESCRIPTION

## About The Pull Request

get_atom_on_turf would return the last movable in chain, even if it was passed a type, which is not the behavior most people would expect and thus had led to errors in multiple other segments of code. Additionally, #90436 also has unintentionally made stabilized crossbreeds work regardless of their storage depth which was an intentional limiter - this restores said behavior.

- Closes #90498
- Closes #90497

## Why It's Good For The Game

Runtimes bad, and so are unintentional change to game's balance. 

## Changelog
:cl:
fix: Fixed runtimes caused by stabilized crossbreeds
fix: Fixed an unintentional buff to stabilized crossbreeds, they now once again need to be put in your backpack or pockets.
/:cl:
