### PR TITLE
Adds the expected suit storage options for the HoP's winter coat. Extends the armor from the coat to the hood.

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -214,8 +214,13 @@
 	bomb = 10
 	acid = 35
 
+/obj/item/clothing/suit/hooded/wintercoat/hop/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_wintercoat_allowed
+
 /obj/item/clothing/head/hooded/winterhood/hop
 	icon_state = "hood_hop"
+	armor_type =/datum/armor/wintercoat_hop
 
 // Botanist
 /obj/item/clothing/suit/hooded/wintercoat/hydro


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/90439

The PR does what it says in the title.

## Why It's Good For The Game

A) This is actually a suit of armor for the most part. (Though not as good as the HoP's actual coat.)

B) These are supposed to have some parity with the standard uniform.

C) There wasn't really a reason why the hood did not have the same values as the chest as far as I could tell.

## Changelog
:cl:
fix: The HoP's winter coat now uses the correct suit storage options (like the HoP's firearm). The hood now also shares the chest piece's armor values.
/:cl:
