### PR TITLE
webmap is now in maps.txt instead of a config entry

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -435,6 +435,9 @@ Example config:
 			if("feedbacklink")
 				if(currentmap.map_name == SSmapping.current_map.map_name)
 					SSmapping.current_map.feedback_link = data
+			if("webmap_url")
+				if(currentmap.map_name == SSmapping.current_map.map_name)
+					SSmapping.current_map.mapping_url = data
 			else
 				log_config("Unknown command in map vote config: '[command]'")
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -785,7 +785,3 @@
 
 // If set, enables the "Link forum account" OOC verb
 /datum/config_entry/string/forum_link_uri
-
-/datum/config_entry/string/webmap_url
-	//ex: "https://webmap.affectedarc07.co.uk/maps/tgstation/"
-	default = ""

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -106,9 +106,6 @@ SUBSYSTEM_DEF(mapping)
 		if(!current_map || current_map.defaulted)
 			to_chat(world, span_boldannounce("Unable to load next or default map config, defaulting to [old_config.map_name]."))
 			current_map = old_config
-	var/mapping_url = config.Get(/datum/config_entry/string/webmap_url)
-	if(mapping_url != "")
-		current_map.mapping_url = mapping_url
 	plane_offset_to_true = list()
 	true_to_offset_planes = list()
 	plane_to_offset = list()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -139,9 +139,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			if(!SSmapping.current_map.mapping_url)
 				return
 			if(is_station_level(mob.z))
-				src << link("[SSmapping.current_map.mapping_url][LOWER_TEXT(sanitize_css_class_name(SSmapping.current_map.map_name))]/?x=[mob.x]&y=[mob.y]&zoom=6")
+				src << link("[SSmapping.current_map.mapping_url]/?x=[mob.x]&y=[mob.y]&zoom=6")
 			else
-				src << link("[SSmapping.current_map.mapping_url][LOWER_TEXT(sanitize_css_class_name(SSmapping.current_map.map_name))]")
+				src << link("[SSmapping.current_map.mapping_url]")
 	if (hsrc)
 		var/datum/real_src = hsrc
 		if(QDELETED(real_src))

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -11,7 +11,8 @@ Format:
 	voteweight [number] (How much to count each player vote as, defaults to 1, setting to 0.5 counts each vote as half a vote, 2 as double, etc, Setting to 0 disables the map but allows players to still pick it)
 	disabled (disables the map)
 	votable (is this map votable)
-	feedbackurl (link in-game shown to players to leave feedback for the map)
+	feedbacklink (link in-game shown to players to leave feedback for the map)
+	webmap_url (link to the a webmap to see the map in the user's browser)
 endmap
 
 # Production-level maps.
@@ -37,6 +38,7 @@ map metastation
 	#voteweight 0.5
 	votable
 	#feedbacklink https://www.youtube.com/watch?v=XG8b7WhANNA
+	#webmap_url https://webmap.affectedarc07.co.uk/maps/tgstation/metastation
 endmap
 
 map tramstation


### PR DESCRIPTION
## About The Pull Request

Currently the button to open a map in webmap is tied to a config entry, which would then take the name of the map being played and get the link to that, however for cases like new/tested/admin uploaded maps where there is no webmap available, this would still have a link to a url that doesn't exist.
Instead, we'll make the webmap link be in ``maps.txt``, same as feedbacklink.

## Why It's Good For The Game

Explained in the about section, this prevents webmaps appearing for maps that aren't supposed to have a webmap link available.

## Changelog

Nothing player-facing, webmaps aren't currently used (afaik) currently cause they're broken for tg codebases.