### PR TITLE
Clear Farsight and Rock Absorber effects on mutation removal

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -652,6 +652,13 @@
 	conflicts = list(/datum/mutation/human/rock_eater)
 	locked = TRUE
 
+/datum/mutation/human/rock_absorber/on_losing(mob/living/carbon/human/owner)
+	. = ..()
+	if(. || QDELING(owner) || HAS_TRAIT(owner, TRAIT_ROCK_METAMORPHIC))
+		return
+	owner.remove_status_effect(/datum/status_effect/golem)
+	owner.remove_status_effect(/datum/status_effect/golem_lightbulb)
+
 // Soft crit is disabed
 /datum/mutation/human/inexorable
 	name = "Inexorable"

--- a/code/datums/mutations/farsight.dm
+++ b/code/datums/mutations/farsight.dm
@@ -59,3 +59,10 @@
 
 /datum/action/cooldown/spell/farsight/is_action_active(atom/movable/screen/movable/action_button/current_button)
 	return active
+
+/datum/action/cooldown/spell/farsight/Remove(mob/living/remove_from)
+	. = ..()
+	if(active)
+		remove_from.client?.view_size.resetToDefault()
+		active = FALSE
+		cooldown_time *= 2


### PR DESCRIPTION

## About The Pull Request

Fixes #90637

Adds on remove effects for Farsight and Rock Absorber, because I forgot.

## Changelog

:cl: Melbert
fix: Losing Farsight or Rock Absorber mutations will properly drop their effects as well
/:cl:


