### PR TITLE
Summon Cheese sometimes has a different invocation

### DIFF
--- a/code/modules/spells/spell_types/conjure/cheese.dm
+++ b/code/modules/spells/spell_types/conjure/cheese.dm
@@ -8,10 +8,31 @@
 	cooldown_time = 1 MINUTES
 	spell_requirements = null
 
-	invocation = "PL'YR DOT PL'CTM' OOO'BEE G!" //player.placeatme 00064B33 9
+	invocation = "PL'YR DOT PL'CTM' OOO'B'ABEE G!" //player.placeatme 00064B33 9
 	invocation_type = INVOCATION_SHOUT
 	garbled_invocation_prob = 0 //i'd rather it remain like this
 
 	summon_radius = 1
 	summon_amount = 9
 	summon_type = list(/obj/item/food/cheese/wheel)
+
+/datum/action/cooldown/spell/conjure/cheese/New(Target, original)
+	. = ..()
+	if(prob(50))
+		return
+	var/cheese_hex_path = uppertext(copytext(REF(/obj/item/food/cheese/wheel), 4, -1))
+	var/list/replacements = list(
+		"0" = "O",
+		"1" = "L",
+		"2" = "Z",
+		"3" = "'E",
+		"4" = "'A",
+		"5" = "S",
+		"6" = "'B",
+		"7" = "T",
+		"8" = "-B",
+		"9" = "G",
+	)
+	for(var/digit in replacements)
+		cheese_hex_path = replacetext(cheese_hex_path, digit, replacements[digit])
+	invocation = "PL'YR DOT PL'CTM' [cheese_hex_path] G!"


### PR DESCRIPTION
## About The Pull Request

When created, each instance of Summon Cheese has a 50% chance of its invocation being changed to use the actual ref string for `/obj/item/food/cheese/wheel`, instead of Skyrim's item id for cheese wheels.

## Why It's Good For The Game

The invocation for Summon Cheese is itself a reference to a debug feature from another video game. Why not add an extra layer of meta-humor by occasionally using the actual ref string for the summoned object's typepath in the invocation?

## Changelog

:cl:
spellcheck: The invocation for Summon Cheese is sometimes more representative of the realities of life aboard the station.
/:cl:
