### PR TITLE
Radio sfx option is in the radio instead of settings

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -477,6 +477,7 @@
 	data["subspace"] = subspace_transmission
 	data["subspaceSwitchable"] = subspace_switchable
 	data["headset"] = FALSE
+	data["radio_noises"] = (user.client?.prefs.read_preference(/datum/preference/numeric/volume/sound_radio_noise))
 
 	return data
 
@@ -484,6 +485,8 @@
 	. = ..()
 	if(.)
 		return
+
+	var/mob/user = ui.user
 	switch(action)
 		if("frequency")
 			if(freqlock != RADIO_FREQENCY_UNLOCKED)
@@ -524,6 +527,15 @@
 				else
 					recalculateChannels()
 				. = TRUE
+		if("set_radio_volume")
+			if(!user.client)
+				return
+			user.client.prefs.write_preference(GLOB.preference_entries[/datum/preference/numeric/volume/sound_radio_noise], params["volume"])
+			//let them know what it'll sound like
+			//we get their read prefs instead of just taking the params beacuse write_preference is what handles ensuring
+			//there's no href exploits.
+			var/volume_modifier = (user.client.prefs.read_preference(/datum/preference/numeric/volume/sound_radio_noise))
+			SEND_SOUND(user, sound('sound/items/radio/radio_receive.ogg', volume = volume_modifier))
 
 /obj/item/radio/examine(mob/user)
 	. = ..()

--- a/code/modules/client/preferences/sounds.dm
+++ b/code/modules/client/preferences/sounds.dm
@@ -110,7 +110,6 @@
 
 /// Controls radio noise volume
 /datum/preference/numeric/volume/sound_radio_noise
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "sound_radio_noise"
 	savefile_identifier = PREFERENCE_PLAYER
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
@@ -110,13 +110,6 @@ export const sound_achievement: FeatureChoiced = {
   component: FeatureDropdownInput,
 };
 
-export const sound_radio_noise: Feature<number> = {
-  name: 'Radio noise volume',
-  category: 'SOUND',
-  description: `Volume of talking and hearing radio chatter sounds.`,
-  component: FeatureSliderInput,
-};
-
 export const sound_ai_vox: Feature<number> = {
   name: 'AI VOX announcements volume',
   category: 'SOUND',

--- a/tgui/packages/tgui/interfaces/Radio.tsx
+++ b/tgui/packages/tgui/interfaces/Radio.tsx
@@ -5,15 +5,32 @@ import {
   LabeledList,
   NumberInput,
   Section,
+  Slider,
 } from 'tgui-core/components';
 import { toFixed } from 'tgui-core/math';
+import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
 import { RADIO_CHANNELS } from '../constants';
 import { Window } from '../layouts';
 
+type RadioData = {
+  freqlock: number;
+  frequency: number;
+  minFrequency: number;
+  maxFrequency: number;
+  listening: BooleanLike;
+  broadcasting: BooleanLike;
+  command: BooleanLike;
+  useCommand: BooleanLike;
+  subspace: BooleanLike;
+  subspaceSwitchable: BooleanLike;
+  channels: string[];
+  radio_noises: number;
+};
+
 export const Radio = (props) => {
-  const { act, data } = useBackend();
+  const { act, data } = useBackend<RadioData>();
   const {
     freqlock,
     frequency,
@@ -25,6 +42,7 @@ export const Radio = (props) => {
     useCommand,
     subspace,
     subspaceSwitchable,
+    radio_noises,
   } = data;
   const tunedChannel = RADIO_CHANNELS.find(
     (channel) => channel.freq === frequency,
@@ -34,7 +52,7 @@ export const Radio = (props) => {
     status: !!value,
   }));
   // Calculate window height
-  let height = 106;
+  let height = 133;
   if (subspace) {
     if (channels.length > 0) {
       height += channels.length * 21 + 6;
@@ -54,7 +72,7 @@ export const Radio = (props) => {
                 </Box>
               )) || (
                 <NumberInput
-                  animate
+                  animated
                   unit="kHz"
                   step={0.2}
                   stepPixelSize={10}
@@ -108,6 +126,20 @@ export const Radio = (props) => {
                   onClick={() => act('subspace')}
                 />
               )}
+            </LabeledList.Item>
+            <LabeledList.Item label="Radio Noise Volume">
+              <Slider
+                onChange={(e, value) => {
+                  act('set_radio_volume', {
+                    volume: value,
+                  });
+                }}
+                minValue={0}
+                maxValue={100}
+                step={1}
+                value={radio_noises}
+                stepPixelSize={10}
+              />
             </LabeledList.Item>
             {!!subspace && (
               <LabeledList.Item label="Channels">


### PR DESCRIPTION
## About The Pull Request

Opinions aren't too strong about taking it out of the settings page, I only did it cause settings doesn't auto update with the pref updating, so I can put it back if wanted.

Adds a volume slider in radios which you can use to edit your own blip volume, which then plays a blip back at you so you know what it sounds like.

## Why It's Good For The Game

You now change the volume using the in-game item instead of having to scroll through a bunch of settings and find it, and you get instant feedback so you know exactly what it's gonna sound like.

https://github.com/user-attachments/assets/fe936ed8-9620-4e81-8782-e6fa99de100a

## Changelog

:cl:
qol: Radios/headsets now have a slider to change the volume from radio noises.
/:cl: