### PR TITLE
Fixes medical stack recipes not producing enough stacks. + Allows smaller medical stack reactions.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -354,28 +354,28 @@
 ///medical stacks
 
 /datum/chemical_reaction/medicine/medsuture
-	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 20, /datum/reagent/medicine/polypyr = 15) //This might be a bit much, reagent cost should be reviewed after implementation.
+	required_reagents = list(/datum/reagent/cellulose = 2, /datum/reagent/toxin/formaldehyde = 4, /datum/reagent/medicine/polypyr = 3) //This might be a bit much, reagent cost should be reviewed after implementation.
 	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE
 
 /datum/chemical_reaction/medicine/medsuture/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	new /obj/item/stack/medical/suture/medicated(get_turf(holder.my_atom), round(created_volume))
+	new /obj/item/stack/medical/suture/medicated(get_turf(holder.my_atom), round(created_volume * 4))
 
 /datum/chemical_reaction/medicine/medmesh
-	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/cellulose = 2, /datum/reagent/consumable/aloejuice = 4, /datum/reagent/space_cleaner/sterilizine = 2)
 	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BURN
 
 /datum/chemical_reaction/medicine/medmesh/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	new /obj/item/stack/medical/mesh/advanced(get_turf(holder.my_atom), round(created_volume))
+	new /obj/item/stack/medical/mesh/advanced(get_turf(holder.my_atom), round(created_volume * 3))
 
 /datum/chemical_reaction/medicine/poultice
-	required_reagents = list(/datum/reagent/toxin/bungotoxin = 20, /datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20)
+	required_reagents = list(/datum/reagent/toxin/bungotoxin = 4, /datum/reagent/cellulose = 4, /datum/reagent/consumable/aloejuice = 4	)
 	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN
 
 /datum/chemical_reaction/medicine/poultice/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	new /obj/item/stack/medical/poultice(get_turf(holder.my_atom), round(created_volume))
+	new /obj/item/stack/medical/poultice(get_turf(holder.my_atom), round(created_volume * 3))
 
 /datum/chemical_reaction/medicine/seraka_destroy //seraka extract is destroyed by sodium hydroxide
 	results = list(/datum/reagent/consumable/sugar = 1)


### PR DESCRIPTION
## About The Pull Request

Medical stack creation was unintentially nerfed at some undetermined point in the past by some unknown person 

Instead of producing producing full 15 or 20 amount stacks, the reaction was changed to produce stacks with a stack count of one.

This PR fixes that and, since creating variable amount stacks is now easy, I've divided the reagents and stacks produced by the lowest common denominator to make the reactions more granular and flexible,

## Why It's Good For The Game

These items are already underutilized and an unintentional ~95% nerf to recipe output is bad even though the original unbugged output is quite high!

Making the recipes more granular improves flavour of medical stack making setups as the stacks will grow visually as more reactions occur, rather than always popping out fully fleshed out. 

## Changelog

:cl:
fix: fixed medical stacks producing far too few items.
qol: medical stack recipes are more granular.
/:cl:

