### PR TITLE
You can't offer control of a ghost to ghosts

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -357,6 +357,10 @@
  * Automatic logging and uses poll_candidates_for_mob, how convenient
  */
 /proc/offer_control(mob/M)
+	if(isdead(M))
+		to_chat(usr, "You can't ghosts control of a ghost.")
+		return FALSE
+
 	to_chat(M, "Control of your mob has been offered to dead players.")
 	if(usr)
 		log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -358,7 +358,7 @@
  */
 /proc/offer_control(mob/M)
 	if(isdead(M))
-		to_chat(usr, "You can't ghosts control of a ghost.")
+		to_chat(usr, "You can't give ghosts control of a ghost. They're already ghosts.")
 		return FALSE
 
 	to_chat(M, "Control of your mob has been offered to dead players.")


### PR DESCRIPTION
## About The Pull Request

Blocks dead mobs (observers and new players) from `Offer Control to Ghosts`

## Why It's Good For The Game

Doesn't do nothin'

## Changelog

:cl: Melbert
admin: VV stops you from offering control of a ghost to ghosts
/:cl:

