### PR TITLE
Grassland Hunt domain doesn't give you a crate for quitting early

### DIFF
--- a/_maps/virtual_domains/grasslands_hunt.dmm
+++ b/_maps/virtual_domains/grasslands_hunt.dmm
@@ -560,9 +560,12 @@
 /turf/open/floor/grass,
 /area/virtual_domain/fullbright)
 "Dk" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
 /obj/effect/landmark/bitrunning/loot_signal,
-/turf/template_noop,
-/area/virtual_domain/safehouse)
+/turf/open/floor/grass,
+/area/virtual_domain/fullbright)
 "DM" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -2476,7 +2479,7 @@ PX
 PX
 PX
 PX
-wq
+Dk
 Lx
 Lx
 Lx
@@ -2555,7 +2558,7 @@ YF
 bd
 fm
 Lx
-Dk
+Lx
 Lx
 od
 Lx

--- a/code/modules/bitrunning/server/map_handling.dm
+++ b/code/modules/bitrunning/server/map_handling.dm
@@ -190,7 +190,7 @@
 		if(isnull(creature))
 			continue
 
-		creature.dust(just_ash = TRUE, force = TRUE) // sometimes mobs just don't die
+		qdel(creature)
 
 	generated_domain.secondary_loot_generated = 0
 


### PR DESCRIPTION

## About The Pull Request

This prevents the Grassland Hunt VDOM from auto-completing when the domain is shut down.

This is because the target mobs are "killed" as the map unloads, and those kills would count towards the domain's win condition. Now, mobs just qdel wholesale when the domain unloads. No death, no funeral.

This ALSO happened because, on the Grassland Hunt domain, the crate point beacon was located directly over the delivery zone. This means that, as the map unloaded, it would dust (kill) the target mobs until the crate spawned in the safehouse (basically the last area to unload), "winning" the domain as it unloads. Now, the beacon has been moved to directly outside the safehouse.

I wasn't sure how to handle this so I went with both solutions at the same time.
## Why It's Good For The Game

Bitrunning isn't a lot of work, but starting and stopping the domain is a bit too easy to warrant a reward.
## Changelog
:cl: Rhials
fix: The grassland hunt domain no longer auto-completes just by closing the domain.
/:cl:
