### PR TITLE
Fix: Minebot command text for activating lights

### DIFF
--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -327,7 +327,7 @@
 	radial_icon_state = "mech_eject"
 	ability_key = BB_MINEBOT_DUMP_ABILITY
 
-/datum/pet_command/minebot_ability/light/retrieve_command_text(atom/living_pet, atom/target)
+/datum/pet_command/minebot_ability/dump/retrieve_command_text(atom/living_pet, atom/target)
 	return "signals [living_pet] to dump its ore!"
 
 /datum/pet_command/attack/minebot


### PR DESCRIPTION
## About The Pull Request

Due to the wrong path being specified, if you try to order the minebot to turn on its lights, it'll talk about dumping ore instead. The actual functionality is fine, but the feedback isn't. This fixes that.

## Why It's Good For The Game

The current bug just makes things confusing. Fewer sources of confusion in this game is better.

## Changelog

:cl:
fix: Made it so minebot commands don't talk about dumping ore when you're toggling the lights.
/:cl:
