### PR TITLE
Reduce the price of nukie keys

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -818,7 +818,7 @@
 	category = /datum/uplink_category/base_keys
 	surplus = 0
 	purchasable_from = UPLINK_NUKE_OPS
-	cost = 15
+	cost = 5
 	cant_discount = TRUE
 
 /datum/uplink_item/base_keys/bomb_key
@@ -826,6 +826,7 @@
 	desc = "Do you fancy yourself an explosives expert? If so, then consider yourself lucky! With this special Authorization Key, \
 		you can blow those corpo suits away with your very own home-made explosive devices. Made in your local firebase's \
 		very own Ordnance Laboratory! *The Syndicate is not responsible for injuries or deaths sustained while utilizing the lab."
+	cost = 15
 	item = /obj/item/keycard/syndicate_bomb
 
 /datum/uplink_item/base_keys/bio_key
@@ -852,7 +853,7 @@
 		pocket during this morning's briefing. He's been looking for it since. Take it, get into the fridge, and cook up whatever \
 		you need before he gets back. And remember: DON'T TELL ANYONE! -M.T"
 	item = /obj/item/keycard/syndicate_fridge
-	cost = 5
+	cost = 2
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
 
 // Hats


### PR DESCRIPTION
## About The Pull Request
Lowers the price of the keycard accesses for nukies

all labs go from 15 TC -> 5 TC
the kitchen goes from 5 TC -> 2 TC

## Why It's Good For The Game
Nukies using these rooms are cool and should be encouraged. I almost never see them being used because they're way too expensive for what they are!

## Changelog
:cl:
balance: The syndicate found a bunch of keycards behind the back of the sofa: They're now much cheaper.
/:cl:
