### PR TITLE
Defaults PKA Modkit limits of 1 of its type per PKA

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -292,7 +292,7 @@
 	//Most modkits are supposed to allow duplicates. The ones that don't should be blocked by PKA code anyways.
 	allow_duplicates = TRUE
 	var/denied_type = null
-	var/maximum_of_type = 99
+	var/maximum_of_type = 1
 	var/cost = 30
 	var/modifier = 1 //For use in any mod kit that has numerical modifiers
 	var/minebot_upgrade = TRUE
@@ -369,6 +369,7 @@
 	desc = "Increases the range of a kinetic accelerator when installed."
 	modifier = 1
 	cost = 25
+	maximum_of_type = 99
 
 /obj/item/borg/upgrade/modkit/range/modify_projectile(obj/projectile/kinetic/K)
 	K.range += modifier
@@ -379,6 +380,7 @@
 	name = "damage increase"
 	desc = "Increases the damage of kinetic accelerator when installed."
 	modifier = 10
+	maximum_of_type = 99
 
 /obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/projectile/kinetic/K)
 	K.damage += modifier
@@ -390,6 +392,7 @@
 	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
 	modifier = 3.2
 	minebot_upgrade = FALSE
+	maximum_of_type = 99
 
 // Recalculate recharge time after adding or removing cooldown mods.
 /obj/item/borg/upgrade/modkit/cooldown/proc/get_recharge_time(obj/item/gun/energy/recharge/kinetic_accelerator/KA)
@@ -419,7 +422,6 @@
 	icon_state = "door_electronics"
 	icon = 'icons/obj/devices/circuitry_n_data.dmi'
 	denied_type = /obj/item/borg/upgrade/modkit/cooldown/minebot
-	maximum_of_type = 1
 	modifier = 10
 	cost = 0
 	minebot_upgrade = TRUE
@@ -431,7 +433,6 @@
 	modifier = 0
 	cost = 10
 	denied_type = /obj/item/borg/upgrade/modkit/aoe
-	maximum_of_type = 1
 	var/turf_aoe = FALSE
 	var/stats_stolen = FALSE
 
@@ -496,7 +497,6 @@
 	name = "minebot passthrough"
 	desc = "Causes kinetic accelerator shots to pass through minebots."
 	denied_type = /obj/item/borg/upgrade/modkit/human_passthrough
-	maximum_of_type = 1
 	cost = 0
 
 /obj/item/borg/upgrade/modkit/minebot_passthrough/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user, transfer_to_loc)
@@ -511,7 +511,6 @@
 	name = "human passthrough"
 	desc = "Causes kinetic accelerator shots to pass through humans, good for preventing friendly fire."
 	denied_type = /obj/item/borg/upgrade/modkit/minebot_passthrough
-	maximum_of_type = 1
 	cost = 0
 
 /obj/item/borg/upgrade/modkit/human_passthrough/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user, transfer_to_loc)
@@ -527,7 +526,6 @@
 	name = "rapid repeater"
 	desc = "Quarters the kinetic accelerator's cooldown on striking a living target, but greatly increases the base cooldown."
 	denied_type = /obj/item/borg/upgrade/modkit/cooldown/repeater
-	maximum_of_type = 1
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
@@ -563,7 +561,6 @@
 	name = "resonator blast"
 	desc = "Causes kinetic accelerator shots to leave and detonate resonator blasts."
 	denied_type = /obj/item/borg/upgrade/modkit/resonator_blasts
-	maximum_of_type = 1
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
@@ -580,7 +577,6 @@
 	name = "death syphon"
 	desc = "Killing or assisting in killing a creature permanently increases your damage against that type of creature."
 	denied_type = /obj/item/borg/upgrade/modkit/bounty
-	maximum_of_type = 1
 	modifier = 1.25
 	cost = 30
 	var/maximum_bounty = 25
@@ -635,7 +631,6 @@
 	desc = "Allows creatures normally incapable of firing guns to operate the weapon when installed."
 	cost = 20
 	denied_type = /obj/item/borg/upgrade/modkit/trigger_guard
-	maximum_of_type = 1
 
 /obj/item/borg/upgrade/modkit/trigger_guard/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user)
 	. = ..()
@@ -654,7 +649,6 @@
 	desc = "Makes your KA yellow. All the fun of having a more powerful KA without actually having a more powerful KA."
 	cost = 0
 	denied_type = /obj/item/borg/upgrade/modkit/chassis_mod
-	maximum_of_type = 1
 	var/chassis_icon = "kineticgun_u"
 	var/chassis_name = "super-kinetic accelerator"
 
@@ -688,7 +682,6 @@
 	desc = "Causes kinetic accelerator bolts to have a white tracer trail and explosion."
 	cost = 0
 	denied_type = /obj/item/borg/upgrade/modkit/tracer
-	maximum_of_type = 1
 	var/bolt_color = COLOR_WHITE
 
 /obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -421,7 +421,6 @@
 	desc = "Decreases the cooldown of a kinetic accelerator. Only rated for minebot use."
 	icon_state = "door_electronics"
 	icon = 'icons/obj/devices/circuitry_n_data.dmi'
-	denied_type = /obj/item/borg/upgrade/modkit/cooldown/minebot
 	modifier = 10
 	cost = 0
 	minebot_upgrade = TRUE
@@ -525,7 +524,6 @@
 /obj/item/borg/upgrade/modkit/cooldown/repeater
 	name = "rapid repeater"
 	desc = "Quarters the kinetic accelerator's cooldown on striking a living target, but greatly increases the base cooldown."
-	denied_type = /obj/item/borg/upgrade/modkit/cooldown/repeater
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
@@ -560,7 +558,6 @@
 /obj/item/borg/upgrade/modkit/resonator_blasts
 	name = "resonator blast"
 	desc = "Causes kinetic accelerator shots to leave and detonate resonator blasts."
-	denied_type = /obj/item/borg/upgrade/modkit/resonator_blasts
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
@@ -576,7 +573,6 @@
 /obj/item/borg/upgrade/modkit/bounty
 	name = "death syphon"
 	desc = "Killing or assisting in killing a creature permanently increases your damage against that type of creature."
-	denied_type = /obj/item/borg/upgrade/modkit/bounty
 	modifier = 1.25
 	cost = 30
 	var/maximum_bounty = 25
@@ -617,7 +613,6 @@
 	name = "decrease pressure penalty"
 	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure environments."
 	modifier = 2
-	denied_type = /obj/item/borg/upgrade/modkit/indoors
 	maximum_of_type = 2
 	cost = 35
 
@@ -630,7 +625,6 @@
 	name = "modified trigger guard"
 	desc = "Allows creatures normally incapable of firing guns to operate the weapon when installed."
 	cost = 20
-	denied_type = /obj/item/borg/upgrade/modkit/trigger_guard
 
 /obj/item/borg/upgrade/modkit/trigger_guard/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -389,6 +389,8 @@
 	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
 	modifier = 3.2
 	minebot_upgrade = FALSE
+	denied_type = /obj/item/borg/upgrade/modkit/cooldown
+	maximum_of_type = 3
 
 // Recalculate recharge time after adding or removing cooldown mods.
 /obj/item/borg/upgrade/modkit/cooldown/proc/get_recharge_time(obj/item/gun/energy/recharge/kinetic_accelerator/KA)
@@ -483,6 +485,8 @@
 	name = "offensive explosion"
 	desc = "Causes the kinetic accelerator to damage mobs in an AoE."
 	modifier = 1
+	denied_type = /obj/item/borg/upgrade/modkit/aoe/mobs
+	maximum_of_type = 1
 
 /obj/item/borg/upgrade/modkit/aoe/mobs/andturfs
 	name = "offensive mining explosion"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -389,8 +389,6 @@
 	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
 	modifier = 3.2
 	minebot_upgrade = FALSE
-	denied_type = /obj/item/borg/upgrade/modkit/cooldown
-	maximum_of_type = 3
 
 // Recalculate recharge time after adding or removing cooldown mods.
 /obj/item/borg/upgrade/modkit/cooldown/proc/get_recharge_time(obj/item/gun/energy/recharge/kinetic_accelerator/KA)
@@ -430,6 +428,7 @@
 /obj/item/borg/upgrade/modkit/aoe
 	modifier = 0
 	cost = 10
+	denied_type = /obj/item/borg/upgrade/modkit/aoe
 	maximum_of_type = 1
 	var/turf_aoe = FALSE
 	var/stats_stolen = FALSE
@@ -478,15 +477,12 @@
 /obj/item/borg/upgrade/modkit/aoe/turfs
 	name = "mining explosion"
 	desc = "Causes the kinetic accelerator to destroy rock in an AoE."
-	denied_type = /obj/item/borg/upgrade/modkit/aoe/turfs
 	turf_aoe = TRUE
 
 /obj/item/borg/upgrade/modkit/aoe/mobs
 	name = "offensive explosion"
 	desc = "Causes the kinetic accelerator to damage mobs in an AoE."
 	modifier = 1
-	denied_type = /obj/item/borg/upgrade/modkit/aoe/mobs
-	maximum_of_type = 1
 
 /obj/item/borg/upgrade/modkit/aoe/mobs/andturfs
 	name = "offensive mining explosion"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -292,7 +292,7 @@
 	//Most modkits are supposed to allow duplicates. The ones that don't should be blocked by PKA code anyways.
 	allow_duplicates = TRUE
 	var/denied_type = null
-	var/maximum_of_type = 1
+	var/maximum_of_type = 99
 	var/cost = 30
 	var/modifier = 1 //For use in any mod kit that has numerical modifiers
 	var/minebot_upgrade = TRUE
@@ -323,14 +323,15 @@
 	else if(istype(KA.loc, /mob/living/basic/mining_drone))
 		to_chat(user, span_notice("The modkit you're trying to install is not rated for minebot use."))
 		return FALSE
-	if(denied_type)
-		var/number_of_denied = 0
-		for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in KA.modkits)
-			if(istype(modkit_upgrade, denied_type))
-				number_of_denied++
-			if(number_of_denied >= maximum_of_type)
-				. = FALSE
-				break
+	if(!denied_type)
+		denied_type = src
+	var/number_of_denied = 0
+	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in KA.modkits)
+		if(istype(modkit_upgrade, denied_type))
+			number_of_denied++
+		if(number_of_denied >= maximum_of_type)
+			. = FALSE
+			break
 	if(KA.get_remaining_mod_capacity() >= cost)
 		if(.)
 			if(transfer_to_loc && !user.transferItemToLoc(src, KA))
@@ -418,6 +419,7 @@
 	icon_state = "door_electronics"
 	icon = 'icons/obj/devices/circuitry_n_data.dmi'
 	denied_type = /obj/item/borg/upgrade/modkit/cooldown/minebot
+	maximum_of_type = 1
 	modifier = 10
 	cost = 0
 	minebot_upgrade = TRUE
@@ -494,6 +496,7 @@
 	name = "minebot passthrough"
 	desc = "Causes kinetic accelerator shots to pass through minebots."
 	denied_type = /obj/item/borg/upgrade/modkit/human_passthrough
+	maximum_of_type = 1
 	cost = 0
 
 /obj/item/borg/upgrade/modkit/minebot_passthrough/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user, transfer_to_loc)
@@ -508,6 +511,7 @@
 	name = "human passthrough"
 	desc = "Causes kinetic accelerator shots to pass through humans, good for preventing friendly fire."
 	denied_type = /obj/item/borg/upgrade/modkit/minebot_passthrough
+	maximum_of_type = 1
 	cost = 0
 
 /obj/item/borg/upgrade/modkit/human_passthrough/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user, transfer_to_loc)
@@ -523,6 +527,7 @@
 	name = "rapid repeater"
 	desc = "Quarters the kinetic accelerator's cooldown on striking a living target, but greatly increases the base cooldown."
 	denied_type = /obj/item/borg/upgrade/modkit/cooldown/repeater
+	maximum_of_type = 1
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
@@ -558,6 +563,7 @@
 	name = "resonator blast"
 	desc = "Causes kinetic accelerator shots to leave and detonate resonator blasts."
 	denied_type = /obj/item/borg/upgrade/modkit/resonator_blasts
+	maximum_of_type = 1
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
@@ -574,6 +580,7 @@
 	name = "death syphon"
 	desc = "Killing or assisting in killing a creature permanently increases your damage against that type of creature."
 	denied_type = /obj/item/borg/upgrade/modkit/bounty
+	maximum_of_type = 1
 	modifier = 1.25
 	cost = 30
 	var/maximum_bounty = 25
@@ -628,6 +635,7 @@
 	desc = "Allows creatures normally incapable of firing guns to operate the weapon when installed."
 	cost = 20
 	denied_type = /obj/item/borg/upgrade/modkit/trigger_guard
+	maximum_of_type = 1
 
 /obj/item/borg/upgrade/modkit/trigger_guard/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user)
 	. = ..()
@@ -646,6 +654,7 @@
 	desc = "Makes your KA yellow. All the fun of having a more powerful KA without actually having a more powerful KA."
 	cost = 0
 	denied_type = /obj/item/borg/upgrade/modkit/chassis_mod
+	maximum_of_type = 1
 	var/chassis_icon = "kineticgun_u"
 	var/chassis_name = "super-kinetic accelerator"
 
@@ -679,6 +688,7 @@
 	desc = "Causes kinetic accelerator bolts to have a white tracer trail and explosion."
 	cost = 0
 	denied_type = /obj/item/borg/upgrade/modkit/tracer
+	maximum_of_type = 1
 	var/bolt_color = COLOR_WHITE
 
 /obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)


### PR DESCRIPTION
## About The Pull Request
Fixes an oversight, making it so if the pka modkit doesnt specify a denied type it will default to itself, making it so that any pka modkit by default will allow for only 1 iteration of itself unless the type or the max amount is adjusted. Gave range, damage and cooldown a max of 99 as they depended on not having a denied type before.

## Why It's Good For The Game
When you stack 10 AoE in PKA, as long as you dont do a direct hit, it will do 100 damage on mobs inside the station, 400 or more in lavaland, being able to one shot each of the legion's phases, killing it in record time. This logic should avoid such future oversights, making it so that anything new added will either be limited to 1 of its type, unless specified.

If specified, to itself, it will allow for childrens of it to also treat their parents as such, very important for things like aoe, tracers, chasis mods, etc.

## Changelog
:cl:
fix: Makes the default limit of PKA modskits to be of 1 of its type. 
/:cl:
