### PR TITLE
agent id card covert action is hidden do_after

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1673,7 +1673,7 @@
 	if(ishuman(interacting_with))
 		interacting_with.balloon_alert(user, "scanning ID card...")
 
-		if(!do_after(user, 2 SECONDS, interacting_with))
+		if(!do_after(user, 2 SECONDS, interacting_with, hidden = TRUE))
 			interacting_with.balloon_alert(user, "interrupted!")
 			return ITEM_INTERACT_BLOCKING
 


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/90984
## Why It's Good For The Game
it's a covert action, pretty sure it was intended to be so.
## Changelog
:cl: grungussuss
fix: agent ID scanning action is a hidden do_after
/:cl:
