### PR TITLE
Fixes roasting sausages on singularities and teslas

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -488,10 +488,11 @@
 		return NONE
 	if (!is_type_in_typecache(interacting_with, ovens))
 		return NONE
-	if (istype(interacting_with, /obj/singularity) && get_dist(user, interacting_with) < 10)
+	if (istype(interacting_with, /obj/singularity) || istype(interacting_with, /obj/energy_ball) && get_dist(user, interacting_with) < 10)
 		to_chat(user, span_notice("You send [held_sausage] towards [interacting_with]."))
 		playsound(src, 'sound/items/tools/rped.ogg', 50, TRUE)
 		beam = user.Beam(interacting_with, icon_state = "rped_upgrade", time = 10 SECONDS)
+		finish_roasting(user, interacting_with)
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 


### PR DESCRIPTION

## About The Pull Request
title

ranged interact didn't actually call the proc to roast the sausage, tesla balls weren't included in ranges even though you can roast on them too. I doubt it was intended for you to have to stand next to a tesla if you want to roast on them.
## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/ab04805f-1671-4380-8867-d5cf836a6ddc)
tasty
## Changelog
:cl:
fix: The advanced roasting stick can once again roast sausages on singularities from a few tiles away!
/:cl:
