### PR TITLE
Holy water will suppress the effect of an evil liver

### DIFF
--- a/code/modules/antagonists/heretic/items/corrupted_organs.dm
+++ b/code/modules/antagonists/heretic/items/corrupted_organs.dm
@@ -100,15 +100,17 @@
 	UnregisterSignal(organ_owner, COMSIG_ATOM_EXPOSE_REAGENTS)
 
 /// If we drank something, add a little extra
-/obj/item/organ/liver/corrupt/proc/on_drank(atom/source, list/reagents, datum/reagents/source_reagents, methods)
+/obj/item/organ/liver/corrupt/proc/on_drank(mob/living/carbon/human, list/reagents, datum/reagents/source_reagents, methods)
 	SIGNAL_HANDLER
 	if (!(methods & INGEST))
 		return
+	if (human.has_reagent(/datum/reagent/water/holywater) || locate(/datum/reagent/water/holywater) in reagents)
+		return
 	var/datum/reagents/extra_reagents = new()
 	extra_reagents.add_reagent(pick(extra_ingredients), amount_added)
-	extra_reagents.trans_to(source, amount_added, transferred_by = src, methods = INJECT)
+	extra_reagents.trans_to(human, amount_added, transferred_by = src, methods = INJECT)
 	if (prob(20))
-		to_chat(source, span_warning("As you take a sip, you feel something bubbling in your stomach..."))
+		to_chat(human, span_warning("As you take a sip, you feel something bubbling in your stomach..."))
 
 
 /// Rapidly become hungry if you are not digesting blood


### PR DESCRIPTION
## About The Pull Request

Closes #91035
This PR makes it so that the effects of a corrupt liver obtained from being sacrificed (normally adds random drugs and alcohol to reagents you drink) are suppressed when drinking holy water or while holy water is in your system.

## Why It's Good For The Game

This is how all of the other heretic-assigned organs work and to be honest I am not sure why I didn't include this one.
As pointed out in the linked issue report, one of the other organs can only be suppressed by drinking blood or holy water but if you have that organ _and_ a corrupt liver then you can't avoid becoming intoxicated.

Now as the effects of the liver are mostly annoying rather than deadly it's not the end of the world, but it's an avoidable conflict when we already have a solution implemented for everything else.

## Changelog

:cl:
balance: The negative effects of a mansus-corrupted liver can be suppressed with holy water, like the other corrupt organs.
/:cl:
