### PR TITLE
[NO GBP] Remove chat fieldset crutch

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -999,36 +999,31 @@ em {
   position: relative;
   max-width: 95%;
   font-size: 120%;
-  padding: 0.2em 0.5em;
-  background: hsl(0, 0%, 8.2%); // Chat background color
-  border: 1px solid;
+  background-color: var(--color-section);
+  padding: var(--space-s) var(--space-m);
   border-color: inherit;
-  border-radius: 0.33em;
   z-index: 0;
 
-  // "Mask" a half of the border
-  // It very rough but it only possible way i see with IE compat
-  // Replace it with normal mask-image when 516 got stable
   &:before {
     content: '';
     position: absolute;
-    left: 0;
-    height: 1.15em;
-    width: 100%;
-    background: hsl(0, 0%, 8.2%); // Chat background color
-    transform: translateY(-50%) scaleX(1.05);
+    inset: 0;
+    border: var(--border-thickness-tiny) solid;
+    border-color: inherit;
+    border-radius: var(--border-radius-medium);
+    mask-image: linear-gradient(to top, black 50%, transparent 50%);
     z-index: -1;
   }
 }
 
 .boxed_message {
   background: hsl(220, 10%, 10%);
-  border: 1em * calc(1px / 12px) solid;
-  border-left: 1em * calc(4px / 12px) solid;
+  border: var(--border-thickness-tiny) solid;
+  border-left: var(--border-thickness-large) solid;
   border-color: hsla(220, 40%, 75%, 0.25);
-  margin: 0.5em 0;
-  padding: 0.5em 0.75em;
-  border-radius: 0.33em;
+  margin: var(--space-m) 0;
+  padding: var(--space-m) var(--space-l);
+  border-radius: var(--border-radius-medium);
 
   &.red_box {
     background: hsl(0, 20%, 10%);
@@ -1051,7 +1046,7 @@ em {
   }
 
   hr {
-    margin: 0.5em -0.75em;
+    margin: var(--space-m) -0.75em;
     border-color: inherit;
   }
 }


### PR DESCRIPTION
## About The Pull Request
Removing crutch which will needed for IE, cause it doesn't support mask-image
I hadn't forgotten that I was going to do that after upgrading to the 516

## Why It's Good For The Game
![dreamseeker_RyXx9iRdCF](https://github.com/user-attachments/assets/03a485d0-013a-49f6-9703-5b1cc2f726d3)

## Changelog

:cl:
fix: Examine box title border will not come out of... borders
/:cl:
