### PR TITLE
Fix faulty wielded force checks

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -9,11 +9,11 @@
 	/// Are we holding the two handed item properly
 	var/wielded = FALSE
 	/// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
-	var/force_multiplier = 0
+	var/force_multiplier
 	/// The force of the item when weilded
-	var/force_wielded = 0
+	var/force_wielded
 	/// The force of the item when unweilded
-	var/force_unwielded = 0
+	var/force_unwielded
 	/// Boolean whether to play sound when wielded
 	var/wieldsound = FALSE
 	/// Boolean whether to play sound when unwielded
@@ -241,9 +241,9 @@
 
 	// update item stats and name
 	var/obj/item/parent_item = parent
-	if(!isnull(force_multiplier))
+	if(force_multiplier > 0)
 		parent_item.force *= force_multiplier
-	else if(!isnull(force_wielded))
+	else if(force_wielded != force_unwielded)
 		parent_item.force = force_wielded
 	if(sharpened_increase)
 		parent_item.force += sharpened_increase

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -291,9 +291,9 @@
 	var/obj/item/parent_item = parent
 	if(sharpened_increase)
 		parent_item.force -= sharpened_increase
-	if(force_multiplier)
+	if(force_multiplier != 1)
 		parent_item.force /= force_multiplier
-	else if(!isnull(force_unwielded))
+	else if(force_unwielded != force_wielded)
 		parent_item.force = force_unwielded
 
 	// update the items name to remove the wielded status

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -9,11 +9,11 @@
 	/// Are we holding the two handed item properly
 	var/wielded = FALSE
 	/// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
-	var/force_multiplier
+	var/force_multiplier = 1
 	/// The force of the item when weilded
-	var/force_wielded
+	var/force_wielded = 0
 	/// The force of the item when unweilded
-	var/force_unwielded
+	var/force_unwielded = 0
 	/// Boolean whether to play sound when wielded
 	var/wieldsound = FALSE
 	/// Boolean whether to play sound when unwielded
@@ -52,7 +52,7 @@
 	wieldsound = FALSE,
 	unwieldsound = FALSE,
 	attacksound = FALSE,
-	force_multiplier = 0,
+	force_multiplier = 1,
 	force_wielded = 0,
 	force_unwielded = 0,
 	icon_wielded = FALSE,
@@ -241,7 +241,7 @@
 
 	// update item stats and name
 	var/obj/item/parent_item = parent
-	if(force_multiplier > 0)
+	if(force_multiplier !== 1)
 		parent_item.force *= force_multiplier
 	else if(force_wielded != force_unwielded)
 		parent_item.force = force_wielded

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -241,7 +241,7 @@
 
 	// update item stats and name
 	var/obj/item/parent_item = parent
-	if(force_multiplier !== 1)
+	if(force_multiplier != 1)
 		parent_item.force *= force_multiplier
 	else if(force_wielded != force_unwielded)
 		parent_item.force = force_wielded


### PR DESCRIPTION
## About The Pull Request

Fixes #90836
Fixes #90841

In a recent merge some checks in `component/two_handed` were changed from `if(!value)` to `if(isnull(value))`.
This change was in error because these values are never null, they default to 0.
I have changed them to more sensible and appropriate numerical checks.

## Changelog

:cl:
fix: Holding a two-handed weapon in both hands will now once again appropriately modify its attack power.
/:cl:
