### PR TITLE
Clean up mob holder code

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -6,10 +6,12 @@
 	icon = null
 	icon_state = ""
 	slot_flags = NONE
+	/// Mob inside of us
 	var/mob/living/held_mob
+	/// True if we've started being destroyed
 	var/destroying = FALSE
 
-/obj/item/clothing/head/mob_holder/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
+/obj/item/clothing/head/mob_holder/Initialize(mapload, mob/living/held_mob, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
 	if(head_icon)
 		worn_icon = head_icon
 	if(worn_state)
@@ -20,29 +22,38 @@
 		righthand_file = rh_icon
 	if(worn_slot_flags)
 		slot_flags = worn_slot_flags
-	update_weight_class(M.held_w_class)
-	deposit(M)
-	. = ..()
+	update_weight_class(held_mob.held_w_class)
+	insert_mob(held_mob)
+	return ..()
 
 /obj/item/clothing/head/mob_holder/Destroy()
 	destroying = TRUE
 	if(held_mob)
-		release(FALSE)
+		release()
 	return ..()
 
-/obj/item/clothing/head/mob_holder/proc/deposit(mob/living/L)
-	if(!istype(L))
+/obj/item/clothing/head/mob_holder/proc/insert_mob(mob/living/new_prisoner)
+	if(!istype(new_prisoner))
 		return FALSE
-	L.setDir(SOUTH)
-	update_visuals(L)
-	held_mob = L
-	L.forceMove(src)
-	name = L.name
-	desc = L.desc
+	new_prisoner.setDir(SOUTH)
+	update_visuals(new_prisoner)
+	held_mob = new_prisoner
+	RegisterSignal(held_mob, COMSIG_QDELETING, PROC_REF(on_mob_deleted))
+	new_prisoner.forceMove(src)
+	name = new_prisoner.name
+	desc = new_prisoner.desc
 	return TRUE
 
-/obj/item/clothing/head/mob_holder/proc/update_visuals(mob/living/L)
-	appearance = L.appearance
+/obj/item/clothing/head/mob_holder/proc/on_mob_deleted()
+	SIGNAL_HANDLER
+	held_mob = null
+	if (isliving(loc))
+		var/mob/living/holder = loc
+		holder.temporarilyRemoveItemFromInventory(src, force = TRUE)
+	qdel(src)
+
+/obj/item/clothing/head/mob_holder/proc/update_visuals(mob/living/held_guy)
+	appearance = held_guy.appearance
 
 /obj/item/clothing/head/mob_holder/on_thrown(mob/living/carbon/user, atom/target)
 	if((item_flags & ABSTRACT) || HAS_TRAIT(src, TRAIT_NODROP))
@@ -56,29 +67,29 @@
 	release()
 	return throw_mob
 
-/obj/item/clothing/head/mob_holder/dropped()
-	..()
+/obj/item/clothing/head/mob_holder/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
+	. = ..()
 	if(held_mob && isturf(loc))
 		release()
 
-/obj/item/clothing/head/mob_holder/proc/release(del_on_release = TRUE, display_messages = TRUE)
+/obj/item/clothing/head/mob_holder/proc/release(display_messages = TRUE)
 	if(!held_mob)
-		if(del_on_release && !destroying)
+		if(!destroying)
 			qdel(src)
 		return FALSE
 	var/mob/living/released_mob = held_mob
 	held_mob = null // stops the held mob from being release()'d twice.
 	if(isliving(loc))
-		var/mob/living/L = loc
+		var/mob/living/captor = loc
 		if(display_messages)
-			to_chat(L, span_warning("[released_mob] wriggles free!"))
-		L.dropItemToGround(src)
+			to_chat(captor, span_warning("[released_mob] wriggles free!"))
+		captor.dropItemToGround(src)
 	released_mob.forceMove(drop_location())
 	released_mob.reset_perspective()
 	released_mob.setDir(SOUTH)
 	if(display_messages)
 		released_mob.visible_message(span_warning("[released_mob] uncurls!"))
-	if(del_on_release && !destroying)
+	if(!destroying)
 		qdel(src)
 	return TRUE
 
@@ -90,14 +101,14 @@
 
 /obj/item/clothing/head/mob_holder/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(held_mob && held_mob == gone)
+	if(held_mob == gone)
 		release()
 
 /obj/item/clothing/head/mob_holder/on_found(mob/finder)
 	if(held_mob?.will_escape_storage())
 		to_chat(finder, span_warning("\A [held_mob.name] pops out! "))
 		finder.visible_message(span_warning("\A [held_mob.name] pops out of the container [finder] is opening!"), ignored_mobs = finder)
-		release(TRUE, FALSE)
+		release(display_messages = FALSE)
 		return
 
 /obj/item/clothing/head/mob_holder/drone/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
@@ -106,15 +117,16 @@
 		return INITIALIZE_HINT_QDEL
 	return ..()
 
-/obj/item/clothing/head/mob_holder/drone/deposit(mob/living/L)
+/obj/item/clothing/head/mob_holder/drone/insert_mob(mob/living/new_prisoner)
 	. = ..()
-	if(!isdrone(L))
+	if(!isdrone(new_prisoner))
 		qdel(src)
+		return
 	name = "drone (hiding)"
 	desc = "This drone is scared and has curled up into a ball!"
 
-/obj/item/clothing/head/mob_holder/drone/update_visuals(mob/living/L)
-	var/mob/living/basic/drone/drone = L
+/obj/item/clothing/head/mob_holder/drone/update_visuals(mob/living/contained)
+	var/mob/living/basic/drone/drone = contained
 	if(!drone)
 		return ..()
 	icon = 'icons/mob/silicon/drone.dmi'
@@ -124,10 +136,10 @@
 
 /obj/item/clothing/head/mob_holder/destructible/Destroy()
 	if(held_mob)
-		release(FALSE, TRUE, TRUE)
+		release(display_messages = TRUE, delete_mob = TRUE)
 	return ..()
 
-/obj/item/clothing/head/mob_holder/destructible/release(del_on_release = TRUE, display_messages = TRUE, delete_mob = FALSE)
+/obj/item/clothing/head/mob_holder/destructible/release(display_messages = TRUE, delete_mob = FALSE)
 	if(delete_mob && held_mob)
 		QDEL_NULL(held_mob)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #90618
This PR ensures that if a mob holder enters any turf it will deposit its mob and despawn, no matter how it gets there.
It also just cleans up the code a little while I was touching the file.

## Changelog

:cl:
fix: Mothroaches and other small animals will now realise that they're free after being dumped from your backpack and resum their daily activities.
/:cl:
