### PR TITLE
Neruwhine can no longer roll voidwalker traumas, fixes high gravity persisting after curing the trauma

### DIFF
--- a/code/datums/components/space_allergy.dm
+++ b/code/datums/components/space_allergy.dm
@@ -7,7 +7,8 @@
 	entered_area(parent, get_area(parent))
 
 /datum/component/planet_allergy/Destroy(force)
-	parent.remove_status_effect(/datum/status_effect/planet_allergy)
+	var/mob/living/as_living = parent
+	as_living.remove_status_effect(/datum/status_effect/planet_allergy)
 	return ..()
 
 /datum/component/planet_allergy/proc/entered_area(mob/living/parent, area/new_area)

--- a/code/datums/components/space_allergy.dm
+++ b/code/datums/components/space_allergy.dm
@@ -4,6 +4,11 @@
 		return COMPONENT_INCOMPATIBLE
 
 	RegisterSignal(parent, COMSIG_ENTER_AREA, PROC_REF(entered_area))
+	entered_area(parent, get_area(parent))
+
+/datum/component/planet_allergy/Destroy(force)
+	parent.remove_status_effect(/datum/status_effect/planet_allergy)
+	return ..()
 
 /datum/component/planet_allergy/proc/entered_area(mob/living/parent, area/new_area)
 	SIGNAL_HANDLER

--- a/code/datums/components/space_allergy.dm
+++ b/code/datums/components/space_allergy.dm
@@ -1,4 +1,8 @@
 /// Slowly kills the affected when they're on a planet.
+/datum/component/planet_allergy
+	/// Status effect applied by this component
+	var/datum/status_effect/planet_allergy/allergy
+
 /datum/component/planet_allergy/Initialize(...)
 	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -7,14 +11,13 @@
 	entered_area(parent, get_area(parent))
 
 /datum/component/planet_allergy/Destroy(force)
-	var/mob/living/as_living = parent
-	as_living.remove_status_effect(/datum/status_effect/planet_allergy)
+	QDEL_NULL(allergy)
 	return ..()
 
 /datum/component/planet_allergy/proc/entered_area(mob/living/parent, area/new_area)
 	SIGNAL_HANDLER
 
 	if(is_on_a_planet(parent) && parent.has_gravity())
-		parent.apply_status_effect(/datum/status_effect/planet_allergy) //your gamer body cant stand real gravity < Soul
+		allergy = parent.apply_status_effect(/datum/status_effect/planet_allergy) //your gamer body cant stand real gravity < Soul
 	else
-		parent.remove_status_effect(/datum/status_effect/planet_allergy)
+		QDEL_NULL(allergy)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -649,6 +649,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 			/datum/brain_trauma/severe/hypnotic_stupor, // These apply the above blacklisted trauma
 			/datum/brain_trauma/severe/hypnotic_trigger,
 			/datum/brain_trauma/special/honorbound, // Designed to be chaplain exclusive
+			/datum/brain_trauma/voided, // Voidwalker exclusive and more of a magical status effect than a trauma
 		)
 
 		// Do give out these traumas but not any of their subtypes, usually because the trauma replaces itself with a subtype


### PR DESCRIPTION

## About The Pull Request
Neruwhine can no longer roll Cosmic Neural Pattern or its stable subtype.
Fixed the planetary gravity damage status effect not clearing itself when you lose the voided trauma.
Closes #90702

## Why It's Good For The Game

Cosmic Neural Pattern is a voidwalker exclusive and is more of a magical status effect than an actual brain trauma, so having it be temporarily rollable is a bit stupid.

## Changelog
:cl:
balance: Neruwhine can no longer roll voidwalker traumas.
fix: Fixed the planetary gravity damage status effect not clearing itself when you lose the voided trauma.
/:cl:
