### PR TITLE
Adds the captain to the security department list.

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -30,6 +30,7 @@
 	department_for_prefs = /datum/job_department/captain
 	departments_list = list(
 		/datum/job_department/command,
+		/datum/job_department/security,
 	)
 
 	family_heirlooms = list(/obj/item/reagent_containers/cup/glass/flask/gold, /obj/item/toy/captainsaid/collector)


### PR DESCRIPTION
## About The Pull Request

Does what it says in the title.

## Why It's Good For The Game

In very many instances, captain gets slapped with security responsibilities either during a security deficit, or as an authority in security matters. 

We actually use department lists to determine whether or not a role is included in things such as our banning panel under certain grouped roles, like security. 

Rather than create a potential problem that can result from this, we can just include captain in the security list so that they get grouped together with security.

## Changelog
:cl:
admin: Adds Security as one of the captain's departments, ensuring that departmental bans also include the captain, who is an effective member of security.
/:cl:
