### PR TITLE
Fix hot spring runtime related to duplicate elements

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -116,8 +116,9 @@
 	// we don't want to end up with 4 different immerse elements, which would cause
 	// the immerse trait to be repeatedly removed and readded as someone moves within the pool,
 	// replacing the status effect over and over, which can be seen through the status effect alert icon.
-	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
-	immerse_added = TRUE
+	if(!immerse_added)
+		AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color, alpha = immerse_overlay_alpha)
+		immerse_added = TRUE
 	icon_state = "pool_[rand(1, 4)]"
 	var/obj/effect/abstract/shared_particle_holder/holder = add_shared_particles(/particles/hotspring_steam, "hot_springs_[GET_TURF_PLANE_OFFSET(src)]", pool_size = 4)
 	// Render the steam over mobs and objects on the game plane


### PR DESCRIPTION

## About The Pull Request

If something is mapped to spawn in on a hot spring tile, the tile will add the immerse element in `/turf/open/water/Entered` before `Initialize` runs, and when it does there's no check if the element has already been added, unlike other spots where the immerse element is added. This fixes that by adding a check on the call in `Initialize`.

## Why It's Good For The Game

Fixes #89816 

## Changelog

No player facing changes
