### PR TITLE
Fix NTNRC chat input not working

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNetChat.jsx
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.jsx
@@ -181,7 +181,7 @@ export const NtosNetChat = (props) => {
                   disabled={this_client && this_client.muted}
                   selfClear
                   mt={1}
-                  onEnter={(e, value) =>
+                  onEnter={(value) =>
                     act('PRG_speak', {
                       message: value,
                     })


### PR DESCRIPTION

## About The Pull Request

So I noticed the NTNRC chat input doesn't actually work. Looking into it, it does send, it just sends an empty message.
I then noticed that a recent inputs rework made changes to most other inputs, which weren't mirrored for this input.
So this does that, and that fixes it.
## Why It's Good For The Game

wooo less jank
## Changelog
:cl:
fix: NTNRC chat input actually works.
/:cl:
