### PR TITLE
Fixes /datum/element/floor_placeable using the wrong proc for moving an item

### DIFF
--- a/code/datums/elements/floor_placeable.dm
+++ b/code/datums/elements/floor_placeable.dm
@@ -30,7 +30,7 @@
 		return NONE
 	if(source.item_flags & ABSTRACT)
 		return NONE
-	if(!user.transferItemToLoc(source, interacting_with, silent = FALSE))
+	if(!user.dropItemToGround(to_drop = source, silent = FALSE, newloc = interacting_with))
 		return ITEM_INTERACT_BLOCKING
 
 	// Items are centered by default, but we move them if click ICON_X and ICON_Y are available


### PR DESCRIPTION

## About The Pull Request

The element name, as it would indicate, is for placing items on the floor. The proc it's using to do so is, specifically, the one for moving items anywhere BUT the floor. This fixes that.
## Why It's Good For The Game

AM I THE ONLY ONE AROUND HERE WHO GIVES A SHIT ABOUT THE PROCS?
Fixes #91083
## Changelog
:cl: Bisar
fix: Things with the behavior for placing on the floor now correctly use the code for placing on the floor.
/:cl:
