### PR TITLE
Fixes roundend report not opening

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -113,6 +113,9 @@
 		to_chat(user, span_userdanger("The [title] browser you tried to open failed a sanity check! Please report this on GitHub!"))
 		return
 	var/window_size = ""
+	if(IS_CLIENT_OR_MOCK(user))
+		var/client/client_user = user
+		user = client_user.mob
 	if(width && height)
 		if(user.client?.prefs?.read_preference(/datum/preference/toggle/ui_scale))
 			var/scaling = user.client.window_scaling
@@ -125,7 +128,7 @@
 		SSassets.transport.send_assets(user, stylesheets)
 	if (scripts.len)
 		SSassets.transport.send_assets(user, scripts)
-	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
+	DIRECT_OUTPUT(user, browse(get_content(), "window=[window_id];[window_size][window_options]"))
 	if (use_onclose)
 		setup_onclose()
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -14,7 +14,11 @@
 	var/content = ""
 
 /datum/browser/New(nuser, nwindow_id, ntitle = 0, nwidth = 0, nheight = 0, atom/nref = null)
-	user = nuser
+	if(IS_CLIENT_OR_MOCK(nuser))
+		var/client/client_user = user
+		user = client_user.mob
+	else
+		user = nuser
 	RegisterSignal(user, COMSIG_QDELETING, PROC_REF(user_deleted))
 	window_id = nwindow_id
 	if (ntitle)
@@ -113,9 +117,6 @@
 		to_chat(user, span_userdanger("The [title] browser you tried to open failed a sanity check! Please report this on GitHub!"))
 		return
 	var/window_size = ""
-	if(IS_CLIENT_OR_MOCK(user))
-		var/client/client_user = user
-		user = client_user.mob
 	if(width && height)
 		if(user.client?.prefs?.read_preference(/datum/preference/toggle/ui_scale))
 			var/scaling = user.client.window_scaling

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -15,7 +15,7 @@
 
 /datum/browser/New(nuser, nwindow_id, ntitle = 0, nwidth = 0, nheight = 0, atom/nref = null)
 	if(IS_CLIENT_OR_MOCK(nuser))
-		var/client/client_user = user
+		var/client/client_user = nuser
 		user = client_user.mob
 	else
 		user = nuser


### PR DESCRIPTION
## About The Pull Request

I was working with something that affects the roundend report and found out it runtimes when trying to open and simply does not open.
Culprit is https://github.com/tgstation/tgstation/pull/90418 which assumes user in any given browser is a mob, when in the case of the roundend report it's a client. I'm not sure if we got any other browsers that do this so I just went for the catchall approach of checking if user is a client and if so, get the mob.

## Why It's Good For The Game

Roundend report now works again, and any other browser that may have been sending client instead of mob.

Fixes https://github.com/tgstation/tgstation/issues/90493

## Changelog

:cl:
fix: Roundend reports now show up again.
/:cl: