### PR TITLE
Fishing lures box peeve

### DIFF
--- a/code/controllers/subsystem/processing/fishing.dm
+++ b/code/controllers/subsystem/processing/fishing.dm
@@ -92,7 +92,7 @@ PROCESSING_SUBSYSTEM_DEF(fishing)
 
 	///init the list of things lures can catch
 	lure_catchables = list()
-	for(var/lure_type in typesof(/obj/item/fishing_lure))
+	for(var/lure_type in subtypesof(/obj/item/fishing_lure))
 		var/obj/item/fishing_lure/lure = new lure_type
 		lure_catchables[lure_type] = list()
 		for(var/obj/item/fish/fish as anything in spawned_fish)

--- a/code/modules/fishing/bait.dm
+++ b/code/modules/fishing/bait.dm
@@ -62,8 +62,8 @@
 	uses_left = 12
 
 /obj/item/fishing_lure
-	name = "artificial minnow"
-	desc = "A fishing lure that may attract small fish. Too tiny, too large, or too picky prey won't be interested in it, though."
+	name = "fishing lure"
+	desc = "It's just that, a plastic piece of fishing equipment, yet fish yearn with every last molecule of their bodies to take a bite of it."
 	icon = 'icons/obj/fishing.dmi'
 	icon_state = "minnow"
 	w_class = WEIGHT_CLASS_SMALL
@@ -89,11 +89,6 @@
 
 ///Called for every fish subtype by the fishing subsystem when initializing, to populate the list of fish that can be catched with this lure.
 /obj/item/fishing_lure/proc/is_catchable_fish(obj/item/fish/fish, list/fish_properties)
-	var/intermediate_size = FISH_SIZE_SMALL_MAX + (FISH_SIZE_NORMAL_MAX - FISH_SIZE_SMALL_MAX)
-	if(!ISINRANGE(fish.size, FISH_SIZE_TINY_MAX * 0.5, intermediate_size))
-		return FALSE
-	if(length(list(/datum/fish_trait/vegan, /datum/fish_trait/picky_eater, /datum/fish_trait/nocturnal, /datum/fish_trait/heavy) & fish.fish_traits))
-		return FALSE
 	return TRUE
 
 /obj/item/fishing_lure/examine(mob/user)
@@ -130,6 +125,19 @@
 	else if(fish in SSfishing.lure_catchables[type])
 		multiplier += 10
 	return multiplier
+
+/obj/item/fishing_lure/minnow
+	name = "artificial minnow"
+	desc = "A fishing lure that may attract small fish. Too tiny, too large, or too picky prey won't be interested in it, though."
+	icon_state = "minnow"
+
+/obj/item/fishing_lure/minnow/is_catchable_fish(obj/item/fish/fish, list/fish_properties)
+	var/intermediate_size = FISH_SIZE_SMALL_MAX + (FISH_SIZE_NORMAL_MAX - FISH_SIZE_SMALL_MAX)
+	if(!ISINRANGE(fish.size, FISH_SIZE_TINY_MAX * 0.5, intermediate_size))
+		return FALSE
+	if(length(list(/datum/fish_trait/vegan, /datum/fish_trait/picky_eater, /datum/fish_trait/nocturnal, /datum/fish_trait/heavy) & fish.fish_traits))
+		return FALSE
+	return TRUE
 
 /obj/item/fishing_lure/plug
 	name = "artificial plug lure"

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -454,7 +454,7 @@
 
 /obj/item/storage/box/fishing_lures/PopulateContents()
 	new /obj/item/paper/lures_instructions(src)
-	var/list/typesof = typesof(/obj/item/fishing_lure)
+	var/list/typesof = subtypesof(/obj/item/fishing_lure)
 	for(var/type in typesof)
 		new type (src)
 	atom_storage.set_holdable(/obj/item/fishing_lure) //can only hold lures


### PR DESCRIPTION
## About The Pull Request
This fixes a small excerpt from #90678: 
>"[...] double-examining it to see what extra items it can hold (normally all lures) only reports the Artificial Minnow as fitting."

By making it use subtypesof instead of typesof for purpose of spawning lures and making the minnow its own subtype.

## Why It's Good For The Game
Fixing a mild botherance.

## Changelog

:cl:
fix: Examining a fishing lures box twice no longer says it can hold just artificial minnows.
/:cl:
