### PR TITLE
Updates the default retool_icon for skins to be the mining icon file.

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
@@ -50,8 +50,10 @@
 	var/backstab_bonus = 30
 	/// Used by retool kits when changing the crusher's appearance
 	var/current_inhand_icon_state = "crusher"
+	/// The file in which our projectile icon resides
+	var/projectile_icon = 'icons/obj/weapons/guns/projectiles.dmi'
 	/// Used by retool kits when changing the crusher's projectile sprite
-	var/projectile_icon = "pulse1"
+	var/projectile_icon_state = "pulse1"
 	/// Wielded damage we deal, aka our "real" damage
 	var/force_wielded = 20
 
@@ -220,7 +222,8 @@
 		return
 	var/obj/projectile/destabilizer/destabilizer = new(proj_turf)
 	SEND_SIGNAL(src, COMSIG_CRUSHER_FIRED_BLAST, target, user, destabilizer)
-	destabilizer.icon_state = projectile_icon
+	destabilizer.icon = projectile_icon
+	destabilizer.icon_state = projectile_icon_state
 	for(var/obj/item/crusher_trophy/attached_trophy as anything in trophies)
 		attached_trophy.on_projectile_fire(destabilizer, user)
 	destabilizer.aim_projectile(target, user, modifiers)

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
@@ -50,6 +50,7 @@
 		pkc.righthand_file = active_skin.retool_righthand_file
 	if(active_skin.retool_worn_file)
 		pkc.worn_icon = active_skin.retool_worn_file
+		pkc.worn_icon_state = active_skin::retool_icon_state
 	if (active_skin.retool_inhand_x)
 		pkc.inhand_x_dimension = active_skin.retool_inhand_x
 	if (active_skin.retool_inhand_y)
@@ -68,6 +69,7 @@
 	pkc.lefthand_file = initial(pkc.lefthand_file)
 	pkc.righthand_file = initial(pkc.righthand_file)
 	pkc.worn_icon = initial(pkc.worn_icon)
+	pkc.worn_icon_state = initial(pkc.worn_icon_state)
 	pkc.inhand_x_dimension = initial(pkc.inhand_x_dimension)
 	pkc.inhand_y_dimension = initial(pkc.inhand_y_dimension)
 	pkc.update_appearance()

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
@@ -76,7 +76,7 @@
 	/// Name of the modification
 	var/name = "error that should be reported to coders"
 	/// Specifies the icon file in which the crusher's new state is stored.
-	var/retool_icon = null
+	var/retool_icon = 'icons/obj/mining.dmi
 	///Specifies the sprite/icon state which the crusher is changed to as an item. Should appear in the icons/obj/mining.dmi file with accompanying "lit" and "recharging" sprites
 	var/retool_icon_state = "ipickaxe"
 	///Specifies the icon state for the crusher's appearance in hand. Should appear in both retool_lefthand_file and retool_righthand_file.

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
@@ -48,6 +48,8 @@
 	if (active_skin.retool_lefthand_file)
 		pkc.lefthand_file = active_skin.retool_lefthand_file
 		pkc.righthand_file = active_skin.retool_righthand_file
+	if(active_skin.retool_worn_file)
+		pkc.worn_icon = active_skin.retool_worn_file
 	if (active_skin.retool_inhand_x)
 		pkc.inhand_x_dimension = active_skin.retool_inhand_x
 	if (active_skin.retool_inhand_y)
@@ -65,6 +67,7 @@
 	pkc.projectile_icon = initial(pkc.projectile_icon)
 	pkc.lefthand_file = initial(pkc.lefthand_file)
 	pkc.righthand_file = initial(pkc.righthand_file)
+	pkc.worn_icon = initial(pkc.worn_icon)
 	pkc.inhand_x_dimension = initial(pkc.inhand_x_dimension)
 	pkc.inhand_y_dimension = initial(pkc.inhand_y_dimension)
 	pkc.update_appearance()
@@ -87,6 +90,8 @@
 	var/retool_lefthand_file = null
 	/// Specifies the right hand inhand icon file. Don't forget to set the left hand file as well.
 	var/retool_righthand_file = null
+	/// Specifies the worn icon file.
+	var/retool_worn_file = null
 	/// Specifies the X dimensions of the new inhand, only relevant with different inhand files.
 	var/retool_inhand_x = null
 	/// Specifies the Y dimensions of the new inhand, only relevant with different inhand files.

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
@@ -44,6 +44,8 @@
 	pkc.current_inhand_icon_state = active_skin.retool_inhand_icon
 	if (active_skin.retool_projectile_icon)
 		pkc.projectile_icon = active_skin.retool_projectile_icon
+	if (active_skin.retool_projectile_icon_state)
+		pkc.projectile_icon_state = active_skin.retool_projectile_icon_state
 	// Should either have both, or neither
 	if (active_skin.retool_lefthand_file)
 		pkc.lefthand_file = active_skin.retool_lefthand_file
@@ -66,6 +68,7 @@
 	pkc.icon_state = initial(pkc.icon_state)
 	pkc.current_inhand_icon_state = initial(pkc.current_inhand_icon_state)
 	pkc.projectile_icon = initial(pkc.projectile_icon)
+	pkc.projectile_icon_state = initial(pkc.projectile_icon_state)
 	pkc.lefthand_file = initial(pkc.lefthand_file)
 	pkc.righthand_file = initial(pkc.righthand_file)
 	pkc.worn_icon = initial(pkc.worn_icon)
@@ -86,8 +89,10 @@
 	var/retool_icon_state = "ipickaxe"
 	///Specifies the icon state for the crusher's appearance in hand. Should appear in both retool_lefthand_file and retool_righthand_file.
 	var/retool_inhand_icon = "ipickaxe"
-	///For if the retool kit changes the projectile's appearance. The sprite should be in icons/obj/weapons/guns/projectiles.dmi.
-	var/retool_projectile_icon = null
+	/// Specifies the icon file in which the crusher's projectile sprite is located.
+	var/retool_projectile_icon = 'icons/obj/weapons/guns/projectiles.dmi'
+	///For if the retool kit changes the projectile's appearance.
+	var/retool_projectile_icon_state = null
 	/// Specifies the left hand inhand icon file. Don't forget to set the right hand file as well.
 	var/retool_lefthand_file = null
 	/// Specifies the right hand inhand icon file. Don't forget to set the left hand file as well.
@@ -120,7 +125,7 @@
 	name = "harpoon"
 	retool_icon_state = "crusher_harpoon"
 	retool_inhand_icon = "crusher_harpoon"
-	retool_projectile_icon = "pulse_harpoon"
+	retool_projectile_icon_state = "pulse_harpoon"
 
 /datum/crusher_skin/harpoon/New(obj/item/kinetic_crusher/new_crusher)
 	. = ..()
@@ -202,5 +207,5 @@
 /datum/crusher_skin/ashen_skull
 	retool_icon_state = "crusher_skull"
 	retool_inhand_icon = "crusher_skull"
-	retool_projectile_icon = "pulse_skull"
+	retool_projectile_icon_state = "pulse_skull"
 	normal_skin = FALSE

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_misc.dm
@@ -76,7 +76,7 @@
 	/// Name of the modification
 	var/name = "error that should be reported to coders"
 	/// Specifies the icon file in which the crusher's new state is stored.
-	var/retool_icon = 'icons/obj/mining.dmi
+	var/retool_icon = 'icons/obj/mining.dmi'
 	///Specifies the sprite/icon state which the crusher is changed to as an item. Should appear in the icons/obj/mining.dmi file with accompanying "lit" and "recharging" sprites
 	var/retool_icon_state = "ipickaxe"
 	///Specifies the icon state for the crusher's appearance in hand. Should appear in both retool_lefthand_file and retool_righthand_file.


### PR DESCRIPTION
## About The Pull Request

Tin. This way if you have a crusher that uses a different icon file for whatever reason, it will correctly swap to the icon that has the default crusher skins.

## Changelog

Nothing player facing

