### PR TITLE
Fixes megacarp not moving in space while ridden

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -449,6 +449,7 @@
 	)
 
 /datum/component/riding/creature/megacarp
+	override_allow_spacemove = TRUE
 
 /datum/component/riding/creature/megacarp/get_rider_offsets_and_layers(pass_index, mob/offsetter)
 	return list(


### PR DESCRIPTION

## About The Pull Request
adds a single line (`override_allow_spacemove = TRUE`) to the megacarp movement datum
## Why It's Good For The Game
it's a big ass fucking shark if the small carp can carry me through space so can the megacarp. if i remember correctly it used to be able to so why not. i want to ride my cool ass shark through space
## Changelog
:cl: Goat
fix: The megacarp (shark) will now be able to fly through space when ridden like its smaller carp siblings.
/:cl:
