### PR TITLE
Fixes ampersands in TM titles breaking the in-game issue report button

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -90,10 +90,10 @@
 		var/list/all_tms = list()
 		for(var/entry in testmerge_data)
 			var/datum/tgs_revision_information/test_merge/tm = entry
-			all_tms += "- \[[url_encode(tm.title)]\]([githuburl]/pull/[tm.number])"
-		var/all_tms_joined = jointext(all_tms, "%0A") // %0A is a newline for URL encoding because i don't trust \n to not break
+			all_tms += "- \[[tm.title]\]([githuburl]/pull/[tm.number])"
+		var/all_tms_joined = jointext(all_tms, "\n")
 
-		concatable += ("&test-merges=" + all_tms_joined)
+		concatable += ("&test-merges=" + url_encode(all_tms_joined))
 
 	DIRECT_OUTPUT(src, link(jointext(concatable, "")))
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -90,7 +90,7 @@
 		var/list/all_tms = list()
 		for(var/entry in testmerge_data)
 			var/datum/tgs_revision_information/test_merge/tm = entry
-			all_tms += "- \[[tm.title]\]([githuburl]/pull/[tm.number])"
+			all_tms += "- \[[url_encode(tm.title)]\]([githuburl]/pull/[tm.number])"
 		var/all_tms_joined = jointext(all_tms, "%0A") // %0A is a newline for URL encoding because i don't trust \n to not break
 
 		concatable += ("&test-merges=" + all_tms_joined)


### PR DESCRIPTION

## About The Pull Request

Titles should be url encoded to prevent ampersands (and other special symbols) from breaking the link. Cannot properly test this locally but this shouldn't break anything.
Closes #90735

## Changelog
:cl:
fix: Fixed ampersands in TM titles breaking the in-game issue report button
/:cl:
