### PR TITLE
player hud stays post roundstart, has more info

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -647,21 +647,16 @@
 	icon = 'icons/hud/lobby/newplayer.dmi'
 	icon_state = null //we only show up when we get update appearance called, cause we need our overlay to not look bad.
 	base_icon_state = "newplayer"
-	maptext_height = 70
+	maptext_height = 75
 	maptext_width = 80
 	maptext_x = OVERLAY_X_DIFF
 	maptext_y = OVERLAY_Y_DIFF
 
+	///Boolean on whether or not we should have our static overlay, so we 'turn' the TV off when collapsing.
 	var/show_static = TRUE
 
 /atom/movable/screen/lobby/new_player_info/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	switch(SSticker.current_state)
-		if(GAME_STATE_PREGAME, GAME_STATE_STARTUP)
-			RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, PROC_REF(hide_info))
-		if(GAME_STATE_SETTING_UP)
-			RegisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP, PROC_REF(show_info))
-
 	START_PROCESSING(SSnewplayer_info, src)
 	update_text()
 	update_appearance(UPDATE_ICON)
@@ -670,26 +665,22 @@
 	STOP_PROCESSING(SSnewplayer_info, src)
 	return ..()
 
-/atom/movable/screen/lobby/new_player_info/update_overlays()
-	. = ..()
-	if(!always_available)
-		return .
-	. += mutable_appearance(icon, "[base_icon_state]_overlay", layer = src.layer+0.03)
-	if(show_static)
-		. += mutable_appearance(icon, "static_base", alpha = 20, layer = src.layer+0.01)
-		//we have this in a separate file because `generate_icon_alpha_mask` puts lighting even on non-existent pixels,
-		//giving the icon a weird background color.
-		var/mutable_appearance/scanline = mutable_appearance(generate_icon_alpha_mask('icons/hud/lobby/newplayer_scanline.dmi', "scanline"), alpha = 20, layer = src.layer+0.02)
-		scanline.pixel_y = OVERLAY_X_DIFF
-		scanline.pixel_x = OVERLAY_Y_DIFF
-		. += scanline
-
 /atom/movable/screen/lobby/new_player_info/update_icon_state()
 	. = ..()
-	if(!always_available)
-		icon_state = "[base_icon_state]_disabled"
-	else
-		icon_state = base_icon_state
+	icon_state = base_icon_state
+
+/atom/movable/screen/lobby/new_player_info/update_overlays()
+	. = ..()
+	. += mutable_appearance(icon, "[base_icon_state]_overlay", layer = src.layer+0.03)
+	if(!show_static)
+		return .
+	. += mutable_appearance(icon, "static_base", alpha = 20, layer = src.layer+0.01)
+	//we have this in a separate file because `generate_icon_alpha_mask` puts lighting even on non-existent pixels,
+	//giving the icon a weird background color.
+	var/mutable_appearance/scanline = mutable_appearance(generate_icon_alpha_mask('icons/hud/lobby/newplayer_scanline.dmi', "scanline"), alpha = 20, layer = src.layer+0.02)
+	scanline.pixel_y = OVERLAY_X_DIFF
+	scanline.pixel_x = OVERLAY_Y_DIFF
+	. += scanline
 
 /atom/movable/screen/lobby/new_player_info/process(seconds_per_tick)
 	update_text()
@@ -708,33 +699,28 @@
 	update_appearance(UPDATE_ICON)
 	update_text()
 
-/atom/movable/screen/lobby/new_player_info/proc/hide_info()
-	SIGNAL_HANDLER
-
-	STOP_PROCESSING(SSnewplayer_info, src)
-	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP)
-	RegisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP, PROC_REF(show_info))
-	always_available = FALSE
-	update_appearance(UPDATE_ICON)
-	update_text()
-
-/atom/movable/screen/lobby/new_player_info/proc/show_info()
-	SIGNAL_HANDLER
-
-	always_available = TRUE
-	update_appearance(UPDATE_ICON)
-	update_text()
-	START_PROCESSING(SSnewplayer_info, src)
-	UnregisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP)
-	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, PROC_REF(hide_info))
-
 /atom/movable/screen/lobby/new_player_info/proc/update_text()
-	if(!always_available || !hud || !show_static)
+	if(!hud || !show_static)
 		maptext = null
 		return
-	var/new_maptext
 	if(!MC_RUNNING())
-		new_maptext = "<span style='text-align: center; vertical-align: middle'>Loading...</span>"
+		maptext = MAPTEXT("<span style='text-align: center; vertical-align: middle'>Loading...</span>")
+		return
+	if(SSticker.IsPostgame())
+		maptext = MAPTEXT("<span style='text-align: center; vertical-align: middle'>Game ended, <br /> \
+			restart soon</span>")
+		return
+
+	var/new_maptext
+	var/round_started = SSticker.HasRoundStarted()
+	if(round_started)
+		new_maptext = "<span style='text-align: center; vertical-align: middle'>[SSmapping.current_map.map_name]<br /> \
+			[LAZYLEN(GLOB.clients)] player\s online<br /> \
+			[ROUND_TIME()] in<br />"
+		var/datum/station_trait/overflow_job_bureaucracy/overflow = locate() in SSstation.station_traits
+		if(overflow)
+			new_maptext += "[overflow.chosen_job_name] overflow"
+		new_maptext += "</span>"
 	else
 		var/time_remaining = SSticker.GetTimeLeft()
 		if(time_remaining > 0)

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -643,7 +643,7 @@
 ///Lobby screen that appears before the game has started showing how many players there are and who is ready.
 /atom/movable/screen/lobby/new_player_info
 	name = "New Player Info"
-	screen_loc = "TOP:-20,CENTER:192"
+	screen_loc = "EAST-3,CENTER:140"
 	icon = 'icons/hud/lobby/newplayer.dmi'
 	icon_state = null //we only show up when we get update appearance called, cause we need our overlay to not look bad.
 	base_icon_state = "newplayer"

--- a/code/controllers/subsystem/processing/newplayer.dm
+++ b/code/controllers/subsystem/processing/newplayer.dm
@@ -2,4 +2,4 @@ PROCESSING_SUBSYSTEM_DEF(newplayer_info)
 	name = "New Player Info"
 	flags = SS_NO_INIT | SS_BACKGROUND
 	wait = 1 SECONDS
-	runlevels = RUNLEVEL_LOBBY|RUNLEVEL_SETUP
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -514,11 +514,17 @@ SUBSYSTEM_DEF(ticker)
 			queued_players -= next_in_line
 			queue_delay = 0
 
+///Whether the game has started, including roundend.
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
 	return current_state >= GAME_STATE_PLAYING
 
+///Whether the game is currently in progress, excluding roundend
 /datum/controller/subsystem/ticker/proc/IsRoundInProgress()
 	return current_state == GAME_STATE_PLAYING
+
+///Whether the game is currently in progress, excluding roundend
+/datum/controller/subsystem/ticker/proc/IsPostgame()
+	return current_state == GAME_STATE_FINISHED
 
 /datum/controller/subsystem/ticker/Recover()
 	current_state = SSticker.current_state


### PR DESCRIPTION
## About The Pull Request

Once the round starts, the TV's text shows the current map, how much time it is in-game, how many players are connected, and what the overflow job is (if the station trait is on). video as demonstration but the overflow text has changed to "[job] overflow" instead of "Overflow job: [job]"

https://github.com/user-attachments/assets/fe74b28b-06de-4827-9c4d-ca2e51f1e0b9

Closes https://github.com/tgstation/tgstation/issues/90651

## Why It's Good For The Game

Gives useful info on the TV instead of having it just magically disappear (which currently doesn't work cause I forgot to deactivate it on initialize for latejoiners) which will become more useful if the stat panel is removed. Also makes overflow job more obvious, the TV is just a good place to put info useful for new players though round time personally was just put there to make the TV feel more full.

Wanted to put this in the original PR but wanted to try to match parity to the stat panel in case this wasn't wanted.

## Changelog

:cl:
qol: The TV on the title screen has round info once the round has started or ended.
fix: The TV now fits on non-widescreen screens.
/:cl: