### PR TITLE
Mood event received with an antag datum is now its own subtype, received mood event value equalized across antagonists, type defined on antag datum instead of being a bare variable

### DIFF
--- a/code/datums/mood_events/antag_moodies.dm
+++ b/code/datums/mood_events/antag_moodies.dm
@@ -1,0 +1,16 @@
+/// Very specifically meant to be the moodlet assigned by an antag datum; not for "antag-related" moodlets
+/datum/mood_event/antag_moodlet
+	mood_change = 6
+	hidden = TRUE
+
+/datum/mood_event/antag_moodlet/focused
+	description = "I have a goal, and I will reach it, whatever it takes!"
+
+/datum/mood_event/antag_moodlet/revolution
+	description = "VIVA LA REVOLUTION!"
+
+/datum/mood_event/antag_moodlet/cult
+	description = "I have seen the truth, praise the almighty one!"
+
+/datum/mood_event/antag_moodlet/heretics
+	description = "THE HIGHER I RISE, THE MORE I SEE."

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -92,11 +92,6 @@
 	mood_change = 6
 	timeout = 2 MINUTES
 
-/datum/mood_event/focused
-	description = "I have a goal, and I will reach it, whatever it takes!" //Used for syndies, nukeops etc so they can focus on their goals
-	mood_change = 4
-	hidden = TRUE
-
 /datum/mood_event/badass_antag
 	description = "I'm a fucking badass and everyone around me knows it. Just look at them; they're all fucking shaking at the mere thought of having me around."
 	mood_change = 7
@@ -108,21 +103,6 @@
 	description = "The voices have released their hooks on my mind! I feel free again!" //creeps get it when they are around their obsession
 	mood_change = 18
 	timeout = 3 SECONDS
-	hidden = TRUE
-
-/datum/mood_event/revolution
-	description = "VIVA LA REVOLUTION!"
-	mood_change = 3
-	hidden = TRUE
-
-/datum/mood_event/cult
-	description = "I have seen the truth, praise the almighty one!"
-	mood_change = 10 //maybe being a cultist isn't that bad after all
-	hidden = TRUE
-
-/datum/mood_event/heretics
-	description = "THE HIGHER I RISE, THE MORE I SEE."
-	mood_change = 10 //maybe being a heretic isnt that bad after all
 	hidden = TRUE
 
 /datum/mood_event/rift_fishing

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	///String dialogue that is added to the player's in-round notes and memories regarding specifics of that antagonist, eg. the nuke code for nuke ops, or your unlock code for traitors.
 	var/antag_memory = ""
 	///typepath of moodlet that the mob will gain when granted this antagonist type.
-	var/antag_moodlet
+	var/datum/mood_event/antag_moodlet/antag_moodlet
 	///If these antags are alone when a shuttle elimination happens.
 	var/can_elimination_hijack = ELIMINATION_NEUTRAL
 	///If above 0, this is the multiplier for the speed at which we hijack the shuttle. Do not directly read, use hijack_speed().

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -7,7 +7,7 @@
 	hijack_speed = 0.5
 	ui_name = "AntagInfoBrother"
 	suicide_cry = "FOR MY BROTHER!!"
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	hardcore_random_bonus = TRUE
 	stinger_sound = 'sound/music/antag/traitor/tatoralert.ogg'
 	VAR_PRIVATE

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -6,7 +6,7 @@
 	roundend_category = "changelings"
 	antagpanel_category = "Changeling"
 	job_rank = ROLE_CHANGELING
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	antag_hud_name = "changeling"
 	hijack_speed = 0.5
 	ui_name = "AntagInfoChangeling"

--- a/code/modules/antagonists/cult/datums/cultist.dm
+++ b/code/modules/antagonists/cult/datums/cultist.dm
@@ -2,7 +2,7 @@
 	name = "Cultist"
 	roundend_category = "cultists"
 	antagpanel_category = "Cult"
-	antag_moodlet = /datum/mood_event/cult
+	antag_moodlet = /datum/mood_event/antag_moodlet/cult
 	suicide_cry = "FOR NAR'SIE!!"
 	preview_outfit = /datum/outfit/cultist
 	job_rank = ROLE_CULTIST

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -8,7 +8,7 @@
 	can_elimination_hijack = ELIMINATION_PREVENT
 	show_in_antagpanel = FALSE
 	show_to_ghosts = TRUE
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	antagpanel_category = ANTAG_GROUP_ERT
 	suicide_cry = "FOR NANOTRASEN!!"
 	count_against_dynamic_roll_chance = FALSE

--- a/code/modules/antagonists/nukeop/datums/operative.dm
+++ b/code/modules/antagonists/nukeop/datums/operative.dm
@@ -4,7 +4,7 @@
 	antagpanel_category = ANTAG_GROUP_SYNDICATE
 	job_rank = ROLE_OPERATIVE
 	antag_hud_name = "synd"
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	show_to_ghosts = TRUE
 	hijack_speed = 2 //If you can't take out the station, take the shuttle instead.
 	suicide_cry = "FOR THE SYNDICATE!!"

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -3,7 +3,7 @@
 	roundend_category = "revolutionaries" // if by some miracle revolutionaries without revolution happen
 	antagpanel_category = "Revolution"
 	job_rank = ROLE_REV
-	antag_moodlet = /datum/mood_event/revolution
+	antag_moodlet = /datum/mood_event/antag_moodlet/revolution
 	antag_hud_name = "rev"
 	suicide_cry = "VIVA LA REVOLUTION!!"
 	stinger_sound = 'sound/music/antag/revolutionary_tide.ogg'

--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -6,7 +6,7 @@
 	hijack_speed = 1
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	suicide_cry = "FOR THE SPIDER CLAN!!"
 	preview_outfit = /datum/outfit/ninja_preview
 	can_assign_self_objectives = TRUE

--- a/code/modules/antagonists/spy/spy.dm
+++ b/code/modules/antagonists/spy/spy.dm
@@ -4,7 +4,7 @@
 	antagpanel_category = "Spy"
 	antag_hud_name = "spy"
 	job_rank = ROLE_SPY
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	hijack_speed = 1
 	ui_name = "AntagInfoSpy"
 	preview_outfit = /datum/outfit/spy

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -8,7 +8,7 @@
 	roundend_category = "traitors"
 	antagpanel_category = "Traitor"
 	job_rank = ROLE_TRAITOR
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	antag_hud_name = "traitor"
 	hijack_speed = 0.5 //10 seconds per hijack stage by default
 	ui_name = "AntagInfoTraitor"

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	antagpanel_category = ANTAG_GROUP_WIZARDS
 	job_rank = ROLE_WIZARD
 	antag_hud_name = "wizard"
-	antag_moodlet = /datum/mood_event/focused
+	antag_moodlet = /datum/mood_event/antag_moodlet/focused
 	hijack_speed = 0.5
 	ui_name = "AntagInfoWizard"
 	suicide_cry = "FOR THE FEDERATION!!"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1739,6 +1739,7 @@
 #include "code\datums\mind\skills.dm"
 #include "code\datums\mocking\client.dm"
 #include "code\datums\mood_events\_mood_event.dm"
+#include "code\datums\mood_events\antag_moodies.dm"
 #include "code\datums\mood_events\area_events.dm"
 #include "code\datums\mood_events\axe_events.dm"
 #include "code\datums\mood_events\beauty_events.dm"


### PR DESCRIPTION
## About The Pull Request

Most of our antagonists receive a semi-permanent mood event whenever they receive the antagonist datum, specified by the antag datum. Some antagonists received an exceptionally high mood increase, while others received the generic one. As well, the antagonist datum didn't actually type the mood_event as such.

This changes antag mood events to be their own subtype of mood_event, as well as setting the antag mood_event values to be equal across the board (6). For most antagonists, this is a very slight buff, though for cult and heretic, this lowers the static mood increase from 10 to 6. To illustrate:

Generic mood event:
4 -> 6
Cult mood event:
10 -> 6
Heretic mood event:
10 -> 6
## Why It's Good For The Game

One type of antagonist being able to functionally ignore mood over other kinds of antagonist didn't seem particularly fair, considering the effects mood and sanity have on things like action and mood speed. This equalizes the mood increase across antagonists so that they all still need to account for their mood, though to a lesser degree on account of the appreciable increase in mood that +6 is.

As well, it cleans up the code just a bit, by having antag mood events be their own specific type, though they have no special behavior as of this PR ( I am working on another PR that will leverage this but it is outside the scope ).
## Changelog
:cl: Bisar
balance: The mood event that antagonists receive when being assigned that antagonist role has been equalized across roles.
balance: For most antagonists, this is a slight increase in the mood bonus.
balance: For heretics and cultists, this is a slight decrease in the mood bonus.
code: Antagonist mood events are their own subtype now.
code: The variable type is now defined in the antagonist datum abstract for antag mood events.
/:cl:
