### PR TITLE
You're no longer able to grind medipens

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -26,6 +26,10 @@
 /obj/item/reagent_containers/hypospray/attack(mob/living/affected_mob, mob/user)
 	inject(affected_mob, user)
 
+///Prevents medipens from being blended to extract their reagents.
+/obj/item/reagent_containers/hypospray/blend_requirements(obj/machinery/reagentgrinder/R)
+	return FALSE
+
 ///Handles all injection checks, injection and logging.
 /obj/item/reagent_containers/hypospray/proc/inject(mob/living/affected_mob, mob/user)
 	if(used_up)


### PR DESCRIPTION

## About The Pull Request

This makes you unable to add medipens to the reagent grinder or the mortar.
## Why It's Good For The Game

Medipens are meant to serve as a restricted means of delivering particular reagents or mixes to yourself or other mobs in certain scenarios; for instance, pressure restrictions on lux pens. Allowing them to be grinded is an oversight that totally disregards that.
## Changelog
:cl: Bisar
fix: You're no longer able to grind medipens.
/:cl:
