### PR TITLE
`TRAIT_UNKNOWN` now properly blocks `get_id_name`

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -90,9 +90,6 @@
 	return
 
 /mob/living/carbon/human/get_id_name(if_no_id = "Unknown")
-	var/obj/item/storage/wallet/wallet = wear_id
-	var/obj/item/modular_computer/pda = wear_id
-	var/obj/item/card/id/id = wear_id
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN))
 		. = if_no_id //You get NOTHING, no id name, good day sir
 		var/list/identity = list(null, null, null)
@@ -100,12 +97,10 @@
 		if(identity[VISIBLE_NAME_FORCED])
 			. = identity[VISIBLE_NAME_FACE] // to return forced names when unknown, instead of ID
 			return
-	if(istype(wallet))
-		id = wallet.front_id
-	if(istype(id))
-		. = id.registered_name
-	else if(istype(pda) && pda.computer_id_slot)
-		. = pda.computer_id_slot.registered_name
+	else
+		. = astype(wear_id, /obj/item/card/id) \
+			|| astype(wear_id, /obj/item/storage/wallet)?.front_id \
+			|| astype(wear_id, /obj/item/modular_computer)?.computer_id_slot?.registered_name
 	if(!.)
 		. = if_no_id //to prevent null-names making the mob unclickable
 	return

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -97,9 +97,10 @@
 		if(identity[VISIBLE_NAME_FORCED])
 			return identity[VISIBLE_NAME_FACE] // to return forced names when unknown, instead of ID
 	else
-		. = astype(wear_id, /obj/item/card/id) \
+		var/obj/item/card/id/id = astype(wear_id, /obj/item/card/id) \
 			|| astype(wear_id, /obj/item/storage/wallet)?.front_id \
-			|| astype(wear_id, /obj/item/modular_computer)?.computer_id_slot?.registered_name
+			|| astype(wear_id, /obj/item/modular_computer)?.computer_id_slot
+		. = id?.registered_name
 	if(!.)
 		. = if_no_id //to prevent null-names making the mob unclickable
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -95,15 +95,13 @@
 		var/list/identity = list(null, null, null)
 		SEND_SIGNAL(src, COMSIG_HUMAN_GET_FORCED_NAME, identity)
 		if(identity[VISIBLE_NAME_FORCED])
-			. = identity[VISIBLE_NAME_FACE] // to return forced names when unknown, instead of ID
-			return
+			return identity[VISIBLE_NAME_FACE] // to return forced names when unknown, instead of ID
 	else
 		. = astype(wear_id, /obj/item/card/id) \
 			|| astype(wear_id, /obj/item/storage/wallet)?.front_id \
 			|| astype(wear_id, /obj/item/modular_computer)?.computer_id_slot?.registered_name
 	if(!.)
 		. = if_no_id //to prevent null-names making the mob unclickable
-	return
 
 /mob/living/carbon/human/get_idcard(hand_first = TRUE)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

`/mob/living/carbon/human/get_id_name` would still check ID and such if the target has `TRAIT_UNKNOWN`, which I'm pretty sure is unintended, so this fixes that.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Prosopagnosia no longer allows you to somehow recognize people in infiltrator modsuits.
/:cl:
