### PR TITLE
Removes the accidental holdover bullet spread on the BR-38 that isn't supposed to be there.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -359,7 +359,6 @@
 	fire_delay = 2
 	burst_size = 1
 	actions_types = list()
-	spread = 10 //slightly inaccurate in burst fire mode, mostly important for long range shooting
 	fire_sound = 'sound/items/weapons/thermalpistol.ogg'
 	suppressor_x_offset = 8
 


### PR DESCRIPTION

## About The Pull Request

This was a component of the gun that existed while the weapon had a two-round burst. It was not removed when the burst was removed.

## Why It's Good For The Game

I've been using this for a while, scope included, and only recently has this actually had an impact. I thought the scoped component was broken or something. Nope!

Honestly it's kind of funny and sells the bit. At the same time, it's an RNG frustration that players probably wouldn't appreciate. This likely wasn't impactful in extreme close range, since a 10 degree divergence is not enough to really cause a shot to go wide within 7 tiles or so. But it did make shooting over long distances sometimes a bit harder than necessary.

Now I know why I somehow managed to nail an assistant in the dome completely on accident despite aiming past him shooting someone breaching the brig while scoped.

## Changelog
:cl:
fix: The BR-38 no longer has a completely unintended accuracy malus built in. 
/:cl:
