### PR TITLE
removes martial art hud as something on base hud

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -33,8 +33,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/atom/movable/screen/alien_plasma_display
 	var/atom/movable/screen/alien_queen_finder
 
-	var/atom/movable/screen/combo/combo_display
-
 	var/atom/movable/screen/action_intent
 	var/atom/movable/screen/zone_select
 	var/atom/movable/screen/pull_icon
@@ -250,7 +248,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	blobpwrdisplay = null
 	alien_plasma_display = null
 	alien_queen_finder = null
-	combo_display = null
 
 	QDEL_LIST_ASSOC_VAL(master_groups)
 	QDEL_LIST_ASSOC_VAL(plane_master_controllers)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -282,9 +282,6 @@
 	zone_select.update_appearance()
 	static_inventory += zone_select
 
-	combo_display = new /atom/movable/screen/combo(null, src)
-	infodisplay += combo_display
-
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
 		if(inv.slot_id)
 			inv_slots[TOBITSHIFT(inv.slot_id) + 1] = inv

--- a/code/_onclick/hud/living.dm
+++ b/code/_onclick/hud/living.dm
@@ -19,9 +19,6 @@
 	floor_change.icon = 'icons/hud/screen_midnight.dmi'
 	static_inventory += floor_change
 
-	combo_display = new /atom/movable/screen/combo(null, src)
-	infodisplay += combo_display
-
 	//mob health doll! assumes whatever sprite the mob is
 	healthdoll = new /atom/movable/screen/healthdoll/living(null, src)
 	infodisplay += healthdoll

--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -24,6 +24,8 @@
 	var/smashes_tables = FALSE
 	/// If TRUE, a combo meter will be displayed on the HUD for the current streak
 	var/display_combos = FALSE
+	///The Combo HUD given to display comboes, if we're set to display them.
+	var/atom/movable/screen/combo/combo_display
 	/// The length of time until streaks are auto-reset.
 	var/combo_timer = 6 SECONDS
 	/// Timer ID for the combo reset timer.
@@ -230,7 +232,7 @@
 		streak = copytext(streak, 1 + length(streak[1]))
 	if(display_combos)
 		timerid = addtimer(CALLBACK(src, PROC_REF(reset_streak), null, FALSE), combo_timer, TIMER_UNIQUE | TIMER_STOPPABLE)
-		holder.hud_used?.combo_display.update_icon_state(streak, combo_timer - 2 SECONDS)
+		combo_display.update_icon_state(streak, combo_timer - 2 SECONDS)
 
 /**
  * Resets the current streak.
@@ -245,7 +247,7 @@
 	current_target = WEAKREF(new_target)
 	streak = ""
 	if(display_combos && update_icon)
-		holder.hud_used?.combo_display.update_icon_state(streak)
+		combo_display.update_icon_state(streak)
 
 /datum/martial_art/proc/smash_table(mob/living/source, mob/living/pushed_mob, obj/structure/table/table)
 	SIGNAL_HANDLER
@@ -334,6 +336,19 @@
 	RegisterSignal(new_holder, COMSIG_LIVING_UNARMED_ATTACK, PROC_REF(unarmed_strike))
 	RegisterSignal(new_holder, COMSIG_LIVING_GRAB, PROC_REF(attempt_grab))
 	RegisterSignals(new_holder, list(COMSIG_LIVING_TABLE_SLAMMING, COMSIG_LIVING_TABLE_LIMB_SLAMMING), PROC_REF(smash_table))
+	if(display_combos)
+		if(new_holder.hud_used)
+			on_hud_created(new_holder)
+		else
+			RegisterSignal(new_holder, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
+
+///Gives the owner of the martial art the combo HUD.
+/datum/martial_art/proc/on_hud_created(mob/source)
+	SIGNAL_HANDLER
+	var/datum/hud/hud_used = source.hud_used
+	combo_display = new(null, hud_used)
+	hud_used.infodisplay += combo_display
+	hud_used.show_hud(hud_used.hud_version)
 
 /**
  * Called when this martial art is removed from a mob.
@@ -344,6 +359,8 @@
 	if(help_verb)
 		remove_verb(remove_from, help_verb)
 	UnregisterSignal(remove_from, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_LIVING_GRAB, COMSIG_LIVING_TABLE_SLAMMING, COMSIG_LIVING_TABLE_LIMB_SLAMMING))
+	if(!isnull(combo_display))
+		QDEL_NULL(combo_display)
 
 /mob/living/proc/verb_switch_style()
 	set name = "Swap Style"

--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -342,14 +342,6 @@
 		else
 			RegisterSignal(new_holder, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
 
-///Gives the owner of the martial art the combo HUD.
-/datum/martial_art/proc/on_hud_created(mob/source)
-	SIGNAL_HANDLER
-	var/datum/hud/hud_used = source.hud_used
-	combo_display = new(null, hud_used)
-	hud_used.infodisplay += combo_display
-	hud_used.show_hud(hud_used.hud_version)
-
 /**
  * Called when this martial art is removed from a mob.
  */
@@ -361,6 +353,14 @@
 	UnregisterSignal(remove_from, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_LIVING_GRAB, COMSIG_LIVING_TABLE_SLAMMING, COMSIG_LIVING_TABLE_LIMB_SLAMMING))
 	if(!isnull(combo_display))
 		QDEL_NULL(combo_display)
+
+///Gives the owner of the martial art the combo HUD.
+/datum/martial_art/proc/on_hud_created(mob/source)
+	SIGNAL_HANDLER
+	var/datum/hud/hud_used = source.hud_used
+	combo_display = new(null, hud_used)
+	hud_used.infodisplay += combo_display
+	hud_used.show_hud(hud_used.hud_version)
 
 /mob/living/proc/verb_switch_style()
 	set name = "Swap Style"


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/90588 - but for martial arts. Currently only 3 martial arts has a combo system, yet every single hud for every living & human has an invisible martial art hud on them 24/7, "just in case".

The HUD in question
![image](https://github.com/user-attachments/assets/a332b406-18bd-4853-b8ce-200342df4093)

## Why It's Good For The Game

Removes having a HUD on every player 24/7 when in most cases it'll never be used, and removes an unnecessary var on the base hud datum.

## Changelog

Nothing player-facing.