### PR TITLE
Fixes items in storages sometimes lingering in observer UI

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1285,19 +1285,23 @@
 	if (!ismob(loc))
 		return ..()
 
-	var/mob/M = loc
-	var/hand_index = M.get_held_index_of_item(src)
+	var/mob/owner = loc
+	var/hand_index = owner.get_held_index_of_item(src)
 	if(!hand_index)
 		return ..()
 
-	M.held_items[hand_index] = null
-	M.update_held_items()
-	if(M.client)
-		M.client.screen -= src
+	owner.held_items[hand_index] = null
+	owner.update_held_items()
+	if(owner.client)
+		owner.client.screen -= src
+	if(owner.observers?.len)
+		for(var/mob/dead/observe as anything in owner.observers)
+			if(observe.client)
+				observe.client.screen -= src
 	layer = initial(layer)
 	SET_PLANE_IMPLICIT(src, initial(plane))
 	appearance_flags &= ~NO_CLIENT_COLOR
-	dropped(M, FALSE)
+	dropped(owner, FALSE)
 	return ..()
 
 /obj/item/proc/canStrip(mob/stripper, mob/owner)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -391,7 +391,7 @@
 	if(observers?.len)
 		for(var/mob/dead/observe as anything in observers)
 			if(observe.client)
-				observe.client.screen -= equipping
+				observe.client.screen -= I
 
 	I.layer = initial(I.layer)
 	SET_PLANE_EXPLICIT(I, initial(I.plane), newloc)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -382,8 +382,7 @@
 		update_held_items()
 
 	if(!I)
-		SEND_SIGNAL(src, COMSIG_MOB_UNEQUIPPED_ITEM, null, force, newloc, no_move, invdrop, silent)
-		return TRUE
+		return FALSE
 
 	if(client)
 		client.screen -= I

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -380,18 +380,29 @@
 	if(hand_index)
 		held_items[hand_index] = null
 		update_held_items()
-	if(I)
-		if(client)
-			client.screen -= I
-		I.layer = initial(I.layer)
-		SET_PLANE_EXPLICIT(I, initial(I.plane), newloc)
-		I.appearance_flags &= ~NO_CLIENT_COLOR
-		if(!no_move && !(I.item_flags & DROPDEL)) //item may be moved/qdel'd immedietely, don't bother moving it
-			if (isnull(newloc))
-				I.moveToNullspace()
-			else
-				I.forceMove(newloc)
-		I.dropped(src, silent)
+
+	if(!I)
+		SEND_SIGNAL(src, COMSIG_MOB_UNEQUIPPED_ITEM, null, force, newloc, no_move, invdrop, silent)
+		return TRUE
+
+	if(client)
+		client.screen -= I
+
+	if(observers?.len)
+		for(var/mob/dead/observe as anything in observers)
+			if(observe.client)
+				observe.client.screen -= equipping
+
+	I.layer = initial(I.layer)
+	SET_PLANE_EXPLICIT(I, initial(I.plane), newloc)
+	I.appearance_flags &= ~NO_CLIENT_COLOR
+	if(!no_move && !(I.item_flags & DROPDEL)) //item may be moved/qdel'd immedietely, don't bother moving it
+		if (isnull(newloc))
+			I.moveToNullspace()
+		else
+			I.forceMove(newloc)
+
+	I.dropped(src, silent)
 	SEND_SIGNAL(I, COMSIG_ITEM_POST_UNEQUIP, force, newloc, no_move, invdrop, silent)
 	SEND_SIGNAL(src, COMSIG_MOB_UNEQUIPPED_ITEM, I, force, newloc, no_move, invdrop, silent)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

doMove on item didn't account for observers, and while doUnEquip should not be an issue, I've added the same observer image removal code as a safeguard to it regardless.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed items in storages sometimes lingering in observer UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
