### PR TITLE
Fixes ampcheck in smes room, duplicate cables, cameras, and small atmos QoL on CatwalkStation

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -2474,14 +2474,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"aOx" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4;
-	initialize_directions = 12
-	},
-/turf/open/openspace,
-/area/station/engineering/atmos/upper)
 "aOK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -8542,10 +8534,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/vending/engivend,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/yellow/visible{
+	name = "N2 to Airmix"
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
@@ -10833,9 +10826,11 @@
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
 "dmq" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/yellow/visible{
+	name = "O2 to Airmix"
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -11366,8 +11361,8 @@
 "duw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible{
-	dir = 8;
-	initialize_directions = 10;
+	dir = 1;
+	initialize_directions = 5;
 	name = "Air Mix Multideck Adapter"
 	},
 /turf/open/openspace,
@@ -12118,6 +12113,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "dHh" = (
@@ -18965,7 +18961,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "fLj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
@@ -19297,7 +19293,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/multiz/dark/visible,
+/obj/machinery/atmospherics/pipe/multiz/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/upper)
 "fQp" = (
@@ -21435,9 +21431,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
 "gvc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Atmos to Loop"
+/obj/machinery/atmospherics/components/binary/pump/off/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -30014,9 +30009,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iYr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/upper)
 "iYJ" = (
@@ -39552,6 +39545,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"lRK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/vending/engivend,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "lRP" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
@@ -41628,13 +41627,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"mxc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/station/engineering/atmos/upper)
 "mxF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -45364,14 +45356,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "nDT" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/components/binary/pump/off/yellow/visible{
+	dir = 4;
+	name = "Plasma to Multideck"
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/main)
 "nEa" = (
@@ -47959,9 +47952,6 @@
 /turf/open/openspace,
 /area/station/hallway/secondary/construction)
 "ouD" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -47969,6 +47959,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/components/binary/pump/off/yellow/visible{
+	dir = 4;
+	name = "NO2 to Multideck"
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/main)
 "ouE" = (
@@ -59409,13 +59403,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "rPY" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/multiz/dark/visible{
+/obj/machinery/atmospherics/pipe/multiz/orange/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rQg" = (
@@ -65894,6 +65888,7 @@
 /area/station/commons/lounge)
 "tRd" = (
 /obj/structure/cable/layer3,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tRi" = (
@@ -71708,7 +71703,6 @@
 /turf/open/floor/engine/hull/reinforced/air,
 /area/station/ai_monitored/turret_protected/ai)
 "vBq" = (
-/obj/machinery/power/port_gen/pacman,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -75315,6 +75309,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "wFX" = (
@@ -78303,13 +78298,14 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "xDy" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/components/binary/pump/off/yellow/visible{
+	dir = 4;
+	name = "CO2 to Multideck"
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/main)
 "xDB" = (
@@ -120995,15 +120991,15 @@ dCm
 fIg
 eEN
 ehR
-rlX
 ehR
 ehR
 ehR
-rlX
 ehR
 ehR
 ehR
-rlX
+ehR
+ehR
+ehR
 ehR
 ehR
 ehR
@@ -123310,7 +123306,7 @@ xdR
 cBn
 oRw
 xrn
-bdE
+lRK
 utf
 epF
 vya
@@ -190642,8 +190638,8 @@ sWu
 iSN
 unl
 fuI
-aOx
-aOx
+jKe
+vZF
 luN
 xKm
 xxv
@@ -190899,7 +190895,7 @@ lVm
 lVm
 unl
 dcR
-mxc
+jKe
 duw
 cTC
 iKr

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -5571,6 +5571,7 @@
 "bJI" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "bJJ" = (
@@ -17170,7 +17171,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fkv" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -26702,6 +26702,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/openspace,
 /area/station/maintenance/department/engine)
 "hYm" = (
@@ -32915,10 +32916,10 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "jPR" = (
@@ -36253,7 +36254,6 @@
 /area/station/maintenance/starboard/aft)
 "kQV" = (
 /obj/structure/girder,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
@@ -38229,12 +38229,10 @@
 	pixel_x = -1;
 	pixel_y = 7
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "AI Upload Foyer";
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/autoname/directional/north{
 	network = list("aiupload")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "lyK" = (
@@ -41990,11 +41988,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "mDD" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "mDF" = (
@@ -43163,6 +43160,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/openspace,
 /area/station/maintenance/department/engine)
 "mWq" = (
@@ -51572,11 +51570,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
-"pyv" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/electrified_grille,
-/turf/closed/wall/r_wall,
-/area/station/engineering/main)
 "pyw" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/random/maintenance/no_decals,
@@ -52331,6 +52324,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "pKk" = (
@@ -59489,7 +59483,8 @@
 /obj/machinery/modular_computer/preset/engineering{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "rRg" = (
@@ -68960,10 +68955,10 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "uKm" = (
@@ -121002,7 +120997,7 @@ eEN
 ehR
 rlX
 ehR
-pyv
+ehR
 ehR
 rlX
 ehR
@@ -180720,8 +180715,8 @@ wKb
 aGf
 aGf
 aGf
-aGf
 ljf
+aGf
 aGf
 aGf
 aGf
@@ -192183,7 +192178,7 @@ lNP
 kWC
 vGm
 kWC
-xqs
+wHc
 rRf
 mDD
 pUh

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -65888,7 +65888,6 @@
 /area/station/commons/lounge)
 "tRd" = (
 /obj/structure/cable/layer3,
-/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tRi" = (
@@ -71707,6 +71706,7 @@
 	dir = 1
 	},
 /obj/structure/cable/multilayer/connected,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "vBt" = (


### PR DESCRIPTION
## About The Pull Request
Title.

<details>

![image](https://github.com/user-attachments/assets/39705d8d-fc80-46c8-a563-36fc34a0f19f)

<summary>
Fixes ampcheck in smes room.
</details>

Also some atmos improvements
Removed random gas meters from walls in gas chambers

<details>

![image](https://github.com/user-attachments/assets/f4340849-cc70-4284-8f20-a007a3445067)

![image](https://github.com/user-attachments/assets/232ca02d-109e-49a7-8df2-0ca9a8ae2aac)

<summary>
Replaced bridges with pumps to prevent accidental flooding when unwreching random roundstart filled pipe.
</details>


<details>
Black pipe on black planting repainted to orange

![image](https://github.com/user-attachments/assets/4e79d14b-8f43-4324-bc1b-1b088bd0cfe2)

No looping in one place

![image](https://github.com/user-attachments/assets/ceea7a12-1209-4b88-a475-f80e0f8d2434)

<summary>
Other changes for better visibility
</details>



## Why It's Good For The Game
Less bugs.
Unwrenching random pipe should not flood atmos and engine with bad gas.
## Changelog
:cl:
fix: fixed ampcheck in smes room computer, some overlapping cables and cameras on CatwalkStation. Also replaced bridges with pumps in atmos
/:cl:
