### PR TITLE
Makes plumber return matter on deconstruct

### DIFF
--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -262,7 +262,12 @@
 				balloon_alert(user, "unanchor first!")
 				return ITEM_INTERACT_BLOCKING
 			if(do_after(user, 2 SECONDS, target = interacting_with))
-				machine_target.deconstruct() //Let's not substract matter
+				var/design_cost = designs[machine_target.type]
+				var/to_return = min(design_cost, max_matter - matter) // Give back matter was used to create smth
+				if(to_return < design_cost)
+					balloon_alert(user, "storage full!")
+				matter += to_return
+				machine_target.deconstruct()
 				playsound(src, 'sound/machines/click.ogg', 50, TRUE) //this is just such a great sound effect
 			return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request

As in title: make plumbers return matter on deconstruct for plumbing machinery.

## Why It's Good For The Game

No more matter (and resources) losses, when you mess up with layer again. And for sake of rebuild and reconstruction - better be able to have at least something instead of annihilate it.

Video from downstream, but it works the same

https://github.com/user-attachments/assets/ff8469b6-1233-4cb1-98ae-02b6121e862d

## Changelog
:cl:
balance: Plumbers will now give back matter you use for assemble machinery.
/:cl:
