### PR TITLE
Fix shuttle engines `anchored` state not matching `engine_state`

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -39,6 +39,9 @@
 	. = ..()
 	AddComponent(/datum/component/simple_rotation)
 	register_context()
+	if(!mapload)
+		engine_state = ENGINE_UNWRENCHED
+		anchored = FALSE
 
 /obj/machinery/power/shuttle_engine/on_construction(mob/user)
 	. = ..()
@@ -190,10 +193,6 @@
 /obj/machinery/power/shuttle_engine/propulsion/burst
 	name = "burst engine"
 	desc = "An engine that releases a large bluespace burst to propel it."
-
-/obj/machinery/power/shuttle_engine/propulsion/burst/cargo
-	engine_state = ENGINE_UNWRENCHED
-	anchored = FALSE
 
 /obj/machinery/power/shuttle_engine/propulsion/burst/left
 	name = "left burst engine"

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -103,7 +103,7 @@
 	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_CE
 	access_view = ACCESS_CE
-	contains = list(/obj/machinery/power/shuttle_engine/propulsion/burst/cargo)
+	contains = list(/obj/machinery/power/shuttle_engine/propulsion/burst)
 	crate_name = "shuttle engine crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 


### PR DESCRIPTION
## About The Pull Request
Building a shuttle engine from a circuit has a misaligned state where you can weld it immediately because it thinks the engine is already anchored when it is not. This results in welded engines being able to be dragged and moved around.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Fix shuttle engines built from a circuit board having it's `anchored` state not matching the correct `engine_state`. This would consider the engine to be anchored already when it was not and allow someone to weld it despite it being able to be dragged and moved around. 
/:cl:
