### PR TITLE
[tgui] Bump dompurify to v3

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.ts
+++ b/tgui/packages/tgui-panel/chat/middleware.ts
@@ -4,6 +4,7 @@
  * @license MIT
  */
 
+import { Store } from 'common/redux';
 import { storage } from 'common/storage';
 import DOMPurify from 'dompurify';
 
@@ -38,7 +39,7 @@ import { selectChat, selectCurrentChatPage } from './selectors';
 // List of blacklisted tags
 const FORBID_TAGS = ['a', 'iframe', 'link', 'video'];
 
-const saveChatToStorage = async (store) => {
+const saveChatToStorage = async (store: Store) => {
   const state = selectChat(store.getState());
   const fromIndex = Math.max(
     0,
@@ -51,7 +52,7 @@ const saveChatToStorage = async (store) => {
   storage.set('chat-messages', messages);
 };
 
-const loadChatFromStorage = async (store) => {
+const loadChatFromStorage = async (store: Store) => {
   const [state, messages] = await Promise.all([
     storage.get('chat-state'),
     storage.get('chat-messages'),
@@ -82,11 +83,11 @@ const loadChatFromStorage = async (store) => {
   store.dispatch(loadChat(state));
 };
 
-export const chatMiddleware = (store) => {
+export const chatMiddleware = (store: Store) => {
   let initialized = false;
   let loaded = false;
-  const sequences = [];
-  const sequences_requested = [];
+  const sequences: number[] = [];
+  const sequences_requested: number[] = [];
   chatRenderer.events.on('batchProcessed', (countByType) => {
     // Use this flag to workaround unread messages caused by
     // loading them from storage. Side effect of that, is that
@@ -117,7 +118,7 @@ export const chatMiddleware = (store) => {
         return;
       }
 
-      const sequence = payload_obj.sequence;
+      const sequence: number = payload_obj.sequence;
       if (sequences.includes(sequence)) {
         return;
       }

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -4,7 +4,7 @@
   "version": "6.0.0",
   "dependencies": {
     "common": "workspace:*",
-    "dompurify": "^2.5.7",
+    "dompurify": "^3.2.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tgui": "workspace:*",

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "common": "workspace:*",
     "dateformat": "^5.0.3",
-    "dompurify": "^2.5.7",
+    "dompurify": "^3.2.5",
     "file-extension-icon-js": "^1.1.6",
     "highlight.js": "^11.10.0",
     "jest": "^29.7.0",

--- a/tgui/packages/tgui/sanitize.ts
+++ b/tgui/packages/tgui/sanitize.ts
@@ -60,13 +60,13 @@ const defAttr = ['class', 'style', 'background'];
  * @param forbidAttr - List of forbidden HTML attributes
  * @param advTags - List of advanced HTML tags allowed for trusted sources
  */
-export const sanitizeText = (
+export function sanitizeText(
   input: string,
   advHtml = false,
   tags = defTag,
   forbidAttr = defAttr,
   advTags = advTag,
-) => {
+) {
   // This is VERY important to think first if you NEED
   // the tag you put in here.  We are pushing all this
   // though dangerouslySetInnerHTML and even though
@@ -79,4 +79,4 @@ export const sanitizeText = (
     ALLOWED_TAGS: tags,
     FORBID_ATTR: forbidAttr,
   });
-};
+}

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -4105,6 +4105,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
+  languageName: node
+  linkType: hard
+
 "@types/uglify-js@npm:*":
   version: 3.17.5
   resolution: "@types/uglify-js@npm:3.17.5"
@@ -8152,10 +8159,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^2.5.7":
-  version: 2.5.7
-  resolution: "dompurify@npm:2.5.7"
-  checksum: 10c0/23c4f737182fcf3e731e458c3930ef4d2916191e4180e1e345f153124dfa7ec117d2810af1754e8854c581131fc75dac914a8391183d1511852ef32b4055f711
+"dompurify@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "dompurify@npm:3.2.5"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/b564167cc588933ad2d25c185296716bdd7124e9d2a75dac76efea831bb22d1230ce5205a1ab6ce4c1010bb32ac35f7a5cb2dd16c78cbf382111f1228362aa59
   languageName: node
   linkType: hard
 
@@ -19723,7 +19735,7 @@ __metadata:
     "@types/react": "npm:^19.1.0"
     "@types/react-dom": "npm:^19.1.2"
     common: "workspace:*"
-    dompurify: "npm:^2.5.7"
+    dompurify: "npm:^3.2.5"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     tgui: "workspace:*"
@@ -19794,7 +19806,7 @@ __metadata:
     "@types/react-dom": "npm:^19.1.2"
     common: "workspace:*"
     dateformat: "npm:^5.0.3"
-    dompurify: "npm:^2.5.7"
+    dompurify: "npm:^3.2.5"
     file-extension-icon-js: "npm:^1.1.6"
     highlight.js: "npm:^11.10.0"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
## About The Pull Request
Thanks to kashargul for pointing out: Dompurify can be bumped up to latest

This cuts our sanitize test time down by 2/3, presumably lending this performance elsewhere. [v3](https://github.com/cure53/DOMPurify/releases?expanded=true&page=3&q=3.0.0) has no more IE support, less associated overhead
## Why It's Good For The Game
Code maintenance
Performance
## Changelog
