### PR TITLE
[MDB Ignore] Makes toolset arms a subtype of arm implants

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -524,7 +524,7 @@
 "tL" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/crate/secure/engineering,
-/obj/item/organ/cyberimp/arm/toolset,
+/obj/item/organ/cyberimp/arm/toolkit/toolset,
 /obj/item/organ/cyberimp/eyes/hud/medical,
 /obj/item/organ/cyberimp/brain/anti_stun,
 /turf/open/floor/iron/dark/airless,

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck2.dmm
@@ -297,7 +297,7 @@
 /obj/item/stack/medical/gauze,
 /obj/item/stack/sticky_tape/surgical,
 /obj/structure/broken_flooring/corner,
-/obj/item/organ/cyberimp/arm/surgery,
+/obj/item/organ/cyberimp/arm/toolkit/surgery,
 /obj/item/organ/cyberimp/eyes/hud/medical,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/medicalwaste)

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -521,7 +521,7 @@
 	pixel_x = 17;
 	pixel_y = 12
 	},
-/obj/item/organ/cyberimp/arm/toolset{
+/obj/item/organ/cyberimp/arm/tookit/toolset{
 	pixel_y = 2;
 	pixel_x = 6
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -521,7 +521,7 @@
 	pixel_x = 17;
 	pixel_y = 12
 	},
-/obj/item/organ/cyberimp/arm/tookit/toolset{
+/obj/item/organ/cyberimp/arm/toolkit/toolset{
 	pixel_y = 2;
 	pixel_x = 6
 	},

--- a/_maps/minigame/deathmatch/sunrise.dmm
+++ b/_maps/minigame/deathmatch/sunrise.dmm
@@ -721,7 +721,7 @@
 /area/deathmatch)
 "Uk" = (
 /obj/structure/closet/crate/coffin,
-/obj/item/organ/cyberimp/arm/shard/katana,
+/obj/item/organ/cyberimp/arm/toolkit/shard/katana,
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/south,

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -273,7 +273,7 @@
 		/datum/job/coroner = /obj/item/organ/tongue/bone, //hes got a bone to pick with you
 		/datum/job/curator = /obj/item/organ/cyberimp/brain/connector,
 		/datum/job/detective = /obj/item/organ/lungs/cybernetic/tier3,
-		/datum/job/doctor = /obj/item/organ/cyberimp/arm/surgery,
+		/datum/job/doctor = /obj/item/organ/cyberimp/arm/toolkit/surgery,
 		/datum/job/geneticist = /obj/item/organ/fly, //we don't care about implants, we have cancer.
 		/datum/job/head_of_personnel = /obj/item/organ/eyes/robotic,
 		/datum/job/head_of_security = /obj/item/organ/eyes/robotic/thermals,
@@ -289,9 +289,9 @@
 		/datum/job/research_director = /obj/item/organ/cyberimp/bci,
 		/datum/job/roboticist = /obj/item/organ/cyberimp/eyes/hud/diagnostic,
 		/datum/job/scientist = /obj/item/organ/ears/cybernetic,
-		/datum/job/security_officer = /obj/item/organ/cyberimp/arm/flash,
+		/datum/job/security_officer = /obj/item/organ/cyberimp/arm/toolkit/flash,
 		/datum/job/shaft_miner = /obj/item/organ/monster_core/rush_gland,
-		/datum/job/station_engineer = /obj/item/organ/cyberimp/arm/toolset,
+		/datum/job/station_engineer = /obj/item/organ/cyberimp/arm/toolkit/toolset,
 		/datum/job/warden = /obj/item/organ/cyberimp/eyes/hud/security,
 	)
 

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -148,8 +148,8 @@
 		// cyberimplants range from a nice bonus to fucking broken bullshit so no subtypesof
 		var/list/selectable_types = list(
 			/obj/item/organ/cyberimp/brain/anti_drop,
-			/obj/item/organ/cyberimp/arm/toolset,
-			/obj/item/organ/cyberimp/arm/surgery,
+			/obj/item/organ/cyberimp/arm/toolkit/toolset,
+			/obj/item/organ/cyberimp/arm/toolkit/surgery,
 			/obj/item/organ/cyberimp/chest/thrusters,
 			/obj/item/organ/lungs/cybernetic/tier3,
 			/obj/item/organ/liver/cybernetic/tier3,

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -313,7 +313,7 @@
 	var/datum/weakref/arm
 
 /obj/item/assembly/flash/armimplant/burn_out()
-	var/obj/item/organ/cyberimp/arm/flash/real_arm = arm.resolve()
+	var/obj/item/organ/cyberimp/arm/toolkit/flash/real_arm = arm.resolve()
 	if(real_arm?.owner)
 		to_chat(real_arm.owner, span_warning("Your photon projector implant overheats and deactivates!"))
 		real_arm.Retract()
@@ -322,7 +322,7 @@
 
 /obj/item/assembly/flash/armimplant/try_use_flash(mob/user = null)
 	if(overheat)
-		var/obj/item/organ/cyberimp/arm/flash/real_arm = arm.resolve()
+		var/obj/item/organ/cyberimp/arm/toolkit/flash/real_arm = arm.resolve()
 		if(real_arm?.owner)
 			to_chat(real_arm.owner, span_warning("Your photon projector is running too hot to be used again so quickly!"))
 		return FALSE

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -8,7 +8,7 @@
 		/obj/item/immortality_talisman,
 		/obj/item/book_of_babel,
 		/obj/item/wisp_lantern,
-		/obj/item/organ/cyberimp/arm/shard/katana,
+		/obj/item/organ/cyberimp/arm/toolkit/shard/katana,
 		/obj/item/clothing/neck/cloak/wolf_coat,
 		/obj/item/clothing/glasses/godeye,
 		/obj/item/clothing/neck/necklace/memento_mori,

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -199,7 +199,7 @@
 	name = "Paperwork Implant Set"
 	desc = "A crate containing two implants, which can be surgically implanted to effectivize crewmembers at paperwork. Warranty void if exposed to electromagnetic pulses."
 	cost = CARGO_CRATE_VALUE * 3
-	contains = list(/obj/item/organ/cyberimp/arm/paperwork = 2)
+	contains = list(/obj/item/organ/cyberimp/arm/toolkit/paperwork = 2)
 	crate_name = "Paperwork implant crate"
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE
 

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -45,7 +45,7 @@
 			rods[nullrod_type] = initial(nullrod_type.menu_description)
 		//special non-nullrod subtyped shit
 		rods[/obj/item/gun/ballistic/bow/divine/with_quiver] = "A divine bow and 10 quivered holy arrows."
-		rods[/obj/item/organ/cyberimp/arm/shard/scythe] = "A shard that implants itself into your arm, \
+		rods[/obj/item/organ/cyberimp/arm/toolkit/shard/scythe] = "A shard that implants itself into your arm, \
 									allowing you to conjure forth a vorpal scythe. \
 									Allows you to behead targets for empowered strikes. \
 									Harms you if you dismiss the scythe without first causing harm to a creature. \

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -5,13 +5,13 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 #define SCYTHE_SATED 1
 #define SCYTHE_EMPOWERED 2
 
-/obj/item/organ/cyberimp/arm/shard/scythe
+/obj/item/organ/cyberimp/arm/toolkit/shard/scythe
 	name = "sinister shard"
 	desc = "This shard seems to be directly linked to some sinister entity. It might be your god! It also gives you a really horrible rash when you hold onto it for too long."
 	items_to_create = list(/obj/item/vorpalscythe)
 	organ_traits = list(TRAIT_MORBID)
 
-/obj/item/organ/cyberimp/arm/shard/scythe/Retract()
+/obj/item/organ/cyberimp/arm/toolkit/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item
 	if(!scythe)
 		return FALSE

--- a/code/modules/mining/lavaland/mining_loot/cursed_katana.dm
+++ b/code/modules/mining/lavaland/mining_loot/cursed_katana.dm
@@ -5,7 +5,7 @@
 #define ATTACK_CLOAK "Dark Cloak"
 #define ATTACK_SHATTER "Shatter"
 
-/obj/item/organ/cyberimp/arm/shard
+/obj/item/organ/cyberimp/arm/toolkit/shard
 	name = "dark spoon shard"
 	desc = "An eerie metal shard surrounded by dark energies...of soup drinking. You probably don't think you should have been able to find this."
 	icon = 'icons/obj/mining_zones/artefacts.dmi'
@@ -15,7 +15,7 @@
 	extend_sound = 'sound/items/unsheath.ogg'
 	retract_sound = 'sound/items/sheath.ogg'
 
-/obj/item/organ/cyberimp/arm/shard/attack_self(mob/user, modifiers)
+/obj/item/organ/cyberimp/arm/toolkit/shard/attack_self(mob/user, modifiers)
 	. = ..()
 	to_chat(user, span_userdanger("The mass goes up your arm and goes inside it!"))
 	playsound(user, 'sound/effects/magic/demon_consume.ogg', 50, TRUE)
@@ -24,15 +24,15 @@
 	user.temporarilyRemoveItemFromInventory(src, TRUE)
 	Insert(user)
 
-/obj/item/organ/cyberimp/arm/shard/screwdriver_act(mob/living/user, obj/item/screwtool)
+/obj/item/organ/cyberimp/arm/toolkit/shard/screwdriver_act(mob/living/user, obj/item/screwtool)
 	return
 
-/obj/item/organ/cyberimp/arm/shard/katana
+/obj/item/organ/cyberimp/arm/toolkit/shard/katana
 	name = "dark shard"
 	desc = "An eerie metal shard surrounded by dark energies."
 	items_to_create = list(/obj/item/cursed_katana)
 
-/obj/item/organ/cyberimp/arm/shard/katana/Retract()
+/obj/item/organ/cyberimp/arm/toolkit/shard/katana/Retract()
 	var/obj/item/cursed_katana/katana = active_item
 	if(!katana || katana.shattered)
 		return FALSE

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -27,7 +27,7 @@
 		if(2)
 			new /obj/item/soulstone/anybody/mining(src)
 		if(3)
-			new /obj/item/organ/cyberimp/arm/shard/katana(src)
+			new /obj/item/organ/cyberimp/arm/toolkit/shard/katana(src)
 		if(4)
 			new /obj/item/clothing/glasses/godeye(src)
 		if(5)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -141,9 +141,9 @@
 		list(
 			// Arms
 			list(
-				/obj/item/organ/cyberimp/arm/combat = 1,
-				/obj/item/organ/cyberimp/arm/surgery = 1000000,
-				/obj/item/organ/cyberimp/arm/toolset = 1500000,
+				/obj/item/organ/cyberimp/arm/toolkit/combat = 1,
+				/obj/item/organ/cyberimp/arm/toolkit/surgery = 1000000,
+				/obj/item/organ/cyberimp/arm/toolkit/toolset = 1500000,
 			) = 15,
 			// Eyes
 			list(

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -427,7 +427,7 @@
 		/datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT * 1.5,
 	)
 	construction_time = 2 SECONDS
-	build_path = /obj/item/organ/cyberimp/arm/surgery
+	build_path = /obj/item/organ/cyberimp/arm/toolkit/surgery
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
@@ -444,7 +444,7 @@
 		/datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT * 1.5,
 	)
 	construction_time = 2 SECONDS
-	build_path = /obj/item/organ/cyberimp/arm/toolset
+	build_path = /obj/item/organ/cyberimp/arm/toolkit/toolset
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -169,7 +169,7 @@
 /obj/item/autosurgeon/syndicate/laser_arm
 	desc = "A single use autosurgeon that contains a combat arms-up laser augment. A screwdriver can be used to remove it, but implants can't be placed back in."
 	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/gun/laser
+	starting_organ = /obj/item/organ/cyberimp/arm/toolkit/gun/laser
 
 /obj/item/autosurgeon/syndicate/thermal_eyes
 	starting_organ = /obj/item/organ/eyes/robotic/thermals
@@ -205,7 +205,7 @@
 	organ_whitelist += /obj/item/organ/tongue
 
 /obj/item/autosurgeon/syndicate/emaggedsurgerytoolset
-	starting_organ = /obj/item/organ/cyberimp/arm/surgery/emagged
+	starting_organ = /obj/item/organ/cyberimp/arm/toolkit/surgery/emagged
 
 /obj/item/autosurgeon/syndicate/emaggedsurgerytoolset/single_use
 	uses = 1

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -36,7 +36,7 @@
 	SIGNAL_HANDLER
 	if(source != hand || QDELETED(hand))
 		return
-	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
+	UnregisterSignal(hand, list(COMSIG_BODYPART_REMOVED, COMSIG_ITEM_ATTACK_SELF))
 	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit
@@ -92,14 +92,6 @@
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
 	. = ..()
 	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
-
-/obj/item/organ/cyberimp/arm/tookit/on_limb_detached(obj/item/bodypart/source)
-	SIGNAL_HANDLER
-	if(source != hand || QDELETED(hand))
-		return
-	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
-	UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
-	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -1,17 +1,49 @@
-/obj/item/organ/cyberimp/arm
+/obj/item/organ/cyberimp/arm/
 	name = "arm-mounted implant"
-	desc = "You shouldn't see this! Adminhelp and report this as an issue on github!"
+	desc = "An implant that goes in your arm to improve it."
 	zone = BODY_ZONE_R_ARM
 	slot = ORGAN_SLOT_RIGHT_ARM_AUG
-	icon_state = "toolkit_generic"
 	w_class = WEIGHT_CLASS_SMALL
-	actions_types = list(/datum/action/item_action/organ_action/toggle)
 	valid_zones = list(
 		BODY_ZONE_R_ARM = ORGAN_SLOT_RIGHT_ARM_AUG,
 		BODY_ZONE_L_ARM = ORGAN_SLOT_LEFT_ARM_AUG,
 	)
 	///A ref for the arm we're taking up. Mostly for the unregister signal upon removal
 	var/obj/hand
+
+/obj/item/organ/cyberimp/arm/get_overlay_state(image_layer, obj/item/bodypart/limb)
+	return "[aug_overlay][zone == BODY_ZONE_L_ARM ? "_left" : "_right"]"
+
+/obj/item/organ/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)
+	. = ..()
+	RegisterSignal(arm_owner, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(on_limb_attached))
+	on_limb_attached(arm_owner, arm_owner.hand_bodyparts[zone == BODY_ZONE_R_ARM ? RIGHT_HANDS : LEFT_HANDS])
+
+/obj/item/organ/cyberimp/arm/on_mob_remove(mob/living/carbon/arm_owner)
+	. = ..()
+	on_limb_detached(hand)
+
+/obj/item/organ/cyberimp/arm/proc/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
+	SIGNAL_HANDLER
+	if(!limb || QDELETED(limb) || limb.body_zone != zone)
+		return
+	if(hand)
+		on_limb_detached(hand)
+	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
+	hand = limb
+
+/obj/item/organ/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
+	SIGNAL_HANDLER
+	if(source != hand || QDELETED(hand))
+		return
+	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
+	hand = null
+
+/obj/item/organ/cyberimp/arm/toolkit
+	name = "arm-mounted toolkit"
+	desc = "You shouldn't see this! Adminhelp and report this as an issue on github!"
+	icon_state = "toolkit_generic"
+	actions_types = list(/datum/action/item_action/organ_action/toggle)
 	//A list of typepaths to create and insert into ourself on init
 	var/list/items_to_create = list()
 	/// Used to store a list of all items inside, for multi-item implants.
@@ -25,7 +57,7 @@
 	/// Do we have a separate icon_state for the hand overlay?
 	var/hand_state = TRUE
 
-/obj/item/organ/cyberimp/arm/Initialize(mapload)
+/obj/item/organ/cyberimp/arm/toolkit/Initialize(mapload)
 	. = ..()
 	if(ispath(active_item))
 		active_item = new active_item(src)
@@ -35,7 +67,7 @@
 		var/atom/new_item = new typepath(src)
 		items_list += WEAKREF(new_item)
 
-/obj/item/organ/cyberimp/arm/Destroy()
+/obj/item/organ/cyberimp/arm/toolkit/Destroy()
 	hand = null
 	active_item = null
 	for(var/datum/weakref/ref in items_list)
@@ -49,40 +81,27 @@
 /datum/action/item_action/organ_action/toggle/toolkit
 	desc = "You can also activate your empty hand or the tool in your hand to open the tools radial menu."
 
-/obj/item/organ/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)
+/obj/item/organ/cyberimp/arm/toolkit/on_mob_insert(mob/living/carbon/arm_owner)
 	. = ..()
-	RegisterSignal(arm_owner, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(on_limb_attached))
 	RegisterSignal(arm_owner, COMSIG_KB_MOB_DROPITEM_DOWN, PROC_REF(dropkey)) //We're nodrop, but we'll watch for the drop hotkey anyway and then stow if possible.
-	on_limb_attached(arm_owner, arm_owner.hand_bodyparts[zone == BODY_ZONE_R_ARM ? RIGHT_HANDS : LEFT_HANDS])
 
-/obj/item/organ/cyberimp/arm/on_mob_remove(mob/living/carbon/arm_owner)
+/obj/item/organ/cyberimp/arm/toolkit/on_mob_remove(mob/living/carbon/arm_owner)
 	. = ..()
 	Retract()
-	UnregisterSignal(arm_owner, list(COMSIG_CARBON_POST_ATTACH_LIMB, COMSIG_KB_MOB_DROPITEM_DOWN))
-	on_limb_detached(hand)
 
-/obj/item/organ/cyberimp/arm/proc/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
-	SIGNAL_HANDLER
-	if(!limb || QDELETED(limb) || limb.body_zone != zone)
-		return
-	if(hand)
-		on_limb_detached(hand)
+/obj/item/organ/cyberimp/arm/toolkit/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
+	. = ..()
 	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
-	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
-	hand = limb
 
-/obj/item/organ/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
-	SIGNAL_HANDLER
-	if(source != hand || QDELETED(hand))
-		return
-	UnregisterSignal(hand, list(COMSIG_ITEM_ATTACK_SELF, COMSIG_BODYPART_REMOVED))
-	hand = null
+/obj/item/organ/cyberimp/arm/tookit/on_limb_detached(obj/item/bodypart/source)
+	. = ..()
+	UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
 
-/obj/item/organ/cyberimp/arm/proc/on_item_attack_self()
+/obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, PROC_REF(ui_action_click))
 
-/obj/item/organ/cyberimp/arm/emp_act(severity)
+/obj/item/organ/cyberimp/arm/toolkit/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF || !IS_ROBOTIC_ORGAN(src))
 		return
@@ -91,10 +110,7 @@
 		// give the owner an idea about why his implant is glitching
 		Retract()
 
-/obj/item/organ/cyberimp/arm/get_overlay_state(image_layer, obj/item/bodypart/limb)
-	return "[aug_overlay][zone == BODY_ZONE_L_ARM ? "_left" : "_right"]"
-
-/obj/item/organ/cyberimp/arm/get_overlay(image_layer, obj/item/bodypart/limb)
+/obj/item/organ/cyberimp/arm/toolkit/get_overlay(image_layer, obj/item/bodypart/limb)
 	if (!hand_state)
 		return ..()
 
@@ -117,7 +133,7 @@
  * quick way to store implant items. In this case, we check to make sure the user has the correct arm
  * selected, and that the item is actually owned by us, and then we'll hand off the rest to Retract()
 **/
-/obj/item/organ/cyberimp/arm/proc/dropkey(mob/living/carbon/host)
+/obj/item/organ/cyberimp/arm/toolkit/proc/dropkey(mob/living/carbon/host)
 	SIGNAL_HANDLER
 	if(!host)
 		return //How did we even get here
@@ -126,7 +142,7 @@
 	if(Retract())
 		return COMSIG_KB_ACTIVATED
 
-/obj/item/organ/cyberimp/arm/proc/Retract()
+/obj/item/organ/cyberimp/arm/toolkit/proc/Retract()
 	if(!active_item || (active_item in src))
 		return FALSE
 	active_item.resistance_flags = active_item::resistance_flags
@@ -147,7 +163,7 @@
 	playsound(get_turf(owner), retract_sound, 50, TRUE)
 	return TRUE
 
-/obj/item/organ/cyberimp/arm/proc/Extend(obj/item/augment)
+/obj/item/organ/cyberimp/arm/toolkit/proc/Extend(obj/item/augment)
 	if(!(augment in src))
 		return
 
@@ -185,12 +201,12 @@
 	if(length(items_list) > 1)
 		RegisterSignals(active_item, list(COMSIG_ITEM_ATTACK_SELF, COMSIG_ITEM_ATTACK_SELF_SECONDARY), PROC_REF(swap_tools)) // secondary for welders
 
-/obj/item/organ/cyberimp/arm/proc/swap_tools(active_item)
+/obj/item/organ/cyberimp/arm/toolkit/proc/swap_tools(active_item)
 	SIGNAL_HANDLER
 	Retract(active_item)
 	INVOKE_ASYNC(src, PROC_REF(ui_action_click))
 
-/obj/item/organ/cyberimp/arm/ui_action_click()
+/obj/item/organ/cyberimp/arm/toolkit/ui_action_click()
 	if((organ_flags & ORGAN_FAILING) || (!active_item && !contents.len))
 		to_chat(owner, span_warning("The implant doesn't respond. It seems to be broken..."))
 		return
@@ -214,7 +230,7 @@
 	else
 		Retract()
 
-/obj/item/organ/cyberimp/arm/gun/emp_act(severity)
+/obj/item/organ/cyberimp/arm/toolkit/gun/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -228,19 +244,19 @@
 		owner.adjustFireLoss(25)
 		organ_flags |= ORGAN_FAILING
 
-/obj/item/organ/cyberimp/arm/gun/laser
+/obj/item/organ/cyberimp/arm/toolkit/gun/laser
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
 	items_to_create = list(/obj/item/gun/energy/laser/mounted/augment)
 
-/obj/item/organ/cyberimp/arm/gun/taser
+/obj/item/organ/cyberimp/arm/toolkit/gun/taser
 	name = "arm-mounted taser implant"
 	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_taser"
 	items_to_create = list(/obj/item/gun/energy/e_gun/advtaser/mounted)
 
-/obj/item/organ/cyberimp/arm/toolset
+/obj/item/organ/cyberimp/arm/toolkit/toolset
 	name = "integrated toolset implant"
 	desc = "A stripped-down version of the engineering cyborg toolset, designed to be installed on subject's arm. Contain advanced versions of every tool."
 	icon_state = "toolkit_engineering"
@@ -256,7 +272,7 @@
 	)
 
 //The order of the item list for this implant is not alphabetized due to it actually affecting how it shows up playerside when opening the implant
-/obj/item/organ/cyberimp/arm/paperwork
+/obj/item/organ/cyberimp/arm/toolkit/paperwork
 	name = "integrated paperwork implant"
 	desc = "A highly sought out implant among heads of personnel, and other high up command staff in Nanotrasen. This implant allows the user to always have the tools necessary for paperwork handy"
 	icon_state = "toolkit_engineering"
@@ -272,7 +288,7 @@
 		/obj/item/stamp/denied,
 	)
 
-/obj/item/organ/cyberimp/arm/paperwork/emag_act(mob/user, obj/item/card/emag/emag_card)
+/obj/item/organ/cyberimp/arm/toolkit/paperwork/emag_act(mob/user, obj/item/card/emag/emag_card)
 	for(var/datum/weakref/created_item in items_list)
 		var/obj/potential_tool = created_item.resolve()
 		if(istype(/obj/item/stamp/chameleon, potential_tool))
@@ -282,7 +298,7 @@
 	items_list += WEAKREF(new /obj/item/stamp/chameleon(src))
 	return TRUE
 
-/obj/item/organ/cyberimp/arm/toolset/emag_act(mob/user, obj/item/card/emag/emag_card)
+/obj/item/organ/cyberimp/arm/toolkit/toolset/emag_act(mob/user, obj/item/card/emag/emag_card)
 	for(var/datum/weakref/created_item in items_list)
 		var/obj/potential_knife = created_item.resolve()
 		if(istype(/obj/item/knife/combat/cyborg, potential_knife))
@@ -292,25 +308,25 @@
 	items_list += WEAKREF(new /obj/item/knife/combat/cyborg(src))
 	return TRUE
 
-/obj/item/organ/cyberimp/arm/esword
+/obj/item/organ/cyberimp/arm/toolkit/esword
 	name = "arm-mounted energy blade"
 	desc = "An illegal and highly dangerous cybernetic implant that can project a deadly blade of concentrated energy."
 	items_to_create = list(/obj/item/melee/energy/blade/hardlight)
 
-/obj/item/organ/cyberimp/arm/medibeam
+/obj/item/organ/cyberimp/arm/toolkit/medibeam
 	name = "integrated medical beamgun"
 	desc = "A cybernetic implant that allows the user to project a healing beam from their hand."
 	icon_state = "toolkit_surgical"
 	aug_overlay = "toolkit_med"
 	items_to_create = list(/obj/item/gun/medbeam)
 
-/obj/item/organ/cyberimp/arm/flash
+/obj/item/organ/cyberimp/arm/toolkit/flash
 	name = "integrated high-intensity photon projector" //Why not
 	desc = "An integrated projector mounted onto a user's arm that is able to be used as a powerful flash."
 	aug_overlay = "toolkit"
 	items_to_create = list(/obj/item/assembly/flash/armimplant)
 
-/obj/item/organ/cyberimp/arm/flash/Initialize(mapload)
+/obj/item/organ/cyberimp/arm/toolkit/flash/Initialize(mapload)
 	. = ..()
 	for(var/datum/weakref/created_item in items_list)
 		var/obj/potential_flash = created_item.resolve()
@@ -319,23 +335,23 @@
 		var/obj/item/assembly/flash/armimplant/flash = potential_flash
 		flash.arm = WEAKREF(src)
 
-/obj/item/organ/cyberimp/arm/flash/Extend()
+/obj/item/organ/cyberimp/arm/toolkit/flash/Extend()
 	. = ..()
 	active_item.set_light_range(7)
 	active_item.set_light_on(TRUE)
 
-/obj/item/organ/cyberimp/arm/flash/Retract()
+/obj/item/organ/cyberimp/arm/toolkit/flash/Retract()
 	if(active_item)
 		active_item.set_light_on(FALSE)
 	return ..()
 
-/obj/item/organ/cyberimp/arm/baton
+/obj/item/organ/cyberimp/arm/toolkit/baton
 	name = "arm electrification implant"
 	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."
 	aug_overlay = "toolkit"
 	items_to_create = list(/obj/item/borg/stun)
 
-/obj/item/organ/cyberimp/arm/combat
+/obj/item/organ/cyberimp/arm/toolkit/combat
 	name = "combat cybernetics implant"
 	desc = "A powerful cybernetic implant that contains combat modules built into the user's arm."
 	aug_overlay = "toolkit"
@@ -346,7 +362,7 @@
 		/obj/item/assembly/flash/armimplant,
 	)
 
-/obj/item/organ/cyberimp/arm/combat/Initialize(mapload)
+/obj/item/organ/cyberimp/arm/toolkit/combat/Initialize(mapload)
 	. = ..()
 	for(var/datum/weakref/created_item in items_list)
 		var/obj/potential_flash = created_item.resolve()
@@ -355,7 +371,7 @@
 		var/obj/item/assembly/flash/armimplant/flash = potential_flash
 		flash.arm = WEAKREF(src)
 
-/obj/item/organ/cyberimp/arm/surgery
+/obj/item/organ/cyberimp/arm/toolkit/surgery
 	name = "surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
 	icon_state = "toolkit_surgical"
@@ -371,7 +387,7 @@
 		/obj/item/surgical_drapes,
 	)
 
-/obj/item/organ/cyberimp/arm/surgery/emagged
+/obj/item/organ/cyberimp/arm/toolkit/surgery/emagged
 	name = "hacked surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm. This one seems to have been tampered with."
 	aug_overlay = "toolkit_med"
@@ -395,17 +411,13 @@
 	desc = "When implanted, this cybernetic implant will enhance the muscles of the arm to deliver more power-per-action. Install one in each arm \
 		to pry open doors with your bare hands!"
 	icon_state = "muscle_implant"
-
 	zone = BODY_ZONE_R_ARM
 	slot = ORGAN_SLOT_RIGHT_ARM_MUSCLE
 	valid_zones = list(
 		BODY_ZONE_R_ARM = ORGAN_SLOT_RIGHT_ARM_MUSCLE,
 		BODY_ZONE_L_ARM = ORGAN_SLOT_LEFT_ARM_MUSCLE,
 	)
-
-	actions_types = list()
 	aug_overlay = "strongarm"
-	hand_state = FALSE
 
 	///The amount of damage the implant adds to our unarmed attacks.
 	var/punch_damage = 5

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -94,8 +94,12 @@
 	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
 
 /obj/item/organ/cyberimp/arm/tookit/on_limb_detached(obj/item/bodypart/source)
-	. = ..()
+	SIGNAL_HANDLER
+	if(source != hand || QDELETED(hand))
+		return
+	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
 	UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
+	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -1,4 +1,4 @@
-/obj/item/organ/cyberimp/arm/
+/obj/item/organ/cyberimp/arm
 	name = "arm-mounted implant"
 	desc = "An implant that goes in your arm to improve it."
 	zone = BODY_ZONE_R_ARM
@@ -36,7 +36,7 @@
 	SIGNAL_HANDLER
 	if(source != hand || QDELETED(hand))
 		return
-	UnregisterSignal(hand, list(COMSIG_BODYPART_REMOVED, COMSIG_ITEM_ATTACK_SELF))
+	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
 	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit
@@ -92,6 +92,12 @@
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
 	. = ..()
 	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
+
+/obj/item/organ/cyberimp/arm/toolkit/on_limb_detached(obj/item/bodypart/source)
+	if(source != hand || QDELETED(hand))
+		return
+	UnregisterSignal(hand, list(COMSIG_BODYPART_REMOVED, COMSIG_ITEM_ATTACK_SELF))
+	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()
 	SIGNAL_HANDLER

--- a/tools/UpdatePaths/Scripts/91029_implant_arm_subtypes.txt
+++ b/tools/UpdatePaths/Scripts/91029_implant_arm_subtypes.txt
@@ -1,0 +1,12 @@
+/obj/item/organ/cyberimp/arm/gun/laser : /obj/item/organ/cyberimp/arm/toolkit/gun/laser{@OLD}
+/obj/item/organ/cyberimp/arm/gun/taser : /obj/item/organ/cyberimp/arm/toolkit/gun/taser{@OLD}
+/obj/item/organ/cyberimp/arm/toolset : /obj/item/organ/cyberimp/arm/toolkit/toolset{@OLD}
+/obj/item/organ/cyberimp/arm/paperwork : /obj/item/organ/cyberimp/arm/toolkit/paperwork{@OLD}
+/obj/item/organ/cyberimp/arm/esword : /obj/item/organ/cyberimp/arm/toolkit/esword{@OLD}
+/obj/item/organ/cyberimp/arm/medibeam : /obj/item/organ/cyberimp/arm/toolkit/medibeam{@OLD}
+/obj/item/organ/cyberimp/arm/flash : /obj/item/organ/cyberimp/arm/toolkit/flash{@OLD}
+/obj/item/organ/cyberimp/arm/baton : /obj/item/organ/cyberimp/arm/toolkit/baton{@OLD}
+/obj/item/organ/cyberimp/arm/combat : /obj/item/organ/cyberimp/arm/toolkit/combat{@OLD}
+/obj/item/organ/cyberimp/arm/surgery : /obj/item/organ/cyberimp/arm/toolkit/surgery{@OLD}
+/obj/item/organ/cyberimp/arm/surgery/emagged : /obj/item/organ/cyberimp/arm/toolkit/surgery/emagged {@OLD}
+/obj/item/organ/cyberimp/arm/shard/scythe : /obj/item/organ/cyberimp/arm/toolkit/shard/scythe{@OLD}


### PR DESCRIPTION

## About The Pull Request
This changes all `/obj/item/organ/cyberimp/arm` implants that had the function of using items in your arm (toolset, surgery, etc) into `/obj/item/organ/cyberimp/arm/toolkit`.  `/obj/item/organ/cyberimp/arm` now only handles the general arm implant like signals. 

## Why It's Good For The Game
The arm implant code right now treats any arm implant like one with an item in it. This is bad as we'd have toolset code for arms that don't use any sort of toolset such as the strongarm implant. This also fixes the strongarm implant giving the broken text anytime you'd use your empty hand.
## Changelog
:cl: Goat
fix: Strongarm implant no longer gives the text about being broken when you use your empty hand.
code: Toolset arms are now a subtype of arm implants instead of all arm implants being treated like toolset arms.
/:cl:
