### PR TITLE
Fixes random input popups when using tgui

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -305,6 +305,8 @@ Turf and target are separate in case you want to teleport some distance from a t
  *   but using ratios (as implemented in the proc) is the recommended approach
  */
 /proc/get_loc_from_mousepos(mousepos_x, mousepos_y, sizex, sizey, client/viewing_client)
+	if(sizex == 0 || sizey == 0) //contexts where this information is not availible should return 0 in size, aka tgui passthrough
+		return list(null, 0, 0)
 	var/turf/baseloc = get_turf(viewing_client.eye)
 	var/list/actual_view = getviewsize(viewing_client ? viewing_client.view : world.view)
 

--- a/tgui/packages/tgui/index.tsx
+++ b/tgui/packages/tgui/index.tsx
@@ -52,7 +52,12 @@ function setupApp() {
   setGlobalStore(store);
 
   setupGlobalEvents();
-  setupHotKeys();
+  setupHotKeys({
+    keyUpVerb: 'KeyUp',
+    keyDownVerb: 'KeyDown',
+    // In the future you could send a winget here to get mousepos/size from the map here if it's necessary
+    verbParamsFn: (verb, key) => `${verb} "${key}" 0 0 0 0`,
+  });
   captureExternalLinks();
 
   store.subscribe(() => render(<App />));


### PR DESCRIPTION
## About The Pull Request
Fixes #91198 
Fixes random inputs popping up when pressing/releasing keys with tgui open.

KeyUp/Down verbs were updated to provide mouse position but not the tgui passthrough.
At the momenti that information is skipped because unfortunately the automatic `[[control.mouse_pos]]` format only works for skin commands. If this information is necessary in the future tgui can invoke manual winget.


