### PR TITLE
Removes redundant vars from custom shuttle consoles + spawned custom shuttle consoles can be disassembled

### DIFF
--- a/code/modules/shuttle/mobile_port/variants/custom/custom_consoles.dm
+++ b/code/modules/shuttle/mobile_port/variants/custom/custom_consoles.dm
@@ -1,12 +1,8 @@
 /obj/machinery/computer/shuttle/custom_shuttle
 	desc = "A shuttle control computer."
-	icon_screen = "shuttle"
-	icon_keyboard = "tech_key"
 	shuttleId = ""
-	light_color = LIGHT_COLOR_CYAN
-	req_access = list()
-	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON
 	possible_destinations = "whiteship_home;"
+	circuit = /obj/item/circuitboard/computer/shuttle/flight_control
 	var/static/list/connections = list(COMSIG_TURF_ADDED_TO_SHUTTLE = PROC_REF(on_loc_added_to_shuttle))
 
 /obj/machinery/computer/shuttle/custom_shuttle/on_construction(mob/user)


### PR DESCRIPTION
## About The Pull Request

Removes some redundant var definitions from the custom shuttle flight console.
Also defines the circuit var for custom shuttle flight consoles, allowing maploaded/adminspawned instances of them to be disassembled.

## Why It's Good For The Game

Cutting down on redundant definitions is generally a good thing.
Also makes maploaded/adminspawned shuttle consoles work like the constructed ones.

## Changelog

Redundant definition removal isn't a player-facing change.

:cl:
fix: If you find a custom shuttle flight control console that was created by an admin or loaded as part of the map, you can dismantle it with a screwdriver.
/:cl:
