### PR TITLE
[Feature] - Parry Kisses

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -566,7 +566,7 @@
 
 /obj/projectile/kiss/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/parriable_projectile)
+	AddComponent(/datum/component/parriable_projectile, parry_trait = TRAIT_CAN_HOLD_ITEMS)
 
 /obj/projectile/kiss/fire(angle, atom/direct_target)
 	if(firer && !silent_blown)


### PR DESCRIPTION

## About The Pull Request
Changed the parry element of kisses to need a innate to all carbon humans trait instead of the super specific mining one that you only get from the style meter.

## Why It's Good For The Game
It's fun. It allows for a fun mechanic that has been relegated to obscurity by both forgotten use of the style meter and how hard is usually to obtain to non miners. Even regular miners dont get it often. It's fun to throw a kiss that goes from pink to RED and just dashes to the objective, or parry a kiss sent to you or someone else and alter the trajectory.

This also very slightly buffs and nerfs the syndi lipstick, as those kisses can now be boostable (15% more damage, faster projectile), but can also be parried.

## Changelog
:cl:
add: Allows kisses to be parried and boosted without the style meter.
/:cl:
