### PR TITLE
Fixes monkeys being weirdly rotated when attached to big manipulators pointing sideways

### DIFF
--- a/code/game/machinery/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator.dm
@@ -167,7 +167,7 @@
 
 /obj/machinery/big_manipulator/Exited(atom/movable/gone, direction)
 	if(gone == monkey_worker?.resolve())
-		var/mob/living/carbon/human/species/monkey/poor_monkey = monkey_worker.resolve()
+		var/mob/living/carbon/human/poor_monkey = monkey_worker.resolve()
 		REMOVE_TRAIT(poor_monkey, TRAIT_AI_PAUSED, "[src]")
 		monkey_worker = null
 		poor_monkey.remove_offsets("[src]")
@@ -253,10 +253,16 @@
 	if(status == STATUS_UNINSTALLING_WORKER)
 		balloon_alert(user, "already uninstalling worker, please wait")
 		return
-	var/mob/living/carbon/human/species/monkey/poor_monkey = monkey_worker.resolve()
-	if(!istype(poor_monkey, /mob/living/carbon/human/species/monkey))
+
+	var/mob/living/carbon/human/poor_monkey = monkey_worker.resolve()
+	if(!ismonkey(poor_monkey))
+		if(!QDELETED(poor_monkey))
+			poor_monkey.drop_all_held_items()
+			poor_monkey.set_lying_angle(0)
+			poor_monkey.forceMove(get_turf(src))
 		monkey_worker = null
 		return
+
 	status = STATUS_UNINSTALLING_WORKER
 	balloon_alert(user, "uninstalling monkey worker...")
 	if(!do_after(user, 3 SECONDS, src))
@@ -264,6 +270,7 @@
 		return
 	balloon_alert(user, "monkey worker uninstalled")
 	poor_monkey.drop_all_held_items()
+	poor_monkey.set_lying_angle(0)
 	poor_monkey.forceMove(get_turf(src))
 	status = STATUS_IDLE
 
@@ -276,7 +283,7 @@
 	if(status == STATUS_INSTALLING_WORKER)
 		balloon_alert(user, "already installing worker, please wait")
 		return
-	var/mob/living/carbon/human/species/monkey/poor_monkey = monkey
+	var/mob/living/carbon/human/poor_monkey = monkey
 	if(poor_monkey.mind)
 		balloon_alert(user, "too smart! might demand pay!")
 		return
@@ -295,6 +302,7 @@
 	status = STATUS_IDLE
 	manipulator_arm.vis_contents += poor_monkey
 	poor_monkey.dir = manipulator_arm.dir
+	poor_monkey.set_lying_angle(dir2angle(manipulator_arm.dir))
 	poor_monkey.add_offsets(
 		"[src]",
 		x_add = 32 + manipulator_arm.calculate_item_offset(TRUE, pixels_to_offset = 16),
@@ -491,7 +499,7 @@
 	if(isnull(obj_resolve))
 		finish_manipulation()
 		return
-	var/mob/living/carbon/human/species/monkey/monkey_resolve = monkey_worker?.resolve()
+	var/mob/living/carbon/human/monkey_resolve = monkey_worker?.resolve()
 	if(isnull(monkey_resolve))
 		finish_manipulation()
 		return
@@ -518,7 +526,7 @@
 	check_end_of_use(im_item, item_was_used = TRUE)
 
 /obj/machinery/big_manipulator/proc/use_thing_with_empty_hand()
-	var/mob/living/carbon/human/species/monkey/monkey_resolve = monkey_worker?.resolve()
+	var/mob/living/carbon/human/monkey_resolve = monkey_worker?.resolve()
 	if(isnull(monkey_resolve))
 		finish_manipulation()
 		return
@@ -779,7 +787,7 @@
 			return TRUE
 		if("worker_combat_mode_change")
 			worker_combat_mode = !worker_combat_mode
-			var/mob/living/carbon/human/species/monkey/monkey_resolve = monkey_worker?.resolve()
+			var/mob/living/carbon/human/monkey_resolve = monkey_worker?.resolve()
 			monkey_resolve?.set_combat_mode(worker_combat_mode)
 			return TRUE
 		if("worker_alt_mode_change")


### PR DESCRIPTION

## About The Pull Request

Attaching monkeys only set their dir to that of the arm, so if you rotated the manipulator to point sideways you ended up with the monkey just staring to the side instead of being attached to the arm.

## Why It's Good For The Game

Fixes visual jank

## Changelog
:cl:
fix: Fixed monkeys being weirdly rotated when attached to big manipulators pointing sideways
/:cl:
