### PR TITLE
Fix flaky hard delete related to nuke disks

### DIFF
--- a/code/datums/components/keep_me_secure.dm
+++ b/code/datums/components/keep_me_secure.dm
@@ -41,6 +41,7 @@
 /datum/component/keep_me_secure/UnregisterFromParent()
 	STOP_PROCESSING(SSobj, src)
 	UnregisterSignal(parent, COMSIG_ATOM_EXAMINE)
+	UnregisterSignal(parent, COMSIG_ATOM_EXAMINE_MORE)
 
 /// Returns whether the game is supposed to consider the parent "secure".
 /datum/component/keep_me_secure/proc/is_secured()


### PR DESCRIPTION
## About The Pull Request

Personal closets spawn with a satchel containing a wallet, the wallet is the random subtype and so spawns with random contents, one of the random contents it can pick is the tech storage random disk spawner, and the tech storage random disk spawner has a chance to spawn an obvious fake nuke disk, but the `keep_me_secure` component on nuke disks doesn't properly unregister all its signals so it wont `qdel` right and so the wallet wont and so the satchel wont and so the closet wont.

## Why It's Good For The Game

Fixes #89268 

## Changelog

No player facing changes