### PR TITLE
Egg boxes can hold other egg-shaped items, like chocolate, boiled, and surprise eggs

### DIFF
--- a/code/datums/storage/subtypes/others/misc.dm
+++ b/code/datums/storage/subtypes/others/misc.dm
@@ -154,7 +154,8 @@
 		/obj/item/food/egg,
 		/obj/item/food/chocolateegg,
 		/obj/item/food/boiledegg,
-		/obj/item/surprise_egg
+		/obj/item/food/grown/eggy,
+		/obj/item/surprise_egg,
 	))
 
 ///Generic fancy holder

--- a/code/datums/storage/subtypes/others/misc.dm
+++ b/code/datums/storage/subtypes/others/misc.dm
@@ -150,7 +150,12 @@
 ///Egg box
 /datum/storage/egg_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
 	. = ..()
-	set_holdable(/obj/item/food/egg)
+	set_holdable(list(
+		/obj/item/food/egg,
+		/obj/item/food/chocolateegg,
+		/obj/item/food/boiledegg,
+		/obj/item/surprise_egg
+	))
 
 ///Generic fancy holder
 /datum/storage/fancy_holder/New(obj/item/storage/fancy/candle_box/parent, max_slots, max_specific_storage, max_total_storage)

--- a/code/datums/storage/subtypes/others/misc.dm
+++ b/code/datums/storage/subtypes/others/misc.dm
@@ -154,6 +154,7 @@
 		/obj/item/food/egg,
 		/obj/item/food/chocolateegg,
 		/obj/item/food/boiledegg,
+		/obj/item/food/scotchegg,
 		/obj/item/food/grown/eggy,
 		/obj/item/surprise_egg,
 	))


### PR DESCRIPTION

## About The Pull Request

While reviewing a storage refactor pr I noticed egg boxes can only hold standard eggs, despite having multiple other egg-shaped things that could also fit in the same things.
So! In this pr we just add chocolate, boiled, and surprise eggs to the list of holdables.
## Why It's Good For The Game

Feels wack when you can't put the egg-shaped objects in the egg-shaped holes.
## Changelog
:cl:
qol: Egg boxes can hold chocolate eggs, boiled eggs, and surprise eggs
/:cl:
