### PR TITLE
Decals will fall downwards

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -24,9 +24,9 @@
 /// Returns either the existing cleanable, the one we created, or null if we can't spawn on that turf
 /turf/proc/spawn_unique_cleanable(obj/effect/decal/cleanable/cleanable_type)
 	var/turf/checkturf = src
-	while (isgroundlessturf(checkturf) && GET_TURF_BELOW())
+	while (isgroundlessturf(checkturf) && checkturf.zPassOut(DOWN))
 		var/turf/below = GET_TURF_BELOW(checkturf)
-		if (!below)
+		if (!below || !below.zPassIn(DOWN))
 			break
 		checkturf = below
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -23,14 +23,18 @@
 /// Use this if your decal is one of one, and thus we should not spawn it if it's there already
 /// Returns either the existing cleanable, the one we created, or null if we can't spawn on that turf
 /turf/proc/spawn_unique_cleanable(obj/effect/decal/cleanable/cleanable_type)
-	if (isgroundlessturf(src))
-		return null
 	var/turf/checkturf = src
+	while (isgroundlessturf(checkturf) && GET_TURF_BELOW())
+		var/turf/below = GET_TURF_BELOW(checkturf)
+		if (!below)
+			break
+		checkturf = below
+
 	// There is no need to spam unique cleanables, they don't stack and it just chews cpu
-	var/obj/effect/decal/cleanable/existing = locate(cleanable_type) in src
+	var/obj/effect/decal/cleanable/existing = locate(cleanable_type) in checkturf
 	if(existing)
 		return existing
-	return new cleanable_type(src)
+	return new cleanable_type(checkturf)
 
 /obj/effect/decal/cleanable/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -23,6 +23,9 @@
 /// Use this if your decal is one of one, and thus we should not spawn it if it's there already
 /// Returns either the existing cleanable, the one we created, or null if we can't spawn on that turf
 /turf/proc/spawn_unique_cleanable(obj/effect/decal/cleanable/cleanable_type)
+	if (isgroundlessturf(src))
+		return null
+	var/turf/checkturf = src
 	// There is no need to spam unique cleanables, they don't stack and it just chews cpu
 	var/obj/effect/decal/cleanable/existing = locate(cleanable_type) in src
 	if(existing)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -15,6 +15,8 @@
 	var/static/list/loc_connections = list(
 		COMSIG_TURF_CHANGE = PROC_REF(on_decal_move),
 	)
+	while(isopenspaceturf(loc) && can_z_move(DOWN, z_move_flags = ZMOVE_ALLOW_ANCHORED))
+		zMove(DOWN, z_move_flags = ZMOVE_ALLOW_ANCHORED)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/effect/decal/blob_act(obj/structure/blob/B)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3089,7 +3089,7 @@
 
 /datum/reagent/ants/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
-	if(!istype(exposed_turf) || isspaceturf(exposed_turf)) // Is the turf valid
+	if(!istype(exposed_turf)) // Is the turf valid
 		return
 	if((reac_volume <= 10)) // Makes sure people don't duplicate ants.
 		return


### PR DESCRIPTION
## About The Pull Request

Decals which attempt to spawn on an openspace turf will drop to the level below until they hit a solid turf.

Here I demonstrate it with an average spaceman activity, spraying flour aimlessly out of a spray bottle:
![dreamseeker_2e37UCLtuY](https://github.com/user-attachments/assets/a282ecdf-8a59-4418-a86e-2e7ceb675c9d)

## Why It's Good For The Game

The other day I watched a drunken miner flying around the upper levels of Catwalkstation and once he became blackout drunk his drunken personality decided to spin rapidly until he vomited. 
The vomit hovered in the air. This will not stand. 

## Changelog

:cl:
fix: You can now bleed or vomit onto people below you rather than creating puddles of substance hovering in mid-air.
/:cl:
