### PR TITLE
Big Manipulator Now With More Manipulation: Adds support to big manipulator for combat mode clicking, right clicking, and adds a UI button for ejecting the monkey; also does a little bit of code cleanup

### DIFF
--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -17,6 +17,7 @@
 #define STATUS_BUSY "busy"
 #define STATUS_IDLE "idle"
 #define STATUS_INSTALLING_WORKER "installing_worker"
+#define STATUS_UNINSTALLING_WORKER "uninstalling_worker"
 
 #define WORKER_SINGLE_USE "single"
 #define WORKER_EMPTY_USE "empty"
@@ -246,10 +247,14 @@
 	if(status == STATUS_BUSY)
 		balloon_alert(user, "turn it off first!")
 		return
+	if(status == STATUS_UNINSTALLING_WORKER)
+		balloon_alert(user, "already uninstalling worker, please wait")
+		return
 	var/mob/living/carbon/human/species/monkey/poor_monkey = monkey_worker.resolve()
 	if(!istype(poor_monkey, /mob/living/carbon/human/species/monkey))
 		monkey_worker = null
 		return
+	status = STATUS_UNINSTALLING_WORKER
 	balloon_alert(user, "uninstalling monkey worker...")
 	if(!do_after(user, 3 SECONDS, src))
 		balloon_alert(user, "interrupted")
@@ -259,6 +264,7 @@
 	poor_monkey.forceMove(get_turf(src))
 	REMOVE_TRAIT(poor_monkey, TRAIT_AI_PAUSED, "[src]")
 	monkey_worker = null
+	status = STATUS_IDLE
 
 /obj/machinery/big_manipulator/mouse_drop_receive(atom/monkey, mob/user, params)
 	if(!ismonkey(monkey) || !isnull(monkey_worker))

--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -161,7 +161,7 @@
 	var/mob/living/carbon/human/monkey_resolve = monkey_worker?.resolve()
 	if(!isnull(monkey_resolve))
 		monkey_resolve.forceMove(get_turf(monkey_resolve))
-		monkey_resolve.remove_offsets(src)
+		monkey_resolve.remove_offsets("[src]")
 		monkey_resolve = null
 	locked_by_this_id = null
 
@@ -255,7 +255,7 @@
 	poor_monkey.forceMove(get_turf(src))
 	REMOVE_TRAIT(poor_monkey, TRAIT_AI_PAUSED, "[src]")
 	monkey_worker = null
-	poor_monkey.remove_offsets(src)
+	poor_monkey.remove_offsets("[src]")
 	status = STATUS_IDLE
 
 /obj/machinery/big_manipulator/mouse_drop_receive(atom/monkey, mob/user, params)
@@ -287,7 +287,7 @@
 	manipulator_arm.vis_contents += poor_monkey
 	poor_monkey.dir = manipulator_arm.dir
 	poor_monkey.add_offsets(
-		type,
+		"[src]",
 		x_add = 32 + manipulator_arm.calculate_item_offset(TRUE, pixels_to_offset = 16),
 		y_add = 32 + manipulator_arm.calculate_item_offset(FALSE, pixels_to_offset = 16)
 	)

--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -148,31 +148,22 @@
 
 /obj/machinery/big_manipulator/Destroy(force)
 	. = ..()
+	manipulator_arm.vis_contents.Cut()
 	qdel(manipulator_arm)
 	if(!isnull(containment_obj))
 		var/obj/containment_resolve = containment_obj?.resolve()
 		containment_resolve?.forceMove(get_turf(containment_resolve))
+		containment_obj = null
 	if(!isnull(filter_obj))
 		var/obj/filter_resolve = filter_obj?.resolve()
 		filter_resolve?.forceMove(get_turf(filter_resolve))
-	var/mob/monkey_resolve = monkey_worker?.resolve()
+		filter_obj = null
+	var/mob/living/carbon/human/monkey_resolve = monkey_worker?.resolve()
 	if(!isnull(monkey_resolve))
 		monkey_resolve.forceMove(get_turf(monkey_resolve))
+		monkey_resolve.remove_offsets(src)
+		monkey_resolve = null
 	locked_by_this_id = null
-
-/obj/machinery/big_manipulator/Exited(atom/movable/gone, direction)
-	if(isnull(monkey_worker))
-		return
-	var/mob/living/carbon/human/species/monkey/poor_monkey = monkey_worker.resolve()
-	if(gone != poor_monkey)
-		return
-	if(!is_type_in_list(poor_monkey, manipulator_arm.vis_contents))
-		return
-	manipulator_arm.vis_contents -= poor_monkey
-	if(interaction_mode == INTERACT_USE)
-		change_mode()
-	poor_monkey.remove_offsets(type)
-	monkey_worker = null
 
 /obj/machinery/big_manipulator/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
@@ -264,6 +255,7 @@
 	poor_monkey.forceMove(get_turf(src))
 	REMOVE_TRAIT(poor_monkey, TRAIT_AI_PAUSED, "[src]")
 	monkey_worker = null
+	poor_monkey.remove_offsets(src)
 	status = STATUS_IDLE
 
 /obj/machinery/big_manipulator/mouse_drop_receive(atom/monkey, mob/user, params)

--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -199,7 +199,7 @@
 
 /obj/machinery/big_manipulator/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
-	if(status == STATUS_BUSY)
+	if(status == STATUS_BUSY || on)
 		to_chat(user, span_warning("[src] is activated!"))
 		return ITEM_INTERACT_BLOCKING
 	rotate_big_hand()
@@ -207,7 +207,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/big_manipulator/can_be_unfasten_wrench(mob/user, silent)
-	if(status == STATUS_BUSY)
+	if(status == STATUS_BUSY || on)
 		to_chat(user, span_warning("[src] is activated!"))
 		return FAILED_UNFASTEN
 	return ..()

--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -243,6 +243,9 @@
 /obj/machinery/big_manipulator/proc/eject_worker(mob/user)
 	if(isnull(monkey_worker))
 		return
+	if(status == STATUS_BUSY)
+		balloon_alert(user, "turn it off first!")
+		return
 	var/mob/living/carbon/human/species/monkey/poor_monkey = monkey_worker.resolve()
 	if(!istype(poor_monkey, /mob/living/carbon/human/species/monkey))
 		monkey_worker = null

--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -165,6 +165,18 @@
 		monkey_resolve = null
 	locked_by_this_id = null
 
+/obj/machinery/big_manipulator/Exited(atom/movable/gone, direction)
+	if(gone == monkey_worker?.resolve())
+		var/mob/living/carbon/human/species/monkey/poor_monkey = monkey_worker.resolve()
+		REMOVE_TRAIT(poor_monkey, TRAIT_AI_PAUSED, "[src]")
+		monkey_worker = null
+		poor_monkey.remove_offsets("[src]")
+		if(interaction_mode == INTERACT_USE)
+			change_mode()
+	if(manipulator_arm.vis_contents.Find(gone))
+		manipulator_arm.vis_contents.Cut(gone)
+	..()
+
 /obj/machinery/big_manipulator/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
 	take_and_drop_turfs_check()
@@ -253,9 +265,6 @@
 	balloon_alert(user, "monkey worker uninstalled")
 	poor_monkey.drop_all_held_items()
 	poor_monkey.forceMove(get_turf(src))
-	REMOVE_TRAIT(poor_monkey, TRAIT_AI_PAUSED, "[src]")
-	monkey_worker = null
-	poor_monkey.remove_offsets("[src]")
 	status = STATUS_IDLE
 
 /obj/machinery/big_manipulator/mouse_drop_receive(atom/monkey, mob/user, params)
@@ -770,7 +779,8 @@
 			return TRUE
 		if("worker_combat_mode_change")
 			worker_combat_mode = !worker_combat_mode
-			astype(monkey_worker?.resolve(), /mob/living/carbon/human/species/monkey)?.set_combat_mode(worker_combat_mode)
+			var/mob/living/carbon/human/species/monkey/monkey_resolve = monkey_worker?.resolve()
+			monkey_resolve?.set_combat_mode(worker_combat_mode)
 			return TRUE
 		if("worker_alt_mode_change")
 			worker_alt_mode = !worker_alt_mode
@@ -938,6 +948,8 @@
 
 #undef STATUS_IDLE
 #undef STATUS_BUSY
+#undef STATUS_INSTALLING_WORKER
+#undef STATUS_UNINSTALLING_WORKER
 
 #undef MIN_DELAY_TIER_1
 #undef MIN_DELAY_TIER_2

--- a/tgui/packages/tgui/interfaces/BigManipulator.tsx
+++ b/tgui/packages/tgui/interfaces/BigManipulator.tsx
@@ -166,7 +166,7 @@ export const BigManipulator = () => {
                 disabled={!has_worker}
                 onClick={() => act('eject_worker')}
               >
-                {has_worker ? 'Eject' : 'No monkey worker'}
+                {has_worker ? 'Eject monkey' : 'No monkey worker'}
               </Button>
             </>
           }

--- a/tgui/packages/tgui/interfaces/BigManipulator.tsx
+++ b/tgui/packages/tgui/interfaces/BigManipulator.tsx
@@ -16,6 +16,9 @@ type ManipulatorData = {
   interaction_delay: number;
   worker_interaction: string;
   highest_priority: BooleanLike;
+  worker_combat_mode: BooleanLike;
+  worker_alt_mode: BooleanLike;
+  has_worker: BooleanLike;
   interaction_mode: string;
   settings_list: PrioritySettings[];
   throw_range: number;
@@ -134,7 +137,10 @@ export const BigManipulator = () => {
     active,
     interaction_mode,
     settings_list,
+    has_worker,
     worker_interaction,
+    worker_combat_mode,
+    worker_alt_mode,
     highest_priority,
     throw_range,
     item_as_filter,
@@ -147,12 +153,22 @@ export const BigManipulator = () => {
         <Section
           title="Action Panel"
           buttons={
-            <Button
-              icon="power-off"
-              selected={active}
-              content={active ? 'On' : 'Off'}
-              onClick={() => act('on')}
-            />
+            <>
+              <Button
+                icon="power-off"
+                selected={active}
+                onClick={() => act('on')}
+              >
+                {active ? 'On' : 'Off'}
+              </Button>
+              <Button
+                tooltip="Eject the monkey worker."
+                disabled={!has_worker}
+                onClick={() => act('eject_worker')}
+              >
+                {has_worker ? 'Eject' : 'No monkey worker'}
+              </Button>
+            </>
           }
         >
           <Box
@@ -190,18 +206,42 @@ export const BigManipulator = () => {
               tooltip="Cycle through types of items to filter"
             />
             {interaction_mode === 'use' && (
-              <ConfigRow
-                label="Worker Interactions"
-                content={worker_interaction.toUpperCase()}
-                onClick={() => act('worker_interaction_change')}
-                tooltip={
-                  worker_interaction === 'normal'
-                    ? 'Interact using the held item'
-                    : worker_interaction === 'single'
-                      ? 'Drop the item after a single cycle'
-                      : 'Interact with an empty hand'
-                }
-              />
+              <>
+                <ConfigRow
+                  label="Worker Interactions"
+                  content={worker_interaction.toUpperCase()}
+                  onClick={() => act('worker_interaction_change')}
+                  tooltip={
+                    worker_interaction === 'normal'
+                      ? 'Interact using the held item'
+                      : worker_interaction === 'single'
+                        ? 'Drop the item after a single cycle'
+                        : 'Interact with an empty hand'
+                  }
+                />
+                <ConfigRow
+                  label="Worker Combat Mode"
+                  content={worker_combat_mode ? 'TRUE' : 'FALSE'}
+                  selected={!!worker_combat_mode}
+                  onClick={() => act('worker_combat_mode_change')}
+                  tooltip={
+                    worker_combat_mode
+                      ? 'Disable combat mode'
+                      : 'Enable combat mode'
+                  }
+                />
+                <ConfigRow
+                  label="Worker Alt Mode"
+                  content={worker_alt_mode ? 'TRUE' : 'FALSE'}
+                  selected={!!worker_alt_mode}
+                  onClick={() => act('worker_alt_mode_change')}
+                  tooltip={
+                    worker_alt_mode
+                      ? 'Disable alternate mode (right click)'
+                      : 'Enable alternate mode (right click)'
+                  }
+                />
+              </>
             )}
             <ConfigRow
               label="Item Filter"


### PR DESCRIPTION

## About The Pull Request

Simply put, this adds support to the big manipulator for making the humanely utilized and well-enriched monkey worker use right click and combat mode for their tool or empty hand use. This allows them to be used for things like butchering (requires combat mode) and boulder breaking (requires right click).

Additionally, I removed the click drag method for ejecting the monkey from the manipulator; now it's a button on the manipulator UI.

Finally, I cleaned up a couple of bugs in the code I noticed.
## Why It's Good For The Game

Allows for more rude goldberg chicanery with the big manipulator that it was lacking otherwise. Cleans up a few bugs.


https://github.com/user-attachments/assets/2c503da4-bfe1-4da9-a29c-a5a35d8f00fc
## Changelog
:cl: Bisar
add: The big manipulator now supports specifying whether the attached monkey should use either combat mode, right clicking, or even both.
qol: Ejecting monkeys from the big manipulator now uses a UI button instead.
fix: You can no longer teleport monkeys into impossible areas with big manipulator unbuckling.
fix: You can no longer simultaneously buckle multiple monkeys into the big manipulator.
fix: The big manipulator will now properly clear old refs to former workers.
/:cl:
