### PR TITLE
Remove dead code from gas canisters

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -48,16 +48,13 @@
 	fire = 80
 	acid = 50
 
-/obj/machinery/portable_atmospherics/canister/Initialize(mapload, datum/gas_mixture/existing_mixture)
+/obj/machinery/portable_atmospherics/canister/Initialize(mapload)
 	. = ..()
 
 	if(mapload)
 		internal_cell = new /obj/item/stock_parts/power_store/cell/high(src)
 
-	if(existing_mixture)
-		air_contents.copy_from(existing_mixture)
-	else
-		create_gas()
+	create_gas()
 
 	if(ispath(gas_type, /datum/gas))
 		desc = "[GLOB.meta_gas_info[gas_type][META_GAS_NAME]]. [GLOB.meta_gas_info[gas_type][META_GAS_DESC]]"


### PR DESCRIPTION

## About The Pull Request
This removes the `existing_mixture` argument from canisters `Initialization()` proc.

I tried searching for its use in the original PR it was added via:
- #57083

And via searching regex patterns for canisters in the codebase and found nothing. So right now it's just dead code that can be removed.

## Why It's Good For The Game
Dead code should die.

## Changelog
:cl:
qol: Remove dead code from gas canisters
/:cl:
