### PR TITLE
Lets you test brain health with the carpenter hammer

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -90,6 +90,10 @@
 	custom_materials = list(/datum/material/wood=SMALL_MATERIAL_AMOUNT*0.5, /datum/material/iron=SMALL_MATERIAL_AMOUNT*0.7)
 	wound_bonus = 35
 
+/obj/item/crowbar/hammer/Initialize(mapload)
+	.=..()
+	AddElement(/datum/element/kneejerk)
+
 /obj/item/crowbar/large/twenty_force //from space ruin
 	name = "heavy crowbar"
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big. It feels oddly heavy.."

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -91,7 +91,7 @@
 	wound_bonus = 35
 
 /obj/item/crowbar/hammer/Initialize(mapload)
-	.=..()
+	. = ..()
 	AddElement(/datum/element/kneejerk)
 
 /obj/item/crowbar/large/twenty_force //from space ruin

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -475,6 +475,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/carpenter_hammer/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/item_killsound, \
+	AddElement(/datum/element/kneejerk), \
 	allowed_mobs = list(/mob/living/carbon/human), \
 	killsound = 'sound/items/weapons/hammer_death_scream.ogg', \
 	replace_default_death_sound = TRUE, \

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -474,8 +474,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/carpenter_hammer/Initialize(mapload)
 	. = ..()
+	AddElement(/datum/element/kneejerk)
 	AddComponent(/datum/component/item_killsound, \
-	AddElement(/datum/element/kneejerk), \
 	allowed_mobs = list(/mob/living/carbon/human), \
 	killsound = 'sound/items/weapons/hammer_death_scream.ogg', \
 	replace_default_death_sound = TRUE, \


### PR DESCRIPTION

## About The Pull Request
Adds the kneejerk element to the carpenter and claw hammer.
I imagine its a oversight cause who knew about this interaction with the existing hammers.
Also tested it and it works.
## Why It's Good For The Game
Makes hammers more uniform. Gavels, chaplains nullrod hammer, pride hammer, and singularity hammer can check for brain health this way. 
The claw and carpenter hammer cannot
## Changelog
:cl:

fix: carpenter and claw hammer can now test for brain health.

/:cl:
