### PR TITLE
Objects crafted from lavaland fauna materials (bone, sinew, hide) are now fireproof and lavaproof. And also reinforced fishing lines.

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -261,6 +261,7 @@
 	cable_color = null
 	custom_materials = null
 	color = null
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /**
  * Red cable restraints

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -248,6 +248,7 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/sinew
 	drop_sound = 'sound/effects/meatslap.ogg'
 	pickup_sound = 'sound/effects/meatslap.ogg'
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/stack/sheet/sinew/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()
@@ -288,7 +289,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	max_amount = 6
 	novariants = FALSE
 	item_flags = NOBLUDGEON
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	w_class = WEIGHT_CLASS_NORMAL
 	layer = MOB_LAYER
 	merge_type = /obj/item/stack/sheet/animalhide/goliath_hide

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -823,6 +823,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	material_type = /datum/material/bone
 	drop_sound = null
 	pickup_sound = null
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/stack/sheet/bone/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()

--- a/code/modules/clothing/gloves/bone.dm
+++ b/code/modules/clothing/gloves/bone.dm
@@ -9,7 +9,7 @@
 	cold_protection = ARMS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
-	resistance_flags = NONE
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	armor_type = /datum/armor/gloves_bracer
 
 /obj/item/clothing/gloves/bracer/Initialize(mapload)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -523,7 +523,7 @@
 	icon_state = "watcher_wreath"
 	worn_y_offset = 10
 	alternate_worn_layer = ABOVE_BODY_FRONT_HEAD_LAYER
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/clothing/neck/wreath/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()

--- a/code/modules/clothing/under/accessories/tribal.dm
+++ b/code/modules/clothing/under/accessories/tribal.dm
@@ -4,12 +4,14 @@
 	desc = "A hunter's talisman, some say the old gods smile on those who wear it."
 	icon_state = "talisman"
 	attachment_slot = NONE
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/clothing/accessory/skullcodpiece
 	name = "skull codpiece"
 	desc = "A skull shaped ornament, intended to protect the important things in life."
 	icon_state = "skull"
 	attachment_slot = GROIN
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/clothing/accessory/skilt
 	name = "sinew skirt"
@@ -17,3 +19,4 @@
 	icon_state = "skilt"
 	minimize_when_attached = FALSE
 	attachment_slot = GROIN
+	resistance_flags = FIRE_PROOF | LAVA_PROOF

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -25,6 +25,7 @@
 	icon_state = "reel_green"
 	line_color = "#2aae34"
 	wiki_desc = "Allows you to fish in lava and plasma rivers and lakes."
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/fishing_line/reinforced/Initialize(mapload)
 	. = ..()
@@ -62,6 +63,7 @@
 	fishing_line_traits = FISHING_LINE_STIFF
 	line_color = "#d1cca3"
 	wiki_desc = "Crafted from sinew. It allows you to fish in lava and plasma like the reinforced line, but it'll make the minigame harder."
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/fishing_line/sinew/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Anything made from lavaland fauna now shares that fauna's immunity to fire and lava. 

### **_This does not confer these protections to the holder or wearer._**

Also applies this to reinforced fishing lines, as they are able to be used in lava.

## Why It's Good For The Game

I want to emphasize that lavaland derived objects and artifacts are generally safe from the hazards of lavaland unless there is an otherwise obvious reason why they should not be (the freeze cube for example). 

For these objects, it is mostly for the sake of verisimilitude; why would the stuff made from the lava/fireproof monsters be susceptible to burning?

In other instances, it is because miners should be the favoured users/wearers of these objects and they are expected to face these hazards as part of their work, and eventually become immune to them as a hazard. If something they wear/carry burns away too readily, it is completely useless to a miner.

## Changelog
:cl:
fix: Objects crafted from lavaland fauna materials (bone, sinew, hide) are now fireproof and lavaproof. And also reinforced fishing lines.
/:cl:
