### PR TITLE
Makes submitting custom command report names intuitive again

### DIFF
--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -60,7 +60,7 @@ function CentComName(props) {
   const [name, setName] = useState(command_name);
 
   function sendName(value) {
-    setName(value)
+    setName(value);
     act('update_command_name', {
       updated_name: value,
     });
@@ -79,7 +79,7 @@ function CentComName(props) {
           fluid
           mt={1}
           value={name}
-          onChange={sendName} //TODO: expensive, replace with setName and use onBlur to send
+          onChange={sendName} // TODO: expensive, replace with setName and use onBlur to send
         />
       )}
     </Section>
@@ -99,7 +99,7 @@ function SubHeader(props) {
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        onChange={(value) => //TODO: expensive, replace with onBlur when added
+        onChange={(value) => // TODO: expensive, replace with onBlur when added
           act('set_subheader', {
             new_subheader: value,
           })

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -78,8 +78,7 @@ function CentComName(props) {
           fluid
           mt={1}
           value={name}
-          onChange={setName}
-          onEnter={sendName}
+          onChange={sendName} //TODO: expensive, replace with setName and use onBlur to send
         />
       )}
     </Section>
@@ -99,7 +98,7 @@ function SubHeader(props) {
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        onChange={(value) =>
+        onChange={(value) => //TODO: expensive, replace with onBlur when added
           act('set_subheader', {
             new_subheader: value,
           })

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -60,6 +60,7 @@ function CentComName(props) {
   const [name, setName] = useState(command_name);
 
   function sendName(value) {
+    setName(value)
     act('update_command_name', {
       updated_name: value,
     });

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -80,7 +80,8 @@ function CentComName(props) {
           fluid
           mt={1}
           value={name}
-          onChange={sendName} // TODO: replace with setName, should send with onBlur
+          // TODO: replace with setName, should send with onBlur
+          onChange={sendName}
         />
       )}
     </Section>
@@ -100,9 +101,8 @@ function SubHeader(props) {
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        onChange={( // TODO: replace with onBlur when added
-          value,
-        ) =>
+        // TODO: replace this with onBlur when added
+        onChange={(value) =>
           act('set_subheader', {
             new_subheader: value,
           })

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -100,7 +100,9 @@ function SubHeader(props) {
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        onChange={(value) => // TODO: replace with onBlur when added
+        onChange={( // TODO: replace with onBlur when added
+          value,
+        ) =>
           act('set_subheader', {
             new_subheader: value,
           })

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -79,7 +79,8 @@ function CentComName(props) {
           fluid
           mt={1}
           value={name}
-          onChange={sendName} // TODO: expensive, replace with setName and use onBlur to send
+          onChange={sendName} // TODO: replace with setName
+          expensive // because this should be onBlur...
         />
       )}
     </Section>
@@ -94,12 +95,12 @@ function SubHeader(props) {
   return (
     <Section title="Set report subheader" textAlign="center">
       <Input
-        expensive
         fluid
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        onChange={(value) => // TODO: expensive, replace with onBlur when added
+        expensive
+        onChange={(value) => // TODO: replace with onBlur when added
           act('set_subheader', {
             new_subheader: value,
           })

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -76,11 +76,11 @@ function CentComName(props) {
       />
       {!!custom_name && (
         <Input
+          expensive
           fluid
           mt={1}
           value={name}
-          onChange={sendName} // TODO: replace with setName
-          expensive // because this should be onBlur...
+          onChange={sendName} // TODO: replace with setName, should send with onBlur
         />
       )}
     </Section>
@@ -95,11 +95,11 @@ function SubHeader(props) {
   return (
     <Section title="Set report subheader" textAlign="center">
       <Input
+        expensive
         fluid
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        expensive
         onChange={(value) => // TODO: replace with onBlur when added
           act('set_subheader', {
             new_subheader: value,


### PR DESCRIPTION
## About The Pull Request
closes #90934 

When the UI input refactor was done, custom command report UI was refactored to be less shit, but in doing so changed how names were submitted. This is unintuitive and isn't well communicated so it was set back to onChange.
Comments were added to relevant places so future readers can know how to fix it

## Changelog

:cl: tonty
admin: Admins no longer need to hit enter to update custom command report names
/:cl: