### PR TITLE
Fixes Civilian Cargo Terminal's initial size

### DIFF
--- a/tgui/packages/tgui/interfaces/CivCargoHoldTerminal.jsx
+++ b/tgui/packages/tgui/interfaces/CivCargoHoldTerminal.jsx
@@ -20,7 +20,7 @@ export const CivCargoHoldTerminal = (props) => {
     <Window width={580} height={375}>
       <Window.Content scrollable>
         <Flex>
-          <Flex.Item>
+          <Flex.Item grow>
             <NoticeBox color={!id_inserted ? 'default' : 'blue'}>
               {id_inserted ? in_text : out_text}
             </NoticeBox>


### PR DESCRIPTION
## About The Pull Request


This pull request aims to fix civilian cargo bounty terminal's initial render size using the Flex.Item's grow property. There is also a  open issue for this which i added below.

https://github.com/tgstation/tgstation/issues/91261



After Changes

![CivCargoTerminal](https://github.com/user-attachments/assets/a9f681f7-d906-4f49-9668-41341b03ddc8)

## Why It's Good For The Game

As a person who uses bounty console time to time i dont like initial screen i am welcomed with.

## Changelog

:cl:
fix: fixed Civilian Bounty Terminal not filling rest of the window when opened first time.
/:cl:


