### PR TITLE
Increases Tank suicide gib threshold from 1000 to 1266

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -192,7 +192,7 @@
 	var/mob/living/carbon/human/human_user = user
 	user.visible_message(span_suicide("[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
-	if(!QDELETED(human_user) && air_contents && air_contents.return_pressure() >= 1000)
+	if(!QDELETED(human_user) && air_contents && air_contents.return_pressure() >= 1266)
 		ADD_TRAIT(human_user, TRAIT_DISFIGURED, TRAIT_GENERIC)
 		human_user.inflate_gib()
 		return MANUAL_SUICIDE

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -4,6 +4,8 @@
 #define ASSEMBLY_BOMB_COEFFICIENT 0.5
 /// Base of the logarithmic function used to calculate assembly bomb explosion size
 #define ASSEMBLY_BOMB_BASE 2.7
+/// Threshold pressure thats required to suicide gib with tanks
+#define TANK_PRESSURE_THRESHOLD 1266
 
 /**
  * # Gas Tank
@@ -192,7 +194,7 @@
 	var/mob/living/carbon/human/human_user = user
 	user.visible_message(span_suicide("[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
-	if(!QDELETED(human_user) && air_contents && air_contents.return_pressure() >= 1266)
+	if(!QDELETED(human_user) && air_contents && air_contents.return_pressure() >= TANK_PRESSURE_THRESHOLD)
 		ADD_TRAIT(human_user, TRAIT_DISFIGURED, TRAIT_GENERIC)
 		human_user.inflate_gib()
 		return MANUAL_SUICIDE
@@ -576,3 +578,4 @@
 #undef ASSEMBLY_BOMB_BASE
 #undef ASSEMBLY_BOMB_COEFFICIENT
 #undef ASSUME_AIR_DT_FACTOR
+#undef TANK_PRESSURE_THRESHOLD


### PR DESCRIPTION
## About The Pull Request
This PR increases the pressure threshold required for gibbing yourself from 1000 to 1266
(Which means you can't suicide with the roundstart internals anymore since they start at 1013)

## Why It's Good For The Game

Everyone having a way to gib themself in their emergency box isn't nice this was already technically added in 
https://github.com/tgstation/tgstation/pull/26597 but got washed out when oxygen tanks capicity got increased.

Everyone having a confident roundstart option to tank suicide is bad since it can be used to game around mechanics like cucking a heretic from being able to sacrafice you or other things that might require your body intact and this will make it atleast require a active choice making you fill the tank to the threshold value to be able to gib you (like how it used to work in the past with the very same intention) but since basic volumes got increased this got removed.

And it makes gibbings (which should be rare) way too common

## Changelog
:cl: Ezel
fix: Oxygen tanks don't gib anymore at the starting pressure unless they're filled more then halfway full
/:cl:
