### PR TITLE
Fix: EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD now actually calls the shuttle

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -277,7 +277,7 @@ SUBSYSTEM_DEF(shuttle)
 			sender_override = "Emergency Shuttle Uplink Alert",
 			color_override = "orange",
 		)
-		if(emergency.timeLeft(1) > emergency_call_time * ALERT_COEFF_AUTOEVAC_CRITICAL)
+		if(EMERGENCY_IDLE_OR_RECALLED || emergency.timeLeft(1) > emergency_call_time * ALERT_COEFF_AUTOEVAC_CRITICAL)
 			emergency.request(null, set_coefficient = ALERT_COEFF_AUTOEVAC_CRITICAL)
 
 /datum/controller/subsystem/shuttle/proc/block_recall(lockout_timer)


### PR DESCRIPTION
## About The Pull Request

There's a function to call the shuttle when a proportion of the crew die. This functionality is probably not turned on on actual tgstation servers but it is a configurable option for people hosting their own forks and whatnot to use.

However, while this works, it doesn't actually call the shuttle, as it seems to require the time remaining for the shuttle to arrive to be greater than 4 minutes, which, as the shuttle hasn't been called, the time remaining is 1 second (the fallback value for when it's not in transit). So it never calls.

(The fix I have here was suggested to me by someone else in the Discord coding channel so I can't take full credit for it.)

## Why It's Good For The Game

It's good for the automatic shuttle call to call the shuttle

## Changelog
:cl: Kapu1178, Cirrial
fix: The server-configurable shuttle call when enough of the station dies will now actually call the shuttle.
/:cl:
