### PR TITLE
Prevents protected audio from crashing the server with no survivors

### DIFF
--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -95,7 +95,7 @@
 
 	if(type == "audio/protected")
 		if(!admins_warned)
-			message_admins(span_notice("Audio returned a protected playback error."))
+			message_admins(span_notice("Audio returned a protected playback error, likely due to being copyrighted."))
 			admins_warned = TRUE
 			addtimer(VARSET_CALLBACK(src, admins_warned, FALSE), 10 SECONDS)
 		return TRUE

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -1,6 +1,3 @@
-/// Each client notifies on protected playback, so this prevents spamming admins.
-GLOBAL_VAR_INIT(admins_warned, FALSE)
-
 /*!
  * Copyright (c) 2020 Aleksej Komarov
  * SPDX-License-Identifier: MIT
@@ -15,6 +12,8 @@ GLOBAL_VAR_INIT(admins_warned, FALSE)
 	var/datum/tgui_window/window
 	var/broken = FALSE
 	var/initialized_at
+	/// Each client notifies on protected playback, so this prevents spamming admins.
+	var/static/admins_warned = FALSE
 
 /datum/tgui_panel/New(client/client, id)
 	src.client = client
@@ -95,10 +94,10 @@ GLOBAL_VAR_INIT(admins_warned, FALSE)
 		return TRUE
 
 	if(type == "audio/protected")
-		if(!GLOB.admins_warned)
+		if(!admins_warned)
 			message_admins(span_notice("Audio returned a protected playback error."))
-			GLOB.admins_warned = TRUE
-			addtimer(CALLBACK(src, GLOBAL_PROC_REF(reset_admins_warned)), 10 SECONDS)
+			admins_warned = TRUE
+			addtimer(VARSET_CALLBACK(src, admins_warned, FALSE), 10 SECONDS)
 		return TRUE
 
 	if(type == "telemetry")
@@ -112,8 +111,3 @@ GLOBAL_VAR_INIT(admins_warned, FALSE)
  */
 /datum/tgui_panel/proc/send_roundrestart()
 	window.send_message("roundrestart")
-
-
-/// Resets the global variable that tracks admin warnings.
-/proc/reset_admins_warned()
-	GLOB.admins_warned = FALSE

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -1,5 +1,5 @@
 /// Each client notifies on protected playback, so this prevents spamming admins.
-var/static/admins_warned = FALSE
+GLOBAL_VAR_INIT(admins_warned, FALSE)
 
 /*!
  * Copyright (c) 2020 Aleksej Komarov

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -95,9 +95,9 @@ GLOBAL_VAR_INIT(admins_warned, FALSE)
 		return TRUE
 
 	if(type == "audio/protected")
-		if(!admins_warned)
+		if(!GLOB.admins_warned)
 			message_admins(span_notice("Audio returned a protected playback error."))
-			admins_warned = TRUE
+			GLOB.admins_warned = TRUE
 			addtimer(CALLBACK(src, GLOBAL_PROC_REF(reset_admins_warned)), 10 SECONDS)
 		return TRUE
 
@@ -116,4 +116,4 @@ GLOBAL_VAR_INIT(admins_warned, FALSE)
 
 /// Resets the global variable that tracks admin warnings.
 /proc/reset_admins_warned()
-	admins_warned = FALSE
+	GLOB.admins_warned = FALSE

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -1,3 +1,6 @@
+/// Each client notifies on protected playback, so this prevents spamming admins.
+var/static/admins_warned = FALSE
+
 /*!
  * Copyright (c) 2020 Aleksej Komarov
  * SPDX-License-Identifier: MIT
@@ -86,9 +89,18 @@
 			),
 		))
 		return TRUE
+
 	if(type == "audio/setAdminMusicVolume")
 		client.admin_music_volume = payload["volume"]
 		return TRUE
+
+	if(type == "audio/protected")
+		if(!admins_warned)
+			message_admins(span_notice("Audio returned a protected playback error."))
+			admins_warned = TRUE
+			addtimer(CALLBACK(src, GLOBAL_PROC_REF(reset_admins_warned)), 10 SECONDS)
+		return TRUE
+
 	if(type == "telemetry")
 		analyze_telemetry(payload)
 		return TRUE
@@ -100,3 +112,8 @@
  */
 /datum/tgui_panel/proc/send_roundrestart()
 	window.send_message("roundrestart")
+
+
+/// Resets the global variable that tracks admin warnings.
+/proc/reset_admins_warned()
+	admins_warned = FALSE

--- a/tgui/packages/tgui-panel/audio/player.ts
+++ b/tgui/packages/tgui-panel/audio/player.ts
@@ -71,6 +71,7 @@ export class AudioPlayer {
         Byond.sendMessage('audio/protected');
       }
       logger.log('playback error', JSON.stringify(error));
+      this.stop();
     });
 
     if (this.options.end) {

--- a/tgui/packages/tgui-panel/audio/player.ts
+++ b/tgui/packages/tgui-panel/audio/player.ts
@@ -70,7 +70,7 @@ export class AudioPlayer {
       if (isProtectedError(error)) {
         Byond.sendMessage('audio/protected');
       }
-      logger.log('playback error', JSON.stringify(error));
+      logger.log('playback error:', JSON.stringify(error));
       this.stop();
     });
 
@@ -86,9 +86,10 @@ export class AudioPlayer {
       });
     }
 
-    audio
-      .play()
-      ?.catch((error) => logger.log('playback error', JSON.stringify(error)));
+    audio.play()?.catch(() => {
+      // no error is passed here, it's sent to the event listener
+      logger.log('playback failed');
+    });
 
     this.onPlaySubscribers.forEach((subscriber) => subscriber());
   }

--- a/tgui/packages/tgui-panel/audio/player.ts
+++ b/tgui/packages/tgui-panel/audio/player.ts
@@ -14,6 +14,15 @@ type AudioOptions = {
   end?: number;
 };
 
+function isProtectedError(error: ErrorEvent): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isTrusted' in error &&
+    error.isTrusted
+  );
+}
+
 export class AudioPlayer {
   element: HTMLAudioElement | null;
   options: AudioOptions;
@@ -40,7 +49,13 @@ export class AudioPlayer {
 
     this.options = options;
 
-    const audio = (this.element = new Audio(url));
+    const audio = new Audio(url);
+    if (!audio) {
+      logger.log('failed to create audio element');
+      return;
+    }
+    this.element = audio;
+
     audio.volume = this.volume;
     audio.playbackRate = this.options.pitch || 1;
 
@@ -52,7 +67,10 @@ export class AudioPlayer {
     });
 
     audio.addEventListener('error', (error) => {
-      logger.log('playback error', error);
+      if (isProtectedError(error)) {
+        Byond.sendMessage('audio/protected');
+      }
+      logger.log('playback error', JSON.stringify(error));
     });
 
     if (this.options.end) {
@@ -67,7 +85,9 @@ export class AudioPlayer {
       });
     }
 
-    audio.play()?.catch((error) => logger.log('playback error', error));
+    audio
+      .play()
+      ?.catch((error) => logger.log('playback error', JSON.stringify(error)));
 
     this.onPlaySubscribers.forEach((subscriber) => subscriber());
   }
@@ -78,7 +98,7 @@ export class AudioPlayer {
     logger.log('stopping');
 
     this.element.pause();
-    this.element = null;
+    this.destroy();
 
     this.onStopSubscribers.forEach((subscriber) => subscriber());
   }


### PR DESCRIPTION

## About The Pull Request
Fixes #90694

I believe the heart of this issue is that the audio player was trying to log an error object, but logs only take strings. This should prevent the blue screen and provide admin feedback
## Why It's Good For The Game
- Everyone survives your fatal attempt to play king gizzard the lizard wizard
- Better admin feedback why you cannot play aforementioned song
## Changelog
:cl:
fix: We're no strangers to bugs: Playing protected audio shouldn't crash the server anymore!
/:cl:
