### PR TITLE
Tourist bots track in dirt occasionally

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/robot_customer.dm
+++ b/code/modules/mob/living/basic/space_fauna/robot_customer.dm
@@ -25,6 +25,8 @@
 	var/clothes_set = "amerifat_clothes"
 	/// Reference to the hud that we show when the player hovers over us.
 	var/datum/atom_hud/hud_to_show_on_hover
+	/// Amount of grim carried by the bot dropped as it goes
+	var/grime_carried = 0
 
 /mob/living/basic/robot_customer/Initialize(
 	mapload,
@@ -50,6 +52,8 @@
 	clothes_set = pick(customer_info.clothing_sets)
 	update_appearance(UPDATE_ICON)
 
+	grime_carried = prob(2) ? 20 : pick(0, 0, rand(0, 3), rand(1, 4), 6)
+
 ///Clean up on the mobs seat etc when its deleted (Either by murder or because it left)
 /mob/living/basic/robot_customer/Destroy()
 	var/datum/venue/attending_venue = ai_controller.blackboard[BB_CUSTOMER_ATTENDING_VENUE]
@@ -63,6 +67,12 @@
 ///Robots need robot gibs...!
 /mob/living/basic/robot_customer/spawn_gibs()
 	new /obj/effect/gibspawner/robot(drop_location(), src)
+
+/mob/living/basic/robot_customer/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
+	. = ..()
+	if(grime_carried && prob(grime_carried * 20) && !throwing && !(movetypes & MOVETYPES_NOT_TOUCHING_GROUND) && has_gravity())
+		new /obj/effect/decal/cleanable/dirt(old_loc)
+		grime_carried--
 
 /mob/living/basic/robot_customer/MouseEntered(location, control, params)
 	. = ..()

--- a/code/modules/mob/living/basic/space_fauna/robot_customer.dm
+++ b/code/modules/mob/living/basic/space_fauna/robot_customer.dm
@@ -70,7 +70,7 @@
 
 /mob/living/basic/robot_customer/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
-	if(grime_carried && prob(grime_carried * 20) && !throwing && !(movetypes & MOVETYPES_NOT_TOUCHING_GROUND) && has_gravity())
+	if(grime_carried && prob(grime_carried * 20) && !throwing && !(movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && has_gravity())
 		new /obj/effect/decal/cleanable/dirt(old_loc)
 		grime_carried--
 

--- a/code/modules/mob/living/basic/space_fauna/robot_customer.dm
+++ b/code/modules/mob/living/basic/space_fauna/robot_customer.dm
@@ -52,7 +52,7 @@
 	clothes_set = pick(customer_info.clothing_sets)
 	update_appearance(UPDATE_ICON)
 
-	grime_carried = prob(2) ? 20 : pick(0, 0, rand(0, 3), rand(1, 4), 6)
+	grime_carried = prob(2) ? 20 : pick(0, 0, 0, 0, rand(0, 2), rand(0, 3), rand(2, 4), 6)
 
 ///Clean up on the mobs seat etc when its deleted (Either by murder or because it left)
 /mob/living/basic/robot_customer/Destroy()


### PR DESCRIPTION
## About The Pull Request

Tourist bots occasionally will spawn dirt under their tracks when walking

## Why It's Good For The Game

Gives the janitor something to do in downtime if the chef or bartender are working with bots. Maybe they can even split some of the proceeds for keeping the bar clean.

## Changelog

:cl: Melbert
add: Tourist bots track in dirt occasionally
/:cl:

