### PR TITLE
Fix deep fryer message timings being off

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -233,6 +233,15 @@ DEFINE_BITFIELD(food_flags, list(
 ///Drinks that are made through rare ingredients, or high levels of processing.
 #define DRINK_PRICE_HIGH 200
 
+/// Time spent deep frying an item after which it becomes fried.
+#define FRYING_TIME_FRIED (15 SECONDS)
+/// Time spent deep frying an item after which it becomes fried to perfection.
+#define FRYING_TIME_PERFECT (50 SECONDS)
+/// Time spent deep frying an item after which it becomes burnt.
+#define FRYING_TIME_BURNT (85 SECONDS)
+/// Time spent deep frying an item after which it starts smelling bad.
+#define FRYING_TIME_WARNING (120 SECONDS)
+
 
 /// Flavour defines (also names) for GLOB.ice_cream_flavours list access. Safer from mispelling than plain text.
 #define ICE_CREAM_VANILLA "vanilla"

--- a/code/datums/elements/food/fried_item.dm
+++ b/code/datums/elements/food/fried_item.dm
@@ -20,22 +20,22 @@
 	var/atom/this_food = target
 
 	switch(fry_time)
-		if(0 to 15 SECONDS)
+		if(0 to FRYING_TIME_FRIED)
 			this_food.add_atom_colour(fried_colors[1], FIXED_COLOUR_PRIORITY)
 			this_food.name = "lightly-fried [this_food.name]"
 			this_food.desc += " It's been lightly fried in a deep fryer."
 
-		if(15 SECONDS to 50 SECONDS)
+		if(FRYING_TIME_FRIED to FRYING_TIME_PERFECT)
 			this_food.add_atom_colour(fried_colors[2], FIXED_COLOUR_PRIORITY)
 			this_food.name = "fried [this_food.name]"
 			this_food.desc += " It's been fried, increasing its tastiness value by [rand(1, 75)]%."
 
-		if(50 SECONDS to 85 SECONDS)
+		if(FRYING_TIME_PERFECT to FRYING_TIME_BURNT)
 			this_food.add_atom_colour(fried_colors[3], FIXED_COLOUR_PRIORITY)
 			this_food.name = "deep-fried [this_food.name]"
 			this_food.desc += " Deep-fried to perfection."
 
-		if(85 SECONDS to INFINITY)
+		if(FRYING_TIME_BURNT to INFINITY)
 			this_food.add_atom_colour(fried_colors[4], FIXED_COLOUR_PRIORITY)
 			this_food.name = "\proper the physical manifestation of the very concept of fried foods"
 			this_food.desc = "A heavily-fried... something. Who can tell anymore?"

--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -1,8 +1,3 @@
-/// The deep fryer pings after this long, letting people know it's "perfect"
-#define DEEPFRYER_COOKTIME 50
-/// The deep fryer pings after this long, reminding people that there's a very burnt object inside
-#define DEEPFRYER_BURNTIME 120
-
 /// Global typecache of things which should never be fried.
 GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/bodybag/bluespace,
@@ -158,17 +153,17 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	grease_level += prob(grease_increase_chance) * grease_Increase_amount
 
 	cook_time += fry_speed * seconds_per_tick SECONDS
-	if(cook_time >= DEEPFRYER_COOKTIME && !frying_fried)
+	if(cook_time >= FRYING_TIME_PERFECT && !frying_fried)
 		frying_fried = TRUE //frying... frying... fried
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE)
 		audible_message(span_notice("[src] dings!"))
-	else if (cook_time >= DEEPFRYER_BURNTIME && !frying_burnt)
+	else if (cook_time >= FRYING_TIME_WARNING && !frying_burnt)
 		frying_burnt = TRUE
-		var/list/asomnia_hadders = list()
+		var/list/anosmia_havers = list()
 		for(var/mob/smeller in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src))
 			if(HAS_TRAIT(smeller, TRAIT_ANOSMIA))
-				asomnia_hadders += smeller
-		visible_message(span_warning("[src] emits an acrid smell!"), ignored_mobs = asomnia_hadders)
+				anosmia_havers += smeller
+		visible_message(span_warning("[src] emits an acrid smell!"), ignored_mobs = anosmia_havers)
 
 	use_energy(active_power_usage)
 
@@ -257,6 +252,3 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 /obj/machinery/deepfryer/proc/on_cleaned(obj/source_component, obj/source)
 	grease_level = 0
 	update_appearance(UPDATE_OVERLAYS)
-
-#undef DEEPFRYER_COOKTIME
-#undef DEEPFRYER_BURNTIME


### PR DESCRIPTION

## About The Pull Request

Seems like on a previous pr that updated fried items we updated the deep fryer and fried item code to use the `SECONDS` define, *except* for the defines used for the warning messages.

While we could just update the `DEEPFRYER_COOKTIME` and `DEEPFRYER_BURNTIME` defines, in this pr we make all of these use a shared set of defines to avoid this happening again as easily in the future.

We also correct a spelling error in a variable, `asomnia_hadders > anosmia_havers`.
## Why It's Good For The Game

Fixes #90545.
## Changelog
:cl:
fix: Deep fryers now properly ding once your item is perfectly fried and smell bad once it's properly burnt again
/:cl:
