### PR TITLE
Better metalgen logging and some behavior fixes

### DIFF
--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -39,20 +39,20 @@
 	// We do this check early so closed turfs are still be able to flood.
 	if(isturf(parent)) // Walls and floors.
 		var/turf/parent_turf = parent
-		flooded_turf = parent_turf.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
+		flooded_turf = parent_turf.ScrapeAway(1, CHANGETURF_INHERIT_AIR | CHANGETURF_FORCEOP) // Ensure that we always forcefully replace the turf, even if the baseturf has the same type
 		delete_parent = FALSE
 
 	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];[TURF_TEMPERATURE((temp_amount || trigger_temperature))]")
 
 	// Logging-related
 	var/admin_message = "[flooded_turf] ignited in [ADMIN_VERBOSEJMP(flooded_turf)]"
-	var/log_message = "ignited [flooded_turf]"
+	var/log_message = "ignited [flooded_turf] at [AREACOORD(flooded_turf)]"
 	if(user)
-		admin_message += " by [ADMIN_LOOKUPFLW(user)]"
+		admin_message += " by [ADMIN_LOOKUPFLW(user)] at [ADMIN_COORDJMP(flooded_turf)]"
 		user.log_message(log_message, LOG_ATTACK, log_globally = FALSE)//only individual log
 	else
-		log_message = "[key_name(user)] " + log_message + " by fire"
-		admin_message += " by fire"
+		log_message = "[key_name(user)] " + log_message + " by fire at [AREACOORD(flooded_turf)]"
+		admin_message += " by fire at [ADMIN_COORDJMP(flooded_turf)]"
 		log_attack(log_message)
 	message_admins(admin_message)
 

--- a/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/_fluid_spread.dm
@@ -157,4 +157,4 @@
 	var/area/fluid_area = get_area(location)
 	if(!istype(holder, /obj/machinery/plumbing) && !(fluid_area.area_flags & QUIET_LOGS)) //excludes standard plumbing equipment as well as deathmatch from spamming admins with this shit
 		message_admins("\A [flood] flood started at [ADMIN_VERBOSEJMP(location)] [source_msg][blame_msg].")
-	log_game("\A [flood] flood started at [location || "nonexistant location"] [holder ? "from [holder] last touched by [holder || "N/A"]" : "with no known source"].")
+	log_game("\A [flood] flood started at [AREACOORD(location)] [source_msg][blame_msg].")

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -96,6 +96,8 @@
 		for(var/obj/object in turf_location)
 			if(object == src)
 				continue
+			if(object.invisibility >= INVISIBILITY_ABSTRACT) // Don't foam landmarks please
+				continue
 			if(turf_location.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(object, TRAIT_T_RAY_VISIBLE))
 				continue
 			if (HAS_TRAIT(loc, TRAIT_ELEVATED_TURF) && !HAS_TRAIT(object, TRAIT_ELEVATING_OBJECT))

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -374,6 +374,8 @@
 	for(var/atom/movable/thing as anything in location)
 		if(thing == src)
 			continue
+		if(thing.invisibility >= INVISIBILITY_ABSTRACT) // Don't smoke landmarks please
+			continue
 		if(location.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(thing, TRAIT_T_RAY_VISIBLE))
 			continue
 		reagents.expose(thing, SMOKE_MACHINE, fraction)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -313,8 +313,9 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 	. = ..()
 	if(!(material_flags & MATERIAL_AFFECT_STATISTICS))
 		return
-	var/integrity_mod = GET_MATERIAL_MODIFIER(material.integrity_modifier, multiplier)
-	modify_max_integrity(ceil(max_integrity * integrity_mod))
+	if(uses_integrity)
+		var/integrity_mod = GET_MATERIAL_MODIFIER(material.integrity_modifier, multiplier)
+		modify_max_integrity(ceil(max_integrity * integrity_mod))
 	var/strength_mod = GET_MATERIAL_MODIFIER(material.strength_modifier, multiplier)
 	force *= strength_mod
 	throwforce *= strength_mod
@@ -326,8 +327,9 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 	. = ..()
 	if(!(material_flags & MATERIAL_AFFECT_STATISTICS))
 		return
-	var/integrity_mod = GET_MATERIAL_MODIFIER(material.integrity_modifier, multiplier)
-	modify_max_integrity(floor(max_integrity / integrity_mod))
+	if(uses_integrity)
+		var/integrity_mod = GET_MATERIAL_MODIFIER(material.integrity_modifier, multiplier)
+		modify_max_integrity(floor(max_integrity / integrity_mod))
 	var/strength_mod = GET_MATERIAL_MODIFIER(material.strength_modifier, multiplier)
 	force /= strength_mod
 	throwforce /= strength_mod

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -784,7 +784,7 @@
 		var/atom/container = holder.my_atom
 		var/area/container_area = get_area(container)
 		var/blame_msg = "with no known fingerprints"
-		var/lastkey = holder.fingerprintslast
+		var/lastkey = container.fingerprintslast
 		if (lastkey)
 			var/mob/scapegoat = get_mob_by_key(lastkey)
 			blame_msg = "last touched by [ADMIN_LOOKUPFLW(scapegoat)]"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -774,11 +774,25 @@
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
 
 /datum/chemical_reaction/metalgen_imprint/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	var/datum/reagent/metalgen/MM = holder.has_reagent(/datum/reagent/metalgen)
-	for(var/datum/reagent/R in holder.reagent_list)
-		if(R.material && R.volume >= 40)
-			MM.data["material"] = R.material
-			holder.remove_reagent(R.type, 40)
+	var/datum/reagent/metalgen/metalgen = holder.has_reagent(/datum/reagent/metalgen)
+	for (var/datum/reagent/metal in holder.reagent_list)
+		if (!metal.material || metal.volume < 40)
+			continue
+
+		metalgen.data["material"] = metal.material
+		holder.remove_reagent(metal.type, 40)
+		var/atom/container = holder.my_atom
+		var/area/container_area = get_area(container)
+		var/blame_msg = "with no known fingerprints"
+		var/lastkey = holder.fingerprintslast
+		if (lastkey)
+			var/mob/scapegoat = get_mob_by_key(lastkey)
+			blame_msg = "last touched by [ADMIN_LOOKUPFLW(scapegoat)]"
+
+		if(!istype(container, /obj/machinery/plumbing) && !(container_area?.area_flags & QUIET_LOGS))
+			message_admins("[metalgen.volume]u of Metalgen have been imprinted with [metal.material::name] in [container] at [ADMIN_VERBOSEJMP(container)] [blame_msg]")
+		log_game("[metalgen.volume]u of Metalgen have been imprinted with [metal.material::name] in [container] at [AREACOORD(container)] [blame_msg]")
+		break
 
 /datum/chemical_reaction/gravitum
 	required_reagents = list(/datum/reagent/wittel = 1, /datum/reagent/sorium = 10)


### PR DESCRIPTION

## About The Pull Request

Metalgen imprinting is now logged, foam and smoke have better logging and so do plasma metalgenned things, metalgen no longer causes a ton of runtimes on almost everything and foam and smoke no longer affect abstract objects.
Also ***hopefully*** solves the issue with infinite hotspot loops, but I don't think anyone knows what exactly occured there.

## Why It's Good For The Game

If servers explode, admins need to know who did it and coders need to know how they did it.

## Changelog
:cl:
fix: Metalgen foam/smoke no longer cause an absurd amount of runtimes
fix: Foam and smoke no longer affect abstract objects like landmarks
admin: Metalgen imprinting is now logged
admin: Improved logging for foam and smoke, and plasma metalgenned objects
/:cl:
