### PR TITLE
Removes the debug box full of fish that doesn't work anymore.

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -414,14 +414,6 @@
 	. = ..()
 	new /obj/item/fishing_line/auto_reel(src)
 
-/obj/item/storage/box/fish_debug
-	name = "box full of fish"
-	illustration = "fish"
-
-/obj/item/storage/box/fish_debug/PopulateContents()
-	for(var/fish_type in subtypesof(/obj/item/fish))
-		new fish_type(src)
-
 ///Used to give the average player info about fishing stuff that's unknown to many.
 /obj/item/paper/paperslip/fishing_tip
 	name = "fishing tip"

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -516,8 +516,8 @@
 /datum/unit_test/fish_randomize_size_weight
 
 /datum/unit_test/fish_randomize_size_weight/Run()
-	var/obj/item/storage/box/fish_debug/box = allocate(/obj/item/storage/box/fish_debug)
-	for(var/obj/item/fish/fish as anything in box)
+	for(var/fish_type in subtypesof(/obj/item/fish))
+		var/obj/item/fish/fish = allocate(fish_type)
 		fish.randomize_size_and_weight()
 
 /datum/unit_test/aquarium_upgrade


### PR DESCRIPTION
## About The Pull Request
Ever since storage items have been refactored to spit out objects that they cannot contain, spawning the box full of fish causes a ton of fish to fall onto the floor. The item was only used back in the days when AnturK first coded fishing and in a more recent unit test, and I want said unit test to iterate through every fish though, not only 7 or so small sized ones that weren't spat out of the box.

## Why It's Good For The Game
One less piece of unmantainable unused crap in the game.

## Changelog
N/A