### PR TITLE
Makes it so beacons cannot be attached without first opening the mech panel (this is an alternative PR)

### DIFF
--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -121,7 +121,7 @@
 	chassis = null
 	return ..()
 
-obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/mecha_to_attach, attach_right = FALSE)
+/obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/mecha_to_attach, attach_right = FALSE)
 	if(!(mecha_to_attach.mecha_flags & PANEL_OPEN))
 		return
 	if(!..())

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -121,12 +121,14 @@
 	chassis = null
 	return ..()
 
-/obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/M, attach_right = FALSE)
+obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/mecha_to_attach, attach_right = FALSE)
+	if(!(mecha_to_attach.mecha_flags & PANEL_OPEN))
+		return
 	if(!..())
 		return
-	M.trackers += src
-	M.diag_hud_set_mechtracking()
-	chassis = M
+	mecha_to_attach.trackers += src
+	mecha_to_attach.diag_hud_set_mechtracking()
+	chassis = mecha_to_attach
 
 /**
  * Attempts to EMP mech that the tracker is attached to, if there is one and tracker is not on cooldown


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to this PR https://github.com/tgstation/tgstation/pull/90846

You have to open the mech's panel before you can attach any tracking beacons.

## Why It's Good For The Game

Listen. This shit fucking _sucks._ It sucks. Some dipshit hits you once with a beacon, skidaddles to maint and deletes your mech. It's fucking shit to experience, it takes almost no effort except to be fast getting in and out, and the pilot typically doesn't get much heads up. This has sucked for years. YEARS.

I fully intend on making mechs more vulnerable to an EMP-based demise via this PR here https://github.com/tgstation/tgstation/pull/90830. But this particular cheese strat is probably way, way stronger as a consequence of that PR if it got through. 

For years, the reason this seemingly was kept in was because it was 'necessary' for mech balance. I don't buy it, I never did, it always felt like an oversight that made using mechs in any destructive capacity a crapshoot if one assistant breaks into somewhere with an exofab and prints the beacon and suicide rushes your mech.

Let's fucking bite the bullet and nix this.

Don't merge this without merging https://github.com/tgstation/tgstation/pull/90830 or sec mains will have an aneurysm and kill me with hammers.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: You have to open the mech's panel before you can insert any tracking beacons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
