### PR TITLE
Heretics can see blessed tiles.

### DIFF
--- a/code/game/atom/alternate_appearance.dm
+++ b/code/game/atom/alternate_appearance.dm
@@ -195,7 +195,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 		return TRUE
 	if (istype(M, /mob/living/basic/construct/wraith))
 		return TRUE
-	if(isrevenant(M) || IS_WIZARD(M))
+	if(isrevenant(M) || IS_WIZARD(M) || IS_HERETIC(M))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Heretics can see blessed tiles.

## Why It's Good For The Game

Heretics, being magic users, should be aware of anti-magic tile effects.

## Changelog

:cl:
qol: Heretics can see blessed tiles.
/:cl:

