### PR TITLE
Fix health analyzer runtime on cybernetic organs

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -335,7 +335,7 @@
 		var/list/cyberimps
 		for(var/obj/item/organ/target_organ as anything in humantarget.organs)
 			if(IS_ROBOTIC_ORGAN(target_organ) && !(target_organ.organ_flags & ORGAN_HIDDEN))
-				LAZYADD(target_organ, target_organ.examine_title(user))
+				LAZYADD(cyberimps, target_organ.examine_title(user))
 			if(target_organ.organ_flags & ORGAN_MUTANT)
 				mutant = TRUE
 		if(LAZYLEN(cyberimps))


### PR DESCRIPTION

## About The Pull Request
we probably shouldn't add a string to people's organs. that's what lists are for.
## Why It's Good For The Game
I have no health and I must scan
## Changelog
:cl:
fix: Health analyzers properly function on patients with cybernetics
/:cl:
