### PR TITLE
Real Fuel No Clickbait©

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -195,7 +195,6 @@
 
 /// Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
-	var/realFuelNoClickbait = reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
 	return reagents.get_reagent_amount(/datum/reagent/fuel) + reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
 
 /// Uses fuel from the welding tool.

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -75,8 +75,7 @@
 /obj/item/weldingtool/update_overlays()
 	. = ..()
 	if(change_icons)
-		var/realFuelNoClickbait = reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
-		var/ratio = (get_fuel() + realFuelNoClickbait) / max_fuel
+		var/ratio = get_fuel() / max_fuel
 		ratio = CEILING(ratio*4, 1) * 25
 		. += "[initial(icon_state)][ratio]"
 	if(welding)
@@ -196,7 +195,8 @@
 
 /// Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
-	return reagents.get_reagent_amount(/datum/reagent/fuel)
+	var/realFuelNoClickbait = reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
+	return reagents.get_reagent_amount(/datum/reagent/fuel) + realFuelNoClickbait
 
 /// Uses fuel from the welding tool.
 /obj/item/weldingtool/use(used = 0)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -196,7 +196,7 @@
 /// Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
 	var/realFuelNoClickbait = reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
-	return reagents.get_reagent_amount(/datum/reagent/fuel) + realFuelNoClickbait
+	return reagents.get_reagent_amount(/datum/reagent/fuel) + reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
 
 /// Uses fuel from the welding tool.
 /obj/item/weldingtool/use(used = 0)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -75,7 +75,8 @@
 /obj/item/weldingtool/update_overlays()
 	. = ..()
 	if(change_icons)
-		var/ratio = get_fuel() / max_fuel
+		var/realFuelNoClickbait = reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
+		var/ratio = (get_fuel() + realFuelNoClickbait) / max_fuel
 		ratio = CEILING(ratio*4, 1) * 25
 		. += "[initial(icon_state)][ratio]"
 	if(welding)


### PR DESCRIPTION

## About The Pull Request
Fixes #91299, by making plasma appear to be fuel for the purposes of checking how full the welder is.
## Why It's Good For The Game
Bugg bad. Stealthy sabotage method being extremely obvious bad.
## Changelog
:cl:
fix: Plasma now contributes to the fuel gauge of rigged welders, making them less extremely obvious.
/:cl:
