### PR TITLE
[NO GBP] Fixes cultists, blood brothers and headrevs sometimes not getting their roundstart items

### DIFF
--- a/code/modules/antagonists/cult/datums/cultist.dm
+++ b/code/modules/antagonists/cult/datums/cultist.dm
@@ -149,11 +149,11 @@
 	if(!where)
 		to_chat(mob, span_userdanger("Unfortunately, you weren't able to get [item]. This is very bad and you should adminhelp immediately (press F1)."))
 		return FALSE
-	else
-		to_chat(mob, span_danger("You have [item] in your [where]."))
-		if(where == "backpack")
-			mob.back.atom_storage?.show_contents(mob)
-		return TRUE
+
+	to_chat(mob, span_danger("You have [item] in your [where]."))
+	if(where == "backpack")
+		mob.back.atom_storage?.show_contents(mob)
+	return TRUE
 
 /datum/antagonist/cult/proc/admin_give_dagger(mob/admin)
 	if(!equip_cultist(metal = FALSE))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -576,7 +576,7 @@
 /// del_on_fail - delete the item upon failure
 /mob/proc/equip_to_storage(obj/item/item, slot, indirect_action = FALSE, del_on_fail = FALSE, initial = FALSE)
 	var/obj/item/worn_item = get_item_by_slot(slot)
-	if (worn_item?.atom_storage?.attempt_insert(item, src, override = TRUE, force = indirect_action ? STORAGE_SOFT_LOCKED : STORAGE_NOT_LOCKED))
+	if (worn_item?.atom_storage?.attempt_insert(item, src, override = TRUE, force = indirect_action ? STORAGE_SOFT_LOCKED : STORAGE_NOT_LOCKED, messages = FALSE))
 		return TRUE
 
 	if (del_on_fail)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -450,7 +450,7 @@
 		"right pocket" = ITEM_SLOT_RPOCKET
 	)
 
-	var/placed_in = equip_in_one_of_slots(item, pockets, indirect_action = TRUE)
+	var/placed_in = equip_in_one_of_slots(item, pockets, qdel_on_fail = FALSE, indirect_action = TRUE)
 
 	if (!placed_in)
 		placed_in = equip_to_storage(item, ITEM_SLOT_BACK, indirect_action = TRUE)


### PR DESCRIPTION

## About The Pull Request

Didn't notice that equip_in_one_of_slots qdeleted by default

Closes #91288

## Changelog
:cl:
fix: Fixed cultists, blood brothers and headrevs sometimes not getting their roundstart items
/:cl:
