### PR TITLE
Fundamentally Evil people no longer get black (and broken) blood

### DIFF
--- a/code/datums/quirks/neutral_quirks/evil.dm
+++ b/code/datums/quirks/neutral_quirks/evil.dm
@@ -15,28 +15,3 @@
 	var/evil_policy = get_policy("[type]") || "Please note that while you may be [LOWER_TEXT(name)], this does NOT give you any additional right to attack people or cause chaos."
 	// We shouldn't need this, but it prevents people using it as a dumb excuse in ahelps.
 	to_chat(quirk_holder, span_big(span_info(evil_policy)))
-	RegisterSignal(quirk_holder, COMSIG_LIVING_CHANGED_BLOOD_TYPE, PROC_REF(make_blood_evil))
-
-/datum/quirk/evil/add(client/client_source)
-	var/mob/living/carbon/human/human_holder = quirk_holder
-	if(!istype(human_holder))
-		return
-	make_blood_evil(human_quirk_holder = human_holder, new_blood_type = human_holder.dna.blood_type)
-
-/datum/quirk/evil/remove()
-	UnregisterSignal(quirk_holder, list(COMSIG_LIVING_CHANGED_BLOOD_TYPE))
-
-/// Get a dynamically generated blood type based off the mob's old blood type and make it 'evil'. Needs to happen whenever the blood type changes.
-/datum/quirk/evil/proc/make_blood_evil(mob/living/carbon/human/human_quirk_holder, datum/blood_type/new_blood_type, update_cached_blood_dna_info)
-	SIGNAL_HANDLER
-
-	// Try to find a corresponding evil blood type for this
-	var/datum/blood_type/evil_blood_type
-	evil_blood_type = get_blood_type("[new_blood_type.id]_but_evil")
-	if(isnull(evil_blood_type)) // this blood type doesn't exist yet in the global list, so make a new one
-		evil_blood_type = new /datum/blood_type/evil(new_blood_type, new_blood_type.compatible_types)
-		GLOB.blood_types[evil_blood_type.id] = evil_blood_type
-	human_quirk_holder.set_blood_type(evil_blood_type)
-
-	if(human_quirk_holder.dna.species.exotic_bloodtype)
-		human_quirk_holder.dna.species.exotic_bloodtype = evil_blood_type

--- a/code/modules/mob/living/blood_types.dm
+++ b/code/modules/mob/living/blood_types.dm
@@ -229,20 +229,3 @@
 
 /datum/blood_type/random_chemical/type_key()
 	return reagent_type
-
-// Similar to the random reagents bloodtype, this one creates a 'but evil' bloodtype
-/datum/blood_type/evil
-	root_abstract_type = /datum/blood_type/evil
-
-/datum/blood_type/evil/New(datum/blood_type/real_blood_type, list/real_compatible_types)
-	src.name = real_blood_type.name
-	. = ..()
-	id = type_key()
-	src.color = BLOOD_COLOR_BLACK // why it gotta be black though
-	src.reagent_type = real_blood_type.reagent_type
-	src.restoration_chem = real_blood_type.reagent_type
-	src.compatible_types = LAZYCOPY(real_compatible_types)
-	src.root_abstract_type = null
-
-/datum/blood_type/evil/type_key()
-	return "[name]_but_evil"


### PR DESCRIPTION

## About The Pull Request

Removes black blood from fundamentally evil people. Its tasteless, makes no sense from an IC perspective, is a dead giveaway that someone is fundamentally evil and also improperly handles compatible types, resulting in it being incompatible with itself (so you get poisoned if you inject your own blood into yourself, lol)

## Why It's Good For The Game

We're overdosing on Homestuck with this one. Its a dead giveaway of an RP quirk with no logic or flavor behind it.

## Changelog
:cl:
del: Fundamentally Evil people no longer get black blood
/:cl:
