### PR TITLE
Catwalk station hop office disposal fix and deletes a door

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -9747,12 +9747,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"cTk" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/station/command/bridge)
 "cTv" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -177476,7 +177470,7 @@ pML
 miZ
 vzB
 dGv
-cTk
+inh
 oLH
 fro
 tCY

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -982,6 +982,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "aqD" = (
@@ -6862,9 +6863,6 @@
 	id = "HoPsToy"
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/door/airlock/wood{
-	name = "Kitchen"
-	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "ccc" = (
@@ -27746,9 +27744,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/command/hop,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "inU" = (


### PR DESCRIPTION

## About The Pull Request
Hop office disposals didnt work since there was a misplaced pipe. it has a working one now.
Also i deleted this door that was on the upper level of their office, it seemed weird and it was called 'kitchen'
![image](https://github.com/user-attachments/assets/7cad22bb-b5c5-4d73-bed3-7d9686729c0e)
Also added a holopad to their office
Also deleted a floating camera console in the bridge.
## Why It's Good For The Game
Disposals working is the intended design.
## Changelog
:cl:
fix: Hop's office on catwalk now has working disposals and removes a floating camera console from the bridge.
/:cl:
