### PR TITLE
Adding space cleaner or water to a rag will consume as you clean to keep it fresher for longer

### DIFF
--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -162,20 +162,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		to_chat(user, span_notice("You remove the water reclaimer from [src]"))
 		return
 
-	if(istype(O, /obj/item/stack/medical/gauze))
-		var/obj/item/stack/medical/gauze/G = O
-		new /obj/item/rag(src.loc)
-		to_chat(user, span_notice("You tear off a strip of gauze and make a rag."))
-		G.use(1)
-		return
-
-	if(istype(O, /obj/item/stack/sheet/cloth))
-		var/obj/item/stack/sheet/cloth/cloth = O
-		new /obj/item/rag(loc)
-		to_chat(user, span_notice("You tear off a strip of cloth and make a rag."))
-		cloth.use(1)
-		return
-
 	if(istype(O, /obj/item/stack/ore/glass))
 		new /obj/item/stack/sheet/sandblock(loc)
 		to_chat(user, span_notice("You wet the sand in the sink and form it into a block."))

--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -137,6 +137,17 @@
 	AddElement(/datum/element/reagents_exposed_on_fire)
 	AddElement(/datum/element/reagents_item_heatable)
 
+/obj/item/rag/examine(mob/user)
+	. = ..()
+	. += span_notice("Adding [/datum/reagent/water::name] or [/datum/reagent/space_cleaner::name] to it would make it a fair bit better at scrubbing.")
+	switch(blood_level)
+		if(1 to 4)
+			. += span_info("The [name] is a bit dirty, but it should still be good for cleaning.")
+		if(5 to 9)
+			. += span_warning("This [name] is dirty! But it still probably has a few wipes left in it.")
+		if(10 to INFINITY)
+			. += span_warning("This [name] is filthy! I couldn't clean a thing with it!")
+
 /obj/item/rag/pickup(mob/user)
 	. = ..()
 	if(prob(5 * blood_level))


### PR DESCRIPTION
## About The Pull Request

Follow up to #90700 because I had some ideas to expand upon it after the fact

- Removes some now dead code in the sink. It can't reach these anymore AFAIK. 

- Makes use of the new blood helper.

- You can use spray bottles directly on rags and it will transfer reagents from the spray to the rag.

- Rags with space cleaner in them will be more effective at cleaning messes - the cleaner will be consumed to avoid bloodying the rag entirely, allowing you to clean longer without needing to refresh the rag. 
   - This is slightly more effective than just using space cleaner spray alone in some situations (cleaning up footsteps), but slightly less effective in others (full on pools of blood). 
   - Other "cleaning" reagents like Water will also have this effect, but drastically weaker than space cleaner. 

## Why It's Good For The Game

Being able to combine cleaning types is (kind of) the pinnacle of janitor gameplay. I'm sure every janitor has had the epiphany that  a mop bucket full of space cleaner could be awesome, for example.

So thought "how do people ACTUALLY use rags? with a cleaning agent" - I figured people spritzing a rag before wiping stuff down would pretty easily transfer to SS13 

## Changelog

:cl: Melbert
add: Adding Space Cleaner or Water to a rag will consume it as you clean to keep the rag fresher for longer.
add: You can spray a rag with a spray bottle directly to transfer reagents over.
/:cl:
