### PR TITLE
Mech EMP vulnerability changes.

### DIFF
--- a/code/__DEFINES/mecha.dm
+++ b/code/__DEFINES/mecha.dm
@@ -62,6 +62,5 @@
 #define MECHA_AMMO_MOUSETRAP "Mousetrap"
 
 /// Values to determine the effects on a mech should it suffer an EMP
-#define MECHA_BASE_EMP_DAMAGE_PROBABILITY 80
 #define MECH_EMP_DAMAGE_LOWER 100
 #define MECH_EMP_DAMAGE_UPPER 180

--- a/code/__DEFINES/mecha.dm
+++ b/code/__DEFINES/mecha.dm
@@ -60,3 +60,8 @@
 #define MECHA_AMMO_PUNCHING_GLOVE "Punching glove"
 #define MECHA_AMMO_BANANA_PEEL "Banana peel"
 #define MECHA_AMMO_MOUSETRAP "Mousetrap"
+
+/// Values to determine the effects on a mech should it suffer an EMP
+#define MECHA_BASE_EMP_DAMAGE_PROBABILITY 80
+#define MECH_EMP_DAMAGE_LOWER 100
+#define MECH_EMP_DAMAGE_UPPER 180

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -454,9 +454,6 @@
 	update_energy_drain()
 
 	if(capacitor)
-		var/datum/armor/stock_armor = get_armor_by_type(armor_type)
-		var/initial_energy = stock_armor.get_rating(ENERGY)
-		set_armor_rating(ENERGY, initial_energy + (capacitor.rating * 5))
 		overclock_temp_danger = initial(overclock_temp_danger) * capacitor.rating
 	else
 		overclock_temp_danger = initial(overclock_temp_danger)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -171,8 +171,8 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 	if(get_charge())
-		use_energy((cell.charge/3)/(severity*2))
-		take_damage(30 / severity, BURN, ENERGY, 1)
+		use_energy((cell.maxcharge/capacitor.raiting)/severity)
+		take_damage(30 / severity, BURN)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
 	//Mess with the focus of the inbuilt camera if present

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -171,7 +171,7 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 	if(get_charge())
-		use_energy((cell.maxcharge/capacitor.raiting)/severity)
+		use_energy((cell.maxcharge / 3) / (severity * capacitor.rating))
 		take_damage(30 / severity, BURN)
 	log_message("EMP detected", LOG_MECHA, color="red")
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -171,7 +171,7 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 	if(get_charge())
-		use_energy((cell.maxcharge / 3) / (severity * capacitor.rating))
+		use_energy(round((cell.maxcharge / 3) / (severity * capacitor.rating), 1))
 		take_damage(30 / severity, BURN)
 	log_message("EMP detected", LOG_MECHA, color="red")
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -171,7 +171,7 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 	if(get_charge())
-		use_energy(round((cell.maxcharge / 3) / (severity * capacitor.rating), 1))
+		use_energy(round((cell.maxcharge / 2) / (severity * capacitor.rating), 1))
 		take_damage(30 / severity, BURN)
 	log_message("EMP detected", LOG_MECHA, color="red")
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -174,7 +174,7 @@
 	var/mecha_explodies_vulnerability = (severity * capacitor.rating) //The more severe the EMP, the worse the outcome. The higher the tier of the capacitor, the less severe the outcome.
 
 	if(get_charge())
-		use_energy(round((cell.maxcharge / 2) / mecha_explodies_vulnerability 1))
+		use_energy(round((cell.maxcharge / 2) / mecha_explodies_vulnerability, 1))
 
 	var/how_hard_are_we_explodies = rand(MECH_EMP_DAMAGE_LOWER, MECH_EMP_DAMAGE_UPPER)
 	take_damage(how_hard_are_we_explodies / mecha_explodies_vulnerability, BURN)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -170,9 +170,15 @@
 	. = ..()
 	if (. & EMP_PROTECT_SELF)
 		return
+
+	var/mecha_explodies_vulnerability = (severity * capacitor.rating) //The more severe the EMP, the worse the outcome. The higher the tier of the capacitor, the less severe the outcome.
+
 	if(get_charge())
-		use_energy(round((cell.maxcharge / 2) / (severity * capacitor.rating), 1))
-		take_damage(120 / severity * capacitor.rating, BURN)
+		use_energy(round((cell.maxcharge / 2) / mecha_explodies_vulnerability 1))
+
+	var/how_hard_are_we_explodies = rand(MECH_EMP_DAMAGE_LOWER, MECH_EMP_DAMAGE_UPPER)
+	take_damage(how_hard_are_we_explodies / mecha_explodies_vulnerability, BURN)
+
 	log_message("EMP detected", LOG_MECHA, color="red")
 
 	//Mess with the focus of the inbuilt camera if present

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -172,7 +172,7 @@
 		return
 	if(get_charge())
 		use_energy(round((cell.maxcharge / 2) / (severity * capacitor.rating), 1))
-		take_damage(30 / severity, BURN)
+		take_damage(120 / severity * capacitor.rating, BURN)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
 	//Mess with the focus of the inbuilt camera if present


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/tgstation/pull/16607 - As far back as this PR, mech power loss from EMPs was severely dampened. This change was with the expectation that mechs would be shot with ion rifles, and seems as though EMP grenades were not factored at all in how they were meant to interact with mechs.

Additionally, mechs strangely gain armor based on their capacitor value, and this armor value is what is used to determine the damage inflicted from EMPs. This is another design decision with ion rifles in mind, and absolutely no regard to any other type of EMP that the mech may encounter.

In this PR, I've changed how both EMPs damage cell charge, as well as how EMPs damage the mech itself.

### Charge Loss

Charge loss from an EMP now utilities the capacitor tier as a multiplier by which the mech loses charge, based on a fraction of its max charge rather than a fraction of its current charge. This is then impacted by severity.

The formula is as follows

``(Max Cell Charge / 2) / (Severity (Heavy = 1, Light = 2) * Capacitor Tier (1-4)``

Even at maximum capacitor tier, the mech will still lose its entire cell charge in about 8 Heavy EMPs. That's 8 shots from an ion rifle, or 8 EMP grenades. Not accounting for already existing power drain.

### Integrity Loss

Mechs suffer from a varied damage roll. The severity of the damage is affected by how severe the EMP is, and how good the mech's capacitor is. At extremely poor capacitors, EMPs can quickly total a mech. At higher capacitors, mechs will still suffer a considerable amount of damage from EMPs, but it will take a few more hits before it is destroyed.

## Why It's Good For The Game

Mech EMP vulnerability has never really been an effective measure against mechs. Most people know that mechs are durable against a large variety of attacks. And if used correctly, can be exceptionally difficult to bring down.

Their supposed weakness is EMPs. Yet the values used for determining the consequences of getting EMP'd are usually quite meager. They seemed to be designed with ion rifles in mind, but that isn't the typical kind of EMP used most of the time. Usually, you see mechs hit with grenades instead.

The way it works presently, EMP grenades are quite literally next to useless. And that kind of sucks.

We have to bite the bullet somewhere. Mechs need something to bring them back down to the same level as a carbon if their attacker is sufficiently prepared for it, because they otherwise possess a great deal of other protections that leave few options open for how to attack them.

Now, you may ask yourself, PR reader. Doesn't this mean ion rifles will eat mechs alive?

Yes. We'll have a look at the ion rifle at a later date.

## Changelog
:cl:
balance: Mechs are considerably more vulnerable to EMPs than they were previously.
balance: The tier of capacitor inside a mech will substantially improve a mech's defenses against EMP damage. Having only tier 1 capacitors will result in your mech rapidly destroyed from repeat EMPs.
balance: Mechs suffer more power loss from EMPs. It can take upwards of 8 heavy strength EMPs to deplete a mechs cell if it has a tier 4 capacitor. It takes only two if it has a tier 1.
balance: Mechs suffer more integrity loss from EMPs. A durand can withstand around 8 heavy strength EMPs before being destroyed if it has a tier 4 capacitor. It won't survive more than two or three if it has a tier 1.
/:cl:
