### PR TITLE
Changes all uses of `notify_ghosts` to use the real names of mobs

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -857,7 +857,7 @@
 	message_admins("[ADMIN_LOOKUPFLW(obsessed)] has been made Obsessed by the midround ruleset.")
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")
 	notify_ghosts(
-		"[obsessed] has developed an obsession with someone!",
+		"[obsessed.real_name] has developed an obsession with someone!",
 		source = obsessed,
 		header = "Love Can Bloom",
 	)

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -275,7 +275,7 @@
 
 	RegisterSignal(owner, COMSIG_ATOM_SPLASHED, PROC_REF(on_splashed))
 	notify_ghosts(
-		"[owner] is blacking out!",
+		"[owner.real_name] is blacking out!",
 		source = owner,
 		header = "Bro I'm not even drunk right now",
 		notify_flags = NOTIFY_CATEGORY_NOFLASH,

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -380,7 +380,7 @@
 		LAZYADD(shields, new /obj/structure/emergency_shield/cult/narsie(shielded_turf))
 
 	notify_ghosts(
-		"[cultist] has begun scribing a Nar'Sie rune!",
+		"[cultist.real_name] has begun scribing a Nar'Sie rune!",
 		source = cultist,
 		header = "Maranax Infirmux!",
 		notify_flags = NOTIFY_CATEGORY_NOFLASH,

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -39,14 +39,19 @@
 		if(deadchat_mode & ANARCHY_MODE) // Choose one, please.
 			stack_trace("deadchat_control component added to [parent.type] with both democracy and anarchy modes enabled.")
 		timerid = addtimer(CALLBACK(src, PROC_REF(democracy_loop)), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
-	notify_ghosts(
-		"[parent] is now deadchat controllable!",
-		source = parent,
-		header = "Ghost Possession!",
-	)
 	if(!ismob(parent) && !SSpoints_of_interest.is_valid_poi(parent))
 		SSpoints_of_interest.make_point_of_interest(parent)
 		generated_point_of_interest = TRUE
+
+	var/parent_name = "[parent]"
+	if(ismob(parent))
+		var/mob/mob_parent = parent
+		parent_name = "[mob_parent.real_name]"
+	notify_ghosts(
+		"[parent_name] is now deadchat controllable!",
+		source = parent,
+		header = "Ghost Possession!",
+	)
 
 /datum/component/deadchat_control/Destroy(force)
 	on_removal?.Invoke()

--- a/code/datums/components/food/ghost_edible.dm
+++ b/code/datums/components/food/ghost_edible.dm
@@ -23,8 +23,13 @@
 	src.bite_chance = bite_chance
 	src.minimum_scale = minimum_scale
 	initial_reagent_volume = atom_parent.reagents.total_volume
+
+	var/parent_name = "[parent]"
+	if(ismob(parent))
+		var/mob/mob_parent = parent
+		parent_name = "[mob_parent.real_name]"
 	notify_ghosts(
-		"[parent] is edible by ghosts!",
+		"[parent_name] is edible by ghosts!",
 		source = parent,
 		header = "Something Tasty!",
 		notify_flags = NOTIFY_CATEGORY_NOFLASH,

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -306,7 +306,7 @@
 		if(istype(consumed_mob, /mob/living/basic/parrot/poly)) // Dusting Poly creates a power surge
 			force_event(/datum/round_event_control/supermatter_surge/poly, "Poly's revenge")
 			notify_ghosts(
-				"[consumed_mob] has been dusted by [atom_source]!",
+				"[consumed_mob.real_name] has been dusted by [atom_source]!",
 				source = atom_source,
 				header = "Polytechnical Difficulties",
 			)

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -96,7 +96,7 @@
 
 	if(carbon_occupant.stat < UNCONSCIOUS)
 		notify_ghosts(
-			"[occupant] is about to be ground up by a malfunctioning organ harvester!",
+			"[carbon_occupant.real_name] is about to be ground up by a malfunctioning organ harvester!",
 			source = src,
 			header = "Gruesome!",
 		)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -125,7 +125,7 @@
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			user.log_message("activated a powersink", LOG_GAME)
 			notify_ghosts(
-				"[user] has activated a power sink!",
+				"[user.real_name] has activated a power sink!",
 				source = src,
 				header = "Shocking News!",
 			)

--- a/code/game/objects/items/devices/reverse_bear_trap.dm
+++ b/code/game/objects/items/devices/reverse_bear_trap.dm
@@ -108,7 +108,7 @@
 	target.equip_to_slot_if_possible(src, ITEM_SLOT_HEAD)
 	arm()
 	notify_ghosts(
-		"[user] put a reverse bear trap on [target]!",
+		"[user.real_name] put a reverse bear trap on [target.real_name]!",
 		source = src,
 		header = "Reverse bear trap armed",
 		notify_flags = NOTIFY_CATEGORY_NOFLASH,

--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -142,7 +142,7 @@
 	if (!(src in user.held_items))
 		return FALSE
 	notify_ghosts(
-		"[user] is shaking [src], hoping to get an answer to \"[selected_message]\"",
+		"[user.real_name] is shaking [src], hoping to get an answer to \"[selected_message]\"",
 		source = src,
 		header = "Magic eightball",
 		click_interact = TRUE,

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -130,7 +130,7 @@
 	target_icon.Blend(icon(icon, icon_state), ICON_OVERLAY)
 	var/mutable_appearance/bomb_target_image = mutable_appearance(target_icon)
 	notify_ghosts(
-		"[user] has planted \a [src] on [target] with a [det_time] second fuse!",
+		"[user.real_name] has planted \a [src] on [target] with a [det_time] second fuse!",
 		source = bomb_target,
 		header = "Explosive Planted",
 		alert_overlay = bomb_target_image,

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -151,7 +151,7 @@
 	adjust_bloodthirst(1)
 	force_bonus = HIS_GRACE_FORCE_BONUS * LAZYLEN(contents)
 	notify_ghosts(
-		"[user] has awoken His Grace!",
+		"[user.real_name] has awoken His Grace!",
 		source = src,
 		header = "All Hail His Grace!",
 	)

--- a/code/game/objects/items/hot_potato.dm
+++ b/code/game/objects/items/hot_potato.dm
@@ -155,7 +155,7 @@
 	active = TRUE
 	if(detonate_explosion) //doesn't send a notification unless it's a genuine, exploding hot potato.
 		notify_ghosts(
-			"[user] has primed a Hot Potato!",
+			"[user.real_name] has primed a Hot Potato!",
 			source = src,
 			header = "Hot Hot Hot!",
 		)

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -129,7 +129,7 @@
 		imp_in.visible_message(span_warning("[imp_in] starts beeping ominously!"))
 		if(notify_ghosts)
 			notify_ghosts(
-				"[imp_in] is about to detonate their explosive implant!",
+				"[imp_in.real_name] is about to detonate their explosive implant!",
 				source = src,
 				header = "Tick Tick Tick...",
 				notify_flags = NOTIFY_CATEGORY_NOFLASH,

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -607,7 +607,7 @@
 	SSblackbox.record_feedback("tally", "heretic_ascended", 1, GLOB.heretic_research_tree[type][HKT_ROUTE])
 	log_heretic_knowledge("[key_name(user)] completed their final ritual at [gameTimestamp()].")
 	notify_ghosts(
-		"[user] has completed an ascension ritual!",
+		"[user.real_name] has completed an ascension ritual!",
 		source = user,
 		header = "A Heretic is Ascending!",
 	)

--- a/code/modules/cards/deck/tarot.dm
+++ b/code/modules/cards/deck/tarot.dm
@@ -54,7 +54,7 @@
 
 	COOLDOWN_START(src, ghost_alert_cooldown, TAROT_GHOST_TIMER)
 	notify_ghosts(
-		"Someone has begun playing with a [src.name] in [get_area(src)]!",
+		"Someone has begun playing with a [name] in [get_area(src)]!",
 		source = src,
 		header = "Haunted Tarot Deck",
 		ghost_sound = 'sound/effects/ghost2.ogg',

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -612,7 +612,7 @@
 		if(istype(potential_fooditem, /obj/item/modular_computer) && prob(75))
 			pda_failure = TRUE
 			notify_ghosts(
-				"[cooker] has overheated their PDA!",
+				"[cooker.real_name] has overheated their PDA!",
 				source = src,
 				notify_flags = NOTIFY_CATEGORY_NOFLASH,
 				header = "Hunger Games: Catching Fire",

--- a/code/modules/mapfluff/ruins/spaceruin_code/garbagetruck.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/garbagetruck.dm
@@ -72,7 +72,7 @@
 	eyeballies.Remove(target)
 	eyeballies.forceMove(get_turf(target))
 	notify_ghosts(
-		"[target] has just had their eyes snatched!",
+		"[target.real_name] has just had their eyes snatched!",
 		source = target,
 		header = "Ouch!",
 	)

--- a/code/modules/mining/lavaland/mining_loot/megafauna/ash_drake.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/ash_drake.dm
@@ -112,7 +112,7 @@
 	COOLDOWN_START(src, summon_cooldown, 60 SECONDS)
 	to_chat(user, span_notice("You call out for aid, attempting to summon spirits to your side."))
 	notify_ghosts(
-		"[user] is raising [user.p_their()] [name], calling for your help!",
+		"[user.real_name] is raising [user.p_their()] [name], calling for your help!",
 		source = user,
 		ignore_key = POLL_IGNORE_SPECTRAL_BLADE,
 		header = "Spectral blade",

--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -239,7 +239,7 @@
 	var/mutable_appearance/alert_overlay = mutable_appearance('icons/obj/aicards.dmi', "pai")
 
 	notify_ghosts(
-		"[user] is requesting a pAI companion! Use the pAI button to submit yourself as one.",
+		"[user.real_name] is requesting a pAI companion! Use the pAI button to submit yourself as one.",
 		source = user,
 		header = "pAI Request!",
 		alert_overlay = alert_overlay,

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -47,7 +47,7 @@
 
 	if(good_kind_of_healing && !reaping && SPT_PROB(0.005, seconds_per_tick)) //janken with the grim reaper!
 		notify_ghosts(
-			"[affected_mob] has entered a game of rock-paper-scissors with death!",
+			"[affected_mob.real_name] has entered a game of rock-paper-scissors with death!",
 			source = affected_mob,
 			header = "Who Will Win?",
 		)

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -50,7 +50,7 @@
 	if(isnull(owner.client))
 		return
 	notify_ghosts(
-		"[owner] has developed spontaneous appendicitis!",
+		"[owner.real_name] has developed spontaneous appendicitis!",
 		source = owner,
 		header = "Whoa, Sick!",
 	)

--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -23,7 +23,7 @@
 		return
 
 	notify_ghosts(
-		"[user] has purchased a BADASS Syndicate Balloon!",
+		"[user.real_name] has purchased a BADASS Syndicate Balloon!",
 		source = .,
 		header = "What are they THINKING?",
 	)


### PR DESCRIPTION

## About The Pull Request

Quite simple - this changes every direct mention of a mob in a `notify_ghosts` message to use `[mob.real_name]` instead of just `[mob]`

## Why It's Good For The Game

makes things less confusing - ghosts can see easily their actual identity anyways, so it's not like there's much of a reason _not_ to do this.

## Changelog
:cl:
qol: Ghost notifications will now use the real names of mobs when something happens (i.e no more "Unknown has completed an ascension ritual!")
/:cl:
