### PR TITLE
more book items fit on bookshelves

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -323,7 +323,6 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 	/obj/item/infuser_book,
 	/obj/item/codex_cicatrix,
 	/obj/item/toy/eldritch_book,
-	/obj/item/book/codex_gigas,
 	/obj/item/toy/talking/codex_gigas,
 )))
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -321,6 +321,10 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 	/obj/item/book,
 	/obj/item/spellbook,
 	/obj/item/infuser_book,
+	/obj/item/codex_cicatrix,
+	/obj/item/toy/eldritch_book,
+	/obj/item/book/codex_gigas,
+	/obj/item/toy/talking/codex_gigas,
 )))
 
 // Jobs


### PR DESCRIPTION
## About The Pull Request

Codex Cicatrix & toy versions of the Cicatrix and Gigas now fit on bookshelves.

## Why It's Good For The Game

These are books we should let them on the shelf.

## Changelog

:cl:
fix: Toy Cicatrix, Toy Gigas and the Codex Cicatrix itself all now fits on bookshelves.
/:cl: