### PR TITLE
Fixes worn offsets gradually compounding

### DIFF
--- a/code/modules/surgery/bodyparts/worn_feature_offset.dm
+++ b/code/modules/surgery/bodyparts/worn_feature_offset.dm
@@ -43,12 +43,8 @@
 /// Applies the current offset to a provided overlay image
 /datum/worn_feature_offset/proc/apply_offset(image/overlay)
 	var/list/offset = get_offset()
-
-	// Reset our applied offset
-	overlay.pixel_w = 0
-	overlay.pixel_z = 0
-	overlay.pixel_w += offset["x"]
-	overlay.pixel_z += offset["y"]
+	overlay.pixel_w = offset["x"]
+	overlay.pixel_z = offset["y"]
 
 /// When the owner of the bodypart changes, update our signal registrations
 /datum/worn_feature_offset/proc/changed_owner(obj/item/bodypart/part, mob/living/new_owner, mob/living/old_owner)

--- a/code/modules/surgery/bodyparts/worn_feature_offset.dm
+++ b/code/modules/surgery/bodyparts/worn_feature_offset.dm
@@ -43,6 +43,10 @@
 /// Applies the current offset to a provided overlay image
 /datum/worn_feature_offset/proc/apply_offset(image/overlay)
 	var/list/offset = get_offset()
+
+	// Reset our applied offset
+	overlay.pixel_w = 0
+	overlay.pixel_z = 0
 	overlay.pixel_w += offset["x"]
 	overlay.pixel_z += offset["y"]
 


### PR DESCRIPTION
## About The Pull Request

Similar to https://github.com/tgstation/tgstation/pull/90512 this should be resetting each time. It's not really a common issue here because there are very few worn item offsets on TG.

## Why It's Good For The Game

## Changelog

:cl:
fix: fixes the worn offset of certain items with worn offsets potentially drifting away with each equip
/:cl: