### PR TITLE
Blind people cant become schizophrenic

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -848,6 +848,7 @@
 			|| candidate.stat == DEAD \
 			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
 			|| !candidate.mind.assigned_role \
+			|| candidate.is_blind()
 		)
 			candidates -= candidate
 

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -848,7 +848,7 @@
 			|| candidate.stat == DEAD \
 			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
 			|| !candidate.mind.assigned_role \
-			|| candidate.is_blind()
+			|| candidate.is_blind_from(QUIRK_TRAIT)
 		)
 			candidates -= candidate
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
 	list(/datum/quirk/numb, /datum/quirk/selfaware),
 	list(/datum/quirk/empath, /datum/quirk/evil),
+	list(/datum/quirk/insanity, /datum/quirk/item_quirk/blindness),
 ))
 
 GLOBAL_LIST_INIT(quirk_string_blacklist, generate_quirk_string_blacklist())

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_INIT(trauma_types, init_subtypes_w_path_keys(/datum/brain_trauma, list()))
+
 //Brain Traumas are the new actual brain damage. Brain damage itself acts as a way to acquire traumas: every time brain damage is dealt, there's a chance of receiving a trauma.
 //This chance gets higher the higher the mob's brainloss is. Removing traumas is a separate thing from removing brain damage: you can get restored to full brain operativity,
 // but keep the quirks, until repaired by neurine, surgery, lobotomy or magic; depending on the resilience
@@ -26,6 +28,11 @@
 		on_lose()
 		owner = null
 	return ..()
+
+///Proc returning TRUE/FALSE on whether or not this brain trauma can roll on this mob,
+///called only on traumas with 'random_gain'.
+/datum/brain_trauma/proc/can_gain(mob/living/carbon/potential_owner)
+	return TRUE
 
 //Called on life ticks
 /datum/brain_trauma/proc/on_life(seconds_per_tick, times_fired)

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -5,6 +5,7 @@
 	gain_text = ""
 	lose_text = ""
 	resilience = TRAUMA_RESILIENCE_SURGERY
+	random_gain = FALSE
 	/// Associated antag datum, used for displaying objectives and antag hud
 	var/datum/antagonist/hypnotized/antagonist
 	var/hypnotic_phrase = ""
@@ -12,7 +13,6 @@
 
 /datum/brain_trauma/hypnosis/New(phrase)
 	if(!phrase)
-		qdel(src)
 		return
 	hypnotic_phrase = phrase
 	try

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -15,7 +15,7 @@
 /datum/brain_trauma/special/imaginary_friend/can_gain(mob/living/carbon/potential_owner)
 	if(potential_owner.stat == DEAD || !potential_owner.client)
 		return FALSE
-	if(potential_owner.is_blind())
+	if(potential_owner.is_blind_from(QUIRK_TRAIT))
 		return FALSE
 	return ..()
 

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -12,12 +12,15 @@
 	var/mob/eye/imaginary_friend/friend
 	var/friend_initialized = FALSE
 
+/datum/brain_trauma/special/imaginary_friend/can_gain(mob/living/carbon/potential_owner)
+	if(potential_owner.stat == DEAD || !potential_owner.client)
+		return FALSE
+	if(potential_owner.is_blind())
+		return FALSE
+	return ..()
+
 /datum/brain_trauma/special/imaginary_friend/on_gain()
-	var/mob/living/M = owner
-	if(M.stat == DEAD || !M.client)
-		qdel(src)
-		return
-	..()
+	. = ..()
 	make_friend()
 	get_ghost()
 

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -14,6 +14,11 @@
 	/// Whether the hallucinations we give are uncapped, ie all the wacky ones
 	var/uncapped = FALSE
 
+/datum/brain_trauma/mild/hallucinations/can_gain(mob/living/carbon/potential_owner)
+	if(potential_owner.is_blind_from(QUIRK_TRAIT))
+		return FALSE
+	return ..()
+
 /datum/brain_trauma/mild/hallucinations/on_life(seconds_per_tick, times_fired)
 	if(owner.stat >= UNCONSCIOUS)
 		return

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -512,6 +512,9 @@
 		trauma = trauma.type
 	if(!initial(trauma.can_gain))
 		return FALSE
+	var/datum/brain_trauma/trauma_type = GLOB.trauma_types[trauma]
+	if(!trauma_type.can_gain(owner))
+		return FALSE
 	if(!resilience)
 		resilience = initial(trauma.resilience)
 

--- a/strings/sillytips.txt
+++ b/strings/sillytips.txt
@@ -40,3 +40,4 @@ You can light a match with the heel of your boot. ...What's that? Friction match
 You can win a pulse rifle from the arcade machine. Honest.
 Your sprite represents your hitbox, so that afro makes you easier to kill. The sacrifices we make for style.
 Gorillas can be killed by land mines placed along forest paths.
+There hasn't been a single case of a blind person with schizophrenia.


### PR DESCRIPTION
## About The Pull Request

People with the blind quirk can't get obsessed/imaginary friend/hallucinations anymore, and can't take both insanity & blind quirks together.
Only affects people who are blinded from the Quirk, temporary blindness like losing your eyes can still get them.

## Why It's Good For The Game

Blind people can't develop schizophrenia, which is pretty much what these traumas are, this is truly a game-shattering error and we must fix this to stop the belief that blind people could become schizophrenic.

## Changelog

:cl:
fix: People using the Blind quirk can no longer get schizophrenia
/:cl: