### PR TITLE
heretic sacrifices no longer spawn and then delete a human just to spawn gib effects

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -426,7 +426,7 @@
 		var/obj/item/organ/to_give = new organ_path
 		to_give.Insert(sac_target)
 
-	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target))
+	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target), sac_target)
 	sac_target.visible_message(span_boldwarning("Several organs force themselves out of [sac_target]!"))
 
 /**
@@ -632,7 +632,7 @@
 		span_userdanger("Your organs are violently pulled out of your chest by shadowy hands!")
 	)
 
-	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target))
+	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target), sac_target)
 
 #undef SACRIFICE_SLEEP_DURATION
 #undef SACRIFICE_REALM_DURATION


### PR DESCRIPTION
## About The Pull Request

this makes it so heretic sacrificing actually uses the sac target as the reference for the `/obj/effect/gibspawner/human/bodypartless`, instead of spawning a human, calling `get_blood_dna_list()` on it, then immediately deleting said human.

## Why It's Good For The Game

this was a waste of performance without a shadow of a doubt.

## Changelog

no player-facing changes.