### PR TITLE
Fix hard delete related to projectile-caused wounds

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -193,8 +193,10 @@
 	if(isatom(wound_source))
 		var/atom/wound_atom = wound_source
 		src.wound_source = wound_atom.name
-	else
+	else if(istext(wound_source))
 		src.wound_source = wound_source
+	else
+		src.wound_source = "Unknown"
 
 	set_victim(L.owner)
 	set_limb(L, replacing)

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -190,9 +190,9 @@
 		qdel(src)
 		return FALSE
 
-	if(isitem(wound_source))
-		var/obj/item/wound_item = wound_source
-		src.wound_source = wound_item.name
+	if(isatom(wound_source))
+		var/atom/wound_atom = wound_source
+		src.wound_source = wound_atom.name
 	else
 		src.wound_source = wound_source
 


### PR DESCRIPTION

## About The Pull Request

`apply_wound` passes a ref to the thing that caused the wound, so that the name can be stored and visible when an autopsy is conducted on the wounded. The problem is projectiles are `/obj/projectile`, not `/obj/item/projectile`, so the else condition (which is there so if it's already being passed a string `wound_source` it will just use that) happens and a ref to the projectile itself is stored in the `wound_source` var, there's no handling for cleaning this up because it's an unintended behavior.  

## Why It's Good For The Game

Hard del fix

## Changelog

No player facing changes
