### PR TITLE
Killing yourself with a fish kills you

### DIFF
--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -106,6 +106,7 @@
 	if(prob(80)) // the percentage is important.
 		soulman.PossessByPlayer(user.ckey)
 		to_chat(soulman, span_notice("You finally feel at peace."))
+		soulman.death()
 	user.gib()
 	qdel(src)
 

--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -103,10 +103,12 @@
 
 /obj/item/fish/soul/proc/good_ending(mob/living/user)
 	var/mob/living/basic/spaceman/soulman = new(get_turf(user))
+	soulman.fully_replace_character_name(user.real_name)
+	addtimer(CALLBACK(soulman, TYPE_PROC_REF(/atom, visible_message), span_notice("[soulman] was too pure for this world...")), 5 SECONDS, TIMER_DELETE_ME)
+	addtimer(CALLBACK(soulman, TYPE_PROC_REF(/mob/living, death)), 5 SECONDS, TIMER_DELETE_ME)
 	if(prob(80)) // the percentage is important.
 		soulman.PossessByPlayer(user.ckey)
 		to_chat(soulman, span_notice("You finally feel at peace."))
-		soulman.death()
 	user.gib()
 	qdel(src)
 
@@ -122,12 +124,7 @@
 	soulbox.throw_at(get_edge_target_turf(get_turf(user), yeet_direction), yeet_distance, 2, user, spin = TRUE)
 	soulbox.AddElement(/datum/element/haunted, haunt_color = "#124CD5")
 	if(prob(86)) // 1 in 7 chance to stay
-		addtimer(CALLBACK(src, PROC_REF(soul_gone), soulbox), 1 SECONDS * iteration)
-
-/obj/item/fish/soul/proc/soul_gone(obj/soulbox)
-	soulbox.visible_message("[soulbox] disappears, as if it was never there to begin with...")
-	new /obj/effect/temp_visual/mook_dust(get_turf(soulbox))
-	qdel(soulbox)
+		soulbox.fade_into_nothing(1 SECONDS * iteration, 0.5 SECONDS)
 
 ///From the cursed spring
 /obj/item/fish/skin_crab


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that if you commit suicide with the soulfish you will feel a brief moment of relief before expiring, rather than simply escaping your previous body and assuming a new and perfectly alive one.

This also fixes a bug where the toolboxes it spawned were supposed to despawn but didn't because the object the timer was held on was deleted before it could fire.

## Why It's Good For The Game

The current effect is funny but I have the cruel opinion that if you kill yourself you should probably usually die while doing it
transforming into a different mob should be like a rare or at least unusual effect and not something you can trivially do with a minor risk just by catching a specific fish

## Changelog

:cl:
balance: when you kill yourself with a soulfish, it will now kill you
fix: also the toolboxes the soulfish suicide spawns will despawn as intended
/:cl:
