### PR TITLE
Fixes detective's revolver not being able to misfire

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -474,7 +474,7 @@
 	return TRUE
 
 /obj/item/gun/ballistic/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	var/could_it_misfire = chambered && chambered.can_misfire
+	var/could_it_misfire = can_misfire || chambered.can_misfire
 	if(target != user && chambered.loaded_projectile && could_it_misfire && prob(misfire_probability) && blow_up(user))
 		to_chat(user, span_userdanger("[src] misfires!"))
 		return


### PR DESCRIPTION

## About The Pull Request

Closes #90994

## Changelog
:cl:
fix: Fixed detective's revolver not being able to misfire
/:cl:
