### PR TITLE
[no gbp] Drowning doesn't make you fitter

### DIFF
--- a/code/datums/elements/swimming_tile.dm
+++ b/code/datums/elements/swimming_tile.dm
@@ -85,8 +85,12 @@
 	if (!HAS_TRAIT(owner, TRAIT_SWIMMER))
 		var/athletics_skill =  (owner.mind?.get_skill_level(/datum/skill/athletics) || 1) - 1
 		owner.apply_damage((stamina_per_second - athletics_skill) * seconds_between_ticks, STAMINA)
-		owner.mind?.adjust_experience(/datum/skill/athletics, 10)
 
+	// If you can't move you're not swimming
+	if (!HAS_TRAIT(owner, TRAIT_INCAPACITATED) && !HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
+		owner.mind?.adjust_experience(/datum/skill/athletics, 3)
+
+	// You might not be swimming but you can breathe
 	if (HAS_TRAIT(owner, TRAIT_NODROWN) || HAS_TRAIT(owner, TRAIT_NOBREATH) || (owner.mob_size >= MOB_SIZE_HUMAN && owner.body_position == STANDING_UP))
 		return
 	if (iscarbon(owner))


### PR DESCRIPTION
## About The Pull Request

Fixes #90790

Decreases the exp gain from swimming and only grants it while you actually have stamina.
Even if it doesn't kill you this shouldn't make you stronger

## Changelog

:cl:
fix: Floating motionless and face down in the water doesn't count as a workout
/:cl:
