### PR TITLE
Changes Whiteship window blastdoors from doors into shutters

### DIFF
--- a/_maps/shuttles/whiteship_birdshot.dmm
+++ b/_maps/shuttles/whiteship_birdshot.dmm
@@ -836,7 +836,7 @@
 /area/shuttle/abandoned/cargo)
 "BZ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -1238,7 +1238,7 @@
 /area/shuttle/abandoned/crew)
 "PC" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -1461,7 +1461,7 @@
 /area/shuttle/abandoned/engine)
 "XX" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -1474,7 +1474,7 @@
 /area/shuttle/abandoned/crew)
 "YJ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -32,7 +32,7 @@
 /area/shuttle/abandoned/medbay)
 "ah" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -45,7 +45,7 @@
 /area/shuttle/abandoned/crew)
 "ak" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -486,7 +486,7 @@
 /area/shuttle/abandoned/bridge)
 "bf" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "af" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -19,7 +19,7 @@
 /area/shuttle/abandoned/cargo)
 "am" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -97,7 +97,7 @@
 /area/shuttle/abandoned/crew)
 "aN" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -462,7 +462,7 @@
 /area/shuttle/abandoned/cargo)
 "su" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -31,7 +31,7 @@
 /area/shuttle/abandoned/bar)
 "af" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -706,7 +706,7 @@
 /area/shuttle/abandoned/crew)
 "bI" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -814,7 +814,7 @@
 "bT" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,
@@ -1136,7 +1136,7 @@
 /area/shuttle/abandoned/cargo)
 "cz" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -1930,7 +1930,7 @@
 /area/shuttle/abandoned/cargo)
 "SY" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -29,7 +29,7 @@
 /area/shuttle/abandoned/cargo)
 "cD" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},
@@ -194,7 +194,7 @@
 /area/shuttle/abandoned/bar)
 "iI" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge";
 	name = "Cockpit Emergency Blast Door"
 	},
@@ -634,7 +634,7 @@
 /area/shuttle/abandoned/bar)
 "FW" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},
@@ -642,7 +642,7 @@
 /area/shuttle/abandoned/crew)
 "Gj" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},
@@ -775,7 +775,7 @@
 /area/shuttle/abandoned/engine)
 "Kx" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},
@@ -823,7 +823,7 @@
 /area/shuttle/abandoned/engine)
 "LK" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},
@@ -1157,7 +1157,7 @@
 /area/shuttle/abandoned/engine)
 "YN" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -34,7 +34,7 @@
 /area/shuttle/abandoned/crew)
 "aj" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -57,7 +57,7 @@
 /area/shuttle/abandoned/engine)
 "am" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -588,7 +588,7 @@
 /area/shuttle/abandoned/bridge)
 "bR" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,
@@ -1332,7 +1332,7 @@
 /area/shuttle/abandoned/cargo)
 "eb" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_obelisk.dmm
+++ b/_maps/shuttles/whiteship_obelisk.dmm
@@ -45,14 +45,14 @@
 "cd" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/effect/decal/cleanable/blood/splatter/over_window,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "ck" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -256,7 +256,7 @@
 /area/shuttle/abandoned/medbay)
 "nw" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -463,7 +463,7 @@
 /area/template_noop)
 "Bl" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridgewindows"
 	},
 /turf/open/floor/mineral/titanium,
@@ -476,7 +476,7 @@
 /area/shuttle/abandoned)
 "BH" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -494,7 +494,7 @@
 "DE" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/effect/decal/cleanable/blood/splatter/over_window,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -508,7 +508,7 @@
 /area/shuttle/abandoned/engine)
 "EJ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
@@ -810,7 +810,7 @@
 "WX" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/effect/decal/cleanable/blood/splatter/over_window,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridgewindows"
 	},
 /turf/open/floor/mineral/titanium,

--- a/_maps/shuttles/whiteship_personalshuttle.dmm
+++ b/_maps/shuttles/whiteship_personalshuttle.dmm
@@ -146,7 +146,7 @@
 /area/shuttle/abandoned/bridge)
 "dx" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},
@@ -288,7 +288,7 @@
 /area/shuttle/abandoned/bridge)
 "sw" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast Door"
 	},

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -461,7 +461,7 @@
 /turf/open/floor/carpet/purple,
 /area/shuttle/abandoned)
 "sl" = (
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
@@ -734,7 +734,7 @@
 /area/shuttle/abandoned)
 "Fw" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
## About The Pull Request

Changed blast doors on whiteship windows from /obj/machinery/door/poddoor to /obj/machinery/door/poddoor/shutters, preventing navigation computers from seeing them as airlocks.

Fixes #88683

## Changelog

:cl:
fix: fixed some whiteship windows having airlock icons placed over them in the navigation computer window
/:cl:

