### PR TITLE
Add a compile error when building on 516.1660

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -9,6 +9,11 @@
 #error You need version 516.1648 or higher
 #endif
 
+// 516.1660 broke (x in vars), which breaks a lot of things.
+#if (DM_VERSION == 516 && DM_BUILD == 1660)
+#error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. Visit www.byond.com/download/build to download a newer release of BYOND.
+#endif
+
 // Keep savefile compatibilty at minimum supported level
 /savefile/byond_version = MIN_COMPILER_VERSION
 

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -11,7 +11,7 @@
 
 // 516.1660 broke (x in vars), which breaks a lot of things.
 #if (DM_VERSION == 516 && DM_BUILD == 1660)
-#error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. Visit www.byond.com/download/build to download a newer release of BYOND.
+#error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. If possible, update your BYOND version. Otherwise, visit www.byond.com/download/build to download an older release.
 #endif
 
 // Keep savefile compatibilty at minimum supported level


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a compile error when building on 516.1660, due to this bug: https://www.byond.com/forum/post/2970007

technically this should be a runtime check, but I don't think anyone actually runs SS13 using a .dmb they didn't just compile.

## Why It's Good For The Game

Prevents any sort of confusion on the rare chance someone tries to use this specific broken build.

## Changelog

No user-facing changes.