### PR TITLE
Firelocks now skip checking uninitialized turfs

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -297,6 +297,8 @@
 			return
 
 	var/turf/checked_turf = source
+	if(!(checked_turf.flags_1 & INITIALIZED_1)) // if the turf is uninitialized, skip it.
+		return
 	var/result = check_atmos(checked_turf)
 
 	if(result && TURF_SHARES(checked_turf))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -297,7 +297,7 @@
 			return
 
 	var/turf/checked_turf = source
-	if(!(checked_turf.flags_1 & INITIALIZED_1)) // if the turf is uninitialized, skip it.
+	if(!(checked_turf.flags_1 & INITIALIZED_1)) // uninitialized turfs won't have atmos setup anyways, so check_atmos would just complain and not work
 		return
 	var/result = check_atmos(checked_turf)
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -280,8 +280,7 @@
 /obj/machinery/door/firedoor/proc/check_atmos(turf/checked_turf)
 	var/datum/gas_mixture/environment = checked_turf.return_air()
 	if(!environment)
-		stack_trace("We tried to check a gas_mixture that doesn't exist for its firetype, what are you DOING")
-		return
+		CRASH("We tried to check a gas_mixture that doesn't exist for its firetype, what are you DOING")
 
 	if(environment.temperature >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		return FIRELOCK_ALARM_TYPE_HOT


### PR DESCRIPTION

## About The Pull Request

this makes it so `/obj/machinery/door/firedoor/proc/process_results()` now returns early if the source turf is uninitialized, which usually happens as a result of holodeck loading.

## Why It's Good For The Game

gets rid of an error, and processing uninitialized turfs feels like a recipe for jank anyways

## Changelog
:cl:
fix: Firelocks now skip checking uninitialized turfs, which caused errors with the holodeck.
/:cl:
