### PR TITLE
War on Tools

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -25,7 +25,7 @@
 	var/safety = TRUE
 	/// If there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
 	var/powered = FALSE
-	/// If the cell can be removed via screwdriver
+	/// If the cell can be removed with hands
 	var/cell_removable = TRUE
 	var/obj/item/shockpaddles/paddles
 	var/obj/item/stock_parts/power_store/cell/cell
@@ -67,7 +67,7 @@
 	if(!cell_removable)
 		return
 	if(cell)
-		. += span_notice("Use a screwdriver to remove the cell.")
+		. += span_notice("Use a RMB to remove the cell.")
 	else
 		. += span_warning("It has no power cell!")
 
@@ -144,14 +144,14 @@
 		var/atom/movable/screen/inventory/hand/hand = over_object
 		living_mob.putItemFromInventoryInHandIfPossible(src, hand.held_index)
 
-/obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/tool)
+/obj/item/defibrillator/attack_hand_secondary(mob/living/user)
 	if(!cell || !cell_removable)
 		return FALSE
 
 	cell.forceMove(get_turf(src))
 	balloon_alert(user, "removed [cell]")
 	cell = null
-	tool.play_tool_sound(src, 50)
+	playsound(src, 'sound/items/tools/screwdriver2.ogg', 50)
 	update_power()
 	return TRUE
 

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -67,7 +67,7 @@
 	if(!cell_removable)
 		return
 	if(cell)
-		. += span_notice("Use a RMB to remove the cell.")
+		. += span_notice("Use RMB to remove the cell.")
 	else
 		. += span_warning("It has no power cell!")
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -620,9 +620,8 @@
 	else
 		. += span_warning("\The [src] does not have a power source installed.")
 
-/obj/item/melee/baton/security/screwdriver_act(mob/living/user, obj/item/tool)
-	if(tryremovecell(user))
-		tool.play_tool_sound(src)
+/obj/item/melee/baton/security/attack_hand_secondary(mob/living/user)
+	(tryremovecell(user))
 	return TRUE
 
 /obj/item/melee/baton/security/attackby(obj/item/item, mob/user, params)
@@ -646,6 +645,7 @@
 	if(cell && can_remove_cell)
 		cell.forceMove(drop_location())
 		to_chat(user, span_notice("You remove the cell from [src]."))
+		playsound(src, 'sound/items/tools/screwdriver2.ogg', 50)
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -643,9 +643,12 @@
 
 /obj/item/melee/baton/security/proc/tryremovecell(mob/user)
 	if(cell && can_remove_cell)
-		cell.forceMove(drop_location())
-		to_chat(user, span_notice("You remove the cell from [src]."))
-		playsound(src, 'sound/items/tools/screwdriver2.ogg', 50)
+		balloon_alert(user, "removing [src]'s power cell...")
+		playsound(user, 'sound/items/tools/screwdriver_operating.ogg', 50)
+		if(do_after(user, 3 SECONDS, src))
+			cell.forceMove(drop_location())
+			to_chat(user, span_notice("You remove the cell from [src]."))
+			playsound(src, 'sound/items/tools/screwdriver2.ogg', 50)
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -644,7 +644,7 @@
 /obj/item/melee/baton/security/proc/tryremovecell(mob/user)
 	if(cell && can_remove_cell)
 		balloon_alert(user, "removing [src]'s power cell...")
-		playsound(user, 'sound/items/tools/screwdriver_operating.ogg', 50)
+		playsound(src, 'sound/items/tools/screwdriver_operating.ogg', 50)
 		if(do_after(user, 3 SECONDS, src))
 			cell.forceMove(drop_location())
 			to_chat(user, span_notice("You remove the cell from [src]."))


### PR DESCRIPTION

## About The Pull Request

The title is a slight exaggeration. This PR does the following:
* Right-mouse button removes baton power cells
* Right-mouse button removes defibrillator power cells

## Why It's Good For The Game
The goal of this PR is to make the game less dependent on tool usage, and players less dependent on tools. Seeking out tools at the start of the round to access basic elements of the game is clunky, annoying, and punishes players who don't break cargo's windoor. 

I believe it is in the best interest for the game to move away from tool dependency for basic gameplay elements.

This PR is currently pretty minor changes, though more tool interactions are planned to be moved to RMB, like seclight and maybe MODsuit unscrewing. The reason for the small list is because (I am really dumb and can't think of any more) I want to start small.

This is technically a "balance" PR.
## Changelog
:cl:
balance: NanoTrasen has refactored their defibrillator and baton designs, making it more user friendly to remove their power cells with right-mouse button.
/:cl:
