### PR TITLE
Significantly tones down the embed probability of flechette rounds

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -144,14 +144,14 @@
 	embed_type = /datum/embedding/bullet/flechette
 
 /datum/embedding/bullet/flechette
-	embed_chance = 100
+	embed_chance = 25
 	fall_chance = 0
 	jostle_chance = 20
 	ignore_throwspeed_threshold = TRUE
 	pain_stam_pct = 0.1
 	pain_mult = 0.5
 	jostle_pain_mult = 1.5
-	rip_time = 1 SECONDS
+	rip_time = 0.5 SECONDS
 
 /obj/projectile/bullet/pellet/flechette/donk
 	name = "\improper Donk Co. 'Donk Spike' flechette"
@@ -172,7 +172,7 @@
 	ignore_throwspeed_threshold = TRUE
 	pain_mult = 1
 	jostle_pain_mult = 1
-	rip_time = 0.5 SECONDS
+	rip_time = 1 SECONDS
 
 // Mech Scattershot
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -145,7 +145,7 @@
 
 /datum/embedding/bullet/flechette
 	embed_chance = 25
-	fall_chance = 0
+	fall_chance = 10
 	jostle_chance = 20
 	ignore_throwspeed_threshold = TRUE
 	pain_stam_pct = 0.1


### PR DESCRIPTION
## About The Pull Request

Reduces the embed probability of standard flechette from 100% (before armor) to 25% (before armor). Also allows them to fall out naturally.

Swaps around the extraction time of Donk Spikes and Flechette.

## Why It's Good For The Game

Well, I cooked a bit too much and the kill time for flechette is not only quite short, but it can lay someone out for a long ass time.

It kind of does triple duty on wounds, blood loss and damage with AP. Here, I'm just touching one of these aspects to have it focus on the other two.

Filling people with spikes really should be the gimmick of Donk Spikes.

## Changelog
:cl:
balance: Reduces the embed probabilities of flechette rounds, they can fall out naturally. Donk spikes still maintain their high embed chance and inability to fall out naturally. Macroplastics launched straight into your body, as sponsored by the Donk Corporation.
/:cl:
