### PR TITLE
You can no longer fish for things in storages, or that you are unable to see

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -432,12 +432,15 @@
 		return
 	if(!COOLDOWN_FINISHED(src, casting_cd))
 		return
+	// Inside of storages, or camera weirdness
+	if(target.z != user.z || !(target in view(user.client?.view || world.view, user)))
+		return
 	COOLDOWN_START(src, casting_cd, 1 SECONDS)
 	// skip firing a projectile if the target is adjacent and can be reached (no order windows in the way),
 	// otherwise it may end up hitting other things on its turf, which is problematic
 	// especially for entities with the profound fisher component, which should only work on
 	// proper fishing spots.
-	if(user.CanReach(target, src))
+	if(target.Adjacent(user, null, null, 0))
 		hook_hit(target, user)
 		return
 	casting = TRUE


### PR DESCRIPTION

## About The Pull Request

Closes #90802

## Changelog
:cl:
fix: You can no longer fish for things in storages, or that you are unable to see
/:cl:
