### PR TITLE
Holy Water blessing blocks all forms of magic-adjacent teleporting, not just cult teleports, making Chaplains a better choice against Heretics and Wizards.

### DIFF
--- a/code/game/objects/effects/blessing.dm
+++ b/code/game/objects/effects/blessing.dm
@@ -25,5 +25,5 @@
 /obj/effect/blessing/proc/block_cult_teleport(datum/source, channel, turf/origin)
 	SIGNAL_HANDLER
 
-	if(channel == TELEPORT_CHANNEL_CULT)
+	if(channel == TELEPORT_CHANNEL_CULT || channel == TELEPORT_CHANNEL_MAGIC)
 		return TRUE

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -112,7 +112,7 @@
 	if(newloc.turf_flags & NOJAUNT)
 		to_chat(user, span_warning("Some strange aura is blocking the way."))
 		return
-	if(destination_area.area_flags & NOTELEPORT || SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE))
+	if(destination_area.area_flags & NOTELEPORT || SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE) || !check_teleport_valid(src, newloc, TELEPORT_CHANNEL_MAGIC))
 		to_chat(user, span_danger("Some dull, universal force is blocking the way. Its overwhelmingly oppressive force feels dangerous."))
 		return
 	if (direction == UP || direction == DOWN)

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -112,7 +112,7 @@
 	if(newloc.turf_flags & NOJAUNT)
 		to_chat(user, span_warning("Some strange aura is blocking the way."))
 		return
-	if(destination_area.area_flags & NOTELEPORT || SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE) || !check_teleport_valid(src, newloc, TELEPORT_CHANNEL_MAGIC))
+	if(SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE) || !check_teleport_valid(src, newloc, TELEPORT_CHANNEL_MAGIC))
 		to_chat(user, span_danger("Some dull, universal force is blocking the way. Its overwhelmingly oppressive force feels dangerous."))
 		return
 	if (direction == UP || direction == DOWN)


### PR DESCRIPTION
## About The Pull Request

Holy Water blessing blocks all forms of magic-adjacent teleporting, not just cult teleports, making Chaplains a better choice against Heretics and Wizards.

## Why It's Good For The Game

Jaunting and teleporting have become incredibly common magic powers for our magic antagonists, and has made mobility an extremely common tool with little to nothing the crew can do about it. This change encourages interdepartmental cooperation, leveraging jobs and their unique mechanics, and makes dealing with extra-slippery magic users who went all in on escape tools more reasonable by providing a way to halt them in their tracks.

I also think this might be a regression, it used to block all jaunts from wizards back in the day but that may have been lost in a refactor by accident

## Changelog

:cl:
balance: Holy Water blessing blocks all forms of magic-adjacent teleporting, not just cult teleports, making Chaplains a better choice against Heretics and Wizards.
/:cl:
