### PR TITLE
Fix express console goody orders being empty

### DIFF
--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -691,6 +691,8 @@
 			var/datum/supply_order/SO = single_order
 			if (SO.pack.crate_type)
 				SO.generate(pod)
+			else if (SO.pack.goody) //Goody orders lack a crate_type and need special handling
+				SO.generateCombo(pod, SO.orderer, SO.pack.contains, SO.pack.cost)
 		else if (istype(single_order, /atom/movable))
 			var/atom/movable/O = single_order
 			O.forceMove(pod)


### PR DESCRIPTION

## About The Pull Request

`/datum/supply_pack/goody` now has `crate_type = null`, meaning separate handling is required for them in express consoles

## Why It's Good For The Game

Fixes #90142 

## Changelog
:cl:
fix: fixed express consoles taking your money and sending nothing when you ordered goodies
/:cl:
