### PR TITLE
Corrects mining export names on icebox

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -1,53 +1,53 @@
 {
-  "version": 1,
-  "map_name": "Ice Box Station",
-  "map_path": "map_files/IceBoxStation",
-  "map_file": "IceBoxStation.dmm",
-  "space_ruin_levels": 0,
-  "space_empty_levels": 0,
-  "planetary": 1,
-  "give_players_hooks": 1,
-  "shuttles": {
-    "cargo": "cargo_box",
-    "ferry": "ferry_fancy",
-    "whiteship": "whiteship_box",
-    "emergency": "emergency_box"
-  },
-  "traits": [
-    {
-      "Mining": true,
-      "Linkage": null,
-      "Gravity": true,
-      "Ice Ruins Underground": true,
-      "Baseturf": "/turf/open/lava/plasma/ice_moon",
-      "No Parallax": true
-    },
-    {
-      "Mining": true,
-      "Linkage": null,
-      "Gravity": true,
-      "Ice Ruins Underground": true,
-      "Baseturf": "/turf/open/openspace/icemoon/keep_below",
-      "No Parallax": true
-    },
-    {
-      "Mining": true,
-      "Linkage": null,
-      "Gravity": true,
-      "Ice Ruins": true,
-      "Weather_Snowstorm": true,
-      "Baseturf": "/turf/open/openspace/icemoon/keep_below",
-      "No Parallax": true
-    }
-  ],
-  "minetype": "ice",
-  "blacklist_file": "iceruinblacklist.txt",
-  "job_changes": {
-    "Captain": {
-      "special_charter": "moon"
-    },
-    "Cook": {
-      "additional_cqc_areas": ["/area/station/service/bar/atrium"]
-    }
-  }
+	"version": 1,
+	"map_name": "Ice Box Station",
+	"map_path": "map_files/IceBoxStation",
+	"map_file": "IceBoxStation.dmm",
+	"space_ruin_levels": 0,
+	"space_empty_levels": 0,
+	"planetary": 1,
+	"give_players_hooks": 1,
+	"shuttles": {
+		"cargo": "cargo_box",
+		"ferry": "ferry_fancy",
+		"whiteship": "whiteship_box",
+		"emergency": "emergency_box"
+	},
+	"traits": [
+		{
+			"Mining": true,
+			"Linkage": null,
+			"Gravity": true,
+			"Ice Ruins Underground": true,
+			"Baseturf": "/turf/open/lava/plasma/ice_moon",
+			"No Parallax": true
+		},
+		{
+			"Mining": true,
+			"Linkage": null,
+			"Gravity": true,
+			"Ice Ruins Underground": true,
+			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
+			"No Parallax": true
+		},
+		{
+			"Mining": true,
+			"Linkage": null,
+			"Gravity": true,
+			"Ice Ruins": true,
+			"Weather_Snowstorm": true,
+			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
+			"No Parallax": true
+		}
+	],
+	"minetype": "ice",
+	"blacklist_file": "iceruinblacklist.txt",
+	"job_changes": {
+		"Captain": {
+			"special_charter": "moon"
+		},
+		"Cook": {
+			"additional_cqc_areas": ["/area/station/service/bar/atrium"]
+		}
+	}
 }

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -1,53 +1,53 @@
 {
-	"version": 1,
-	"map_name": "Ice Box Station",
-	"map_path": "map_files/IceBoxStation",
-	"map_file": "IceBoxStation.dmm",
-	"space_ruin_levels": 0,
-	"space_empty_levels": 0,
-	"planetary": 1,
-	"give_players_hooks": 1,
-	"shuttles": {
-		"cargo": "cargo_box",
-		"ferry": "ferry_fancy",
-		"whiteship": "whiteship_box",
-		"emergency": "emergency_box"
-	},
-	"traits": [
-		{
-			"Mining": true,
-			"Linkage": null,
-			"Gravity": true,
-			"Ice Ruins Underground": true,
-			"Baseturf": "/turf/open/lava/plasma/ice_moon",
-			"No Parallax": true
-		},
-		{
-			"Mining": true,
-			"Linkage": null,
-			"Gravity": true,
-			"Ice Ruins Underground": true,
-			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
-			"No Parallax": true
-		},
-		{
-			"Mining": true,
-			"Linkage": null,
-			"Gravity": true,
-			"Ice Ruins": true,
-			"Weather_Snowstorm": true,
-			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
-			"No Parallax": true
-		}
-	],
-	"minetype": "none",
-	"blacklist_file": "iceruinblacklist.txt",
-	"job_changes": {
-		"Captain": {
-			"special_charter": "moon"
-		},
-		"Cook": {
-			"additional_cqc_areas": ["/area/station/service/bar/atrium"]
-		}
-	}
+  "version": 1,
+  "map_name": "Ice Box Station",
+  "map_path": "map_files/IceBoxStation",
+  "map_file": "IceBoxStation.dmm",
+  "space_ruin_levels": 0,
+  "space_empty_levels": 0,
+  "planetary": 1,
+  "give_players_hooks": 1,
+  "shuttles": {
+    "cargo": "cargo_box",
+    "ferry": "ferry_fancy",
+    "whiteship": "whiteship_box",
+    "emergency": "emergency_box"
+  },
+  "traits": [
+    {
+      "Mining": true,
+      "Linkage": null,
+      "Gravity": true,
+      "Ice Ruins Underground": true,
+      "Baseturf": "/turf/open/lava/plasma/ice_moon",
+      "No Parallax": true
+    },
+    {
+      "Mining": true,
+      "Linkage": null,
+      "Gravity": true,
+      "Ice Ruins Underground": true,
+      "Baseturf": "/turf/open/openspace/icemoon/keep_below",
+      "No Parallax": true
+    },
+    {
+      "Mining": true,
+      "Linkage": null,
+      "Gravity": true,
+      "Ice Ruins": true,
+      "Weather_Snowstorm": true,
+      "Baseturf": "/turf/open/openspace/icemoon/keep_below",
+      "No Parallax": true
+    }
+  ],
+  "minetype": "ice",
+  "blacklist_file": "iceruinblacklist.txt",
+  "job_changes": {
+    "Captain": {
+      "special_charter": "moon"
+    },
+    "Cook": {
+      "additional_cqc_areas": ["/area/station/service/bar/atrium"]
+    }
+  }
 }

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -242,3 +242,8 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define AWAYSTART_SNOWCABIN "AWAYSTART_SNOWCABIN"
 #define AWAYSTART_SNOWDIN "AWAYSTART_SNOWDIN"
 #define AWAYSTART_UNDERGROUND "AWAYSTART_UNDERGROUND"
+
+// Minetypes for maps
+#define MINETYPE_NONE "none"
+#define MINETYPE_LAVALAND "lavaland"
+#define MINETYPE_ICE "ice"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -448,9 +448,9 @@ Used by the AI doomsday and the self-destruct nuke.
 
 #ifndef LOWMEMORYMODE
 
-	if(current_map.minetype == "lavaland")
+	if(current_map.minetype == MINETYPE_LAVALAND)
 		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland.dmm", default_traits = ZTRAITS_LAVALAND)
-	else if (!isnull(current_map.minetype) && current_map.minetype != "none")
+	else if (!isnull(current_map.minetype) && current_map.minetype != MINETYPE_NONE && current_map.minetype != MINETYPE_ICE)
 		INIT_ANNOUNCE("WARNING: An unknown minetype '[current_map.minetype]' was set! This is being ignored! Update the maploader code!")
 #endif
 
@@ -511,7 +511,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 /datum/controller/subsystem/mapping/proc/preloadRuinTemplates()
 	// Still supporting bans by filename
 	var/list/banned = generateMapList("spaceruinblacklist.txt")
-	if(current_map.minetype == "lavaland")
+	if(current_map.minetype == MINETYPE_LAVALAND)
 		banned += generateMapList("lavaruinblacklist.txt")
 	else if(current_map.blacklist_file)
 		banned += generateMapList(current_map.blacklist_file)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -31,7 +31,7 @@
 	var/planetary = FALSE
 
 	///The type of mining Z-level that should be loaded.
-	var/minetype = "lavaland"
+	var/minetype = MINETYPE_LAVALAND
 	///If no minetype is set, this will be the blacklist file used
 	var/blacklist_file
 

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -1,9 +1,26 @@
 //Tendril chest artifacts and ruin loot.
 //Consumable or one-use items like the magic D20 and gluttony's blessing are omitted
+/datum/export/lavaland
+	unit_name = "lava planet artifact"
+	/// Prefix to add to our unit name after generation
+	var/prefix = null
+
+/datum/export/lavaland/New()
+	. = ..()
+	switch (SSmapping.current_map.minetype)
+		if (MINETYPE_NONE)
+			unit_name = "unknown artifact"
+		if (MINETYPE_LAVALAND)
+			unit_name = "lava planet artifact"
+		if (MINETYPE_ICE)
+			unit_name = "ice moon artifact"
+
+	if (prefix)
+		unit_name = "[prefix] [unit_name]"
 
 /datum/export/lavaland/minor
 	cost = CARGO_CRATE_VALUE * 20
-	unit_name = "minor lava planet artifact"
+	prefix = "minor"
 	export_types = list(
 		/obj/item/immortality_talisman,
 		/obj/item/book_of_babel,
@@ -31,7 +48,6 @@
 
 /datum/export/lavaland/major //valuable chest/ruin loot, minor megafauna loot
 	cost = CARGO_CRATE_VALUE * 40
-	unit_name = "lava planet artifact"
 	export_types = list(
 		/obj/item/dragons_blood,
 		/obj/item/guardian_creator/miner,
@@ -48,7 +64,7 @@
 
 /datum/export/lavaland/megafauna
 	cost = CARGO_CRATE_VALUE * 80
-	unit_name = "major lava planet artifact"
+	prefix = "major"
 	export_types = list(
 		/obj/item/hierophant_club,
 		/obj/item/melee/cleaving_saw,


### PR DESCRIPTION

## About The Pull Request

Closes #90666, converts minetypes to defines, gives icebox a minetype define which could also be used later to give mining suits some fur or something.

## Changelog
:cl:
fix: Icebox artifact exports no longer claim they're from a lava planet
/:cl:
