### PR TITLE
Relatively dirty fix for dept radio custom say emotes

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/original_message = message
 	message = get_message_mods(message, message_mods)
 	saymode = SSradio.saymodes[message_mods[RADIO_KEY]]
-	if (!forced && !saymode)
+	if (!forced && (!saymode || message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT))
 		message = check_for_custom_say_emote(message, message_mods)
 
 	if(!message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

To my understanding, you couldn't do a custom say emote over the departmental radio key `h`, as the code only checked for radio key'd message mods, however the dept radio key isn't considered a normal key, it's a radio extension.

This just adds a secondary check, which allows the mixed emote to work when chatting over the dept key.


This _does_ affect the AI's holopad speech.
Whereas before, using an asterisk would do something like `"This is a good*game guys."
now it'll cut off everything before the asterisk: `"game guys."
I don't personally see much of a problem here, but I can look at fixing that bit if requested.
## Why It's Good For The Game

No more `[Medical] John Smith says, "sighs*I hate this place."`
Rejoice for `[Medical] John Smith sighs, "I hate this place."`

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now do a custom say emote over the dept radio key 'h'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
