### PR TITLE
Fixes PDA notepad program always showing a blank field upon being opened.

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNotepad.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.tsx
@@ -333,7 +333,7 @@ export const NtosNotepad = (props) => {
   const { note } = data;
   const [documentName, setDocumentName] = useState(DEFAULT_DOCUMENT_NAME);
   const [originalText, setOriginalText] = useState(note);
-  const [text, setText] = useState('');
+  const [text, setText] = useState(note);
   const [statuses, setStatuses] = useState<Statuses>({
     line: 0,
     column: 0,


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin.
A previous pr seems to have accidentally set this to an empty string when changing it, despite this needing to be set to `note` to work.
This fixes that.
## Why It's Good For The Game

less jank
## Changelog
:cl:
fix: PDA notepad app no longer always shows a blank field upon being opened.
/:cl:
