### PR TITLE
Bluespace Light Replacer no longer has a range restriction

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -72,10 +72,6 @@
 	// target not in range
 	if(interacting_with.z != user.z)
 		return NONE
-	// only restrict range if emagged
-	if(obj_flags & EMAGGED && get_dist(interacting_with, user) > 7)
-		user.balloon_alert(user, "out of range!")
-		return ITEM_INTERACT_BLOCKING
 
 	//replace lights & stuff
 	return do_action(interacting_with, user) ? ITEM_INTERACT_SUCCESS : NONE

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -72,8 +72,8 @@
 	// target not in range
 	if(interacting_with.z != user.z)
 		return NONE
-	// target not in view
-	if(!(interacting_with in view(7, get_turf(user))))
+	// only restrict range if emagged
+	if(obj_flags & EMAGGED && get_dist(interacting_with, user) > 7)
 		user.balloon_alert(user, "out of range!")
 		return ITEM_INTERACT_BLOCKING
 


### PR DESCRIPTION

## About The Pull Request

The bluespace light replacer is totally underwhelming by having its range limited to what's in view; this pull request removes the range restriction entirely. Now the only restriction is being on the same z-level.
## Why It's Good For The Game

The bluespace light replacer already can't be emagged, so limiting its range to what's in your immediate view seems pointless; light fixtures are already hard-as-hell to click, so some bored HoP or Warden replacing a few lights through their camera console isn't going to invalidate the janitor. As well, it gives antag janitors a plausible reason to ask for a security camera console to be installed in their office.
## Changelog
:cl: Bisar
qol: Bluespace light replacer no longer has a range limit.
/:cl:
