### PR TITLE
Makes it so that there is an actual tracer on the tesla cannon hitscan beam.

### DIFF
--- a/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
@@ -60,3 +60,15 @@
 
 /obj/effect/projectile/tracer/sniper
 	icon_state = "sniper"
+
+/obj/effect/projectile/tracer/lightning
+	icon = 'icons/effects/beam.dmi'
+	icon_state = "lightning2"
+
+/obj/effect/projectile/tracer/lightning/Initialize(mapload)
+	. = ..()
+	update_appearance()
+
+/obj/effect/projectile/tracer/lightning/update_icon_state()
+	. = ..()
+	icon_state = "lightning[rand(1, 12)]"

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -29,14 +29,12 @@
 	name = "tesla bolt"
 	icon_state = null
 	hitscan = TRUE
+	muzzle_type = /obj/effect/projectile/muzzle/stun
+	tracer_type = /obj/effect/projectile/tracer/stun
+	impact_type = /obj/effect/projectile/impact/stun
+	impact_effect_type = null
 	damage = 5
 	var/shock_damage = 10
-	var/datum/beam/chain
-
-/obj/projectile/energy/tesla_cannon/fire(setAngle)
-	if(firer)
-		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]", time = 0.5 SECONDS)
-	return ..()
 
 /obj/projectile/energy/tesla_cannon/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -29,9 +29,7 @@
 	name = "tesla bolt"
 	icon_state = null
 	hitscan = TRUE
-	muzzle_type = /obj/effect/projectile/muzzle/stun
-	tracer_type = /obj/effect/projectile/tracer/stun
-	impact_type = /obj/effect/projectile/impact/stun
+	tracer_type = /obj/effect/projectile/tracer/lightning
 	impact_effect_type = null
 	damage = 5
 	var/shock_damage = 10


### PR DESCRIPTION
## About The Pull Request

Tesla cannon beams are no longer invisible.

![image](https://github.com/user-attachments/assets/8addda48-a77d-43e0-b6da-8b794962c07d)

fixes https://github.com/tgstation/tgstation/issues/90976

Or, at least, the part here that is actually a bug and not just talking about intended features.

## Why It's Good For The Game

You should be able to see what is killing you, even if it is killing you quickly.

## Changelog
:cl:
fix: The tesla cannon now fires actually visible bolts.
/:cl:
