### PR TITLE
Add Maplint for Multiz+Regular Cables

### DIFF
--- a/tools/maplint/lints/multiz_cables.yml
+++ b/tools/maplint/lints/multiz_cables.yml
@@ -1,0 +1,4 @@
+/obj/structure/grille:
+  banned_neighbors:
+  - /obj/structure/cable
+  - /obj/structure/cable/multilayer/multiz

--- a/tools/maplint/lints/multiz_cables.yml
+++ b/tools/maplint/lints/multiz_cables.yml
@@ -1,5 +1,3 @@
 =/obj/structure/cable/multilayer/multiz:
   banned_neighbors:
   - /obj/structure/cable
-  - /obj/structure/cable/layer1
-  - /obj/structure/cable/layer3

--- a/tools/maplint/lints/multiz_cables.yml
+++ b/tools/maplint/lints/multiz_cables.yml
@@ -1,4 +1,5 @@
-/obj/structure/grille:
+=/obj/structure/cable/multilayer/multiz:
   banned_neighbors:
   - /obj/structure/cable
-  - /obj/structure/cable/multilayer/multiz
+  - /obj/structure/cable/layer1
+  - /obj/structure/cable/layer3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a maplint for multi-z cable adapters being placed on the same turf as a standard cable.

## Why It's Good For The Game

Multi-z cable adapters delete any regular cables on the same turf as them, which causes the create and destroy unit test to fail in an obnoxious way without telling you the location of what's failing. 

Been a while since I've written one of these so hopefully this is correct.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

No player facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
