### PR TITLE
Removes 'thrownby' var on items

### DIFF
--- a/code/datums/components/boomerang.dm
+++ b/code/datums/components/boomerang.dm
@@ -64,7 +64,7 @@
 	SIGNAL_HANDLER
 	if (!COOLDOWN_FINISHED(src, last_boomerang_throw) || caught)
 		return
-	aerodynamic_swing(init_throwing_datum, parent)
+	aerodynamic_swing(init_throwing_datum)
 
 /**
  * Proc that triggers when the thrown boomerang does not hit a target.
@@ -75,22 +75,23 @@
 	SIGNAL_HANDLER
 	if(!COOLDOWN_FINISHED(src, last_boomerang_throw))
 		return
-	var/obj/item/true_parent = parent
-	aerodynamic_swing(throwingdatum, true_parent)
+	aerodynamic_swing(throwingdatum)
 
 /**
  * Proc that triggers when the thrown boomerang has been fully thrown, rethrowing the boomerang back to the thrower, and producing visible feedback.
  * * throwing_datum: The thrownthing datum that originally impacted the object, that we use to build the new throwing datum for the rebound.
  * * hit_atom: The atom that has been hit by the boomerang'd object.
  */
-/datum/component/boomerang/proc/aerodynamic_swing(datum/thrownthing/throwingdatum, obj/item/true_parent)
-	var/mob/thrown_by = true_parent.thrownby?.resolve()
+/datum/component/boomerang/proc/aerodynamic_swing(datum/thrownthing/throwingdatum)
+	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/obj/item/true_parent = parent
 	if(thrown_by)
-		addtimer(CALLBACK(true_parent, TYPE_PROC_REF(/atom/movable, throw_at), thrown_by, boomerang_throw_range, throwingdatum.speed, null, TRUE), 0.1 SECONDS)
+		addtimer(CALLBACK(true_parent, TYPE_PROC_REF(/atom/movable, throw_at), thrown_by, boomerang_throw_range, throwingdatum.speed, thrown_by, TRUE), 0.1 SECONDS)
 		COOLDOWN_START(src, last_boomerang_throw, BOOMERANG_REBOUND_INTERVAL)
-	var/mob/thrower = throwingdatum?.get_thrower()
-	true_parent.visible_message(span_danger("[true_parent] is flying back at [thrower]!"), \
-						span_danger("You see [true_parent] fly back at you!"), \
-						span_hear("You hear an aerodynamic woosh!"))
+	true_parent.visible_message(
+		span_danger("[true_parent] is flying back at [thrown_by]!"),
+		span_danger("You see [true_parent] fly back at you!"),
+		span_hear("You hear an aerodynamic woosh!"),
+	)
 
 #undef BOOMERANG_REBOUND_INTERVAL

--- a/code/datums/elements/relay_attackers.dm
+++ b/code/datums/elements/relay_attackers.dm
@@ -74,7 +74,7 @@
 	var/obj/item/hit_item = hit_atom
 	if(!hit_item.throwforce)
 		return
-	var/mob/thrown_by = hit_item.thrownby?.resolve()
+	var/mob/thrown_by = throwingdatum.get_thrower()
 	if(!ismob(thrown_by))
 		return
 	relay_attacker(target, thrown_by, hit_item.damtype == STAMINA ? ATTACKER_STAMINA_ATTACK : ATTACKER_DAMAGING_ATTACK)

--- a/code/datums/proximity_monitor/fields/heretic_arena.dm
+++ b/code/datums/proximity_monitor/fields/heretic_arena.dm
@@ -197,6 +197,7 @@ GLOBAL_LIST_EMPTY(heretic_arenas)
 
 /datum/status_effect/arena_tracker/on_apply()
 	RegisterSignal(owner, SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION), PROC_REF(on_enter_crit))
+	RegisterSignal(owner, COMSIG_MOVABLE_IMPACT_ZONE, PROC_REF(on_impact_zone))
 	RegisterSignal(owner, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(damage_taken))
 	owner.add_traits(list(TRAIT_ELDRITCH_ARENA_PARTICIPANT, TRAIT_NO_TELEPORT), TRAIT_STATUS_EFFECT(id))
 	crown_overlay = mutable_appearance('icons/mob/effects/crown.dmi', "arena_fighter", -HALO_LAYER)
@@ -248,20 +249,22 @@ GLOBAL_LIST_EMPTY(heretic_arenas)
 		last_attacker = WEAKREF(attacking_object.loc)
 		return
 
-	// Track being hit by a mob throwing a stick
-	if(isitem(attacking_object))
-		var/obj/item/thrown_item = attacking_item
-		var/thrown_by = thrown_item.thrownby?.resolve()
-		if(ismob(thrown_by))
-			last_attacker = WEAKREF(thrown_by)
-			return
-
 	// Edge case. If our attacking_item is a gun which the owner has dropped we need to find out who shot us
 	// Track being hit by a mob shooting a stick
 	if(isprojectile(attacking_object))
 		var/obj/projectile/attacking_projectile = attacking_object
 		if(ismob(attacking_projectile.firer))
 			last_attacker = WEAKREF(attacking_projectile.firer)
+
+///Called when impacted by something thrown at us, setting the last attacker to the person throwing the item.
+/datum/status_effect/arena_tracker/proc/on_impact_zone(atom/source, mob/living/hitby, zone, blocked, datum/thrownthing/throwingdatum)
+	SIGNAL_HANDLER
+	// Track being hit by a mob throwing a stick
+	if(!isitem(throwingdatum.thrownthing))
+		return
+	var/thrown_by = throwingdatum.get_thrower()
+	if(ismob(thrown_by))
+		last_attacker = WEAKREF(thrown_by)
 
 /datum/antagonist/heretic_arena_participant
 	name = "Arena Participant"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -890,7 +890,6 @@
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, gentle = FALSE, quickstart = TRUE, throw_type_path = /datum/thrownthing)
 	if(HAS_TRAIT(src, TRAIT_NODROP))
 		return
-	thrownby = WEAKREF(thrower)
 	callback = CALLBACK(src, PROC_REF(after_throw), callback) //replace their callback with our own
 	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, force, gentle, quickstart = quickstart)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -171,8 +171,6 @@
 	///This is a bitfield that defines what variations exist for bodyparts like Digi legs. See: code\_DEFINES\inventory.dm
 	var/supports_variations_flags = NONE
 
-	///A weakref to the mob who threw the item
-	var/datum/weakref/thrownby = null //I cannot verbally describe how much I hate this var
 	///Items can by default thrown up to 10 tiles by TK users
 	tk_throw_range = 10
 

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -71,7 +71,7 @@
 	diceroll(user, in_hand = TRUE)
 
 /obj/item/dice/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	var/mob/thrown_by = thrownby?.resolve()
+	var/mob/thrown_by = throwingdatum.get_thrower()
 	if(thrown_by)
 		diceroll(thrown_by)
 	return ..()

--- a/code/game/objects/items/drug_items.dm
+++ b/code/game/objects/items/drug_items.dm
@@ -64,7 +64,7 @@
 	playsound(src, 'sound/items/ampoule_snap.ogg', 40)
 	update_appearance()
 
-/obj/item/reagent_containers/cup/blastoff_ampoule/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+/obj/item/reagent_containers/cup/blastoff_ampoule/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum, do_splash = TRUE)
 	. = ..()
 	if(.)
 		return
@@ -74,7 +74,7 @@
 	playsound(src, SFX_SHATTER, 40, TRUE)
 	transfer_fingerprints_to(ampoule_shard)
 	spillable = TRUE
-	SplashReagents(hit_atom, TRUE)
+	SplashReagents(hit_atom, throwingdatum)
 	qdel(src)
 	hit_atom.Bumped(ampoule_shard)
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -796,7 +796,7 @@
 /obj/item/melee/baton/security/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!. && active && prob(throw_stun_chance) && isliving(hit_atom))
-		finalize_baton_attack(hit_atom, thrownby?.resolve(), in_attack_chain = FALSE)
+		finalize_baton_attack(hit_atom, throwingdatum.get_thrower(), in_attack_chain = FALSE)
 
 /obj/item/melee/baton/security/emp_act(severity)
 	. = ..()
@@ -925,7 +925,7 @@
 	if(!active)
 		return ..()
 	var/caught = hit_atom.hitby(src, skipcatch = FALSE, hitpush = FALSE, throwingdatum = throwingdatum)
-	var/mob/thrown_by = thrownby?.resolve()
+	var/mob/thrown_by = throwingdatum.get_thrower()
 	if(isliving(hit_atom) && !iscyborg(hit_atom) && !caught && prob(throw_stun_chance))//if they are a living creature and they didn't catch it
 		finalize_baton_attack(hit_atom, thrown_by, in_attack_chain = FALSE)
 

--- a/code/modules/mapfluff/ruins/lavalandruin_code/biodome_winter.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/biodome_winter.dm
@@ -28,7 +28,7 @@
 /obj/item/freeze_cube/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	icon_state = initial(icon_state)
 	var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
-	var/mob/thrown_by = thrownby?.resolve()
+	var/mob/thrown_by = throwingdatum.get_thrower()
 	if(ismovable(hit_atom) && !caught && (!thrown_by || thrown_by && COOLDOWN_FINISHED(src, freeze_cooldown)))
 		freeze_hit_atom(hit_atom)
 	if(thrown_by && !caught)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -219,8 +219,6 @@
 		return ..()
 
 	var/obj/item/thrown_item = AM
-	if(thrown_item.thrownby == WEAKREF(src)) //No throwing stuff at yourself to trigger hit reactions
-		return ..()
 
 	if(check_block(AM, thrown_item.throwforce, "\the [thrown_item.name]", THROWN_PROJECTILE_ATTACK, 0, thrown_item.damtype))
 		hitpush = FALSE
@@ -236,7 +234,7 @@
 	if(blocked)
 		return SUCCESSFUL_BLOCK
 
-	var/mob/thrown_by = thrown_item.thrownby?.resolve()
+	var/mob/thrown_by = throwingdatum.get_thrower()
 	if(thrown_by)
 		log_combat(thrown_by, src, "threw and hit", thrown_item)
 	else

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -219,7 +219,7 @@
 		return ..()
 
 	var/obj/item/thrown_item = AM
-	if(throwingdatum.get_thrower() != WEAKREF(src)) //No throwing stuff at yourself to trigger hit reactions
+	if(throwingdatum.get_thrower() != src) //No throwing stuff at yourself to trigger hit reactions
 		if(check_block(AM, thrown_item.throwforce, "\the [thrown_item.name]", THROWN_PROJECTILE_ATTACK, 0, thrown_item.damtype))
 			hitpush = FALSE
 			skipcatch = TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -219,11 +219,11 @@
 		return ..()
 
 	var/obj/item/thrown_item = AM
-
-	if(check_block(AM, thrown_item.throwforce, "\the [thrown_item.name]", THROWN_PROJECTILE_ATTACK, 0, thrown_item.damtype))
-		hitpush = FALSE
-		skipcatch = TRUE
-		blocked = TRUE
+	if(throwingdatum.get_thrower() != WEAKREF(src)) //No throwing stuff at yourself to trigger hit reactions
+		if(check_block(AM, thrown_item.throwforce, "\the [thrown_item.name]", THROWN_PROJECTILE_ATTACK, 0, thrown_item.damtype))
+			hitpush = FALSE
+			skipcatch = TRUE
+			blocked = TRUE
 
 	var/zone = get_random_valid_zone(BODY_ZONE_CHEST, 65)//Hits a random part of the body, geared towards the chest
 	var/nosell_hit = (SEND_SIGNAL(thrown_item, COMSIG_MOVABLE_IMPACT_ZONE, src, zone, blocked, throwingdatum) & MOVABLE_IMPACT_ZONE_OVERRIDE) // TODO: find a better way to handle hitpush and skipcatch for humans

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -326,7 +326,7 @@
 /mob/living/simple_animal/bot/secbot/hitby(atom/movable/hitting_atom, skipcatch = FALSE, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)
 	if(isitem(hitting_atom))
 		var/obj/item/item_hitby = hitting_atom
-		var/mob/thrown_by = item_hitby.thrownby?.resolve()
+		var/mob/thrown_by = throwingdatum.get_thrower()
 		if(item_hitby.throwforce < src.health && thrown_by && ishuman(thrown_by))
 			var/mob/living/carbon/human/human_throwee = thrown_by
 			retaliate(human_throwee)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -126,7 +126,7 @@
 
 	return ..()
 
-/// Tries to splash the target. Used on both right-click and normal click when in combat mode.
+/// Tries to splash the target, called when right-clicking with a reagent container.
 /obj/item/reagent_containers/proc/try_splash(mob/user, atom/target)
 	if (!spillable)
 		return FALSE
@@ -161,11 +161,6 @@
 
 	for(var/datum/reagent/reagent as anything in reagents.reagent_list)
 		reagent_text += "[reagent] ([num2text(reagent.volume)]),"
-
-	var/mob/thrown_by = thrownby?.resolve()
-	if(isturf(target) && reagents.reagent_list.len && thrown_by)
-		log_combat(thrown_by, target, "splashed (thrown) [english_list(reagents.reagent_list)]")
-		message_admins("[ADMIN_LOOKUPFLW(thrown_by)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] at [ADMIN_VERBOSEJMP(target)].")
 
 	reagents.expose(target, TOUCH)
 	log_combat(user, target, "splashed", reagent_text)
@@ -206,22 +201,21 @@
 /obj/item/reagent_containers/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum, do_splash = TRUE)
 	. = ..()
 	if(do_splash)
-		SplashReagents(hit_atom, TRUE)
+		SplashReagents(hit_atom, throwingdatum)
 
-/obj/item/reagent_containers/proc/bartender_check(atom/target)
+/obj/item/reagent_containers/proc/bartender_check(atom/target, mob/thrown_by)
 	. = FALSE
-	var/mob/thrown_by = thrownby?.resolve()
 	if(target.CanPass(src, get_dir(target, src)) && thrown_by && HAS_TRAIT(thrown_by, TRAIT_BOOZE_SLIDER))
 		. = TRUE
 
-/obj/item/reagent_containers/proc/SplashReagents(atom/target, thrown = FALSE, override_spillable = FALSE)
+/obj/item/reagent_containers/proc/SplashReagents(atom/target, datum/thrownthing/throwingdatum, override_spillable = FALSE)
 	if(!reagents || !reagents.total_volume || (!spillable && !override_spillable))
 		return
-	var/mob/thrown_by = thrownby?.resolve()
+	var/mob/thrown_by = throwingdatum.get_thrower()
 
 	if(ismob(target) && target.reagents)
 		var/splash_multiplier = 1
-		if(thrown)
+		if(throwingdatum)
 			splash_multiplier *= (rand(5,10) * 0.1) //Not all of it makes contact with the target
 		var/mob/M = target
 		var/turf/target_turf = get_turf(target)
@@ -236,7 +230,7 @@
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
 
-	else if(bartender_check(target) && thrown)
+	else if(bartender_check(target, thrown_by) && throwingdatum)
 		visible_message(span_notice("[src] lands onto \the [target] without spilling a single drop."))
 		return
 

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -16,16 +16,16 @@
 	. = ..()
 	if(!.) //if the bottle wasn't caught
 		var/mob/thrower = throwingdatum?.get_thrower()
-		smash(hit_atom, thrower, TRUE)
+		smash(hit_atom, thrower, throwingdatum)
 
-/obj/item/reagent_containers/cup/glass/proc/smash(atom/target, mob/thrower, ranged = FALSE, break_top = FALSE)
+/obj/item/reagent_containers/cup/glass/proc/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top = FALSE)
 	if(!isGlass)
 		return
 	if(QDELING(src) || !target) //Invalid loc
 		return
-	if(bartender_check(target) && ranged)
+	if(bartender_check(target, thrower) && throwingdatum)
 		return
-	SplashReagents(target, ranged, override_spillable = TRUE)
+	SplashReagents(target, throwingdatum, override_spillable = TRUE)
 	var/obj/item/broken_bottle/B = new (loc)
 	B.mimic_broken(src, target, break_top)
 	qdel(src)
@@ -388,10 +388,10 @@
 		base_container_type = /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton, \
 	)
 
-/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/smash(atom/target, mob/thrower, ranged = FALSE)
-	if(bartender_check(target) && ranged)
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
+	if(bartender_check(target, thrower) && throwingdatum)
 		return
-	SplashReagents(target, ranged, override_spillable = TRUE)
+	SplashReagents(target, throwingdatum, override_spillable = TRUE)
 	var/obj/item/broken_bottle/bottle_shard = new (loc)
 	bottle_shard.mimic_broken(src, target)
 	qdel(src)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -122,12 +122,12 @@
 	volume = 50
 	custom_price = PAYCHECK_CREW * 0.9
 
-/obj/item/reagent_containers/cup/glass/bottle/smash(mob/living/target, mob/thrower, ranged = FALSE, break_top)
-	if(bartender_check(target) && ranged)
+/obj/item/reagent_containers/cup/glass/bottle/smash(mob/living/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
+	if(bartender_check(target, thrower) && throwingdatum)
 		return
-	SplashReagents(target, ranged, override_spillable = TRUE)
+	SplashReagents(target, throwingdatum, override_spillable = TRUE)
 	var/obj/item/broken_bottle/broken = new(drop_location())
-	if(!ranged && thrower)
+	if(!throwingdatum && thrower)
 		thrower.put_in_hands(broken)
 	broken.mimic_broken(src, target, break_top)
 	broken.inhand_icon_state = broken_inhand_icon_state
@@ -748,7 +748,7 @@
 			span_danger("You fail your stunt and cut [src] in half, spilling it over you!"),
 			)
 		user.add_mood_event("sabrage_fail", /datum/mood_event/sabrage_fail)
-		return smash(target = user, ranged = FALSE, break_top = TRUE)
+		return smash(target = user, break_top = TRUE)
 
 /obj/item/reagent_containers/cup/glass/bottle/champagne/update_icon_state()
 	. = ..()
@@ -930,7 +930,7 @@
 /obj/item/reagent_containers/cup/glass/bottle/molotov/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum, do_splash = FALSE)
 	..(hit_atom, throwingdatum, do_splash = FALSE)
 
-/obj/item/reagent_containers/cup/glass/bottle/molotov/smash(atom/target, mob/thrower, ranged = FALSE)
+/obj/item/reagent_containers/cup/glass/bottle/molotov/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
 	var/firestarter = 0
 	for(var/datum/reagent/contained_reagent in reagents.reagent_list)
 		for(var/accelerant_type in accelerants)

--- a/code/modules/religion/sparring/sparring_datum.dm
+++ b/code/modules/religion/sparring/sparring_datum.dm
@@ -118,12 +118,14 @@
 
 /datum/sparring_match/proc/thrown_interference(datum/source, atom/movable/thrown_movable, skipcatch = FALSE, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)
 	SIGNAL_HANDLER
-	if(isitem(thrown_movable))
-		var/mob/living/honorbound = source
-		var/obj/item/thrown_item = thrown_movable
-		var/mob/thrown_by = thrown_item.thrownby?.resolve()
-		if(thrown_item.throwforce < honorbound.health && ishuman(thrown_by))
-			INVOKE_ASYNC(src, PROC_REF(flub), thrown_by)
+
+	if(!isitem(thrown_movable))
+		return
+	var/mob/living/honorbound = source
+	var/obj/item/thrown_item = thrown_movable
+	var/mob/thrown_by = throwingdatum.get_thrower()
+	if(thrown_item.throwforce < honorbound.health && ishuman(thrown_by))
+		INVOKE_ASYNC(src, PROC_REF(flub), thrown_by)
 
 /datum/sparring_match/proc/projectile_interference(datum/participant, obj/projectile/proj)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Fully removes thrownby as a var on items, and is now instead handled by throwingdatums' ``get_thrower()`` proc

Also replaces the early return for throwing things at yourself (it now only prevents the call for check_block and therefore hit reaction stuff), since the only way to throw things at yourself is with boomerangs, which currently only works because it doesn't pass you as the thrower for boomerang's return

Speaking of, boomerangs now see the thrower as thrower on returns

Before (Boomerangs don't pass you as the thrower, so it shows you as being hit by nothing):
![image](https://github.com/user-attachments/assets/44c17c02-5618-44c6-b821-2089752946c8)

After (Boomerangs pass you and you can affect yourself, so it sees you hitting yourself & it still batons you):
![image](https://github.com/user-attachments/assets/dafe6212-cf58-4a9d-aae1-3ef97faa5dbd)

This is gonna be used for https://github.com/tgstation/tgstation/pull/90689 as well.

## Why It's Good For The Game

Better logging for boomeranged items, removes a deprecated var and better consistency for thrown items leaving better readability.

## Changelog
:cl:
admin: People throwing boomeranged items and hitting themselves now logs it as them hitting themselves (rather than being hit by the air).
/:cl: