### PR TITLE
Fixes MODsuit control units not updating their worn icons when activating with no parts deployed

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -313,7 +313,10 @@
 			module.part_activated = FALSE
 	update_charge_alert()
 	update_appearance(UPDATE_ICON_STATE)
-	wearer.update_clothing()
+	var/updated_slots = slot_flags
+	for (var/slot_key in mod_parts)
+		updated_slots |= text2num(slot_key)
+	wearer.update_clothing(updated_slots)
 
 /// Quickly deploys all the suit parts and if successful, seals them and turns on the suit. Intended mostly for outfits.
 /obj/item/mod/control/proc/quick_activation()

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -214,15 +214,19 @@
 /obj/item/mod/control/allow_attack_hand_drop(mob/user)
 	if(user != wearer)
 		return ..()
+
 	if(active)
 		balloon_alert(wearer, "unit active!")
 		playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, FALSE, SILENCED_SOUND_EXTRARANGE)
 		return
+
 	for(var/obj/item/part as anything in get_parts())
 		if(part.loc != src)
 			balloon_alert(user, "parts extended!")
 			playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, FALSE, SILENCED_SOUND_EXTRARANGE)
 			return FALSE
+
+	return ..()
 
 /obj/item/mod/control/mouse_drop_dragged(atom/over_object, mob/user)
 	if(user != wearer || !istype(over_object, /atom/movable/screen/inventory/hand))


### PR DESCRIPTION

## About The Pull Request

``update_clothing`` by default doesn't update anything. Also fixed a missing return in ``allow_attack_hand_drop`` that always failed the proc.

## Why It's Good For The Game

Bug fixed.

## Changelog
:cl:
fix: Fixed MODsuit control units not updating their worn icons when activating with no parts deployed
/:cl:
