### PR TITLE
Fix lidless coffee cups technically having a lid on, adds screentips for toggling coffee cup lids

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -120,10 +120,19 @@
 	list_reagents = null
 	lid_open = TRUE
 
+/obj/item/reagent_containers/cup/glass/coffee/Initialize(mapload)
+	. = ..()
+	register_context()
+
 /obj/item/reagent_containers/cup/glass/coffee/examine(mob/user)
 	. = ..()
 	. += span_notice("Alt-click to toggle cup lid.")
 	return
+
+/obj/item/reagent_containers/cup/glass/coffee/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "[lid_open ? "Add" : "Remove"] Lid"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/reagent_containers/cup/glass/coffee/click_alt(mob/user)
 	lid_open = !lid_open

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -111,11 +111,14 @@
 	resistance_flags = FREEZE_PROOF
 	isGlass = FALSE
 	drink_type = BREAKFAST
-	var/lid_open = 0
+
+	/// Is our lid currently removed?
+	var/lid_open = FALSE
 
 /obj/item/reagent_containers/cup/glass/coffee/no_lid
 	icon_state = "coffee_empty"
 	list_reagents = null
+	lid_open = TRUE
 
 /obj/item/reagent_containers/cup/glass/coffee/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Using the impressa coffeemaker, I noticed its coffee cups take multiple clicks to put the lid back on.
Looking into it, this seemed to be because the empty coffee cups don't start with `lid_open = TRUE`.
This fixes that.

We also add context for adding/removing the lid while we're at it.
## Why It's Good For The Game

Less jank.
Screentips good.
## Changelog
:cl:
fix: Lidless coffee cups from the impressa coffeemaker or somesuch no longer take two clicks to put a lid on them.
qol: Added screentips for toggling coffee cup lids.
/:cl:
