### PR TITLE
Fix multitool arrow hard delete

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -105,7 +105,7 @@
 	user_hud.infodisplay += arrow
 	user_hud.show_hud(user_hud.hud_version)
 
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), arrow), 1.5 SECONDS)
+	QDEL_IN(arrow, 1.5 SECONDS)
 
 /obj/item/multitool/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] puts the [src] to [user.p_their()] chest. It looks like [user.p_theyre()] trying to pulse [user.p_their()] heart off!"))

--- a/code/modules/engineering/tools/multitool.dm
+++ b/code/modules/engineering/tools/multitool.dm
@@ -3,3 +3,7 @@
 	icon_state = "multitool_arrow"
 	pixel_x = -32
 	pixel_y = -32
+
+/atom/movable/screen/multitool_arrow/Destroy()
+	hud?.infodisplay -= src
+	return ..()

--- a/code/modules/engineering/tools/multitool.dm
+++ b/code/modules/engineering/tools/multitool.dm
@@ -5,5 +5,7 @@
 	pixel_y = -32
 
 /atom/movable/screen/multitool_arrow/Destroy()
-	hud?.infodisplay -= src
+	if(hud)
+		hud.infodisplay -= src
+		INVOKE_ASYNC(hud, TYPE_PROC_REF(/datum/hud, show_hud), hud.hud_version)
 	return ..()


### PR DESCRIPTION

## About The Pull Request
When using the multitool APC search function, the arrow hud is deleted without being removed from the hud list. This causes a hard delete and, eventually, the broken hud display depicted in https://github.com/tgstation/tgstation/pull/91047
This fixes that, and replaces the explicit timer creation with `QDEL_IN` which does the same thing
## Why It's Good For The Game
Hard deletes bad, nulls in huds bad
## Changelog
:cl:
fix: Fixed another(?) possible case of multitool APC searching causing broken huds
/:cl:
