### PR TITLE
Adding a few checks for machines that use disks

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -193,7 +193,10 @@
 					if(!inserted_disk)
 						return
 
-					user.put_in_hands(inserted_disk)
+					if(!user || !Adjacent(user))
+						inserted_disk.forceMove(drop_location())
+					else
+						user.put_in_hands(inserted_disk)
 					inserted_disk = null
 					playsound(src, 'sound/machines/card_slide.ogg', 50)
 					return TRUE

--- a/code/modules/research/ordnance/doppler_array.dm
+++ b/code/modules/research/ordnance/doppler_array.dm
@@ -207,10 +207,10 @@
 /obj/machinery/doppler_array/proc/eject_disk(mob/user)
 	if(!inserted_disk)
 		return FALSE
-	if(user)
-		user.put_in_hands(inserted_disk)
-	else
+	if(!user || !Adjacent(user))
 		inserted_disk.forceMove(drop_location())
+	else
+		user.put_in_hands(inserted_disk)
 	playsound(src, 'sound/machines/card_slide.ogg', 50)
 	return TRUE
 

--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -220,10 +220,10 @@
 /obj/machinery/atmospherics/components/binary/tank_compressor/proc/eject_disk(mob/user)
 	if(!inserted_disk)
 		return FALSE
-	if(user)
-		user.put_in_hands(inserted_disk)
-	else
+	if(!user || !Adjacent(user))
 		inserted_disk.forceMove(drop_location())
+	else
+		user.put_in_hands(inserted_disk)
 	playsound(src, 'sound/machines/card_slide.ogg', 50)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Fixes a bug(?) where you, being non-carbon, could teleport disks from various machines to your location (for example, playing as an AI or cyborg, carbons with telekinesis too)

## Why It's Good For The Game

teleporting disks is bad...

## Changelog

:cl:
fix: Now if you are not near the console the disk will drop in its place instead of your location
/:cl: