### PR TITLE
Fix cross-server newscasters

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -254,7 +254,7 @@
 	var/list/timers
 
 /datum/world_topic/create_news_channel/Run(list/input)
-	var/message_delay = input["delay"]
+	var/message_delay = text2num(input["delay"])
 	var/timer_id = addtimer(CALLBACK(src, PROC_REF(create_channel), input), message_delay)
 	input["timer_id"] = timer_id
 	LAZYADD(timers, timer_id)


### PR DESCRIPTION
## About The Pull Request

Noticed this runtime while doing other stuff, cross-server newscasters fail to create the channel because when it receives the data from world topic the delay comes in as a string, which it tries and fails to pass to addtimer as the duration.

## Why It's Good For The Game

Make the feature work

## Changelog
:cl:
fix: fixed cross-server newscaster functionality
/:cl:
