### PR TITLE
Moves goliath cloak worn sprite to neck layer

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -110,8 +110,9 @@
 
 /obj/item/clothing/suit/hooded/cloak/goliath
 	name = "goliath cloak"
-	icon_state = "goliath_cloak"
 	desc = "A staunch, practical cape made out of numerous monster materials, it is coveted amongst exiles & hermits."
+	icon_state = "goliath_cloak"
+	alternate_worn_layer = NECK_LAYER
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	cold_protection = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION

## About The Pull Request

Goliath cloak is now NECK_LAYER visually, which makes it go above belts when worn on your neck.

## Why It's Good For The Game

It looks really weird when your rigging or toolbelt is showing through your cloak.

## Changelog
:cl:
fix: Riggings and toolbelts no longer render through the goliath cloak when worn in your suit slot.
/:cl:
