### PR TITLE
Fixes a small division by zero runtime with examining fishing spots (no it doesn't crash the server)

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -491,7 +491,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 			var/percent_rod_weight = rod_weights[reward] / total_rod_weight
 			var/obj/item/fish/prototype = reward
 			var/init_name = initial(prototype.name)
-			var/ratio = percent_weight/percent_rod_weight
+			var/ratio = percent_rod_weight ? percent_weight/percent_rod_weight : INFINITY
 			if(ratio < 0.9)
 				init_name = span_bold(init_name)
 				if(ratio < 0.3)


### PR DESCRIPTION
## About The Pull Request
```
[2025-04-24 01:48:29.738] RUNTIME: runtime error: Division by zero
 - proc name: get catchable fish names (/datum/fish_source/proc/get_catchable_fish_names)
 -   source file: code/modules/fishing/sources/_fish_source.dm,494
```

## Why It's Good For The Game
Fixed a small issue that prevented examining fishing spots from doing its thing.

## Changelog

:cl:
fix: examining fishing spots twice with sufficient skill level while holding a rod should work more reliably.
/:cl:
