### PR TITLE
Heretic Blade + Rust minor nerfs

### DIFF
--- a/code/datums/proximity_monitor/fields/heretic_arena.dm
+++ b/code/datums/proximity_monitor/fields/heretic_arena.dm
@@ -158,16 +158,6 @@ GLOBAL_LIST_EMPTY(heretic_arenas)
 	owner.add_overlay(crown_overlay)
 	owner.remove_traits(list(TRAIT_ELDRITCH_ARENA_PARTICIPANT, TRAIT_NO_TELEPORT), TRAIT_STATUS_EFFECT(id))
 
-	// The mansus celebrates your efforts
-	if(IS_HERETIC(owner))
-		owner.heal_overall_damage(60, 60, 60)
-		owner.adjustToxLoss(-60, forced = TRUE) // Slime heretics everywhere...
-		owner.adjustOxyLoss(-60)
-		if(iscarbon(owner))
-			var/mob/living/carbon/carbon_owner = owner
-			for(var/datum/wound/wound as anything in carbon_owner.all_wounds)
-				wound.remove_wound()
-
 	if(arena_victor) // No need to spam if we've already killed at least 1 person
 		return
 	if(IS_HERETIC(owner))

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -7,7 +7,6 @@
 	desc = "A torn, dust-caked hood. Strange eyes line the inside."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	flash_protect = FLASH_PROTECTION_WELDER
 
 /obj/item/clothing/head/hooded/cult_hoodie/eldritch/Initialize(mapload)
 	. = ..()
@@ -28,10 +27,10 @@
 	var/hood_up = FALSE
 
 /datum/armor/cultrobes_eldritch
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
+	melee = 30
+	bullet = 30
+	laser = 30
+	energy = 30
 	bomb = 35
 	bio = 20
 	fire = 20


### PR DESCRIPTION
## About The Pull Request

This PR removes the heal from Wolves among Sheep, and it nerfs the armor of Eldritch Armor, and removes its flashproofing.

## Why It's Good For The Game

Rust + Blade crosspathing is overperforming ingame and among players I've talked to is widely considered the strongest heretic pathing. It combines the amazing sustain and durability of rust with the offensive power of blade. Heretic is rather challenging to nerf without reworks. I've targeted the armor because it's the one crosspath knowledge I see people in these paths using consistently, and the stats on it are extremely good right now. Wolves I've removed the free massive heal from critting someone. I feel that right now combined with all of the other durability stuff it makes this spell completely risk-free. 

## Changelog

:cl:
balance: Wolves among Sheep no longer heals the Heretic for critting someone.
balance: Armor stats on the Eldritch Armor have been adjusted.
balance: The Eldritch Armor no longer grants flash protection.
/:cl: