### PR TITLE
adds 1s of delay to "perish"

### DIFF
--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -333,7 +333,7 @@
 		colossus = firer
 		colossus.say("Perish.", spans = list("colossus", "yell"))
 
-	SLEEP_CHECK_DEATH(0.5 SECONDS, firer) //gives dumbasses in melee range a slim chance to retreat
+	SLEEP_CHECK_DEATH(1.5 SECONDS, firer) //gives dumbasses in melee range a slim chance to retreat
 	var/finale_counter = 10
 	for(var/i in 1 to 20)
 		if(finale_counter > 4 && colossus)


### PR DESCRIPTION

## About The Pull Request
in the colossus fight, adds 1 second of delay between the telegraph "Perish." and the actual attack, because it's currently nearly impossible to react in time if you're within melee range, specially in high ping
## Why It's Good For The Game
prevents this from happening

https://github.com/user-attachments/assets/ca9c1eae-718a-4a90-8959-83dccc09dbc9
## Changelog
:cl:
balance: Added a second of reaction time to the Colossus' final attack.
/:cl:
