### PR TITLE
Adds trophy display cases to wawa

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -1726,6 +1726,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/station/service/library)
 "aDd" = (
@@ -29020,6 +29021,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
+"kfs" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/displaycase/trophy,
+/turf/open/floor/glass/reinforced,
+/area/station/service/bar)
 "kfG" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -31572,6 +31579,7 @@
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/camera/autoname/directional/east,
+/obj/structure/displaycase/trophy,
 /turf/open/floor/glass/reinforced,
 /area/station/service/bar)
 "kXz" = (
@@ -161483,7 +161491,7 @@ rDg
 les
 pdp
 hCK
-ilQ
+kfs
 mGW
 mGW
 mGW


### PR DESCRIPTION
## About The Pull Request
Puts a trophy display case in the library and two outside on the glass floor balcony 
![wawa1](https://github.com/user-attachments/assets/5ce14dea-028f-46fb-8dd9-f82fc63eeb99)
![wawa2](https://github.com/user-attachments/assets/e1a7f205-3fd4-4848-9fed-a9e29c8e59a4)

## Why It's Good For The Game
curator gameplay, I need somewhere to store my amazing treasures (useless garbage). Two are outside since the library itself is already full of stuff and there's painting outside anyways so the curator already has some claim over the area. 
## Changelog
:cl: Goat
map: wawa now has curator trophy cases
/:cl:
