### PR TITLE
personal player panel improvements

### DIFF
--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -27,7 +27,6 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(show_player_panel, R_ADMIN, "Show Player Panel", mo
 	if(player.client)
 		body += "<br>\[<b>First Seen:</b> [player.client.player_join_date]\]"
 		body += "<br>\[<b>Byond account registered on:</b> [player.client.account_join_date]\]"
-		body += "<br>\[IP: [player.client.address]\]"
 		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
 		if(CONFIG_GET(string/centcom_ban_db))
 			body += "<a href='byond://?_src_=holder;[HrefToken()];centcomlookup=[player.client.ckey]'>Search</a>"

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -25,7 +25,9 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(show_player_panel, R_ADMIN, "Show Player Panel", mo
 		body += "<br>\[<A href='byond://?_src_=holder;[HrefToken()];ppbyckey=[player.ckey];ppbyckeyorigmob=[REF(player)]'>Find Updated Panel</A>\]"
 
 	if(player.client)
-		body += "<br>\[<b>First Seen:</b> [player.client.player_join_date]\]\[<b>Byond account registered on:</b> [player.client.account_join_date]\]"
+		body += "<br>\[<b>First Seen:</b> [player.client.player_join_date]\]"
+		body += "<br>\[<b>Byond account registered on:</b> [player.client.account_join_date]\]"
+		body += "<br>\[IP: [player.client.address]\]"
 		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
 		if(CONFIG_GET(string/centcom_ban_db))
 			body += "<a href='byond://?_src_=holder;[HrefToken()];centcomlookup=[player.client.ckey]'>Search</a>"
@@ -146,7 +148,7 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(show_player_panel, R_ADMIN, "Show Player Panel", mo
 	body += "<br>"
 	body += "</body></html>"
 
-	user << browse(body, "window=adminplayeropts-[REF(player)];size=550x515")
+	user << browse(body, "window=adminplayeropts-[REF(player)];size=550x540")
 	BLACKBOX_LOG_ADMIN_VERB("Player Panel")
 
 /client/proc/cmd_admin_godmode(mob/mob in GLOB.mob_list)


### PR DESCRIPTION
## About The Pull Request

adds breaks between the lines of first seen, byond account registered tab.

<details>
<summary>OUTDATED PREVIEW</summary>

<h3> before: </h3>

![image](https://github.com/user-attachments/assets/9390dbc8-31af-4ef9-80f1-56b4fc4956d1)

<h3> after: </h3>

![image](https://github.com/user-attachments/assets/e593be28-c498-41e0-8be4-53b8524315ba)


</details>

## Why It's Good For The Game
line breaks are neat for readibility.
## Changelog
:cl: grungussuss
qol: added some line breaks for the admin player panel for readibility
/:cl:
