### PR TITLE
Refactor folder attackby into item interaction procs, adding screentips and consistency

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -93,6 +93,7 @@
 		return insertables_act(user, tool)
 	if(IS_WRITING_UTENSIL(tool))
 		return writing_utensil_act(user, tool)
+	return NONE
 
 /obj/item/folder/proc/insertables_act(mob/living/user, obj/item/tool)
 	if(!user.transferItemToLoc(tool, src, silent = FALSE))

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -47,7 +47,7 @@
 
 /obj/item/folder/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	if(is_type_in_typecache(target, folder_insertables))
-		// As this is show on the paper, we clarify we are picking it up.
+		// As this is shown on the paper, we clarify we are picking it up.
 		context[SCREENTIP_CONTEXT_LMB] = "Insert Into [folder_type_name]"
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -20,7 +20,7 @@
 	/// icon_state of overlay for papers inside of this folder
 	var/paper_overlay_state = "folder_paper"
 	/// Name to display for use-on-item screentips, to avoid overly long screentips.
-	var/folder_type_name = "Folder"
+	var/folder_type_name = "folder"
 
 /obj/item/folder/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins filing an imaginary death warrant! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -48,7 +48,7 @@
 /obj/item/folder/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	if(is_type_in_typecache(target, folder_insertables))
 		// As this is shown on the paper, we clarify we are picking it up.
-		context[SCREENTIP_CONTEXT_LMB] = "Insert Into [folder_type_name]"
+		context[SCREENTIP_CONTEXT_LMB] = "Insert into [folder_type_name]"
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE
 

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -120,13 +120,13 @@
 		return interact_with_insertables(interacting_with, user)
 
 /obj/item/folder/proc/interact_with_insertables(obj/item/interacting_with, mob/living/user)
-	if(interacting_with.loc == user) // Make sure to update the user's inventory
-		if(!user.dropItemToGround(interacting_with, silent = TRUE))
+	if(interacting_with.loc == user)
+		if(!user.transferItemToLoc(interacting_with, src, silent = TRUE))
 			return ITEM_INTERACT_BLOCKING
 	else
 		interacting_with.do_pickup_animation(src)
+		interacting_with.forceMove(src)
 
-	interacting_with.forceMove(src)
 	playsound(src, interacting_with.pickup_sound, PICKUP_SOUND_VOLUME, interacting_with.sound_vary, ignore_walls = FALSE)
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -19,6 +19,8 @@
 	var/contents_hidden = FALSE
 	/// icon_state of overlay for papers inside of this folder
 	var/paper_overlay_state = "folder_paper"
+	/// Name to display for use-on-item screentips, to avoid overly long screentips.
+	var/folder_type_name = "Folder"
 
 /obj/item/folder/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins filing an imaginary death warrant! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -28,6 +30,8 @@
 	update_icon()
 	. = ..()
 	AddElement(/datum/element/burn_on_item_ignition)
+	register_item_context()
+	register_context()
 
 /obj/item/folder/Destroy()
 	for(var/obj/important_thing in contents)
@@ -41,18 +45,23 @@
 	if(length(contents) && !contents_hidden)
 		. += span_notice("<b>Right-click</b> to remove [contents[1]].")
 
-/obj/item/folder/proc/rename(mob/user, obj/item/writing_instrument)
-	if(!user.can_write(writing_instrument))
-		return
+/obj/item/folder/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
+	if(is_type_in_typecache(target, folder_insertables))
+		// As this is show on the paper, we clarify we are picking it up.
+		context[SCREENTIP_CONTEXT_LMB] = "Insert Into [folder_type_name]"
+		return CONTEXTUAL_SCREENTIP_SET
+	return NONE
 
-	var/inputvalue = tgui_input_text(user, "What would you like to label the folder?", "Folder Labelling", max_length = MAX_NAME_LEN)
-
-	if(!inputvalue)
-		return
-
-	if(user.can_perform_action(src))
-		name = "folder[(inputvalue ? " - '[inputvalue]'" : null)]"
-		playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
+/obj/item/folder/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		return NONE
+	if(is_type_in_typecache(held_item, folder_insertables))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(IS_WRITING_UTENSIL(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Rename"
+		return CONTEXTUAL_SCREENTIP_SET
+	return NONE
 
 /obj/item/folder/proc/remove_item(obj/item/Item, mob/user)
 	if(istype(Item))
@@ -79,15 +88,48 @@
 	paper_overlay = contents[1].color_atom_overlay(paper_overlay)
 	return paper_overlay
 
-/obj/item/folder/attackby(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
-	if(is_type_in_typecache(weapon, folder_insertables))
-		//Add paper, photo or documents into the folder
-		if(!user.transferItemToLoc(weapon, src))
-			return
-		to_chat(user, span_notice("You put [weapon] into [src]."))
-		update_appearance()
-	else if(IS_WRITING_UTENSIL(weapon))
-		rename(user, weapon)
+/obj/item/folder/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(is_type_in_typecache(tool, folder_insertables))
+		return insertables_act(user, tool)
+	if(IS_WRITING_UTENSIL(tool))
+		return writing_utensil_act(user, tool)
+
+/obj/item/folder/proc/insertables_act(mob/living/user, obj/item/tool)
+	if(!user.transferItemToLoc(tool, src, silent = FALSE))
+		return ITEM_INTERACT_BLOCKING
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
+
+/obj/item/folder/proc/writing_utensil_act(mob/user, obj/item/writing_instrument)
+	if(!user.can_write(writing_instrument))
+		return ITEM_INTERACT_BLOCKING
+
+	var/inputvalue = tgui_input_text(user, "What would you like to label the folder?", "Folder Labelling", max_length = MAX_NAME_LEN)
+
+	if(!inputvalue)
+		return ITEM_INTERACT_BLOCKING
+	if(!user.can_perform_action(src))
+		return ITEM_INTERACT_BLOCKING
+
+	name = "folder[(inputvalue ? " - '[inputvalue]'" : null)]"
+	playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/item/folder/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(is_type_in_typecache(interacting_with, folder_insertables))
+		return interact_with_insertables(interacting_with, user)
+
+/obj/item/folder/proc/interact_with_insertables(obj/item/interacting_with, mob/living/user)
+	if(interacting_with.loc == user) // Make sure to update the user's inventory
+		if(!user.dropItemToGround(interacting_with, silent = TRUE))
+			return ITEM_INTERACT_BLOCKING
+	else
+		interacting_with.do_pickup_animation(src)
+
+	interacting_with.forceMove(src)
+	playsound(src, interacting_with.pickup_sound, PICKUP_SOUND_VOLUME, interacting_with.sound_vary, ignore_walls = FALSE)
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/folder/attack_self(mob/user)
 	add_fingerprint(usr)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -415,8 +415,8 @@
 	return new_plane
 
 /obj/item/paper/attackby(obj/item/attacking_item, mob/living/user, list/modifiers, list/attack_modifiers)
-	// Enable picking paper up by clicking on it with the clipboard or folder
-	if(istype(attacking_item, /obj/item/clipboard) || istype(attacking_item, /obj/item/folder) || istype(attacking_item, /obj/item/paper_bin))
+	// Enable picking paper up by clicking on it with the clipboard or paper bin
+	if(istype(attacking_item, /obj/item/clipboard) || istype(attacking_item, /obj/item/paper_bin))
 		attacking_item.attackby(src, user)
 		return
 

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -9,6 +9,7 @@
 	pickup_sound = 'sound/items/handling/disk_pickup.ogg'
 	contents_hidden = TRUE
 	paper_overlay_state = "paperbiscuit_paper"
+	folder_type_name = "Biscuit"
 	/// Is biscuit cracked open or not?
 	var/cracked = FALSE
 	/// The paper slip inside, if there is one
@@ -48,7 +49,7 @@
 /obj/item/folder/biscuit/proc/crack_check(mob/user)
 	if (cracked)
 		return TRUE
-	balloon_alert(user, "unopened!")
+	balloon_alert(user, "open first!")
 	return FALSE
 
 /obj/item/folder/biscuit/examine()
@@ -59,6 +60,12 @@
 		. += span_notice("You'll need to crack it open to access its contents.")
 		if(contained_slip)
 			. += "This one contains [contained_slip.name]."
+
+/obj/item/folder/biscuit/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+	if((held_item == src) && !cracked)
+		context[SCREENTIP_CONTEXT_LMB] = "Crack Open"
+		return CONTEXTUAL_SCREENTIP_SET
 
 //The next few checks are done to prevent you from reaching the contents or putting anything inside when it's not cracked open
 /obj/item/folder/biscuit/remove_item(obj/item/item, mob/user)
@@ -73,10 +80,14 @@
 
 	return ..()
 
-/obj/item/folder/biscuit/attackby(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
-	if (is_type_in_typecache(weapon, folder_insertables) && !crack_check(user))
-		return
+/obj/item/folder/biscuit/insertables_act(mob/living/user, obj/item/tool)
+	if(!crack_check(user))
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
+/obj/item/folder/biscuit/interact_with_insertables(atom/interacting_with, mob/living/user)
+	if(!crack_check(user))
+		return ITEM_INTERACT_BLOCKING
 	return ..()
 
 /obj/item/folder/biscuit/attack_self(mob/user)
@@ -124,6 +135,12 @@
 	. = ..()
 	if(!has_been_sealed)
 		. += span_notice("This one could be sealed <b>in hand</b>. Once sealed, the contents are inaccessible until cracked open again - but once opened this is irreversible.")
+
+/obj/item/folder/biscuit/unsealed/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+	if((held_item == src) && !has_been_sealed)
+		context[SCREENTIP_CONTEXT_LMB] = "Seal"
+		return CONTEXTUAL_SCREENTIP_SET
 
 //Asks if you want to seal the biscuit, after you do that it behaves like a normal paper biscuit.
 /obj/item/folder/biscuit/unsealed/attack_self(mob/user)

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -9,7 +9,7 @@
 	pickup_sound = 'sound/items/handling/disk_pickup.ogg'
 	contents_hidden = TRUE
 	paper_overlay_state = "paperbiscuit_paper"
-	folder_type_name = "Biscuit"
+	folder_type_name = "biscuit"
 	/// Is biscuit cracked open or not?
 	var/cracked = FALSE
 	/// The paper slip inside, if there is one
@@ -64,7 +64,7 @@
 /obj/item/folder/biscuit/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()
 	if((held_item == src) && !cracked)
-		context[SCREENTIP_CONTEXT_LMB] = "Crack Open"
+		context[SCREENTIP_CONTEXT_LMB] = "Crack open"
 		return CONTEXTUAL_SCREENTIP_SET
 
 //The next few checks are done to prevent you from reaching the contents or putting anything inside when it's not cracked open


### PR DESCRIPTION

## About The Pull Request

Folders still used `attackby(...)` where they should be using `item_interaction(...)`, and this aims to resolve that.
Or, well, the primary thing that started this was the following code:
https://github.com/tgstation/tgstation/blob/a165e9e1ef8157c5a696512f965adfc36ee05cbf/code/modules/paperwork/paper.dm#L417-L421
Evil.

So this aims to rectify one of those issues, by refactoring folders' interactions into the modern systems.
In the process we add screentips, and play some animations/sounds where we didn't for consistency.

...Also adjusts the balloon alert played when trying to insert paper into a closed biscuit card from `"unopened!"` to `"open first!"`, because that feels clearer to the player as to what the issue is.
## Why It's Good For The Game

Less weird inventory jank.
Screentips good.
Having sounds and animations for interactions is good, having _consistent_ sounds and animations is better.
## Changelog
:cl:
refactor: Refactored the folder/biscuit interaction chain. Please report any issues.
fix: Picking up paper into a folder/biscuit by clicking on the paper with it is now less prone to inventory jank.
qol: Picking up paper into a folder/biscuit now plays the pickup animation, consistent with inserting it otherwise.
qol: Folders and biscuit cards now have screentips.
sound: Inserting paper into a folder now plays the pickup/drop sounds, consistent with taking it out.
/:cl:
