### PR TITLE
Being intoxicated has a chance for you to not register the trauma of surgery based on intoxication. Puts some whiskey in Tram and Meta's robotics lab. For that authentic back alley surgeon feel.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58270,6 +58270,15 @@
 	pixel_x = 9
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "uBC" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -54775,6 +54775,18 @@
 "soq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science)
+"soD" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 14;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "spk" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -179320,7 +179332,7 @@ xgO
 muZ
 dzu
 doK
-uJH
+soD
 psa
 eQY
 nns

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -174,8 +174,11 @@
 		CRASH("Not passed a target, how did we get here?")
 	if(!surgery_effects_mood)
 		return
-	if(HAS_TRAIT(target, TRAIT_ANALGESIA))
-		target.clear_mood_event(SURGERY_MOOD_CATEGORY) //incase they gained the trait mid-surgery. has the added side effect that if someone has a bad surgical memory/mood and gets drunk & goes back to surgery, they'll forget they hated it, which is kinda funny imo.
+	var/drunken_patient = target.get_drunk_amount()
+	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 100)
+
+	if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && proc(drunken_ignorance_probability))
+		target.clear_mood_event(SURGERY_MOOD_CATEGORY) //incase they gained the trait mid-surgery (or became drunk). has the added side effect that if someone has a bad surgical memory/mood and gets drunk & goes back to surgery, they'll forget they hated it, which is kinda funny imo.
 		return
 	if(target.stat >= UNCONSCIOUS)
 		var/datum/mood_event/surgery/target_mood_event = target.mob_mood?.mood_events[SURGERY_MOOD_CATEGORY]
@@ -320,8 +323,13 @@
  * * mechanical_surgery - Boolean flag that represents if a surgery step is done on a mechanical limb (therefore does not force scream)
  */
 /datum/surgery_step/proc/display_pain(mob/living/target, pain_message, mechanical_surgery = FALSE)
+	// Determine how drunk our patient is
+	var/drunken_patient = target.get_drunk_amount()
+	// Create a probability to ignore the pain based on drunkenness level
+	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 100)
+
 	if(target.stat < UNCONSCIOUS)
-		if(HAS_TRAIT(target, TRAIT_ANALGESIA))
+		if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && prob(drunken_ignorance_probability))
 			if(!pain_message)
 				return
 			to_chat(target, span_notice("You feel a dull, numb sensation as your body is surgically operated on."))

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -179,7 +179,7 @@
 	// Create a probability to ignore the pain based on drunkenness level
 	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 90)
 
-	if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && proc(drunken_ignorance_probability))
+	if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && prob(drunken_ignorance_probability))
 		target.clear_mood_event(SURGERY_MOOD_CATEGORY) //incase they gained the trait mid-surgery (or became drunk). has the added side effect that if someone has a bad surgical memory/mood and gets drunk & goes back to surgery, they'll forget they hated it, which is kinda funny imo.
 		return
 	if(target.stat >= UNCONSCIOUS)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -177,7 +177,7 @@
 	// Determine how drunk our patient is
 	var/drunken_patient = target.get_drunk_amount()
 	// Create a probability to ignore the pain based on drunkenness level
-	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 100)
+	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 90)
 
 	if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && proc(drunken_ignorance_probability))
 		target.clear_mood_event(SURGERY_MOOD_CATEGORY) //incase they gained the trait mid-surgery (or became drunk). has the added side effect that if someone has a bad surgical memory/mood and gets drunk & goes back to surgery, they'll forget they hated it, which is kinda funny imo.
@@ -328,7 +328,7 @@
 	// Determine how drunk our patient is
 	var/drunken_patient = target.get_drunk_amount()
 	// Create a probability to ignore the pain based on drunkenness level
-	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 100)
+	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 90)
 
 	if(target.stat < UNCONSCIOUS)
 		if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && prob(drunken_ignorance_probability))

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -174,7 +174,9 @@
 		CRASH("Not passed a target, how did we get here?")
 	if(!surgery_effects_mood)
 		return
+	// Determine how drunk our patient is
 	var/drunken_patient = target.get_drunk_amount()
+	// Create a probability to ignore the pain based on drunkenness level
 	var/drunken_ignorance_probability = clamp(drunken_patient, 0, 100)
 
 	if(HAS_TRAIT(target, TRAIT_ANALGESIA) || drunken_patient && proc(drunken_ignorance_probability))

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -241,6 +241,10 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/storage/backpack/messenger/science = 3,
 		/obj/item/radio/headset/headset_sci = 2,
 	)
+	premium = list(
+		/obj/item/reagent_containers/cup/glass/bottle/whiskey = 1,
+		/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass = 3,
+	)
 	contraband = list(
 		/obj/item/clothing/under/costume/mech_suit = 2,
 		/obj/item/clothing/suit/hooded/techpriest = 2,
@@ -278,6 +282,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 	payment_department = ACCOUNT_SCI
+
 /obj/item/vending_refill/wardrobe/science_wardrobe
 	machine_name = "SciDrobe"
 

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -241,10 +241,6 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/storage/backpack/messenger/science = 3,
 		/obj/item/radio/headset/headset_sci = 2,
 	)
-	premium = list(
-		/obj/item/reagent_containers/cup/glass/bottle/whiskey = 1,
-		/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass = 3,
-	)
 	contraband = list(
 		/obj/item/clothing/under/costume/mech_suit = 2,
 		/obj/item/clothing/suit/hooded/techpriest = 2,


### PR DESCRIPTION
## About The Pull Request

Based on how intoxicated you are, it is possible for you to avoid obtaining moodlets and screaming from being cut open during surgery.

Adds some whiskey to the Tram and Meta robotics labs, as well as a shot glass to drink it.

## Why It's Good For The Game

Alcohol is a valid anesthetic in this game, but the only way through which you can avoid these moodlets is actually going fully under, so alcohol is less ideal by comparison.

Having the option of liquoring up before surgery to try and tough out the trauma is very on theme with the games themes of medical malpractice. 

On that note, roboticists using alcohol rather than proper anesthetic is equally on brand. I just want to see a robo pessimistically pouring their patient and themself a drink before picking up a scalpel.

## Changelog
:cl:
qol: Being intoxicated enough can potentially beat back the trauma of surgery. It's not reliable.
qol: Robotics on Tram and Metastation have a bottle of whiskey. You know, for taking the edge off.
/:cl:
