### PR TITLE
Recycler ignores incorporeal mobs

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -197,11 +197,11 @@
 		if(obj_flags & EMAGGED)
 			for(var/CRUNCH in crunchy_nom) // Eat them and keep going because we don't care about safety.
 				if(!isliving(CRUNCH)) // MMIs and brains will get eaten like normal items
-					return
+					continue
 
 				var/mob/living/living_mob = CRUNCH
 				if(living_mob.incorporeal_move)
-					return
+					continue
 
 				if(!is_operational) //we ran out of power after recycling a large amount to living stuff, time to stop
 					break

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -196,11 +196,17 @@
 	if(living_detected) // First, check if we have any living beings detected.
 		if(obj_flags & EMAGGED)
 			for(var/CRUNCH in crunchy_nom) // Eat them and keep going because we don't care about safety.
-				if(isliving(CRUNCH)) // MMIs and brains will get eaten like normal items
-					if(!is_operational) //we ran out of power after recycling a large amount to living stuff, time to stop
-						break
-					crush_living(CRUNCH)
-					use_energy(active_power_usage)
+				if(!isliving(CRUNCH)) // MMIs and brains will get eaten like normal items
+					return
+
+				var/mob/living/living_mob = CRUNCH
+				if(living_mob.incorporeal_move)
+					return
+
+				if(!is_operational) //we ran out of power after recycling a large amount to living stuff, time to stop
+					break
+				crush_living(CRUNCH)
+				use_energy(active_power_usage)
 		else // Stop processing right now without eating anything.
 			emergency_stop()
 			return


### PR DESCRIPTION

## About The Pull Request

Incorporeal mobs do not interact with the recycler.
## Why It's Good For The Game

Makes sense. Also you can run back and forth into one as revenant to make splat noises repeatedly. Now that is fixed.
## Changelog
:cl: Rhials
fix: Revenants can no longer be fake-eaten by the recycler.
/:cl:
