### PR TITLE
A cell getting deleted from an energy gun that needs the cell to function instead has a new cell reinserted and a stack trace called

### DIFF
--- a/code/game/objects/items/gun_maintenance.dm
+++ b/code/game/objects/items/gun_maintenance.dm
@@ -61,6 +61,7 @@
 
 		if(energy_gun_to_fix.debrick_this_bitch()) //Granted, this is NOT meant to be possible, but it could come up while an admin isn't around, and this is the most straightforward way for a player to get this resolved IC.
 			use_charge = TRUE
+			to_chat(user, span_alert("You should probably tel an admin you had to replace the cell in [energy_gun_to_fix]. This is not an intended feature of [energy_gun_to_fix].")) // This is maybe laying it on thick, but...
 
 	if(!use_charge)
 		balloon_alert(user, "no need for repair!")

--- a/code/game/objects/items/gun_maintenance.dm
+++ b/code/game/objects/items/gun_maintenance.dm
@@ -46,6 +46,7 @@
 
 		if(ballistic_gun_to_fix.misfire_probability > initial(ballistic_gun_to_fix.misfire_probability))
 			ballistic_gun_to_fix.misfire_probability = initial(ballistic_gun_to_fix.misfire_probability)
+			use_charge = TRUE
 
 		if(istype(ballistic_gun_to_fix, /obj/item/gun/ballistic/rifle/boltaction))
 			var/obj/item/gun/ballistic/rifle/boltaction/rifle_to_fix = ballistic_gun_to_fix
@@ -53,7 +54,13 @@
 				rifle_to_fix.jammed = FALSE
 				rifle_to_fix.unjam_chance = initial(rifle_to_fix.unjam_chance)
 				rifle_to_fix.jamming_chance = initial(rifle_to_fix.jamming_chance)
-		use_charge = TRUE
+				use_charge = TRUE
+
+	if(istype(gun_to_fix, /obj/item/gun/energy)) //Granted, this is NOT meant to be possible, but it will come up while an admin isn't around, and this is the most straightforward way for a player to get this resolved IC.
+		var/obj/item/gun/energy/energy_gun_to_fix = gun_to_fix
+
+		if(energy_gun_to_fix.debrick_this_bitch()) //Granted, this is NOT meant to be possible, but it could come up while an admin isn't around, and this is the most straightforward way for a player to get this resolved IC.
+			use_charge = TRUE
 
 	if(!use_charge)
 		balloon_alert(user, "no need for repair!")

--- a/code/game/objects/items/gun_maintenance.dm
+++ b/code/game/objects/items/gun_maintenance.dm
@@ -56,13 +56,6 @@
 				rifle_to_fix.jamming_chance = initial(rifle_to_fix.jamming_chance)
 				use_charge = TRUE
 
-	if(istype(gun_to_fix, /obj/item/gun/energy)) //Granted, this is NOT meant to be possible, but it will come up while an admin isn't around, and this is the most straightforward way for a player to get this resolved IC.
-		var/obj/item/gun/energy/energy_gun_to_fix = gun_to_fix
-
-		if(energy_gun_to_fix.debrick_this_bitch()) //Granted, this is NOT meant to be possible, but it could come up while an admin isn't around, and this is the most straightforward way for a player to get this resolved IC.
-			use_charge = TRUE
-			to_chat(user, span_alert("You should probably tel an admin you had to replace the cell in [energy_gun_to_fix]. This is not an intended feature of [energy_gun_to_fix].")) // This is maybe laying it on thick, but...
-
 	if(!use_charge)
 		balloon_alert(user, "no need for repair!")
 		return ITEM_INTERACT_BLOCKING

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -307,6 +307,18 @@
 		playsound(src, dry_fire_sound, 30, TRUE)
 		return OXYLOSS
 
+///Used to restore an energy gun's cell if it, for whatever reason, no longer exists. This is mostly only useful for admins fixing energy weapons.
+/obj/item/gun/energy/proc/debrick_this_bitch()
+	if(cell) //We have a cell? Don't run.
+		return
+
+	if(cell_type)
+		cell = new cell_type(src)
+	else
+		cell = new(src)
+	cell.use(cell.maxcharge)
+	update_appearance()
+
 /obj/item/gun/energy/vv_edit_var(var_name, var_value)
 	switch(var_name)
 		if(NAMEOF(src, selfcharge))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -166,7 +166,7 @@
 		cell = null
 		update_appearance()
 
-	if(!QDELING(src) && cell_madnatory)
+	if(!QDELING(src) && cell_madnatory && !cell)
 		if(cell_type)
 			cell = new cell_type(src)
 		else

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -310,7 +310,7 @@
 ///Used to restore an energy gun's cell if it, for whatever reason, no longer exists. This is mostly only useful for admins fixing energy weapons.
 /obj/item/gun/energy/proc/debrick_this_bitch()
 	if(cell) //We have a cell? Don't run.
-		return
+		return FALSE
 
 	if(cell_type)
 		cell = new cell_type(src)
@@ -318,6 +318,7 @@
 		cell = new(src)
 	cell.use(cell.maxcharge)
 	update_appearance()
+	return TRUE
 
 /obj/item/gun/energy/vv_edit_var(var_name, var_value)
 	switch(var_name)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -10,6 +10,8 @@
 	/// What type of power cell this uses
 	var/obj/item/stock_parts/power_store/cell
 	var/cell_type = /obj/item/stock_parts/power_store/cell
+	/// If we need a cell to function. If TRUE, should it get deleted somehow, we resinsert a new cell.
+	var/cell_madnatory = TRUE
 	///if the weapon has custom icons for individual ammo types it can switch between. ie disabler beams, taser, laser/lethals, ect.
 	var/modifystate = FALSE
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
@@ -164,6 +166,15 @@
 		cell = null
 		update_appearance()
 
+	if(!QDELING(src) && cell_madnatory)
+		if(cell_type)
+			cell = new cell_type(src)
+		else
+			cell = new(src)
+		cell.use(cell.maxcharge)
+		update_appearance()
+		stack_trace("Cell deleted somehow???")
+
 /obj/item/gun/energy/process(seconds_per_tick)
 	if(selfcharge && cell && cell.percent() < 100)
 		charge_timer += seconds_per_tick
@@ -306,19 +317,6 @@
 		user.visible_message(span_suicide("[user] is pretending to melt [user.p_their()] face off with [src]! It looks like [user.p_theyre()] trying to commit suicide!</b>"))
 		playsound(src, dry_fire_sound, 30, TRUE)
 		return OXYLOSS
-
-///Used to restore an energy gun's cell if it, for whatever reason, no longer exists. This is mostly only useful for admins fixing energy weapons.
-/obj/item/gun/energy/proc/debrick_this_bitch()
-	if(cell) //We have a cell? Don't run.
-		return FALSE
-
-	if(cell_type)
-		cell = new cell_type(src)
-	else
-		cell = new(src)
-	cell.use(cell.maxcharge)
-	update_appearance()
-	return TRUE
 
 /obj/item/gun/energy/vv_edit_var(var_name, var_value)
 	switch(var_name)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -149,7 +149,6 @@
 
 /obj/item/gun/energy/Destroy()
 	if (cell)
-		cell_mandatory = FALSE
 		QDEL_NULL(cell)
 	STOP_PROCESSING(SSobj, src)
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -149,6 +149,7 @@
 
 /obj/item/gun/energy/Destroy()
 	if (cell)
+		cell_mandatory = FALSE
 		QDEL_NULL(cell)
 	STOP_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

Also some minor gun maintenance kit fixes while I'm here.

## Why It's Good For The Game

This is a continuous issue as long as energy weapon cells are not abstracted, but physical objects. 

## Changelog
:cl:
fix: A cell being deleted from an energy gun that needs it will instead just have a new cell inserted into the gun and a stack trace called.
fix: The gun maintenance kit only uses charges if it actually manages to fix parts of the gun.
/:cl:
