### PR TITLE
Invisible walls can be leaned on

### DIFF
--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -1,4 +1,4 @@
-/// Things with this component can be leaned onto, optionally exclusive to RMB dragging
+/// Things with this component can be leaned onto
 /datum/component/leanable
 	/// How much will mobs that lean onto this object be offset
 	var/leaning_offset = 11

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -62,6 +62,24 @@
 	desc = "You have a bad feeling about this."
 	alpha = 0
 
+/obj/effect/forcefield/mime/Initialize(mapload)
+	. = ..()
+	var/static/list/loc_connections = list(
+		COMSIG_MOUSEDROPPED_ONTO = PROC_REF(mousedrop_receive),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/effect/forcefield/mime/proc/mousedrop_receive(atom/source, atom/movable/dropped, mob/user, params)
+	SIGNAL_HANDLER
+	// Reroute the call to ourselves so leanable component can trigger
+	if (dropped == user)
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, mouse_drop_receive), dropped, user, params)
+		return COMPONENT_CANCEL_MOUSEDROPPED_ONTO
+
+/obj/effect/forcefield/mime/mouse_drop_receive(mob/living/dropping, mob/user, params)
+	. = ..()
+	LoadComponent(/datum/component/leanable, dropping)
+
 /obj/effect/forcefield/mime/advanced
 	name = "invisible blockade"
 	desc = "You're gonna be here awhile."


### PR DESCRIPTION

## About The Pull Request

By dragging yourself onto a tile with an invisible wall on it, you can lean on one.

![dreamseeker_hLaRxidmVW](https://github.com/user-attachments/assets/0342cfed-d457-49d7-b5e1-c30a1f52aef9)

## Why It's Good For The Game

Leaning on invisible walls is like, Miming 101. Also can probably be used in maint fu with funny effects.

## Changelog
:cl:
add: Invisible walls can be leaned on
/:cl:
