### PR TITLE
RPD ui refactor

### DIFF
--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 import {
   Box,
   Button,
@@ -7,6 +7,7 @@ import {
   LabeledList,
   Section,
   Stack,
+  StyleableSection,
   Tabs,
 } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
@@ -231,39 +232,45 @@ function RecipeRow(props: RecipeRowProps) {
   const { recipe, shownCategory } = props;
 
   return (
-    <Stack fill>
-      {recipe.previews.map((preview) => (
-        <Stack.Item key={preview.dir}>
-          <ImageButton
-            asset={['pipes32x32', preview.dir + '-' + preview.icon_state]}
-            color="blue"
-            imageSize={32}
-            onClick={() => {
-              act('pipe_type', {
-                pipe_type: recipe.pipe_index,
-                category: shownCategory.cat_name,
-              });
-              act('setdir', {
-                dir: preview.dir,
-                flipped: preview.flipped,
-              });
-            }}
-            selected={preview.selected}
-            tooltip={preview.dir_name}
-            tooltipPosition="bottom"
-          />
-        </Stack.Item>
-      ))}
-      <Stack.Item
-        align="center"
-        color="label"
-        grow
-        textAlign="right"
-        verticalAlign="middle"
-      >
-        {recipe.pipe_name}
-      </Stack.Item>
-    </Stack>
+    <StyleableSection
+      textStyle={{
+        color: 'var(--color-label)',
+        fontSize: '1em',
+        fontWeight: 'normal',
+        textAlign: 'right',
+      }}
+      title={recipe.pipe_name}
+      titleStyle={{
+        borderBottom: '1px solid var(--color-border)',
+        padding: 0,
+      }}
+    >
+      <Stack fill wrap>
+        {recipe.previews.map((preview) => (
+          <Stack.Item key={preview.dir}>
+            <ImageButton
+              asset={['pipes32x32', preview.dir + '-' + preview.icon_state]}
+              color="blue"
+              imageSize={58}
+              assetSize={30}
+              onClick={() => {
+                act('pipe_type', {
+                  pipe_type: recipe.pipe_index,
+                  category: shownCategory.cat_name,
+                });
+                act('setdir', {
+                  dir: preview.dir,
+                  flipped: preview.flipped,
+                });
+              }}
+              selected={preview.selected}
+              tooltip={preview.dir_name}
+              tooltipPosition="bottom"
+            />
+          </Stack.Item>
+        ))}
+      </Stack>
+    </StyleableSection>
   );
 }
 
@@ -291,16 +298,13 @@ function PipeTypeSection(props) {
         ))}
       </Tabs>
       <Section fill scrollable>
-        <Stack fill vertical>
-          {shownCategory?.recipes.map((recipe) => (
-            <Fragment key={recipe.pipe_index}>
-              <Stack.Item>
-                <RecipeRow recipe={recipe} shownCategory={shownCategory} />
-              </Stack.Item>
-              <Stack.Divider />
-            </Fragment>
-          ))}
-        </Stack>
+        {shownCategory?.recipes.map((recipe) => (
+          <RecipeRow
+            key={recipe.pipe_name}
+            recipe={recipe}
+            shownCategory={shownCategory}
+          />
+        ))}
       </Section>
     </Stack>
   );

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
@@ -19,14 +19,14 @@ const ROOT_CATEGORIES = ['Atmospherics', 'Disposals', 'Transit Tubes'] as const;
 
 export const ICON_BY_CATEGORY_NAME = {
   Atmospherics: 'wrench',
-  Disposals: 'trash-alt',
-  'Transit Tubes': 'bus',
-  Pipes: 'grip-lines',
   Binary: 'arrows-left-right',
-  'Disposal Pipes': 'grip-lines',
   Devices: 'microchip',
+  'Disposal Pipes': 'grip-lines',
+  Disposals: 'trash-alt',
   'Heat Exchange': 'thermometer-half',
+  Pipes: 'grip-lines',
   'Station Equipment': 'microchip',
+  'Transit Tubes': 'bus',
 } as const;
 
 const TOOLS = [
@@ -49,25 +49,10 @@ const TOOLS = [
 ] as const;
 
 type DirectionsAllowed = {
+  east: BooleanLike;
   north: BooleanLike;
   south: BooleanLike;
-  east: BooleanLike;
   west: BooleanLike;
-};
-
-type Colors = {
-  green: string;
-  blue: string;
-  red: string;
-  orange: string;
-  cyan: string;
-  dark: string;
-  yellow: string;
-  brown: string;
-  pink: string;
-  purple: string;
-  violet: string;
-  omni: string;
 };
 
 type Category = {
@@ -76,33 +61,33 @@ type Category = {
 };
 
 type Recipe = {
-  pipe_name: string;
   pipe_index: number;
+  pipe_name: string;
   previews: Preview[];
 };
 
 type Preview = {
-  selected: BooleanLike;
-  dir: string;
   dir_name: string;
-  icon_state: string;
+  dir: string;
   flipped: BooleanLike;
+  icon_state: string;
+  selected: BooleanLike;
 };
 
 type Data = {
-  // Static
-  paint_colors: Colors;
-  max_pipe_layers: number;
   // Dynamic
-  category: number;
-  pipe_layers: number;
-  multi_layer: BooleanLike;
   categories: Category[];
-  selected_recipe: string;
-  selected_color: string;
-  selected_category: string;
-  mode: number;
+  category: number;
   init_directions: DirectionsAllowed;
+  mode: number;
+  multi_layer: BooleanLike;
+  pipe_layers: number;
+  selected_category: string;
+  selected_color: string;
+  selected_recipe: string;
+  // Static
+  max_pipe_layers: number;
+  paint_colors: Record<string, string>;
 };
 
 export function ColorItem(props) {
@@ -294,8 +279,8 @@ function PipeTypeSection(props) {
     categories[0];
 
   return (
-    <Section>
-      <Tabs>
+    <Stack fill vertical>
+      <Tabs mb={-1}>
         {categories.map((category, i) => (
           <Tabs.Tab
             key={category.cat_name}
@@ -307,27 +292,29 @@ function PipeTypeSection(props) {
           </Tabs.Tab>
         ))}
       </Tabs>
-      <Table>
-        {shownCategory?.recipes.map((recipe) => (
-          <Table.Row
-            key={recipe.pipe_index}
-            style={{ borderBottom: '1px solid #333' }}
-          >
-            <Table.Cell collapsing py="2px" pb="1px">
-              <PreviewSelect
-                previews={recipe.previews}
-                pipe_type={recipe.pipe_index}
-                category={shownCategory.cat_name}
-              />
-            </Table.Cell>
-            <Table.Cell />
-            <Table.Cell style={{ verticalAlign: 'middle' }}>
-              {recipe.pipe_name}
-            </Table.Cell>
-          </Table.Row>
-        ))}
-      </Table>
-    </Section>
+      <Section fill scrollable>
+        <Table>
+          {shownCategory?.recipes.map((recipe) => (
+            <Table.Row
+              key={recipe.pipe_index}
+              style={{ borderBottom: '1px solid #333' }}
+            >
+              <Table.Cell collapsing py="2px" pb="1px">
+                <PreviewSelect
+                  previews={recipe.previews}
+                  pipe_type={recipe.pipe_index}
+                  category={shownCategory.cat_name}
+                />
+              </Table.Cell>
+              <Table.Cell />
+              <Table.Cell style={{ verticalAlign: 'middle' }}>
+                {recipe.pipe_name}
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table>
+      </Section>
+    </Stack>
   );
 }
 
@@ -415,7 +402,7 @@ export function RapidPipeDispenser(props) {
 
   return (
     <Window width={550} height={580}>
-      <Window.Content scrollable>
+      <Window.Content>
         <Stack fill vertical>
           <Stack.Item>
             <Stack fill>

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import {
   Box,
   Button,
   ColorBox,
+  ImageButton,
   LabeledList,
   Section,
   Stack,
-  Table,
   Tabs,
 } from 'tgui-core/components';
-import { BooleanLike, classes } from 'tgui-core/react';
+import { BooleanLike } from 'tgui-core/react';
 import { capitalizeAll } from 'tgui-core/string';
 
 import { useBackend } from '../backend';
@@ -221,52 +221,49 @@ function LayerSelect(props) {
   );
 }
 
-type PreviewSelectProps = {
-  previews: Preview[];
-  pipe_type: number;
-  category: string;
+type RecipeRowProps = {
+  recipe: Recipe;
+  shownCategory: Category;
 };
 
-function PreviewSelect(props: PreviewSelectProps) {
+function RecipeRow(props: RecipeRowProps) {
   const { act } = useBackend<Data>();
-  const { previews, pipe_type, category } = props;
+  const { recipe, shownCategory } = props;
 
   return (
-    <Box>
-      {previews.map((preview) => (
-        <Button
-          ml={0}
-          key={preview.dir}
-          tooltip={preview.dir_name}
-          selected={preview.selected}
-          style={{
-            width: '40px',
-            height: '40px',
-            padding: '0',
-          }}
-          onClick={() => {
-            act('pipe_type', {
-              pipe_type: pipe_type,
-              category: category,
-            });
-            act('setdir', {
-              dir: preview.dir,
-              flipped: preview.flipped,
-            });
-          }}
-        >
-          <Box
-            className={classes([
-              'pipes32x32',
-              preview.dir + '-' + preview.icon_state,
-            ])}
-            style={{
-              transform: 'scale(1.5) translate(9.5%, 9.5%)',
+    <Stack fill>
+      {recipe.previews.map((preview) => (
+        <Stack.Item key={preview.dir}>
+          <ImageButton
+            asset={['pipes32x32', preview.dir + '-' + preview.icon_state]}
+            color="blue"
+            imageSize={32}
+            onClick={() => {
+              act('pipe_type', {
+                pipe_type: recipe.pipe_index,
+                category: shownCategory.cat_name,
+              });
+              act('setdir', {
+                dir: preview.dir,
+                flipped: preview.flipped,
+              });
             }}
+            selected={preview.selected}
+            tooltip={preview.dir_name}
+            tooltipPosition="bottom"
           />
-        </Button>
+        </Stack.Item>
       ))}
-    </Box>
+      <Stack.Item
+        align="center"
+        color="label"
+        grow
+        textAlign="right"
+        verticalAlign="middle"
+      >
+        {recipe.pipe_name}
+      </Stack.Item>
+    </Stack>
   );
 }
 
@@ -274,6 +271,7 @@ function PipeTypeSection(props) {
   const { data } = useBackend<Data>();
   const { categories = [], selected_category } = data;
   const [categoryName, setCategoryName] = useState(selected_category);
+
   const shownCategory =
     categories.find((category) => category.cat_name === categoryName) ||
     categories[0];
@@ -293,26 +291,16 @@ function PipeTypeSection(props) {
         ))}
       </Tabs>
       <Section fill scrollable>
-        <Table>
+        <Stack fill vertical>
           {shownCategory?.recipes.map((recipe) => (
-            <Table.Row
-              key={recipe.pipe_index}
-              style={{ borderBottom: '1px solid #333' }}
-            >
-              <Table.Cell collapsing py="2px" pb="1px">
-                <PreviewSelect
-                  previews={recipe.previews}
-                  pipe_type={recipe.pipe_index}
-                  category={shownCategory.cat_name}
-                />
-              </Table.Cell>
-              <Table.Cell />
-              <Table.Cell style={{ verticalAlign: 'middle' }}>
-                {recipe.pipe_name}
-              </Table.Cell>
-            </Table.Row>
+            <Fragment key={recipe.pipe_index}>
+              <Stack.Item>
+                <RecipeRow recipe={recipe} shownCategory={shownCategory} />
+              </Stack.Item>
+              <Stack.Divider />
+            </Fragment>
           ))}
-        </Table>
+        </Stack>
       </Section>
     </Stack>
   );

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
@@ -15,7 +15,7 @@ import { capitalizeAll } from 'tgui-core/string';
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 
-const ROOT_CATEGORIES = ['Atmospherics', 'Disposals', 'Transit Tubes'];
+const ROOT_CATEGORIES = ['Atmospherics', 'Disposals', 'Transit Tubes'] as const;
 
 export const ICON_BY_CATEGORY_NAME = {
   Atmospherics: 'wrench',
@@ -27,7 +27,7 @@ export const ICON_BY_CATEGORY_NAME = {
   Devices: 'microchip',
   'Heat Exchange': 'thermometer-half',
   'Station Equipment': 'microchip',
-};
+} as const;
 
 const TOOLS = [
   {
@@ -46,7 +46,7 @@ const TOOLS = [
     name: 'Reprogram',
     bitmask: 8,
   },
-];
+] as const;
 
 type DirectionsAllowed = {
   north: BooleanLike;
@@ -105,10 +105,11 @@ type Data = {
   init_directions: DirectionsAllowed;
 };
 
-export const ColorItem = (props) => {
+export function ColorItem(props) {
   const { act, data } = useBackend<Data>();
-  const { selected_color, paint_colors } = data;
+  const { selected_color, paint_colors = {} } = data;
   const colorNames = Object.keys(paint_colors);
+
   return (
     <LabeledList.Item label="Color">
       {colorNames.map((colorName) => (
@@ -134,11 +135,12 @@ export const ColorItem = (props) => {
       </Box>
     </LabeledList.Item>
   );
-};
+}
 
-const ModeItem = (props) => {
+function ModeItem(props) {
   const { act, data } = useBackend<Data>();
   const { mode } = data;
+
   return (
     <LabeledList.Item label="Modes">
       {TOOLS.map((tool) => (
@@ -156,11 +158,12 @@ const ModeItem = (props) => {
       ))}
     </LabeledList.Item>
   );
-};
+}
 
-const CategoryItem = (props) => {
+function CategoryItem(props) {
   const { act, data } = useBackend<Data>();
   const { category: rootCategoryIndex } = data;
+
   return (
     <LabeledList.Item label="Category">
       {ROOT_CATEGORIES.map((categoryName, i) => (
@@ -176,11 +179,12 @@ const CategoryItem = (props) => {
       ))}
     </LabeledList.Item>
   );
-};
+}
 
-const SelectionSection = (props) => {
+function SelectionSection(props) {
   const { data } = useBackend<Data>();
   const { category: rootCategoryIndex } = data;
+
   return (
     <Section fill>
       <LabeledList>
@@ -191,34 +195,33 @@ const SelectionSection = (props) => {
       </LabeledList>
     </Section>
   );
-};
+}
 
-const LayerSelect = (props) => {
+function layerToBitmask(layer: number) {
+  return 1 << layer;
+}
+
+function LayerSelect(props) {
   const { act, data } = useBackend<Data>();
-  const { pipe_layers, multi_layer, max_pipe_layers } = data;
-  const layer_to_bitmask = (layer: number) => {
-    return 1 << layer;
-  };
+  const { pipe_layers, multi_layer, max_pipe_layers = 1 } = data;
 
   return (
     <LabeledList.Item label="Layer">
-      {Array(max_pipe_layers)
-        .keys()
-        .map((layer) => (
-          <Button.Checkbox
-            key={layer}
-            checked={
-              multi_layer
-                ? pipe_layers & layer_to_bitmask(layer)
-                : layer_to_bitmask(layer) === pipe_layers
-            }
-            onClick={() =>
-              act('pipe_layers', { pipe_layers: layer_to_bitmask(layer) })
-            }
-          >
-            {layer + 1}
-          </Button.Checkbox>
-        ))}
+      {Array.from({ length: max_pipe_layers }).map((_, layer) => (
+        <Button.Checkbox
+          key={layer}
+          checked={
+            multi_layer
+              ? pipe_layers & layerToBitmask(layer)
+              : layerToBitmask(layer) === pipe_layers
+          }
+          onClick={() =>
+            act('pipe_layers', { pipe_layers: layerToBitmask(layer) })
+          }
+        >
+          {layer + 1}
+        </Button.Checkbox>
+      ))}
       <Button.Checkbox
         key="multilayer"
         checked={multi_layer}
@@ -231,13 +234,21 @@ const LayerSelect = (props) => {
       </Button.Checkbox>
     </LabeledList.Item>
   );
+}
+
+type PreviewSelectProps = {
+  previews: Preview[];
+  pipe_type: number;
+  category: string;
 };
 
-const PreviewSelect = (props) => {
+function PreviewSelect(props: PreviewSelectProps) {
   const { act } = useBackend<Data>();
+  const { previews, pipe_type, category } = props;
+
   return (
     <Box>
-      {props.previews.map((preview) => (
+      {previews.map((preview) => (
         <Button
           ml={0}
           key={preview.dir}
@@ -250,8 +261,8 @@ const PreviewSelect = (props) => {
           }}
           onClick={() => {
             act('pipe_type', {
-              pipe_type: props.pipe_type,
-              category: props.category,
+              pipe_type: pipe_type,
+              category: category,
             });
             act('setdir', {
               dir: preview.dir,
@@ -272,9 +283,9 @@ const PreviewSelect = (props) => {
       ))}
     </Box>
   );
-};
+}
 
-const PipeTypeSection = (props) => {
+function PipeTypeSection(props) {
   const { data } = useBackend<Data>();
   const { categories = [], selected_category } = data;
   const [categoryName, setCategoryName] = useState(selected_category);
@@ -318,11 +329,12 @@ const PipeTypeSection = (props) => {
       </Table>
     </Section>
   );
-};
+}
 
-export const SmartPipeBlockSection = (props) => {
+export function SmartPipeBlockSection(props) {
   const { act, data } = useBackend<Data>();
   const { init_directions = [] } = data;
+
   return (
     <Section fill>
       <Stack vertical textAlign="center">
@@ -395,11 +407,12 @@ export const SmartPipeBlockSection = (props) => {
       </Stack>
     </Section>
   );
-};
+}
 
-export const RapidPipeDispenser = (props) => {
+export function RapidPipeDispenser(props) {
   const { data } = useBackend<Data>();
   const { category: rootCategoryIndex } = data;
+
   return (
     <Window width={550} height={580}>
       <Window.Content scrollable>
@@ -423,4 +436,4 @@ export const RapidPipeDispenser = (props) => {
       </Window.Content>
     </Window>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.tsx
@@ -249,7 +249,7 @@ function RecipeRow(props: RecipeRowProps) {
         {recipe.previews.map((preview) => (
           <Stack.Item key={preview.dir}>
             <ImageButton
-              asset={['pipes32x32', preview.dir + '-' + preview.icon_state]}
+              asset={['pipes32x32', `${preview.dir}-${preview.icon_state}`]}
               color="blue"
               imageSize={58}
               assetSize={30}


### PR DESCRIPTION
## About The Pull Request
Fixes a possible bluescreen in the RPD. Issue was caused when the backend didn't send the static data that the UI relied upon to populate pipe layers (perhaps due to throttling)

Reworks the UI a bit so that the content section is scrollable instead of the entire window. This prevents the top content from disappearing if you're scrolling available pipes. Adds some extra typing where it was type: any

![image](https://github.com/user-attachments/assets/d8e4e0b6-1798-4c76-bf94-10a50f916b3b)

## Why It's Good For The Game
Fixes #90992
## Changelog
:cl:
fix: Fixed an uncommon bluescreen in the rapid pipe dispenser UI.
/:cl:
