### PR TITLE
[NO GBP] Bumps tgui-core to v3.1.4, command reports use onBlur

### DIFF
--- a/tgui/packages/tgui-bench/package.json
+++ b/tgui/packages/tgui-bench/package.json
@@ -11,7 +11,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tgui": "workspace:*",
-    "tgui-core": "^3.1.2"
+    "tgui-core": "^3.1.4"
   },
   "devDependencies": {
     "@types/react": "^19.1.0",

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -8,7 +8,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tgui": "workspace:*",
-    "tgui-core": "^3.1.2",
+    "tgui-core": "^3.1.4",
     "tgui-dev-server": "workspace:*"
   },
   "devDependencies": {

--- a/tgui/packages/tgui-say/package.json
+++ b/tgui/packages/tgui-say/package.json
@@ -7,7 +7,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tgui": "workspace:*",
-    "tgui-core": "^3.1.2"
+    "tgui-core": "^3.1.4"
   },
   "devDependencies": {
     "@types/react": "^19.1.0",

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -74,13 +74,7 @@ function CentComName(props) {
         onSelected={sendName}
       />
       {!!custom_name && (
-        <Input
-          fluid
-          mt={1}
-          value={name}
-          onChange={setName}
-          onBlur={sendName}
-        />
+        <Input fluid mt={1} value={name} onChange={setName} onBlur={sendName} />
       )}
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -60,7 +60,6 @@ function CentComName(props) {
   const [name, setName] = useState(command_name);
 
   function sendName(value) {
-    setName(value);
     act('update_command_name', {
       updated_name: value,
     });
@@ -76,12 +75,11 @@ function CentComName(props) {
       />
       {!!custom_name && (
         <Input
-          expensive
           fluid
           mt={1}
           value={name}
-          // TODO: replace with setName, should send with onBlur
-          onChange={sendName}
+          onChange={setName}
+          onBlur={sendName}
         />
       )}
     </Section>
@@ -96,13 +94,11 @@ function SubHeader(props) {
   return (
     <Section title="Set report subheader" textAlign="center">
       <Input
-        expensive
         fluid
         mt={1}
         value={subheader}
         placeholder="Keep blank to not include a subheader"
-        // TODO: replace this with onBlur when added
-        onChange={(value) =>
+        onBlur={(value) =>
           act('set_subheader', {
             new_subheader: value,
           })

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -60,6 +60,7 @@ function CentComName(props) {
   const [name, setName] = useState(command_name);
 
   function sendName(value) {
+    setName(value);
     act('update_command_name', {
       updated_name: value,
     });

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -13,7 +13,7 @@
     "marked": "^4.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tgui-core": "^3.1.2",
+    "tgui-core": "^3.1.4",
     "tgui-dev-server": "workspace:*"
   },
   "devDependencies": {

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -19783,19 +19783,19 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     tgui: "workspace:*"
-    tgui-core: "npm:^3.1.2"
+    tgui-core: "npm:^3.1.4"
   languageName: unknown
   linkType: soft
 
-"tgui-core@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "tgui-core@npm:3.1.2"
+"tgui-core@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "tgui-core@npm:3.1.4"
   dependencies:
     "@floating-ui/react": "npm:^0.27.6"
   peerDependencies:
     react: ^19.1.0
     react-dom: ^19.1.0
-  checksum: 10c0/bac08177a0509f52e8cb1912d85727c27b70de7dd0ca9c8fd3a863c81aca4b3ca52f09a65f75a4f9a0957f9d9ece0f2b0a16861ab05802fcc3375b2695c361bc
+  checksum: 10c0/1f0caef121de74275c08dceef926d4d1e6260eaee32cbe1ee5614456d339de4c887ce13b7b2774674feba37b56bd99204519d3eadcc57b0df3f172aa37644704
   languageName: node
   linkType: hard
 
@@ -19823,7 +19823,7 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     tgui: "workspace:*"
-    tgui-core: "npm:^3.1.2"
+    tgui-core: "npm:^3.1.4"
     tgui-dev-server: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -19838,7 +19838,7 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     tgui: "workspace:*"
-    tgui-core: "npm:^3.1.2"
+    tgui-core: "npm:^3.1.4"
     vitest: "npm:^3.1.1"
   languageName: unknown
   linkType: soft
@@ -19898,7 +19898,7 @@ __metadata:
     marked: "npm:^4.3.0"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
-    tgui-core: "npm:^3.1.2"
+    tgui-core: "npm:^3.1.4"
     tgui-dev-server: "workspace:*"
     vitest: "npm:^3.1.1"
   languageName: unknown


### PR DESCRIPTION
I was supposed to bump it yesterday but I forgor and #90935 got merged... but now it uses the new onBlur and should avoid the expensive polling that acting in onChange would make.

![muh-cat](https://github.com/user-attachments/assets/e0567c39-7781-48c8-88d3-37b9c9294e18)

^ This is me.