### PR TITLE
MODlink scryers now alert the user if they try to call without a charged cell

### DIFF
--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -269,6 +269,10 @@
 /obj/item/clothing/neck/link_scryer/ui_action_click(mob/user)
 	if(mod_link.link_call)
 		mod_link.end_call()
+	else if(QDELETED(cell))
+		user.balloon_alert(user, "no cell installed!")
+	else if(!cell.charge)
+		user.balloon_alert(user, "no charge!")
 	else
 		call_link(user, mod_link)
 


### PR DESCRIPTION
## About The Pull Request

This makes it so if you try to use a MODlink scryer without a power cell, or with an empty cell, it'll show a balloon alert to the user saying "no cell installed!" or "no charge!", rather than silently failing.

## Why It's Good For The Game

when I ported modlinks downstream, a few people got confused bc they didn't realize they needed cells after being printed.
this makes it more clear what the issue is.

## Changelog
:cl:
qol: MODlink scryers now alert the user if they try to call without a charged power cell.
/:cl:
