### PR TITLE
Points are abbreviated again in the RD console header

### DIFF
--- a/tgui/packages/tgui/interfaces/Techweb/Content.tsx
+++ b/tgui/packages/tgui/interfaces/Techweb/Content.tsx
@@ -10,6 +10,7 @@ export function TechwebContent(props) {
     d_disk,
     node_cache,
     points_last_tick,
+    point_types_abbreviations = [],
     points,
     queue_nodes = [],
     sec_protocols,
@@ -33,7 +34,7 @@ export function TechwebContent(props) {
                 </span>
               </LabeledList.Item>
               {Object.keys(points).map((k) => (
-                <LabeledList.Item key={k} label="Points">
+                <LabeledList.Item key={k} label={point_types_abbreviations[k]}>
                   <b>{points[k]}</b>
                   {!!points_last_tick[k] && ` (+${points_last_tick[k]}/sec)`}
                 </LabeledList.Item>


### PR DESCRIPTION
## About The Pull Request

Now says "Gen. Res." instead of "Points"
![image](https://github.com/user-attachments/assets/7746a364-05a7-45fd-832d-c1550421e415)

## Why It's Good For The Game

In https://github.com/tgstation/tgstation/pull/81202 I added easier support for different types of research points, then we regressed a bit when we got the new UI, this re-adds that part so not every type of point is called "Points".

## Changelog

:cl:
spellcheck: The header for RD consoles now says what type of points it's counting.
/:cl: