### PR TITLE
Constructs now have their respective factions

### DIFF
--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -85,6 +85,8 @@
 #define FACTION_VINES "vines"
 ///raptor factions
 #define FACTION_RAPTOR "raptor"
+///holy faction, for anything part of the church
+#define FACTION_HOLY "holy"
 // Antagonist factions
 
 /// Cultists and their constructs

--- a/code/modules/mob/living/basic/cult/constructs/artificer.dm
+++ b/code/modules/mob/living/basic/cult/constructs/artificer.dm
@@ -61,6 +61,7 @@
 	ADD_TRAIT(src, TRAIT_ANGELIC, INNATE_TRAIT)
 
 /mob/living/basic/construct/artificer/mystic
+	faction = list(ROLE_WIZARD)
 	theme = THEME_WIZARD
 	construct_spells = list(
 		/datum/action/cooldown/spell/conjure/cult_floor,

--- a/code/modules/mob/living/basic/cult/constructs/artificer.dm
+++ b/code/modules/mob/living/basic/cult/constructs/artificer.dm
@@ -48,6 +48,7 @@
 // Alternate artificer themes
 /mob/living/basic/construct/artificer/angelic
 	desc = "A bulbous construct dedicated to building and maintaining holy armies."
+	faction = list(FACTION_HOLY)
 	theme = THEME_HOLY
 	construct_spells = list(
 		/datum/action/cooldown/spell/conjure/soulstone/purified,

--- a/code/modules/mob/living/basic/cult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/basic/cult/constructs/juggernaut.dm
@@ -61,4 +61,5 @@
 	ADD_TRAIT(src, TRAIT_ANGELIC, INNATE_TRAIT)
 
 /mob/living/basic/construct/juggernaut/mystic
+	faction = list(ROLE_WIZARD)
 	theme = THEME_WIZARD

--- a/code/modules/mob/living/basic/cult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/basic/cult/constructs/juggernaut.dm
@@ -54,6 +54,7 @@
 
 // Alternate juggernaut themes
 /mob/living/basic/construct/juggernaut/angelic
+	faction = list(FACTION_HOLY)
 	theme = THEME_HOLY
 
 /mob/living/basic/construct/juggernaut/angelic/Initialize(mapload)

--- a/code/modules/mob/living/basic/cult/constructs/wraith.dm
+++ b/code/modules/mob/living/basic/cult/constructs/wraith.dm
@@ -32,6 +32,7 @@
 
 // Alternate wraith themes
 /mob/living/basic/construct/wraith/angelic
+	faction = list(FACTION_HOLY)
 	theme = THEME_HOLY
 	construct_spells = list(
 		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/shift/angelic,

--- a/code/modules/mob/living/basic/cult/constructs/wraith.dm
+++ b/code/modules/mob/living/basic/cult/constructs/wraith.dm
@@ -43,6 +43,7 @@
 	ADD_TRAIT(src, TRAIT_ANGELIC, INNATE_TRAIT)
 
 /mob/living/basic/construct/wraith/mystic
+	faction = list(ROLE_WIZARD)
 	theme = THEME_WIZARD
 	construct_spells = list(
 		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/shift/mystic,

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -533,7 +533,6 @@
 	hitsound = 'sound/items/weapons/punch3.ogg'
 	trigger_range = 0
 	antimagic_flags = MAGIC_RESISTANCE_HOLY
-	ignored_factions = list(FACTION_CULT)
 	range = 105
 	speed = 0.15
 

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -59,6 +59,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	to_chat(chap, span_boldnotice("\"[quote]\""))
 	to_chat(chap, span_notice("[desc]"))
+	chap.faction |= FACTION_HOLY
 
 /// Activates if religious sect is reset by admins, should clean up anything you added on conversion.
 /datum/religion_sect/proc/on_deconversion(mob/living/chap)
@@ -66,6 +67,7 @@
 	to_chat(chap, span_boldnotice("You have lost the approval of \the [name]."))
 	if(chap.mind.holy_role == HOLY_ROLE_HIGHPRIEST)
 		to_chat(chap, span_notice("Return to an altar to reform your sect."))
+	chap.faction -= FACTION_HOLY
 
 /// Returns TRUE if the item can be sacrificed. Can be modified to fit item being tested as well as person offering. Returning TRUE will stop the attackby sequence and proceed to on_sacrifice.
 /datum/religion_sect/proc/can_sacrifice(obj/item/sacrifice, mob/living/chap)

--- a/code/modules/spells/spell_types/projectile/_basic_projectile.dm
+++ b/code/modules/spells/spell_types/projectile/_basic_projectile.dm
@@ -28,3 +28,4 @@
 	to_fire.aim_projectile(target, caster)
 	SEND_SIGNAL(caster, COMSIG_MOB_SPELL_PROJECTILE, src, target, to_fire)
 	to_fire.fire()
+	return to_fire

--- a/code/modules/spells/spell_types/projectile/juggernaut.dm
+++ b/code/modules/spells/spell_types/projectile/juggernaut.dm
@@ -12,3 +12,8 @@
 	spell_requirements = NONE
 
 	projectile_type = /obj/projectile/magic/aoe/juggernaut
+
+/datum/action/cooldown/spell/basic_projectile/juggernaut/fire_projectile(atom/target, mob/caster)
+	var/obj/projectile/magic/aoe/juggernaut/to_fire = ..()
+	to_fire.ignored_factions = caster.faction
+	return to_fire


### PR DESCRIPTION
## About The Pull Request

Holy constructs are now part of a new Holy faction, that all Chaplains get once they choose a sect.
Wizard constructs are now part of the Wizard faction
Juggernaut's Gaunlet Echo spell now respects factions (so ignores cult as cult, wizards as wizard, and their creator as holy)

https://github.com/user-attachments/assets/e56f958d-fffa-4534-8b39-a95f9d160865

## Why It's Good For The Game

Makes constructs less likely to friendly fire and makes holy constructs able to use their spells to fight Cult.

## Changelog

:cl: Ezel/Improvedname, JohnFulpWillard
fix: Constructs now have their proper factions, so Wizard constructs can't hit Wizard Apprentices.
fix: Juggernaut's Gauntlet echo spell now respects factions.
/:cl:
