### PR TITLE
Adds big and scary return types to /mob/living/get_id_card() ( as /obj/item/card/id ) and /mob/living/get_access() ( as list )

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -639,7 +639,7 @@
 /**
  * Returns the access list for this mob
  */
-/mob/living/proc/get_access() as list
+/mob/living/proc/get_access() as /list
 	var/list/access_list = list()
 	SEND_SIGNAL(src, COMSIG_MOB_RETRIEVE_SIMPLE_ACCESS, access_list)
 	var/obj/item/card/id/id = get_idcard()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -624,7 +624,7 @@
  * Argument:
  * * hand_firsts - boolean that checks the hands of the mob first if TRUE.
  */
-/mob/living/proc/get_idcard(hand_first)
+/mob/living/proc/get_idcard(hand_first) as /obj/item/card/id
 	if(!length(held_items)) //Early return for mobs without hands.
 		return
 	//Check hands
@@ -639,7 +639,7 @@
 /**
  * Returns the access list for this mob
  */
-/mob/living/proc/get_access()
+/mob/living/proc/get_access() as list
 	var/list/access_list = list()
 	SEND_SIGNAL(src, COMSIG_MOB_RETRIEVE_SIMPLE_ACCESS, access_list)
 	var/obj/item/card/id/id = get_idcard()


### PR DESCRIPTION
## About The Pull Request

These are two procs that don't actually get used very often ( the wheel is reinvented with id checking boilerplate chicanery in a shitload of places ) but they were just sitting there. I've added return types to them because I'm working on another PR where I use them, and I figured it was appropriate to atomize my having explicitly defined their return type.
## Why It's Good For The Game

Gives contributors a taste of compiler-time type assertion so that they can be hardened for the wars ahead.

Let us use pretty syntax like some_guy.get_access().Find(ACCESS_CAPTAIN) without having to assign a variable.

Sets these up for a refactor of a lot of how we check accesses down the line because my GBP is getting beat to the bricks by all my feature PRs.
## Changelog
:cl: Bisar
code: /mob/living/get_id_card() and /mob/living/get_access() now have compile-time type-assertion for their return types.
/:cl:
