### PR TITLE
Split compile all maps workflow into two parallel jobs

### DIFF
--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -8,7 +8,8 @@ on:
         type: string
 
 jobs:
-  compile_all_maps:
+  compile_all_stations:
+    name: Compile All Station Maps
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
@@ -22,6 +23,27 @@ jobs:
         run: |
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
+      - name: Check client Compatibility
+        uses: tgstation/byond-client-compatibility-check@v3
+        with:
+          dmb-location: tgstation.dmb
+          max-required-client-version: ${{inputs.max_required_byond_client}}
+
+  compile_all_templates:
+    name: Compile All Templates
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: ./.github/actions/setup_node
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
+      - name: Compile All Maps
+        run: |
+          source $HOME/BYOND/byond/bin/byondsetup
+          tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_TEMPLATES
       - name: Check client Compatibility
         uses: tgstation/byond-client-compatibility-check@v3
         with:

--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -44,8 +44,3 @@ jobs:
         run: |
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_TEMPLATES
-      - name: Check client Compatibility
-        uses: tgstation/byond-client-compatibility-check@v3
-        with:
-          dmb-location: tgstation.dmb
-          max-required-client-version: ${{inputs.max_required_byond_client}}

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -15,9 +15,8 @@
 		#include "map_files\CatwalkStation\CatwalkStation_2023.dmm"
 		#include "map_files\NebulaStation\NebulaStation.dmm"
 		#include "map_files\wawastation\wawastation.dmm"
-
-		#ifdef CIBUILDING
-			#include "templates.dm"
-		#endif
+	#endif
+	#ifdef ALL_TEMPLATES
+		#include "templates.dm"
 	#endif
 #endif

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -211,7 +211,7 @@ export const DmMapsIncludeTarget = new Juke.Target({
 export const DmTarget = new Juke.Target({
   parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter, SkipIconCutter],
   dependsOn: ({ get }) => [
-    get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
+    get(DefineParameter).includes('ALL_TEMPLATES') && DmMapsIncludeTarget,
     !get(SkipIconCutter) && IconCutterTarget,
   ],
   inputs: [
@@ -284,7 +284,7 @@ export const DmTestTarget = new Juke.Target({
 export const AutowikiTarget = new Juke.Target({
   parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
   dependsOn: ({ get }) => [
-    get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
+    get(DefineParameter).includes('ALL_TEMPLATES') && DmMapsIncludeTarget,
     IconCutterTarget,
   ],
   outputs: [


### PR DESCRIPTION

## About The Pull Request

- Change `_basemap.dm` so instead of templates being included when `CIBUILDING` is defined, it's based off a separate `ALL_TEMPLATES` flag, like `ALL_MAPS`, also made it not dependent on `ALL_MAPS` being defined, so the two can run separately
- Changes build.js to generate `templates.dm`  with the `ALL_TEMPLATES` flag instead of `ALL_MAPS`
- Change the compile all maps workflow to have two separate jobs, one that does `ALL_MAPS` and one that does `ALL_TEMPLATES`

## Why It's Good For The Game

The downstreams are starting to run out of memory during this workflow because we have extra templates and maps, splitting it this way should alleviate that problem (for rough, non-scientific numbers: Combined workflow reaches 3.5GB and then crashes during holodeck templates using bubber code, split like this the maps workflow reaches 1GB and finishes, the templates workflow reaches 1.5GB and finishes)

## Changelog

No player facing changes
