### PR TITLE
Fixes weather getting stuck and not affecting mobs

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(weather)
 		if(!length(weather_event.subsystem_tasks) || weather_event.stage != MAIN_STAGE)
 			continue
 
-		if(weather_event.currentpart == SSWEATHER_MOBS)
+		if(weather_event.subsystem_tasks[weather_event.task_index] == SSWEATHER_MOBS)
 			if(!resumed)
 				weather_event.current_mobs = GLOB.mob_living_list.Copy()
 			var/list/current_mobs_cache = weather_event.current_mobs // cache for performance
@@ -31,9 +31,9 @@ SUBSYSTEM_DEF(weather)
 				if(MC_TICK_CHECK)
 					return
 			resumed = FALSE
-			weather_event.currentpart = weather_event.subsystem_tasks[WRAP_UP(weather_event.currentpart, weather_event.subsystem_tasks.len)]
+			weather_event.task_index = WRAP_UP(weather_event.task_index, weather_event.subsystem_tasks.len)
 
-		if(weather_event.currentpart == SSWEATHER_TURFS)
+		if(weather_event.subsystem_tasks[weather_event.task_index] == SSWEATHER_TURFS)
 			if(!resumed)
 				weather_event.turf_iteration = ROUND_PROB(weather_event.weather_turfs_per_tick)
 			while(weather_event.turf_iteration)
@@ -44,9 +44,9 @@ SUBSYSTEM_DEF(weather)
 				if(MC_TICK_CHECK)
 					return
 			resumed = FALSE
-			weather_event.currentpart = weather_event.subsystem_tasks[WRAP_UP(weather_event.currentpart, weather_event.subsystem_tasks.len)]
+			weather_event.task_index = WRAP_UP(weather_event.task_index, weather_event.subsystem_tasks.len)
 
-		if(weather_event.currentpart == SSWEATHER_THUNDER)
+		if(weather_event.subsystem_tasks[weather_event.task_index] == SSWEATHER_THUNDER)
 			if(!resumed)
 				weather_event.thunder_iteration = ROUND_PROB(weather_event.thunder_turfs_per_tick)
 			while(weather_event.thunder_iteration)
@@ -57,7 +57,7 @@ SUBSYSTEM_DEF(weather)
 				if(MC_TICK_CHECK)
 					return
 			resumed = FALSE
-			weather_event.currentpart = weather_event.subsystem_tasks[WRAP_UP(weather_event.currentpart, weather_event.subsystem_tasks.len)]
+			weather_event.task_index = WRAP_UP(weather_event.task_index, weather_event.subsystem_tasks.len)
 
 	// start random weather on relevant levels
 	for(var/z in eligible_zlevels)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -114,8 +114,8 @@
 	var/turf_iteration = 0
 	/// The weather thunder counter to keep track of how much thunder we have processed so far
 	var/thunder_iteration = 0
-	/// The current section our weather subsystem is processing
-	var/currentpart
+	/// Index of the current section our weather subsystem is processing from our subsystem_tasks
+	var/task_index = 1
 	/// The list of allowed tasks our weather subsystem is allowed to process (determined by weather_flags)
 	var/list/subsystem_tasks = list()
 
@@ -164,9 +164,6 @@
 		subsystem_tasks += SSWEATHER_TURFS
 	if(weather_flags & (WEATHER_THUNDER))
 		subsystem_tasks += SSWEATHER_THUNDER
-
-	if(length(subsystem_tasks))
-		currentpart = subsystem_tasks[1]
 
 	setup_weather_areas()
 	setup_weather_turfs()


### PR DESCRIPTION

## About The Pull Request

Weather subsystem code mixed up defines and indexes resulting in broken behavior when you only had mobs and thunder defined in a subsystem. Solved this by converting currentpart from define to active task index

Closes #90677

## Changelog
:cl:
fix: Ash storms do damage again
/:cl:
