### PR TITLE
Stickmen summoned by the papier-mache robe are once again hostile

### DIFF
--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -293,7 +293,7 @@
 
 	var/mob/living/stickman = new /mob/living/basic/stickman/lesser(get_turf(summoner))
 
-	stickman.faction += summoner.faction
+	stickman.faction |= summoner.faction - FACTION_NEUTRAL //These bad boys shouldn't inherit the neutral faction from the crew
 
 	COOLDOWN_START(src, summoning_cooldown, 3 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request
Most human mobs have the neutral faction, Stickmen are supposed to be hostile to everyone but their summoner and perhaps any more concrete faction the owner had when they were summoned (e.g. carp, syndies, cult...)

## Why It's Good For The Game
Fixing a nit.

## Changelog

:cl:
fix: Stickmen summoned by the papier-mache robe are once again hostile.
/:cl:
