### PR TITLE
changes minimum age from 17 to 18

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -430,7 +430,7 @@
 #define OFFSET_HELD "held"
 
 //MINOR TWEAKS/MISC
-#define AGE_MIN 17 //youngest a character can be
+#define AGE_MIN 18 //youngest a character can be
 #define AGE_MAX 85 //oldest a character can be
 #define AGE_MINOR 20 //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN 30 //youngest a wizard can be


### PR DESCRIPTION
## About The Pull Request

does what the title says

## Why It's Good For The Game

people just use this to be creepy. we require people to be at least 18 to play, why would we intentionally let someone roleplay as underage. why would nanotrasen hire a 17 year old??? recent events on the station have shown that keeping this around is a bad idea.

## Changelog

:cl:
config: The minimum age on all Nanotrasen research stations is now 18.
/:cl:
