### PR TITLE
Adds duct tape. Adds additional items for the purpose of various projectile based 'home construction projects' into the contraband section of parts vendors.

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -156,6 +156,7 @@
 
 /datum/embedding/sticky_tape/duct
 	embed_chance = 0 //Wrapping something in duct tape is basically ensuring it never embeds.
+
 /obj/item/stack/sticky_tape/duct/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!object_repair_value)
 		return NONE

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -19,6 +19,7 @@
 	var/obj/tape_gag = /obj/item/clothing/mask/muzzle/tape
 	greyscale_config = /datum/greyscale_config/tape
 	greyscale_colors = "#B2B2B2#BD6A62"
+	var/object_repair_value = 0
 
 /datum/embedding/sticky_tape
 	pain_mult = 0
@@ -82,6 +83,34 @@
 
 	return ITEM_INTERACT_SUCCESS
 
+/obj/item/stack/sticky_tape/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!object_repair_value)
+		return NONE
+
+	if(!isobj(interacting_with))
+		return NONE
+
+	if(iseffect(interacting_with))
+		return NONE
+
+	var/obj/item/object_to_repair = interacting_with
+	var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
+
+	if(!object_is_damaged)
+		return ITEM_INTERACT_BLOCKING
+
+	user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
+	playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
+
+	if(!do_after(user, 3 SECONDS, target = object_to_repair))
+		return ITEM_INTERACT_BLOCKING
+
+	object_to_repair.repair_damage(object_repair_value)
+	use(1)
+	to_chat(user, span_notice("You finish repairing [object_to_repair] with [src]."))
+
+	return ITEM_INTERACT_SUCCESS
+
 /obj/item/stack/sticky_tape/super
 	name = "super sticky tape"
 	singular_name = "super sticky tape"
@@ -142,3 +171,17 @@
 
 /obj/item/stack/sticky_tape/surgical/get_surgery_tool_overlay(tray_extended)
 	return "tape" + (tray_extended ? "" : "_out")
+
+/obj/item/stack/sticky_tape/duct
+	name = "duct tape"
+	singular_name = "duct tape"
+	desc = "Tape designed for sealing punctures, holes and breakages in objects. Engineers swear by this stuff for practically all kinds of repairs. Maybe a little TOO much..."
+	prefix = "duct taped"
+	conferred_embed = /datum/embedding/sticky_tape/duct
+	merge_type = /obj/item/stack/sticky_tape/duct
+	object_repair_value = 30
+	amount = 10
+	max_amount = 10
+
+/datum/embedding/sticky_tape/duct
+	embed_chance = 0 //Wrapping something in duct tape is basically ensuring it never embeds.

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -156,16 +156,8 @@
 
 /datum/embedding/sticky_tape/duct
 	embed_chance = 0 //Wrapping something in duct tape is basically ensuring it never embeds.
-
-
 /obj/item/stack/sticky_tape/duct/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!object_repair_value)
-		return NONE
-
-	if(!isobj(interacting_with) || !issilicon(interacting_with))
-		return NONE
-
-	if(iseffect(interacting_with))
 		return NONE
 
 	if(issilicon(interacting_with))
@@ -183,25 +175,27 @@
 			return ITEM_INTERACT_BLOCKING
 
 		robotic_pal.adjustBruteLoss(-object_repair_value)
+		use(1)
+		to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
+		return ITEM_INTERACT_SUCCESS
 
-	else
+	if(!isobj(interacting_with) || iseffect(interacting_with)))
+		return NONE
 
-		var/obj/item/object_to_repair = interacting_with
-		var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
+	var/obj/item/object_to_repair = interacting_with
+	var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
 
-		if(!object_is_damaged)
-			user.balloon_alert(user, "[object_to_repair] is not damaged!")
-			return ITEM_INTERACT_BLOCKING
+	if(!object_is_damaged)
+		user.balloon_alert(user, "[object_to_repair] is not damaged!")
+		return ITEM_INTERACT_BLOCKING
 
-		user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
-		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
+	user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
+	playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
 
-		if(!do_after(user, 3 SECONDS, target = object_to_repair))
-			return ITEM_INTERACT_BLOCKING
+	if(!do_after(user, 3 SECONDS, target = object_to_repair))
+		return ITEM_INTERACT_BLOCKING
 
-		object_to_repair.repair_damage(object_repair_value)
-
+	object_to_repair.repair_damage(object_repair_value)
 	use(1)
 	to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
-
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -180,7 +180,7 @@
 		to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
 		return ITEM_INTERACT_SUCCESS
 
-	if(!isobj(interacting_with) || iseffect(interacting_with)))
+	if(!isobj(interacting_with) || iseffect(interacting_with))
 		return NONE
 
 	var/obj/item/object_to_repair = interacting_with

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -87,27 +87,47 @@
 	if(!object_repair_value)
 		return NONE
 
-	if(!isobj(interacting_with))
+	if(!isobj(interacting_with) || !issilicon(interacting_with))
 		return NONE
 
 	if(iseffect(interacting_with))
 		return NONE
 
-	var/obj/item/object_to_repair = interacting_with
-	var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
+	if(issilicon(interacting_with))
+		var/mob/living/silicon/robotic_pal = interacting_with
+		var/robot_is_damaged = robotic_pal.getBruteLoss()
 
-	if(!object_is_damaged)
-		return ITEM_INTERACT_BLOCKING
+		if(!robot_is_damaged)
+			user.balloon_alert(user, "[robotic_pal] is not damaged!")
+			return ITEM_INTERACT_BLOCKING
 
-	user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
-	playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
+		user.visible_message(span_notice("[user] begins repairing [robotic_pal] with [src]."), span_notice("You begin repairing [robotic_pal] with [src]."))
+		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
 
-	if(!do_after(user, 3 SECONDS, target = object_to_repair))
-		return ITEM_INTERACT_BLOCKING
+		if(!do_after(user, 3 SECONDS, target = robotic_pal))
+			return ITEM_INTERACT_BLOCKING
 
-	object_to_repair.repair_damage(object_repair_value)
+		robotic_pal.adjustBruteLoss(-object_repair_value)
+
+	else
+
+		var/obj/item/object_to_repair = interacting_with
+		var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
+
+		if(!object_is_damaged)
+			user.balloon_alert(user, "[object_to_repair] is not damaged!")
+			return ITEM_INTERACT_BLOCKING
+
+		user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
+		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
+
+		if(!do_after(user, 3 SECONDS, target = object_to_repair))
+			return ITEM_INTERACT_BLOCKING
+
+		object_to_repair.repair_damage(object_repair_value)
+
 	use(1)
-	to_chat(user, span_notice("You finish repairing [object_to_repair] with [src]."))
+	to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
 
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -19,7 +19,6 @@
 	var/obj/tape_gag = /obj/item/clothing/mask/muzzle/tape
 	greyscale_config = /datum/greyscale_config/tape
 	greyscale_colors = "#B2B2B2#BD6A62"
-	var/object_repair_value = 0
 
 /datum/embedding/sticky_tape
 	pain_mult = 0
@@ -80,54 +79,6 @@
 	if(isgrenade(target))
 		var/obj/item/grenade/sticky_bomb = target
 		sticky_bomb.sticky = TRUE
-
-	return ITEM_INTERACT_SUCCESS
-
-/obj/item/stack/sticky_tape/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	if(!object_repair_value)
-		return NONE
-
-	if(!isobj(interacting_with) || !issilicon(interacting_with))
-		return NONE
-
-	if(iseffect(interacting_with))
-		return NONE
-
-	if(issilicon(interacting_with))
-		var/mob/living/silicon/robotic_pal = interacting_with
-		var/robot_is_damaged = robotic_pal.getBruteLoss()
-
-		if(!robot_is_damaged)
-			user.balloon_alert(user, "[robotic_pal] is not damaged!")
-			return ITEM_INTERACT_BLOCKING
-
-		user.visible_message(span_notice("[user] begins repairing [robotic_pal] with [src]."), span_notice("You begin repairing [robotic_pal] with [src]."))
-		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
-
-		if(!do_after(user, 3 SECONDS, target = robotic_pal))
-			return ITEM_INTERACT_BLOCKING
-
-		robotic_pal.adjustBruteLoss(-object_repair_value)
-
-	else
-
-		var/obj/item/object_to_repair = interacting_with
-		var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
-
-		if(!object_is_damaged)
-			user.balloon_alert(user, "[object_to_repair] is not damaged!")
-			return ITEM_INTERACT_BLOCKING
-
-		user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
-		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
-
-		if(!do_after(user, 3 SECONDS, target = object_to_repair))
-			return ITEM_INTERACT_BLOCKING
-
-		object_to_repair.repair_damage(object_repair_value)
-
-	use(1)
-	to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
 
 	return ITEM_INTERACT_SUCCESS
 
@@ -199,9 +150,58 @@
 	prefix = "duct taped"
 	conferred_embed = /datum/embedding/sticky_tape/duct
 	merge_type = /obj/item/stack/sticky_tape/duct
-	object_repair_value = 30
+	var/object_repair_value = 30
 	amount = 10
 	max_amount = 10
 
 /datum/embedding/sticky_tape/duct
 	embed_chance = 0 //Wrapping something in duct tape is basically ensuring it never embeds.
+
+
+/obj/item/stack/sticky_tape/duct/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!object_repair_value)
+		return NONE
+
+	if(!isobj(interacting_with) || !issilicon(interacting_with))
+		return NONE
+
+	if(iseffect(interacting_with))
+		return NONE
+
+	if(issilicon(interacting_with))
+		var/mob/living/silicon/robotic_pal = interacting_with
+		var/robot_is_damaged = robotic_pal.getBruteLoss()
+
+		if(!robot_is_damaged)
+			user.balloon_alert(user, "[robotic_pal] is not damaged!")
+			return ITEM_INTERACT_BLOCKING
+
+		user.visible_message(span_notice("[user] begins repairing [robotic_pal] with [src]."), span_notice("You begin repairing [robotic_pal] with [src]."))
+		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
+
+		if(!do_after(user, 3 SECONDS, target = robotic_pal))
+			return ITEM_INTERACT_BLOCKING
+
+		robotic_pal.adjustBruteLoss(-object_repair_value)
+
+	else
+
+		var/obj/item/object_to_repair = interacting_with
+		var/object_is_damaged = object_to_repair.get_integrity() < object_to_repair.max_integrity
+
+		if(!object_is_damaged)
+			user.balloon_alert(user, "[object_to_repair] is not damaged!")
+			return ITEM_INTERACT_BLOCKING
+
+		user.visible_message(span_notice("[user] begins repairing [object_to_repair] with [src]."), span_notice("You begin repairing [object_to_repair] with [src]."))
+		playsound(user, 'sound/items/duct_tape/duct_tape_rip.ogg', 50, TRUE)
+
+		if(!do_after(user, 3 SECONDS, target = object_to_repair))
+			return ITEM_INTERACT_BLOCKING
+
+		object_to_repair.repair_damage(object_repair_value)
+
+	use(1)
+	to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
+
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -14,7 +14,8 @@
 		/obj/item/stock_parts/matter_bin = 3,
 		/obj/item/stock_parts/micro_laser = 3,
 		/obj/item/stock_parts/scanning_module = 3,
-		/obj/item/wirecutters = 1,
+		/obj/item/wirecutters = 2,
+		/obj/item/stack/sticky_tape/duct = 3,
 	)
 	contraband = list(
 		/obj/item/assembly/health = 2,
@@ -23,6 +24,9 @@
 		/obj/item/stock_parts/power_store/cell/high = 1,
 		/obj/item/stock_parts/power_store/battery/high = 1,
 		/obj/item/market_uplink/blackmarket = 1,
+		/obj/item/screwdriver = 2,
+		/obj/item/assembly/mousetrap = 4,
+		/obj/item/weaponcrafting/stock = 2,
 	)
 	premium = list(
 		/obj/item/assembly/igniter/condenser = 2,

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -17,6 +17,7 @@
 		/obj/item/electronics/airalarm = 10,
 		/obj/item/electronics/firealarm = 10,
 		/obj/item/electronics/firelock = 10,
+		/obj/item/stack/sticky_tape/duct = 10,
 	)
 	contraband = list(
 		/obj/item/stock_parts/power_store/cell/potato = 3,


### PR DESCRIPTION
## About The Pull Request

Adds duct tape. By right-clicking an object which has suffered integrity damage or borg, you can repair it using duct tape. This includes items that have no dedicated repair tool. (I suspect this will need some additional work for anything that might change states as a result of integrity loss)

Duct tape can be found in engineering vendors and parts vendors. Taping something up in duct tape makes it impossible for that item to embed if it otherwise was capable of doing so.

In addition, some additional objects are now in the part vendor's contraband section. This includes screwdrivers, mousetraps and a rifle stock.

## Why It's Good For The Game

A) Duct tape should already be in the game.

It gets mentioned in a few places in the code, we have tape, and the theme of the experience is workplace unsafety. Why _wouldn't_ engineers be fixing up things using duct tape?

B) It allows for players to repair damaged objects that wouldn't otherwise be capable of being repaired.

It isn't something that frequently comes up, as damage on objects isn't terribly visible a whole lot of the time. But knowing something was splashed by acid or smacked up in an explosion and having no direct way to repair it that isn't reconstruction (if that is even possible) kinda blows. 

C) Having a more broadly accessible tape type helps with improvised firearm construction

A common complaint I get about pipeguns, pneumatic cannons and pipe pistols is that sourcing some parts are abnormally more difficult than others. The stock, the mousetraps, a spare screwdriver and the tape. While you can use any kind of tape, the only reasonably common vendor tape is surgical tape, and you otherwise need to get an autolathe to get a few additional parts. 

It often has people wondering if that is truly 'improvised' given you have to use a lathe in most scenarios.

With some of the more pesky parts being more accessible, it might help put the 'improvised' back into their construction, though you'll probably need to source the money for purchasing them.

The mousetraps especially are a bit weirdly hard to locate.

## Changelog
:cl:
add: Duct tape! Right-click objects and cyborgs with duct tape to repair them if they have been damaged! Wrap objects in duct tape to make it completely incapable of embedding! Find them in your nearest Part-Mart or Engi-Vend vending machines today!
balance: Part-Mart vending machines now have mousetraps, spare screwdrivers and rifle stocks in their contraband section.
/:cl:
