### PR TITLE
Stops the squeak component from playing step sounds when you are not walking

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -85,7 +85,7 @@
 	var/mob/living/carbon/human/owner = source.loc
 	if(CHECK_MOVE_LOOP_FLAGS(owner, MOVEMENT_LOOP_OUTSIDE_CONTROL))
 		return
-	if(owner.buckled || owner.throwing || owner.movement_type & (VENTCRAWLING | FLYING) || HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
+	if(owner.buckled || owner.throwing || (owner.movement_type & (VENTCRAWLING | FLYING)) || HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
 		return
 	if(steps > step_delay)
 		play_squeak()

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -85,6 +85,8 @@
 	var/mob/living/carbon/human/owner = source.loc
 	if(CHECK_MOVE_LOOP_FLAGS(owner, MOVEMENT_LOOP_OUTSIDE_CONTROL))
 		return
+	if(owner.buckled || owner.throwing || owner.movement_type & (VENTCRAWLING | FLYING) || HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
+		return
 	if(steps > step_delay)
 		play_squeak()
 		steps = 0


### PR DESCRIPTION
## About The Pull Request

Tin. When you're in a wheel chair/etc and wearing shoes that squeak, the step sound effect plays even though you're not moving using your feet.
This fixes that probable oversight?

## Why It's Good For The Game

The Immersion

## Changelog

:cl:
fix: shoes with the squeak component will no longer play a squeaking sound when you aren't actually walking (like in a wheelchair for instance)
/:cl:
