### PR TITLE
Removes Blob HUD as a var on every single hud

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -162,9 +162,6 @@
 	..()
 	var/atom/movable/screen/using
 
-	blobpwrdisplay = new /atom/movable/screen/blob_power_display(null, src)
-	infodisplay += blobpwrdisplay
-
 	healths = new /atom/movable/screen/healths/blob(null, src)
 	infodisplay += healths
 

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -151,16 +151,18 @@
 		var/mob/eye/blob/B = usr
 		B.relocate_core()
 
+/atom/movable/screen/blob_power_display
+	name = "blob power"
+	icon_state = "block"
+	screen_loc = ui_health
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	plane = ABOVE_HUD_PLANE
+
 /datum/hud/blob_overmind/New(mob/owner)
 	..()
 	var/atom/movable/screen/using
 
-	blobpwrdisplay = new /atom/movable/screen(null, src)
-	blobpwrdisplay.name = "blob power"
-	blobpwrdisplay.icon_state = "block"
-	blobpwrdisplay.screen_loc = ui_health
-	blobpwrdisplay.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	SET_PLANE_EXPLICIT(blobpwrdisplay, ABOVE_HUD_PLANE, owner)
+	blobpwrdisplay = new /atom/movable/screen/blob_power_display(null, src)
 	infodisplay += blobpwrdisplay
 
 	healths = new /atom/movable/screen/healths/blob(null, src)

--- a/code/_onclick/hud/blobbernaut.dm
+++ b/code/_onclick/hud/blobbernaut.dm
@@ -1,5 +1,0 @@
-/datum/hud/living/blobbernaut/New(mob/living/owner)
-	. = ..()
-
-	blobpwrdisplay = new /atom/movable/screen/healths/blob/overmind(null, src)
-	infodisplay += blobpwrdisplay

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -292,6 +292,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 /datum/hud/proc/get_plane_group(key)
 	return master_groups[key]
 
+///Creates the mob's visible HUD, returns FALSE if it can't, TRUE if it did.
 /mob/proc/create_mob_hud()
 	if(!client || hud_used)
 		return FALSE

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -297,10 +297,11 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 /mob/proc/create_mob_hud()
 	if(!client || hud_used)
-		return
+		return FALSE
 	set_hud_used(new hud_type(src))
 	update_sight()
 	SEND_SIGNAL(src, COMSIG_MOB_HUD_CREATED)
+	return TRUE
 
 /mob/proc/set_hud_used(datum/hud/new_hud)
 	hud_used = new_hud

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -28,8 +28,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/inventory_shown = FALSE //Equipped item inventory
 	var/hotkey_ui_hidden = FALSE //This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
 
-	var/atom/movable/screen/blobpwrdisplay
-
 	var/atom/movable/screen/alien_plasma_display
 	var/atom/movable/screen/alien_queen_finder
 
@@ -247,7 +245,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	healthdoll = null
 	spacesuit = null
 	hunger = null
-	blobpwrdisplay = null
 	alien_plasma_display = null
 	alien_queen_finder = null
 	combo_display = null

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -274,12 +274,12 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if(!blob_core)
 		return FALSE
 	var/current_health = round((blob_core.get_integrity() / blob_core.max_integrity) * 100)
-	hud_used.healths.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#82ed00'>[current_health]%</font></div>")
+	var/new_maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#82ed00'>[current_health]%</font></div>")
+	hud_used.healths.maptext = new_maptext
 	for(var/mob/living/basic/blob_minion/blobbernaut/blobbernaut in blob_mobs)
-		var/datum/hud/using_hud = blobbernaut.hud_used
-		if(!using_hud?.blobpwrdisplay)
+		if(isnull(blobbernaut.overmind_hud))
 			continue
-		using_hud.blobpwrdisplay.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#82ed00'>[current_health]%</font></div>")
+		blobbernaut.overmind_hud.maptext = new_maptext
 
 /mob/eye/blob/proc/add_points(points)
 	blob_points = clamp(blob_points + points, 0, max_blob_points)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -53,6 +53,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	/// The list of strains the blob can reroll for.
 	var/list/strain_choices
 
+	///The HUD given to blobs with their power
+	var/atom/movable/screen/blob_power_display/blob_power_hud
+
 /mob/eye/blob/Initialize(mapload, starting_points = OVERMIND_STARTING_POINTS)
 	ADD_TRAIT(src, TRAIT_BLOB_ALLY, INNATE_TRAIT)
 	validate_location()
@@ -73,6 +76,14 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	GLOB.blob_telepathy_mobs |= src
+
+/mob/eye/blob/create_mob_hud()
+	. = ..()
+	if(!.)
+		return
+	blob_power_hud = new(null, src)
+	hud_used.infodisplay += blob_power_hud
+	hud_used.show_hud(hud_used.hud_version)
 
 /mob/eye/blob/proc/validate_location()
 	var/turf/T = get_turf(src)
@@ -233,6 +244,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /mob/eye/blob/Destroy()
 	QDEL_NULL(blobstrain)
+	QDEL_NULL(blob_power_hud)
 	for(var/BL in GLOB.blobs)
 		var/obj/structure/blob/B = BL
 		if(B && B.overmind == src)
@@ -283,7 +295,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /mob/eye/blob/proc/add_points(points)
 	blob_points = clamp(blob_points + points, 0, max_blob_points)
-	hud_used.blobpwrdisplay.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#e36600'>[round(blob_points)]</font></div>")
+	blob_power_hud.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#e36600'>[round(blob_points)]</font></div>")
 
 /mob/eye/blob/say(
 	message,

--- a/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
+++ b/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
@@ -34,15 +34,14 @@
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_BLOBBERNAUT, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 	AddElement(/datum/element/damage_threshold, 10)
-/*
-	if(hud_used)
-		var/datum/hud/hud_used = hud_used
-		overmind_hud = new(null, hud_used)
-		hud_used.infodisplay += lingchemdisplay
-		hud_used.show_hud(hud_used.hud_version)
-	else
-		RegisterSignal(src, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
-*/
+
+/mob/living/basic/blob_minion/blobbernaut/Destroy()
+	QDEL_NULL(overmind_hud)
+	return ..()
+
+/mob/living/basic/blob_minion/blobbernaut/death(gibbed)
+	flick("blobbernaut_death", src)
+	return ..()
 
 /mob/living/basic/blob_minion/blobbernaut/create_mob_hud()
 	. = ..()
@@ -51,10 +50,6 @@
 	overmind_hud = new(null, hud_used)
 	hud_used.infodisplay += overmind_hud
 	hud_used.show_hud(hud_used.hud_version)
-
-/mob/living/basic/blob_minion/blobbernaut/death(gibbed)
-	flick("blobbernaut_death", src)
-	return ..()
 
 /// This variant is the one actually spawned by blob factories, takes damage when away from blob tiles
 /mob/living/basic/blob_minion/blobbernaut/minion

--- a/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
+++ b/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
@@ -24,14 +24,33 @@
 	verb_yell = "bellows"
 	pressure_resistance = 50
 	mob_size = MOB_SIZE_LARGE
-	hud_type = /datum/hud/living/blobbernaut
 	gold_core_spawnable = HOSTILE_SPAWN
 	ai_controller = /datum/ai_controller/basic_controller/blobbernaut
+
+	///The HUD given to blobbernauts, updated by the Blob itself
+	var/atom/movable/screen/healths/blob/overmind/overmind_hud
 
 /mob/living/basic/blob_minion/blobbernaut/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_BLOBBERNAUT, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 	AddElement(/datum/element/damage_threshold, 10)
+/*
+	if(hud_used)
+		var/datum/hud/hud_used = hud_used
+		overmind_hud = new(null, hud_used)
+		hud_used.infodisplay += lingchemdisplay
+		hud_used.show_hud(hud_used.hud_version)
+	else
+		RegisterSignal(src, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
+*/
+
+/mob/living/basic/blob_minion/blobbernaut/create_mob_hud()
+	. = ..()
+	if(!.)
+		return
+	overmind_hud = new(null, hud_used)
+	hud_used.infodisplay += overmind_hud
+	hud_used.show_hud(hud_used.hud_version)
 
 /mob/living/basic/blob_minion/blobbernaut/death(gibbed)
 	flick("blobbernaut_death", src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -599,7 +599,6 @@
 #include "code\_onclick\hud\alien.dm"
 #include "code\_onclick\hud\alien_larva.dm"
 #include "code\_onclick\hud\blob_overmind.dm"
-#include "code\_onclick\hud\blobbernaut.dm"
 #include "code\_onclick\hud\credits.dm"
 #include "code\_onclick\hud\drones.dm"
 #include "code\_onclick\hud\fullscreen.dm"


### PR DESCRIPTION
## About The Pull Request

Blob Overminds & Blobbernauts use a HUD that shows them the overmind's health, which is currently a var called ``blobpwrdisplay`` and exists on every single HUD in the game. This moves them to the respective mobs, removing the need to do this.

## Why It's Good For The Game

Modularizes HUDs a bit more and removes a bad special var on base hud datum. pmo.

## Changelog

Nothing player-facing.