### PR TITLE
Adds scrollbars to windows that missed them (yet again, the fight never ends) + some tiny little adjustment(s)

### DIFF
--- a/tgui/packages/tgui/interfaces/DnaConsole/index.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/index.jsx
@@ -37,7 +37,7 @@ export const DnaConsole = (props) => {
           {timeToPulse}s
         </Dimmer>
       )}
-      <Window.Content>
+      <Window.Content scrollable>
         <Stack fill vertical>
           <Stack.Item>
             <DnaScanner />

--- a/tgui/packages/tgui/interfaces/ExperimentConfigure.tsx
+++ b/tgui/packages/tgui/interfaces/ExperimentConfigure.tsx
@@ -148,11 +148,15 @@ export function Experiment(props) {
           <Stack.Item>{name}</Stack.Item>
           <Stack.Item color="rgba(255, 255, 255, 0.5)">
             <div className="ExperimentConfigure__TagContainer">
-              {tag}
-              <Tooltip content={performance_hint} position="bottom-start">
-                <Icon name="question-circle" mx={0.5} />
-                <div className="ExperimentConfigure__PerformanceHint" />
-              </Tooltip>
+              <Stack>
+                <Stack.Item>{tag}</Stack.Item>
+                <Stack.Item>
+                  <Tooltip content={performance_hint} position="bottom-start">
+                    <Icon name="question-circle" mx={0.5} />
+                    <div className="ExperimentConfigure__PerformanceHint" />
+                  </Tooltip>
+                </Stack.Item>
+              </Stack>
             </div>
           </Stack.Item>
         </Stack>

--- a/tgui/packages/tgui/interfaces/ExperimentConfigure.tsx
+++ b/tgui/packages/tgui/interfaces/ExperimentConfigure.tsx
@@ -219,32 +219,38 @@ export function ExperimentConfigure(props) {
               <TechwebServer key={techweb} techwebs={techwebs} />
             ))}
         </Section>
+        <Stack vertical>
+          {techwebs.some((e) => e.selected) && (
+            <Stack.Item>
+              <Section
+                title="Experiments"
+                className="ExperimentConfigure__ExperimentsContainer"
+                fill
+              >
+                <Box mb={1} color="label">
+                  {textContent}
+                </Box>
+                {experiments.map((exp, i) => (
+                  <Experiment key={i} exp={exp} />
+                ))}
+              </Section>
+            </Stack.Item>
+          )}
 
-        {techwebs.some((e) => e.selected) && (
-          <Section
-            title="Experiments"
-            className="ExperimentConfigure__ExperimentsContainer"
-          >
-            <Box mb={1} color="label">
-              {textContent}
-            </Box>
-            {experiments.map((exp, i) => (
-              <Experiment key={i} exp={exp} />
-            ))}
-          </Section>
-        )}
-
-        {!!has_start_callback && (
-          <Button
-            fluid
-            className="ExperimentConfigure__PerformExperiment"
-            onClick={() => act('start_experiment_callback')}
-            disabled={!experiments.some((e) => e.selected)}
-            icon="flask"
-          >
-            Perform Experiment
-          </Button>
-        )}
+          {!!has_start_callback && (
+            <Stack.Item>
+              <Button
+                fluid
+                className="ExperimentConfigure__PerformExperiment"
+                onClick={() => act('start_experiment_callback')}
+                disabled={!experiments.some((e) => e.selected)}
+                icon="flask"
+              >
+                Perform Experiment
+              </Button>
+            </Stack.Item>
+          )}
+        </Stack>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/Mule.tsx
+++ b/tgui/packages/tgui/interfaces/Mule.tsx
@@ -156,7 +156,7 @@ export const Mule = (props) => {
 
   return (
     <Window width={350} height={500}>
-      <Window.Content>
+      <Window.Content scrollable>
         <InterfaceLockNoticeBox />
         <Section
           title="Status"

--- a/tgui/packages/tgui/interfaces/Radio.tsx
+++ b/tgui/packages/tgui/interfaces/Radio.tsx
@@ -55,13 +55,13 @@ export const Radio = (props) => {
   let height = 133;
   if (subspace) {
     if (channels.length > 0) {
-      height += channels.length * 21 + 6;
+      height += channels.length * 20 + 6;
     } else {
       height += 24;
     }
   }
   return (
-    <Window width={360} height={height}>
+    <Window width={376} height={height}>
       <Window.Content>
         <Section>
           <LabeledList>

--- a/tgui/packages/tgui/interfaces/Radio.tsx
+++ b/tgui/packages/tgui/interfaces/Radio.tsx
@@ -6,6 +6,7 @@ import {
   NumberInput,
   Section,
   Slider,
+  Stack,
 } from 'tgui-core/components';
 import { toFixed } from 'tgui-core/math';
 import { BooleanLike } from 'tgui-core/react';
@@ -55,7 +56,7 @@ export const Radio = (props) => {
   let height = 133;
   if (subspace) {
     if (channels.length > 0) {
-      height += channels.length * 20 + 6;
+      height += channels.length * 25 + 8;
     } else {
       height += 24;
     }
@@ -148,20 +149,22 @@ export const Radio = (props) => {
                     No encryption keys installed.
                   </Box>
                 )}
-                {channels.map((channel) => (
-                  <Box key={channel.name}>
-                    <Button
-                      icon={channel.status ? 'check-square-o' : 'square-o'}
-                      selected={channel.status}
-                      content={channel.name}
-                      onClick={() =>
-                        act('channel', {
-                          channel: channel.name,
-                        })
-                      }
-                    />
-                  </Box>
-                ))}
+                <Stack vertical>
+                  {channels.map((channel) => (
+                    <Box key={channel.name}>
+                      <Button
+                        icon={channel.status ? 'check-square-o' : 'square-o'}
+                        selected={channel.status}
+                        content={channel.name}
+                        onClick={() =>
+                          act('channel', {
+                            channel: channel.name,
+                          })
+                        }
+                      />
+                    </Box>
+                  ))}
+                </Stack>
               </LabeledList.Item>
             )}
           </LabeledList>

--- a/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
+++ b/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
@@ -75,7 +75,7 @@ class SurgeryInitiatorInner extends Component<
 
     return (
       <Window width={400} height={350} title={`Surgery on ${target_name}`}>
-        <Window.Content>
+        <Window.Content scrollable>
           <Stack fill height="100%">
             <Stack.Item width="30%">
               <BodyZoneSelector

--- a/tgui/packages/tgui/interfaces/Techweb/disks/disks.tsx
+++ b/tgui/packages/tgui/interfaces/Techweb/disks/disks.tsx
@@ -1,4 +1,4 @@
-import { Section } from 'tgui-core/components';
+import { Section, VirtualList } from 'tgui-core/components';
 
 import { useRemappedBackend } from '../helpers';
 import { TechNode } from '../nodes/TechNode';
@@ -36,7 +36,15 @@ export function TechwebTechDisk(props) {
 
   const { stored_research } = t_disk;
 
-  return Object.keys(stored_research)
-    .map((x) => ({ id: x }))
-    .map((n) => <TechNode key={n.id} nocontrols node={n as TechwebNode} />);
+  return (
+    <Section scrollable fill>
+      <VirtualList>
+        {Object.keys(stored_research)
+          .map((x) => ({ id: x }))
+          .map((n) => (
+            <TechNode key={n.id} nocontrols node={n as TechwebNode} />
+          ))}
+      </VirtualList>
+    </Section>
+  );
 }

--- a/tgui/packages/tgui/interfaces/Techweb/nodes/detail.tsx
+++ b/tgui/packages/tgui/interfaces/Techweb/nodes/detail.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
-import { Button, Divider, Flex, Tabs } from 'tgui-core/components';
+import {
+  Button,
+  Divider,
+  Flex,
+  Section,
+  Tabs,
+  VirtualList,
+} from 'tgui-core/components';
 
 import { useRemappedBackend } from '../helpers';
 import { useTechWebRoute } from '../hooks';
@@ -87,16 +94,24 @@ export function TechNodeDetail(props: TechNodeDetailProps) {
       </Flex.Item>
       {tabIndex === 0 && (
         <Flex.Item className="Techweb__OverviewNodes" grow>
-          {prereqNodes.map((n) => (
-            <TechNode key={n.id} node={n} />
-          ))}
+          <Section scrollable fill>
+            <VirtualList>
+              {prereqNodes.map((n) => (
+                <TechNode key={n.id} node={n} />
+              ))}
+            </VirtualList>
+          </Section>
         </Flex.Item>
       )}
       {tabIndex === 1 && (
         <Flex.Item className="Techweb__OverviewNodes" grow>
-          {unlockedNodes.map((n) => (
-            <TechNode key={n.id} node={n} />
-          ))}
+          <Section scrollable fill>
+            <VirtualList>
+              {unlockedNodes.map((n) => (
+                <TechNode key={n.id} node={n} />
+              ))}
+            </VirtualList>
+          </Section>
         </Flex.Item>
       )}
     </Flex>


### PR DESCRIPTION
## About The Pull Request
Required, unlocks and tech disk tabs all missed scrollbars. So I've just wrapped them in `Section` plus added some `VirtualList`s in case the list gets quite long (as it is the case with debug disk). 

Lookin more thoroughly i've found several more broken windows such as experiment scanner (not a scrollbar problem, but perform experiment button could be under the experiments themselves if you have to much of them), surgery initiator, mule bot interface, dna machine and even a headset (noticeable for the cap's one, but the fix isnt adding scrollbar but rather adjusting window size to accommodate new buttons).
<details>
<summary>Screenshots</summary>
 
![image](https://github.com/user-attachments/assets/1da512c6-5cd7-456e-9282-890ac83256ea)

![image](https://github.com/user-attachments/assets/35953e60-94a5-4ee2-8ee9-793474c2bda5)

![image](https://github.com/user-attachments/assets/5c9b49b3-1651-42f2-a3ef-554693990125)

![image](https://github.com/user-attachments/assets/75de64bd-6c32-48bb-a30b-a550ea19ffad)

![image](https://github.com/user-attachments/assets/01bf35f5-ab95-421d-b3bc-3d2cfd26c8aa)

![image](https://github.com/user-attachments/assets/a6219981-845f-40a4-8c56-ff35e3b2d311)

![image](https://github.com/user-attachments/assets/cc0a4a48-6c2a-4365-9889-db33e5cbb05d)

![image](https://github.com/user-attachments/assets/01cfc369-c970-4131-b704-8df6b7c627d9)

</details>

<details>
<summary>Tiny change in question </summary>

actual reason im making this pr
![image](https://github.com/user-attachments/assets/0eb34dc0-bed0-4458-90e3-c40be61f476a)

![image](https://github.com/user-attachments/assets/1c257383-73b9-4a51-a627-85cb740a49fc)

</details>

## Why It's Good For The Game

## Changelog
:cl:
fix: Fixed some more missing scrollbars in well everything that is left. Probably. I haven't looked that thoroughly.
fix: Experiment little question mark tooltip now occupies a single line instead of two
/:cl:
