### PR TITLE
Add thermal regulator module to mining vendor

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -125,6 +125,6 @@
 	cost_per_order = 3000
 
 /datum/orderable_item/mining/mod_thermal
-    purchase_path = /obj/item/mod/module/thermal_regulator
-    desc = "A MODsuit module that helps regulate the user's body temperature in extreme environments."
-    cost_per_order = 1200
+	purchase_path = /obj/item/mod/module/thermal_regulator
+	desc = "A MODsuit module that helps regulate the user's body temperature in extreme environments."
+	cost_per_order = 1200

--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -123,3 +123,8 @@
 /datum/orderable_item/mining/grapple_gun
 	purchase_path = /obj/item/grapple_gun
 	cost_per_order = 3000
+
+/datum/orderable_item/mining/mod_thermal
+    purchase_path = /obj/item/mod/module/thermal_regulator
+    desc = "A MODsuit module that helps regulate the user's body temperature in extreme environments."
+    cost_per_order = 1200


### PR DESCRIPTION
## About The Pull Request
Adds the MOD thermal regulator module to the mining equipment vendor for 780 points (1200 points if using express) to help regulate thermal levels for miners on Icebox and space mining. It's neat and fun, making it easy for miners to grab if they don't want to wait for it to be researched and sent to robotics for printing. After all, if PKA upgrades can be researched and printed for free, there are still options to buy them from the mining vendor.

![image](https://github.com/user-attachments/assets/f24e9639-2f16-4a7d-99d3-00da13b7889f)


## Why It's Good For The Game
- Provides temperature protection for miners should they want to use it in icebox or go space mining

## Changelog
:cl:
add: Adds MOD thermal regulator module to mining vendor
/:cl: