### PR TITLE
adds snail swabbing

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -43,6 +43,7 @@
 #define CELL_LINE_TABLE_PUG "cell_line_pug_table"
 #define CELL_LINE_TABLE_SLIME "cell_line_slime_table"
 #define CELL_LINE_TABLE_SNAKE "cell_line_snake_table"
+#define CELL_LINE_TABLE_SNAIL "cell_line_snail_table"
 #define CELL_LINE_TABLE_VATBEAST "cell_line_vatbeast_table"
 #define CELL_LINE_TABLE_NETHER "cell_line_nether_table"
 #define CELL_LINE_TABLE_GLUTTON "cell_line_glutton_table"

--- a/code/_globalvars/lists/xenobiology.dm
+++ b/code/_globalvars/lists/xenobiology.dm
@@ -59,6 +59,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 	CELL_LINE_TABLE_PUG = list(/datum/micro_organism/cell_line/pug = 1),
 	CELL_LINE_TABLE_SLIME = list(/datum/micro_organism/cell_line/slime = 1),
 	CELL_LINE_TABLE_SNAKE = list(/datum/micro_organism/cell_line/snake = 1),
+	CELL_LINE_TABLE_SNAIL = list(/datum/micro_organism/cell_line/snail = 1),
 	CELL_LINE_TABLE_VATBEAST = list(/datum/micro_organism/cell_line/vat_beast = 1),
 	CELL_LINE_TABLE_NETHER = list(/datum/micro_organism/cell_line/netherworld = 1),
 	CELL_LINE_TABLE_CLOWN = list(

--- a/code/modules/mob/living/basic/snails/snail.dm
+++ b/code/modules/mob/living/basic/snails/snail.dm
@@ -44,6 +44,7 @@
 	AddElement(/datum/element/basic_eating, food_types = eatable_food)
 	create_reagents(100, REAGENT_HOLDER_ALIVE)
 	RegisterSignal(reagents, COMSIG_REAGENTS_HOLDER_UPDATED, PROC_REF(on_reagents_update))
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_SNAIL, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
 	if (minion_path)
 		AddElement(/datum/element/regal_rat_minion, converted_path = minion_path, success_balloon = "gurgle", pet_commands = GLOB.regal_rat_minion_commands)

--- a/code/modules/reagents/reagent_containers/watering_can.dm
+++ b/code/modules/reagents/reagent_containers/watering_can.dm
@@ -12,6 +12,11 @@
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = list(20,100)
 
+/obj/item/reagent_containers/cup/watering_can/Initialize(mapload, vol)
+	. = ..()
+	if(mapload)
+		AddElement(/datum/element/swabable, CELL_LINE_TABLE_SNAIL, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+
 /obj/item/reagent_containers/cup/watering_can/wood
 	name = "wood watering can"
 	desc = "An old metal-made watering can but shoddily painted to look like it was made of wood for some dubious reason..."

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -708,4 +708,26 @@
 
 	resulting_atom = /mob/living/basic/mega_arachnid
 
+/datum/micro_organism/cell_line/snail
+	desc = "gastropod epithelial cells"
+	required_reagents = list(
+		/datum/reagent/consumable/nutriment/protein,
+		/datum/reagent/iron,
+	)
+
+	supplementary_reagents = list(
+		/datum/reagent/yuck = 2,
+		/datum/reagent/blood = 2,
+		/datum/reagent/consumable/applejuice = 2,
+		/datum/reagent/consumable/mold = 1,
+	)
+
+	suppressive_reagents = list(
+		/datum/reagent/toxin/pestkiller = -2,
+		/datum/reagent/consumable/salt = -3,
+		/datum/reagent/consumable/ethanol/bug_spray = -1,
+	)
+	virus_suspectibility = 0
+	resulting_atom = /mob/living/basic/snail
+
 #undef VAT_GROWTH_RATE


### PR DESCRIPTION

## About The Pull Request
a player requested i add this, i think its harmless enough to add, but u can now swab snails, or mapped in watering cans in botany for snail samples

## Why It's Good For The Game
adds a few more beneficial creatures to the cytology pool, these ones specifically being helpful for botanists.

## Changelog
:cl:
add: snails are now growable from cytology. u can swab snails or watering cans for samples
/:cl:
