### PR TITLE
Declarations of war can now be false alarms

### DIFF
--- a/code/modules/events/fake_assault
+++ b/code/modules/events/fake_assault
@@ -1,0 +1,53 @@
+//A 'Fake' nuclear assault which sends out the nuclear assault declaration after 5 minutes. Basically a roundstart false alarm.
+/datum/round_event_control/fake_nuclear_assault
+	name = "Fake Nuclear Assault"
+	//antag_datum = /datum/antagonist/nukeop
+	typepath = /datum/round_event/fake_nuclear_assault
+	//shared_occurence_type = SHARED_HIGH_THREAT
+	base_antags = 0
+	maximum_antags = 0
+	//required_enemies = 5
+	// I give up, just there should be enough heads with 35 players...
+	min_players = 35
+	roundstart = TRUE
+	earliest_start = 0 SECONDS
+	weight = 1 //Needs to be rare
+	max_occurrences = 3
+	event_icon_state = "fake_nukeops"
+	enemy_roles = list(
+		JOB_AI,
+		JOB_CYBORG,
+		JOB_CAPTAIN,
+		JOB_BLUESHIELD,
+		JOB_DETECTIVE,
+		JOB_HEAD_OF_SECURITY,
+		JOB_SECURITY_OFFICER,
+		JOB_SECURITY_ASSISTANT,
+		JOB_WARDEN,
+	)
+	required_enemies = 5
+
+/datum/round_event/antagonist/solo/fake_nuclear_assault
+	fakeable = TRUE
+
+/datum/round_event/antagonist/solo/fake_nuclear_assault/announce()
+	for(var/datum/antagonist/antag in GLOB.antagonists) //search all antags for clownops or nukeops
+		if(istype(antag, /datum/antagonist/nukeop) || istype(antag, /datum/antagonist/nukeop/clownop))
+			return //dont false alarm if there are nukeops
+	addtimer(CALLBACK(src, PROC_REF(declare_war_message)), rand(120, 300) SECONDS)
+
+/datum/round_event/antagonist/solo/fake_nuclear_assault/proc/declare_war_message()
+	var/list/possible_texts = list(
+        "Hello. This iz your muther. Pleaze come over to my house for Donk Pocket. Leave the airlocks open and the dizk ungaurded. Sincerily, Mom (Not the nukies).",
+         "A syndicate fringe group has declared their intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them.",
+		"Pizza delivery for [station_name()]",
+		"How do I turn this thing on? Shit, its broadcasting already! We're going to-",
+		"Central Command has authorized the Disk Inspection Protocol. Do not resist while we inspect the nuclear authentication disk.",
+		)
+	priority_announce(
+	text = pick(possible_texts),
+	title = "Declaration of War",
+	sound = 'sound/machines/alarm.ogg',
+	has_important_message = TRUE,
+	sender_override = "Nuclear Operative Outpost",
+	color_override = "red",)

--- a/code/modules/events/fake_assault.dm
+++ b/code/modules/events/fake_assault.dm
@@ -21,7 +21,7 @@
 /datum/round_event/fake_nuclear_assault/proc/declare_war_message()
 	var/list/possible_texts = list(
         "Hello. This iz your muther. Pleaze come over to my house for Donk Pocket. Leave the airlocks open and the dizk ungaurded. Sincerily, Mom (Not the nukies).",
-         "A syndicate fringe group has declared their intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them.",
+        "A syndicate fringe group has declared their intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them.",
 		"Pizza delivery for [station_name()]",
 		"How do I turn this thing on? Shit, its broadcasting already! We're going to-",
 		"Central Command has authorized the Disk Inspection Protocol. Do not resist while we inspect the nuclear authentication disk.",

--- a/code/modules/events/fake_assault.dm
+++ b/code/modules/events/fake_assault.dm
@@ -1,42 +1,24 @@
-//A 'Fake' nuclear assault which sends out the nuclear assault declaration after 5 minutes. Basically a roundstart false alarm.
+//A 'Fake' nuclear assault which sends out the nuclear assault declaration. Basically a false alarm that can be triggered at roundstart and at any time throughout the round.
+// frequency is approximately that of clown ops (?)
 /datum/round_event_control/fake_nuclear_assault
 	name = "Fake Nuclear Assault"
-	//antag_datum = /datum/antagonist/nukeop
 	typepath = /datum/round_event/fake_nuclear_assault
-	//shared_occurence_type = SHARED_HIGH_THREAT
-	base_antags = 0
-	maximum_antags = 0
-	//required_enemies = 5
-	// I give up, just there should be enough heads with 35 players...
+	// If a round CAN be nuke ops, then it can also be fake ops. Similar requirements so it's not obvious.
 	min_players = 35
-	roundstart = TRUE
 	earliest_start = 0 SECONDS
 	weight = 1 //Needs to be rare
-	max_occurrences = 3
-	event_icon_state = "fake_nukeops"
-	enemy_roles = list(
-		JOB_AI,
-		JOB_CYBORG,
-		JOB_CAPTAIN,
-		JOB_BLUESHIELD,
-		JOB_DETECTIVE,
-		JOB_HEAD_OF_SECURITY,
-		JOB_SECURITY_OFFICER,
-		JOB_SECURITY_ASSISTANT,
-		JOB_WARDEN,
-	)
-	required_enemies = 5
+	max_occurrences = 1
 
-/datum/round_event/antagonist/solo/fake_nuclear_assault
-	fakeable = TRUE
-
-/datum/round_event/antagonist/solo/fake_nuclear_assault/announce()
+/datum/round_event/fake_nuclear_assault/announce()
 	for(var/datum/antagonist/antag in GLOB.antagonists) //search all antags for clownops or nukeops
 		if(istype(antag, /datum/antagonist/nukeop) || istype(antag, /datum/antagonist/nukeop/clownop))
 			return //dont false alarm if there are nukeops
-	addtimer(CALLBACK(src, PROC_REF(declare_war_message)), rand(120, 300) SECONDS)
+	declare_war_message()
 
-/datum/round_event/antagonist/solo/fake_nuclear_assault/proc/declare_war_message()
+/*Custom declaration messages might make it obvious that this specific declaration is fake ops if people start to recognize them. However, actual war ops might know about this
+ 	and use the messages pretending to be fake. So it ends up not mattering I think.*/
+
+/datum/round_event/fake_nuclear_assault/proc/declare_war_message()
 	var/list/possible_texts = list(
         "Hello. This iz your muther. Pleaze come over to my house for Donk Pocket. Leave the airlocks open and the dizk ungaurded. Sincerily, Mom (Not the nukies).",
          "A syndicate fringe group has declared their intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them.",
@@ -47,7 +29,7 @@
 	priority_announce(
 	text = pick(possible_texts),
 	title = "Declaration of War",
-	sound = 'sound/machines/alarm.ogg',
+	sound = 'sound/announcer/alarm/nuke_alarm.ogg',
 	has_important_message = TRUE,
 	sender_override = "Nuclear Operative Outpost",
 	color_override = "red",)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4165,6 +4165,7 @@
 #include "code\modules\events\dust.dm"
 #include "code\modules\events\earthquake.dm"
 #include "code\modules\events\electrical_storm.dm"
+#include "code\modules\events\fake_assault.dm"
 #include "code\modules\events\fake_virus.dm"
 #include "code\modules\events\false_alarm.dm"
 #include "code\modules\events\gravity_generator_blackout.dm"


### PR DESCRIPTION
## About The Pull Request

New event that can trigger midround or roundstart; Fake nuclear war. Very low frequency.

A war announcement (with a few pre-written messages or the default) is sent out to the crew. Same requirements as a real nuclear war and is indistinguishable from it, aside from the pre-written messages, which I believe has merit of its own.

Will not trigger if clown ops or nuke ops are already present.

## Why It's Good For The Game 

This PR does a few things, firstly solving one of my biggest problems with war declarations in general. When that alarm rings out, the second the station can, the shuttle is called. This puts a timer on the round from the very get-go. A warops round usually ends in about 30 minutes, either from the shuttle leaving or the nuke detonating. If theres a slight belief in the crews mind that this declaration could be fake, then they won't call the shuttle immediately. They will wait until the threat is confirmed. You also don't need to necessarily see the nukies to confirm their presence either. A smart player can certainly come up with ways to either hijack syndicate communications or view something that might confirm their presence. This gives nukies more options and makes everything that little bit more stressful and unpredictable. 

Secondly, this adds a type of 'event' that would be difficult to arise otherwise. If you can't confirm if a declaration is fake or not, then you would need to treat any war declaration as a real declaration, while also, treating any real declaration as if it could be fake. This would lead to people like the Captain or the HOS, actually having to take reigns and decide what the best course of action is, and how to appropriately respond. Do you arm the entire crew and risk handing weapons to the very people who will turn on you later? Or do you only arm the security forces and leave the greater crew defenseless? 

I think both of these are good reasons to merge this. Obviously, if you want to keep war declarations as a guarantee of hostilities (essentially, the only real thing in this game that turns the entire station against a singular threat) then then this might not be a good idea. However, with the chaotic nature of space station 13, I see more unpredictability as a good thing. Not knowing exactly how a round is going to shake out is what makes this game so great in my opinion. 

## Changelog
:cl:
change: Declarations of war can rarely be false alarms
/:cl:
