### PR TITLE
Fix being able to turn on telecomms hub after EMP

### DIFF
--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -35,13 +35,17 @@
 
 /obj/machinery/telecomms/hub/update_power()
 	var/old_on = on
-	if (toggled && (machine_stat & (BROKEN|NOPOWER|EMPED)))
+
+	if (!toggled)
+		on = FALSE
+		soundloop.stop()
+	else if (machine_stat & (BROKEN | NOPOWER | EMPED))
 		on = FALSE
 		soundloop.stop()
 	else
 		on = TRUE
 		soundloop.start()
-	if(old_on != on)
+	if (old_on != on)
 		update_appearance()
 
 /obj/machinery/telecomms/hub/Initialize(mapload)

--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -35,17 +35,16 @@
 
 /obj/machinery/telecomms/hub/update_power()
 	var/old_on = on
-
-	if (!toggled)
-		on = FALSE
-		soundloop.stop()
-	else if (machine_stat & (BROKEN | NOPOWER | EMPED))
-		on = FALSE
-		soundloop.stop()
+	if(toggled)
+		if(machine_stat & (BROKEN|NOPOWER|EMPED))
+			on = FALSE
+			soundloop.stop()
+		else
+			on = TRUE
+			soundloop.start()
 	else
-		on = TRUE
-		soundloop.start()
-	if (old_on != on)
+		on = FALSE
+	if(old_on != on)
 		update_appearance()
 
 /obj/machinery/telecomms/hub/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Fixes #91293 

## Why It's Good For The Game

Not intended behaviour for tcomms machinery to work after heavy EMP just by turning it off and on

## Changelog

:cl:
fix: Now the telecomm hub does not turn on with a multitool after EMP
/:cl: