### PR TITLE
Fixes bungotoxin dizziness to confusion translation mechanic.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1260,7 +1260,7 @@
 		. = UPDATE_MOB_HEALTH
 
 	// If our mob's currently dizzy from anything else, we will also gain confusion
-	var/mob_dizziness = affected_mob.get_timed_status_effect_duration(/datum/status_effect/confusion)
+	var/mob_dizziness = affected_mob.get_timed_status_effect_duration(/datum/status_effect/dizziness)
 	if(mob_dizziness > 0)
 		// Gain confusion equal to about half the duration of our current dizziness
 		affected_mob.set_confusion(mob_dizziness / 2)


### PR DESCRIPTION

## About The Pull Request

This PR fixes the long broken, lesser known secondary effect of bungotoxin, where it sets the victims confusion to their dizziness.

## Why It's Good For The Game

bug are bad mkay

And our valued players can make funny deathmixes again.

## Changelog

:cl:
fix: Bungotoxins secondary effect that sets the victims confusion depending on their dizziness now works again.
/:cl:

