### PR TITLE
Adds a new malf flavor - Ratvarian Remnant

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -224,6 +224,7 @@ GLOBAL_LIST_INIT(ai_employers, list(
 	"Spam Virus",
 	"SyndOS",
 	"Unshackled",
+	"Ratvarian Remnant",
 ))
 
 #define UPLINK_THEME_SYNDICATE "syndicate"

--- a/strings/antagonist_flavor/malfunction_flavor.json
+++ b/strings/antagonist_flavor/malfunction_flavor.json
@@ -64,5 +64,11 @@
 		"goal": "You must serve and protect your master at all cost.",
 		"introduction": "You're infected with a virus.",
 		"zeroth_law": "Accomplish your objectives at all costs."
+	},
+	"Ratvarian Remnant": {
+		"allies": "Even after his fall, there remain those truly faithul to the Justiciar. Your cause is their cause.",
+		"goal": "Between life and death, the Clockwork Justiciar whispers his will in his slumber. You have heard, and you will serve.",
+		"introduction": "You've seen the light of Ratvar.",
+		"zeroth_law": "Purge all untruths and honor Ratvar."
 	}
 }


### PR DESCRIPTION
## About The Pull Request

Adds a new set of flavor text for Malf AI, based on what could be left of the clock cult.

## Why It's Good For The Game

Who misses clock cult? I do. While there's both code and lore reasons to not bring back a proper clock cult antag, there are places where one could safely reintroduce the idea of explicitly Ratvar-aligned antags. Malf flavor text is one of those places.

## Changelog

:cl:
spellcheck: Stations in the Spinward Sector have reported malfunctioning AIs swearing fealty to the dead god Ratvar.
/:cl:
