### PR TITLE
Demons can now exit their blood crawl

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -288,7 +288,7 @@
 
 /obj/item/antag_spawner/slaughter_demon/spawn_antag(client/C, turf/T, kind = "", datum/mind/user)
 	var/mob/living/basic/demon/spawned = new demon_type(T)
-	new /obj/effect/dummy/phased_mob(T, spawned)
+	new /obj/effect/dummy/phased_mob/blood(T, spawned)
 
 	spawned.PossessByPlayer(C.key)
 


### PR DESCRIPTION

## About The Pull Request

When a wizard created a demon it had the wrong type of phased mob, its been fixed now.
## Why It's Good For The Game

Demons need to leave blood crawl to actually do things.
## Changelog
:cl:
fix: Wizard spawned demons can now leave their blood crawls and are not stuck in the blood realm forever.
/:cl:
