### PR TITLE
Fixes the flipped table spawners

### DIFF
--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -386,12 +386,12 @@ again.
 
 /obj/effect/spawner/structure/flipped_table/Initialize(mapload)
 	. = ..()
-	var/obj/structure/table/table_to_flipped = new table_to_spawn(loc)
-	table_to_flipped.dir = dir
-	RegisterSignal(table_to_flipped, COMSIG_ATOM_SMOOTHED_ICON, PROC_REF(on_icon_smoothed))
+	var/obj/structure/table/table_to_flip = new table_to_spawn(loc)
+	table_to_flip.dir = dir
+	RegisterSignal(table_to_flip, COMSIG_ATOM_SMOOTHED_ICON, PROC_REF(on_icon_smoothed))
 
 /// The flip_table() proc HAS to be run after smooth_icon() is completed or else we will get runtimes.
-/obj/effect/spawner/structure/flipped_table/proc/on_icon_smoothed(obj/structure/table/table_to_flipped)
+/obj/effect/spawner/structure/flipped_table/proc/on_icon_smoothed(obj/structure/table/table_to_flip)
 	SIGNAL_HANDLER
-	table_to_flipped.flip_table(table_to_flipped.dir)
-	UnregisterSignal(table_to_flipped, COMSIG_ATOM_SMOOTHED_ICON)
+	table_to_flip.flip_table(table_to_flip.dir)
+	UnregisterSignal(table_to_flip, COMSIG_ATOM_SMOOTHED_ICON)

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -388,5 +388,9 @@ again.
 	. = ..()
 	var/obj/structure/table/table_to_flipped = new table_to_spawn(loc)
 	table_to_flipped.dir = dir
-	table_to_flipped.flip_table()
+	RegisterSignal(table_to_flipped, COMSIG_ATOM_SMOOTHED_ICON, PROC_REF(on_icon_smoothed))
 
+/obj/effect/spawner/structure/flipped_table/proc/on_icon_smoothed(obj/structure/table/table_to_flipped)
+	SIGNAL_HANDLER
+	table_to_flipped.flip_table(table_to_flipped.dir)
+	UnregisterSignal(table_to_flipped, COMSIG_ATOM_SMOOTHED_ICON)

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -390,6 +390,7 @@ again.
 	table_to_flipped.dir = dir
 	RegisterSignal(table_to_flipped, COMSIG_ATOM_SMOOTHED_ICON, PROC_REF(on_icon_smoothed))
 
+/// The flip_table() proc HAS to be run after smooth_icon() is completed or else we will get runtimes.
 /obj/effect/spawner/structure/flipped_table/proc/on_icon_smoothed(obj/structure/table/table_to_flipped)
 	SIGNAL_HANDLER
 	table_to_flipped.flip_table(table_to_flipped.dir)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -78,7 +78,7 @@
 	ADD_TRAIT(src, TRAIT_COMBAT_MODE_SKIP_INTERACTION, INNATE_TRAIT)
 
 	if(can_flip && is_flipped)
-		flip_table()
+		flip_table(dir)
 		return
 
 	make_climbable()
@@ -121,7 +121,7 @@
 	is_flipped = FALSE
 
 //proc that removes elements present in now-flipped tables
-/obj/structure/table/proc/flip_table(new_dir)
+/obj/structure/table/proc/flip_table(new_dir = SOUTH)
 	playsound(src, 'sound/items/trayhit/trayhit1.ogg', 100)
 	RemoveElement(/datum/element/climbable)
 	RemoveElement(/datum/element/footstep_override, priority = STEP_SOUND_TABLE_PRIORITY)


### PR DESCRIPTION
## About The Pull Request

They weren't actually working turns out. There was a race condition with icon smoothing, so it needs to be flipped after the table gets smoothed. On top of that the dir wasn't being passed properly.

## Why It's Good For The Game

Stuff that actually works!

This will allow for things like this on mapload:

![image](https://github.com/user-attachments/assets/372297d7-2a30-4d85-8e89-91d14fd584d7)


## Changelog

:cl:
fix: fixes flipped table spawners not initializing correctly
/:cl: