### PR TITLE
Adds missing auth device and dragnet beacon to catwalk

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -18395,6 +18395,10 @@
 /area/station/medical/virology)
 "fAH" = (
 /obj/structure/table,
+/obj/item/dragnet_beacon{
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /obj/item/gun/energy/e_gun/dragnet{
 	pixel_x = -4;
 	pixel_y = 8
@@ -76090,10 +76094,13 @@
 /obj/machinery/button/door/directional/west{
 	id = "hosprivacy";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
-	pixel_y = 24
+	pixel_x = 8;
+	pixel_y = 25
 	},
 /obj/machinery/holopad/secure,
+/obj/machinery/keycard_auth/wall_mounted/directional/north{
+	pixel_x = -6
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "wMc" = (


### PR DESCRIPTION
## About The Pull Request

Adds a missing auth device to the HoS office
And adds a missing dragnet beacon to armoury 

## Why It's Good For The Game

So yknow they auctally can use the stuff

## Changelog

:cl: Ezel
fix: Adds missing dragnet beacon to catwalk
fix: Adds missing HoS office authenication device.
/:cl:

