### PR TITLE
Fix categories in preferences menu

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/TabbedMenu.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/TabbedMenu.tsx
@@ -10,7 +10,6 @@ export function TabbedMenu(props: TabbedMenuProps) {
   const sectionRef = useRef<HTMLDivElement>(null);
   const categoryRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  console.log(categoryRefs);
   return (
     <Stack vertical fill>
       <Stack.Item>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/TabbedMenu.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/TabbedMenu.tsx
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ComponentProps,
-  createRef,
-  ReactNode,
-  RefObject,
-} from 'react';
+import { ComponentProps, ReactNode, useRef } from 'react';
 import { Button, Flex, Section, Stack } from 'tgui-core/components';
 
 type TabbedMenuProps = {
@@ -12,83 +6,66 @@ type TabbedMenuProps = {
   contentProps?: ComponentProps<typeof Flex>;
 };
 
-export class TabbedMenu extends Component<TabbedMenuProps> {
-  categoryRefs: Record<string, RefObject<HTMLDivElement | null>> = {};
-  sectionRef: RefObject<HTMLDivElement | null> = createRef();
+export function TabbedMenu(props: TabbedMenuProps) {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const categoryRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  getCategoryRef(category: string): RefObject<HTMLDivElement | null> {
-    if (!this.categoryRefs[category]) {
-      this.categoryRefs[category] = createRef();
-    }
+  console.log(categoryRefs);
+  return (
+    <Stack vertical fill>
+      <Stack.Item>
+        <Stack fill px={5}>
+          {props.categoryEntries.map(([category]) => (
+            <Stack.Item key={category} grow basis="content">
+              <Button
+                align="center"
+                fontSize="1.2em"
+                fluid
+                onClick={() => {
+                  const offsetTop = categoryRefs.current[category]?.offsetTop;
+                  if (offsetTop === undefined) {
+                    return;
+                  }
 
-    return this.categoryRefs[category];
-  }
+                  const currentSection = sectionRef.current;
+                  if (!currentSection) {
+                    return;
+                  }
 
-  render() {
-    return (
-      <Stack vertical fill>
-        <Stack.Item>
-          <Stack fill px={5}>
-            {this.props.categoryEntries.map(([category]) => {
-              return (
-                <Stack.Item key={category} grow basis="content">
-                  <Button
-                    align="center"
-                    fontSize="1.2em"
-                    fluid
-                    onClick={() => {
-                      const offsetTop =
-                        this.categoryRefs[category].current?.offsetTop;
+                  currentSection.scrollTop = offsetTop;
+                }}
+              >
+                {category}
+              </Button>
+            </Stack.Item>
+          ))}
+        </Stack>
+      </Stack.Item>
 
-                      if (offsetTop === undefined) {
-                        return;
-                      }
-
-                      const currentSection = this.sectionRef.current;
-
-                      if (!currentSection) {
-                        return;
-                      }
-
-                      currentSection.scrollTop = offsetTop;
-                    }}
-                  >
-                    {category}
-                  </Button>
-                </Stack.Item>
-              );
-            })}
-          </Stack>
-        </Stack.Item>
-
-        <Stack.Item
-          grow
-          innerRef={this.sectionRef}
-          position="relative"
-          overflowY="scroll"
-          {...{
-            ...this.props.contentProps,
-
-            // Otherwise, TypeScript complains about invalid prop
-            className: undefined,
-          }}
-        >
-          <Stack vertical fill px={2}>
-            {this.props.categoryEntries.map(([category, children]) => {
-              return (
-                <Stack.Item
-                  key={category}
-                  innerRef={this.getCategoryRef(category)}
-                >
-                  <Section fill title={category}>
-                    {children}
-                  </Section>
-                </Stack.Item>
-              );
-            })}
-          </Stack>
-        </Stack.Item>
-      </Stack>
-    );
-  }
+      <Stack.Item
+        grow
+        ref={sectionRef}
+        position="relative"
+        overflowY="scroll"
+        {...{
+          ...props.contentProps,
+        }}
+      >
+        <Stack vertical fill px={2}>
+          {props.categoryEntries.map(([category, children]) => (
+            <div
+              key={category}
+              ref={(ref) => {
+                categoryRefs.current[category] = ref;
+              }}
+            >
+              <Section fill title={category}>
+                {children}
+              </Section>
+            </div>
+          ))}
+        </Stack>
+      </Stack.Item>
+    </Stack>
+  );
 }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/TabbedMenu.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/TabbedMenu.tsx
@@ -46,9 +46,7 @@ export function TabbedMenu(props: TabbedMenuProps) {
         ref={sectionRef}
         position="relative"
         overflowY="scroll"
-        {...{
-          ...props.contentProps,
-        }}
+        {...props.contentProps}
       >
         <Stack vertical fill px={2}>
           {props.categoryEntries.map(([category, children]) => (


### PR DESCRIPTION
## About The Pull Request
Fixes categories navigation in prefs and transfer it to FC
Closes #90652

## Why It's Good For The Game
Less bugs
TS tells me to go fuck myself on this use of `ref` in `Stack.Item`, so I used `div`
It works, but I have very little experience with refs, so I hope I did it right

https://github.com/user-attachments/assets/34e1b042-eab5-4d90-a707-7bfeb37af1bc

## Changelog

:cl:
fix: Navigating to categories in preferences works again
/:cl:
