### PR TITLE
Adds the Desynchronizer to the syndicate uplink

### DIFF
--- a/code/game/objects/items/devices/desynchronizer.dm
+++ b/code/game/objects/items/devices/desynchronizer.dm
@@ -99,3 +99,8 @@
 
 /obj/effect/abstract/sync_holder/AllowDrop()
 	return TRUE //no dropping spaghetti out of your spacetime pocket
+
+/obj/item/desynchronizer/syndie
+	name = "expirimental desynchronizer"
+	desc = "An experimental device that can temporarily desynchronize the user from spacetime, effectively making them disappear while it's active."
+	max_duration = 30 SECONDS

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -238,6 +238,12 @@
 	item = /obj/item/grenade/hypnotic
 	cost = 12
 
+/datum/uplink_item/device_tools/desynchronizer
+	name = "Expirimental Desynchronizer"
+	desc = "An experimental device that can temporarily desynchronize the user from spacetime upto 30 seconds, effectively making them disappear while it's active, The cooldown is double the time spent while desynchronized"
+	item = /obj/item/desynchronizer/syndie
+	cost = 6
+
 /datum/uplink_item/device_tools/singularity_beacon
 	name = "Power Beacon"
 	desc = "When screwed to wiring attached to an electric grid and activated, this large device pulls any \


### PR DESCRIPTION
## About The Pull Request

Adds desynchronizer from illegal RnD techtree to the syndicate uplink for 6 TC
This version is nerfed down to the max of 30 seconds, meaning if you spent the full 30 seconds in it the cooldown will be the double of that.
This will allow syndicates to phase out like immortality talisman this allows them several things.
1. Stalling for cooldowns, Reloading your guns etc
2. Using it to dodge explosions, maxcaps/grenades etc.
3. Using it just for a moment of stealth

## Why It's Good For The Game
We have so many aggresive tools for syndicate and the lack of defensive/utility ones and this is one of those more niche tools that would fit it.

## Changelog
:cl: Ezel
add: Adds the Expirimental Desynchronizer to the syndicate uplinkg
/:cl:

