### PR TITLE
Fixes bungo pits not inheriting stats and genes from the fruit.

### DIFF
--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -57,7 +57,7 @@
 
 	if(istype(source, /obj/item/food/grown) && ispath(trash, /obj/item/food))
 		var/obj/item/food/grown/plant = source
-		trash_item = new trash(edible_object.drop_location())
+		trash_item = new trash(edible_object.drop_location(), plant.seed)
 		trash_item.reagents?.set_all_reagents_purity(plant.seed.get_reagent_purity())
 	else
 		trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())

--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -57,7 +57,7 @@
 
 	if(istype(source, /obj/item/food/grown) && ispath(trash, /obj/item/food))
 		var/obj/item/food/grown/plant = source
-		trash_item = new trash(edible_object.drop_location(), plant.seed)
+		trash_item = ispath(trash, /obj/item/food/grown) ? new trash(edible_object.drop_location(), plant.seed) : new trash(edible_object.drop_location())
 		trash_item.reagents?.set_all_reagents_purity(plant.seed.get_reagent_purity())
 	else
 		trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())


### PR DESCRIPTION

## About The Pull Request

This PR fixes and issue where /obj/food/grown items that were produced as a trash product from other /obj/food/grown items did not inherit seed characteristics. 

This only(?) affected the bungo pit, as it is currently the only item of this class(?).

## Why It's Good For The Game

Tot botanists are sad when they can't reexperience the hottest meta strategy of 2022. 

## Changelog

:cl:
fix: fixed bungo pits not inheriting genes and stats from the fruit.
/:cl:

