### PR TITLE
Fixes syrup bottle runtimes

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -518,7 +518,7 @@
 	context[SCREENTIP_CONTEXT_ALT_LMB] = (cap_on ? "Remove Pump Cap" : "Add Pump Cap")
 	if(IS_WRITING_UTENSIL(held_item))
 		context[SCREENTIP_CONTEXT_LMB] = "Write Label"
-	else if(cap_on && held_item.is_refillable())
+	else if(cap_on && held_item?.is_refillable())
 		context[SCREENTIP_CONTEXT_LMB] = "Use Pump"
 
 	return CONTEXTUAL_SCREENTIP_SET
@@ -571,7 +571,7 @@
 		icon_state = "syrup_open"
 		spillable = TRUE
 		balloon_alert(user, "removed pump cap")
-		
+
 	update_icon_state()
 	return CLICK_ACTION_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

Didn't nullcheck held_item so it would runtime every time you hovered over it with an empty hand

## Changelog
:cl:
fix: Fixed syrup bottle runtimes
/:cl:
