### PR TITLE
Reduces Nukie Keycard Prices, and increases ordnance keycard to 30 Tc

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -818,7 +818,7 @@
 	category = /datum/uplink_category/base_keys
 	surplus = 0
 	purchasable_from = UPLINK_NUKE_OPS
-	cost = 15
+	cost = 5
 	cant_discount = TRUE
 
 /datum/uplink_item/base_keys/bomb_key
@@ -826,6 +826,7 @@
 	desc = "Do you fancy yourself an explosives expert? If so, then consider yourself lucky! With this special Authorization Key, \
 		you can blow those corpo suits away with your very own home-made explosive devices. Made in your local firebase's \
 		very own Ordnance Laboratory! *The Syndicate is not responsible for injuries or deaths sustained while utilizing the lab."
+	cost = 15
 	item = /obj/item/keycard/syndicate_bomb
 
 /datum/uplink_item/base_keys/bio_key
@@ -852,7 +853,6 @@
 		pocket during this morning's briefing. He's been looking for it since. Take it, get into the fridge, and cook up whatever \
 		you need before he gets back. And remember: DON'T TELL ANYONE! -M.T"
 	item = /obj/item/keycard/syndicate_fridge
-	cost = 5
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
 
 /datum/uplink_item/base_keys/custodial_key
@@ -860,7 +860,6 @@
 	desc = "Your workplace dirty? No problem! with this card you gain access to the custodial. Containing a janitorial cart \
 	with some janitorial supplies and an canister of water vapour."
 	item = /obj/item/keycard/syndicate_custodial
-	cost = 10
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
 
 // Hats

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -826,7 +826,7 @@
 	desc = "Do you fancy yourself an explosives expert? If so, then consider yourself lucky! With this special Authorization Key, \
 		you can blow those corpo suits away with your very own home-made explosive devices. Made in your local firebase's \
 		very own Ordnance Laboratory! *The Syndicate is not responsible for injuries or deaths sustained while utilizing the lab."
-	cost = 15
+	cost = 30
 	item = /obj/item/keycard/syndicate_bomb
 
 /datum/uplink_item/base_keys/bio_key


### PR DESCRIPTION
## About The Pull Request
Redo's https://github.com/tgstation/tgstation/pull/90697

Reduces all keys to 5 TC except from Ordnance key which is increased to 30 TC

## Why It's Good For The Game

Nukies using these rooms are cool and should be encouraged. I almost never see them being used because they're way too expensive for what they are!

Also increases ordnance keycard 30 TC with the new addition of the electroyzer/cooling loop this allows nukies to make hydrogen bombs which is one of the strongest bombs in the game

## Changelog
:cl: Ezel
balance: Chem/Xeno/Custodial Nukie Keycard lowered to 5
balance: Ordnance Nukie Keycard increased to 30
/:cl:

