### PR TITLE
Disable screentip images for clients on BYOND 516.1657+

### DIFF
--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -4,3 +4,9 @@
 /// Checks to see if a /client has fully gone through New() as a safeguard against certain operations.
 /// Should return the boolean value of the fully_created var, which should be TRUE if New() has finished running. FALSE otherwise.
 #define VALIDATE_CLIENT_INITIALIZATION(target) (target.fully_created)
+
+/// The minimum client BYOND build to disable screentip icons for.
+#define MIN_BYOND_BUILD_DISABLE_SCREENTIP_ICONS 1657
+/// The maximum client BYOND build to disable screentip icons for.
+/// Update this whenever https://www.byond.com/forum/post/2967731 is fixed.
+#define MAX_BYOND_BUILD_DISABLE_SCREENTIP_ICONS 1699

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -896,6 +896,9 @@
 
 			if (contextual_screentip_returns & CONTEXTUAL_SCREENTIP_SET)
 				var/screentip_images = active_hud.screentip_images
+				// Disable screentip images for clients affected by https://www.byond.com/forum/post/2967731
+				if(ISINRANGE(client?.byond_build, MIN_BYOND_BUILD_DISABLE_SCREENTIP_ICONS, MAX_BYOND_BUILD_DISABLE_SCREENTIP_ICONS))
+					screentip_images = FALSE
 				// LMB and RMB on one line...
 				var/lmb_text = build_context(context, SCREENTIP_CONTEXT_LMB, screentip_images)
 				var/rmb_text = build_context(context, SCREENTIP_CONTEXT_RMB, screentip_images)


### PR DESCRIPTION

## About The Pull Request

self-explanatory - this always disables screentip images for clients on BYOND 516.1657 and later, due to https://www.byond.com/forum/post/2967731 (https://github.com/tgstation/tgstation/issues/90373)

whenever the bug is fixed, please update the `MAX_BYOND_BUILD_DISABLE_SCREENTIP_ICONS` define.

![2025-04-13 (1744591910) ~ dreamseeker](https://github.com/user-attachments/assets/3eefcf21-d8f9-40a1-9d72-4fdca243c0eb)

## Why It's Good For The Game

so people stop complaining about a bug that's out of our control

## Changelog
:cl:
fix: Screentip images will no longer appear for players on BYOND versions suffering from the bug that makes them way too big.
/:cl:
