### PR TITLE
Fixes a few bad combat logs

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
@@ -7,7 +7,6 @@
 	var/damage = rand(1, 9)
 	if (prob(90))
 		playsound(loc, SFX_PUNCH, 25, TRUE, -1)
-		log_combat(user, src, "attacked")
 		visible_message(span_danger("[user] kicks [src]!"), \
 						span_userdanger("[user] kicks you!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
 		to_chat(user, span_danger("You kick [src]!"))
@@ -16,11 +15,13 @@
 
 		var/obj/item/bodypart/affecting = get_bodypart(get_random_valid_zone(user.zone_selected))
 		apply_damage(damage, BRUTE, affecting)
+		log_combat(user, src, "attacked")
 	else
 		playsound(loc, 'sound/items/weapons/punchmiss.ogg', 25, TRUE, -1)
 		visible_message(span_danger("[user]'s kick misses [src]!"), \
 						span_danger("You avoid [user]'s kick!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, user)
 		to_chat(user, span_warning("Your kick misses [src]!"))
+		log_combat(user, src, "attacked and missed")
 
 /mob/living/carbon/alien/larva/attack_hulk(mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -168,6 +168,7 @@
 								span_userdanger("[src] tears [worn_mask] off of your face!"))
 
 	if(!target.equip_to_slot_if_possible(src, ITEM_SLOT_MASK, 0, 1, 1))
+		log_combat(target, src, "failed facehugged by")
 		return FALSE
 	log_combat(target, src, "was facehugged by")
 	return TRUE // time for a smoke

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -241,10 +241,10 @@
 		visible_message(span_danger("[user] slashes at [src]!"), \
 						span_userdanger("[user] slashes at you!"), span_hear("You hear a sickening sound of a slice!"), null, user)
 		to_chat(user, span_danger("You slash at [src]!"))
+		if(dismembering_strike(user, user.zone_selected)) //Dismemberment successful
+			apply_damage(damage, BRUTE, affecting, armor_block)
 		log_combat(user, src, "attacked")
-		if(!dismembering_strike(user, user.zone_selected)) //Dismemberment successful
-			return TRUE
-		apply_damage(damage, BRUTE, affecting, armor_block)
+		return TRUE
 
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/worm, list/modifiers)
 	. = ..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -234,24 +234,40 @@
 	if(blocked)
 		return SUCCESSFUL_BLOCK
 
-	var/mob/thrown_by = throwingdatum.get_thrower()
-	if(thrown_by)
-		log_combat(thrown_by, src, "threw and hit", thrown_item)
-	else
-		log_combat(thrown_item, src, "hit ")
 	if(nosell_hit)
+		log_hit_combat(throwingdatum.get_thrower(), thrown_item)
 		return ..()
-	visible_message(span_danger("[src] is hit by [thrown_item]!"), \
-					span_userdanger("You're hit by [thrown_item]!"))
+
+	visible_message(span_danger("[src] is hit by [thrown_item]!"),
+		span_userdanger("You're hit by [thrown_item]!"))
 	if(!thrown_item.throwforce)
+		log_hit_combat(throwingdatum.get_thrower(), thrown_item)
 		return
-	var/armor = run_armor_check(zone, MELEE, "Your armor has protected your [parse_zone_with_bodypart(zone)].", "Your armor has softened hit to your [parse_zone_with_bodypart(zone)].", thrown_item.armour_penetration, "", FALSE, thrown_item.weak_against_armour)
+
+	var/armor = run_armor_check(
+		zone,
+		MELEE,
+		"Your armor has protected your [parse_zone_with_bodypart(zone)].",
+		"Your armor has softened hit to your [parse_zone_with_bodypart(zone)].",
+		thrown_item.armour_penetration,
+		"",
+		FALSE,
+		thrown_item.weak_against_armour,
+	)
 	apply_damage(thrown_item.throwforce, thrown_item.damtype, zone, armor, sharpness = thrown_item.get_sharpness(), wound_bonus = (nosell_hit * CANT_WOUND), attacking_item = thrown_item)
+	log_hit_combat(throwingdatum.get_thrower(), thrown_item)
+
 	if(QDELETED(src)) //Damage can delete the mob.
 		return
 	if(body_position == LYING_DOWN) // physics says it's significantly harder to push someone by constantly chucking random furniture at them if they are down on the floor.
 		hitpush = FALSE
+
 	return ..()
+
+/mob/living/proc/log_hit_combat(mob/thrown_by, obj/item/thrown_item)
+	if(thrown_by)
+		return log_combat(thrown_by, src, "threw and hit", thrown_item)
+	return log_combat(thrown_item, src, "hit ")
 
 /mob/living/proc/create_splatter(splatter_dir)
 	new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(src), splatter_dir)
@@ -418,7 +434,6 @@
 	var/armor_block = run_armor_check(user.zone_selected, MELEE, armour_penetration = user.armour_penetration)
 
 	to_chat(user, span_danger("You [user.attack_verb_simple] [src]!"))
-	log_combat(user, src, "attacked")
 	var/damage_done = apply_damage(
 		damage = damage,
 		damagetype = user.melee_damage_type,
@@ -429,6 +444,7 @@
 		sharpness = user.sharpness,
 		attack_direction = get_dir(user, src),
 	)
+	log_combat(user, src, "attacked")
 	return damage_done
 
 /mob/living/attack_hand(mob/living/carbon/human/user, list/modifiers)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -268,7 +268,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		Stun(40)
 		step(src,get_dir(user,src))
 		visible_message(span_danger("[user] forces back [src]!"), \
-			span_userdanger("[user] forces back [src]!"), null, COMBAT_MESSAGE_RANGE)
+			span_userdanger("[user] forces you back!"), null, COMBAT_MESSAGE_RANGE)
 		log_combat(user, src, "pushed")
 	playsound(loc, 'sound/items/weapons/pierce.ogg', 50, TRUE, -1)
 

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -253,25 +253,24 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 #undef MODERATE_DAMAGE_UPPER_BOUND
 
 /mob/living/silicon/robot/attack_alien(mob/living/carbon/alien/adult/user, list/modifiers)
-	if (LAZYACCESS(modifiers, RIGHT_CLICK))
-		if(body_position == STANDING_UP)
-			user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
-			var/obj/item/I = get_active_held_item()
-			if(I)
-				uneq_active()
-				visible_message(span_danger("[user] disarmed [src]!"), \
-					span_userdanger("[user] has disabled [src]'s active module!"), null, COMBAT_MESSAGE_RANGE)
-				log_combat(user, src, "disarmed", "[I ? " removing \the [I]" : ""]")
-			else
-				Stun(40)
-				step(src,get_dir(user,src))
-				log_combat(user, src, "pushed")
-				visible_message(span_danger("[user] forces back [src]!"), \
-					span_userdanger("[user] forces back [src]!"), null, COMBAT_MESSAGE_RANGE)
-			playsound(loc, 'sound/items/weapons/pierce.ogg', 50, TRUE, -1)
+	if (!LAZYACCESS(modifiers, RIGHT_CLICK))
+		return ..()
+	if(body_position != STANDING_UP)
+		return
+	user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
+	var/obj/item/I = get_active_held_item()
+	if(I)
+		uneq_active()
+		visible_message(span_danger("[user] disarmed [src]!"), \
+			span_userdanger("[user] has disabled [src]'s active module!"), null, COMBAT_MESSAGE_RANGE)
+		log_combat(user, src, "disarmed", "[I ? " removing \the [I]" : ""]")
 	else
-		..()
-	return
+		Stun(40)
+		step(src,get_dir(user,src))
+		visible_message(span_danger("[user] forces back [src]!"), \
+			span_userdanger("[user] forces back [src]!"), null, COMBAT_MESSAGE_RANGE)
+		log_combat(user, src, "pushed")
+	playsound(loc, 'sound/items/weapons/pierce.ogg', 50, TRUE, -1)
 
 /mob/living/silicon/robot/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	add_fingerprint(user)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -6,23 +6,25 @@
 	return 2
 
 /mob/living/silicon/attack_alien(mob/living/carbon/alien/adult/user, list/modifiers)
-	if(..()) //if harm or disarm intent
-		var/damage = rand(user.melee_damage_lower, user.melee_damage_upper)
-		if (prob(90))
-			log_combat(user, src, "attacked")
-			playsound(loc, 'sound/items/weapons/slash.ogg', 25, TRUE, -1)
-			visible_message(span_danger("[user] slashes at [src]!"), \
-							span_userdanger("[user] slashes at you!"), null, null, user)
-			to_chat(user, span_danger("You slash at [src]!"))
-			if(prob(8))
-				flash_act(affect_silicon = 1)
-			log_combat(user, src, "attacked")
-			adjustBruteLoss(damage)
-		else
-			playsound(loc, 'sound/items/weapons/slashmiss.ogg', 25, TRUE, -1)
-			visible_message(span_danger("[user]'s swipe misses [src]!"), \
-							span_danger("You avoid [user]'s swipe!"), null, null, user)
-			to_chat(user, span_warning("Your swipe misses [src]!"))
+	. = ..()
+	if(!.) //if harm or disarm intent
+		return
+	var/damage = rand(user.melee_damage_lower, user.melee_damage_upper)
+	if (prob(90))
+		playsound(loc, 'sound/items/weapons/slash.ogg', 25, TRUE, -1)
+		visible_message(span_danger("[user] slashes at [src]!"), \
+						span_userdanger("[user] slashes at you!"), null, null, user)
+		to_chat(user, span_danger("You slash at [src]!"))
+		if(prob(8))
+			flash_act(affect_silicon = 1)
+		adjustBruteLoss(damage)
+		log_combat(user, src, "attacked")
+	else
+		playsound(loc, 'sound/items/weapons/slashmiss.ogg', 25, TRUE, -1)
+		visible_message(span_danger("[user]'s swipe misses [src]!"),
+						span_danger("You avoid [user]'s swipe!"), null, null, user)
+		to_chat(user, span_warning("Your swipe misses [src]!"))
+		log_combat(user, src, "attacked and missed")
 
 /mob/living/silicon/attack_animal(mob/living/simple_animal/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes the following issues:

1. Simple animals & Basic animals attacking things show their previous HP as "NEWHP"
2. throwing things show their previous HP as "NEWHP"
3. Silicons being attacked by Xenomorphs logs combat twice, and both show their previous HP as "NEWHP"
4. Silicons being attacked by Xenomorph and missing doesn't log the attempted attack.
5. Failing to be facehugged doesn't log the attempt.
6. Attacking an Alien larva showed their previous HP as "NEWHP", and didn't log misses.

## Why It's Good For The Game

It's nice when logs show the right information and show combat even if they miss the punch.

## Changelog

:cl:
admin: Fixed a few bad combat logs for basic/simple animals, thrown things, and xenomorph stuff.
/:cl: