### PR TITLE
Optimize character loading TGUI windows by denying dummies their eyelids

### DIFF
--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -10,6 +10,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 /mob/living/carbon/human/dummy/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_GODMODE, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_PREVENT_BLINKING, INNATE_TRAIT)
 
 /mob/living/carbon/human/dummy/Destroy()
 	in_use = FALSE


### PR DESCRIPTION
## About The Pull Request

I update. One preference. It runs many many calls for `animate_eyelid`. This is extremely resource intensive and we shouldn't do it. The previews do not need to blink anyway.

## Why It's Good For The Game

Makes character previews less expensive on the server-side.

## Changelog

:cl: Chestlet
fix: Removed eyelids from dummies to make all TGUI windows in which they appear more optimized.
/:cl:
