### PR TITLE
Fixes sterilizine in surgery tray

### DIFF
--- a/code/datums/storage/subtypes/others/misc.dm
+++ b/code/datums/storage/subtypes/others/misc.dm
@@ -29,6 +29,7 @@
 		/obj/item/clothing/mask/surgical,
 		/obj/item/hemostat,
 		/obj/item/razor,
+		/obj/item/reagent_containers/medigel/sterilizine,
 		/obj/item/retractor,
 		/obj/item/scalpel,
 		/obj/item/stack/medical/bone_gel,


### PR DESCRIPTION
## About The Pull Request

Fixes the list of allowed items in the surgery tray. The tray starts with sterilizine, but you can't put it back on the tray because it's not whitelisted.

## Why It's Good For The Game

Fixes bug

## Changelog

:cl: LT3
fix: You can put sterilizine back in the surgery tray after removing it
/:cl:
