### PR TITLE
Open-Canopy Mechs (Paddy, MK-I) take bonus projectile damage if the pilot is not a humanoid

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -118,10 +118,11 @@
 	//allows bullets to hit the pilot of open-canopy mechs
 	if(!(mecha_flags & IS_ENCLOSED) \
 		&& LAZYLEN(occupants) \
-		&& !(mecha_flags & SILICON_PILOT) \
 		&& (def_zone == BODY_ZONE_HEAD || def_zone == BODY_ZONE_CHEST))
 		var/mob/living/hitmob = pick(occupants)
-		return hitmob.projectile_hit(hitting_projectile, def_zone, piercing_hit) //If the sides are open, the occupant can be hit
+		if(ishuman(hitmob))
+			return hitmob.projectile_hit(hitting_projectile, def_zone, piercing_hit) //If the sides are open, the occupant can be hit
+		hitting_projectile.damage = hitting_projectile.damage * 3 //no organic blocking the shot means we hit the juicy unarmored internals
 
 	. = ..()
 


### PR DESCRIPTION

## About The Pull Request
Alternative to #91118;
If an open-canopy mech is shot at chest-level or above (which would normally apply the attack to the pilot), and the pilot is not a humanoid (IE, is an AI, Posi, or MMI pilot), the mech will take bonus damage. Currently, it is set to *__triple__* the damage.
## Why It's Good For The Game
The purpose of this PR is to make the cheese strat of giving Paddy to a posi cube less combat viable, without completely removing the feature. As of my test, a regular laser rifle with 3x damage will destroy a Paddy in four shots.

IC reasoning, for what it may matter, is the internal cockpit having zero internal-facing armor. A humanoid pilot will act as a meatshield, protecting the delicate internals. An empty chair, not so much.
## Changelog
:cl:
balance: Mechs with non-humanoid pilots being shot in the cockpit will take triple projectile damage.
/:cl:
I'm not hyper committed to 3x being the correct value. But it needs to be a tangible downside, while not being a one-hit kill. Four shots for a kill does fit the bill.
