### PR TITLE
Explicitly centers items placed on a table before checking for x/y modifiers from a mouseclick

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -498,6 +498,8 @@
 	if(!user.dropItemToGround(to_drop = tool, silent = FALSE, newloc = get_turf(src)))
 		return ITEM_INTERACT_BLOCKING
 	// Items are centered by default, but we move them if click ICON_X and ICON_Y are available
+	tool.pixel_x = 0
+	tool.pixel_y = 0
 	if(LAZYACCESS(modifiers, ICON_X) && LAZYACCESS(modifiers, ICON_Y))
 		// Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
 		tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(ICON_SIZE_X*0.5), ICON_SIZE_X*0.5)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -495,15 +495,15 @@
 /obj/structure/table/proc/table_place_act(mob/living/user, obj/item/tool, list/modifiers)
 	if(tool.item_flags & ABSTRACT)
 		return NONE
-	if(!user.dropItemToGround(to_drop = tool, silent = FALSE, newloc = get_turf(src)))
+	var/vector_x = 0
+	var/vector_y = 0
+	if(LAZYACCESS(modifiers, ICON_X))
+		vector_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(ICON_SIZE_X*0.5), ICON_SIZE_X*0.5)
+	if(LAZYACCESS(modifiers, ICON_Y))
+		vector_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(ICON_SIZE_Y*0.5), ICON_SIZE_Y*0.5)
+	var/vector/offset_vector = vector(vector_x, vector_y)
+	if(!user.dropItemToGround(to_drop = tool, silent = FALSE, newloc = get_turf(src), offset_vector = offset_vector))
 		return ITEM_INTERACT_BLOCKING
-	// Items are centered by default, but we move them if click ICON_X and ICON_Y are available
-	tool.pixel_x = 0
-	tool.pixel_y = 0
-	if(LAZYACCESS(modifiers, ICON_X) && LAZYACCESS(modifiers, ICON_Y))
-		// Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
-		tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(ICON_SIZE_X*0.5), ICON_SIZE_X*0.5)
-		tool.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(ICON_SIZE_Y*0.5), ICON_SIZE_Y*0.5)
 	AfterPutItemOnTable(tool, user)
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -334,7 +334,13 @@
  * * If it was, returns the item.
  * If the item can be dropped, it will be forceMove()'d to the ground and the turf's Entered() will be called.
 */
-/mob/proc/dropItemToGround(obj/item/to_drop, force = FALSE, silent = FALSE, invdrop = TRUE, turf/newloc = null)
+/mob/proc/dropItemToGround(
+	obj/item/to_drop,
+	force = FALSE,
+	silent = FALSE,
+	invdrop = TRUE,
+	turf/newloc = null,
+	vector/offset_vector = vector(rand(-6, 6), rand(-6, 6)))
 	if(isnull(to_drop))
 		return
 
@@ -345,8 +351,8 @@
 		return
 
 	if(!(to_drop.item_flags & NO_PIXEL_RANDOM_DROP))
-		to_drop.pixel_x = to_drop.base_pixel_x + rand(-6, 6)
-		to_drop.pixel_y = to_drop.base_pixel_y + rand(-6, 6)
+		to_drop.pixel_x = to_drop.base_pixel_x + offset_vector.x
+		to_drop.pixel_y = to_drop.base_pixel_y + offset_vector.y
 	to_drop.do_drop_animation(src)
 	return to_drop
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1459,7 +1459,13 @@
 
 	return ..()
 
-/mob/living/carbon/dropItemToGround(obj/item/to_drop, force = FALSE, silent = FALSE, invdrop = TRUE, turf/newloc = null)
+/mob/living/carbon/dropItemToGround(
+	obj/item/to_drop,
+	force = FALSE,
+	silent = FALSE,
+	invdrop = TRUE,
+	turf/newloc = null,
+	offset_vector = vector(rand(6, -6), rand(6, -6)))
 	if(to_drop && (organs.Find(to_drop) || bodyparts.Find(to_drop))) //let's not do this, aight?
 		return FALSE
 	return ..()


### PR DESCRIPTION

## About The Pull Request

It seems the murky past of our procs for moving items caused an unintended but embraced behavior of alt click table-placed items being centered. Converting it to use the proc for moving an item straight to a turf removed that behavior. This reimplements it. I'm marking it as a qol because it doesn't feel like a fix, so much as codifying a beneficial unintended behavior?
## Why It's Good For The Game

A maintainer said it should do it so I made it do it!
Fixes #91082
## Changelog
:cl: Bisar
qol: Items are centered when placed on tables via the alt-click menu explicitly.
/:cl:
