### PR TITLE
Fixes Character Preferences name input

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
@@ -154,7 +154,7 @@ export function NameInput(props: NameInputProps) {
             <Input
               autoSelect
               expensive
-              onChange={updateName}
+              onEnter={updateName}
               onEscape={() => {
                 setLastNameBeforeEdit(null);
               }}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
@@ -153,7 +153,6 @@ export function NameInput(props: NameInputProps) {
           {editing ? (
             <Input
               autoSelect
-              expensive
               onBlur={updateName}
               onEscape={() => {
                 setLastNameBeforeEdit(null);

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/names.tsx
@@ -154,7 +154,7 @@ export function NameInput(props: NameInputProps) {
             <Input
               autoSelect
               expensive
-              onEnter={updateName}
+              onBlur={updateName}
               onEscape={() => {
                 setLastNameBeforeEdit(null);
               }}


### PR DESCRIPTION
## About The Pull Request

The character preferences name input was updating the last name value to "null" on every input. This was causing it to return as soon as it detected a value, because it determines if it's editing by comparing this value to what you currently have typed.  This changes the input to instead use onBlur so that it doesn't null out the value until after you finish changing the name.
## Why It's Good For The Game

Makes an input functional again.
## Changelog
:cl: Bisar
fix: The name input for the character preferences should be functional again.
/:cl:
