### PR TITLE
[NO GBP] Fixes camera consoles crashing clients 

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -188,6 +188,14 @@
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
 
+/datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
+	if(viewing_hud.master_groups[key])
+		stack_trace("Key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob].")
+		return
+
+	set_hud(viewing_hud)
+	show_hud()
+
 /datum/plane_master_group/popup/build_planes_offset(datum/hud/source, new_offset, use_scale = TRUE)
 	return ..(source, new_offset, FALSE)
 

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -193,6 +193,8 @@
 		stack_trace("Key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob].")
 		return
 
+	relay_loc = "1,1"
+	rebuild_plane_masters()
 	set_hud(viewing_hud)
 	show_hud()
 

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -15,7 +15,7 @@
 	var/map = ""
 	/// Controls the screen_loc that owned plane masters will use when generating relays. Due to a Byond bug, relays using the CENTER positional loc
 	/// Will be improperly offset
-	var/relay_loc = "SCREEN_SOUTHWEST"
+	var/relay_loc = "1,1"
 
 /datum/plane_master_group/New(key, map = "")
 	. = ..()
@@ -187,18 +187,6 @@
 /// This is because it's annoying to get turfs to position inside it correctly
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
-
-// This code somehow prevents windows with byond stuff in them from crashing clients when closing said window
-// rebuild_plane_masters() is a must have here. Without it crash happen on live servers, but not locally
-/datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
-	if(viewing_hud.master_groups[key])
-		stack_trace("Key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob].")
-		return
-
-	relay_loc = "SCREEN_SOUTHWEST"
-	rebuild_plane_masters()
-	set_hud(viewing_hud)
-	show_hud()
 
 /datum/plane_master_group/popup/build_planes_offset(datum/hud/source, new_offset, use_scale = TRUE)
 	return ..(source, new_offset, FALSE)

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -195,7 +195,7 @@
 		stack_trace("Key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob].")
 		return
 
-	relay_loc = "1,1"
+	relay_loc = "SCREEN_SOUTHWEST"
 	rebuild_plane_masters()
 	set_hud(viewing_hud)
 	show_hud()

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -188,6 +188,8 @@
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
 
+// This code somehow prevents windows with byond stuff in them from crashing clients when closing said window
+// rebuild_plane_masters() is a must have here. Without it crash happen on live servers, but not locally
 /datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
 	if(viewing_hud.master_groups[key])
 		stack_trace("Key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob].")

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -393,7 +393,7 @@
  * Other vars such as alpha will automatically be applied with the render source
  */
 /atom/movable/screen/plane_master/proc/generate_render_relays()
-	var/relay_loc = home?.relay_loc || "SCREEN_SOUTHWEST"
+	var/relay_loc = home?.relay_loc || "1,1"
 	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"
@@ -427,7 +427,7 @@
 	if(!length(relays) && !initial(render_target))
 		render_target = OFFSET_RENDER_TARGET(get_plane_master_render_base(name), offset)
 	if(!relay_loc)
-		relay_loc = "SCREEN_SOUTHWEST"
+		relay_loc = "1,1"
 		// If we're using a submap (say for a popup window) make sure we draw onto it
 		if(home?.map)
 			relay_loc = "[home.map]:[relay_loc]"


### PR DESCRIPTION
## About The Pull Request
Fixes client crashes when closing windows with byond rendered content.
The issue was reintroduced by https://github.com/tgstation/tgstation/pull/90460
Closes: https://github.com/tgstation/tgstation/issues/89330
It does work. (sometimes?)
I didn't manage to reproduce the issue locally, but it exists live. 
## Why It's Good For The Game
Less bugs
## Changelog
:cl:

fix: camera consoles, admin supply pod launcher etc. no longer close game when they are closed
/:cl:
