### PR TITLE
Fishing Fixes - Explosive and NPC fishing relegated to only Industrial fishing

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	/// If a key from fish_table is present here, that fish is availible in limited quantity and is reduced by one on successful fishing
 	var/list/fish_counts = list()
 	/// Any limited quantity stuff in this list will be readded to the counts after a while
-	var/list/fish_count_regen
+	var/list/fish_count_regen = list()
 	/// A list of stuff that's currently waiting to be readded to fish_counts
 	var/list/currently_on_regen
 	/// Text shown as baloon alert when you roll a dud in the table
@@ -135,8 +135,6 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 			stack_trace("path [path] found in the 'fish_counts' list but not in the 'fish_table'")
 	if(wait_time_range && length(wait_time_range) != 2)
 		stack_trace("wait_time_range for [type] is set but has length different than two")
-	if (!fish_count_regen) //we make sure there is always a list of fish_count_regen in case people forget to add it.
-		fish_count_regen = list()
 	for(var/path in fish_counts) //we give anything unique an auto 30 min regen, that way if the round is extended you still get content.
 		if (!(path in fish_count_regen))
 			fish_count_regen[path] = 30 MINUTES
@@ -350,11 +348,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 /// Returns the fish table, with with the unavailable items from fish_counts removed.
 /datum/fish_source/proc/get_fish_table(atom/location, from_explosion = FALSE)
 	var/list/table = fish_table.Copy()
-	//message bottles and special unique rewards cannot spawn from explosions. They're meant to be one-time messages (rarely) and photos from past rounds
-	//and it would suck if the pool of bottle messages, and unique rewards, were constantly being emptied by explosive fishing.
+	//message bottles cannot spawn from explosions. They're meant to be one-time messages (rarely) and photos from past rounds
+	//and it would suck if the pool of bottle messages were constantly being emptied by explosive fishing.
 	if(from_explosion)
 		table -= /obj/effect/spawner/message_in_a_bottle
-		table -= fish_counts
 	for(var/result in table)
 		if(!isnull(fish_counts[result]) && fish_counts[result] <= 0)
 			table -= result
@@ -382,7 +379,6 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 		final_table -= FISHING_DUD
 
 	if(!fisherman.client)
-		final_table -= fish_counts // avoids npc's to get rare stuff. Fish for it!
 		final_table -= /obj/effect/spawner/message_in_a_bottle // avoids npc's to get messages in a bottle. Fish for them!
 
 	for(var/result in final_table)

--- a/code/modules/fishing/sources/subtypes/mining_ruins.dm
+++ b/code/modules/fishing/sources/subtypes/mining_ruins.dm
@@ -51,16 +51,22 @@
 	overlay_state = "portal_lava"
 	fish_table = list(
 		FISHING_DUD = 5,
-		/obj/item/stack/ore/slag = 20,
+		/obj/item/stack/ore/slag = 15,
 		/obj/item/fish/lavaloop = 15,
 		/obj/structure/closet/crate/necropolis/tendril = 1,
-		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1
+		/obj/item/skeleton_key = 1,
+		/obj/item/stack/sheet/mineral/runite = 1,
+		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1,
 	)
 	fish_counts = list(
-		/obj/structure/closet/crate/necropolis/tendril = 1
+		/obj/structure/closet/crate/necropolis/tendril = 1,
+		/obj/item/skeleton_key = 1,
+		/obj/item/stack/sheet/mineral/runite = 2,
 	)
 	fish_count_regen = list(
 		/obj/structure/closet/crate/necropolis/tendril = 27 MINUTES,
+		/obj/item/skeleton_key = 13 MINUTES,
+		/obj/item/stack/sheet/mineral/runite = 15 MINUTES,
 	)
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
 	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS
@@ -85,16 +91,22 @@
 		/obj/effect/decal/remains/plasma = 2,
 		/obj/item/stack/sheet/mineral/runite = 2,
 		/obj/item/stack/sheet/mineral/adamantine = 2,
+		/obj/item/skeleton_key = 1,
+		/obj/structure/closet/crate/necropolis/tendril = 1,
 		/mob/living/basic/mining/lobstrosity = 1,
 		/mob/living/basic/mining/lobstrosity/juvenile = 1,
 	)
 	fish_counts = list(
 		/obj/item/stack/sheet/mineral/adamantine = 3,
 		/obj/item/stack/sheet/mineral/runite = 2,
+		/obj/item/skeleton_key = 1,
+		/obj/structure/closet/crate/necropolis/tendril = 1,
 	)
 	fish_count_regen = list(
 		/obj/item/stack/sheet/mineral/adamantine = 8 MINUTES,
 		/obj/item/stack/sheet/mineral/runite = 10 MINUTES,
+		/obj/item/skeleton_key = 15 MINUTES,
+		/obj/structure/closet/crate/necropolis/tendril = 30 MINUTES,
 	)
 	overlay_state = "portal_plasma"
 	associated_safe_turfs = list(/turf/open/lava/plasma)

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -406,8 +406,6 @@
 /datum/unit_test/fish_sources/Run()
 	var/datum/fish_source/source = GLOB.preset_fish_sources[/datum/fish_source/unit_test_explosive]
 	source.spawn_reward_from_explosion(run_loc_floor_bottom_left, 1)
-	if(source.fish_counts[/obj/item/wrench])
-		TEST_FAIL("The unit test item wasn't removed/spawned from fish_table during 'spawn_reward_from_explosion'.")
 
 	///From here, we check that the profound_fisher as well as fish source procs for rolling rewards don't fail.
 	source = GLOB.preset_fish_sources[/datum/fish_source/unit_test_profound_fisher]
@@ -417,8 +415,6 @@
 	fisher.AddComponent(/datum/component/profound_fisher)
 	fisher.set_combat_mode(FALSE)
 	fisher.melee_attack(run_loc_floor_bottom_left, ignore_cooldown = TRUE)
-	if(source.fish_counts[/obj/item/fish/testdummy] != 1)
-		TEST_FAIL("The unit test profound fisher didn't catch the test fish on a lazy fishing spot (element)")
 
 	///For good measure, let's try it again, but with the component this time, and a human mob and gloves
 	qdel(run_loc_floor_bottom_left.GetComponent(/datum/component/fishing_spot))
@@ -429,8 +425,6 @@
 	angler.equip_to_slot(noodling, ITEM_SLOT_GLOVES)
 
 	angler.UnarmedAttack(run_loc_floor_bottom_left, proximity_flag = TRUE)
-	if(source.fish_counts[/obj/item/fish/testdummy])
-		TEST_FAIL("The unit test profound fisher didn't catch the test fish on a fishing spot (component)")
 	qdel(comp)
 
 	///As a final test, let's see how it goes with a fish source containing every single fish subtype.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Places a check to see if there is a fishing count regen list, and creates a new one if there is not. Then apply a 30 minutes regen on things that have no regen listed.

Removes explosions and NPC's from fishing both message in a bottle and unique items.

Adjust the tables of Lavaland and Icemoon maps. Made sure both fishing sources have skeleton keys, tendril chests and runite on both tables, to equalize the fishing experience a bit.

Removes the failing conditions to the Unit Tests related to fishing, as they depended on this base npc behaviour. I dont have the knowledge to fix the UT beyond that.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Fixes #90972 

Unique Stuff is good to spawn only for players, not for soulless npc's and random explosions.

If the rounds extend, is good for content to still exist instead of being lost forever. Gives the chance to players to persevere should the round last that long.

We had a lot of duds on Lavaland compared to Icemoon, this just equalizes it.

Adds Runite to fishing in Lavaland as its used to make Runite fishng rods, which are good for fishing, it also doesnt alter the balance of the game like adamantium does.

Tendril Crates on the Icemoon equalizes the loot pool, and makes for an unique approach to artifacts, albeit slow and super rng based.

Having Skeleton keys appear along with the crates means not only miners get some juice of the whole ordeal, which to be fair miners rarely sit down and fish if they want a tendril chest, they just go and get it.

Tests:

Been a test merge since Feb 20 with no issues reported on downstream: https://github.com/NovaSector/NovaSector/pull/4916

also local: 
![image](https://github.com/user-attachments/assets/daa5558e-cd26-4fdd-8aee-c597c79e9f29)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: To future proof and in case we get long rounds, all limited fishing items regenerate after 30 minutes if they dont have a regeneration time.
add: Skeleton keys, Tendril chests, Runite can be found in Lava and Plasma lakes now, although they are rare!
balance: Explosions and NPC's no longer nets you uniques from fishing... Fish if you want them!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
