### PR TITLE
Fixes tactical medkits not giving medibots a bezerk skin

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -257,6 +257,9 @@
 	damagetype_healed = HEAL_ALL_DAMAGE
 	storage_type = /datum/storage/medkit/tactical
 
+/obj/item/storage/medkit/tactical/get_medbot_skin()
+	return "bezerk"
+
 /obj/item/storage/medkit/tactical/PopulateContents()
 	if(empty)
 		return


### PR DESCRIPTION

## About The Pull Request

Only the lite version had the skin override, so tactical and premium tactical kits just made regular medibots (visually, they still heal all types at once)

## Changelog
:cl:
fix: Fixed tactical medkits not giving medibots a bezerk skin
/:cl:
