### PR TITLE
Bite the Hand that (Doesn't) Feed: Felinids who are both insane and hungry might bite.

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -70,6 +70,7 @@
 	head.unarmed_damage_high = 15
 	head.unarmed_effectiveness = 15
 	head.unarmed_attack_effect = ATTACK_EFFECT_BITE
+	head.unarmed_sharpness = SHARP_POINTY
 
 /obj/item/organ/tongue/carp/on_mob_remove(mob/living/carbon/tongue_owner)
 	. = ..()
@@ -87,6 +88,7 @@
 	head.unarmed_damage_high = initial(head.unarmed_damage_high)
 	head.unarmed_effectiveness = initial(head.unarmed_effectiveness)
 	head.unarmed_attack_effect = initial(head.unarmed_attack_effect)
+	head.unarmed_sharpness = initial(head.unarmed_sharpness)
 
 /obj/item/organ/tongue/carp/on_life(seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -483,14 +483,11 @@
 
 // Sometimes, felinids go a bit haywire and bite people. Based entirely on mania and hunger.
 /obj/item/organ/brain/felinid/get_attacking_limb(mob/living/carbon/human/target)
-	if(owner.mob_mood)
-		var/starving_cat_bonus = owner.nutrition <= NUTRITION_LEVEL_HUNGRY ? 1 : 10
-		var/crazy_feral_cat = clamp((starving_cat_bonus * owner.mob_mood.sanity_level), 0, 100)
-		if(prob(crazy_feral_cat))
-			var/obj/item/bodypart/crazy_feral_cat_brain_container = owner.get_bodypart(BODY_ZONE_HEAD)
-			if(crazy_feral_cat_brain_container)
-				return crazy_feral_cat_brain_container
-	. = ..()
+	var/starving_cat_bonus = owner.nutrition <= NUTRITION_LEVEL_HUNGRY ? 1 : 10
+	var/crazy_feral_cat = clamp((starving_cat_bonus * owner.mob_mood?.sanity_level), 0, 100)
+	if(prob(crazy_feral_cat))
+		return owner.get_bodypart(BODY_ZONE_HEAD) || ..()
+	return ..()
 
 /obj/item/organ/brain/lizard
 	name = "lizard brain"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -481,6 +481,17 @@
 /obj/item/organ/brain/felinid //A bit smaller than average
 	brain_size = 0.8
 
+// Sometimes, felinids go a bit haywire and bite people. Based entirely on mania and hunger.
+/obj/item/organ/brain/felinid/get_attacking_limb(mob/living/carbon/human/target)
+	if(owner.mob_mood)
+		var/starving_cat_bonus = owner.nutrition <= NUTRITION_LEVEL_HUNGRY ? 1 : 10
+		var/crazy_feral_cat = clamp((starving_cat_bonus * owner.mob_mood.sanity_level), 0, 100)
+		if(prob(crazy_feral_cat))
+			var/obj/item/bodypart/crazy_feral_cat_brain_container = owner.get_bodypart(BODY_ZONE_HEAD)
+			if(crazy_feral_cat_brain_container)
+				return crazy_feral_cat_brain_container
+	. = ..()
+
 /obj/item/organ/brain/lizard
 	name = "lizard brain"
 	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -975,7 +975,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			target.force_say()
 		log_combat(user, target, "punched")
 
-	if(biting && target.mob_biotypes & MOB_ORGANIC) //Good for you. You probably just ate someone alive.
+	if(biting && (target.mob_biotypes & MOB_ORGANIC)) //Good for you. You probably just ate someone alive.
 		var/datum/reagents/tasty_meal = new()
 		tasty_meal.add_reagent(/datum/reagent/consumable/nutriment/protein, round(damage/3, 1))
 		tasty_meal.trans_to(user, tasty_meal.total_volume, transferred_by = user, methods = INGEST)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -850,13 +850,21 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		attacking_bodypart = brain.get_attacking_limb(target)
 	if(!attacking_bodypart)
 		attacking_bodypart = user.get_active_hand()
+
+	// Whether or not we get some protein for a successful attack. Nom.
+	var/biting = FALSE
+
 	var/atk_verb = pick(attacking_bodypart.unarmed_attack_verbs)
 	var/atk_effect = attacking_bodypart.unarmed_attack_effect
 
 	if(atk_effect == ATTACK_EFFECT_BITE)
-		if(user.is_mouth_covered(ITEM_SLOT_MASK))
-			to_chat(user, span_warning("You can't [atk_verb] with your mouth covered!"))
-			return FALSE
+		if(user.is_mouth_covered(ITEM_SLOT_MASK)) //In the event we can't bite, emergency swap to attacking hand.
+			attacking_bodypart = user.get_active_hand()
+			atk_verb = pick(attacking_bodypart.unarmed_attack_verbs)
+			atk_effect = attacking_bodypart.unarmed_attack_effect
+		else
+			biting = TRUE
+
 	user.do_attack_animation(target, atk_effect)
 
 	//has our target been shoved recently? If so, they're staggered and we get an easy hit.
@@ -867,6 +875,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	var/damage = rand(attacking_bodypart.unarmed_damage_low, attacking_bodypart.unarmed_damage_high)
 	var/limb_accuracy = attacking_bodypart.unarmed_effectiveness
+	var/limb_sharpness = attacking_bodypart.unarmed_sharpness
 
 	if(grappled)
 		var/pummel_bonus = attacking_bodypart.unarmed_pummeling_bonus
@@ -956,14 +965,17 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			target.force_say()
 		log_combat(user, target, grappled ? "grapple punched" : "kicked")
 		final_armor_block -= limb_accuracy
-		target.apply_damage(damage, attack_type, affecting, final_armor_block, attack_direction = attack_direction)
+		target.apply_damage(damage, attack_type, affecting, final_armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
 	else // Normal attacks do not gain the benefit of armor penetration.
-		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction)
+		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
 		if(damage >= 9)
 			target.force_say()
 		log_combat(user, target, "punched")
 
-	SEND_SIGNAL(target, COMSIG_HUMAN_GOT_PUNCHED, user, damage, attack_type, affecting, final_armor_block, kicking)
+	if(biting && target.mob_biotypes & MOB_ORGANIC) //Good for you. You probably just ate someone alive.
+		user.reagents.add_reagent(/datum/reagent/consumable/nutriment/protein, round(damage/3, 1))
+
+	SEND_SIGNAL(target, COMSIG_HUMAN_GOT_PUNCHED, user, damage, attack_type, affecting, final_armor_block, kicking, limb_sharpness)
 
 	// If our target is staggered and has sustained enough damage, we can apply a randomly determined status effect to inflict when we punch them.
 	// The effects are based on the punching effectiveness of our attacker. Some effects are not reachable by the average human, and require augmentation to reach or being a species with a heavy punch effectiveness.

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -262,6 +262,12 @@
 			SPECIES_PERK_NAME = "Hydrophobia",
 			SPECIES_PERK_DESC = "Felinids don't like getting soaked with water.",
 		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+			SPECIES_PERK_ICON = FA_ICON_ANGRY,
+			SPECIES_PERK_NAME = "'Fight or Flight' Defense Response",
+			SPECIES_PERK_DESC = "Felinids who become mentally unstable (and deprived of food) exhibit an \
+				extreme 'fight or flight' response against aggressors. They sometimes bite people. Violently.",
+		),
 	)
-
 	return to_add

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -186,6 +186,8 @@
 	var/unarmed_effectiveness = 10
 	/// Multiplier applied to effectiveness and damage when attacking a grabbed target.
 	var/unarmed_pummeling_bonus = 1
+	/// The 'sharpness' of the limb. Could indicate claws, teeth or spines. Should default to NONE, or blunt.
+	var/unarmed_sharpness = NONE
 
 	/// Traits that are given to the holder of the part. This does not update automatically on life(), only when the organs are initially generated or inserted!
 	var/list/bodypart_traits = list()

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -405,7 +405,7 @@
 	return span_boldwarning("Your stomach cramps in pain!")
 
 /// If damage is high enough, we may end up vomiting out whatever we had stored
-/obj/item/organ/stomach/proc/on_punched(datum/source, mob/living/carbon/human/attacker, damage, attack_type, obj/item/bodypart/affecting, final_armor_block, kicking)
+/obj/item/organ/stomach/proc/on_punched(datum/source, mob/living/carbon/human/attacker, damage, attack_type, obj/item/bodypart/affecting, final_armor_block, kicking, limb_sharpness)
 	SIGNAL_HANDLER
 	if (!length(stomach_contents) || damage < 9 || final_armor_block || kicking)
 		return

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -610,12 +610,28 @@
 
 /obj/item/organ/tongue/cat
 	name = "felinid tongue"
-	desc = "A fleshy muscle mostly used for meowing."
+	desc = "A fleshy muscle mostly used for meowing. Or biting."
 	say_mod = "meows"
 	liked_foodtypes = SEAFOOD | ORANGES | BUGS | GORE
 	disliked_foodtypes = GROSS | CLOTH | RAW
 	organ_traits = list(TRAIT_WOUND_LICKER, TRAIT_FISH_EATER)
 	languages_native = list(/datum/language/nekomimetic)
+
+/obj/item/organ/tongue/cat/on_bodypart_insert(obj/item/bodypart/head)
+	. = ..()
+	head.unarmed_damage_low += 5
+	head.unarmed_damage_high += 10
+	head.unarmed_effectiveness += 10
+	head.unarmed_attack_effect = ATTACK_EFFECT_BITE
+	head.unarmed_sharpness = SHARP_EDGED
+
+/obj/item/organ/tongue/cat/on_bodypart_remove(obj/item/bodypart/head)
+	. = ..()
+	head.unarmed_damage_low -= 5
+	head.unarmed_damage_high -= 10
+	head.unarmed_effectiveness -= 10
+	head.unarmed_attack_effect = initial(head.unarmed_attack_effect)
+	head.unarmed_sharpness = initial(head.unarmed_sharpness)
 
 /obj/item/organ/tongue/jelly
 	name = "jelly tongue"


### PR DESCRIPTION
## About The Pull Request

Felinids have an increasing potential to bite you instead of punch you based on whether or not they're hungry, and how insane they are. The more insane, the more likely they are to bite.

Sometimes they bite anyway.

Will this matter at all? Probably not.

Also adds a minor buff to carp teeth and makes their teeth pointy.

## Why It's Good For The Game

We were joking about felinids biting people and I thought it was funny to make it a felinid problem they deal with when things are going bad for them. It is unlikely to be something that can be actively exploited, since it needs you to be suffering from two debuffs to occur with any amount of frequency to be noticeable. But the idea of a felinid that has been going through enough shit to snap and just maul someone is funny as hell. ~~As well as maybe give some IC reason as to why people don't like felinids beyond just being cat people.~~

## Changelog
:cl:
add: Felinids, when sufficiently manic and starving, will sometimes take a chunk out of their fellow spessman. With their teeth.
balance: Carp-infused mutants have pointy teeth.
/:cl:
