### PR TITLE
Air alarms on contaminated mode won't scrub pluoxium

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 		vent.update_appearance(UPDATE_ICON)
 
 	var/list/filtered = subtypesof(/datum/gas)
-	filtered -= list(/datum/gas/oxygen, /datum/gas/nitrogen)
+	filtered -= list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/pluoxium)
 	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
 		scrubber.on = TRUE
 		scrubber.filter_types = filtered.Copy()


### PR DESCRIPTION
## About The Pull Request
Adds pluoxium to the list of gases not scrubbed in contaminated mode on air alarms
## Why It's Good For The Game
Pluoxium is basically air plus, no reason for it to be scrubbed and also means atmos techs that want to switch rooms for pluoxium have to manually set air alarms lest they remove the air
## Changelog
:cl:
qol: Pluoxium, an oxygen substitute, will no longer be scrubbed when setting air alarms to contaminated.
/:cl:
