### PR TITLE
spiders webbing fix

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
@@ -60,13 +60,17 @@
 
 	if(!ismovable(to_wrap) || to_wrap == owner)
 		return FALSE
-
-	if(isspider(to_wrap))
-		owner.balloon_alert(owner, "can't wrap spiders!")
-		return FALSE
-	if(ismegafauna(to_wrap))
-		owner.balloon_alert(owner, "can't wrap, too strong!")
-		return FALSE
+	if(isliving(to_wrap))
+		var/mob/living/living_target = to_wrap
+		if(living_target.mob_biotypes & MOB_SPECIAL)
+			owner.balloon_alert(owner, "can't wrap, too strong!")
+			return FALSE
+		if(living_target.mob_biotypes & MOB_SPIRIT)
+			owner.balloon_alert(owner, "can't wrap ghosts!")
+			return FALSE
+		if(isspider(living_target))
+			owner.balloon_alert(owner, "can't wrap spiders!")
+			return FALSE
 	var/atom/movable/target_movable = to_wrap
 	if(target_movable.anchored)
 		return FALSE

--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
@@ -110,7 +110,7 @@
 			to_chat(owner, span_warning("[living_wrapped] is not edible!"))
 
 	to_wrap.forceMove(casing)
-	if(to_wrap.mob_biotypes & MOB_HUMANOID)
+	if(isliving(to_wrap)&& (to_wrap.mob_biotypes & MOB_HUMANOID))
 		casing.icon_state = pick("cocoon_large1", "cocoon_large2", "cocoon_large3")
 	else
 		casing.icon_state = pick("cocoon1", "cocoon2", "cocoon3")

--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
@@ -64,7 +64,9 @@
 	if(isspider(to_wrap))
 		owner.balloon_alert(owner, "can't wrap spiders!")
 		return FALSE
-
+	if(ismegafauna(to_wrap))
+		owner.balloon_alert(owner, "can't wrap, too strong!")
+		return FALSE
 	var/atom/movable/target_movable = to_wrap
 	if(target_movable.anchored)
 		return FALSE
@@ -108,5 +110,7 @@
 			to_chat(owner, span_warning("[living_wrapped] is not edible!"))
 
 	to_wrap.forceMove(casing)
-	if(to_wrap.density || ismob(to_wrap))
+	if(iscarbon(to_wrap))
 		casing.icon_state = pick("cocoon_large1", "cocoon_large2", "cocoon_large3")
+	else
+		casing.icon_state = pick("cocoon1", "cocoon2", "cocoon3")

--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/wrap.dm
@@ -87,7 +87,7 @@
 	else
 		owner.balloon_alert(owner, "interrupted!")
 
-/datum/action/cooldown/mob_cooldown/wrap/proc/wrap_target(atom/movable/to_wrap)
+/datum/action/cooldown/mob_cooldown/wrap/proc/wrap_target(mob/living/to_wrap)
 	var/obj/structure/spider/cocoon/casing = new(to_wrap.loc)
 	if(isliving(to_wrap))
 		var/mob/living/living_wrapped = to_wrap
@@ -110,7 +110,7 @@
 			to_chat(owner, span_warning("[living_wrapped] is not edible!"))
 
 	to_wrap.forceMove(casing)
-	if(iscarbon(to_wrap))
+	if(to_wrap.mob_biotypes & MOB_HUMANOID)
 		casing.icon_state = pick("cocoon_large1", "cocoon_large2", "cocoon_large3")
 	else
 		casing.icon_state = pick("cocoon1", "cocoon2", "cocoon3")


### PR DESCRIPTION

## About The Pull Request
Closes #90538 
- Megafauna now can't be webbed. 
- Fixes sprites of non-carbon cocoons.
![Before](https://github.com/user-attachments/assets/7c95f5b2-c9ed-44eb-bce8-6f098bc0829f)
![After](https://github.com/user-attachments/assets/c2190daa-c82a-4922-9965-95a1accb3d91)
## Why It's Good For The Game
Webbed mobs now look like webbed mobs. 
Webbed humans now look like webbed humans. 
Webbed megafauna now don't exist. 
## Changelog
:cl:
balance: spiders can't wrap megafauna
fix: nonhuman spider cocoons looks accordingly  
/:cl:
