### PR TITLE
Resolves some specific object repair behaviours not being acknowledged by duct tape

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -202,14 +202,6 @@
 	else
 		object_to_repair.repair_damage(object_repair_value)
 
-	if(ismecha(object_to_repair))
-		var/obj/vehicle/sealed/mecha/mecha_to_repair = object_to_repair
-		mecha_to_repair.diag_hud_set_mechhealth()
-
-	if(istype(object_to_repair, /obj/structure/window))
-		var/obj/structure/window/window_to_repair
-		window_to_repair.update_nearby_icons()
-
 	use(1)
 	to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -196,7 +196,20 @@
 	if(!do_after(user, 3 SECONDS, target = object_to_repair))
 		return ITEM_INTERACT_BLOCKING
 
-	object_to_repair.repair_damage(object_repair_value)
+	if(isclothing(object_to_repair))
+		var/obj/item/clothing/clothing_to_repair = object_to_repair
+		clothing_to_repair.repair()
+	else
+		object_to_repair.repair_damage(object_repair_value)
+
+	if(ismecha(object_to_repair))
+		var/obj/vehicle/sealed/mecha/mecha_to_repair = object_to_repair
+		mecha_to_repair.diag_hud_set_mechhealth()
+
+	if(istype(object_to_repair, /obj/structure/window))
+		var/obj/structure/window/window_to_repair
+		window_to_repair.update_nearby_icons()
+
 	use(1)
 	to_chat(user, span_notice("You finish repairing [interacting_with] with [src]."))
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -213,8 +213,7 @@
 		return FALSE
 	to_chat(user, span_notice("You begin repairing [src]..."))
 	if(tool.use_tool(src, user, 4 SECONDS, volume = 50))
-		atom_integrity = max_integrity
-		update_nearby_icons()
+		repair_damage(max_integrity)
 		to_chat(user, span_notice("You repair [src]."))
 	return ITEM_INTERACT_SUCCESS
 
@@ -323,6 +322,10 @@
 	. = ..()
 	if(.) //received damage
 		update_nearby_icons()
+
+/obj/structure/window/repair_damage(amount)
+	. = ..()
+	update_nearby_icons()
 
 /obj/structure/window/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -414,19 +414,18 @@
 	while(atom_integrity < max_integrity)
 		if(W.use_tool(src, user, 2.5 SECONDS, volume=50))
 			did_the_thing = TRUE
-			atom_integrity += min(10, (max_integrity - atom_integrity))
+			repair_damage(10)
 			audible_message(span_hear("You hear welding."))
 		else
 			break
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
-		diag_hud_set_mechhealth()
 	else
 		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 
 
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)
-	atom_integrity = max_integrity
+	repair_damage(max_integrity)
 	if(cell && charge_cell)
 		cell.charge = cell.maxcharge
 		diag_hud_set_mechcell()
@@ -440,6 +439,9 @@
 		clear_internal_damage(MECHA_CABIN_AIR_BREACH)
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		clear_internal_damage(MECHA_INT_CONTROL_LOST)
+
+/obj/vehicle/sealed/mecha/repair_damage(amount)
+	. = ..()
 	diag_hud_set_mechhealth()
 
 /obj/vehicle/sealed/mecha/narsie_act()


### PR DESCRIPTION

## About The Pull Request

When duct tape repairs mechs, windows or clothing, it properly updates icons and other effects that normally occur when repaired.

## Why It's Good For The Game

It ends up creating some weird interactions due to directly repairing the objects integrity.

## Changelog
:cl:
fix: Duct tape properly updates the various icons and visuals of mechs, windows and clothing that it repairs.
/:cl:
