### PR TITLE
You can rotate scanner gates

### DIFF
--- a/code/__DEFINES/rotation.dm
+++ b/code/__DEFINES/rotation.dm
@@ -8,6 +8,8 @@
 #define ROTATION_NO_FLIPPING (1<<3)
 /// If an object needs to have an empty spot available in target direction (used for windoors and railings)
 #define ROTATION_NEEDS_ROOM (1<<4)
+/// The turf the object is on needs to be unblocked for the rotation to occur
+#define ROTATION_NEEDS_UNBLOCKED (1<<5)
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE -90

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -115,6 +115,13 @@
 			if(!silent)
 				rotated_obj.balloon_alert(user, "can't rotate in that direction!")
 			return FALSE
+
+	if(rotation_flags & ROTATION_NEEDS_UNBLOCKED)
+		var/turf/rotate_turf = get_turf(rotated_obj)
+		if(rotate_turf.is_blocked_turf(source_atom = rotated_obj))
+			if(!silent)
+				rotated_obj.balloon_alert(user, "rotation is blocked!")
+			return FALSE
 	return TRUE
 
 /datum/component/simple_rotation/proc/default_post_rotation(mob/user, degrees)

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -87,6 +87,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	AddComponent(/datum/component/simple_rotation, ROTATION_IGNORE_ANCHORED|ROTATION_REQUIRE_WRENCH|ROTATION_NEEDS_UNBLOCKED)
 	register_context()
 
 /obj/machinery/scanner_gate/Destroy(force)
@@ -97,6 +98,10 @@
 	. = ..()
 	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
 		minus_false_beep = scanning_module.tier //The better are scanninning modules - the lower is chance of False Positives
+
+/obj/machinery/scanner_gate/setDir(newdir)
+	. = ..()
+	scanline?.setDir(newdir)
 
 /obj/machinery/scanner_gate/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds `simple_rotation` to scanner gates

## Why It's Good For The Game

These have dir sprites but no way to obtain them in game (AFAIK). 

## Changelog

:cl: Melbert
qol: You can rotate scanner gates (even though it functionally does nothing)
/:cl:
