### PR TITLE
[NO GBP] Fixes the MOD Soul Core saying it has no charge in the UI while worn

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -604,7 +604,7 @@
 
 /obj/item/mod/core/soul/get_chargebar_string()
 	var/mob/living/wearer = mod.wearer
-	if(wearer || HAS_TRAIT(wearer, TRAIT_NO_SOUL))
+	if(!wearer || HAS_TRAIT(wearer, TRAIT_NO_SOUL))
 		return "No power source detected."
 	if(CONFIG_GET(flag/disable_human_mood))
 		return "Infinite"


### PR DESCRIPTION
## About The Pull Request

I made an oopsie and forgot a single NOT operation in the line that checks if the suit is being worn.
This also almost certainly fixes a runtime that I assume would happen when looking at the interface of a suit not currently being worn.

## Why It's Good For The Game

The soul core isn't supposed to tell you there's no charge source when it is clearly fully functioning.

## Changelog

:cl:
fix: The MOD soul core no longer tells you there's no charge source while worn.
/:cl:
