### PR TITLE
Removes menu under the title bar

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -8,53 +8,6 @@ macro "default"
 		name = "SHIFT+UP"
 		command = ".winset :map.right-click=true"
 
-
-menu "menu"
-	elem
-		name = "&File"
-		command = ""
-		saved-params = "is-checked"
-	elem
-		name = "&Quick screenshot\tF2"
-		command = ".screenshot auto"
-		category = "&File"
-		saved-params = "is-checked"
-	elem
-		name = "&Save screenshot as...\tShift+F2"
-		command = ".screenshot"
-		category = "&File"
-		saved-params = "is-checked"
-	elem
-		name = ""
-		command = ""
-		category = "&File"
-		saved-params = "is-checked"
-	elem "reconnectbutton"
-		name = "&Reconnect"
-		command = ".reconnect"
-		category = "&File"
-		saved-params = "is-checked"
-	elem
-		name = "&Quit\tAlt-F4"
-		command = ".quit"
-		category = "&File"
-		saved-params = "is-checked"
-	elem "help-menu"
-		name = "&Help"
-		command = ""
-		saved-params = "is-checked"
-	elem
-		name = "&Admin Help\tF1"
-		command = "adminhelp"
-		category = "&Help"
-		saved-params = "is-checked"
-	elem
-		name = "&Hotkeys"
-		command = "Hotkeys-Help"
-		category = "&Help"
-		saved-params = "is-checked"
-
-
 window "mainwindow"
 	elem "mainwindow"
 		type = MAIN
@@ -434,32 +387,6 @@ window "popupwindow"
 		saved-params = "pos;size;is-minimized;is-maximized"
 		statusbar = false
 		can-resize = false
-
-window "preferences_window"
-	elem "preferences_window"
-		type = MAIN
-		pos = 281,0
-		size = 1280x1000
-		anchor1 = -1,-1
-		anchor2 = -1,-1
-		is-visible = false
-		saved-params = "pos;size;is-minimized;is-maximized"
-		statusbar = false
-	elem "preferences_browser"
-		type = BROWSER
-		pos = 0,0
-		size = 960x1000
-		anchor1 = 0,0
-		anchor2 = 75,100
-		saved-params = ""
-	elem "character_preview_map"
-		type = MAP
-		pos = 960,0
-		size = 320x1000
-		anchor1 = 75,0
-		anchor2 = 100,100
-		right-click = true
-		saved-params = "zoom;letterbox;zoom-mode"
 
 window "statwindow"
 	elem "statwindow"

--- a/tgui/packages/tgui-panel/Panel.tsx
+++ b/tgui/packages/tgui-panel/Panel.tsx
@@ -12,7 +12,7 @@ import { ChatPanel, ChatTabs } from './chat';
 import { useGame } from './game';
 import { Notifications } from './Notifications';
 import { PingIndicator } from './ping';
-import { ReconnectButton } from './reconnect';
+import { ReconnectButton, ReconnectMenu } from './reconnect';
 import { SettingsPanel, useSettings } from './settings';
 
 export const Panel = (props) => {
@@ -35,6 +35,9 @@ export const Panel = (props) => {
             <Stack mr={1} align="center">
               <Stack.Item grow overflowX="auto">
                 <ChatTabs />
+              </Stack.Item>
+              <Stack.Item>
+                <ReconnectButton />
               </Stack.Item>
               <Stack.Item>
                 <PingIndicator />
@@ -82,7 +85,7 @@ export const Panel = (props) => {
             </Pane.Content>
             <Notifications>
               {game.connectionLostAt && (
-                <Notifications.Item rightSlot={<ReconnectButton />}>
+                <Notifications.Item rightSlot={<ReconnectMenu />}>
                   You are either AFK, experiencing lag or the connection has
                   closed.
                 </Notifications.Item>

--- a/tgui/packages/tgui-panel/reconnect.tsx
+++ b/tgui/packages/tgui-panel/reconnect.tsx
@@ -11,7 +11,7 @@ setInterval(() => {
   });
 }, 5000);
 
-export const ReconnectButton = () => {
+export const ReconnectMenu = () => {
   if (!url) {
     return null;
   }
@@ -36,5 +36,18 @@ export const ReconnectButton = () => {
         }}
       />
     </>
+  );
+};
+
+export const ReconnectButton = () => {
+  return (
+    <Button.Confirm
+      color="red"
+      icon="power-off"
+      tooltip="Reconnects your game"
+      onClick={() => {
+        Byond.command('.reconnect');
+      }}
+    />
   );
 };


### PR DESCRIPTION
## About The Pull Request

Removes the "File" "Help" & "Admin" tabs at the top left of your screen (Also removes dead code for the old html prefs menu).

Looks like this now

https://github.com/user-attachments/assets/394b4d8d-ef57-4645-b248-889513c19870

## Why It's Good For The Game

It's a big white bar for 3 whole buttons where most of the things in it don't need to be there.

Screenshot - Quick Screenshot is already a default BYOND hotkey but it doesn't matter because why would you take a screenshot with buttons at the corner of your screen over just using your OS' screenshot functionality that you use for literally everything else?
Reconnect has been replaced by the TGUI chat's reconnect button, which has become actually functional over the years and I think is able to replace it at this point, however I added another reconnect button (requiring a double click) left of the ping display.
Quit is just Alt+F4.

Adminhelp is already a hotkey and in the Escape menu, and as a new player I never thought of even looking through those dropdowns beacuse despite being on your screen it's something you'd never really look at.
Hotkey help is probably one of the most useless TGUI panels in the game. Some players may like it but it's completely pointless over the hotkeys settings page. It's also technically still accessible through the stat panel (until that gets removed) so it's still around for the time being.

For why we want the bar removed, it's very annoying to have a small beam of white light on the screen until you break it (fullscreening and unfullscreening gets rid of it btw).
With someone using a custom color for my title bars, it goes from a darkmode, to a beam of white light, to the darkmode stat panel & game screen. It's just a big clash that makes the game a little more annoying to look at.
It also being replaced by full screen means we can't have anything players rely on in it as full screened players will not be able to access it, so it's better to have the options with it elsewhere. 

## Changelog

:cl:
del: Removed the sub-title menu.
/:cl: