### PR TITLE
Fixes holoparasites taking damage from ash storms inside of immune hosts, miner holoparas are now storm immune

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -329,19 +329,21 @@
 	if(!(mob_turf.z in impacted_z_levels))
 		return
 
-	if((immunity_type && HAS_TRAIT(mob_to_check, immunity_type)) || HAS_TRAIT(mob_to_check, TRAIT_WEATHER_IMMUNE))
+	if(!(mob_turf.loc in impacted_areas))
 		return
 
-	var/atom/loc_to_check = mob_to_check.loc
-	while(loc_to_check != mob_turf)
-		if((immunity_type && HAS_TRAIT(loc_to_check, immunity_type)) || HAS_TRAIT(loc_to_check, TRAIT_WEATHER_IMMUNE))
+	var/atom/to_check = mob_to_check
+	while(!isturf(to_check))
+		if(recursive_weather_protection_check(to_check))
 			return
-		loc_to_check = loc_to_check.loc
-
-	if(!(get_area(mob_to_check) in impacted_areas))
-		return
-
+		to_check = to_check.loc
 	return TRUE
+
+/**
+ * Returns TRUE if the atom should protect itself or its contents from weather
+ */
+/datum/weather/proc/recursive_weather_protection_check(atom/to_check)
+	return HAS_TRAIT(to_check, TRAIT_WEATHER_IMMUNE) || (immunity_type && HAS_TRAIT(to_check, immunity_type))
 
 /**
  * Returns TRUE if the turf can be affected by the weather

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -52,13 +52,13 @@
 	GLOB.ash_storm_sounds += weak_sounds
 	return ..()
 
-/datum/weather/ash_storm/can_weather_act_mob(mob/living/mob_to_check)
+/datum/weather/ash_storm/recursive_weather_protection_check(atom/to_check)
 	. = ..()
-	if(!. || !ishuman(mob_to_check))
+	if(. || !ishuman(to_check))
 		return
-	var/mob/living/carbon/human/human_to_check = mob_to_check
+	var/mob/living/carbon/human/human_to_check = to_check
 	if(human_to_check.get_thermal_protection() >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
-		return FALSE
+		return TRUE
 
 /datum/weather/ash_storm/weather_act_mob(mob/living/victim)
 	victim.adjustFireLoss(4, required_bodytype = BODYTYPE_ORGANIC)

--- a/code/modules/mob/living/basic/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_creator.dm
@@ -211,3 +211,12 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		/mob/living/basic/guardian/standard, // Can mine walls
 		/mob/living/basic/guardian/support, // Heals and teleports you
 	)
+
+/obj/item/guardian_creator/miner/spawn_guardian(mob/living/user, mob/dead/candidate, guardian_path)
+	var/mob/living/basic/guardian/guardian = ..()
+	if (!guardian)
+		return
+	// Immune to planetary weather effects
+	ADD_TRAIT(guardian, TRAIT_ASHSTORM_IMMUNE, INNATE_TRAIT)
+	ADD_TRAIT(guardian, TRAIT_SNOWSTORM_IMMUNE, INNATE_TRAIT)
+	return guardian


### PR DESCRIPTION

## About The Pull Request
Closes #91040 by making the check on the ash storm be inside of the recursive parent checking, makes power miners (holoparasites) spawned from the dusty shard ash and snowstorm immune

## Why It's Good For The Game

Fixes bug, latter makes you take double damage if you don't have protection, and if you do it prevents your miner from going outside of your body during a storm. Them having protection from storms is kinda fitting.

## Changelog
:cl:
balance: Power Miners are now ash and snowstorm immune
fix: Holoparasites no longer take damage from ash storms inside of storm-protected hosts
/:cl:
