### PR TITLE
Fixes advanced cameras not showing static

### DIFF
--- a/code/modules/mob/eye/camera/remote.dm
+++ b/code/modules/mob/eye/camera/remote.dm
@@ -70,6 +70,8 @@
 		var/client/new_user_client = GetViewerClient()
 		if(user_image && new_user_client)
 			new_user_client.images += user_image
+		if(use_visibility)
+			update_visibility()
 
 /**
  * Sets the camera's user image to this icon and state.


### PR DESCRIPTION
## About The Pull Request

Now when you start using an advanced camera console, assuming it uses visibility, it'll automatically update to show static from the very start, rather than requiring you move first.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/91074

## Changelog

:cl:
fix: Advanced camera consoles now shows static when you first open it, rather than only kicking in when you start to look around.
/:cl: