### PR TITLE
Partially fixes emissives not transforming with their parent

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -91,8 +91,8 @@ GLOBAL_LIST_INIT(emissive_color, EMISSIVE_COLOR)
 GLOBAL_LIST_INIT(em_block_color, EM_BLOCK_COLOR)
 
 /// A set of appearance flags applied to all emissive and emissive blocker overlays.
-/// KEEP_APART to prevent parent hooking, KEEP_TOGETHER for children, and we reset the color and alpha of our parent so nothing gets overridden
-#define EMISSIVE_APPEARANCE_FLAGS (KEEP_APART|KEEP_TOGETHER|RESET_COLOR|RESET_ALPHA)
+/// KEEP_APART to prevent parent hooking, KEEP_TOGETHER for children, and we reset the color of our parent so emissives get proper coloring based on [EMISSIVE_COLOR]
+#define EMISSIVE_APPEARANCE_FLAGS (KEEP_APART|KEEP_TOGETHER|RESET_COLOR)
 /// The color matrix used to mask out emissive blockers on the emissive plane. Alpha should default to zero, be solely dependent on the RGB value of [EMISSIVE_COLOR], and be independent of the RGB value of [EM_BLOCK_COLOR].
 #define EM_MASK_MATRIX list(0,0,0,1/3, 0,0,0,1/3, 0,0,0,1/3, 0,0,0,0, 1,1,1,0)
 /// A globally cached version of [EM_MASK_MATRIX] for quick access.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -128,6 +128,14 @@
 	/// Example: If req_one_access = list(ACCESS_ENGINE, ACCESS_CE)- then the user must have either ACCESS_ENGINE or ACCESS_CE in order to use the object.
 	var/list/req_one_access
 
+/mutable_appearance/emissive_blocker
+
+/mutable_appearance/emissive_blocker/New()
+	. = ..()
+	// Need to do this here because it's overridden by the parent call
+	// This is a microop which is the sole reason why this child exists, because its static this is a really cheap way to set color without setting or checking it every time we create an atom
+	color = EM_BLOCK_COLOR
+
 /atom/movable/Initialize(mapload, ...)
 	. = ..()
 #ifdef UNIT_TESTS
@@ -159,13 +167,12 @@
 			else
 				managed_overlays = em_block
 	else
-		var/static/mutable_appearance/blocker = new()
+		var/static/mutable_appearance/emissive_blocker/blocker = new()
 		blocker.icon = icon
 		blocker.icon_state = icon_state
 		blocker.dir = dir
-		blocker.color = EM_BLOCK_COLOR
 		blocker.appearance_flags = appearance_flags | EMISSIVE_APPEARANCE_FLAGS
-		SET_PLANE_EXPLICIT(blocker, EMISSIVE_PLANE, src)
+		blocker.plane = GET_NEW_PLANE(EMISSIVE_PLANE, PLANE_TO_OFFSET(plane)) // Flattens the micro for a microop
 		// Ok so this is really cursed, but I want to set with this blocker cheaply while
 		// Still allowing it to be removed from the overlays list later
 		// So I'm gonna flatten it, then insert the flattened overlay into overlays AND the managed overlays list, directly

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -128,14 +128,6 @@
 	/// Example: If req_one_access = list(ACCESS_ENGINE, ACCESS_CE)- then the user must have either ACCESS_ENGINE or ACCESS_CE in order to use the object.
 	var/list/req_one_access
 
-/mutable_appearance/emissive_blocker
-
-/mutable_appearance/emissive_blocker/New()
-	. = ..()
-	// Need to do this here because it's overridden by the parent call
-	color = EM_BLOCK_COLOR
-	appearance_flags = EMISSIVE_APPEARANCE_FLAGS
-
 /atom/movable/Initialize(mapload, ...)
 	. = ..()
 #ifdef UNIT_TESTS
@@ -167,12 +159,13 @@
 			else
 				managed_overlays = em_block
 	else
-		var/static/mutable_appearance/emissive_blocker/blocker = new()
+		var/static/mutable_appearance/blocker = new()
 		blocker.icon = icon
 		blocker.icon_state = icon_state
 		blocker.dir = dir
-		blocker.appearance_flags |= appearance_flags
-		blocker.plane = GET_NEW_PLANE(EMISSIVE_PLANE, PLANE_TO_OFFSET(plane))
+		blocker.color = EM_BLOCK_COLOR
+		blocker.appearance_flags = appearance_flags | EMISSIVE_APPEARANCE_FLAGS
+		SET_PLANE_EXPLICIT(blocker, EMISSIVE_PLANE, src)
 		// Ok so this is really cursed, but I want to set with this blocker cheaply while
 		// Still allowing it to be removed from the overlays list later
 		// So I'm gonna flatten it, then insert the flattened overlay into overlays AND the managed overlays list, directly

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -172,7 +172,7 @@
 		blocker.icon_state = icon_state
 		blocker.dir = dir
 		blocker.appearance_flags = appearance_flags | EMISSIVE_APPEARANCE_FLAGS
-		blocker.plane = GET_NEW_PLANE(EMISSIVE_PLANE, PLANE_TO_OFFSET(plane)) // Flattens the micro for a microop
+		blocker.plane = GET_NEW_PLANE(EMISSIVE_PLANE, PLANE_TO_OFFSET(plane)) // Takes a light path through the normal macro for a microop
 		// Ok so this is really cursed, but I want to set with this blocker cheaply while
 		// Still allowing it to be removed from the overlays list later
 		// So I'm gonna flatten it, then insert the flattened overlay into overlays AND the managed overlays list, directly

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -153,7 +153,7 @@
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
 		/datum/reagent/consumable/sugar = 3,
-		/datum/reagent/consumable/italian_coco = 3,
+		/datum/reagent/consumable/hot_coco = 3,
 		/datum/reagent/consumable/sprinkles = 1,
 	) //the coco reagent is just bitter.
 	tastes = list("donut" = 4, "bitterness" = 1)

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -153,7 +153,7 @@
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
 		/datum/reagent/consumable/sugar = 3,
-		/datum/reagent/consumable/hot_coco = 3,
+		/datum/reagent/consumable/italian_coco = 3,
 		/datum/reagent/consumable/sprinkles = 1,
 	) //the coco reagent is just bitter.
 	tastes = list("donut" = 4, "bitterness" = 1)


### PR DESCRIPTION
## About The Pull Request

### This fix currently does not work on mobs, or a lot of objects, due to a [BYOND bug](https://www.byond.com/forum/post/2969321) involving nested overlays

Incorrect assumption led to the standard emissive blocker very quickly stacking all existing appearance flags, which caused it to get RESET_TRANSFORM and stop rotating with the parent. This fixes that.

Additionally, removed RESET_ALPHA from emissives - this should improve how they look on items with changed alpha and stop them from oddly lighting the turf behind.

## Why Is This Good For The Game

Emissives ignoring parent's alpha makes them look really weird when parent's alpha is not 255, as they end up weirdly lighting the turf behind. Same with emissive blockers, creating weird looking shadow blobs in space.

## Changelog
:cl:
fix: Fixed rotated objects having odd shadows or not blocking emissives/space light when they should.
qol: Emissives now inherit object's transparency.
/:cl:
