### PR TITLE
Immobile shuttles will not appear launchable on flight control consoles.

### DIFF
--- a/code/modules/shuttle/mobile_port/mobile_port.dm
+++ b/code/modules/shuttle/mobile_port/mobile_port.dm
@@ -295,6 +295,9 @@
 	if(mode == SHUTTLE_IGNITING && destination == destination_port)
 		return
 
+	if(!canMove())
+		return
+
 	switch(mode)
 		if(SHUTTLE_CALL)
 			if(destination_port == destination)

--- a/code/modules/shuttle/shuttle_consoles/shuttle_console.dm
+++ b/code/modules/shuttle/shuttle_consoles/shuttle_console.dm
@@ -99,6 +99,9 @@
 	if(!length(data["locations"]))
 		data["locked"] = TRUE
 		data["status"] = "Locked"
+	if(!mobile_docking_port.canMove())
+		data["locked"] = TRUE
+		data["status"] = "Immobile"
 	return data
 
 /**


### PR DESCRIPTION
## About The Pull Request

Custom shuttles introduced a weird edge case in shuttle code where the flight control console shows the shuttle as able to be launched, despite a lack of engines making it unable to move. This fixes that edge case by specifically showing the shuttle as immobile in the console.

## Why It's Good For The Game

I tried to launch a custom shuttle but I couldn't figure out why it wasn't moving. This fix at least lets players know that it won't launch when it can't.

## Changelog

:cl:
fix: Shuttle flight control computers will show you when the linked shuttle cannot move.
/:cl:
