### PR TITLE
Fix cable coil icon breaking with layer hubs

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -468,10 +468,14 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 	. += "<b>Use it in hand</b> to change the layer you are placing on, amongst other things."
 
 /obj/item/stack/cable_coil/update_name()
+	if(novariants)
+		return
 	. = ..()
 	name = "cable [(amount < 3) ? "piece" : "coil"]"
 
 /obj/item/stack/cable_coil/update_desc()
+	if(novariants)
+		return
 	. = ..()
 	desc = "A [(amount < 3) ? "piece" : "coil"] of insulated power cable."
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -526,36 +526,41 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 		return
 	switch(layer_result)
 		if("Layer 1")
+			icon = initial(icon)
+			novariants = FALSE
 			set_cable_color(CABLE_COLOR_RED)
 			target_type = /obj/structure/cable/layer1
 			target_layer = CABLE_LAYER_1
-			novariants = FALSE
 		if("Layer 2")
+			icon = initial(icon)
+			novariants = FALSE
 			set_cable_color(CABLE_COLOR_YELLOW)
 			target_type = /obj/structure/cable
 			target_layer = CABLE_LAYER_2
-			novariants = FALSE
 		if("Layer 3")
+			icon = initial(icon)
+			novariants = FALSE
 			set_cable_color(CABLE_COLOR_BLUE)
 			target_type = /obj/structure/cable/layer3
 			target_layer = CABLE_LAYER_3
-			novariants = FALSE
 		if("Multilayer cable hub")
 			name = "multilayer cable hub"
 			desc = "A multilayer cable hub."
+			icon = 'icons/obj/pipes_n_cables/structures.dmi'
 			icon_state = "cable_bridge"
+			novariants = TRUE
 			set_cable_color(CABLE_COLOR_WHITE)
 			target_type = /obj/structure/cable/multilayer
 			target_layer = CABLE_LAYER_2
-			novariants = TRUE
 		if("Multi Z layer cable hub")
 			name = "multi z layer cable hub"
 			desc = "A multi-z layer cable hub."
+			icon = 'icons/obj/pipes_n_cables/structures.dmi'
 			icon_state = "cablerelay-broken-cable"
+			novariants = TRUE
 			set_cable_color(CABLE_COLOR_WHITE)
 			target_type = /obj/structure/cable/multilayer/multiz
 			target_layer = CABLE_LAYER_2
-			novariants = TRUE
 		if("Cable restraints")
 			if (amount >= CABLE_RESTRAINTS_COST)
 				if(use(CABLE_RESTRAINTS_COST))


### PR DESCRIPTION

## About The Pull Request

The icons for the multilayer and multi z layer cable hubs are in a separate dmi than the cable coil, so when you tried to switch to either of them by using cable coil in hand it'd just go invisible. This makes sure the icon gets changed to the right one if you select those (and gets switched back when you choose cable coil). It also moves the setting of `novariants` to be above the `set_cable_color` call because it's checked in that call and so it needs to be the updated value. This also adds a check for `novariants` in `update_name` and `update_desc` because currently the changed name and desc for the cable hubs gets overwritten by these calls (triggered by `update_appearance` at the end of `attack_self`)

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed cable coil going invisible when you select the two cable hub options
/:cl:
