### PR TITLE
Dissallow non R_VAREDIT admins from using VV topic and modifying traits

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -49,7 +49,7 @@
  * This proc is for "high level" actions like admin heal/set species/etc/etc. The low level debugging things should go in admin/view_variables/topic_basic.dm in case this runtimes.
  */
 /datum/proc/vv_do_topic(list/href_list)
-	if(!usr || !usr.client || !usr.client.holder || !check_rights(NONE))
+	if(!usr || !usr.client || !usr.client.holder || !check_rights(R_VAREDIT))
 		return FALSE //This is VV, not to be called by anything else.
 	if(SEND_SIGNAL(src, COMSIG_VV_TOPIC, usr, href_list) & COMPONENT_VV_HANDLED)
 		return FALSE

--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -100,6 +100,8 @@ ADMIN_VERB(cmd_admin_check_player_exp, R_ADMIN, "Player Playtime", "View player 
 /datum/admins/proc/modify_traits(datum/D)
 	if(!D)
 		return
+	if(!check_rights(R_VAREDIT))
+		return
 
 	var/add_or_remove = input("Remove/Add?", "Trait Remove/Add") as null|anything in list("Add","Remove")
 	if(!add_or_remove)

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -126,7 +126,7 @@
 			new_val = input("Enter the new damage type for [editing]","Set Damtype", existing_val) in list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN)
 		else
 			new_val = input("Enter the new value for [editing]'s [href_list["var_tweak"]]","Set [href_list["var_tweak"]]", existing_val) as num|null
-		if(isnull(new_val) || new_val == existing_val || QDELETED(editing) || !check_rights(NONE))
+		if(isnull(new_val) || new_val == existing_val || QDELETED(editing) || !check_rights(R_VAREDIT))
 			return
 
 		switch(href_list["var_tweak"])

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -1,7 +1,7 @@
 //DO NOT ADD MORE TO THIS FILE.
 //Use vv_do_topic() for datums!
 /client/proc/view_var_Topic(href, href_list, hsrc)
-	if( (usr.client != src) || !src.holder || !holder.CheckAdminHref(href, href_list))
+	if(!check_rights_for(src, R_VAREDIT) || !holder.CheckAdminHref(href, href_list))
 		return
 	var/target = GET_VV_TARGET
 	vv_do_basic(target, href_list, href)
@@ -16,145 +16,132 @@
 			vars_target = vars_target.vars[href_list["special_varname"]]
 		debug_variables(vars_target)
 
-//Stuff below aren't in dropdowns/etc.
+//~CARN: for renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records).
+	if(href_list["rename"])
 
-	if(check_rights(R_VAREDIT))
+		var/mob/M = locate(href_list["rename"]) in GLOB.mob_list
+		if(!istype(M))
+			to_chat(usr, "This can only be used on instances of type /mob", confidential = TRUE)
+			return
 
-	//~CARN: for renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records).
+		var/new_name = stripped_input(usr,"What would you like to name this mob?","Input a name",M.real_name,MAX_NAME_LEN)
 
-		if(href_list["rename"])
-			if(!check_rights(NONE))
-				return
+		// If the new name is something that would be restricted by IC chat filters,
+		// give the admin a warning but allow them to do it anyway if they want.
+		if(is_ic_filtered(new_name) || is_soft_ic_filtered(new_name) && tgui_alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "IC Chat Filter Conflict", list("Confirm", "Cancel")) == "Cancel")
+			return
 
-			var/mob/M = locate(href_list["rename"]) in GLOB.mob_list
-			if(!istype(M))
-				to_chat(usr, "This can only be used on instances of type /mob", confidential = TRUE)
-				return
+		if( !new_name || !M )
+			return
 
-			var/new_name = stripped_input(usr,"What would you like to name this mob?","Input a name",M.real_name,MAX_NAME_LEN)
+		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")
+		M.fully_replace_character_name(M.real_name,new_name)
+		vv_update_display(M, "name", new_name)
+		vv_update_display(M, "real_name", M.real_name || "No real name")
 
-			// If the new name is something that would be restricted by IC chat filters,
-			// give the admin a warning but allow them to do it anyway if they want.
-			if(is_ic_filtered(new_name) || is_soft_ic_filtered(new_name) && tgui_alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "IC Chat Filter Conflict", list("Confirm", "Cancel")) == "Cancel")
-				return
+	else if(href_list["rotatedatum"])
 
-			if( !new_name || !M )
-				return
+		var/atom/A = locate(href_list["rotatedatum"])
+		if(!istype(A))
+			to_chat(usr, "This can only be done to instances of type /atom", confidential = TRUE)
+			return
 
-			message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")
-			M.fully_replace_character_name(M.real_name,new_name)
-			vv_update_display(M, "name", new_name)
-			vv_update_display(M, "real_name", M.real_name || "No real name")
-
-		else if(href_list["rotatedatum"])
-			if(!check_rights(NONE))
-				return
-
-			var/atom/A = locate(href_list["rotatedatum"])
-			if(!istype(A))
-				to_chat(usr, "This can only be done to instances of type /atom", confidential = TRUE)
-				return
-
-			switch(href_list["rotatedir"])
-				if("right")
-					A.setDir(turn(A.dir, -45))
-				if("left")
-					A.setDir(turn(A.dir, 45))
-			vv_update_display(A, "dir", dir2text(A.dir))
+		switch(href_list["rotatedir"])
+			if("right")
+				A.setDir(turn(A.dir, -45))
+			if("left")
+				A.setDir(turn(A.dir, 45))
+		vv_update_display(A, "dir", dir2text(A.dir))
 
 
-		else if(href_list["adjustDamage"] && href_list["mobToDamage"])
-			if(!check_rights(NONE))
-				return
+	else if(href_list["adjustDamage"] && href_list["mobToDamage"])
 
-			var/mob/living/L = locate(href_list["mobToDamage"]) in GLOB.mob_list
-			if(!istype(L))
-				return
+		var/mob/living/L = locate(href_list["mobToDamage"]) in GLOB.mob_list
+		if(!istype(L))
+			return
 
-			var/Text = href_list["adjustDamage"]
+		var/Text = href_list["adjustDamage"]
 
-			var/amount = input("Deal how much damage to mob? (Negative values here heal)","Adjust [Text]loss",0) as num|null
+		var/amount = input("Deal how much damage to mob? (Negative values here heal)","Adjust [Text]loss",0) as num|null
 
-			if (isnull(amount))
-				return
+		if (isnull(amount))
+			return
 
-			if(!L)
-				to_chat(usr, "Mob doesn't exist anymore", confidential = TRUE)
-				return
+		if(!L)
+			to_chat(usr, "Mob doesn't exist anymore", confidential = TRUE)
+			return
 
-			var/newamt
-			switch(Text)
-				if("brute")
-					L.adjustBruteLoss(amount, forced = TRUE)
-					newamt = L.getBruteLoss()
-				if("fire")
-					L.adjustFireLoss(amount, forced = TRUE)
-					newamt = L.getFireLoss()
-				if("toxin")
-					L.adjustToxLoss(amount, forced = TRUE)
-					newamt = L.getToxLoss()
-				if("oxygen")
-					L.adjustOxyLoss(amount, forced = TRUE)
-					newamt = L.getOxyLoss()
-				if("brain")
-					L.adjustOrganLoss(ORGAN_SLOT_BRAIN, amount)
-					newamt = L.get_organ_loss(ORGAN_SLOT_BRAIN)
-				if("stamina")
-					L.adjustStaminaLoss(amount, forced = TRUE)
-					newamt = L.getStaminaLoss()
-				else
-					to_chat(usr, "You caused an error. DEBUG: Text:[Text] Mob:[L]", confidential = TRUE)
-					return
-
-			if(amount != 0)
-				var/log_msg = "[key_name(usr)] dealt [amount] amount of [Text] damage to [key_name(L)]"
-				message_admins("[key_name(usr)] dealt [amount] amount of [Text] damage to [ADMIN_LOOKUPFLW(L)]")
-				log_admin(log_msg)
-				admin_ticket_log(L, "<font color='blue'>[log_msg]</font>")
-				vv_update_display(L, Text, "[newamt]")
-
-		else if(href_list["item_to_tweak"] && href_list["var_tweak"])
-			if(!check_rights(NONE))
-				return
-
-			var/obj/item/editing = locate(href_list["item_to_tweak"])
-			if(!istype(editing) || QDELING(editing))
-				return
-
-			var/existing_val = -1
-			switch(href_list["var_tweak"])
-				if("damtype")
-					existing_val = editing.damtype
-				if("force")
-					existing_val = editing.force
-				if("wound")
-					existing_val = editing.wound_bonus
-				if("bare wound")
-					existing_val = editing.bare_wound_bonus
-				else
-					CRASH("Invalid var_tweak passed to item vv set var: [href_list["var_tweak"]]")
-
-			var/new_val
-			if(href_list["var_tweak"] == "damtype")
-				new_val = input("Enter the new damage type for [editing]","Set Damtype", existing_val) in list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN)
+		var/newamt
+		switch(Text)
+			if("brute")
+				L.adjustBruteLoss(amount, forced = TRUE)
+				newamt = L.getBruteLoss()
+			if("fire")
+				L.adjustFireLoss(amount, forced = TRUE)
+				newamt = L.getFireLoss()
+			if("toxin")
+				L.adjustToxLoss(amount, forced = TRUE)
+				newamt = L.getToxLoss()
+			if("oxygen")
+				L.adjustOxyLoss(amount, forced = TRUE)
+				newamt = L.getOxyLoss()
+			if("brain")
+				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, amount)
+				newamt = L.get_organ_loss(ORGAN_SLOT_BRAIN)
+			if("stamina")
+				L.adjustStaminaLoss(amount, forced = TRUE)
+				newamt = L.getStaminaLoss()
 			else
-				new_val = input("Enter the new value for [editing]'s [href_list["var_tweak"]]","Set [href_list["var_tweak"]]", existing_val) as num|null
-			if(isnull(new_val) || new_val == existing_val || QDELETED(editing) || !check_rights(NONE))
+				to_chat(usr, "You caused an error. DEBUG: Text:[Text] Mob:[L]", confidential = TRUE)
 				return
 
-			switch(href_list["var_tweak"])
-				if("damtype")
-					editing.damtype = new_val
-				if("force")
-					editing.force = new_val
-				if("wound")
-					editing.wound_bonus = new_val
-				if("bare wound")
-					editing.bare_wound_bonus = new_val
+		if(amount != 0)
+			var/log_msg = "[key_name(usr)] dealt [amount] amount of [Text] damage to [key_name(L)]"
+			message_admins("[key_name(usr)] dealt [amount] amount of [Text] damage to [ADMIN_LOOKUPFLW(L)]")
+			log_admin(log_msg)
+			admin_ticket_log(L, "<font color='blue'>[log_msg]</font>")
+			vv_update_display(L, Text, "[newamt]")
 
-			message_admins("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
-			log_admin("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
-			vv_update_display(editing, href_list["var_tweak"], istext(new_val) ? uppertext(new_val) : new_val)
+	else if(href_list["item_to_tweak"] && href_list["var_tweak"])
+
+		var/obj/item/editing = locate(href_list["item_to_tweak"])
+		if(!istype(editing) || QDELING(editing))
+			return
+
+		var/existing_val = -1
+		switch(href_list["var_tweak"])
+			if("damtype")
+				existing_val = editing.damtype
+			if("force")
+				existing_val = editing.force
+			if("wound")
+				existing_val = editing.wound_bonus
+			if("bare wound")
+				existing_val = editing.bare_wound_bonus
+			else
+				CRASH("Invalid var_tweak passed to item vv set var: [href_list["var_tweak"]]")
+
+		var/new_val
+		if(href_list["var_tweak"] == "damtype")
+			new_val = input("Enter the new damage type for [editing]","Set Damtype", existing_val) in list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN)
+		else
+			new_val = input("Enter the new value for [editing]'s [href_list["var_tweak"]]","Set [href_list["var_tweak"]]", existing_val) as num|null
+		if(isnull(new_val) || new_val == existing_val || QDELETED(editing) || !check_rights(NONE))
+			return
+
+		switch(href_list["var_tweak"])
+			if("damtype")
+				editing.damtype = new_val
+			if("force")
+				editing.force = new_val
+			if("wound")
+				editing.wound_bonus = new_val
+			if("bare wound")
+				editing.bare_wound_bonus = new_val
+
+		message_admins("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
+		log_admin("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
+		vv_update_display(editing, href_list["var_tweak"], istext(new_val) ? uppertext(new_val) : new_val)
 
 	//Finally, refresh if something modified the list.
 	if(href_list["datumrefresh"])


### PR DESCRIPTION
## About The Pull Request

So
A) Modifying traits pretty self explanatory was a missing check
B) imo given the type of data that can be seen in vv this shouldnt be exposed to literally anyone with an admin datum especially considering actually showing it to someone else and editing it is R_admin and r_varedit

the giant diff is just indentation change
Showing vv to other players is unaffected by this

## Changelog
:cl:
fix: fixed some vv issues
/:cl:
