### PR TITLE
Fixes a weird misaligned mop on Tramstation

### DIFF
--- a/_maps/map_files/tramstation/maintenance_modules/servicecargolower_1.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/servicecargolower_1.dmm
@@ -20,13 +20,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/greater)
-"e" = (
-/obj/item/mop{
-	pixel_x = -1;
-	pixel_y = -30
-	},
-/turf/closed/wall,
-/area/station/maintenance/starboard/greater)
 "f" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -228,6 +221,7 @@
 	pixel_x = -10;
 	pixel_y = 18
 	},
+/obj/item/mop,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "H" = (
@@ -760,7 +754,7 @@ K
 K
 A
 j
-e
+K
 G
 K
 Z


### PR DESCRIPTION

## About The Pull Request

On a specific Tramstation module there happens to be a weird var edited mop that not only is placed directly on a wall, but has also its x/y values changed to physically appear to be standing inside the room below.

![image](https://github.com/user-attachments/assets/58b9e20b-0fda-41be-98ab-855dbd8f4e63)

who let that happen I don't know it was pretty jarring spotting it while running through the hallway above

## Why It's Good For The Game

You can no longer grab a mop from within the darkness while being in the room above its location.

## Changelog
:cl:
fix: Tramstation, fixes a mop that happened to be grabbable while being 2 tiles above its location in an entirely different room
/:cl:
