### PR TITLE
Adds 2u sanguarite to atropine medipens

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -289,7 +289,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"
-	desc = "A rapid way to save a person from a critical injury state!"
+	desc = "A rapid way to save a person from a critical injury state! Additionally contains a powerful coagulant to prevent blood loss."
 	icon_state = "atropen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -293,7 +293,7 @@
 	icon_state = "atropen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"
-	list_reagents = list(/datum/reagent/medicine/atropine = 10)
+	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/snail
 	name = "snail shot"


### PR DESCRIPTION

## About The Pull Request

Adds 2u sanguarite (Coagulant) to atropine medipens (The ones provided to nuclear operatives and in the advanced medkit)

## Why It's Good For The Game

Every crew member who isnt a syndicate operative spawns with a medipen with coagulant. It doesn't make sense why syndicate operatives somehow have worse medipens provided to them in their survival kits, while being basically a direct upgrade otherwise. 

In my experience, bleeds tend to be an absolute killer of nukies. Letting nukies deal with a single bleed by default puts them on-par with any other human in this regard, and reinforces the belief that 'the medipen in the survival box helps with bleeds'.

## Changelog
:cl:
add: Adds 2u sanguarite to atropens
/:cl:
