### PR TITLE
Weapons that cannot fit into turrets also cannot fit into emitters.

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -45,6 +45,8 @@
 	var/datum/effect_system/spark_spread/sparks
 	///Stores the type of gun we are using inside the emitter
 	var/obj/item/gun/energy/gun
+	///A list of guns we don't want to allow in emitters. Ever.
+	var/list/blacklisted_guns = list(/obj/item/gun/energy/dueling)
 	///List of all the properties of the inserted gun
 	var/list/gun_properties
 	//only used to always have the gun properties on non-letal (no other instances found)
@@ -353,6 +355,9 @@
 	if(!istype(energy_gun, /obj/item/gun/energy))
 		return
 	if(!user.transferItemToLoc(energy_gun, src))
+		return
+	if(is_type_in_list(energy_gun, blacklisted_guns))
+		user.balloon_alert(user, "[energy_gun] won't fit!")
 		return
 	gun = energy_gun
 	gun_properties = gun.get_turret_properties()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -45,8 +45,6 @@
 	var/datum/effect_system/spark_spread/sparks
 	///Stores the type of gun we are using inside the emitter
 	var/obj/item/gun/energy/gun
-	///A list of guns we don't want to allow in emitters. Ever.
-	var/list/blacklisted_guns = list(/obj/item/gun/energy/dueling)
 	///List of all the properties of the inserted gun
 	var/list/gun_properties
 	//only used to always have the gun properties on non-letal (no other instances found)
@@ -356,7 +354,7 @@
 		return
 	if(!user.transferItemToLoc(energy_gun, src))
 		return
-	if(is_type_in_list(energy_gun, blacklisted_guns))
+	if(energy_gun.gun_flags & TURRET_INCOMPATIBLE)
 		user.balloon_alert(user, "[energy_gun] won't fit!")
 		return
 	gun = energy_gun


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/90260

Weapons that cannot fit into turrets can not fit into emitters. This only affects the dueling pistol as of writing.

## Why It's Good For The Game

Sorry everyone, this is TOO fun, we have to turn it around.

## Changelog
:cl:
fix: Weapons that cannot fit into turrets also cannot fit into emitters.
/:cl:
