### PR TITLE
Construction bag can now hold stacks of rods and stacks of sheets up to size 'small', can also now hold RCD ammo

### DIFF
--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -217,6 +217,9 @@
 		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stock_parts,
 		/obj/item/wallframe/camera,
+		/obj/item/stack/sheet,
+		/obj/item/rcd_ammo,
+		/obj/item/stack/rods,
 	))
 
 ///Harpoon quiver bag


### PR DESCRIPTION

## About The Pull Request

The pull requests's details are captured in the title. The construction bag can now hold these things.
## Why It's Good For The Game

The construction bag being unable to carry the fundamental materials for construction makes no damn sense at all. This makes them able to carry around up to a 'small' size stack of a given material, to facilitate the bag being used for, uh, construction.


https://github.com/user-attachments/assets/a8a7adce-48f3-44da-9221-048d171af501
## Changelog
:cl: Bisar
balance: Construction bags can now carry stacks of material up to size 'small', and can now also carry RCD ammo.
/:cl:
