### PR TITLE
Makes Centcom Navigation much easier on the admins(For their IC larp)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2634,9 +2634,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
-"lZ" = (
-/turf/closed/indestructible/riveted,
-/area/space)
 "mc" = (
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
@@ -2796,12 +2793,6 @@
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/pen/red,
-/obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
-	name = "XCC Shutter 3 Control";
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -2811,12 +2802,6 @@
 "mT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/button/door/indestructible{
-	id = "XCCsecdepartment";
-	name = "CC Security Checkpoint Control";
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -2995,8 +2980,8 @@
 /area/centcom/central_command_areas/fore)
 "nM" = (
 /obj/machinery/door/poddoor/shutters{
-	id = "XCCsecdepartment";
-	name = "XCC Security Checkpoint Shutters"
+	id = "CCsec1";
+	name = "CC Security Checkpoint Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -3877,11 +3862,11 @@
 	},
 /area/centcom/central_command_areas/fore)
 "rI" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsec3";
-	name = "XCC Checkpoint 3 Shutters"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "CCsec1";
+	name = "CC Checkpoint 1 Shutters"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "rJ" = (
@@ -4322,6 +4307,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"tA" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "CCFerry";
+	name = "CC Ferry Hangar"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/ferry)
 "tF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Locker Room"
@@ -4805,12 +4800,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "vG" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsec1";
-	name = "XCC Checkpoint 1 Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "CCsec4";
+	name = "CC Checkpoint 4 Shutters"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -4827,12 +4822,12 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "vP" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCcustoms2";
-	name = "XCC Customs 2 Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "CCcustoms2";
+	name = "CC Customs 2 Shutters"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -4848,12 +4843,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "vU" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCcustoms1";
-	name = "XCC Customs 1 Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "CCcustoms1";
+	name = "CC Customs 1 Shutters"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -4943,13 +4938,13 @@
 	dir = 1
 	},
 /obj/machinery/button/door/indestructible{
-	id = "XCCcustoms1";
+	id = "CCcustoms1";
 	name = "CC Customs 1 Control";
 	pixel_x = 8;
 	pixel_y = -24
 	},
 /obj/machinery/button/door/indestructible{
-	id = "XCCcustoms2";
+	id = "CCcustoms2";
 	name = "CC Customs 2 Control";
 	pixel_x = -8;
 	pixel_y = -24
@@ -4988,18 +4983,18 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "wv" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCFerry";
-	name = "XCC Ferry Hangar"
-	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "CCFerry";
+	name = "CC Ferry Hangar"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "ww" = (
 /obj/machinery/button/door/indestructible{
-	id = "XCCFerry";
+	id = "CCFerry";
 	name = "Hanger Bay Shutters";
 	pixel_y = 24;
 	req_access = list("cent_general")
@@ -5275,8 +5270,8 @@
 /area/centcom/central_command_areas/ferry)
 "xS" = (
 /obj/machinery/button/door/indestructible{
-	id = "XCCsec1";
-	name = "CC Shutter 1 Control";
+	id = "CCsec4";
+	name = "CC Shutter 4 Control";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -6161,11 +6156,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "BE" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
-	id = "XCCsec3";
+	id = "CCsec3";
 	name = "CC Main Access Shutters"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "BF" = (
@@ -6940,6 +6935,14 @@
 /obj/structure/sign/warning/secure_area,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/control)
+"Fs" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "CCsec1";
+	name = "CC Checkpoint 1 Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/fore)
 "Fu" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/machinery/firealarm/directional/west,
@@ -7342,30 +7345,28 @@
 "HY" = (
 /obj/machinery/photocopier,
 /obj/machinery/button/door/indestructible{
-	id = "XCCFerry";
-	name = "Hanger Bay Shutters";
-	pixel_x = -8;
+	id = "CCsec3";
+	name = "CC Shutter 3 Control";
 	pixel_y = 24
 	},
 /obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
-	name = "CC Main Access Control";
-	pixel_x = 8;
-	pixel_y = 24
+	id = "CCcustoms2";
+	name = "CC Shutter 2 Control";
+	pixel_x = 9;
+	pixel_y = 32
 	},
 /obj/machinery/button/door/indestructible{
-	id = "XCCsec1";
+	id = "CCsec1";
 	name = "CC Shutter 1 Control";
-	pixel_x = 8;
-	pixel_y = 38
-	},
-/obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
-	name = "XCC Shutter 3 Control";
-	pixel_x = -8;
-	pixel_y = 38
+	pixel_y = 40
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/indestructible{
+	id = "CCsec4";
+	name = "CC Shutter 4 Control";
+	pixel_x = -9;
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "HZ" = (
@@ -7621,6 +7622,26 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"Kq" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "CCsec4";
+	name = "CC Checkpoint 4 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"Ku" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "CCcustoms2";
+	name = "CC Customs 2 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "Kv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -7738,7 +7759,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/button/door/indestructible{
-	id = "XCCFerry";
+	id = "CCFerry";
 	name = "Hanger Bay Shutters";
 	pixel_y = -38
 	},
@@ -7938,6 +7959,16 @@
 /obj/structure/flora/bush/sparsegrass,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"LH" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "CCcustoms1";
+	name = "CC Customs 1 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "LI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -8941,7 +8972,7 @@
 "Qk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
+	id = "CCsec3";
 	name = "CC Main Access Control"
 	},
 /obj/machinery/airalarm/directional/south,
@@ -9465,6 +9496,14 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
+"SI" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "CCsec3";
+	name = "CC Main Access Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "SJ" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -10158,7 +10197,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door/indestructible{
-	id = "XCCcustoms1";
+	id = "CCcustoms1";
 	name = "CC Emergency Docks Control";
 	pixel_x = 24;
 	pixel_y = 24
@@ -10335,16 +10374,6 @@
 "WR" = (
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
-"WS" = (
-/obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
-	name = "XCC Shutter 3 Control";
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/supply)
 "WU" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office"
@@ -47376,7 +47405,7 @@ Hz
 Hz
 aK
 mD
-wv
+tA
 wv
 wv
 mD
@@ -51455,7 +51484,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iF
 iQ
 wa
@@ -51712,7 +51741,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iG
 iR
 Ie
@@ -51969,7 +51998,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iG
 iR
 Ie
@@ -52226,7 +52255,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iF
 iR
 Ie
@@ -52258,7 +52287,7 @@ iF
 rK
 mQ
 io
-vG
+Kq
 vG
 vG
 vG
@@ -52483,7 +52512,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iG
 iR
 Ie
@@ -52740,7 +52769,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iG
 iR
 Ws
@@ -52997,7 +53026,7 @@ aa
 aa
 aa
 aa
-lZ
+aa
 iF
 iS
 iZ
@@ -53022,7 +53051,7 @@ ov
 oO
 do
 hz
-WS
+hz
 qS
 Nx
 ZX
@@ -54309,7 +54338,7 @@ Ox
 Ox
 qt
 Fv
-rI
+Fs
 NU
 tM
 Ab
@@ -54323,7 +54352,7 @@ iu
 Ab
 Ab
 qT
-BE
+SI
 NU
 wH
 Ab
@@ -56371,7 +56400,7 @@ iu
 MF
 io
 vP
-vP
+Ku
 vP
 vP
 vP
@@ -58941,7 +58970,7 @@ fm
 eK
 cg
 vU
-vU
+LH
 vU
 vU
 vU


### PR DESCRIPTION
Buttons made lotsa nonsense even 2 buttons opening literally the same shutter sets. this streamlines it more that even a monkey like me could understand

Before:
![image](https://github.com/user-attachments/assets/e8ce33af-2d44-4ef2-92a3-084d5f8ad15e)

After:
![image](https://github.com/user-attachments/assets/ab651874-600b-47d7-89c9-7bbe77c6987f)


## Changelog


:cl: Ezel
map: Rewired Centcom Checkpoint buttons to be more accurate
/:cl:

