### PR TITLE
Halves Settler quirk nutrition retention bonus

### DIFF
--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -27,7 +27,7 @@
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
-	human_quirkholder.physiology.hunger_mod *= 0.5 //good for you, shortass, you don't get hungry nearly as often
+	human_quirkholder.physiology.hunger_mod *= 0.75 //good for you, shortass, you don't get hungry nearly as often
 	human_quirkholder.add_traits(settler_traits, QUIRK_TRAIT)
 
 /datum/quirk/item_quirk/settler/add_unique(client/client_source)
@@ -40,5 +40,5 @@
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
 	human_quirkholder.remove_movespeed_modifier(/datum/movespeed_modifier/settler)
-	human_quirkholder.physiology.hunger_mod *= 2
+	human_quirkholder.physiology.hunger_mod /= 0.75
 	human_quirkholder.remove_traits(settler_traits, QUIRK_TRAIT)


### PR DESCRIPTION
## About The Pull Request

Settler hunger modifier goes from 0.5 to 0.75

## Why It's Good For The Game

ON AVERAGE a player at standard sanity, standard nutrition, standard blood level will take ~20 minutes before they get "hungry". (This is more like ~15minutes if they move around a lot.)

At high sanity, this is increased to ~25 minutes. (You get up to a 0.75 modifier with high sanity.)

With settler, this is increased to **~40 minutes**. (Settler currently gives a 0.5 modifier.)

That means at high sanity, with Settler, it takes **~50 minutes** for someone to get hungry! (0.375 total modifier)

This is really high! It's almost a full round! Wow! I don't think it's necessarily healthy to have a quirk basically disable the hunger system.

Reducing settler to 0.75 brings it to much more reasonable ranges - somewhere between +5-+15 minutes, rather than +20-+30.

## Changelog

:cl: Melbert
balance: Settler's bonus reduction to passive hunger drain has been halved, ensuring they will at least get hungry once per round (but they still get hungry considerably less)
/:cl:
