### PR TITLE
Configurable Spy Bounties

### DIFF
--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -1,3 +1,38 @@
+/// Spy config: Changes the amount of time between bounty refreshes
+/datum/config_entry/number/spy_bounty_refresh_timer
+	default = 12 MINUTES
+	min_val = 2 MINUTES
+	// You can set this to like, 100 hours if you really wanted
+
+/// Spy config: Changes the amount of easy bounties given out at once
+/datum/config_entry/number/spy_bounty_max_easy
+	default = 4
+	min_val = 1
+	max_val = 8 // More bounties would need to be added
+	integer = TRUE
+
+/// Spy config: Changes the amount of medium bounties given out at once
+/datum/config_entry/number/spy_bounty_max_medium
+	default = 2
+	min_val = 1
+	max_val = 6 // More bounties would need to be added
+	integer = TRUE
+
+/// Spy config: Changes the amount of hard bounties given out at once
+/datum/config_entry/number/spy_bounty_max_hard
+	default = 2
+	min_val = 1
+	max_val = 4 // More bounties would need to be added
+	integer = TRUE
+
+/// Spy config: Adjusts how many hard bounties are given out per refresh.
+/// At 1 (default), every refresh gives another hard bounty up until the max is reached.
+/// At 0.5, it will take two refreshes before a second hard bounty is given.
+/datum/config_entry/number/spy_bounty_hard_bounties_per_refresh
+	default = 1
+	min_val = 0.1
+	// Some arbitrarily large number would just result in max hard bounties on first refresh
+
 /**
  * ## Spy bounty handler
  *
@@ -16,7 +51,8 @@
 	/// List of all items stolen in the last pool of bounties.
 	/// Same as above - strings that represent stolen items.
 	var/list/claimed_bounties_from_last_pool = list()
-	/// Override for the number of attempts to make a bounty.
+	/// When rolling for bounties, the number of attempts is calculated based on the number of bounties to give out.
+	/// This number will override that calculation with a set value - used for testing and debugging.
 	var/num_attempts_override = 0
 
 	/// Assoc list that dictates how much of each bounty difficulty to give out at once.
@@ -51,6 +87,13 @@
 	)
 
 /datum/spy_bounty_handler/New()
+	refresh_time = CONFIG_GET(number/spy_bounty_refresh_timer)
+	base_bounties_to_give = list(
+		SPY_DIFFICULTY_EASY = CONFIG_GET(number/spy_bounty_max_easy),
+		SPY_DIFFICULTY_MEDIUM = CONFIG_GET(number/spy_bounty_max_medium),
+		SPY_DIFFICULTY_HARD = CONFIG_GET(number/spy_bounty_max_hard),
+	)
+
 	for(var/datum/spy_bounty/bounty as anything in subtypesof(/datum/spy_bounty))
 		var/weight = initial(bounty.weight)
 		var/difficulty = initial(bounty.difficulty)
@@ -88,10 +131,13 @@
 	PRIVATE_PROC(TRUE)
 
 	var/list/bounties_to_give = base_bounties_to_give.Copy()
+	// The game doesnt start giving out hard bounties until some number of refreshes have passed
+	var/hard_bounties = min(floor(num_refreshes * CONFIG_GET(number/spy_bounty_hard_bounties_per_refresh)), base_bounties_to_give[SPY_DIFFICULTY_HARD])
+	// These hard bounties are given out as medium bounties instead
+	var/converted_medium_bounties = max(0, base_bounties_to_give[SPY_DIFFICULTY_HARD] - hard_bounties)
 
-	if(num_refreshes < base_bounties_to_give[SPY_DIFFICULTY_HARD])
-		bounties_to_give[SPY_DIFFICULTY_HARD] = num_refreshes
-		bounties_to_give[SPY_DIFFICULTY_MEDIUM] += (base_bounties_to_give[SPY_DIFFICULTY_HARD] - num_refreshes)
+	bounties_to_give[SPY_DIFFICULTY_HARD] = hard_bounties
+	bounties_to_give[SPY_DIFFICULTY_MEDIUM] += converted_medium_bounties
 
 	for(var/difficulty in bounties)
 		QDEL_LIST(bounties[difficulty])

--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -33,6 +33,18 @@
 	min_val = 0.1
 	// Some arbitrarily large number would just result in max hard bounties on first refresh
 
+/// Spy config: Adjusts the tc threshold for easy bounties.
+/datum/config_entry/number/spy_easy_reward_tc_threshold
+	default = SPY_LOWER_COST_THRESHOLD
+	min_val = 0
+	integer = TRUE
+
+/// Spy config: Adjusts the tc threshold for hard bounties.
+/datum/config_entry/number/spy_hard_reward_tc_threshold
+	default = SPY_UPPER_COST_THRESHOLD + 1
+	min_val = 0
+	integer = TRUE
+
 /**
  * ## Spy bounty handler
  *
@@ -108,11 +120,11 @@
 			continue
 		// This will have some overlap, and that's intentional -
 		// Adds some variety, rare moments where you can get a hard reward for an easier bounty (or visa versa)
-		if(item.cost <= SPY_LOWER_COST_THRESHOLD)
+		if(item.cost <= CONFIG_GET(number/spy_easy_reward_tc_threshold))
 			possible_uplink_items[SPY_DIFFICULTY_EASY] += item
-		if(item.cost >= SPY_LOWER_COST_THRESHOLD && item.cost <= SPY_UPPER_COST_THRESHOLD)
+		if(item.cost >= CONFIG_GET(number/spy_easy_reward_tc_threshold) && item.cost <= CONFIG_GET(number/spy_hard_reward_tc_threshold))
 			possible_uplink_items[SPY_DIFFICULTY_MEDIUM] += item
-		if(item.cost >= SPY_UPPER_COST_THRESHOLD)
+		if(item.cost >= CONFIG_GET(number/spy_hard_reward_tc_threshold))
 			possible_uplink_items[SPY_DIFFICULTY_HARD] += item
 
 	refresh_bounty_list()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -571,11 +571,11 @@ SPY_BOUNTY_MAX_MEDIUM 2
 SPY_BOUNTY_MAX_HARD 2
 ## Changes amount of refreshes necessary per each hard bounty
 ## 1 = A hard bounty is added per refresh (until the max)
-## 0.5 = A hard bounty is added every 2 refreshes (until the max)
+## 0.5 = A hard bounty is added every 2 refreshes (until the max).
 SPY_BOUNTY_HARD_BOUNTIES_PER_REFRESH 1
 ## Easy bounties grant uplink rewards that cost this much TC (or lower).
 ## Also functions as the lower end for medium bounties.
 SPY_EASY_REWARD_TC_THRESHOLD 5
-## Hard bounties grant uplink rewards that cost this much TC (or lower).
+## Hard bounties grant uplink rewards that cost this much TC (or higher).
 ## Also functions as the upper end for medium bounties.
 SPY_HARD_REWARD_TC_THRESHOLD 15

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -559,3 +559,17 @@ RANDOM_LOOT_WEIGHT_MODIFIER 1
 ## Custom shuttle spam prevention. Changine these numbers allows you to change the maxsize and amount of custom shuttles.
 MAX_SHUTTLE_COUNT 6
 MAX_SHUTTLE_SIZE 300
+
+### Spy config
+## Changes refresh period between bounties - in deciseconds
+SPY_BOUNTY_REFRESH_TIMER 7200
+## Changes amount of easy bounties offered at once. Limit = 8
+SPY_BOUNTY_MAX_EASY 4
+## Changes amount of medium bounties offered at once. Limit = 6
+SPY_BOUNTY_MAX_MEDIUM 2
+## Changes amount of hard bounties offered at once. Limit = 4
+SPY_BOUNTY_MAX_HARD 2
+## Changes amount of refreshes necessary per each hard bounty
+## 1 = A hard bounty is added per refresh (until the max)
+## 0.5 = A hard bounty is added every 2 refreshes (until the max)
+SPY_BOUNTY_HARD_BOUNTIES_PER_REFRESH 1

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -573,7 +573,9 @@ SPY_BOUNTY_MAX_HARD 2
 ## 1 = A hard bounty is added per refresh (until the max)
 ## 0.5 = A hard bounty is added every 2 refreshes (until the max)
 SPY_BOUNTY_HARD_BOUNTIES_PER_REFRESH 1
-## Easy bounties grant uplink rewards that cost this much TC (or lower). Also functions as the lower end for medium bounties.
+## Easy bounties grant uplink rewards that cost this much TC (or lower).
+## Also functions as the lower end for medium bounties.
 SPY_EASY_REWARD_TC_THRESHOLD 5
-## Hard bounties grant uplink rewards that cost this much TC (or lower). Also functions as the upper end for medium bounties.
+## Hard bounties grant uplink rewards that cost this much TC (or lower).
+## Also functions as the upper end for medium bounties.
 SPY_HARD_REWARD_TC_THRESHOLD 15

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -573,3 +573,7 @@ SPY_BOUNTY_MAX_HARD 2
 ## 1 = A hard bounty is added per refresh (until the max)
 ## 0.5 = A hard bounty is added every 2 refreshes (until the max)
 SPY_BOUNTY_HARD_BOUNTIES_PER_REFRESH 1
+## Easy bounties grant uplink rewards that cost this much TC (or lower). Also functions as the lower end for medium bounties.
+SPY_EASY_REWARD_TC_THRESHOLD 5
+## Hard bounties grant uplink rewards that cost this much TC (or lower). Also functions as the upper end for medium bounties.
+SPY_HARD_REWARD_TC_THRESHOLD 15


### PR DESCRIPTION
## About The Pull Request

```
### Spy config
## Changes refresh period between bounties - in deciseconds
SPY_BOUNTY_REFRESH_TIMER 7200
## Changes amount of easy bounties offered at once. Limit = 8
SPY_BOUNTY_MAX_EASY 4
## Changes amount of medium bounties offered at once. Limit = 6
SPY_BOUNTY_MAX_MEDIUM 2
## Changes amount of hard bounties offered at once. Limit = 4
SPY_BOUNTY_MAX_HARD 2
## Changes amount of refreshes necessary per each hard bounty
## 1 = A hard bounty is added per refresh (until the max)
## 0.5 = A hard bounty is added every 2 refreshes (until the max)
SPY_BOUNTY_HARD_BOUNTIES_PER_REFRESH 1
## Easy bounties grant uplink rewards that cost this much TC (or lower). 
## Also functions as the lower end for medium bounties.
SPY_EASY_REWARD_TC_THRESHOLD 5
## Hard bounties grant uplink rewards that cost this much TC (or lower). 
## Also functions as the upper end for medium bounties.
SPY_HARD_REWARD_TC_THRESHOLD 15
```

## Why It's Good For The Game

Lets faster or slower paced servers tweak Spy to their desire, either by limiting them to cheaper rewards, slowing the rate at which they get access to stronger rewards, or making it easier by giving them a longer refresh period.

## Changelog

:cl: Melbert
config: Spy Bounties are configurable
/:cl:
