### PR TITLE
Fixes the scrubber in Wawa Chapel Office

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -24092,7 +24092,7 @@
 /area/station/hallway/primary/central)
 "iwd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)


### PR DESCRIPTION

## About The Pull Request

Rotates this scrubber to be linked to the pipenet.

![image](https://github.com/user-attachments/assets/c5722d29-7c59-4aff-b34a-b8f661aeb2f2)

(this is it unrotated)
## Why It's Good For The Game

The air must flow.
## Changelog
:cl: Rhials
fix: The scrubber in the Wawastation Chapel Office has been fixed.
/:cl:
