### PR TITLE
Adds `fluid` to the medical notes `TextArea` so it doesn't take up only half the window for no reason

### DIFF
--- a/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
@@ -49,6 +49,7 @@ export const NoteKeeper = (props) => {
     <Section buttons={<NoteTabs />} fill scrollable title="Notes">
       {writing && (
         <TextArea
+          fluid
           height="100%"
           maxLength={1024}
           onEnter={addNote}


### PR DESCRIPTION

## About The Pull Request

Tin.
## Why It's Good For The Game

Full window instead of being cut off at the red line, is much less awkward.

![image](https://github.com/user-attachments/assets/5c0cab07-43a6-4064-94e2-5d4e010ad81e)
## Changelog
:cl:
fix: The medical notes input box actually takes up the full window, instead of only half of it.
/:cl:
