### PR TITLE
Mecha cargo holds no longer shove themselves inside themselves when being deleted

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -113,7 +113,7 @@
 	if(prob(25))
 		to_chat(human_user, span_userdanger("An otherwordly presence tears and atomizes your [their_poor_arm.name] as you try to touch the hole in the very fabric of reality!"))
 		their_poor_arm.dismember()
-		forceMove(their_poor_arm, src) // stored for later fishage
+		their_poor_arm.forceMove(src) // stored for later fishage
 	else
 		to_chat(human_user,span_danger("You pull your hand away from the hole as the eldritch energy flails, trying to latch onto existence itself!"))
 	return TRUE
@@ -141,7 +141,7 @@
 	var/obj/item/bodypart/head/head = locate() in human_user.bodyparts
 	if(head)
 		head.dismember()
-		forceMove(head, src) // stored for later fishage
+		head.forceMove(src) // stored for later fishage
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -308,7 +308,7 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 /obj/item/mecha_parts/mecha_equipment/ejector/detach(atom/moveto)
 	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
 	workmech.cargo_hold = null
-	drop_contents(moveto.drop_location())
+	drop_contents(moveto?.drop_location())
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/Destroy()

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -330,11 +330,10 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 
 /// Spit out everything in our storage
 /obj/item/mecha_parts/mecha_equipment/ejector/proc/drop_contents(atom/drop_loc = drop_location(), drop_prob = 100)
-	for(var/atom/stored in src)
+	for(var/atom/movable/stored in src)
 		if(prob(drop_prob))
-			stored.forceMove(droploc || get_turf(src))
+			stored.forceMove(drop_loc || get_turf(src))
 			step_rand(stored)
-	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/relay_container_resist_act(mob/living/user, obj/container)
 	to_chat(user, span_notice("You lean on the back of [container] and start pushing so it falls out of [src]."))

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -305,21 +305,35 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
 	workmech.cargo_hold = src
 
-/obj/item/mecha_parts/mecha_equipment/ejector/detach()
+/obj/item/mecha_parts/mecha_equipment/ejector/detach(atom/moveto)
 	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
 	workmech.cargo_hold = null
+	drop_contents(moveto)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/Destroy()
-	for(var/atom/stored in contents)
-		forceMove(stored, drop_location())
-		step_rand(stored)
+	// Failsafe so we don't delete players
+	var/atom/droploc = drop_location() || get_turf(src)
+	for(var/mob/stored in get_all_contents())
+		if(stored.client)
+			stack_trace("[stored] was in [src] when it was deleted! We skipped deconstruct(), or something.")
+			stored.forceMove(droploc)
+	return ..()
+
+/obj/item/mecha_parts/mecha_equipment/ejector/atom_deconstruct(damage_flag)
+	drop_contents()
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/contents_explosion(severity, target)
-	for(var/obj/stored in contents)
-		if(prob(10 * severity))
-			stored.forceMove(drop_location())
+	drop_contents(drop_prob = 10 * severity)
+	return ..()
+
+/// Spit out everything in our storage
+/obj/item/mecha_parts/mecha_equipment/ejector/proc/drop_contents(atom/drop_loc = drop_location(), drop_prob = 100)
+	for(var/atom/stored in src)
+		if(prob(drop_prob))
+			stored.forceMove(droploc || get_turf(src))
+			step_rand(stored)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/relay_container_resist_act(mob/living/user, obj/container)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -308,7 +308,7 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 /obj/item/mecha_parts/mecha_equipment/ejector/detach(atom/moveto)
 	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
 	workmech.cargo_hold = null
-	drop_contents(moveto?.drop_location())
+	drop_contents(isturf(moveto) ? moveto : moveto?.drop_location())
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/Destroy()

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -308,7 +308,7 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 /obj/item/mecha_parts/mecha_equipment/ejector/detach(atom/moveto)
 	var/obj/vehicle/sealed/mecha/ripley/workmech = chassis
 	workmech.cargo_hold = null
-	drop_contents(moveto)
+	drop_contents(moveto.drop_location())
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/ejector/Destroy()

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -211,6 +211,13 @@ if $grep 'AddElement\(/datum/element/update_icon_updates_onmob.+ITEM_SLOT_HANDS'
 	st=1
 fi;
 
+part "forceMove sanity"
+if $grep 'forceMove\(\s*(\w+\(\)|\w+)\s*,\s*(\w+\(\)|\w+)\s*\)' $code_files; then
+	echo
+	echo -e "${RED}ERROR: forceMove() call with two arguments - this is not how forceMove() is invoked! It's x.forceMove(y), not forceMove(x, y).${NC}"
+	st=1
+fi;
+
 part "common spelling mistakes"
 if $grep -i 'centcomm' $code_files; then
 	echo


### PR DESCRIPTION
## About The Pull Request

`forceMove(x, y)` is not valid code

## Why It's Good For The Game

I don't think it fixes the "player getting deleted" issue but it fixes this silly code

## Changelog

:cl: Melbert
fix: Mecha cargo holds no longer shove themselves inside themselves when being deleted
/:cl:
