### PR TITLE
Icebox rods delete themselves at the world border

### DIFF
--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -131,7 +131,8 @@
 		// Did we reach our destination? We're probably on Icebox. Let's get rid of ourselves.
 		// Ordinarily this won't happen as the average destination is the edge of the map and
 		// the rod will auto transition to a new z-level.
-		if(y == destination_turf.y || x == destination_turf.x)
+		// If the rod is parallel to the destination at the world border, it is likely stuck (once again, icebox)
+		if((loc == destination_turf) || ((y == destination_turf.y || x == destination_turf.x) && (y == world.maxy || x == world.maxx || x == 1 || y == 1)))
 			qdel(src)
 			return
 

--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -131,7 +131,7 @@
 		// Did we reach our destination? We're probably on Icebox. Let's get rid of ourselves.
 		// Ordinarily this won't happen as the average destination is the edge of the map and
 		// the rod will auto transition to a new z-level.
-		if(loc == destination_turf)
+		if(y == destination_turf.y || x == destination_turf.x)
 			qdel(src)
 			return
 


### PR DESCRIPTION

## About The Pull Request

Immovable rods will now delete themselves upon reaching the world border on Icebox.

Normally they would miss their target turf, and would get stuck at the world border. This is weird and not right.
## Why It's Good For The Game

No free exercise for the RD.
## Changelog
:cl: Rhials
fix: Immovable rods self-delete at the icebox world border.
/:cl:
