### PR TITLE
Bitrunner Glitch antagonists will not spawn on peaceful domains

### DIFF
--- a/code/modules/bitrunning/event.dm
+++ b/code/modules/bitrunning/event.dm
@@ -30,7 +30,7 @@
 /datum/round_event_control/bitrunning_glitch/proc/validate_servers()
 	active_servers.Cut()
 	for(var/obj/machinery/quantum_server/server in SSmachines.get_machines_by_type(/obj/machinery/quantum_server))
-		if(server.validate_mutation_candidates())
+		if(server.validate_mutation_candidates() && server.generated_domain.difficulty != BITRUNNER_DIFFICULTY_NONE)
 			active_servers.Add(WEAKREF(server))
 
 	return length(active_servers) > 0


### PR DESCRIPTION

## About The Pull Request

This prevents the cyber malfunction event from running on peaceful difficulty bitrunner simulations.

More specifically, mobs in a peaceful simulation will not be considered for glitch mutation.

@jlsnow301 would like to know your thoughts on this as well.
## Why It's Good For The Game

You don't get any weapons on peaceful simulations. In a 1v1 standoff between a bitrunner without ability disks loaded and a glitch mob, it generally doesn't end well for the former. The result is also usually the same after they use up their second and third respawns.

Bitrunners should at least have a fighting chance at completing their objectives when a glitch spawns. This is the case for most other maps, but not any of the peaceful ones.
## Changelog
:cl: Rhials
balance: Bitrunning simulations of the lowest threat will not spawn Bitrunner Glitches
/:cl:
