### PR TITLE
{NO GBP} Reduces stamina damage from rubbershot by a single point per pellet.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -104,7 +104,7 @@
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubber shot pellet"
 	damage = 3
-	stamina = 11
+	stamina = 10
 	sharpness = NONE
 	embed_type = null
 	speed = 0.8


### PR DESCRIPTION
## About The Pull Request

Reduces rubbershot pellets from 11 stamina damage to 10 stamina damage.

## Why It's Good For The Game

So fun fact. Stamina crit threshold is particularly generous about when it tips you over into stamina crit. 

Fired from a combat shotgun, rubbershot would deal 99 stamina damage at point blank. Resulting in you entering stamina crit if you didn't have any armor at all.

By reducing this by exactly one point, this no longer happens. 

This is another PR I was reluctant to do but honestly, this change was recent enough that I frankly do hold a lot more of the blame for it. A few steps back isn't going to hurt anyone. These things still spew damage at whatever you point them at.

"But Anne, what about rubbershot in riot shotguns!"

It did 66 stamina damage total. At 60 damage, you can still slow down someone in a sec vest with a point blank shot. For the most part, it will probably be completely unnoticeable for the riot shotgun. I don't even know why it was an uneven number to be completely honest with you.

## Changelog
:cl:
balance: Reduces rubbershot stamina damage from 11 damage per pellet to 10 damage per pellet.
/:cl:
