### PR TITLE
Invisible holosigns fix

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -11,6 +11,8 @@
 	resistance_flags = FREEZE_PROOF
 	var/obj/item/holosign_creator/projector
 	var/use_vis_overlay = TRUE
+	/// Doesn't become invisible when spraypainted
+	flags_1 = UNPAINTABLE_1
 
 /datum/armor/structure_holosign
 	bullet = 50

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -18,6 +18,8 @@
 	var/flaps_layer = ABOVE_MOB_LAYER
 	/// Alpha of the flaps
 	var/flaps_alpha = 255
+	/// Doesn't become invisible when spraypainted
+	flags_1 = UNPAINTABLE_1
 	/// Limits how much damage from environmental fire we can take per second
 	COOLDOWN_DECLARE(burn_damage_cd)
 


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/91152. It seems that the invisibleness is caused by vis overlays.

## Why It's Good For The Game

Invisible plastic flaps and sec holobarriers bad.

## Changelog

:cl:
fix: you can no longer spraypaint holobarriers and plastic flaps to make them invisible
/:cl: