### PR TITLE
Fix guardian basic attacks

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -220,12 +220,14 @@
 		return FALSE
 	var/result = target.attack_basic_mob(src, modifiers)
 	SEND_SIGNAL(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, target, result)
+	if(!ignore_cooldown)
+		changeNext_move(melee_attack_cooldown) // Set it again because objects like to fuck with it in attack_basic_mob
 	return result
 
 /mob/living/basic/proc/early_melee_attack(atom/target, list/modifiers, ignore_cooldown = FALSE)
 	face_atom(target)
 	if(!ignore_cooldown)
-		changeNext_move(melee_attack_cooldown)
+		changeNext_move(melee_attack_cooldown) // Set cooldown early in case it is cancelled
 	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, target, Adjacent(target), modifiers) & COMPONENT_HOSTILE_NO_ATTACK)
 		return FALSE //but more importantly return before attack_animal called
 	return TRUE

--- a/code/modules/mob/living/basic/guardian/guardian_types/standard.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/standard.dm
@@ -23,17 +23,19 @@
 
 /mob/living/basic/guardian/standard/do_attack_animation(atom/attacked_atom, visual_effect_icon, used_item, no_effect)
 	. = ..()
-	if (!isliving(attacked_atom) || !isclosedturf(attacked_atom))
+	if (!isliving(attacked_atom) && !isclosedturf(attacked_atom))
 		return
 	var/msg = ""
 	for(var/i in 1 to 9)
 		msg += battlecry
 	say("[msg]!!", ignore_spam = TRUE)
 	for(var/sounds in 1 to 4)
-		addtimer(CALLBACK(src, PROC_REF(do_attack_sound), attacked_atom.loc), sounds DECISECONDS, TIMER_DELETE_ME)
+		addtimer(CALLBACK(src, PROC_REF(do_attack_sound), attacked_atom), sounds DECISECONDS, TIMER_DELETE_ME)
 
 /// Echo our punching sounds
 /mob/living/basic/guardian/standard/proc/do_attack_sound(atom/playing_from)
+	if (QDELETED(playing_from))
+		return
 	playsound(playing_from, attack_sound, 50, TRUE, TRUE)
 
 /// Action to change our battlecry


### PR DESCRIPTION
## About The Pull Request

Fixes #90902

There were a couple of problems:
- The check `if (!isliving(attacked_atom) || !isclosedturf(attacked_atom))` would obviously always early return before performing the war cry because we don't have any walls in the game which are also living mobs. I fixed it.
- Attack chain refactoring meant that attacking nonliving targets as a basic mob would reset the attack cooldown to the default rather than the mob one. Maybe when we kill simple mobs we can remove that code and let basic mobs handle it themselves?
- For some reason we were playing a sound on the loc of an attacked atom instead of the atom, which is an area if you are punching a wall, which runtimes. Now we just play it on the atom, IDK why we weren't doing that.

## Changelog

:cl:
fix: Standard Holoparasites will once again yell their battlecry and can rapidly punch windows.
/:cl:
