### PR TITLE
You can now load the grenade launcher on the m-90gl

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -182,8 +182,7 @@
 /obj/item/gun/ballistic/automatic/m90/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(isammocasing(tool))
 		if(istype(tool, underbarrel.magazine.ammo_type))
-			underbarrel.attack_self(user)
-			underbarrel.attackby(tool, user, list2params(modifiers))
+			underbarrel.item_interaction(user, tool, modifiers)
 		return ITEM_INTERACT_BLOCKING
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Changes a attackby() call into an item_interaction() call in the M-90gl code.

Fixes https://github.com/tgstation/tgstation/issues/90812

## Why It's Good For The Game

Most likely broke during a refactor.

## Changelog
:cl:
fix: The grenade launcher of the M-90gl can be reloaded once again.
/:cl:
