### PR TITLE
Pre compile builds for tests

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -45,9 +45,16 @@ jobs:
     with:
       max_required_byond_client: ${{ needs.collect_data.outputs.max_required_byond_client }}
 
+  setup_build_artifacts:
+    name: Setup build artifacts
+    needs: collect_data
+    uses: ./.github/workflows/setup_build_artifacts.yml
+    with:
+      build_versions: ${{ needs.collect_data.outputs.required_build_versions }}
+
   run_all_tests:
     name: Integration Tests
-    needs: collect_data
+    needs: [collect_data, setup_build_artifacts]
     uses: ./.github/workflows/perform_regular_version_tests.yml
     with:
       maps: ${{ needs.collect_data.outputs.maps }}
@@ -56,7 +63,7 @@ jobs:
   run_alternate_tests:
     if: needs.collect_data.outputs.alternate_tests != '[]'
     name: Alternate Tests
-    needs: collect_data
+    needs: [collect_data, setup_build_artifacts]
     uses: ./.github/workflows/perform_alternate_version_tests.yml
     with:
       alternate_tests: ${{ needs.collect_data.outputs.alternate_tests }}

--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -12,6 +12,9 @@ on:
       max_required_byond_client:
         description: "The max required byond client version"
         value: ${{ jobs.collect_data.outputs.max_required_byond_client }}
+      required_build_versions:
+        description: "Build versions that need to be precompiled"
+        value: ${{ jobs.collect_data.outputs.required_build_versions }}
 
 jobs:
   collect_data:
@@ -21,6 +24,7 @@ jobs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
       max_required_byond_client: ${{ steps.max_required_byond_client.outputs.max_required_byond_client }}
+      required_build_versions: ${{ steps.setup_required_build_versions.outputs.required_build_versions }}
 
     steps:
       - uses: actions/checkout@v4
@@ -43,3 +47,15 @@ jobs:
           echo "max_required_byond_client=$(grep -Ev '^[[:blank:]]{0,}#{1,}|^[[:blank:]]{0,}$' .github/max_required_byond_client.txt | tail -n1)" >> $GITHUB_OUTPUT
       - name: Set up BYOND cache
         uses: ./.github/actions/restore_or_install_byond
+      - name: Set up required build versions
+        id: setup_required_build_versions
+        run: |
+          DEFAULT_VERSION='[{"major": "${{ env.BYOND_MAJOR }}","minor": "${{ env.BYOND_MINOR }}"}]'
+          ALTERNATE_VERSIONS='${{ steps.alternate_test_finder.outputs.alternate_tests }}'
+
+          REQUIRED_BUILD_VERSIONS=$(jq -nc \
+            --argjson alternate "$ALTERNATE_VERSIONS" \
+            --argjson default "$DEFAULT_VERSION" '
+            ($alternate + $default) | map({major, minor}) | unique
+          ')
+          echo "required_build_versions=$REQUIRED_BUILD_VERSIONS" >> $GITHUB_OUTPUT

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -30,6 +30,16 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
+        with:
+          major: ${{ inputs.major }}
+          minor: ${{ inputs.minor }}
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-${{ inputs.major || env.BYOND_MAJOR }}-${{ inputs.minor || env.BYOND_MINOR}}
+          path: ./
       - name: Setup database
         run: |
           sudo systemctl start mysql
@@ -37,24 +47,12 @@ jobs:
           mysql -u root -proot tg_ci < SQL/tgstation_schema.sql
           mysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'
           mysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
-      - name: Setup Node
-        uses: ./.github/actions/setup_node
       - name: Install rust-g
         run: |
           bash tools/ci/install_rust_g.sh
       - name: Install dreamluau
         run: |
           bash tools/ci/install_dreamluau.sh
-      - name: Restore BYOND from Cache
-        uses: ./.github/actions/restore_or_install_byond
-        with:
-          major: ${{ inputs.major }}
-          minor: ${{ inputs.minor }}
-      - name: Compile Tests
-        id: compile_tests
-        run: |
-          source $HOME/BYOND/byond/bin/byondsetup
-          tools/build/build --ci dm -DCIBUILDING -DANSICOLORS -Werror -ITG0001 -I"loop_checks"
       - name: Run Tests
         id: run_tests
         run: |

--- a/.github/workflows/setup_build_artifact.yml
+++ b/.github/workflows/setup_build_artifact.yml
@@ -1,0 +1,42 @@
+on:
+  workflow_call:
+    inputs:
+      major:
+        required: true
+        type: string
+      minor:
+        required: true
+        type: string
+
+jobs:
+  setup_build_artifact:
+    name: Setup build artifact (${{ format('{0}.{1}', inputs.major, inputs.minor) }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: ./.github/actions/setup_node
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
+        with:
+          major: ${{ inputs.major }}
+          minor: ${{ inputs.minor }}
+      - name: Compile
+        run: |
+          source $HOME/BYOND/byond/bin/byondsetup
+          tools/build/build --ci dm -DCIBUILDING -DANSICOLORS -Werror -ITG0001 -I"loop_checks"
+      - name: Setup variable for output path
+        run: |
+          OUTPUT_DIR="target"
+          echo "OUTPUT_DIR=$OUTPUT_DIR" >> $GITHUB_ENV
+      - name: Copy output files
+        run: |
+          bash tools/ci/copy_build_output.sh $OUTPUT_DIR
+      - name: Upload artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-${{ inputs.major }}-${{ inputs.minor }}
+          path: ${{ env.OUTPUT_DIR }}
+          retention-days: 1

--- a/.github/workflows/setup_build_artifacts.yml
+++ b/.github/workflows/setup_build_artifacts.yml
@@ -1,0 +1,21 @@
+name: Setup build artifacts
+
+on:
+  workflow_call:
+    inputs:
+      build_versions:
+        required: true
+        type: string
+
+jobs:
+  run:
+    uses: ./.github/workflows/setup_build_artifact.yml
+
+    strategy:
+      fail-fast: true
+      matrix:
+        setup: ${{ fromJSON(inputs.build_versions) }}
+
+    with:
+      major: ${{ matrix.setup.major }}
+      minor: ${{ matrix.setup.minor }}

--- a/tools/ci/copy_build_output.sh
+++ b/tools/ci/copy_build_output.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mkdir -p \
+    $1/icons \
+    $1/tgui/public \
+
+cp tgstation.dmb tgstation.rsc $1/
+cp -r icons/* $1/icons/
+cp -r tgui/public/* $1/tgui/public/


### PR DESCRIPTION
## About The Pull Request

Pre compile build and save as artifact for further use in integration and alternate tests.
Which saves us some time on compilation (compilation takes ~50s) for every test - we just download compilation output artifact.

So totally we save 434s ( (50s * 11 tests) - (83s + 3s * 11 tests) ) for runners.

Workflow also supports multiple alternate tests.

<details>
<summary>
Before (per each test)
</summary>

![image](https://github.com/user-attachments/assets/af94f91a-50df-4a30-a51e-751429b55fd5)
</details>

<details>
<summary>
After
</summary>

Once per whole CI
![image](https://github.com/user-attachments/assets/0a31fbd2-145d-4f7f-9ea7-3e674b859da7)

Per each test
![image](https://github.com/user-attachments/assets/a9d5377f-add0-4c27-8f3c-9404915b285c)

</details>

## Changelog

Nothing player facing