### PR TITLE
Fixes fishpeople swimming slow in deep water

### DIFF
--- a/code/__DEFINES/traits/declarations.dm
+++ b/code/__DEFINES/traits/declarations.dm
@@ -189,7 +189,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NOBREATH "no_breath"
 /// Mob doesn't take oxygen damage in deep water
 #define TRAIT_NODROWN "amphibious"
-/// Mob doesn't take stamina damage from deep water
+/// Mob doesn't take stamina damage from deep water and doesn't get slowdown from swimming
 #define TRAIT_SWIMMER "swimmer"
 /// Mob is currently disguised as something else (like a morph being another mob or an object). Holds a reference to the thing that applied the trait.
 #define TRAIT_DISGUISED "disguised"

--- a/code/datums/elements/swimming_tile.dm
+++ b/code/datums/elements/swimming_tile.dm
@@ -75,8 +75,7 @@
 	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_IMMERSED), PROC_REF(stop_swimming))
 
 /datum/status_effect/swimming/on_remove()
-	if (!HAS_TRAIT(owner, TRAIT_SWIMMER))
-		owner.remove_movespeed_modifier(/datum/movespeed_modifier/swimming_deep)
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/swimming_deep)
 	UnregisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_IMMERSED))
 
 /datum/status_effect/swimming/tick(seconds_between_ticks)

--- a/code/datums/elements/swimming_tile.dm
+++ b/code/datums/elements/swimming_tile.dm
@@ -70,9 +70,13 @@
 	. = ..()
 	stamina_per_second = ticking_stamina_cost
 	oxygen_per_second = ticking_oxy_damage
+	if (!HAS_TRAIT(owner, TRAIT_SWIMMER))
+		owner.add_movespeed_modifier(/datum/movespeed_modifier/swimming_deep)
 	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_IMMERSED), PROC_REF(stop_swimming))
 
 /datum/status_effect/swimming/on_remove()
+	if (!HAS_TRAIT(owner, TRAIT_SWIMMER))
+		owner.remove_movespeed_modifier(/datum/movespeed_modifier/swimming_deep)
 	UnregisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_IMMERSED))
 
 /datum/status_effect/swimming/tick(seconds_between_ticks)

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -219,22 +219,16 @@
 
 /obj/item/organ/tail/fish/proc/check_location(mob/living/carbon/source, atom/movable/old_loc, dir, forced)
 	SIGNAL_HANDLER
-	var/turf/open/current_turf = get_turf(source)
-	var/turf/open/old_turf = get_turf(old_loc)
-	var/was_water = istype(old_turf, /turf/open/water)
-	var/is_water = istype(current_turf, /turf/open/water) && !HAS_TRAIT(current_turf, TRAIT_TURF_IGNORE_SLOWDOWN)
+	var/was_water = istype(old_loc, /turf/open/water)
+	var/is_water = istype(source.loc, /turf/open/water) && !HAS_TRAIT(source.loc, TRAIT_TURF_IGNORE_SLOWDOWN)
 	if(was_water && !is_water)
 		source.remove_movespeed_modifier(/datum/movespeed_modifier/fish_on_water)
 		source.remove_actionspeed_modifier(/datum/actionspeed_modifier/fish_on_water)
 		source.add_traits(list(TRAIT_OFF_BALANCE_TACKLER, TRAIT_NO_STAGGER, TRAIT_NO_THROW_HITPUSH), type)
 	else if(!was_water && is_water)
-		source.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/fish_on_water, multiplicative_slowdown = -current_turf.slowdown)
+		source.add_movespeed_modifier(/datum/movespeed_modifier/fish_on_water)
 		source.add_actionspeed_modifier(/datum/actionspeed_modifier/fish_on_water)
 		source.add_traits(list(TRAIT_OFF_BALANCE_TACKLER, TRAIT_NO_STAGGER, TRAIT_NO_THROW_HITPUSH), type)
-	else if (was_water && is_water)
-		if (current_turf.slowdown != old_turf.slowdown)
-			source.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/fish_on_water, multiplicative_slowdown = -current_turf.slowdown)
-
 
 /datum/bodypart_overlay/mutant/tail/fish
 	feature_key = "fish_tail"

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -219,16 +219,22 @@
 
 /obj/item/organ/tail/fish/proc/check_location(mob/living/carbon/source, atom/movable/old_loc, dir, forced)
 	SIGNAL_HANDLER
-	var/was_water = istype(old_loc, /turf/open/water)
-	var/is_water = istype(source.loc, /turf/open/water) && !HAS_TRAIT(source.loc, TRAIT_TURF_IGNORE_SLOWDOWN)
+	var/turf/open/current_turf = get_turf(source)
+	var/turf/open/old_turf = get_turf(old_loc)
+	var/was_water = istype(old_turf, /turf/open/water)
+	var/is_water = istype(current_turf, /turf/open/water) && !HAS_TRAIT(current_turf, TRAIT_TURF_IGNORE_SLOWDOWN)
 	if(was_water && !is_water)
 		source.remove_movespeed_modifier(/datum/movespeed_modifier/fish_on_water)
 		source.remove_actionspeed_modifier(/datum/actionspeed_modifier/fish_on_water)
 		source.add_traits(list(TRAIT_OFF_BALANCE_TACKLER, TRAIT_NO_STAGGER, TRAIT_NO_THROW_HITPUSH), type)
 	else if(!was_water && is_water)
-		source.add_movespeed_modifier(/datum/movespeed_modifier/fish_on_water)
+		source.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/fish_on_water, multiplicative_slowdown = -current_turf.slowdown)
 		source.add_actionspeed_modifier(/datum/actionspeed_modifier/fish_on_water)
 		source.add_traits(list(TRAIT_OFF_BALANCE_TACKLER, TRAIT_NO_STAGGER, TRAIT_NO_THROW_HITPUSH), type)
+	else if (was_water && is_water)
+		if (current_turf.slowdown != old_turf.slowdown)
+			source.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/fish_on_water, multiplicative_slowdown = -current_turf.slowdown)
+
 
 /datum/bodypart_overlay/mutant/tail/fish
 	feature_key = "fish_tail"

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -79,7 +79,6 @@
 	desc = "Less shallow water."
 	icon_state = "deep_riverwater_motion"
 	immerse_overlay = "immerse_deep"
-	slowdown = 8
 	baseturfs = /turf/open/water/no_planet_atmos/deep
 
 /turf/open/water/no_planet_atmos/deep/make_immersed()
@@ -107,7 +106,6 @@
 /turf/open/water/deep_beach
 	name = "deep water"
 	desc = "Don't forget your life jacket."
-	slowdown = 8
 	immerse_overlay = "immerse_deep"
 	icon = 'icons/turf/beach.dmi'
 	icon_state = "deepwater"

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -179,10 +179,15 @@
 /datum/movespeed_modifier/magic_ties
 	multiplicative_slowdown = 0.5
 
-///speed bonus given by the fish tail organ when inside water.
+///Speed bonus given by the fish tail organ when inside water.
 /datum/movespeed_modifier/fish_on_water
 	blacklisted_movetypes = MOVETYPES_NOT_TOUCHING_GROUND
-	variable = TRUE
+	multiplicative_slowdown = - /turf/open/water::slowdown
+
+///Slowdown for swimming on deep water tiles
+/datum/movespeed_modifier/swimming_deep
+	blacklisted_movetypes = MOVETYPES_NOT_TOUCHING_GROUND
+	multiplicative_slowdown = 7
 
 /datum/movespeed_modifier/tail_dragger
 	multiplicative_slowdown = 4

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -182,7 +182,7 @@
 ///speed bonus given by the fish tail organ when inside water.
 /datum/movespeed_modifier/fish_on_water
 	blacklisted_movetypes = MOVETYPES_NOT_TOUCHING_GROUND
-	multiplicative_slowdown = - /turf/open/water::slowdown
+	variable = TRUE
 
 /datum/movespeed_modifier/tail_dragger
 	multiplicative_slowdown = 4


### PR DESCRIPTION
## About The Pull Request
Instead of having the deep water tile slow people down, they get slowed down by the swimming status effect. Fishpeople are immune to that slowdown.
## Why It's Good For The Game
glug
## Changelog
:cl:
fix: fixed fish infused people swimming slow in deep water
/:cl:
