### PR TITLE
Job assignment code at round start now properly respects any overflow caps set in the config files.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -556,6 +556,11 @@ SUBSYSTEM_DEF(job)
 		if (BEOVERFLOW)
 			var/datum/job/overflow_role_datum = get_job_type(overflow_role)
 
+			if((overflow_role_datum.current_positions >= overflow_role_datum.spawn_positions) && overflow_role_datum.spawn_positions != -1)
+				job_debug("HU: Overflow role player cap reached, trying to reject: [player]")
+				try_reject_player(player)
+				return
+
 			if(check_job_eligibility(player, overflow_role_datum, debug_prefix = "HU", add_job_to_log = TRUE) != JOB_AVAILABLE)
 				job_debug("HU: Player cannot be overflow, trying to reject: [player]")
 				try_reject_player(player)
@@ -899,7 +904,13 @@ SUBSYSTEM_DEF(job)
 	// appear normal from the UI. By passing in JP_ANY, it will return all players that have the overflow job pref (which should be a toggle)
 	// set to any level.
 	var/list/overflow_candidates = find_occupation_candidates(overflow_datum, JP_ANY)
+	job_debug("OVRFLW: Attempting to assign the overflow role to [length(overflow_candidates)] players.")
 	for(var/mob/dead/new_player/player in overflow_candidates)
+		if((overflow_datum.current_positions >= overflow_datum.spawn_positions) && overflow_datum.spawn_positions != -1)
+			job_debug("OVRFLW: Overflow role cap reached, role only assigned to [overflow_datum.current_positions] players.")
+			job_debug("OVRFLW: Overflow Job is now full, Job: [overflow_datum], Positions: [overflow_datum.current_positions], Limit: [overflow_datum.spawn_positions]")
+			return
+
 		// Eligibility checks done as part of find_occupation_candidates, so skip them.
 		assign_role(player, get_job_type(overflow_role), do_eligibility_checks = FALSE)
 		job_debug("OVRFLW: Assigned overflow to player: [player]")


### PR DESCRIPTION

## About The Pull Request

Makes overflow assignment respect the `OVERFLOW_CAP` config setting from game_options.txt by actually checking for available positions instead of just always assuming it's infinite.

This fixes an oversight by myself, the last person to meaningfully touch this code.

This is currently TM only because when job assignment fails, the shift fails. And although I'm fairly sure the overflow isn't used as like a final turbo fallback in some edge case, I'm not sure and want it tested first (also useful to test it now since one of our servers has an overflow cap in place).

## Why It's Good For The Game

Just makes the code actually respect what's set in the config. Somewhat useful.

## Changelog

:cl:
fix: Job assignment code at round start now properly respects any overflow caps set in the config files.
/:cl:
