### PR TITLE
Punctuation cleaning for diamond statues

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -165,15 +165,15 @@
 	abstract_type = /obj/structure/statue/diamond
 
 /obj/structure/statue/diamond/captain
-	name = "statue of THE captain."
+	name = "statue of THE captain"
 	icon_state = "cap"
 
 /obj/structure/statue/diamond/ai1
-	name = "statue of the AI hologram."
+	name = "statue of the AI hologram"
 	icon_state = "ai1"
 
 /obj/structure/statue/diamond/ai2
-	name = "statue of the AI core."
+	name = "statue of the AI core"
 	icon_state = "ai2"
 
 ////////////////////////bananium///////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request

Removes some punctuation at the end of the diamond material statues.
## Why It's Good For The Game

It looks weird and is inconsistent with like, everything else in the game.
## Changelog
:cl: Rhials
spellcheck: Diamond material statue names are no longer punctuated.
/:cl:
