### PR TITLE
Human monkeyfication is reversible with mutadone again

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -42,6 +42,8 @@
 
 /datum/species/monkey/on_species_gain(mob/living/carbon/human/human_who_gained_species, datum/species/old_species, pref_load, regenerate_icons)
 	. = ..()
+	if (pref_load)
+		ADD_TRAIT(human_who_gained_species, TRAIT_BORN_MONKEY, INNATE_TRAIT) // Not a species trait, you cannot escape your genetic destiny
 	passtable_on(human_who_gained_species, SPECIES_TRAIT)
 	human_who_gained_species.dna.add_mutation(/datum/mutation/human/race, MUT_NORMAL)
 	human_who_gained_species.dna.activate_mutation(/datum/mutation/human/race)
@@ -180,3 +182,15 @@
 	return ..()
 
 #undef MONKEY_SPEC_ATTACK_BITE_MISS_CHANCE
+
+/// Monkeys you can play as on monkey day
+/datum/species/monkey/roundstart
+	inherent_traits = list(
+		TRAIT_BORN_MONKEY,
+		TRAIT_NO_AUGMENTS,
+		TRAIT_NO_BLOOD_OVERLAY,
+		TRAIT_NO_DNA_COPY,
+		TRAIT_NO_UNDERWEAR,
+		TRAIT_VENTCRAWLER_NUDE,
+		TRAIT_WEAK_SOUL,
+	)

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -182,15 +182,3 @@
 	return ..()
 
 #undef MONKEY_SPEC_ATTACK_BITE_MISS_CHANCE
-
-/// Monkeys you can play as on monkey day
-/datum/species/monkey/roundstart
-	inherent_traits = list(
-		TRAIT_BORN_MONKEY,
-		TRAIT_NO_AUGMENTS,
-		TRAIT_NO_BLOOD_OVERLAY,
-		TRAIT_NO_DNA_COPY,
-		TRAIT_NO_UNDERWEAR,
-		TRAIT_VENTCRAWLER_NUDE,
-		TRAIT_WEAK_SOUL,
-	)

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -112,12 +112,6 @@
 			SPECIES_PERK_DESC = "Monkeys are primitive humans, and can't do most things a human can do. Computers are impossible, \
 				complex machines are right out, and most clothes don't fit your smaller form.",
 		),
-		list(
-			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
-			SPECIES_PERK_ICON = "capsules",
-			SPECIES_PERK_NAME = "Mutadone Averse",
-			SPECIES_PERK_DESC = "Monkeys are reverted into normal humans upon being exposed to Mutadone.",
-		),
 	)
 
 	return to_add

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1172,7 +1172,7 @@
 	var/mob/living/carbon/human/human_mob = affected_mob
 	if (ismonkey(human_mob))
 		if (!HAS_TRAIT(human_mob, TRAIT_BORN_MONKEY))
-			human_mob.dna.remove_mutation(/datum/mutation/human/race, mutadone = TRUE)
+			human_mob.dna.remove_mutation(/datum/mutation/human/race, mutadone = FALSE) // This is the only time mutadone should remove monkeyism
 	else if (HAS_TRAIT(human_mob, TRAIT_BORN_MONKEY))
 		human_mob.monkeyize()
 


### PR DESCRIPTION
## About The Pull Request

Originally I was just going to make this PR to remove the false information on the roundstart monkey infobox, but then I found out that a more recent change to mutadone had broken this feature entirely and it was now impossible to demonkify someone using mutadone.

This PR should restore the intended behaviour that monkeys turned into humans will return to monkeys when exposed to mutadone and humans turned into monkeys will return to humans when exposed to mutadone, based on what they were at roundstart.

## Changelog

:cl:
fix: If you are turned into a monkey via the DNA scanner, mutadone can once again turn you back. If you are a monkey turned into a human via the DNA scanner, mutadone can also turn you back.
fix: If you are lucky enough to have the opportunity to be a monkey as a roundstart species, the species info box will not lie to you about mutadone.
/:cl:
