### PR TITLE
Fixes persistent paintings load order

### DIFF
--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -94,6 +94,9 @@
 SUBSYSTEM_DEF(persistent_paintings)
 	name = "Persistent Paintings"
 	flags = SS_NO_FIRE
+	dependencies = list(
+		/datum/controller/subsystem/persistence,
+	)
 
 	/// A list of painting frames that this controls
 	var/list/obj/structure/sign/painting/painting_frames = list()


### PR DESCRIPTION
## About The Pull Request

Persistent paintings should be loaded after persistence itself

## Why It's Good For The Game

Bugfix confirmed to be working (test merging this fix live currently).

## Changelog

:cl:
fix: fixes persistent paintings not loading
/:cl:
