### PR TITLE
adds auto-updating for status display image on alert level change

### DIFF
--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -5,11 +5,14 @@ SUBSYSTEM_DEF(security_level)
 	var/datum/security_level/current_security_level
 	/// A list of initialised security level datums.
 	var/list/available_levels = list()
+	/// A list of alert icon states for use in [/obj/machinery/status_display/evac] (to differentiate them from other display images)
+	var/list/alert_level_icons = list()
 
 /datum/controller/subsystem/security_level/Initialize()
 	for(var/iterating_security_level_type in subtypesof(/datum/security_level))
 		var/datum/security_level/new_security_level = new iterating_security_level_type
 		available_levels[new_security_level.name] = new_security_level
+		alert_level_icons += new_security_level.status_display_icon_state
 	current_security_level = available_levels[number_level_to_text(SEC_LEVEL_GREEN)]
 	return SS_INIT_SUCCESS
 

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -391,10 +391,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 	AddComponent(/datum/component/usb_port, list(
 		/obj/item/circuit_component/status_display,
 	))
+	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(on_sec_level_change))
 	find_and_hang_on_wall()
 
 /obj/machinery/status_display/evac/Destroy()
 	SSradio.remove_object(src,frequency)
+	UnregisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED)
 	return ..()
 
 /obj/machinery/status_display/evac/process()
@@ -457,6 +459,18 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 	if(vname == NAMEOF(src, current_mode))
 		update_appearance()
 		update()
+
+/// Signal handler for [COMSIG_SECURITY_LEVEL_CHANGED] - Autoupdates our display to show current alert level.
+/// Changes only when we are in 'alert' mode ([SD_PICTURE] and one of the alert's icon state already set)
+/obj/machinery/status_display/evac/proc/on_sec_level_change(datum/source, new_level)
+	SIGNAL_HANDLER
+	if(current_mode != SD_PICTURE)
+		return
+	if(!(current_picture in SSsecurity_level.alert_level_icons))
+		return
+
+	var/datum/security_level/alert_level = SSsecurity_level.available_levels[SSsecurity_level.number_level_to_text(new_level)]
+	set_picture(alert_level.status_display_icon_state)
 
 /// Supply display which shows the status of the supply shuttle.
 /obj/machinery/status_display/supply


### PR DESCRIPTION

## About The Pull Request
Status display in the alert mode will now change their sprite when sec level changes
closes #90576

https://imgur.com/a/BiNqeBC
## Why It's Good For The Game
Makes status display consistent with fire alarms, so they both update their color according to current security level
## Changelog
:cl:
fix: Status display software got updated and it can now automatically change its image in response to current security level when in security level mode
/:cl:
