### PR TITLE
Configurable events (removes mult config)

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -351,16 +351,6 @@
 
 /datum/config_entry/flag/forbid_station_traits
 
-/datum/config_entry/number/events_min_time_mul // Multipliers for random events minimal starting time and minimal players amounts
-	default = 1
-	min_val = 0
-	integer = FALSE
-
-/datum/config_entry/number/events_min_players_mul
-	default = 1
-	min_val = 0
-	integer = FALSE
-
 /datum/config_entry/number/events_frequency_lower
 	default = 2.5 MINUTES
 	min_val = 0
@@ -419,6 +409,8 @@
 	min_val = 0
 
 /datum/config_entry/flag/dynamic_config_enabled
+
+/datum/config_entry/flag/events_config_enabled
 
 /datum/config_entry/string/drone_required_role
 	default = "Silicon"

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -6,6 +6,8 @@ SUBSYSTEM_DEF(events)
 	runlevels = RUNLEVEL_GAME
 	///list of all datum/round_event_control. Used for selecting events based on weight and occurrences.
 	var/list/control = list()
+	///assoc list of all datum/round_event_control, ordered by name. name => event
+	var/list/events_by_name = list()
 	///list of all existing /datum/round_event currently being run.
 	var/list/running = list()
 	///cache of currently running events, for lag checking.
@@ -25,15 +27,35 @@ SUBSYSTEM_DEF(events)
 		if(!event.typepath || !event.valid_for_map())
 			continue //don't want this one! leave it for the garbage collector
 		control += event //add it to the list of all events (controls)
+		events_by_name[event.name] = event
 
 	frequency_lower = CONFIG_GET(number/events_frequency_lower)
 	frequency_upper = CONFIG_GET(number/events_frequency_upper)
+
+	if(CONFIG_GET(flag/events_config_enabled))
+		setup_config()
 
 	reschedule()
 	// Instantiate our holidays list if it hasn't been already
 	if(isnull(GLOB.holidays))
 		fill_holidays()
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/events/proc/setup_config()
+	var/json_file = file("[global.config.directory]/events.json")
+	if(!fexists(json_file))
+		return
+	var/list/configuration = json_decode(file2text(json_file))
+	for(var/variable in configuration)
+		var/datum/round_event_control/event = events_by_name[variable]
+		if(!event)
+			stack_trace("Invalid event [event] attempting to be configured.")
+			continue
+		for(var/event_variable in configuration[variable])
+			if(!(event.vars.Find(event_variable)))
+				stack_trace("Invalid event configuration variable [event_variable] in variable changes for [variable].")
+				continue
+			event.vars[event_variable] = configuration[variable][event_variable]
 
 /datum/controller/subsystem/events/fire(resumed = FALSE)
 	if(!resumed)

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -41,6 +41,7 @@ SUBSYSTEM_DEF(events)
 		fill_holidays()
 	return SS_INIT_SUCCESS
 
+///Takes the events config json and applies any var edits made there to their respective event.
 /datum/controller/subsystem/events/proc/setup_config()
 	var/json_file = file("[global.config.directory]/events.json")
 	if(!fexists(json_file))

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -42,9 +42,6 @@
 	var/map_flags = NONE
 
 /datum/round_event_control/New()
-	if(config && !wizardevent) // Magic is unaffected by configs
-		earliest_start = CEILING(earliest_start * CONFIG_GET(number/events_min_time_mul), 1)
-		min_players = CEILING(min_players * CONFIG_GET(number/events_min_players_mul), 1)
 	if(!length(admin_setup))
 		return
 	var/list/admin_setup_types = admin_setup.Copy()

--- a/config/events.json
+++ b/config/events.json
@@ -351,5 +351,5 @@
 	"Space Vines": {
 		"min_players": 10,
 		"weight": 15
-	},
+	}
 }

--- a/config/events.json
+++ b/config/events.json
@@ -1,0 +1,166 @@
+{
+	"Space Pirates": {
+		"min_players": 20,
+		"weight": 10
+	},
+	"Spawn Bitrunning Glitch": {
+		"min_players": 1,
+		"weight": 100
+	},
+	"Aurora Caelus": {
+		"min_players": 0,
+		"weight": 1,
+		"earliest_start": 3000
+	},
+	"Spontaneous Brain Trauma": {
+		"min_players": 13,
+		"weight": 25
+	},
+	"Brand Intelligence": {
+		"min_players": 20,
+		"weight": 5
+	},
+	"Bureaucratic Error": {
+		"min_players": 0,
+		"weight": 5
+	},
+	"Camera Failure": {
+		"min_players": 0,
+		"weight": 100
+	},
+	"Carp Migration": {
+		"min_players": 12,
+		"weight": 15,
+		"earliest_start": 6000
+	},
+	"Disease Outbreak: Classic": {
+		"min_players": 10,
+		"weight": 5
+	},
+	"Disease Outbreak: Advanced": {
+		"min_players": 35,
+		"weight": 15,
+		"earliest_start": 9000
+	},
+	"Space Dust: Minor": {
+		"min_players": 0,
+		"weight": 200,
+		"earliest_start": 0
+	},
+	"Electrical Storm": {
+		"min_players": 5,
+		"weight": 20,
+		"earliest_start": 6000
+	},
+	"Fake Virus": {
+		"min_players": 0,
+		"weight": 20
+	},
+	"False Alarm": {
+		"min_players": 0,
+		"weight": 20
+	},
+	"Gravity Generator Blackout": {
+		"min_players": 0,
+		"weight": 30
+	},
+	"Grey Tide": {
+		"min_players": 5,
+		"weight": 10
+	},
+	"Grid Check": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Random Heart Attack": {
+		"min_players": 40,
+		"weight": 20
+	},
+	"Ion Storm": {
+		"min_players": 2,
+		"weight": 15
+	},
+	"Market Crash": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Mass Hallucination": {
+		"min_players": 1,
+		"weight": 10
+	},
+	"Mice Migration": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Portal Storm: Syndicate Shocktroops": {
+		"min_players": 15,
+		"weight": 2,
+		"earliest_start": 18000
+	},
+	"Portal Storm: Constructs": {
+		"min_players": 0,
+		"weight": 0
+	},
+	"Processor Overload": {
+		"min_players": 20,
+		"weight": 15
+	},
+	"Radiation Leak": {
+		"min_players": 0,
+		"weight": 15
+	},
+	"Radiation Storm": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Sandstorm: Directional": {
+		"min_players": 35,
+		"weight": 10,
+		"earliest_start": 21000
+	},
+	"Sandstorm: Classic": {
+		"min_players": 0,
+		"weight": 0,
+		"earliest_start": 0
+	},
+	"Scrubber Overflow: Normal": {
+		"min_players": 10,
+		"weight": 10
+	},
+	"Scrubber Overflow: Threatening": {
+		"min_players": 25,
+		"weight": 4,
+		"earliest_start": 21000
+	},
+	"Scrubber Overflow: Catastrophic": {
+		"min_players": 35,
+		"weight": 2,
+		"earliest_start": 27000
+	},
+	"Scrubber Overflow: Every Vent": {
+		"min_players": 10,
+		"weight": 0
+	},
+	"Shuttle Catastrophe": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Shuttle Insurance": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Spider Infestation": {
+		"min_players": 20,
+		"weight": 10
+	},
+	"Stray Cargo Pod": {
+		"min_players": 0,
+		"weight": 20,
+		"earliest_start": 6000
+	},
+	"Stray Syndicate Cargo Pod": {
+		"min_players": 0,
+		"weight": 6,
+		"earliest_start": 18000
+	}
+}

--- a/config/events.json
+++ b/config/events.json
@@ -162,5 +162,94 @@
 		"min_players": 0,
 		"weight": 6,
 		"earliest_start": 18000
-	}
+	},
+	"Supermatter Surge": {
+		"min_players": 0,
+		"weight": 15
+	},
+	"Supermatter Surge: Poly's Revenge": {
+		"min_players": 0,
+		"weight": 0
+	},
+	"Tram Malfunction": {
+		"min_players": 0,
+		"weight": 30,
+		"earliest_start": 9000
+	},
+	"Ventilation Clog: Minor": {
+		"min_players": 0,
+		"weight": 25,
+		"earliest_start": 3000
+	},
+	"Ventilation Clog: Major": {
+		"min_players": 0,
+		"weight": 10,
+		"earliest_start": 6000
+	},
+	"Ventilation Clog: Critical": {
+		"min_players": 15,
+		"weight": 8,
+		"earliest_start": 15000
+	},
+	"Ventilation Clog: Strange": {
+		"min_players": 0,
+		"weight": 5,
+		"earliest_start": 3000
+	},
+	"Wisdom Cow": {
+		"min_players": 0,
+		"weight": 20
+	},
+	"Wormholes": {
+		"min_players": 2,
+		"weight": 1
+	},
+	"Anomaly: Energetic Flux": {
+		"min_players": 1,
+		"weight": 15
+	},
+	"Anomaly: Bioscrambler": {
+		"min_players": 10,
+		"weight": 20
+	},
+	"Anomaly: Bluespace": {
+		"min_players": 1,
+		"weight": 15
+	},
+	"Anomaly: Dimensional": {
+		"min_players": 10,
+		"weight": 20
+	},
+	"Anomaly: Ectoplasmic Outburst": {
+		"min_players": 30,
+		"weight": 4
+	},
+	"Anomaly: Hyper-Energetic Flux": {
+		"min_players": 10,
+		"weight": 20
+	},
+	"Anomaly: Gravitational": {
+		"min_players": 1,
+		"weight": 25
+	},
+	"Anomaly: Gravitational (High Intensity)": {
+		"min_players": 1,
+		"weight": 15
+	},
+	"Anomaly: Hallucination": {
+		"min_players": 10,
+		"weight": 20
+	},
+	"Anomaly: Pyroclastic": {
+		"min_players": 1,
+		"weight": 20
+	},
+	"Anomaly: Vortex": {
+		"min_players": 20,
+		"weight": 10
+	},
+	"Abductors": {
+		"min_players": 20,
+		"weight": 10
+	},
 }

--- a/config/events.json
+++ b/config/events.json
@@ -252,4 +252,104 @@
 		"min_players": 20,
 		"weight": 10
 	},
+	"Alien Infestation": {
+		"min_players": 10,
+		"weight": 5
+	},
+	"Blob": {
+		"min_players": 20,
+		"weight": 10
+	},
+	"Changeling Meteor": {
+		"min_players": 20,
+		"weight": 8
+	},
+	"Spawn Fugitives": {
+		"min_players": 20,
+		"weight": 10,
+		"earliest_start": 18000
+	},
+	"Spawn Morph": {
+		"min_players": 0,
+		"weight": 0
+	},
+	"Spawn Nightmare": {
+		"min_players": 20,
+		"weight": 10
+	},
+	"Lone Operative": {
+		"min_players": 0,
+		"weight": 0
+	},
+	"Spawn Revenant": {
+		"min_players": 5,
+		"weight": 7
+	},
+	"Random Human-level Intelligence": {
+		"min_players": 0,
+		"weight": 10
+	},
+	"Station-wide Human-level Intelligence": {
+		"min_players": 0,
+		"weight": 0
+	},
+	"Spawn Slaughter Demon": {
+		"min_players": 20,
+		"weight": 1,
+		"earliest_start": 36000
+	},
+	"Spawn Space Dragon": {
+		"min_players": 20,
+		"weight": 7
+	},
+	"Spawn Space Ninja": {
+		"min_players": 20,
+		"weight": 10
+	},
+	"Immovable Rod": {
+		"min_players": 15,
+		"weight": 10
+	},
+	"Dark Matt-eor": {
+		"min_players": 0,
+		"weight": 0
+	},
+	"Meteor Wave: Normal": {
+		"min_players": 15,
+		"weight": 4,
+		"earliest_start": 15000
+	},
+	"Meteor Wave: Threatening": {
+		"min_players": 20,
+		"weight": 5,
+		"earliest_start": 21000
+	},
+	"Meteor Wave: Catastrophic": {
+		"min_players": 25,
+		"weight": 7,
+		"earliest_start": 27000
+	},
+	"Meteor Wave: Meaty": {
+		"min_players": 15,
+		"weight": 2,
+		"earliest_start": 15000
+	},
+	"Major Space Dust": {
+		"min_players": 15,
+		"weight": 14,
+		"earliest_start": 9000
+	},
+	"Stray Meteor": {
+		"min_players": 15,
+		"weight": 15
+	},
+	"Shuttle Loan": {
+		"min_players": 0,
+		"weight": 10,
+		"earliest_start": 4200
+	},
+	"Space Vines": {
+		"min_players": 10,
+		"weight": 15
+	},
 }

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -139,7 +139,7 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## Uncomment to enable dynamic ruleset config file.
 DYNAMIC_CONFIG_ENABLED
 
-## Uncomment to enable dynamic ruleset config file.
+## Uncomment to enable event weight/min players config file.
 #EVENTS_CONFIG_ENABLED
 
 ## RANDOM EVENTS ###

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -139,7 +139,7 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## Uncomment to enable dynamic ruleset config file.
 DYNAMIC_CONFIG_ENABLED
 
-## Uncomment to enable event weight/min players config file.
+## Uncomment to enable event editing config file.
 #EVENTS_CONFIG_ENABLED
 
 ## RANDOM EVENTS ###

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -139,20 +139,15 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## Uncomment to enable dynamic ruleset config file.
 DYNAMIC_CONFIG_ENABLED
 
+## Uncomment to enable dynamic ruleset config file.
+#EVENTS_CONFIG_ENABLED
+
 ## RANDOM EVENTS ###
 ## Comment this out to disable random events during the round.
 ALLOW_RANDOM_EVENTS
 
 ## Uncomment this to disable station traits.
 #FORBID_STATION_TRAITS
-
-## Multiplier for earliest start time of dangerous events.
-## Set to 0 to make dangerous events available from round start.
-EVENTS_MIN_TIME_MUL 1
-
-## Multiplier for minimal player count (players = alive non-AFK humans) for dangerous events to start.
-## Set to 0 to make dangerous events available for all populations.
-EVENTS_MIN_PLAYERS_MUL 1
 
 ## The lower bound, in deciseconds, for how soon another random event can be scheduled.
 ## Defaults to 1500 deciseconds or 2.5 minutes


### PR DESCRIPTION
## About The Pull Request

As said in https://forums.tgstation13.org/viewtopic.php?t=38517 - Admins don't want to touch the event multiplier configs because,
``for example changing the mult to 1.5 would make heart attack only roll on 60+ pop``

and ends with;
``it would be better to make a pull request to the codebase and alter the min_player var on the events that are issues``

So why not let ALL events be editable by admins?
This PR makes every single event possible to be edited, though the json only comes with the non-wizard non-holiday ones (though they are totally addable if admins want to put it in, I just didnt think we should make it obvious it's possible so they DONT)

The config is off by default (no effect regardless since I have it the same as code-side).

## Why It's Good For The Game

The multiplier config is rendered irrelevant by instead being able to tweak the individual events to your liking, especially when one touch of that causes certain events to be rendered never runnable.
This is (sorta) an admin request, and it also makes event rarities and such an admin issue, therefore not our problem anymore (mostly), wahoo.

Get FUCKED, Grid Check!
![image](https://github.com/user-attachments/assets/ff4314b5-4404-4f8e-905d-2d4824f8aa71)

## Changelog

:cl:
config: Removed event time/weight multipliers, now all events vars are editable in config.
/:cl: