### PR TITLE
Resolves merge skew, fixes broken quirk equipping

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -327,6 +327,8 @@ GLOBAL_LIST_INIT(tool_items, list(
 #define LOCATION_GLOVES "on your hands"
 /// Items placed in the eye/glasses slot.
 #define LOCATION_EYES "covering your eyes"
+/// Items placed in the mask slot.
+#define LOCATION_MASK "covering your face"
 /// Items placed on the head/hat slot.
 #define LOCATION_HEAD "on your head"
 /// Items placed in the neck slot.

--- a/code/datums/quirks/negative_quirks/immunodeficiency.dm
+++ b/code/datums/quirks/negative_quirks/immunodeficiency.dm
@@ -13,14 +13,20 @@
 	)
 
 /datum/quirk/item_quirk/immunodeficiency/add_unique(client/client_source)
-	var/obj/item/clothing/mask/surgical/ppe = new
-	give_item_to_holder(ppe, list(LOCATION_MASK = ITEM_SLOT_MASK, LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
+	give_item_to_holder(
+		/obj/item/clothing/mask/surgical,
+		list(
+			LOCATION_MASK,
+			LOCATION_BACKPACK,
+			LOCATION_HANDS,
+		)
+	)
 	give_item_to_holder(
 		/obj/item/storage/pill_bottle/immunodeficiency,
 		list(
-			LOCATION_LPOCKET = ITEM_SLOT_LPOCKET,
-			LOCATION_RPOCKET = ITEM_SLOT_RPOCKET,
-			LOCATION_BACKPACK = ITEM_SLOT_BACKPACK,
-			LOCATION_HANDS = ITEM_SLOT_HANDS,
+			LOCATION_LPOCKET,
+			LOCATION_RPOCKET,
+			LOCATION_BACKPACK,
+			LOCATION_HANDS,
 		)
 	)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -113,17 +113,18 @@
 
 /mob/living/carbon/proc/equip_in_one_of_slots(obj/item/equipping, list/slots, qdel_on_fail = TRUE, indirect_action = FALSE)
 	var/static/list/equip_slots = list(
-		LOCATION_LPOCKET,
-		LOCATION_RPOCKET,
-		LOCATION_HANDS,
-		LOCATION_GLOVES,
-		LOCATION_EYES,
-		LOCATION_HEAD,
-		LOCATION_NECK,
-		LOCATION_ID,
+		LOCATION_LPOCKET = ITEM_SLOT_LPOCKET,
+		LOCATION_RPOCKET = ITEM_SLOT_RPOCKET,
+		LOCATION_HANDS = ITEM_SLOT_HANDS,
+		LOCATION_GLOVES = ITEM_SLOT_GLOVES,
+		LOCATION_EYES = ITEM_SLOT_EYES,
+		LOCATION_MASK = ITEM_SLOT_MASK,
+		LOCATION_HEAD = ITEM_SLOT_HEAD,
+		LOCATION_NECK = ITEM_SLOT_NECK,
+		LOCATION_ID = ITEM_SLOT_ID,
 	)
 	var/static/list/storage_slots = list(
-		LOCATION_BACKPACK,
+		LOCATION_BACKPACK = ITEM_SLOT_BACK,
 	)
 
 	for(var/slot in slots)


### PR DESCRIPTION

## About The Pull Request

#90869 and #90937 ran into some nice merge skew issues, where the latter got in despite its slot lists needing to be adjusted to go with the former.

...But `LOCATION_MASK` never existed. So this pr adds that.

......But `equip_in_one_of_slots(...)` wouldn't actually do anything, because of trying to treat a regular list like an associative list with corresponding item slots. So this pr adds those corresponding item slots.

This should fix our issues.
## Why It's Good For The Game

less jank
also hey resolves our merge skew
## Changelog
:cl:
fix: Fixes quirks and the scarf trait just dropping items to the ground.
/:cl:
