### PR TITLE
Slimes with a 0% mutation make perfect copies that also cant mutate

### DIFF
--- a/code/modules/mob/living/basic/slime/actions.dm
+++ b/code/modules/mob/living/basic/slime/actions.dm
@@ -142,7 +142,10 @@
 			baby.befriend(slime_friend)
 
 		babies += baby
-		baby.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
+		if(mutation_chance == 0) //Slimes that cant mutate should make exact copies that also cant mutate
+			baby.mutation_chance = 0
+		else
+			baby.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
 		SSblackbox.record_feedback("tally", "slime_babies_born", 1, baby.slime_type.colour)
 
 	var/mob/living/basic/slime/new_slime = pick(babies) // slime that the OG slime will move into.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If a slime has a 0% mutation chance, its children will also have a 0% mutation chance

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If you go out of your way to make it so slimes have a 0% chance to mutate, then you shouldn't have to worry about future generations suddenly mutating. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

Slimes with 0% mutation chance can no longer create children that can mutate.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Slimes with a 0% mutation chance can no longer create children that can mutate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
