### PR TITLE
Fixes recycler spitting indestructible items indirectly stored on a mob

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -201,7 +201,14 @@
 		return
 	winset(flashed_client, "mainwindow", "flash=5")
 
-///Recursively checks if an item is inside a given type/atom, even through layers of storage. Returns the atom if it finds it.
+/**
+ * Recursively checks if an item is inside a given type/atom, even through layers of storage.
+ * Returns the atom if it finds it.
+ *
+ * Arguments
+ * * atom/movable/target - the atom whos loc we are checking for
+ * * type - the location(typepath or solid atom) the target maybe stored in
+ */
 /proc/recursive_loc_check(atom/movable/target, type)
 	var/atom/atom_to_find = null
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -160,7 +160,7 @@
 			continue
 
 		if (thing.resistance_flags & INDESTRUCTIBLE)
-			if (!isturf(thing.loc) && !isliving(thing.loc))
+			if (!isturf(thing.loc) && !recursive_loc_check(thing, /mob/living))
 				thing.forceMove(loc)
 			not_eaten += 1
 			continue


### PR DESCRIPTION
## About The Pull Request
- Fixes #91281

## Changelog
:cl:
fix: recycler won't spit out indestructible items if its indirectly stored on the mob
/:cl:
