### PR TITLE
Lightning strikes thrice: Stops lightning from causing spurious CI failures

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -432,7 +432,7 @@
 			continue
 		if(hit_thing.invisibility != INVISIBILITY_NONE)
 			continue
-		if(HAS_TRAIT(src, TRAIT_UNDERFLOOR))
+		if(HAS_TRAIT(hit_thing, TRAIT_UNDERFLOOR))
 			continue
 		hit_thing.take_damage(20, BURN, ENERGY, FALSE)
 	playsound(weather_turf, 'sound/effects/magic/lightningbolt.ogg', 100, extrarange = 10, falloff_distance = 10)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -428,7 +428,7 @@
 	for(var/obj/hit_thing in weather_turf)
 		if(QDELETED(hit_thing)) // stop, it's already dead
 			continue
-		if(hit_thing.uses_integrity)
+		if(!hit_thing.uses_integrity)
 			continue
 		if(hit_thing.invisibility != INVISIBILITY_NONE)
 			continue

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -426,6 +426,8 @@
 		hit_mob.electrocute_act(50, "thunder", flags = SHOCK_TESLA|SHOCK_NOGLOVES)
 
 	for(var/obj/hit_thing in weather_turf)
+		if(QDELETED(hit_thing)) // stop, it's already dead
+			continue
 		hit_thing.take_damage(20, BURN, ENERGY, FALSE)
 	playsound(weather_turf, 'sound/effects/magic/lightningbolt.ogg', 100, extrarange = 10, falloff_distance = 10)
 	weather_turf.visible_message(span_danger("A thunderbolt strikes [weather_turf]!"))

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -428,6 +428,12 @@
 	for(var/obj/hit_thing in weather_turf)
 		if(QDELETED(hit_thing)) // stop, it's already dead
 			continue
+		if(hit_thing.uses_integrity)
+			continue
+		if(hit_thing.invisibility != INVISIBILITY_NONE)
+			continue
+		if(HAS_TRAIT(src, TRAIT_UNDERFLOOR))
+			continue
 		hit_thing.take_damage(20, BURN, ENERGY, FALSE)
 	playsound(weather_turf, 'sound/effects/magic/lightningbolt.ogg', 100, extrarange = 10, falloff_distance = 10)
 	weather_turf.visible_message(span_danger("A thunderbolt strikes [weather_turf]!"))


### PR DESCRIPTION
## About The Pull Request

So Thor was very displeased with this one particular CI run, and decided to strike the same turf with lightning four consecutive times.

![image](https://github.com/user-attachments/assets/4de88c60-7dd7-44ce-ab44-2b93d565a198)

This resulted in trying to hit the same wire that already had been long since nuked by an initial blast. _three more times_.

Fixes that from happening in the future.

## Why It's Good For The Game

Less flaky CI failures from the wrathful gods

## Changelog

Nothing player facing