### PR TITLE
Fixes ntos file manager showing "Rename" instead of the file names

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosFileManager.jsx
+++ b/tgui/packages/tgui/interfaces/NtosFileManager.jsx
@@ -72,7 +72,6 @@ const FileTable = (props) => {
               <Button.Input
                 fluid
                 value={file.name}
-                tooltip="Rename"
                 onCommit={(value) => onRename(file.name, value)}
               />
             ) : (

--- a/tgui/packages/tgui/interfaces/NtosFileManager.jsx
+++ b/tgui/packages/tgui/interfaces/NtosFileManager.jsx
@@ -71,8 +71,8 @@ const FileTable = (props) => {
             {!file.undeletable ? (
               <Button.Input
                 fluid
-                buttonText="Rename"
                 value={file.name}
+                tooltip="Rename"
                 onCommit={(value) => onRename(file.name, value)}
               />
             ) : (


### PR DESCRIPTION

## About The Pull Request

It seems that in the recent tgui inputs rework these input buttons accidentally got their text set to "Rename", which makes the UI practically unusable due to every file looking the same.
This just removes that, and as per `Button.Input` documentation that makes it default to `value`.
This fixes our issue.

Previously, this value was a *tooltip*. However, it looks like the new `Button.Input` doesn't have the option for a tooltip.
As such, this doesn't re-implement that.
## Why It's Good For The Game

This is unreadable, especially when trying to move files from a disk:
![image](https://github.com/user-attachments/assets/92d682cd-a583-4001-a7f9-5327c53c00b5)
## Changelog
:cl:
fix: NTos file manager program actually shows the program names, instead of the
/:cl:
