### PR TITLE
You can now read what cards are in a hand of cards + a related bugfix

### DIFF
--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -19,14 +19,19 @@
 
 /obj/item/toy/cards/cardhand/examine(mob/user)
 	. = ..()
+	var/broadcast_check = FALSE
 	for(var/obj/item/toy/singlecard/card in fetch_card_atoms())
 		if(user.is_holding(src) || card.flipped)
 			. += span_notice("The hand contains a: [card.cardname]")
+			if(!card.flipped)
+				broadcast_check = TRUE
 		else if(HAS_TRAIT(user, TRAIT_XRAY_VISION))
 			. += span_notice("You scan the cardhand with your x-ray vision and there is a: [card.cardname]")
 		var/marked_color = card.getMarkedColor(user)
 		if(marked_color)
 			. += span_notice("There is a [marked_color] mark on the corner of a card in the cardhand!")
+	if(broadcast_check)
+		user.visible_message(span_notice("[user] checks [user.p_their()] cards."))
 
 
 /obj/item/toy/cards/cardhand/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -69,7 +69,7 @@
 /obj/item/toy/cards/cardhand/proc/check_menu(mob/living/user)
 	return isliving(user) && !user.incapacitated
 
-/obj/item/toy/cards/cardhand/attackby(obj/item/weapon, mob/living/user, params, flip_card = FALSE)
+/obj/item/toy/cards/cardhand/attackby(obj/item/weapon, mob/living/user, list/params, list/attack_modifier, flip_card = FALSE)
 	var/obj/item/toy/singlecard/card
 
 	if(istype(weapon, /obj/item/toy/singlecard))

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -19,6 +19,7 @@
 
 /obj/item/toy/cards/cardhand/examine(mob/user)
 	. = ..()
+	. += span_notice("There are [count_cards()] cards.")
 	var/broadcast_check = FALSE
 	for(var/obj/item/toy/singlecard/card in fetch_card_atoms())
 		if(user.is_holding(src) || card.flipped)

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -20,11 +20,14 @@
 /obj/item/toy/cards/cardhand/examine(mob/user)
 	. = ..()
 	for(var/obj/item/toy/singlecard/card in fetch_card_atoms())
-		if(HAS_TRAIT(user, TRAIT_XRAY_VISION))
+		if(user.is_holding(src) || card.flipped)
+			. += span_notice("The hand contains a: [card.cardname]")
+		else if(HAS_TRAIT(user, TRAIT_XRAY_VISION))
 			. += span_notice("You scan the cardhand with your x-ray vision and there is a: [card.cardname]")
 		var/marked_color = card.getMarkedColor(user)
 		if(marked_color)
 			. += span_notice("There is a [marked_color] mark on the corner of a card in the cardhand!")
+
 
 /obj/item/toy/cards/cardhand/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(istype(held_item, /obj/item/toy/cards/deck))

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -147,7 +147,7 @@
 	name = flipped ? cardname : "card"
 	return ..()
 
-/obj/item/toy/singlecard/attackby(obj/item/item, mob/living/user, params, flip_card=FALSE)
+/obj/item/toy/singlecard/attackby(obj/item/item, mob/living/user, list/params, list/attack_modifier, flip_card=FALSE)
 	var/obj/item/toy/singlecard/card
 
 	if(istype(item, /obj/item/toy/cards/deck))


### PR DESCRIPTION

## About The Pull Request

When you inspect a hand of cards in your hand you will see all the cards in it. When anyone inspects a hand of cards outside of your hand they will see all face up cards.

Also fixes a bug that caused cards to improperly flip when added to a hand.
## Why It's Good For The Game

When playing games that involve larger hand sizes (see: everything besides texas hold'em), hands can become unreadable from sprites alone. This adds a way to actually see whats in your hand and other people's hands if they're placed face up on the table.
## Changelog
:cl:
qol: Inspecting a hand of cards now tells you what cards you can see in it.
fix: Adding cards to a hand no longer automatically flips them.
/:cl:
