### PR TITLE
Fix wibbly runtime

### DIFF
--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -313,10 +313,12 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 		animate(offset = random_roll - 1, time = rand() * 20 + 10)
 
 /proc/remove_wibbly_filters(atom/in_atom, remove_duration = 0)
+	if(QDELETED(in_atom))
+		return
 	var/filter
 	for(var/i in 1 to 7)
 		filter = in_atom.get_filter("wibbly-[i]")
-		if(remove_duration == 0 || QDELETED(in_atom))
+		if(remove_duration == 0)
 			animate(filter)
 			in_atom.remove_filter("wibbly-[i]")
 			continue

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -316,7 +316,7 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 	var/filter
 	for(var/i in 1 to 7)
 		filter = in_atom.get_filter("wibbly-[i]")
-		if(remove_duration == 0)
+		if(remove_duration == 0 || QDELETED(in_atom))
 			animate(filter)
 			in_atom.remove_filter("wibbly-[i]")
 			continue


### PR DESCRIPTION
## About The Pull Request

Wibbly filters were being set to be removed on a timer, but the item associated with the callback could be qdeleted before that went off causing the 'addtimer callback with a callback assigned to a qdeleted object' stack trace. This was commonly seen in holograms, like the floorsigns below.

![image](https://github.com/user-attachments/assets/bf19eed6-244b-4178-96d5-6d9997001b96)

![image](https://github.com/user-attachments/assets/70bce1b3-1fe2-4ed7-b2f7-1c8f0a906612)

## Why It's Good For The Game

Less flaky CI failures.

## Changelog

Nothing player facing