### PR TITLE
Fix some wacky shuttle pipe interactions

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -28,6 +28,14 @@
 		volume = UNARY_PIPE_VOLUME * device_type
 	. = ..()
 
+/obj/machinery/atmospherics/pipe/set_volume(new_volume)
+	if(volume == new_volume)
+		return
+	var/datum/gas_mixture/gasmix = parent?.air
+	if(gasmix)
+		gasmix.volume = gasmix.volume + new_volume - volume
+	volume = new_volume
+
 /obj/machinery/atmospherics/pipe/setup_hiding()
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -28,7 +28,7 @@
 		volume = UNARY_PIPE_VOLUME * device_type
 	. = ..()
 
-/obj/machinery/atmospherics/pipe/set_volume(new_volume)
+/obj/machinery/atmospherics/pipe/proc/set_volume(new_volume)
 	if(volume == new_volume)
 		return
 	var/datum/gas_mixture/gasmix = parent?.air

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -74,10 +74,11 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 			if (init_dir & j)
 				new_volume += UNARY_PIPE_VOLUME
 			j <<= 1
-		set_volume(max(new_volume, UNARY_PIPE_VOLUME * 2))
+		new_volume = max(new_volume, UNARY_PIPE_VOLUME * 2) // Minimum 2 directions
+		set_volume(new_volume)
 	else
-		set_volume(UNARY_PIPE_VOLUME * 4)
 		initialize_directions = ALL_CARDINALS
+		set_volume(UNARY_PIPE_VOLUME * 4)
 
 //mapping helpers
 /obj/machinery/atmospherics/pipe/smart/simple

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -71,15 +71,8 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 /obj/machinery/atmospherics/pipe/smart/set_init_directions(init_dir)
 	if(init_dir)
 		initialize_directions = init_dir
-		var/j = 1
-		for (var/i in 1 to 4)
-			if (init_dir & j)
-				volume += UNARY_PIPE_VOLUME
-			j <<= 1
-		volume = max(volume, UNARY_PIPE_VOLUME * 2) // Minimum 2 directions
 	else
 		initialize_directions = ALL_CARDINALS
-		volume = UNARY_PIPE_VOLUME * 4
 
 //mapping helpers
 /obj/machinery/atmospherics/pipe/smart/simple

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -29,10 +29,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		connections |= connected_dir
 		new_volume += UNARY_PIPE_VOLUME
 	new_volume = max(new_volume, UNARY_PIPE_VOLUME * 2)
-
-	if(parent && parent.air && parent.air.volume)
-		parent.air.volume = parent.air.volume + new_volume - volume // Update associate pipenet with new volume.
-	volume = new_volume
+	set_volume(new_volume)
 
 	//set the correct direction for this node in case of binary directions
 	switch(connections)
@@ -70,8 +67,16 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 
 /obj/machinery/atmospherics/pipe/smart/set_init_directions(init_dir)
 	if(init_dir)
+		var/new_volume = 0
 		initialize_directions = init_dir
+		var/j = 1
+		for (var/i in 1 to 4)
+			if (init_dir & j)
+				new_volume += UNARY_PIPE_VOLUME
+			j <<= 1
+		set_volume(max(new_volume, UNARY_PIPE_VOLUME * 2))
 	else
+		set_volume(UNARY_PIPE_VOLUME * 4)
 		initialize_directions = ALL_CARDINALS
 
 //mapping helpers

--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -250,7 +250,7 @@ All ShuttleMove procs go here
 	if(is_mining_level(z)) //Avoids double logging and landing on other Z-levels due to badminnery
 		SSblackbox.record_feedback("associative", "colonies_dropped", 1, list("x" = x, "y" = y, "z" = z))
 
-/obj/machinery/atmospherics/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+/obj/machinery/atmospherics/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
 	. = ..()
 	if(pipe_vision_img)
 		pipe_vision_img.loc = loc


### PR DESCRIPTION

## About The Pull Request
Fixes #90648
And also fixes that pipes would often make nonsensical connections during shuttle rotations

Zero/negative volume:
Caused by set_init_directions fighting with code elsewhere for how big pipes should be. When the shuttle moved, init_directions would get called again, updating the pipe (but not the pipenet) volume to 140. Later, update_pipe_icon uses that modified volume as the "old" volume when calculating how much volume to remove from the pipenet, so frequently removes too much.

Incorrect connections: 
There's two steps when pipes go through a shuttle transition, first shuttleRotate, then afterShuttleMove, where connections are made. However, afterShuttleMove is called before shuttleRotate has been called for every atom, causing connections to happen to devices that have yet to be rotated away. Changing to use lateShuttleMove seems to fix this issue, as it is only called once the 'rotate' step has fully completed.
## Why It's Good For The Game
i can't breathe without my air
## Changelog
:cl:
fix: Shuttle atmos volumes should no longer become negative
fix: Shuttle atmos devices will no longer make illegal connections during rotations
/:cl:
