### PR TITLE
Fix cleaning mobs not cleaning all their equipment

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1139,7 +1139,7 @@
 			continue
 		if(!(covered & slot))
 			// /obj/item/wash() already updates our clothing slot
-			. ||= worn.wash(clean_types)
+			. = worn.wash(clean_types) || .
 
 /// if any of our bodyparts are bleeding
 /mob/living/carbon/proc/is_bleeding()


### PR DESCRIPTION
## About The Pull Request

`. ||= wash` = Only wash if `.` is not `TRUE`. Very funny

## Changelog

:cl: Melbert
fix: Cleaning a mob cleans all of their equipment again
/:cl:
