### PR TITLE
Fix a runtime with FOV when moving diagonally

### DIFF
--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -37,7 +37,7 @@
 
 	if(dir & EAST)
 		dir_x += vector_len
-	else if(dir & EAST)
+	else if(dir & WEST)
 		dir_x -= vector_len
 
 	///Calculate angle

--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -27,21 +27,18 @@
 	var/vector_len = sqrt(abs(rel_x) ** 2 + abs(rel_y) ** 2)
 
 	/// Getting a direction vector
-	var/dir_x
-	var/dir_y
-	switch(dir)
-		if(SOUTH)
-			dir_x = 0
-			dir_y = -vector_len
-		if(NORTH)
-			dir_x = 0
-			dir_y = vector_len
-		if(EAST)
-			dir_x = vector_len
-			dir_y = 0
-		if(WEST)
-			dir_x = -vector_len
-			dir_y = 0
+	var/dir_x = 0 // based on east/west
+	var/dir_y = 0 // based on north/south
+
+	if(dir & NORTH)
+		dir_y += vector_len
+	else if(dir & SOUTH)
+		dir_y -= vector_len
+
+	if(dir & EAST)
+		dir_x += vector_len
+	else if(dir & EAST)
+		dir_x -= vector_len
 
 	///Calculate angle
 	var/angle = arccos((dir_x * rel_x + dir_y * rel_y) / (sqrt(dir_x**2 + dir_y**2) * sqrt(rel_x**2 + rel_y**2)))


### PR DESCRIPTION
## About The Pull Request

This fixes `/mob/living/proc/in_fov` to check `dir` using bitflags instead of just a switch statement, as otherwise a `dir` being diagonal (i.e `NORTH | EAST`) would result in both `dir_x` and `dir_y` not being set - which leads to a divide by zero runtime.

credit to @MrMelbert for pointing this out in the discord

Fixes https://github.com/tgstation/tgstation/issues/74850

## Why It's Good For The Game

runtimes bad. and this technically should make it work properly for diagonal movement.

## Changelog
:cl:
fix: Fixed FOV checks improperly handling diagonal directions.
/:cl:
