### PR TITLE
Fix map linter conditional rule crashing

### DIFF
--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -235,8 +235,8 @@ class WhenCondition(ConditionalRule):
                 # If something is a float (number), check it as an int and a float
                 # Hack for integer value parsing
                 if var_edits[var_name] % 1 == 0:
-                    return str(int(var_edits[var_name])).strip() != expected_value.strip()
-            return str(var_edits[var_name]).strip() != expected_value.strip()
+                    return str(int(var_edits[var_name])).strip() != unexpected_value.strip()
+            return str(var_edits[var_name]).strip() != unexpected_value.strip()
 
         elif self.match_like is not None:
             var_name = self.match_like.group(1)


### PR DESCRIPTION

## About The Pull Request
Our maplint README.md says:

```
The following conditions are valid:
- **{var_name} is set**: The variable named *var_name* has been modified.
- **{var_name} is not set**: The variable named *var_name* has not been modified.
- **{var_name} is '{value}'**: The variable named *var_name* has a specific value.
- **{var_name} is not '{value}'**: The variable named *var_name* does not have a specific value.
- **{var_name} like '{regex}'**: The variable named *var_name* matches the provided regex.
```

Yet when you try to use the `**{var_name} is not '{value}'**` rule it crashes. This was never caught because it was not used anywhere. The fix is really simple since someone c/p the same var without renaming it.

## Why It's Good For The Game
Map linter rules work now.

## Changelog
:cl:
fix: Fix map linter conditional rule crashing
/:cl:
