### PR TITLE
Drinking alcohol cures severe anxiety

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -239,7 +239,7 @@
 
 	. = cures.len
 	for(var/C_id in cures)
-		if(!affected_mob.reagents.has_reagent(C_id))
+		if(!affected_mob.reagents.has_reagent(target_reagent = C_id, check_subtypes = TRUE))
 			.--
 	if(!. || (needs_all_cures && . < cures.len))
 		return FALSE

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -4,7 +4,7 @@
 	max_stages = 4
 	spread_text = "On contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Ethanol"
+	cure_text = "Ethanol (Liquid Courage)"
 	cures = list(/datum/reagent/consumable/ethanol)
 	agent = "Excess Lepidopticides"
 	viable_mobtypes = list(/mob/living/carbon/human)


### PR DESCRIPTION
## About The Pull Request

The disease 'Severe Anxiety' is a tongue in cheek joke that alcohol is a cure for anxiety, but the reagent check doesn't actually look for subtypes. Includes them, so drinking alcohol actually cures the disease.

## Why It's Good For The Game

Drink away your worries.

## Changelog

:cl: LT3
fix: Severe anxiety can be cured by drinking any type of alcohol
/:cl: