### PR TITLE
Mech internal damage threshold is no longer 15, but instead a threshold equal to a tenth of the mechs maximum integrity

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -90,8 +90,6 @@
 
 	///Bitflags for internal damage
 	var/internal_damage = NONE
-	/// damage amount above which we can take internal damages
-	var/internal_damage_threshold = 15
 	/// % chance for internal damage to occur
 	var/internal_damage_probability = 20
 	/// list of possibly dealt internal damage for this mech type

--- a/code/modules/vehicles/mecha/mecha_damage.dm
+++ b/code/modules/vehicles/mecha/mecha_damage.dm
@@ -24,6 +24,7 @@
 
 ///tries to deal internal damaget depending on the damage amount
 /obj/vehicle/sealed/mecha/proc/try_deal_internal_damage(damage)
+	var/internal_damage_threshold = (max_intergrity/10) /// Mech internal damage can only occur if the resulting hit exceeds a tenth of the mecha's maximum integrity in a single blow.
 	if(damage < internal_damage_threshold)
 		return
 	if(!prob(internal_damage_probability))

--- a/code/modules/vehicles/mecha/mecha_damage.dm
+++ b/code/modules/vehicles/mecha/mecha_damage.dm
@@ -24,7 +24,7 @@
 
 ///tries to deal internal damaget depending on the damage amount
 /obj/vehicle/sealed/mecha/proc/try_deal_internal_damage(damage)
-	var/internal_damage_threshold = (max_intergrity/10) /// Mech internal damage can only occur if the resulting hit exceeds a tenth of the mecha's maximum integrity in a single blow.
+	var/internal_damage_threshold = (max_integrity/10) /// Mech internal damage can only occur if the resulting hit exceeds a tenth of the mecha's maximum integrity in a single blow.
 	if(damage < internal_damage_threshold)
 		return
 	if(!prob(internal_damage_probability))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.

Ostensibly, this means that a single attack must meet or exceed a damage threshold equal to a tenth of the mech's integrity. Thus, any attack that could kill the mech in about 10 hits.

Here are some thresholds for comparison.

| Mech | Threshold |
| ------------- | ------------- |
| APLU MK-I "Ripley" | 20  |
| APLU MK-II "Ripley" | 25  |
| APLU "Paddy" | 25 |
| APLU "Big Bess" | 10 |
| Clarke | 25 |
| Gygax | 25 |
| Dark Gygax | 30 |
| Durand | 40 |
| Justice | 20 (if it hits) |
| Mauler | 50 |

## Why It's Good For The Game

I think a significant part of why internal integrity damage is as bad as it is is because of the 15 damage threshold being as low as it is. 15 damage is not at all a difficult value to reach. A lot of our most common weapons actually jump past this threshold.

Even if the mech you are using is otherwise fairly durable, sometimes you don't actually get much of a chance to avoid this threshold.

By using max integrity, we can treat internal damage more like you've just sustained a IMMENSE hit in one go, rather than pilots rolling the dice every time they engage with an enemy with even as much as a toolbox.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Rather than rolling for internal damage whenever they suffer 15 or more damage, they instead must suffer an attack that deals at least 10% of its max integrity in a single blow before it rolls for internal damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
