### PR TITLE
scales the statusbar correctly according to monitor scale

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -128,9 +128,9 @@ window "mapwindow"
 	elem "status_bar"
 		type = LABEL
 		pos = 0,464
-		size = 280x16
-		anchor1 = 0,100
-		anchor2 = -1,-1
+		size = 210x16
+		anchor1 = 0,99
+		anchor2 = 30,100
 		text-color = #ffffff
 		background-color = #222222
 		border = line

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -127,10 +127,10 @@ window "mapwindow"
 		style = ".center { text-align: center; } .maptext { font-family: 'Grand9K Pixel'; font-size: 6pt; -dm-text-outline: 1px black; color: white; line-height: 1.0; } .command_headset { font-weight: bold; } .context { font-family: 'Pixellari'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'TinyUnicode'; font-size: 12pt; line-height: 0.75; } .small { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; } .big { font-family: 'Pixellari'; font-size: 12pt; } .reallybig { font-size: 12pt; } .extremelybig { font-size: 12pt; } .greentext { color: #00FF00; font-size: 6pt; } .redtext { color: #FF0000; font-size: 6pt; } .clown { color: #FF69BF; font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; }"
 	elem "status_bar"
 		type = LABEL
-		pos = 0,464
-		size = 210x16
+		pos = 0,470
+		size = 210x10
 		anchor1 = 0,99
-		anchor2 = 30,100
+		anchor2 = 20,100
 		text-color = #ffffff
 		background-color = #222222
 		border = line

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -128,7 +128,7 @@ window "mapwindow"
 	elem "status_bar"
 		type = LABEL
 		pos = 0,470
-		size = 210x10
+		size = 128x10
 		anchor1 = 0,99
 		anchor2 = 20,100
 		text-color = #ffffff

--- a/tgui/packages/tgui-panel/settings/scaling.ts
+++ b/tgui/packages/tgui-panel/settings/scaling.ts
@@ -11,6 +11,7 @@ const ELEMENTS_TO_ADJUST = [
   'inputbuttons.saybutton',
   'inputbuttons.mebutton',
   'inputbuttons.oocbutton',
+  'mapwindow.status_bar',
 ];
 
 const DEFAULT_BUTTON_FONT_SIZE = 4;


### PR DESCRIPTION

## About The Pull Request
the statusbar wasn't resizing like the rest of the ui now does

## Why It's Good For The Game
it does that now, which is neat

4k 200% scale
before:
![d9Keu55RLONuy4rw@2x](https://github.com/user-attachments/assets/15640fd0-f1aa-441e-b34f-ecae43d7d016)

after:
![sfYXv5hzIqjqTCTH@2x](https://github.com/user-attachments/assets/f6e5e8b9-2de4-4db4-b185-c7b15f1b9fba)

1920x1200 100% scale
before:
![SHMbuQ5PQqyF5qHA@2x](https://github.com/user-attachments/assets/dad012ab-3bca-4307-b9b0-80ea862135a8)

after:
![BYMNAvY00lec0qir@2x](https://github.com/user-attachments/assets/0bfb8ff6-e2b4-4c34-8c22-e74ab5d65953)

## Changelog
:cl:
qol: the statusbar at the bottom left now properly scales with your display
/:cl:
