### PR TITLE
Fixes false walls not properly smoothing with objects

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -65,7 +65,7 @@
 	if(opening)
 		smoothing_flags = NONE
 	else
-		smoothing_flags = SMOOTH_BITMASK
+		smoothing_flags = SMOOTH_BITMASK | SMOOTH_OBJ
 		QUEUE_SMOOTH(src)
 
 /obj/structure/falsewall/update_icon_state()


### PR DESCRIPTION

## About The Pull Request

Port of my downstream fix, https://github.com/Monkestation/Monkestation2.0/pull/6622

This makes it so false walls properly restore `SMOOTH_OBJ` to their `smoothing_flags` when closed.

<details>
<summary><h3>Before Fix</h3></summary>

https://github.com/user-attachments/assets/81000516-1cba-4d3c-988e-51582ed2741d

</details>

<details>
<summary><h3>After Fix</h3></summary>

https://github.com/user-attachments/assets/01cbbf04-b3d5-4e71-8a20-6bee77a6ab21

</details>

## Why It's Good For The Game

because having multiple false walls next to each other that look weird after u open them once is annoying.

## Changelog
:cl:
fix: False walls properly smooth with objects now, such as other false walls.
/:cl:
