### PR TITLE
Return link underlines

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -31,7 +31,6 @@ a {
   cursor: var(--cursor-pointer);
   color: var(--color-hyperlink);
   transition: color var(--transition-time-medium);
-  text-decoration: none;
 
   &:hover {
     color: hsl(from var(--color-hyperlink) h s calc(l + var(--adjust-hover)));

--- a/tgui/packages/tgui/styles/atomic/links.scss
+++ b/tgui/packages/tgui/styles/atomic/links.scss
@@ -7,7 +7,6 @@ a {
   cursor: var(--cursor-pointer);
   color: var(--color-hyperlink);
   transition: color var(--transition-time-medium);
-  text-decoration: none;
 
   &:hover,
   &:active {


### PR DESCRIPTION
## About The Pull Request

Closes #90531

As slick as it is, having a universal indicator that works regardless of color (especially for the colorblind folk) is kinda nice

This is a problem (Normal / Deuteranopia / Protanopia / Tritanopia)

![image](https://github.com/user-attachments/assets/f51e792e-598b-4813-bbaa-63610505c6e7)

![image](https://github.com/user-attachments/assets/9bd2cabf-a83b-4779-80bb-213f59047627)

![image](https://github.com/user-attachments/assets/f7397a13-e9c2-4618-9cef-62ce12ce529e)

![image](https://github.com/user-attachments/assets/16c84fa9-5de0-476f-8c86-dc4d3d1277b6)

## Changelog

:cl: Melbert
del: Links have underlines again
/:cl:

