### PR TITLE
Allow boats to travel over water

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -140,12 +140,12 @@
 /datum/component/riding/vehicle/lavaboat
 	ride_check_flags = NONE // not sure
 	keytype = /obj/item/oar
-	/// The one turf we can move on.
-	var/allowed_turf = /turf/open/lava
+	/// The turfs we can move on.
+	var/allowed_turfs = list(/turf/open/lava, /turf/open/water)
 
 /datum/component/riding/vehicle/lavaboat/Initialize(mob/living/riding_mob, force, ride_check_flags, potion_boost)
 	. = ..()
-	allowed_turf_typecache = typecacheof(allowed_turf)
+	allowed_turf_typecache = typecacheof(allowed_turfs)
 
 /datum/component/riding/vehicle/lavaboat/get_parent_offsets_and_layers()
 	return list(

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -11,7 +11,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	can_buckle = TRUE
 	key_type = /obj/item/oar
-	var/allowed_turf = /turf/open/lava
 
 /obj/vehicle/ridden/lavaboat/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Since we now have deep water that makes people drown, it makes sense to go the extra mile and incorporate the ability for boats to travel over water. This should allow some cool mapping stuff where you can make islands that are only reachable by boat.

## Why It's Good For The Game
Mapping benefits.

## Changelog
:cl:
add: Allow boats to travel over water
/:cl:
