### PR TITLE
Feeding the supermatter a nuke will make it explode

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -312,9 +312,9 @@
 				header = "Polytechnical Difficulties",
 			)
 		consumed_mob.dust(force = TRUE)
-		matter_increase += 100 * object_size
+		matter_increase += 100 * object_size * 2
 		if(is_clown_job(consumed_mob.mind?.assigned_role))
-			damage_increase += rand(-30, 30) // HONK
+			damage_increase += rand(-30, 30) * 2 // HONK
 	else if(isobj(consumed_object))
 		if(!iseffect(consumed_object))
 			var/suspicion = ""

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -297,6 +297,7 @@
 	var/matter_increase = 0
 	var/damage_increase = 0
 	var/radiation_range = 6
+	var/effects_calculated = FALSE
 
 	if(isliving(consumed_object))
 		var/mob/living/consumed_mob = consumed_object
@@ -315,6 +316,7 @@
 		matter_increase += 100 * object_size * 2
 		if(is_clown_job(consumed_mob.mind?.assigned_role))
 			damage_increase += rand(-30, 30) * 2 // HONK
+		effects_calculated = TRUE
 	else if(isobj(consumed_object))
 		if(!iseffect(consumed_object))
 			var/suspicion = ""
@@ -322,19 +324,30 @@
 				suspicion = "last touched by [consumed_object.fingerprintslast]"
 				message_admins("[atom_source] has consumed [consumed_object], [suspicion] [ADMIN_JMP(atom_source)].")
 			atom_source.investigate_log("has consumed [consumed_object] - [suspicion].", INVESTIGATE_ENGINE)
+
+		var/is_nuke = FALSE
+		if (consumed_object.type == /obj/item/nuke_core) // No subtypes, the supermatter sliver shouldn't trigger this
+			is_nuke = TRUE
+		else if (istype(consumed_object, /obj/machinery/nuclearbomb))
+			var/obj/machinery/nuclearbomb/bomb = consumed_object
+			is_nuke = !!bomb.core
+
+		if (is_nuke)
+			object_size = 10
+			radiation_range *= 2
+			matter_increase += 10000
+			damage_increase += 110
+			effects_calculated = TRUE
+
 		qdel(consumed_object)
-	if(!iseffect(consumed_object) && !isliving(consumed_object))
+
+	if(!iseffect(consumed_object) && !effects_calculated)
 		if(isitem(consumed_object))
 			var/obj/item/consumed_item = consumed_object
 			object_size = consumed_item.w_class
 			matter_increase += 70 * object_size
 		else
 			matter_increase += min(0.5 * consumed_object.max_integrity, 1000)
-	if (istype(consumed_object, /obj/machinery/nuclearbomb) || consumed_object.type == /obj/item/nuke_core) // No subtypes, the supermatter sliver shouldn't trigger this
-		object_size = 10
-		radiation_range *= 2
-		matter_increase += 10000
-		damage_increase += 110
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
 	radiation_pulse(atom_source, max_range = radiation_range, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -315,16 +315,8 @@
 		matter_increase += 100 * object_size
 		if(is_clown_job(consumed_mob.mind?.assigned_role))
 			damage_increase += rand(-30, 30) // HONK
-		consume_returns(matter_increase, damage_increase)
 	else if(isobj(consumed_object))
 		if(!iseffect(consumed_object))
-			if (istype(consumed_object, /obj/machinery/nuclearbomb))
-				var/obj/machinery/nuclearbomb/bomb = consumed_object
-				if (!isnull(bomb.core))
-					object_size = 10
-					radiation_range *= 2
-					matter_increase += 10000
-					damage_increase += 110
 			var/suspicion = ""
 			if(consumed_object.fingerprintslast)
 				suspicion = "last touched by [consumed_object.fingerprintslast]"
@@ -338,6 +330,11 @@
 			matter_increase += 70 * object_size
 		else
 			matter_increase += min(0.5 * consumed_object.max_integrity, 1000)
+	if (istype(consumed_object, /obj/machinery/nuclearbomb) || consumed_object.type == /obj/item/nuke_core) // No subtypes, the supermatter sliver shouldn't trigger this
+		object_size = 10
+		radiation_range *= 2
+		matter_increase += 10000
+		damage_increase += 110
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
 	radiation_pulse(atom_source, max_range = radiation_range, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -296,6 +296,7 @@
 	var/object_size = 0
 	var/matter_increase = 0
 	var/damage_increase = 0
+	var/radiation_range = 6
 
 	if(isliving(consumed_object))
 		var/mob/living/consumed_mob = consumed_object
@@ -317,6 +318,13 @@
 		consume_returns(matter_increase, damage_increase)
 	else if(isobj(consumed_object))
 		if(!iseffect(consumed_object))
+			if (istype(consumed_object, /obj/machinery/nuclearbomb))
+				var/obj/machinery/nuclearbomb/bomb = consumed_object
+				if (!isnull(bomb.core))
+					object_size = 10
+					radiation_range *= 2
+					matter_increase += 10000
+					damage_increase += 110
 			var/suspicion = ""
 			if(consumed_object.fingerprintslast)
 				suspicion = "last touched by [consumed_object.fingerprintslast]"
@@ -332,7 +340,7 @@
 			matter_increase += min(0.5 * consumed_object.max_integrity, 1000)
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
-	radiation_pulse(atom_source, max_range = 6, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)
+	radiation_pulse(atom_source, max_range = radiation_range, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)
 	for(var/mob/living/near_mob in range(10))
 		atom_source.investigate_log("has irradiated [key_name(near_mob)] after consuming [consumed_object].", INVESTIGATE_ENGINE)
 		if (HAS_TRAIT(near_mob, TRAIT_RADIMMUNE) || issilicon(near_mob))


### PR DESCRIPTION
## About The Pull Request

Feeding the nuclear bomb (or its radioactive core) to the Supermatter will cause an oversized radiation pulse, generate a large amount of energy, and immediately damage the supermatter sufficiently to start delaminating.
If the core isn't in the bomb it won't do this (meaning that the beer nuke doesn't do it sorry)

I wish there was a nicer interface for these special supermatter interactions but I also can't be bothered to figure one out right now

ALSO for some reason `consume_returns` was being called twice if a living mob hit the crystal which seems like an unintended bug that has been in the codebase for three years?
I fixed this but also doubled the values being passed into it because at this point I guess those are the values we expect to get for mobs running into the supermatter

## Why It's Good For The Game

Someone posted a clip today of a group of people pushing a nuke into the supermatter and then it ate it and nothing happened.
That is sad, if you feed the supermatter a big bomb full of energy then it should explode.

Damaging it immediately enough for it to explode might be over the top in which case let me know, but having a movable bomb around is reasonably uncommon if nukies aren't on the station as the station one is not usually movable. Traitors extracting the nuke core also cannot be done without a specific traitor objective giving you special tools.
Doing like 90 damage would, with a default supermatter setup, generally just make it yell loudly but then slowly heal itself without any required input which made me sad.

## Changelog

:cl:
balance: The supermatter will react negatively to being fed nuclear fissile materials
/:cl:
