### PR TITLE
Fix runtime related to pea bullets

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -185,6 +185,6 @@
 		blocked = 100
 		target.visible_message(span_danger("\The [src] is deflected!"), span_userdanger("You are protected against \the [src]!"))
 	. = ..()
-	if(reagents & NO_REACT) //first impact on a noncarbon
+	if(reagents.flags & NO_REACT) //first impact on a noncarbon
 		reagents.flags &= ~(NO_REACT)
 		reagents.handle_reactions()


### PR DESCRIPTION
## About The Pull Request

The peashooter and probably gatfruit runtimes every time a bullet hits because it tries to `&` a datum and a number

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: fixed a runtime related to pea bullet impacts
/:cl:
