### PR TITLE
Adds Common Second Language quirk, tweaks to partial understanding

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -73,11 +73,6 @@
 	#define HEARING_SPANS 6
 	#define HEARING_MESSAGE_MODE 7
 	#define HEARING_RANGE 8
-/// Send to a movable after some other movable has heard them speak in another language they do not understand
-/// Args: (atom/movable/translating_for, language_type, list/mutual_understanding)
-/// Adding 100 understanding of the language to the mutual_understanding list will stop the translation
-/// Otherwise it affects how much of the sentence will be translated (% wise)
-#define COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED "movable_language_being_translated"
 
 ///called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -73,6 +73,11 @@
 	#define HEARING_SPANS 6
 	#define HEARING_MESSAGE_MODE 7
 	#define HEARING_RANGE 8
+/// Send to a movable after some other movable has heard them speak in another language they do not understand
+/// Args: (atom/movable/translating_for, language_type, list/mutual_understanding)
+/// Adding 100 understanding of the language to the mutual_understanding list will stop the translation
+/// Otherwise it affects how much of the sentence will be translated (% wise)
+#define COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED "movable_language_being_translated"
 
 ///called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"
@@ -138,4 +143,3 @@
 #define COMSIG_MOVABLE_BUMP_PUSHED "movable_bump_pushed"
 	/// Stop it from moving
 	#define COMPONENT_NO_PUSH (1<<0)
-

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -5,6 +5,8 @@
 #define RADIO_EXTENSION "department specific"
 #define RADIO_KEY "department specific key"
 #define LANGUAGE_EXTENSION "language specific"
+/// Message mod which contains a list of bonus "mutual understanding" to allow arbitrary understanding of any speech
+#define LANGUAGE_MUTUAL_BONUS "language mutual bonus"
 #define SAY_MOD_VERB "say_mod_verb"
 
 //Message modes. Each one defines a radio channel, more or less.

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/social_anxiety, /datum/quirk/mute),
 	list(/datum/quirk/mute, /datum/quirk/softspoken),
 	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
-	list(/datum/quirk/bilingual, /datum/quirk/foreigner),
+	list(/datum/quirk/bilingual, /datum/quirk/foreigner, /datum/quirk/csl),
 	list(/datum/quirk/spacer_born, /datum/quirk/item_quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),

--- a/code/datums/quirks/negative_quirks/csl.dm
+++ b/code/datums/quirks/negative_quirks/csl.dm
@@ -13,7 +13,7 @@
 		quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
 	else
 		quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_ATOM)
-	quirk_holder.grant_partial_language(/datum/language/common, text2num(client_source?.preferences?.read_preference(/datum/preference/choiced/csl_strength)) || 90, type)
+	quirk_holder.grant_partial_language(/datum/language/common, text2num(client_source?.prefs?.read_preference(/datum/preference/choiced/csl_strength)) || 90, type)
 	RegisterSignal(quirk_holder, COMSIG_SPECIES_GAIN, PROC_REF(reremove_common))
 	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(translate_everything))
 	RegisterSignal(quirk_holder, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED, PROC_REF(translate_parts))

--- a/code/datums/quirks/negative_quirks/csl.dm
+++ b/code/datums/quirks/negative_quirks/csl.dm
@@ -4,9 +4,11 @@
 		Some words in common will sound foreign, and you may drift back to your native tongue \
 		when you are anxious or upset."
 	icon = FA_ICON_LANDMARK_DOME
+	quirk_flags = QUIRK_HIDE_FROM_SCAN
 	value = -2
 	gain_text = span_danger("You have difficulty parsing Common.")
 	lose_text = span_notice("Common starts to click for you.")
+	medical_record_text = "Patient is CSL."
 	/// What language typepath is our primary language?
 	var/native_language
 

--- a/code/datums/quirks/negative_quirks/csl.dm
+++ b/code/datums/quirks/negative_quirks/csl.dm
@@ -8,12 +8,12 @@
 	gain_text = span_danger("You have difficulty parsing Common.")
 	lose_text = span_notice("Common starts to click for you.")
 
-/datum/quirk/csl/add()
+/datum/quirk/csl/add(client/client_source)
 	if(iscarbon(quirk_holder))
 		quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
 	else
 		quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_ATOM)
-	quirk_holder.grant_partial_language(/datum/language/common, 90, type)
+	quirk_holder.grant_partial_language(/datum/language/common, text2num(client_source?.preferences?.read_preference(/datum/preference/choiced/csl_strength)) || 90, type)
 	RegisterSignal(quirk_holder, COMSIG_SPECIES_GAIN, PROC_REF(reremove_common))
 	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(translate_everything))
 	RegisterSignal(quirk_holder, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED, PROC_REF(translate_parts))
@@ -22,6 +22,9 @@
 	UnregisterSignal(quirk_holder, COMSIG_SPECIES_GAIN)
 	UnregisterSignal(quirk_holder, COMSIG_MOB_SAY)
 	UnregisterSignal(quirk_holder, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED)
+
+	if(QDELING(quirk_holder))
+		return
 
 	quirk_holder.remove_partial_language(/datum/language/common, type)
 	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
@@ -87,3 +90,9 @@
 
 	// starts at 95%, then goes down to 20%
 	mutual_understanding[native_language] = max(mutual_understanding[native_language], round(quirk_holder.mob_mood?.sanity + 20, 5))
+
+/datum/quirk_constant_data/csl
+	associated_typepath = /datum/quirk/csl
+	customization_options = list(
+		/datum/preference/choiced/csl_strength,
+	)

--- a/code/datums/quirks/negative_quirks/csl.dm
+++ b/code/datums/quirks/negative_quirks/csl.dm
@@ -1,0 +1,89 @@
+/datum/quirk/csl
+	name = "Common Second Language"
+	desc = "Common is not your native tongue - it's something you had to pick up along the way. \
+		Parsing common will be difficult (but not impossible), and you may drift back to your native tongue \
+		when you are stressed, anxious, or angry."
+	icon = FA_ICON_LANDMARK_DOME
+	value = -2
+	gain_text = span_danger("You have difficulty parsing Common.")
+	lose_text = span_notice("Common starts to click for you.")
+
+/datum/quirk/csl/add()
+	if(iscarbon(quirk_holder))
+		quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
+	else
+		quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_ATOM)
+	quirk_holder.grant_partial_language(/datum/language/common, 90, type)
+	RegisterSignal(quirk_holder, COMSIG_SPECIES_GAIN, PROC_REF(reremove_common))
+	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(translate_everything))
+	RegisterSignal(quirk_holder, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED, PROC_REF(translate_parts))
+
+/datum/quirk/csl/remove()
+	UnregisterSignal(quirk_holder, COMSIG_SPECIES_GAIN)
+	UnregisterSignal(quirk_holder, COMSIG_MOB_SAY)
+	UnregisterSignal(quirk_holder, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED)
+
+	quirk_holder.remove_partial_language(/datum/language/common, type)
+	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
+	if(istype(carbon_quirk_holder) && carbon_quirk_holder.dna.species)
+		// only give back common if they're a species that should speak it
+		var/datum/language_holder/species_holder = GLOB.prototype_language_holders[carbon_quirk_holder.dna.species.species_language_holder]
+		if(LAZYACCESS(species_holder.spoken_languages, /datum/language/common))
+			quirk_holder.grant_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
+	else
+		quirk_holder.grant_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_ATOM)
+
+/datum/quirk/csl/is_species_appropriate(datum/species/mob_species)
+	var/datum/language_holder/species_holder = GLOB.prototype_language_holders[mob_species.species_language_holder]
+	if(isnull(species_holder))
+		return FALSE
+	if(length(species_holder.spoken_languages) < 2)
+		return FALSE
+	return ..()
+
+/// Gets our native language from our list of spoken languages
+/datum/quirk/csl/proc/get_native_language()
+	var/list/language_pool = quirk_holder.get_language_holder()?.spoken_languages?.Copy()
+	if(!length(language_pool))
+		return // no languages to pick from at all?
+
+	// Don't want this
+	language_pool -= /datum/language/common
+	// If we have native languages set, prefer them
+	var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_by_type(/obj/item/organ/tongue)
+	if(length(tongue?.languages_native) > 0)
+		language_pool &= tongue.languages_native
+
+	if(length(language_pool) < 1)
+		return // guess we couldn't find one
+
+	return language_pool[1]
+
+// Every time we change species we need to re-remove common from our list
+/datum/quirk/csl/proc/reremove_common(...)
+	SIGNAL_HANDLER
+	quirk_holder.remove_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
+
+// At low sanity we translate everything to our native language
+/datum/quirk/csl/proc/translate_everything(datum/source, list/say_args)
+	SIGNAL_HANDLER
+
+	if(say_args[SPEECH_FORCED] || quirk_holder.mob_mood?.sanity > 75)
+		return
+	say_args[SPEECH_LANGUAGE] = get_native_language()
+
+// While all of our messages become our native language, we also add some mutual understanding to everyone else
+/datum/quirk/csl/proc/translate_parts(datum/source, atom/movable/translating_for, language, list/mutual_understanding)
+	SIGNAL_HANDLER
+
+	if(quirk_holder.mob_mood?.sanity > 75)
+		return
+
+	var/native_language = get_native_language()
+	if(isnull(native_language) || native_language != language)
+		return // guh? i guess we do nothing
+	if(quirk_holder.get_selected_language() == native_language)
+		return // we are willingly speaking
+
+	// starts at 95%, then goes down to 20%
+	mutual_understanding[native_language] = max(mutual_understanding[native_language], round(quirk_holder.mob_mood?.sanity + 20, 5))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1609,6 +1609,7 @@
 
 /// Gets a lazylist of all mutually understood languages.
 /atom/movable/proc/get_partially_understood_languages() as /list
+	RETURN_TYPE(/list)
 	return get_language_holder().best_mutual_languages
 
 /// Gets a random spoken language, useful for forced speech and such.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1608,7 +1608,7 @@
 	return get_language_holder().get_random_understood_language()
 
 /// Gets a lazylist of all mutually understood languages.
-/atom/movable/proc/get_partially_understood_languages()
+/atom/movable/proc/get_partially_understood_languages() as /list
 	return get_language_holder().best_mutual_languages
 
 /// Gets a random spoken language, useful for forced speech and such.

--- a/code/game/machinery/telecomms/computers/logbrowser.dm
+++ b/code/game/machinery/telecomms/computers/logbrowser.dm
@@ -59,7 +59,7 @@
 					message_out = "\"[message_in]\""
 				else if(!user.has_language(language))
 					// Language unknown: scramble
-					message_out = "\"[language_instance.scramble_sentence(message_in, user.get_partially_understood_languages())]\""
+					message_out = "\"[language_instance.scramble_paragraph(message_in, user.get_partially_understood_languages())]\""
 				else
 					message_out = "(Unintelligible)"
 				packet_out["message"] = message_out

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -266,8 +266,13 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return "makes a strange sound."
 
 	if(!has_language(language))
-		var/list/mutual_languages = get_partially_understood_languages()?.Copy() || list()
-		SEND_SIGNAL(speaker, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED, src, language, mutual_languages)
+		var/list/mutual_languages
+		// Get what we can kinda understand, factor in any bonuses passed in from say mods
+		var/list/partially_understood_languages = get_partially_understood_languages()
+		if(LAZYLEN(partially_understood_languages))
+			mutual_languages = partially_understood_languages.Copy()
+			for(var/bonus_language in message_mods[LANGUAGE_MUTUAL_BONUS])
+				mutual_languages[bonus_language] = max(message_mods[LANGUAGE_MUTUAL_BONUS][bonus_language], mutual_languages[bonus_language])
 
 		var/datum/language/dialect = GLOB.language_datum_instances[language]
 		raw_message = dialect.scramble_paragraph(raw_message, mutual_languages)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -266,8 +266,11 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return "makes a strange sound."
 
 	if(!has_language(language))
+		var/list/mutual_languages = get_partially_understood_languages()?.Copy() || list()
+		SEND_SIGNAL(speaker, COMSIG_MOVABLE_LANGUAGE_BEING_TRANSLATED, src, language, mutual_languages)
+
 		var/datum/language/dialect = GLOB.language_datum_instances[language]
-		raw_message = dialect.scramble_sentence(raw_message, get_partially_understood_languages())
+		raw_message = dialect.scramble_paragraph(raw_message, mutual_languages)
 
 	return raw_message
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -180,7 +180,7 @@
 	invocation = "Ta'gh fara'qha fel d'amar det!"
 
 /datum/action/innate/cult/blood_spell/emp/Activate()
-	owner.whisper(invocation, language = /datum/language/common)
+	owner.whisper(invocation, language = /datum/language/common, forced = "cult invocation")
 	owner.visible_message(span_warning("[owner]'s hand flashes a bright blue!"), \
 		span_cult_italic("You speak the cursed words, emitting an EMP blast from your hand."))
 	empulse(owner, 2, 5)
@@ -219,7 +219,7 @@
 
 /datum/action/innate/cult/blood_spell/dagger/Activate()
 	var/turf/owner_turf = get_turf(owner)
-	owner.whisper(invocation, language = /datum/language/common)
+	owner.whisper(invocation, language = /datum/language/common, forced = "cult invocation")
 	owner.visible_message(span_warning("[owner]'s hand glows red for a moment."), \
 		span_cult_italic("Your plea for aid is answered, and light begins to shimmer and take form within your hand!"))
 	var/obj/item/summoned_blade = new summoned_type(owner_turf)
@@ -293,7 +293,7 @@
 			span_cult_italic("You invoke the veiling spell, hiding nearby runes."))
 		charges--
 		SEND_SOUND(owner, sound('sound/effects/magic/smoke.ogg',0,1,25))
-		owner.whisper(invocation, language = /datum/language/common)
+		owner.whisper(invocation, language = /datum/language/common, forced = "cult invocation")
 		for(var/obj/effect/rune/R in range(5,owner))
 			R.conceal()
 		for(var/obj/structure/destructible/cult/S in range(5,owner))
@@ -311,7 +311,7 @@
 		owner.visible_message(span_warning("A flash of light shines from [owner]'s hand!"), \
 			span_cult_italic("You invoke the counterspell, revealing nearby runes."))
 		charges--
-		owner.whisper(invocation, language = /datum/language/common)
+		owner.whisper(invocation, language = /datum/language/common, forced = "cult invocation")
 		SEND_SOUND(owner, sound('sound/effects/magic/enter_blood.ogg',0,1,25))
 		for(var/obj/effect/rune/R in range(7,owner)) //More range in case you weren't standing in exactly the same spot
 			R.reveal()
@@ -413,7 +413,7 @@
 
 /obj/item/melee/blood_magic/proc/cast_spell(atom/target, mob/living/carbon/user)
 	if(invocation)
-		user.whisper(invocation, language = /datum/language/common)
+		user.whisper(invocation, language = /datum/language/common, forced = "cult invocation")
 	if(health_cost)
 		if(user.active_hand_index == 1)
 			user.apply_damage(health_cost, BRUTE, BODY_ZONE_L_ARM, wound_bonus = CANT_WOUND)

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -48,7 +48,7 @@
 	var/my_message
 	if(!message || !user.mind)
 		return
-	user.whisper("O bidai nabora se[pick("'","`")]sma!", language = /datum/language/common)
+	user.whisper("O bidai nabora se[pick("'","`")]sma!", language = /datum/language/common, forced = "cult invocation")
 	user.whisper(html_decode(message), filterproof = TRUE)
 	var/title = "Acolyte"
 	var/span = "cult italic"

--- a/code/modules/client/preferences/language.dm
+++ b/code/modules/client/preferences/language.dm
@@ -82,3 +82,21 @@
 
 /datum/preference/choiced/language_skill/apply_to_human(mob/living/carbon/human/target, value)
 	return
+
+/datum/preference/choiced/csl_strength
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "csl_strength"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/csl_strength/create_default_value()
+	return "90%"
+
+/datum/preference/choiced/csl_strength/is_accessible(datum/preferences/preferences)
+	return ..() && (/datum/quirk/csl::name in preferences.all_quirks)
+
+/datum/preference/choiced/csl_strength/init_possible_values()
+	return list("90%", "75%", "50%", "33%", "25%", "10%")
+
+/datum/preference/choiced/csl_strength/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/code/modules/language/_language.dm
+++ b/code/modules/language/_language.dm
@@ -231,6 +231,7 @@
  * Takes into account any languages the hearer knows that has mutual understanding with this language.
  */
 /datum/language/proc/scramble_paragraph(input, list/mutual_languages)
+	// perfect understanding, no need to scramble
 	if(mutual_languages?[type] >= 100)
 		return input
 

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -417,16 +417,15 @@
 	taste_sensitivity = 32
 	liked_foodtypes = GROSS | MEAT | RAW | GORE
 	disliked_foodtypes = NONE
-
-// List of english words that translate to zombie phrases
-GLOBAL_LIST_INIT(english_to_zombie, list())
+	// List of english words that translate to zombie phrases
+	var/static/list/english_to_zombie = list()
 
 /obj/item/organ/tongue/zombie/proc/add_word_to_translations(english_word, zombie_word)
-	GLOB.english_to_zombie[english_word] = zombie_word
+	english_to_zombie[english_word] = zombie_word
 	// zombies don't care about grammar (any tense or form is all translated to the same word)
-	GLOB.english_to_zombie[english_word + plural_s(english_word)] = zombie_word
-	GLOB.english_to_zombie[english_word + "ing"] = zombie_word
-	GLOB.english_to_zombie[english_word + "ed"] = zombie_word
+	english_to_zombie[english_word + plural_s(english_word)] = zombie_word
+	english_to_zombie[english_word + "ing"] = zombie_word
+	english_to_zombie[english_word + "ed"] = zombie_word
 
 /obj/item/organ/tongue/zombie/proc/load_zombie_translations()
 	var/list/zombie_translation = strings("zombie_replacement.json", "zombie")
@@ -435,20 +434,20 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 		var/list/data = islist(zombie_translation[zombie_word]) ? zombie_translation[zombie_word] : list(zombie_translation[zombie_word])
 		for(var/english_word in data)
 			add_word_to_translations(english_word, zombie_word)
-	GLOB.english_to_zombie = sort_list(GLOB.english_to_zombie) // Alphabetizes the list (for debugging)
+	english_to_zombie = sort_list(english_to_zombie) // Alphabetizes the list (for debugging)
 
 /obj/item/organ/tongue/zombie/modify_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		// setup the global list for translation if it hasn't already been done
-		if(!length(GLOB.english_to_zombie))
+		if(!length(english_to_zombie))
 			load_zombie_translations()
 
 		// make a list of all words that can be translated
 		var/list/message_word_list = splittext(message, " ")
 		var/list/translated_word_list = list()
 		for(var/word in message_word_list)
-			word = GLOB.english_to_zombie[LOWER_TEXT(word)]
+			word = english_to_zombie[LOWER_TEXT(word)]
 			translated_word_list += word ? word : FALSE
 
 		// all occurrences of characters "eiou" (case-insensitive) are replaced with "r"
@@ -540,6 +539,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	modifies_speech = FALSE
 	liked_foodtypes = VEGETABLES
 	disliked_foodtypes = FRUIT | CLOTH
+	languages_native = list(/datum/language/calcic)
 
 /obj/item/organ/tongue/robot
 	name = "robotic voicebox"
@@ -612,6 +612,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	liked_foodtypes = MEAT | BUGS
 	disliked_foodtypes = GROSS
 	toxic_foodtypes = NONE
+	languages_native = list(/datum/language/slime)
 
 /obj/item/organ/tongue/jelly/get_food_taste_reaction(obj/item/food, foodtypes = NONE)
 	// a silver slime created this? what a delicacy!
@@ -625,6 +626,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	say_mod = "chimpers"
 	liked_foodtypes = MEAT | FRUIT | BUGS
 	disliked_foodtypes = CLOTH
+	languages_native = list(/datum/language/monkey)
 
 /obj/item/organ/tongue/moth
 	name = "moth tongue"
@@ -635,17 +637,13 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	toxic_foodtypes = MEAT | RAW | SEAFOOD
 	languages_native = list(/datum/language/moffic)
 
-/obj/item/organ/tongue/zombie
-	name = "rotting tongue"
-	desc = "Makes you speak like you're at the dentist and you just absolutely refuse to spit because you forgot to mention you were allergic to space shellfish."
-	say_mod = "moans"
-
 /obj/item/organ/tongue/mush
 	name = "mush-tongue-room"
 	desc = "You poof with this. Got it?"
 	icon = 'icons/obj/service/hydroponics/seeds.dmi'
 	icon_state = "mycelium-angel"
 	say_mod = "poofs"
+	languages_native = list(/datum/language/mushroom)
 
 /obj/item/organ/tongue/pod
 	name = "pod tongue"
@@ -655,6 +653,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	disliked_foodtypes = GORE | MEAT | DAIRY | SEAFOOD | BUGS
 	foodtype_flags = PODPERSON_ORGAN_FOODTYPES
 	color = COLOR_LIME
+	languages_native = list(/datum/language/sylvan)
 
 /obj/item/organ/tongue/golem
 	name = "golem tongue"
@@ -666,3 +665,4 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	liked_foodtypes = STONE
 	disliked_foodtypes = NONE //you don't care for much else besides stone
 	toxic_foodtypes = NONE //you can eat fucking uranium
+	languages_native = list(/datum/language/terrum)

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -483,6 +483,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	taste_sensitivity = 10 // LIZARDS ARE ALIENS CONFIRMED
 	modifies_speech = TRUE // not really, they just hiss
 	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.8,aresample=%SAMPLE_RATE%,atempo=1/0.8,aformat=channel_layouts=mono [p0]; [out2] asetrate=%SAMPLE_RATE%*1.2,aresample=%SAMPLE_RATE%,atempo=1/1.2,aformat=channel_layouts=mono[p2]; [p0][0][p2] amix=inputs=3"}
+
 // Aliens can only speak alien and a few other languages.
 /obj/item/organ/tongue/alien/get_possible_languages()
 	return list(
@@ -589,6 +590,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	attack_verb_continuous = list("shocks", "jolts", "zaps")
 	attack_verb_simple = list("shock", "jolt", "zap")
 	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.99,aresample=%SAMPLE_RATE%,volume=0.3 [p0]; [p0][out2] amix=inputs=2"}
+	languages_native = list(/datum/language/voltaic)
 
 // Ethereal tongues can speak all default + voltaic
 /obj/item/organ/tongue/ethereal/get_possible_languages()
@@ -601,6 +603,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	liked_foodtypes = SEAFOOD | ORANGES | BUGS | GORE
 	disliked_foodtypes = GROSS | CLOTH | RAW
 	organ_traits = list(TRAIT_WOUND_LICKER, TRAIT_FISH_EATER)
+	languages_native = list(/datum/language/nekomimetic)
 
 /obj/item/organ/tongue/jelly
 	name = "jelly tongue"
@@ -630,6 +633,7 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 	liked_foodtypes = VEGETABLES | DAIRY | CLOTH
 	disliked_foodtypes = FRUIT | GROSS | BUGS | GORE
 	toxic_foodtypes = MEAT | RAW | SEAFOOD
+	languages_native = list(/datum/language/moffic)
 
 /obj/item/organ/tongue/zombie
 	name = "rotting tongue"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1802,6 +1802,7 @@
 #include "code\datums\quirks\negative_quirks\chronic_illness.dm"
 #include "code\datums\quirks\negative_quirks\claustrophobia.dm"
 #include "code\datums\quirks\negative_quirks\clumsy.dm"
+#include "code\datums\quirks\negative_quirks\csl.dm"
 #include "code\datums\quirks\negative_quirks\cursed.dm"
 #include "code\datums\quirks\negative_quirks\deafness.dm"
 #include "code\datums\quirks\negative_quirks\depression.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/language.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/language.tsx
@@ -21,3 +21,9 @@ export const language_skill: FeatureChoiced = {
   description: 'The percentage of the language you can understand.',
   component: FeatureDropdownInput,
 };
+
+export const csl_strength: FeatureChoiced = {
+  name: 'Language Skill',
+  description: 'The percentage of Common you can understand.',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

- Tweaks partial understanding. 

Paragraphs are now split into sentences first creating more natural breaks between sentences.

- Adds "Common Second Language" quirk

This quirk changes your default understanding of common (up to) 90% (your choice), meaning you drop the occasional word.

![image](https://github.com/user-attachments/assets/63e9d67b-7db2-4d23-9d0f-bae175962db4)

![image](https://github.com/user-attachments/assets/840ef391-5126-4ba7-9298-804686bcd6df)

Additionally, when your sanity drops below a threshold, you become forced to speak your native language, albeit with a partial understanding applied for everyone else. 

Incompatible with similar language quirks + can't be taken by humans (yet?)

## Why It's Good For The Game

Just a fun way to play around with the new "partial understanding" system.

## Changelog

:cl: Melbert
add: "Common Second Language" quirk
qol: Language translations chunk sentences together better, making partial understanding a bit easier to parse.
/:cl:
