### PR TITLE
update rust-g to 3.9.0 and use `formatted_timestamp` for `human_readable_timestamp`

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -363,8 +363,7 @@
 #define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
 
 /// Returns the timestamp as a string
-/proc/rustg_unix_timestamp()
-	return RUSTG_CALL(RUST_G, "unix_timestamp")()
+#define rustg_unix_timestamp(...) (RUSTG_CALL(RUST_G, "unix_timestamp")())
 
 #define rustg_raw_read_toml_file(path) json_decode(RUSTG_CALL(RUST_G, "toml_file_to_json")(path) || "null")
 
@@ -392,3 +391,10 @@
 	#define url_decode(text) rustg_url_decode(text)
 #endif
 
+/// Returns the current timestamp (in local time), formatted with the given format string.
+/// See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for documentation on the formatting syntax.
+#define rustg_formatted_timestamp(format) RUSTG_CALL(RUST_G, "formatted_timestamp")(format)
+
+/// Returns the current timestamp (with the given UTC offset in hours), formatted with the given format string.
+/// See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for documentation on the formatting syntax.
+#define rustg_formatted_timestamp_tz(format, offset) RUSTG_CALL(RUST_G, "formatted_timestamp")(format, offset)

--- a/code/modules/logging/log_holder.dm
+++ b/code/modules/logging/log_holder.dm
@@ -275,20 +275,8 @@ ADMIN_VERB(log_viewer_new, R_ADMIN|R_DEBUG, "View Round Logs", "View the rounds 
 	category_instance.category_header = category_header
 	init_category_file(category_instance, category_header)
 
-/datum/log_holder/proc/human_readable_timestamp(precision = 3)
-	var/start = time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss", TIMEZONE_UTC)
-	// now we grab the millis from the rustg timestamp
-	var/rustg_stamp = rustg_unix_timestamp()
-	var/list/timestamp = splittext(rustg_stamp, ".")
-#ifdef UNIT_TESTS
-	if(length(timestamp) != 2)
-		stack_trace("rustg returned illegally formatted string '[rustg_stamp]'")
-		return start
-#endif
-	var/millis = timestamp[2]
-	if(length(millis) > precision)
-		millis = copytext(millis, 1, precision + 1)
-	return "[start].[millis]"
+/datum/log_holder/proc/human_readable_timestamp()
+	return rustg_formatted_timestamp("%Y-%m-%d %H:%M:%S%.3f")
 
 /// Adds an entry to the given category, if the category is disabled it will not be logged.
 /// If the category does not exist, we will CRASH and log to the error category.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=516
 export BYOND_MINOR=1659
 
 #rust_g git tag
-export RUST_G_VERSION=3.8.0
+export RUST_G_VERSION=3.9.0
 
 #node version
 export NODE_VERSION_LTS=22.11.0


### PR DESCRIPTION
## About The Pull Request

This updates rust-g to [3.9.0](https://github.com/tgstation/rust-g/releases/tag/3.9.0), and also improves some code related to logging a little:
- `rustg_unix_timestamp` is now a define instead of a proc
  - this is somewhat of a hot call, as it gets called every time a log entry is written, so this is prolly worth it imo
- `/datum/log_holder/proc/human_readable_timestamp()` now uses `rustg_formatted_timestamp`, instead of the current stupid BS with `time2text` and then adding fractional seconds by using splittext on the unix timestamp???
  - i've confirmed that the output of the old and new code are identical.

(partially ports my impl from https://github.com/Monkestation/Monkestation2.0/pull/6540)

## Why It's Good For The Game

because using _splittext_ on a timestamp to add a fractional part is stupid, when we can now just use rust-g to format it all in one go.

## Changelog

No user-facing changes.
