### PR TITLE
Fixes runtimes with splashing reagents

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -229,7 +229,7 @@
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
 
-	else if(bartender_check(target, thrown_by) && throwingdatum)
+	else if(throwingdatum && bartender_check(target, thrown_by))
 		visible_message(span_notice("[src] lands onto \the [target] without spilling a single drop."))
 		return
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -210,7 +210,7 @@
 /obj/item/reagent_containers/proc/SplashReagents(atom/target, datum/thrownthing/throwingdatum, override_spillable = FALSE)
 	if(!reagents || !reagents.total_volume || (!spillable && !override_spillable) || reagent_flags & SMART_CAP)
 		return
-	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/mob/thrown_by = throwingdatum?.get_thrower()
 
 	if(ismob(target) && target.reagents)
 		var/splash_multiplier = 1


### PR DESCRIPTION
## About The Pull Request
- Fixes #91207

We have 2 checks to see if the throwing datum is null meaning it's an expected condition
https://github.com/tgstation/tgstation/blob/6094f8a522febf765f72e6936ce12d0cc7a4ee99/code/modules/reagents/reagent_containers.dm#L217-L218
https://github.com/tgstation/tgstation/blob/6094f8a522febf765f72e6936ce12d0cc7a4ee99/code/modules/reagents/reagent_containers.dm#L232

So we obtain the thrower only if the datum is available which was the cause of the runtimes


## Changelog
:cl:
fix: fixes runtimes with splashing reagents
/:cl:
