### PR TITLE
Recharge magazine scaling (and a magazine grammar tweak)

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -158,10 +158,11 @@
 
 	if(istype(charging, /obj/item/ammo_box/magazine/recharge)) //if you add any more snowflake ones, make sure to update the examine messages too.
 		var/obj/item/ammo_box/magazine/recharge/power_pack = charging
-		if(power_pack.stored_ammo.len < power_pack.max_ammo)
-			power_pack.stored_ammo += new power_pack.ammo_type(power_pack)
-			use_energy(active_power_usage * recharge_coeff * seconds_per_tick)
-			using_power = TRUE
+		for(var/charge_iterations in 1 to recharge_coeff)
+			if(power_pack.stored_ammo.len < power_pack.max_ammo)
+				power_pack.stored_ammo += new power_pack.ammo_type(power_pack)
+				use_energy(active_power_usage * seconds_per_tick)
+				using_power = TRUE
 		update_appearance()
 		return
 

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -159,10 +159,11 @@
 	if(istype(charging, /obj/item/ammo_box/magazine/recharge)) //if you add any more snowflake ones, make sure to update the examine messages too.
 		var/obj/item/ammo_box/magazine/recharge/power_pack = charging
 		for(var/charge_iterations in 1 to recharge_coeff)
-			if(power_pack.stored_ammo.len < power_pack.max_ammo)
-				power_pack.stored_ammo += new power_pack.ammo_type(power_pack)
-				use_energy(active_power_usage * seconds_per_tick)
-				using_power = TRUE
+			if(power_pack.stored_ammo.len >= power_pack.max_ammo)
+				break
+			power_pack.stored_ammo += new power_pack.ammo_type(power_pack)
+			use_energy(active_power_usage * seconds_per_tick)
+			using_power = TRUE
 		update_appearance()
 		return
 

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -226,7 +226,7 @@
 	. += "It has <b>[shells_left]</b> [casing_phrasing]\s remaining."
 	// this is kind of awkward phrasing, but it's the top/ready ammo in the box
 	// intended for people who have like three mislabeled magazines
-	. += span_notice("The [top_round] is ready in [src].")
+	. += span_notice("[top_round] is ready in [src].")
 
 /obj/item/ammo_box/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -226,7 +226,7 @@
 	. += "It has <b>[shells_left]</b> [casing_phrasing]\s remaining."
 	// this is kind of awkward phrasing, but it's the top/ready ammo in the box
 	// intended for people who have like three mislabeled magazines
-	. += span_notice("The [top_round.name] is ready.")
+	. += span_notice("\A <b>[top_round]</b> is ready.")
 
 /obj/item/ammo_box/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -220,13 +220,13 @@
 /obj/item/ammo_box/examine(mob/user)
 	. = ..()
 	var/shells_left = LAZYLEN(stored_ammo)
-	var/top_round = get_round()
+	var/obj/item/ammo_casing/top_round = get_round()
 	if(!top_round)
 		return
 	. += "It has <b>[shells_left]</b> [casing_phrasing]\s remaining."
 	// this is kind of awkward phrasing, but it's the top/ready ammo in the box
 	// intended for people who have like three mislabeled magazines
-	. += span_notice("[top_round] is ready in [src].")
+	. += span_notice("The [top_round.name] is ready.")
 
 /obj/item/ammo_box/update_icon_state()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Rechargeable magazines (e.g. those used in the CTF laser rifle and nowhere else) now recharge faster based on `recharge_coeff` which is directly based on what tier of capacitor is in the recharger.
Tweaks some grammar relating to what casing is ready at the top of a magazine.
## Why It's Good For The Game
Upgrading a recharger should make this neglected magazine type good, actually.
Also the grammar thing irked me.
## Changelog

:cl:
qol: Shoving a rechargeable magazine into a recharger now has refill speed scale with part tier/recharge efficiency. This probably doesn't matter very much because no regularly-available gun uses rechargeable magazines.
spellcheck: Examining magazines should no longer have two instances of "The" prefixing a casing. Maybe. Probably.
/:cl: