### PR TITLE
Refactors holochip `attackby` into `item_interaction`, adds screentips

### DIFF
--- a/code/game/objects/items/credit_holochip.dm
+++ b/code/game/objects/items/credit_holochip.dm
@@ -20,11 +20,18 @@
 		return INITIALIZE_HINT_QDEL
 	add_traits(list(TRAIT_FISHING_BAIT, TRAIT_BAIT_ALLOW_FISHING_DUD), INNATE_TRAIT)
 	update_appearance()
+	register_context()
 
 /obj/item/holochip/examine(mob/user)
 	. = ..()
 	. += "[span_notice("It's loaded with [credits] credit[( credits > 1 ) ? "s" : ""]")]\n"+\
 	span_notice("Alt-Click to split.")
+
+/obj/item/holochip/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(istype(held_item, /obj/item/holochip))
+		context[SCREENTIP_CONTEXT_LMB] = "Merge Into"
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Extract Credits"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/holochip/get_item_credit_value()
 	return credits

--- a/code/game/objects/items/credit_holochip.dm
+++ b/code/game/objects/items/credit_holochip.dm
@@ -95,14 +95,16 @@
 	else
 		return 0
 
-/obj/item/holochip/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	..()
-	if(istype(I, /obj/item/holochip))
-		var/obj/item/holochip/H = I
-		credits += H.credits
-		to_chat(user, span_notice("You insert the credits into [src]."))
-		update_appearance()
-		qdel(H)
+/obj/item/holochip/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/holochip))
+		return NONE
+
+	var/obj/item/holochip/merged_holochip = tool
+	credits += merged_holochip.credits
+	balloon_alert(user, "merged!")
+	update_appearance()
+	qdel(merged_holochip)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/holochip/click_alt(mob/user)
 	if(loc != user)


### PR DESCRIPTION

## About The Pull Request

On the tin.
We just refactor another `attackby(...)` into `item_interaction(...)` and add screentips in the process.
We also replace the `to_chat(...)` with a shorter balloon alert.
I would want to add an item transfer animation, but I'm leaving that until I add a proper item transfer animation rather than pickup animation later.
## Why It's Good For The Game

Attackby begone
Usage screentips good
## Changelog
:cl:
code: Refactored holochip merging. Please report any issues.
qol: Holochips now have usage screentips.
/:cl:
