### PR TITLE
Heretic ritual peeve with stacks

### DIFF
--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -28,7 +28,7 @@
 /obj/item/stack/spacecash/get_item_credit_value()
 	return (amount*value)
 
-/obj/item/stack/spacecash/merge(obj/item/stack/S)
+/obj/item/stack/spacecash/merge(obj/item/stack/target_stack, limit)
 	. = ..()
 	update_desc()
 

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -163,21 +163,6 @@
 		if(isliving(sacrificed))
 			continue
 
-		if(isstack(sacrificed))
-			var/obj/item/stack/sac_stack = sacrificed
-			var/how_much_to_use = 0
-			for(var/requirement in required_atoms)
-				// If it's not requirement type and type is not a list, skip over this check
-				if(!istype(sacrificed, requirement) && !islist(requirement))
-					continue
-				// If requirement *is* a list and the stack *is* in the list, skip over this check
-				if(islist(requirement) && !is_type_in_list(sacrificed, requirement))
-					continue
-				how_much_to_use = min(required_atoms[requirement], sac_stack.amount)
-				break
-			sac_stack.use(how_much_to_use)
-			continue
-
 		selected_atoms -= sacrificed
 		qdel(sacrificed)
 

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -106,6 +106,8 @@
 	if(!ritual.recipe_snowflake_check(user, atoms_in_range, selected_atoms, loc))
 		return FALSE
 
+	var/list/stack_reqs = list()
+
 	// Now go through all our nearby atoms and see which are good for our ritual.
 	for(var/atom/nearby_atom as anything in atoms_in_range)
 		// Go through all of our required atoms
@@ -126,17 +128,12 @@
 			// If it's a stack, we gotta see if it has more than one inside,
 			// as our requirements may want more than one item of a stack
 			// It's also important that we split the required amount from the stack and add that
-			// to the selected_atoms instead so we don't thinker with the source stack(s) too much.
+			// to the selected_atoms AFTERWARD so we don't change anything if the reqs aren't met.
 			if(isstack(nearby_atom))
 				var/obj/item/stack/picked_stack = nearby_atom
-				var/amount_to_give = min(picked_stack.amount || requirements_list[req_type])
-				var/obj/item/stack/our_stack = locate(picked_stack.merge_type) in selected_atoms
-				if(!our_stack)
-					our_stack = picked_stack.split_stack(amount = amount_to_give)
-					selected_atoms |= our_stack
-				else
-					picked_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)
-				requirements_list[req_type] -= amount_to_give
+				if(!stack_reqs[req_type])
+					stack_reqs[req_type] = requirements_list[req_type]
+				requirements_list[req_type] -= min(picked_stack.amount || requirements_list[req_type])
 
 			// Otherwise, just add the mark down the item as fulfilled x1
 			else
@@ -172,11 +169,21 @@
 		loc.balloon_alert(user, "ritual failed, missing components!")
 		// Then let them know what they're missing
 		to_chat(user, span_hierophant_warning("You are missing [english_list(what_are_we_missing)] in order to complete the ritual \"[ritual.name]\"."))
-		for(var/obj/item/stack/stack in selected_atoms)
-			var/obj/item/stack/possible_original_stack = (locate(stack.type) in stack.loc) || (locate(stack.type) in atoms_in_range)
-			if(possible_original_stack?.can_merge(stack))
-				possible_original_stack.merge(stack)
 		return FALSE
+
+	//Everything's good, proceed and collect from the available stacks what's needed if needed.
+	if(length(stack_reqs))
+		for(var/obj/item/stack/nearby_stack in atoms_in_range)
+			for(var/stack_path as anything in stack_reqs)
+				if(!istype(nearby_atom, req_type))
+					continue
+				var/amount_to_give = min(picked_stack.amount || requirements_list[req_type])
+				var/obj/item/stack/our_stack = locate(nearby_stack.merge_type) in selected_atoms
+				if(!our_stack)
+					our_stack = picked_stack.split_stack(amount = amount_to_give)
+					selected_atoms |= our_stack
+				else
+					picked_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)
 
 	// If we made it here, the ritual had all necessary components, and we can try to cast it.
 	// This doesn't necessarily mean the ritual will succeed, but it's valid!

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -174,16 +174,16 @@
 	//Everything's good, proceed and collect from the available stacks what's needed if needed.
 	if(length(stack_reqs))
 		for(var/obj/item/stack/nearby_stack in atoms_in_range)
-			for(var/stack_path as anything in stack_reqs)
-				if(!istype(nearby_atom, req_type))
+			for(var/stack_path in stack_reqs)
+				if(!istype(nearby_stack, stack_path))
 					continue
-				var/amount_to_give = min(picked_stack.amount || requirements_list[req_type])
+				var/amount_to_give = min(nearby_stack.amount || stack_reqs[stack_path])
 				var/obj/item/stack/our_stack = locate(nearby_stack.merge_type) in selected_atoms
 				if(!our_stack)
-					our_stack = picked_stack.split_stack(amount = amount_to_give)
+					our_stack = nearby_stack.split_stack(amount = amount_to_give)
 					selected_atoms |= our_stack
 				else
-					picked_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)
+					nearby_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)
 
 	// If we made it here, the ritual had all necessary components, and we can try to cast it.
 	// This doesn't necessarily mean the ritual will succeed, but it's valid!

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -117,7 +117,7 @@
 				continue
 			// If req_type is a list of types, check all of them for one match.
 			if(islist(req_type))
-				if(!(is_type_in_list(nearby_atom, req_type)))
+				if(!is_type_in_list(nearby_atom, req_type))
 					continue
 			else if(!istype(nearby_atom, req_type))
 				continue
@@ -175,7 +175,7 @@
 	if(length(stack_reqs))
 		for(var/obj/item/stack/nearby_stack in atoms_in_range)
 			for(var/stack_path in stack_reqs)
-				if(!istype(nearby_stack, stack_path))
+				if(!istype(nearby_stack, stack_path) && (!islist(stack_path) || !is_type_in_list(nearby_stack, stack_path)))
 					continue
 				var/amount_to_give = min(nearby_stack.amount || stack_reqs[stack_path])
 				var/obj/item/stack/our_stack = locate(nearby_stack.merge_type) in selected_atoms

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -172,6 +172,10 @@
 		loc.balloon_alert(user, "ritual failed, missing components!")
 		// Then let them know what they're missing
 		to_chat(user, span_hierophant_warning("You are missing [english_list(what_are_we_missing)] in order to complete the ritual \"[ritual.name]\"."))
+		for(var/obj/item/stack/stack in selected_atoms)
+			var/obj/item/stack/possible_original_stack = (locate(stack.type) in stack.loc) || (locate(stack.type) in atoms_in_range)
+			if(possible_original_stack?.can_merge(stack))
+				possible_original_stack.merge(stack)
 		return FALSE
 
 	// If we made it here, the ritual had all necessary components, and we can try to cast it.

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -132,7 +132,7 @@
 				var/amount_to_give = min(picked_stack.amount || requirements_list[req_type])
 				var/obj/item/stack/our_stack = locate(picked_stack.merge_type) in selected_atoms
 				if(!our_stack)
-					our_stack = picked_stack.split_stack(amount_to_give)
+					our_stack = picked_stack.split_stack(amount = amount_to_give)
 					selected_atoms |= our_stack
 				else
 					picked_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -130,7 +130,7 @@
 			if(isstack(nearby_atom))
 				var/obj/item/stack/picked_stack = nearby_atom
 				var/amount_to_give = min(picked_stack.amount || requirements_list[req_type])
-				var/obj/item/stack/our_stack = locate(req_type) in selected_atoms
+				var/obj/item/stack/our_stack = locate(picked_stack.merge_type) in selected_atoms
 				if(!our_stack)
 					our_stack = picked_stack.split_stack(amount_to_give)
 					selected_atoms |= our_stack

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -135,7 +135,7 @@
 					our_stack = picked_stack.split_stack(amount_to_give)
 					selected_atoms |= our_stack
 				else
-					our_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)
+					picked_stack.merge(our_stack, limit = our_stack.amount + amount_to_give)
 				requirements_list[req_type] -= amount_to_give
 
 			// Otherwise, just add the mark down the item as fulfilled x1


### PR DESCRIPTION
## About The Pull Request
When a ritual requires a stack, we shouldn't add the stack itself to the list of selected components, but rather split the req amount from the stack and add the resulting item from that proccall to said list instead.

Normally, this shouldn't be a problem, as cleaning up a selected stack is handled in its own way in `heretic_knowledge/cleanup_atoms()`, however some rituals may have a delay, which would make the original stack temporarily invisible. Kinda quirky. Also it's better to handle stack specific behavior in one proc than two.
In the case the ritual fails from missing components, nothing much happens anyway, because the split stack is dropped on the same turf of the original stack.

## Why It's Good For The Game

This probably fixes #90828 and it's a bit more elegant way to handle stacks imo.

## Changelog

:cl:
fix: Sundered blade ritual shouldn't delete more than one sheet of silver or titanium.
/:cl:
