### PR TITLE
Removes a harmful stereotype from the meatbun by replacing it with cannibalism, which is barely frowned upon in SS13

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -681,7 +681,7 @@
 
 /obj/item/food/meatbun
 	name = "meat bun"
-	desc = "Has the potential to not be dog."
+	desc = "Has the potential to not be human."
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "meatbun"
 	food_reagents = list(


### PR DESCRIPTION
## About The Pull Request
Changes the meatbun's description, which was most likely perpetuating a harmful stereotype
## Why It's Good For The Game
I thought it was lowkey racist, so I changed it into cannibalism which is 'haha funni' sometimes
EDIT: this is stupid
## Changelog
:cl:
add: Added a Rimworld reference
del: Removed a potential harmful stereotype
/:cl:
