### PR TITLE
Fixes item pickup animation playing when you move some things to containers on your person

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -351,8 +351,16 @@
 	return to_drop
 
 //for when the item will be immediately placed in a loc other than the ground
-/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, silent = TRUE)
+/mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE, silent = TRUE, animated = null)
 	. = doUnEquip(I, force, newloc, FALSE, silent = silent)
+	//This proc wears a lot of hats for moving items around in different ways,
+	//so we assume unhandled cases for checking to animate can safely be handled
+	//with the same logic we handle animating putting items in container (container on your person isn't animated)
+	if(isnull(animated))
+		//if the item's ultimate location is us, we don't animate putting it wherever
+		animated = !(get(newloc, /mob) == src)
+	if(!animated)
+		return
 	I.do_pickup_animation(newloc, src)
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC, newloc is for signal handling checks only which hints where you want to move the object after removal

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -359,9 +359,8 @@
 	if(isnull(animated))
 		//if the item's ultimate location is us, we don't animate putting it wherever
 		animated = !(get(newloc, /mob) == src)
-	if(!animated)
-		return
-	I.do_pickup_animation(newloc, src)
+	if(animated)
+		I.do_pickup_animation(newloc, src)
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC, newloc is for signal handling checks only which hints where you want to move the object after removal
 //item MUST BE FORCEMOVE'D OR QDEL'D


### PR DESCRIPTION
## About The Pull Request

There's a lot of adhoc calls to the proc we use for people putting items somewhere that don't necessarily fit into our use of datums for storage, so the special case I handled for storage datums not playing the animation wasn't covering them.

This pull request attempts to patch the rest of the cases where this would apply; the result should be that putting items inside other items on your person won't play an animation in any case.
## Why It's Good For The Game

Consistent player feedback for actions that would reasonably be unnoticeable if not surreptitious.
Fixes #91126


## Changelog
:cl: Bisar
fix: Animations for moving items into other items on your person shouldn't play any more.
/:cl:
