### PR TITLE
Fixes accessories getting endlessly offset into oblivion after repeated attachment

### DIFF
--- a/code/modules/clothing/under/accessories/_accessories.dm
+++ b/code/modules/clothing/under/accessories/_accessories.dm
@@ -143,6 +143,9 @@
 
 	if(minimize_when_attached)
 		transform *= 2
+		// Reset our visual offset
+		pixel_w = 0
+		pixel_z = 0
 		// just randomize position
 		pixel_x = rand(4, -4)
 		pixel_y = rand(4, -4)

--- a/code/modules/clothing/under/accessories/_accessories.dm
+++ b/code/modules/clothing/under/accessories/_accessories.dm
@@ -143,7 +143,7 @@
 
 	if(minimize_when_attached)
 		transform *= 2
-		// Reset our visual offset
+		// Reset our applied offset
 		pixel_w = 0
 		pixel_z = 0
 		// just randomize position


### PR DESCRIPTION

## About The Pull Request

So a lot of accessories when applied to an outfit shrink and offset themselves.
A recent `pixel_x/y`>`pixel_w/z` transition pr seems to have adjusted the offset used to instead use `pixel_w/z`, but didn't actually adjust the *resetting* part to use `pixel_w/z` as well. This caused the offsets to slowly accumulate, further and further offsetting the accessory.

We fix this by adding two lines resetting our `pixel_w/z` offset.
We don't remove or rename the `pixel_x/y` part, because that is still needed to randomly offset our position when dropped, and we don't use `pixel_w/z` for that as of writing.
## Why It's Good For The Game

Fixes #90492.
## Changelog
:cl:
fix: Fixed accessories getting slowly but surely offset further down-right each time you attached them to an outfit.
/:cl:
