### PR TITLE
fixed M.S.G not updating connected modules on destroy [NO GBP]

### DIFF
--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -246,6 +246,9 @@
 
 /obj/machinery/modular_shield_generator/Destroy()
 	QDEL_LIST(deployed_shields)
+	for(var/obj/machinery/modular_shield/module/disconnecting in connected_modules)
+		disconnecting.shield_generator = null
+		disconnecting.update_icon_state()
 	return ..()
 
 /obj/machinery/modular_shield_generator/update_icon_state()


### PR DESCRIPTION

## About The Pull Request

Just has the generator go through its list of connected modules and removes itself from them

## Why It's Good For The Game

Its annoying to have to screwdriver and wrench to update everything.

## Changelog
:cl:
fix: Modular shield generator modules no longer remember or miss their generator when its destroyed
/:cl:
