### PR TITLE
Fixes "begins" in autopsy surgery step

### DIFF
--- a/code/modules/surgery/autopsy.dm
+++ b/code/modules/surgery/autopsy.dm
@@ -38,7 +38,7 @@
 	display_results(
 		user,
 		target,
-		span_notice("You begins performing an autopsy on [target]..."),
+		span_notice("You begin performing an autopsy on [target]..."),
 		span_notice("[user] uses [tool] to perform an autopsy on [target]."),
 		span_notice("[user] uses [tool] on [target]'s chest."),
 	)


### PR DESCRIPTION
## About The Pull Request

small grammar fix

## Changelog

:cl:
spellcheck: Fixes "begins" in the autopsy surgery step.
/:cl: