### PR TITLE
Makes more megafauna loot sellable

### DIFF
--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -26,6 +26,7 @@
 		/obj/item/clothing/gloves/gauntlets,
 		/obj/item/jacobs_ladder,
 		/obj/item/borg/upgrade/modkit/lifesteal,
+		/obj/item/clockwork_alloy
 	)
 
 /datum/export/lavaland/major //valuable chest/ruin loot, minor megafauna loot
@@ -39,6 +40,8 @@
 		/obj/item/melee/ghost_sword,
 		/obj/item/prisoncube,
 		/obj/item/rod_of_asclepius,
+		/obj/item/knife/hunting/wildhunter
+		/obj/item/cain_and_abel
 	)
 
 //Megafauna loot, except for ash drakes
@@ -55,6 +58,12 @@
 		/obj/item/soulscythe,
 		/obj/item/storm_staff,
 		/obj/item/clothing/suit/hooded/hostile_environment,
+		/obj/item/wendigo_blood
+		/obj/item/wendigo_skull
+		/obj/item/ice_energy_crystal
+		/obj/item/resurrection_crystal
+		/obj/item/clothing/shoes/winterboots/ice_boots/ice_trail
+		/obj/item/pickaxe/drill/jackhammer/demonic
 	)
 
 /datum/export/lavaland/megafauna/total_printout(datum/export_report/ex, notes = TRUE) //in the unlikely case a miner feels like selling megafauna loot

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -26,7 +26,7 @@
 		/obj/item/clothing/gloves/gauntlets,
 		/obj/item/jacobs_ladder,
 		/obj/item/borg/upgrade/modkit/lifesteal,
-		/obj/item/clockwork_alloy
+		/obj/item/clockwork_alloy,
 	)
 
 /datum/export/lavaland/major //valuable chest/ruin loot, minor megafauna loot
@@ -40,8 +40,8 @@
 		/obj/item/melee/ghost_sword,
 		/obj/item/prisoncube,
 		/obj/item/rod_of_asclepius,
-		/obj/item/knife/hunting/wildhunter
-		/obj/item/cain_and_abel
+		/obj/item/knife/hunting/wildhunter,
+		/obj/item/cain_and_abel,
 	)
 
 //Megafauna loot, except for ash drakes
@@ -58,12 +58,12 @@
 		/obj/item/soulscythe,
 		/obj/item/storm_staff,
 		/obj/item/clothing/suit/hooded/hostile_environment,
-		/obj/item/wendigo_blood
-		/obj/item/wendigo_skull
-		/obj/item/ice_energy_crystal
-		/obj/item/resurrection_crystal
-		/obj/item/clothing/shoes/winterboots/ice_boots/ice_trail
-		/obj/item/pickaxe/drill/jackhammer/demonic
+		/obj/item/wendigo_blood,
+		/obj/item/wendigo_skull,
+		/obj/item/ice_energy_crystal,
+		/obj/item/resurrection_crystal,
+		/obj/item/clothing/shoes/winterboots/ice_boots/ice_trail,
+		/obj/item/pickaxe/drill/jackhammer/demonic,
 	)
 
 /datum/export/lavaland/megafauna/total_printout(datum/export_report/ex, notes = TRUE) //in the unlikely case a miner feels like selling megafauna loot


### PR DESCRIPTION

## About The Pull Request
Clockwork alloy is now in the minor loot category, cain & abel alongside the wildhunter knife are in the major category, and all of the DFM & Wendigo drops are now megafauna category loot.
## Why It's Good For The Game
DFM & Wendigo should be able to have their loot sold. Parts of the godslayer armor are useless if you don't have all of them so selling them give them some use. Colossus already has a fuck ton of loot so cain & abel are in the major category so you don't get a bajillion credits for killing a colossus. Wildhunter is a bonus drop from BDM for killing it with a crusher and it's not as impactful so it's only major loot.
## Changelog
:cl: Goat
balance: More megafauna loot is worth something to export. Notably the demonic frost miner's and the wendigo's drops are now actually worth something.
/:cl:
