### PR TITLE
Fixes inconsistent PKC descriptions and broken bubblegum/wendigo trophies

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -99,7 +99,15 @@
 )
 	if(!original)
 		return
-	if(require_twohands)
+	var/obj/item/parent_item = parent
+	if(wielded)
+		if(sharpened_increase)
+			parent_item.force -= sharpened_increase
+		if(force_multiplier)
+			parent_item.force /= force_multiplier
+		else if(!isnull(force_unwielded))
+			parent_item.force = force_unwielded
+	if(!isnull(require_twohands))
 		src.require_twohands = require_twohands
 	if(wieldsound)
 		src.wieldsound = wieldsound
@@ -109,9 +117,9 @@
 		src.attacksound = attacksound
 	if(force_multiplier)
 		src.force_multiplier = force_multiplier
-	if(force_wielded)
+	if(!isnull(force_wielded))
 		src.force_wielded = force_wielded
-	if(force_unwielded)
+	if(isnull(force_unwielded))
 		src.force_unwielded = force_unwielded
 	if(icon_wielded)
 		src.icon_wielded = icon_wielded
@@ -119,6 +127,14 @@
 		src.wield_callback = wield_callback
 	if(unwield_callback)
 		src.unwield_callback = unwield_callback
+	if(!wielded)
+		return
+	if(!isnull(force_multiplier))
+		parent_item.force *= force_multiplier
+	else if(!isnull(force_wielded))
+		parent_item.force = force_wielded
+	if(!isnull(sharpened_increase))
+		parent_item.force += sharpened_increase
 
 // register signals withthe parent item
 /datum/component/two_handed/RegisterWithParent()
@@ -225,9 +241,9 @@
 
 	// update item stats and name
 	var/obj/item/parent_item = parent
-	if(force_multiplier)
+	if(!isnull(force_multiplier))
 		parent_item.force *= force_multiplier
-	else if(force_wielded)
+	else if(!isnull(force_wielded))
 		parent_item.force = force_wielded
 	if(sharpened_increase)
 		parent_item.force += sharpened_increase
@@ -277,7 +293,7 @@
 		parent_item.force -= sharpened_increase
 	if(force_multiplier)
 		parent_item.force /= force_multiplier
-	else if(force_unwielded)
+	else if(!isnull(force_unwielded))
 		parent_item.force = force_unwielded
 
 	// update the items name to remove the wielded status

--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
@@ -52,6 +52,8 @@
 	var/current_inhand_icon_state = "crusher"
 	/// Used by retool kits when changing the crusher's projectile sprite
 	var/projectile_icon = "pulse1"
+	/// Wielded damage we deal, aka our "real" damage
+	var/force_wielded = 20
 
 /obj/item/kinetic_crusher/Initialize(mapload)
 	. = ..()
@@ -60,7 +62,7 @@
 		effectiveness = 110, \
 	)
 	//technically it's huge and bulky, but this provides an incentive to use it
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
+	update_wielding()
 	register_context()
 
 /obj/item/kinetic_crusher/add_context(atom/source, list/context, obj/item/held_item, mob/user)
@@ -83,8 +85,8 @@
 
 /obj/item/kinetic_crusher/examine(mob/living/user)
 	. = ..()
-	. += span_notice("Mark a large creature with a destabilizing force with right-click, then hit them in melee to do <b>[force + detonation_damage]</b> damage.")
-	. += span_notice("Does <b>[force + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force + detonation_damage]</b>.")
+	. += span_notice("Mark a large creature with a destabilizing force with right-click, then hit them in melee to do <b>[force_wielded + detonation_damage]</b> damage.")
+	. += span_notice("Does <b>[force_wielded + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force_wielded + detonation_damage]</b>.")
 	for(var/obj/item/crusher_trophy/crusher_trophy as anything in trophies)
 		. += span_notice("It has \a [crusher_trophy] attached, which causes [crusher_trophy.effect_desc()].")
 
@@ -242,6 +244,10 @@
 		charged = TRUE
 		update_appearance()
 		playsound(src.loc, 'sound/items/weapons/kinetic_reload.ogg', 60, TRUE)
+
+/// Updates the two handed component with new damage values
+/obj/item/kinetic_crusher/proc/update_wielding()
+	AddComponent(/datum/component/two_handed, force_unwielded = 0, force_wielded = force_wielded)
 
 /obj/item/kinetic_crusher/ui_action_click(mob/user, actiontype)
 	set_light_on(!light_on)

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_megafauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_megafauna.dm
@@ -57,17 +57,19 @@
 
 /obj/item/crusher_trophy/demon_claws/add_to(obj/item/kinetic_crusher/pkc, mob/living/user)
 	. = ..()
-	if(.)
-		pkc.force += bonus_value * 0.2
-		pkc.detonation_damage += bonus_value * 0.8
-		AddComponent(/datum/component/two_handed, force_wielded=(20 + bonus_value * 0.2))
+	if(!.)
+		return
+	pkc.force_wielded += bonus_value * 0.2
+	pkc.detonation_damage += bonus_value * 0.8
+	pkc.update_wielding()
 
 /obj/item/crusher_trophy/demon_claws/remove_from(obj/item/kinetic_crusher/pkc, mob/living/user)
 	. = ..()
-	if(.)
-		pkc.force -= bonus_value * 0.2
-		pkc.detonation_damage -= bonus_value * 0.8
-		AddComponent(/datum/component/two_handed, force_wielded=20)
+	if(!.)
+		return
+	pkc.force_wielded -= bonus_value * 0.2
+	pkc.detonation_damage -= bonus_value * 0.8
+	pkc.update_wielding()
 
 /obj/item/crusher_trophy/demon_claws/on_melee_hit(mob/living/target, mob/living/user)
 	user.heal_ordered_damage(bonus_value * 0.1, damage_heal_order)
@@ -152,13 +154,17 @@
 
 /obj/item/crusher_trophy/wendigo_horn/add_to(obj/item/kinetic_crusher/crusher, mob/living/user)
 	. = ..()
-	if(.)
-		crusher.AddComponent(/datum/component/two_handed, force_wielded=40)
+	if(!.)
+		return
+	crusher.force_wielded += 20
+	crusher.update_wielding()
 
 /obj/item/crusher_trophy/wendigo_horn/remove_from(obj/item/kinetic_crusher/crusher, mob/living/user)
 	. = ..()
-	if(.)
-		crusher.AddComponent(/datum/component/two_handed, force_wielded=20)
+	if(!.)
+		return
+	crusher.force_wielded -= 20
+	crusher.update_wielding()
 
 // Goliath Broodmother
 /obj/item/crusher_trophy/broodmother_tongue


### PR DESCRIPTION

## About The Pull Request
Bubblegum trophy has attempted to modify its' *own* dual wielding, so if you attached and detached it you were able to have a tiny 20 force two handed weapon. Yeah. This PR implements a way for trophies to consistently modify their damage, and fixes some oversights (values not being assigned/updating) in two handed component code.

Closes #90731

## Changelog
:cl:
fix: Fixed inconsistent proto-kinetic crusher descriptions
fix: Fixed Bubblegum and Wendigo crusher trophies sometimes not working.
/:cl:
