### PR TITLE
You can now examine things through advanced camera consoles, holopad calls, and while looking up/down

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -9,7 +9,6 @@
 ///from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_SHIFT "shift_click"
 //	#define COMSIG_MOB_CANCEL_CLICKON (1<<0) //shared with other forms of click, this is so you're aware it exists here too.
-	#define COMPONENT_ALLOW_EXAMINATE (1<<1) //! Allows the user to examinate regardless of client.eye.
 ///from base of atom/ShiftClick()
 #define COMSIG_SHIFT_CLICKED_ON "shift_clicked_on"
 ///from base of atom/CtrlClickOn(): (/mob)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -345,7 +345,7 @@
 	var/shiftclick_flags = SEND_SIGNAL(user, COMSIG_CLICK_SHIFT, src)
 	if(shiftclick_flags & COMSIG_MOB_CANCEL_CLICKON)
 		return
-	if(user.client && (user.client.eye == user || user.client.eye == user.loc || shiftclick_flags & COMPONENT_ALLOW_EXAMINATE))
+	if(user.client)
 		user.examinate(src)
 
 /mob/proc/TurfAdjacent(turf/tile)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -221,7 +221,6 @@
 		return INITIALIZE_HINT_QDEL
 	owner = new_owner
 	START_PROCESSING(SSobj, src)
-	RegisterSignal(owner, COMSIG_CLICK_SHIFT, PROC_REF(examinate_check))
 	RegisterSignal(owner, COMSIG_CARBON_REGENERATE_LIMBS, PROC_REF(unlist_head))
 	RegisterSignal(owner, COMSIG_LIVING_REVIVE, PROC_REF(retrieve_head))
 	RegisterSignal(owner, COMSIG_HUMAN_PREFS_APPLIED, PROC_REF(update_prefs_name))
@@ -248,11 +247,6 @@
 	detached_head.name = wearer.real_name
 	var/obj/item/organ/brain/brain = locate(/obj/item/organ/brain) in detached_head
 	brain.name = "[wearer.name]'s brain"
-
-/obj/item/dullahan_relay/proc/examinate_check(mob/user, atom/source)
-	SIGNAL_HANDLER
-	if(user.client.eye == src)
-		return COMPONENT_ALLOW_EXAMINATE
 
 /obj/item/dullahan_relay/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -128,12 +128,6 @@
 		return
 	update_ai_detect_hud()
 
-///Called when the AI shiftclicks on something to examinate it.
-/mob/eye/camera/ai/proc/examinate_check(mob/user, atom/source)
-	SIGNAL_HANDLER
-	if(user.client.eye == src)
-		return COMPONENT_ALLOW_EXAMINATE
-
 /*----------------------------------------------------*/
 
 /atom/proc/move_camera_by_click()
@@ -205,7 +199,6 @@
 	eyeobj.ai = src
 	eyeobj.name = "[name] (AI Eye)"
 	eyeobj.setLoc(loc, TRUE)
-	eyeobj.RegisterSignal(src, COMSIG_CLICK_SHIFT, TYPE_PROC_REF(/mob/eye/camera/ai, examinate_check))
 	set_eyeobj_visible(TRUE)
 
 /mob/living/silicon/ai/proc/set_eyeobj_visible(state = TRUE)


### PR DESCRIPTION

## About The Pull Request

While playing around with stuff, I noticed an odd inconsistency in when we can and can't examine:

Camera console/app? Yes.
Advanced camera console? No.
AI? Yes.
Holopad call? No.
In a locker? Yes.
Looking up or down? No.

Looking into it, I found it to come down to this line of code:
https://github.com/tgstation/tgstation/blob/9234188a87d2715260008923094fc94db024cae3/code/_onclick/click.dm#L348
Where we check whether the user's eye is the user, the user's loc, or the `COMPONENT_ALLOW_EXAMINATE` flag.
AIs have their own eye object, and so they work because of the `COMPONENT_ALLOW_EXAMINATE` flag getting set on the signal.
Camera consoles work because your eye is still you, while you look through them.
Lockers work because it also checks for your loc being your eye.
Everything else on the previous list doesn't, because it moves your eye!

Okay, well. Why? Why do those checks exist?

This was last touched four months ago, in a pr letting AIs examine (#89146). This didn't change the logic.
https://github.com/tgstation/tgstation/blob/89ead63f7dad55b525081cf978491e2aead1c939/code/_onclick/click.dm#L345
It was last changed meaningfully six years ago, in a dullahan examining fix pr (#48633). This added the `COMPONENT_ALLOW_EXAMINATE` part, without touching the eye parts. It doesn't mention why the eye parts exist.
https://github.com/tgstation/tgstation/blob/c5b5d9613091b267be5437a3f7b9436046113069/code/_onclick/click.dm#L306
The next last change before it was ten years ago, in a commit mentioning locker examine fixes (6b524f09a94649bb944a853d0f6a383a80075577). Doesn't mention why the eye part exists, just adds onto it.
https://github.com/tgstation/tgstation/blob/6b524f09a94649bb944a853d0f6a383a80075577/code/_onclick/click.dm#L203
Okay, well. Before then? Twelve years ago. Click code rework commit (475042a21213783df2fa8c0d08751eed542afb57). No mention of why. In a new file.
https://github.com/tgstation/tgstation/blob/475042a21213783df2fa8c0d08751eed542afb57/code/_onclick/click.dm#L195
Well. Okay. Fuck. And before this, then? Anything?
https://github.com/tgstation/tgstation/blob/7274c58078f172b4c52ea668a93fb071c672de99/code/game/atoms.dm#L1102-L1111
I see.
It was a camera check, indirectly, kind of.
But since then cameras have been reworked, things no longer work that way, and we have canonized examining through cameras in that most recent AI examine pr.

So away it goes! And so do all the weird exceptions!
## Why It's Good For The Game

Consistency between camera consoles and AI examines.
It's also horribly unintuitive when you're using an advanced console and inexplicably can't examine people.

For holocalls it's just a nuisance to not be able to, really.

With us now having a bunch of multi-z maps, and one trying to make the most use of it, I think it's for the best that looking up/down let you actually examine stuff.
I mean, especially when you *could* already examine things on the floor below you- but only if you weren't looking down.

It's all just kinda jank and unintuitive, really.
## Changelog
:cl:
balance: You can now examine things through advanced camera consoles.
balance: You can now examine things while in a holopad call.
balance: You can now examine things while looking up or down.
/:cl:
