### PR TITLE
Reduce MMI component message cooldown.

### DIFF
--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -1,4 +1,4 @@
-#define MMI_MESSAGE_COOLDOWN (1 SECONDS)
+#define MMI_MESSAGE_COOLDOWN (0.1 SECONDS)
 
 /**
  * # Man-Machine Interface Component


### PR DESCRIPTION

## About The Pull Request
Reduces the cooldown from 1 second to 0.1 seconds, still more than enough to prevent super laggy recursive spam, but short enough not to impede any legitimate uses of MMI messaging, such as alerts, sensors, or MMI translators.
## Why It's Good For The Game
What if, completely hypothetically, with no relation to something that actually happened, and solely as a thought experiment we promise, I was to have made a circuit with a toggle switch and accompanying alerts for the MMI inside it to use, where the MMI then proceeded to press said switch twice within 1 second, thus only receiving one message as to the state of the switch.

 Well, that might make hypothetical me get hyperfixated-ly annoyed at this very specific gripe, maybe even enough to make a PR addressing it. (for legal reasons this is not an IDED pr and I reserve the right to refuse to self incriminate.)

TLDR: 1 second is really long given the main issue with not having a cooldown is infinite exponential recurrsion.
## Changelog
:cl:
balance: Massively reduce the MMI component message cooldown.
/:cl:
