### PR TITLE
Prevents machine frames from being completed on the same tile as identical machines.

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -279,9 +279,6 @@
 		return .
 	if(state != FRAME_STATE_BOARD_INSTALLED)
 		return .
-	if(locate(circuit.build_path) in loc)
-		balloon_alert(user, "identical machine present!")
-		return ITEM_INTERACT_BLOCKING
 	if(finalize_construction(user, tool))
 		return ITEM_INTERACT_SUCCESS
 
@@ -440,6 +437,9 @@
  * * tool - the tool used to finalize the construction
  */
 /obj/structure/frame/machine/finalize_construction(mob/living/user, obj/item/tool)
+	if(locate(circuit.build_path) in loc)
+		balloon_alert(user, "identical machine present!")
+		return FALSE
 	for(var/component in req_components)
 		if(req_components[component] > 0)
 			user.balloon_alert(user, "missing components!")

--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -279,7 +279,9 @@
 		return .
 	if(state != FRAME_STATE_BOARD_INSTALLED)
 		return .
-
+	if(locate(circuit.build_path) in loc)
+		balloon_alert(user, "identical machine present!")
+		return ITEM_INTERACT_BLOCKING
 	if(finalize_construction(user, tool))
 		return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

relevant for all non dense machines

If you screwdriver a machine frame and there is already an identical machine on that tile present it will fail and notify you of this.

This fix does not need to come before https://github.com/tgstation/tgstation/pull/91122 as that machine cant be abused if stacked on the same tile (it just looks ugly and weird)


https://github.com/user-attachments/assets/3ef989f2-1053-48ad-85a8-f73d2bddfe82



You will still be allowed to stack non-dense machines like a mass driver on the same tile as a launchpad or quantum pad, but you wont be able to spam 30 launchpads and 30 mass drivers on the same tile.

(I went back in to test to make sure its still possible image is of me making a mass driver ontop of a quantum pad)
![image](https://github.com/user-attachments/assets/c3ce2e26-ad63-48dd-8816-047b7fb3a666)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently you can spam an infinite amount of launch pads and mass drivers and quantum pads on the same tile due to them being machines that arnt dense.

These can all be abused for instant kills and teleport spam on the same tile. (This is a very dangerous combination as teleport spam can involve the act of relocating people to the tile.)

And if its not merged ill abuse it (I already did to make a launchpad spam machine that can rapid fire on the same tile the round I discovered it)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: You can no longer finish a machine frame if it is on the same tile as a machine that it would become.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
