### PR TITLE
You fall down stairs if staggered (or in hard crit, or dead)

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -149,6 +149,7 @@
 		if(!guy.has_status_effect(/datum/status_effect/staggered))
 			continue
 		guy.AdjustParalyzed(2 SECONDS)
+		guy.adjust_staggered(2 SECONDS)
 		guy.AdjustKnockdown(5 SECONDS)
 		guy.spin(1 SECONDS, 0.25 SECONDS)
 		guy.apply_damage(rand(4, 8), BRUTE, spread_damage = TRUE)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -142,8 +142,19 @@
 
 /obj/structure/stairs/intercept_zImpact(list/falling_movables, levels = 1)
 	. = ..()
-	if(levels == 1 && isTerminator()) // Stairs won't save you from a steep fall.
-		. |= FALL_INTERCEPTED | FALL_NO_MESSAGE | FALL_RETAIN_PULL
+	// falling from a higher z level onto stairs
+	if(levels != 1 || !isTerminator())
+		return
+	for(var/mob/living/guy in falling_movables)
+		if(!guy.has_status_effect(/datum/status_effect/staggered))
+			continue
+		guy.AdjustParalyzed(2 SECONDS)
+		guy.AdjustKnockdown(5 SECONDS)
+		guy.spin(1 SECONDS, 0.25 SECONDS)
+		guy.apply_damage(rand(4, 8), BRUTE, spread_damage = TRUE)
+		GLOB.move_manager.move_towards(guy, get_ranged_target_turf(src, REVERSE_DIR(dir), 2), delay = 0.4 SECONDS, timeout = 1 SECONDS)
+		to_chat(guy, span_warning("You fall down [src]!"))
+	. |= FALL_INTERCEPTED | FALL_NO_MESSAGE | FALL_RETAIN_PULL
 
 /obj/structure/stairs/proc/isTerminator() //If this is the last stair in a chain and should move mobs up
 	if(terminator_mode != STAIR_TERMINATOR_AUTOMATIC)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -156,7 +156,7 @@
 /obj/structure/stairs/proc/can_fall_down_stairs(mob/living/falling)
 	if(falling.buckled || falling.pulledby)
 		return FALSE
-	if(falling.stat == DEAD) // if you shove a dead guy down the stairs, they'd probably roll
+	if(falling.stat >= HARD_CRIT) // if you shove a dead guy down the stairs, they'd probably roll
 		return TRUE
 	if(falling.has_status_effect(/datum/status_effect/staggered)) // off balance
 		return TRUE

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -146,16 +146,30 @@
 	if(levels != 1 || !isTerminator())
 		return
 	for(var/mob/living/guy in falling_movables)
-		if(!guy.has_status_effect(/datum/status_effect/staggered))
+		if(!can_fall_down_stairs(guy))
 			continue
-		guy.AdjustParalyzed(2 SECONDS)
-		guy.adjust_staggered(2 SECONDS)
-		guy.AdjustKnockdown(5 SECONDS)
-		guy.spin(1 SECONDS, 0.25 SECONDS)
-		guy.apply_damage(rand(4, 8), BRUTE, spread_damage = TRUE)
-		GLOB.move_manager.move_towards(guy, get_ranged_target_turf(src, REVERSE_DIR(dir), 2), delay = 0.4 SECONDS, timeout = 1 SECONDS)
 		to_chat(guy, span_warning("You fall down [src]!"))
+		on_fall(guy)
 	. |= FALL_INTERCEPTED | FALL_NO_MESSAGE | FALL_RETAIN_PULL
+
+/// Will the passed mob tumble down the stairs instead of walking?
+/obj/structure/stairs/proc/can_fall_down_stairs(mob/living/falling)
+	if(falling.buckled || falling.pulledby)
+		return FALSE
+	if(falling.stat == DEAD) // if you shove a dead guy down the stairs, they'd probably roll
+		return TRUE
+	if(falling.has_status_effect(/datum/status_effect/staggered)) // off balance
+		return TRUE
+	return FALSE
+
+/// What happens when a mob tumbles down the stairs
+/obj/structure/stairs/proc/on_fall(mob/living/falling)
+	falling.AdjustParalyzed(2 SECONDS)
+	falling.adjust_staggered(2 SECONDS)
+	falling.AdjustKnockdown(5 SECONDS)
+	falling.spin(1 SECONDS, 0.25 SECONDS)
+	falling.apply_damage(rand(4, 8), BRUTE, spread_damage = TRUE)
+	GLOB.move_manager.move_towards(falling, get_ranged_target_turf(src, REVERSE_DIR(dir), 2), delay = 0.4 SECONDS, timeout = 1 SECONDS)
 
 /obj/structure/stairs/proc/isTerminator() //If this is the last stair in a chain and should move mobs up
 	if(terminator_mode != STAIR_TERMINATOR_AUTOMATIC)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -156,7 +156,7 @@
 /obj/structure/stairs/proc/can_fall_down_stairs(mob/living/falling)
 	if(falling.buckled || falling.pulledby)
 		return FALSE
-	if(falling.stat >= HARD_CRIT) // if you shove a dead guy down the stairs, they'd probably roll
+	if(falling.stat >= UNCONSCIOUS) // if you shove someone unconscious down the stairs, they'd probably roll
 		return TRUE
 	if(falling.has_status_effect(/datum/status_effect/staggered)) // off balance
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Trying to travel down stairs while staggered (like from a shove) will result in you falling down the stairs

This means shove + shove results in someone tumbling down (but not just a single shove)

https://github.com/user-attachments/assets/e5a9eaa5-28c7-4096-ac65-5f44a11196fd

## Why It's Good For The Game

Combats stair combat with stair combat. (Stair swapping is annoying and jank, but giving players a way to punish stair swapping would help counteract that.) 

## Changelog

:cl: Melbert
balance: If you're staggered, and try to walk down stairs, you'll instead fall down the stairs (stunning and causing damage).
balance: Hard crit and dead people will also roll down the stairs.
/:cl:
