### PR TITLE
Fixes some tgui bluescreen issues

### DIFF
--- a/tgui/packages/tgui/stories/Storage.stories.tsx
+++ b/tgui/packages/tgui/stories/Storage.stories.tsx
@@ -6,7 +6,6 @@
 
 import { storage } from 'common/storage';
 import { Button, LabeledList, NoticeBox, Section } from 'tgui-core/components';
-import { formatSiUnit } from 'tgui-core/format';
 
 export const meta = {
   title: 'Storage',
@@ -36,9 +35,6 @@ const Story = (props) => {
       <LabeledList>
         <LabeledList.Item label="Keys in use">
           {localStorage.length}
-        </LabeledList.Item>
-        <LabeledList.Item label="Remaining space">
-          {formatSiUnit(localStorage.remainingSpace, 0, 'B')}
         </LabeledList.Item>
       </LabeledList>
     </Section>

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html>
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8" />
 
     <!-- Inlined metadata -->

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -35,12 +35,12 @@ ooooo      ooo     .     .oooooo.    .oooooo..o
  8       `888    888 . `88b    d88' oo     .d8P
 o8o        `8    "888"  `Y8bood8P'  8""88888P'
 </div>
-      <marquee class="FatalError__header">
+      <p class="FatalError__header">
         A fatal exception has occurred at 002B:C562F1B7 in TGUI. The current
         application will be terminated. Send the copy of the following stack
         trace to an authorized Nanotrasen incident handler at
         https://github.com/tgstation/tgstation. Thank you for your cooperation.
-      </marquee>
+      </p>
       <div id="FatalError__stack" class="FatalError__stack"></div>
       <div class="FatalError__footer">
         <!-- tgui:nt-copyright -->


### PR DESCRIPTION

## About The Pull Request
Fixes #90730

both `localstorage.remainingStorage` and `marquee` are invalid this century

![image](https://github.com/user-attachments/assets/b9fda011-1bb9-460e-8a2d-e418bfa70021)
## Why It's Good For The Game
Bug fix
## Changelog
:cl:
fix: Fixed unwrapped tgui bluescreen text
/:cl:
