### PR TITLE
Fixes airlocks starting without their glass overlays

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -164,11 +164,10 @@
 	return .
 
 /obj/machinery/door/airlock/Initialize(mapload)
-	. = ..()
-
-	set_wires(get_wires())
 	if(glass)
 		airlock_material = "glass"
+	. = ..()
+	set_wires(get_wires())
 	if(security_level > AIRLOCK_SECURITY_IRON)
 		atom_integrity = normal_integrity * AIRLOCK_INTEGRITY_MULTIPLIER
 		max_integrity = normal_integrity * AIRLOCK_INTEGRITY_MULTIPLIER


### PR DESCRIPTION

## About The Pull Request

#90998 added update_apperance into door init which breaks glass overlays on all doors until you open and close them because glass material is not set in time.

## Changelog
:cl:
fix: Fixed airlocks starting without their glass overlays
/:cl:
