### PR TITLE
Fixes offset visual bug with cyborg tools that pick up items

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -72,6 +72,8 @@
 			break
 	if(itemcheck)
 		var/obj/item/item = atom
+		item.pixel_x = 0
+		item.pixel_y = 0
 		item.forceMove(src)
 		stored = item
 		RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))


### PR DESCRIPTION

## About The Pull Request
Resets `pixel_x` and `pixel_y` of an item about to be picked up by any cyborg apparatus tool. These offsets being kept were causing a visual bug (and they just get changed again when the item is dropped anyway).
## Why It's Good For The Game
Fixes this:
![image](https://github.com/user-attachments/assets/1181d373-6d1c-4ed3-914d-6f69d8cfb95f)
## Changelog
:cl:
fix: Fixed a visual bug with cyborg tools that are able to carry items.
/:cl:
