### PR TITLE
Shuffle around fancy storage code, fix some stuff, minor changes

### DIFF
--- a/code/datums/storage/subtypes/others/fancy_storage.dm
+++ b/code/datums/storage/subtypes/others/fancy_storage.dm
@@ -1,0 +1,119 @@
+/**
+ * Storage datums used for fancy storages
+ */
+
+/// Donut Boxes
+/datum/storage/donut_box
+	max_slots = 6
+
+/datum/storage/donut_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(/obj/item/food/donut)
+
+/// Egg Boxes
+/datum/storage/egg_box
+	max_slots = 12
+	// So we have two rows of 6, like the box visually has
+	screen_max_columns = 6
+
+/datum/storage/egg_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(list(
+		/obj/item/food/egg,
+		/obj/item/food/chocolateegg,
+		/obj/item/food/boiledegg,
+		/obj/item/food/scotchegg,
+		/obj/item/food/grown/eggy,
+		/obj/item/surprise_egg,
+	))
+
+/// Candle Boxes
+/datum/storage/candle_box
+	max_slots = 5
+
+/datum/storage/candle_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(/obj/item/flashlight/flare/candle)
+
+/// Cigarette Boxes
+/datum/storage/cigarette_box
+	max_slots = 6
+	display_contents = FALSE
+
+/datum/storage/cigarette_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(list(
+		/obj/item/cigarette,
+		/obj/item/lighter,
+	))
+
+/// Rolling Paper Packs
+/datum/storage/rolling_paper_pack
+	max_slots = 10
+	screen_max_columns = 5
+
+/datum/storage/rolling_paper_pack/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(/obj/item/rollingpaper)
+
+/// Cigar Boxes
+/datum/storage/cigar_box
+	max_slots = 5
+	display_contents = FALSE
+
+/datum/storage/cigar_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(list(
+		/obj/item/cigarette/cigar,
+	))
+
+/// Heart-Shaped Chocolate Boxes
+/datum/storage/heart_box
+	max_slots = 8
+	screen_max_columns = 4
+
+/datum/storage/heart_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(/obj/item/food/bonbon)
+
+/// Nugget Boxes
+/datum/storage/nugget_box
+	max_slots = 6
+
+/datum/storage/nugget_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(list(
+		/obj/item/food/nugget,
+		/obj/item/fish/fryish,
+	))
+
+/// Jars of Pickles
+/datum/storage/pickles_jar
+	max_slots = 10
+	max_total_storage = WEIGHT_CLASS_SMALL * 10
+	screen_max_columns = 5
+
+/datum/storage/pickles_jar/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(/obj/item/food/pickle)
+
+/// Coffee Condiment Displays
+/datum/storage/coffee_condi_display
+	max_slots = 14
+
+/datum/storage/coffee_condi_display/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(list(
+		/obj/item/reagent_containers/condiment/pack/sugar,
+		/obj/item/reagent_containers/condiment/creamer,
+		/obj/item/reagent_containers/condiment/pack/astrotame,
+		/obj/item/reagent_containers/condiment/chocolate,
+	))
+
+/// Coffee Cart Racks
+/datum/storage/coffee_cart_rack
+	max_slots = 4
+
+/datum/storage/coffee_cart_rack/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(/obj/item/coffee_cartridge)

--- a/code/datums/storage/subtypes/others/misc.dm
+++ b/code/datums/storage/subtypes/others/misc.dm
@@ -142,68 +142,6 @@
 /datum/storage/briefcase
 	max_total_storage = 21
 
-//=======================Fancy storages======================
-///Donut box
-/datum/storage/donut/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(/obj/item/food/donut)
-
-///Egg box
-/datum/storage/egg_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(list(
-		/obj/item/food/egg,
-		/obj/item/food/chocolateegg,
-		/obj/item/food/boiledegg,
-		/obj/item/food/scotchegg,
-		/obj/item/food/grown/eggy,
-		/obj/item/surprise_egg,
-	))
-
-///Generic fancy holder
-/datum/storage/fancy_holder/New(obj/item/storage/fancy/candle_box/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(parent.spawn_type)
-
-///Heart box
-/datum/storage/heart_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(/obj/item/food/bonbon)
-
-///Cigrate boxes
-/datum/storage/cigarette_box
-	display_contents = FALSE
-
-/datum/storage/cigarette_box/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(list(
-		/obj/item/cigarette,
-		/obj/item/lighter,
-	))
-
-///Coffee condiment display
-/datum/storage/coffee_condi_display
-	max_slots = 14
-
-/datum/storage/coffee_condi_display/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(list(
-		/obj/item/reagent_containers/condiment/pack/sugar,
-		/obj/item/reagent_containers/condiment/creamer,
-		/obj/item/reagent_containers/condiment/pack/astrotame,
-		/obj/item/reagent_containers/condiment/chocolate,
-	))
-
-///Coffee cart rack
-/datum/storage/coffee_cart_rack
-	max_slots = 4
-
-/datum/storage/coffee_cart_rack/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(/obj/item/coffee_cartridge)
-
-//=================================================
-
 ///Pill bottle
 /datum/storage/pillbottle
 	allow_quick_gather = TRUE
@@ -216,7 +154,6 @@
 		/obj/item/reagent_containers/applicator,
 		/obj/item/food/bait/natural,
 	))
-
 
 ///Six pack beer
 /datum/storage/sixcan

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -30,11 +30,6 @@
 	/// Whether it supports open and closed state icons.
 	var/has_open_closed_states = TRUE
 
-/obj/item/storage/fancy/Initialize(mapload)
-	. = ..()
-
-	atom_storage.max_slots = spawn_count
-
 /obj/item/storage/fancy/PopulateContents()
 	if(!spawn_type)
 		return
@@ -103,7 +98,7 @@
 	appearance_flags = KEEP_TOGETHER|LONG_GLIDE
 	custom_premium_price = PAYCHECK_COMMAND * 1.75
 	contents_tag = "donut"
-	storage_type = /datum/storage/donut
+	storage_type = /datum/storage/donut_box
 
 /obj/item/storage/fancy/donut_box/PopulateContents()
 	. = ..()
@@ -179,7 +174,7 @@
 	spawn_count = 5
 	open_status = FANCY_CONTAINER_ALWAYS_OPEN
 	contents_tag = "candle"
-	storage_type = /datum/storage/fancy_holder
+	storage_type = /datum/storage/candle_box
 
 ////////////
 //CIG PACK//
@@ -396,7 +391,7 @@
 	spawn_count = 10
 	custom_price = PAYCHECK_LOWER
 	has_open_closed_states = FALSE
-	storage_type = /datum/storage/fancy_holder
+	storage_type = /datum/storage/rolling_paper_pack
 
 /obj/item/storage/fancy/rollingpapers/update_overlays()
 	. = ..()
@@ -415,14 +410,11 @@
 	base_icon_state = "cigarcase"
 	w_class = WEIGHT_CLASS_NORMAL
 	contents_tag = "premium cigar"
+	storage_type = /datum/storage/cigar_box
 	spawn_type = /obj/item/cigarette/cigar/premium
 	spawn_count = 5
 	spawn_coupon = FALSE
 	display_cigs = FALSE
-
-/obj/item/storage/fancy/cigarettes/cigars/Initialize(mapload)
-	. = ..()
-	atom_storage.set_holdable(/obj/item/cigarette/cigar)
 
 /obj/item/storage/fancy/cigarettes/cigars/update_icon_state()
 	. = ..()
@@ -486,7 +478,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	spawn_type = /obj/item/food/nugget
 	spawn_count = 6
-	storage_type = /datum/storage/fancy_holder
+	storage_type = /datum/storage/nugget_box
 
 /*
  * Jar of pickles
@@ -505,7 +497,7 @@
 	custom_materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	open_status = FANCY_CONTAINER_ALWAYS_OPEN
 	has_open_closed_states = FALSE
-	storage_type = /datum/storage/fancy_holder
+	storage_type = /datum/storage/pickles_jar
 
 /obj/item/storage/fancy/pickles_jar/update_icon_state()
 	. = ..()

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -486,7 +486,7 @@
 	name = "coffeemaker cartridge rack"
 	desc = "A small rack for storing coffeemaker cartridges."
 	icon = 'icons/obj/food/containers.dmi'
-	icon_state = "coffee_cartrack4"
+	icon_state = "coffee_cartrack1"
 	base_icon_state = "coffee_cartrack"
 	contents_tag = "coffee cartridge"
 	open_status = FANCY_CONTAINER_ALWAYS_OPEN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2007,6 +2007,7 @@
 #include "code\datums\storage\subtypes\others\cards.dm"
 #include "code\datums\storage\subtypes\others\carpskin_bag.dm"
 #include "code\datums\storage\subtypes\others\extract_inventory.dm"
+#include "code\datums\storage\subtypes\others\fancy_storage.dm"
 #include "code\datums\storage\subtypes\others\fish_case.dm"
 #include "code\datums\storage\subtypes\others\misc.dm"
 #include "code\datums\storage\subtypes\others\pod.dm"


### PR DESCRIPTION

## About The Pull Request

So this is all because of a leftover bit making all fancy holders set their `max_slots` to the `spawn_count`, which of course would override the custom storage datums.
https://github.com/tgstation/tgstation/blob/526e006583eee95d809b4062938072f78974ed78/code/game/objects/items/storage/fancy.dm#L33-L36
This just moves all of the fancy storage items away from auto-calculating storage based on those vars entirely, making new storage datums for all of the ones which didn't have one yet.
We also move this out of the misc file, because a misc file is meaningless if everything together makes it bloated.

We also do some minor fixes and changes.
- The pickle jar could only hold seven small items, even though it'd take ten pickles, so we make it hold ten small items.
- Coffee cartridge racks started with the sprite for 4 of them, so we make it start with the sprite for 1 of them.
- Nugget fish in the bugget box :)
- We make a few of the visual storages with even amounts above 7 split their storage up into two even rows, so their UI actually looks full when full.
## Why It's Good For The Game

Less jank good 👍 

It feels kinda awkward when you have a full box of stuff, visually full of stuff, and the storage UI is for a significant portion empty- but you can't put in more.
This makes it so the full storage UI actually matches the object looking full.

It's funny if Fryish, the nugget fish, can be stored in a nugget box.
## Changelog
:cl:
balance: Egg boxes' storage UI is now 6 slots wide, such that it contains an even dozen slots when full.
balance: The storage UIs for heart-shaped chocolate boxes, pickle jars, and rolling paper packs are now 4, 5, and 5 slots wide respectively, such that they fill the whole storage UI when full.
balance: Fryish and its fried snack cousins can now be stored in nugget boxes.
fix: Pickle jars can actually hold the ten pickles they spawn with.
fix: Fertile egg boxes, coffee condiment displays, and coffee cart racks have the right amount of slots.
fix: Coffee cart racks spawn with the sprite for holding 1 cartridge like they do, rather than looking like they're holding 4 cartridges.
/:cl:
