### PR TITLE
Tape recorders record audible emotes and gunshots

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -119,6 +119,10 @@
 	var/is_visual = emote_type & EMOTE_VISIBLE
 	var/is_audible = emote_type & EMOTE_AUDIBLE
 
+	if(is_audible)
+		for(var/obj/item/taperecorder/rec in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, user))
+			rec.hear_non_spoken(msg, user)
+
 	// Emote doesn't get printed to chat, runechat only
 	if(is_runechat)
 		for(var/mob/viewer as anything in viewers(user))

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -114,13 +114,13 @@
 			frequency = rand(MIN_EMOTE_PITCH, MAX_EMOTE_PITCH)
 		playsound(source = user,soundin = tmp_sound,vol = 50, vary = FALSE, ignore_walls = sound_wall_ignore, frequency = frequency)
 
-
+	var/is_runechat = emote_type & EMOTE_RUNECHAT
 	var/is_important = emote_type & EMOTE_IMPORTANT
 	var/is_visual = emote_type & EMOTE_VISIBLE
 	var/is_audible = emote_type & EMOTE_AUDIBLE
 
 	// Emote doesn't get printed to chat, runechat only
-	if(emote_type & EMOTE_RUNECHAT)
+	if(is_runechat)
 		for(var/mob/viewer as anything in viewers(user))
 			if(isnull(viewer.client))
 				continue

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -153,6 +153,7 @@
 	return ..()
 
 
+// hear only saying, not audible emote/shots
 /obj/item/taperecorder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, list/message_mods = list(), message_range)
 	. = ..()
 	if(message_mods[MODE_RELAY] || !mytape || istype(speaker, /obj/item/taperecorder))
@@ -161,6 +162,10 @@
 	mytape.timestamp += mytape.used_capacity
 	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()]: [raw_message]"
 
+/obj/item/taperecorder/proc/hear_raw(message, atom/movable/speaker)
+	if(mytape && recording)
+		mytape.timestamp += mytape.used_capacity
+		mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss")]\] [speaker.GetVoice()] [message]"
 
 /obj/item/taperecorder/verb/record()
 	set name = "Start Recording"

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -156,16 +156,18 @@
 // hear only saying, not audible emote/shots
 /obj/item/taperecorder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, list/message_mods = list(), message_range)
 	. = ..()
-	if(message_mods[MODE_RELAY] || !mytape || istype(speaker, /obj/item/taperecorder))
+	if(message_mods[MODE_RELAY] || !recording || !mytape || istype(speaker, /obj/item/taperecorder))
 		return
 
 	mytape.timestamp += mytape.used_capacity
 	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()]: [raw_message]"
 
 /obj/item/taperecorder/proc/hear_raw(message, atom/movable/speaker)
-	if(mytape && recording)
-		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss")]\] [speaker.GetVoice()] [message]"
+	if(!recording || !mytape || istype(speaker, /obj/item/taperecorder))
+		return
+
+	mytape.timestamp += mytape.used_capacity
+	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()] [message]"
 
 /obj/item/taperecorder/verb/record()
 	set name = "Start Recording"

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -160,14 +160,14 @@
 		return
 
 	mytape.timestamp += mytape.used_capacity
-	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()]: [raw_message]"
+	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()]: \"[raw_message]\""
 
-/obj/item/taperecorder/proc/hear_raw(message, atom/movable/speaker)
+/obj/item/taperecorder/proc/hear_non_spoken(raw_message, atom/movable/speaker)
 	if(!recording || !mytape || istype(speaker, /obj/item/taperecorder))
 		return
 
 	mytape.timestamp += mytape.used_capacity
-	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()] [message]"
+	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss", NO_TIMEZONE)]\] [speaker.GetVoice()] [raw_message]"
 
 /obj/item/taperecorder/verb/record()
 	set name = "Start Recording"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -375,7 +375,7 @@
 	message = "coughs!"
 	message_mime = "acts out an exaggerated cough!"
 	vary = TRUE
-	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE | EMOTE_RUNECHAT
+	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 
 /datum/emote/living/cough/can_run_emote(mob/user, status_check = TRUE , intentional, params)
 	return !HAS_TRAIT(user, TRAIT_SOOTHED_THROAT) && ..()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -375,7 +375,7 @@
 	message = "coughs!"
 	message_mime = "acts out an exaggerated cough!"
 	vary = TRUE
-	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
+	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE | EMOTE_RUNECHAT
 
 /datum/emote/living/cough/can_run_emote(mob/user, status_check = TRUE , intentional, params)
 	return !HAS_TRAIT(user, TRAIT_SOOTHED_THROAT) && ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -361,9 +361,6 @@
 	if(self_message)
 		hearers -= src
 
-	for(var/obj/item/taperecorder/rec in hearers)
-		rec.hear_raw(message, src)
-
 	var/raw_msg = message
 	if(audible_message_flags & EMOTE_MESSAGE)
 		message = span_emote("<b>[src]</b> [message]")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -286,6 +286,7 @@
 
 	if(!islist(ignored_mobs))
 		ignored_mobs = list(ignored_mobs)
+
 	var/list/hearers = get_hearers_in_view(vision_distance, src) //caches the hearers and then removes ignored mobs.
 	hearers -= ignored_mobs
 
@@ -359,9 +360,14 @@
 	var/list/hearers = get_hearers_in_view(hearing_distance, src)
 	if(self_message)
 		hearers -= src
+
+	for(var/obj/item/taperecorder/rec in hearers)
+		rec.hear_raw(message, src)
+
 	var/raw_msg = message
 	if(audible_message_flags & EMOTE_MESSAGE)
 		message = span_emote("<b>[src]</b> [message]")
+
 	for(var/mob/M in hearers)
 		if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags) && M.can_hear())
 			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -207,12 +207,14 @@
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
 	if(recoil && !tk_firing(user))
 		shake_camera(user, recoil + 1, recoil)
+
 	fire_sounds()
+
 	if(suppressed || !message)
 		return FALSE
 
 	for(var/obj/item/taperecorder/rec in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src))
-		rec.hear_raw("making gunshot!", src)
+		rec.hear_non_spoken("making gunshot!", src)
 
 	if(tk_firing(user))
 		visible_message(

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -210,6 +210,10 @@
 	fire_sounds()
 	if(suppressed || !message)
 		return FALSE
+
+	for(var/obj/item/taperecorder/rec in get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src))
+		rec.hear_raw("making gunshot!", src)
+
 	if(tk_firing(user))
 		visible_message(
 			span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),


### PR DESCRIPTION
## About The Pull Request

Adds the ability for a tape recorder to record emotes and gunshots.

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/ce2506b3-ee7d-4421-9b21-791edc439632)

## Changelog

:cl:
qol: improves the use of the tape recorder (record emotes and gunshots)
/:cl:
