### PR TITLE
Silicons have 66% understanding of uncommon roundstart languages

### DIFF
--- a/code/modules/language/_language_holder.dm
+++ b/code/modules/language/_language_holder.dm
@@ -457,6 +457,14 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 		/datum/language/machine = list(LANGUAGE_ATOM),
 	)
 
+/// For intelligent synthetics like cyborgs and the AI, not for basic baby bots ran on a raspberry pi
+/datum/language_holder/synthetic/silicon
+
+/datum/language_holder/synthetic/silicon/New(atom/new_owner)
+	. = ..()
+	for(var/lang in GLOB.uncommon_roundstart_languages)
+		grant_partial_language(lang, 66, LANGUAGE_ATOM)
+
 /datum/language_holder/moth
 	understood_languages = list(
 		/datum/language/common = list(LANGUAGE_ATOM),

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -4,7 +4,7 @@
 	verb_ask = "queries"
 	verb_exclaim = "declares"
 	verb_yell = "alarms"
-	initial_language_holder = /datum/language_holder/synthetic
+	initial_language_holder = /datum/language_holder/synthetic/silicon
 	bubble_icon = "machine"
 	mob_biotypes = MOB_ROBOTIC
 	death_sound = 'sound/mobs/non-humanoids/cyborg/borg_deathsound.ogg'


### PR DESCRIPTION
## About The Pull Request

Silicons have 66% understanding of uncommon roundstart languages

## Why It's Good For The Game

Joke reason: 

![image](https://github.com/user-attachments/assets/12f9ede6-d808-4b61-848a-dcc8a38df6c9)

Serious reason: I understand why the original change was made, and the points mentioned in the PR were very valid. But at the same time, I think silicons being unable to parse most languages is a flavor fail. My thoughts are using partial languages as a compromise would assuage the concerns of the original PR while still giving us some of the flavor of omniscient AI. If you disagree (Particularly you JohnFulpWillard) feel free to close this.

(And of course we can always tweak the number. I had the thought of adjusting the % of given languages depending on how close they are to common - so languages like Voltaic are much lower, ~20%.)

## Changelog

:cl: Melbert
add: Cyborgs and the AI have regained understanding of various non-human languages, but only partially (66%).
/:cl:
