### PR TITLE
Catwalk Survillence Update

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -12964,10 +12964,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/east,
 /obj/structure/cable,
-/obj/machinery/computer/security/telescreen/rd/directional/east{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "dTJ" = (
@@ -19526,7 +19522,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
+	name = "Security Maintenance";
+	aiControlDisabled = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/barricade/wooden/crude,
@@ -21954,10 +21951,6 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "gAZ" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen/cmo/directional/east{
-	pixel_x = 0;
-	pixel_y = 3
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "gBf" = (
@@ -26460,10 +26453,10 @@
 "hRx" = (
 /obj/machinery/door/airlock/grunge{
 	aiControlDisabled = 1;
-	name = "Prison Maintenance"
+	name = "Prisoner Education Chamber"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "hRD" = (
@@ -34452,6 +34445,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/computer/security/telescreen/rd/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "kkM" = (
@@ -45215,7 +45209,8 @@
 /area/space/nearstation)
 "nxH" = (
 /obj/machinery/door/airlock/security{
-	aiControlDisabled = 1
+	aiControlDisabled = 1;
+	name = "Prisoner Education Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/plating,
@@ -69707,7 +69702,6 @@
 "uOH" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "uOR" = (
@@ -71709,6 +71703,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/cmo/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "vtc" = (
@@ -79408,7 +79403,6 @@
 "xLX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "xLY" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -59008,7 +59008,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/camera/autoname/directional/north{
-	network = list(""ss13","medbay"");
+	network = list("ss13","medbay");
 	c_tag = "Medbay - Lower Cryo"
 	},
 /obj/structure/extinguisher_cabinet/directional/north,

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -2939,7 +2939,10 @@
 /area/station/ai_monitored/security/armory)
 "aWk" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	c_tag = "Medbay - Upper Chief Medical Office West";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "aWm" = (
@@ -4447,7 +4450,10 @@
 "btJ" = (
 /obj/structure/chair/sofa/corp,
 /obj/item/clothing/head/soft/blue,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Break Room"
+	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "buh" = (
@@ -4972,7 +4978,10 @@
 	name = "Virology Requests Console"
 	},
 /obj/effect/spawner/random/trash/bin,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	c_tag = "Medbay - Virology Upper";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
 "bBv" = (
@@ -5902,7 +5911,10 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Chemistry East"
+	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
@@ -6161,7 +6173,10 @@
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	c_tag = "Medbay - Lower Virology West Hallway";
+	network = list("ss13","medbay")
+	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
@@ -8190,7 +8205,9 @@
 /area/station/commons/toilet/auxiliary)
 "cwO" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	c_tag = "Medbay - Upper Plumbing Area West"
+	},
 /turf/open/openspace,
 /area/station/medical/chemistry)
 "cwP" = (
@@ -9484,7 +9501,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Virology East Hallway"
+	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
@@ -12942,17 +12962,12 @@
 /area/station/science/robotics/lab)
 "dTv" = (
 /obj/structure/table/reinforced,
-/obj/item/computer_disk{
-	pixel_y = 6
-	},
-/obj/item/computer_disk{
-	pixel_x = -6
-	},
-/obj/item/computer_disk{
-	pixel_x = 6
-	},
 /obj/machinery/newscaster/directional/east,
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen/rd/directional/east{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "dTJ" = (
@@ -15519,7 +15534,9 @@
 /turf/open/floor/plating,
 /area/station/security/mechbay)
 "eHR" = (
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("minisat")
+	},
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -10;
@@ -15933,7 +15950,10 @@
 	pixel_x = 15;
 	pixel_y = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Pharmacy"
+	},
 /obj/machinery/button/door/directional/south{
 	id = "chemshutters";
 	name = "Chemistry Shutters"
@@ -20032,7 +20052,10 @@
 /area/station/maintenance/starboard/lesser)
 "fYu" = (
 /obj/structure/bodycontainer/morgue/beeper_off,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Secure Morgue"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
 "fYF" = (
@@ -21931,14 +21954,9 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "gAZ" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/stamp/head/cmo{
-	pixel_x = 4;
-	pixel_y = 13
+/obj/machinery/computer/security/telescreen/cmo/directional/east{
+	pixel_x = 0;
+	pixel_y = 3
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
@@ -22184,7 +22202,9 @@
 /area/station/security/checkpoint/supply)
 "gFI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "gFR" = (
@@ -23186,7 +23206,9 @@
 "gWd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "gWi" = (
@@ -23280,7 +23302,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	c_tag = "Medbay - Lower Virology South Hallway";
+	network = list("ss13","medbay")
+	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
@@ -23443,15 +23468,26 @@
 /area/station/command/heads_quarters/captain/private)
 "gZq" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/item/folder/white{
+	pixel_y = 1;
+	pixel_x = 5
 	},
-/obj/item/clothing/neck/stethoscope{
+/obj/item/folder/blue{
 	pixel_x = 2;
-	pixel_y = 4
+	pixel_y = 1
 	},
-/obj/item/toy/figure/cmo,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/stamp/head/cmo{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "gZu" = (
@@ -26733,7 +26769,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("minisat")
+	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
@@ -28228,7 +28266,10 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Chemistry South"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "ivM" = (
@@ -29068,10 +29109,20 @@
 /area/station/maintenance/disposal/incinerator)
 "iGD" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/briefcase/secure,
+/obj/item/storage/briefcase/secure{
+	pixel_y = 8;
+	pixel_x = 1
+	},
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
+/obj/item/computer_disk{
+	pixel_x = -6
+	},
+/obj/item/computer_disk,
+/obj/item/computer_disk{
+	pixel_x = 6
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "iGH" = (
@@ -34148,9 +34199,7 @@
 	id = "securestoragecw";
 	name = "Secure Storage"
 	},
-/obj/machinery/computer/security/telescreen/engine/directional/east{
-	name = "Engine Monitor"
-	},
+/obj/machinery/computer/security/telescreen/ce/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
 "khf" = (
@@ -34915,7 +34964,9 @@
 /turf/open/openspace,
 /area/station/hallway/primary/fore)
 "krT" = (
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("aicore")
+	},
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai)
@@ -35273,7 +35324,10 @@
 /area/station/maintenance/disposal/incinerator)
 "kwK" = (
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Morgue"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
 "kwQ" = (
@@ -36351,6 +36405,10 @@
 	pixel_x = 10;
 	pixel_y = 1
 	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 2;
+	pixel_y = 4
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "kPN" = (
@@ -36436,7 +36494,10 @@
 /obj/effect/turf_decal/tile/blue/full,
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Central West"
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "kQn" = (
@@ -37319,7 +37380,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/tcommsat/server)
 "leJ" = (
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Storage East Hallway"
+	},
 /turf/open/openspace,
 /area/station/medical/chemistry)
 "leL" = (
@@ -42633,7 +42697,9 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	c_tag = "Medbay - Lower South Hallway"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mJl" = (
@@ -42949,7 +43015,10 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	c_tag = "Medbay - Upper Chief Medical Office South";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "mOE" = (
@@ -43051,7 +43120,9 @@
 "mPQ" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/dark,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "mPV" = (
@@ -43993,7 +44064,9 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/white/textured_corner{
 	dir = 8
 	},
@@ -44296,7 +44369,9 @@
 "nlG" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light_switch/directional/east,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("aicore")
+	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
 "nlP" = (
@@ -44856,7 +44931,9 @@
 /area/station/cargo/storage)
 "ntJ" = (
 /obj/structure/railing,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("aicore")
+	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
 "ntN" = (
@@ -45535,7 +45612,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Medbay - Upper Medical Storage North"
+	},
 /obj/machinery/light_switch/directional/north,
 /turf/open/openspace,
 /area/station/medical/storage)
@@ -46180,7 +46259,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("minisat")
+	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
@@ -46902,7 +46983,9 @@
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "nYD" = (
@@ -49618,7 +49701,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Central Hallway"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oOY" = (
@@ -50166,7 +50252,8 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/south{
-	dir = 5
+	dir = 5;
+	network = list("aicore")
 	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
@@ -50856,6 +50943,10 @@
 	},
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Cryo"
+	},
 /turf/open/openspace,
 /area/station/medical/cryo)
 "pgM" = (
@@ -51512,10 +51603,13 @@
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Virology Entrance"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/virology)
 "ptk" = (
@@ -55291,7 +55385,9 @@
 	pixel_y = -3
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	c_tag = "Medbay - Upper Medical Storage South"
+	},
 /turf/open/openspace,
 /area/station/medical/storage)
 "qBl" = (
@@ -56238,7 +56334,10 @@
 "qQQ" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Virology Pen"
+	},
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "qQS" = (
@@ -56853,7 +56952,10 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Chemistry Storage"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/medbay/central)
 "ran" = (
@@ -57850,7 +57952,9 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("minisat")
+	},
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white/textured_half,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -58102,6 +58206,10 @@
 /area/station/maintenance/port/aft)
 "rto" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/cmo{
+	pixel_y = 10;
+	pixel_x = -1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "rtx" = (
@@ -58899,7 +59007,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list(""ss13","medbay"");
+	c_tag = "Medbay - Lower Cryo"
+	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
@@ -60620,7 +60731,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower North Treatment Center"
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "sfn" = (
@@ -61573,7 +61687,10 @@
 /area/station/maintenance/starboard/lesser)
 "stW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Upper Plumbing Area East"
+	},
 /turf/open/floor/engine/hull/air,
 /area/station/medical/chemistry)
 "stX" = (
@@ -62010,7 +62127,10 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Operating Room"
+	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/surgery)
@@ -62702,7 +62822,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("minisat")
+	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
@@ -63406,7 +63528,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /obj/structure/table/glass,
 /obj/machinery/light/directional/south,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower South Treatment Center"
+	},
 /obj/item/wrench/medical{
 	pixel_x = -1;
 	pixel_y = 2
@@ -64413,7 +64538,10 @@
 	dir = 4
 	},
 /obj/machinery/vending/wallmed/directional/north,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lobby"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "toH" = (
@@ -65754,7 +65882,10 @@
 	pixel_y = -1
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	c_tag = "Medbay - Lower Virology";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
 "tKB" = (
@@ -67442,7 +67573,9 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("aicore")
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai)
 "ukI" = (
@@ -68908,7 +69041,9 @@
 	pixel_x = -9;
 	pixel_y = 2
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uEn" = (
@@ -69413,7 +69548,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	c_tag = "Medbay - Lower Morgue"
+	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -70095,7 +70232,10 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	c_tag = "Medbay - Lower Virology Patient Room";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology)
 "uXE" = (
@@ -70340,7 +70480,10 @@
 	dir = 10
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Medbay - Upper Hallway";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "vcm" = (
@@ -71577,7 +71720,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
 "vtm" = (
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Medbay - Upper Storage North Hallway"
+	},
 /obj/effect/turf_decal/siding/blue/corner,
 /turf/open/openspace,
 /area/station/medical/medbay/central)
@@ -75981,7 +76126,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("aicore")
+	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "wKb" = (
@@ -78066,7 +78213,10 @@
 /area/station/security/checkpoint/customs)
 "xrX" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Lower Hallway North"
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "xsh" = (
@@ -79298,7 +79448,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Medbay - Lower Virology North Hallway"
+	},
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
 "xML" = (
@@ -79804,7 +79956,9 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("minisat")
+	},
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -80643,13 +80797,13 @@
 /area/station/science/explab)
 "yfv" = (
 /obj/structure/table/wood,
-/obj/item/folder/white,
-/obj/item/flashlight/pen{
-	pixel_x = -6
-	},
 /obj/item/binoculars{
 	pixel_x = -5;
 	pixel_y = 6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 3;
+	pixel_y = -1
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)


### PR DESCRIPTION
## About The Pull Request
Sets Minisat AI core on its own proper Cameras
Sets Engine on its proper Camera network
Gives RD CE and CMO their Screen Monitor
Removes 2 Cameras from maintenance rooms
Prison maintenance is now AI Control disabled to prevent law 2 escapes

## Why It's Good For The Game

Proper Networks for cameras is important otherwise it will all show up on the SS13 network
For the AI control on prison maintenance is to prevent law 2'ing the ai and getting out quickly
Cameras Removed for rooms AI probaly shouldn't see (like Prison Eductation)

## Changelog
:cl: Ezel
map: Gives CE/CMO/RD their proper camera monitors
map: Medbay Camera's is now its own proper network
map: Removes a camera from Prison maintenance and Security closet
map: Disables AI control on Prison Maintenance Door
fix: Minisat Camera's now use the proper network
fix: Engine Camera's now use the proper network
/:cl:

