### PR TITLE
SSid_access now has a proc for getting information about an ID holder from their ID, there is also a define to invoke this proc in a less verbose way

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -591,3 +591,8 @@
 #define FORCE_ADD_ALL 2
 /// Used in ID card access adding procs. Will stack trace on fail.
 #define ERROR_ON_FAIL 3
+
+#define ID_DATA(T) SSid_access.__in_character_record_id_information(T)
+#define SILICON_OVERRIDE "silicon_override"
+#define CHAMELEON_OVERRIDE "chameleon_override"
+#define ID_READ_FAILURE "id_read_failure"

--- a/code/controllers/subsystem/networks/id_access.dm
+++ b/code/controllers/subsystem/networks/id_access.dm
@@ -518,3 +518,75 @@ SUBSYSTEM_DEF(id_access)
 			tally++
 
 	return tally
+
+/**
+ * Helper proc for creating a copy of the in-character information you could render from scanning for an ID card.
+ * Accounts for chameleon cards, silicons, and ID read failures.
+ * Pertinently, it also returns relevant information for their bank account (if they have one).
+ * To return bank account info for a chameleon card, bypass_chameleon must be set to TRUE. Otherwise it returns
+ * a bogey record.
+ * datum/source -
+ */
+/datum/controller/subsystem/id_access/proc/__in_character_record_id_information(
+	atom/movable/target_of_record,
+	bypass_chameleon = FALSE
+	) as /alist
+
+	var/alist/returned_record = alist(
+		"Name" = null,
+		"Age" = null,
+		"Assignment" = null,
+		"Account ID" = null,
+		"Account Holder" = null,
+		"Account Assignment" = null,
+		"Accesses" = null,
+	)
+	. = returned_record
+	if(isnull(target_of_record))
+		.["Name"] = ID_READ_FAILURE
+		.["Age"] = ID_READ_FAILURE
+		.["Assignment"] = ID_READ_FAILURE
+		.["Account ID"] = ID_READ_FAILURE
+		.["Account Holder"] = ID_READ_FAILURE
+		.["Account Assignment"] = ID_READ_FAILURE
+		.[ID_READ_FAILURE] = ID_READ_FAILURE
+		return .
+	var/mob/living/target = astype(target_of_record, /mob/living)
+	if(target)
+		if(!issilicon(target))
+			. = __in_character_record_id_information(astype(target.get_idcard(), /obj/item/card/id/advanced))
+			return .
+		.["Name"] = target.name
+		.["Age"] = "INSPECT MANUFACTURER MANIFEST"
+		.["Account ID"] = 0
+		.["Account Holder"] = "NO ACCOUNT."
+		.["Account Assignment"] = "NO ACCOUNT."
+		.["Bank Account"] = "N/A"
+		.["Assignment"] = target.mind?.assigned_role?.title
+		.[SILICON_OVERRIDE] = SILICON_OVERRIDE
+		return .
+	var/obj/item/card/id/advanced/id_card = astype(target_of_record, /obj/item/card/id/advanced)
+	if(id_card)
+		.["Name"] = id_card.registered_name || "Unknown"
+		.["Age"] = id_card.registered_age || "Unknown"
+		.["Assignment"] = id_card.assignment || "Unassigned"
+		.["Accesses"] = id_card.access
+		var/datum/bank_account/id_account = id_card.registered_account
+		if(istype(id_card, /obj/item/card/id/advanced/chameleon) && !bypass_chameleon)
+			// Generate a bogey record based only on the ID card
+			// Generates a random bank account number every time as a 'spot the thread' for anyone who
+			// went through records for this entry for whatever reason.
+			.["Account ID"] = rand(111111, 999999)
+			.["Account Holder"] = .["Name"]
+			.["Account Assignment"] = .["Assignment"]
+			.[CHAMELEON_OVERRIDE] = CHAMELEON_OVERRIDE
+			return .
+		if(!id_account)
+			.["Account ID"] = 0
+			.["Account Holder"] = "NO ACCOUNT."
+			.["Account Assignment"] = "NO ACCOUNT."
+			return .
+		.["Account ID"] = id_account.account_id
+		.["Account Holder"] = id_account.account_holder
+		.["Account Assignment"] = id_account.account_job?.title || "Unassigned"
+		return .

--- a/code/controllers/subsystem/networks/id_access.dm
+++ b/code/controllers/subsystem/networks/id_access.dm
@@ -590,3 +590,5 @@ SUBSYSTEM_DEF(id_access)
 		.["Account Holder"] = id_account.account_holder
 		.["Account Assignment"] = id_account.account_job?.title || "Unassigned"
 		return .
+	else
+		. = ID_DATA(null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As part of the ore silo logging PR I'm working on I needed a way to get the information on someone's ID in a robust and consistent way. I decided on adding this proc to SSID_access and also adding a define to invoke it since it's otherwise quite verbose.

```
/datum/controller/subsystem/id_access/proc/__in_character_record_id_information(
	atom/movable/target_of_record,
	bypass_chameleon = FALSE
	) as /alist
#define ID_DATA(subject) SSid_access.__in_character_record_id_information(subject)
```

This proc expects either a living mob or an ID. It returns an alist of:

"Name" Current ID name
"Age" Current ID age
"Assignment" Current ID job
"Account ID" ID# of the attached bank account if a standard ID, random number if chameleon ID
"Account Holder" Name of attached bank account holder if one is attached, current ID name if chameleon
"Account Assignment" 'title' of the job datum of the attached bank account if normal ID, current ID name if chameleon
"Accesses" a list of the accesses on the ID, in the style of our other access lists

Additionally, if it fails to read an ID, it also adds

		[ID_READ_FAILURE] = ID_READ_FAILURE

Finally, there are overrides for if 

The card is a chameleon card.
The being scanned is a silicon.

Which appends, respectively,

		.[SILICON_OVERRIDE] = SILICON_OVERRIDE
		.[CHAMELEON_OVERRIDE] = CHAMELEON_OVERRIDE

And does special handling.

This collects a significant quantity of relevant information into a single convenient proc call, which is also named to reflect that the information returned is meant to serve as an in character record of what is being read (if it is used anywhere).


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Offers standardized information returned from an ID for scenarios where the information of an ID is especially relevant, rather than writing boilerplate ID reading code for varying situations. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Bisar
code: A proc has been added to the subsystem for ID access to serve to standardize the way information is read and returned from a given ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
