### PR TITLE
Callouts after death fix

### DIFF
--- a/code/datums/components/callouts.dm
+++ b/code/datums/components/callouts.dm
@@ -61,7 +61,10 @@
 /datum/component/callouts/proc/on_ctrl_click(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(!isitem(parent))
+	if (!isitem(parent))
+		return
+
+	if (user.incapacitated)
 		return
 
 	var/obj/item/item_parent = parent
@@ -94,6 +97,9 @@
 	SIGNAL_HANDLER
 
 	if (!LAZYACCESS(modifiers, SHIFT_CLICK) || !LAZYACCESS(modifiers, MIDDLE_CLICK))
+		return
+
+	if (user.incapacitated)
 		return
 
 	if (!active)


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/90931

## Why It's Good For The Game

Can't callout while incapacitated (dead, stunned, etc.). While cuffed reverts to proper "leg" pointing.

## Changelog

:cl:
fix: callouts no longer work while you are incapacitated
/:cl: