### PR TITLE
Puts a gas mixer infront every gas chamber in atmos

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -11917,7 +11917,8 @@
 /area/station/security/checkpoint/medical/medsci)
 "cSr" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
-	color = "#FFFF00"
+	color = "#FFFF00";
+	name = "n2 mixer"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -12663,6 +12664,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"dcu" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	name = "co2 mixer"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dcz" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -44560,8 +44568,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/break_room)
 "lcA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	name = "no2 mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -75181,8 +75190,9 @@
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
 "sLV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	name = "o2 mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -91737,6 +91747,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"wSK" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	name = "air mixer"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wSR" = (
 /turf/closed/wall,
 /area/station/maintenance/disposal/incinerator)
@@ -119549,11 +119566,11 @@ iMf
 iMf
 iVz
 iMf
-lcA
+wSK
 hgs
 jXN
 sXb
-lcA
+dcu
 ltD
 iMf
 qJb

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -26809,6 +26809,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
+"hDS" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "nitrogen mixer"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hDU" = (
 /turf/closed/wall/r_wall,
 /area/station/command/gateway)
@@ -43564,8 +43572,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/command/storage/eva)
 "mvG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 1;
+	name = "co2 mixer";
+	color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -61716,7 +61726,8 @@
 "ruw" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
-	name = "plasma mixer"
+	name = "plasma mixer";
+	color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -62149,8 +62160,10 @@
 /turf/open/floor/plating,
 /area/station/commons/dorms/laundry)
 "rBQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "o2 mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -70377,6 +70390,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
+"tTB" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 4;
+	color = "#FFFF00";
+	name = "no2 mixer"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tTK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -249032,7 +249053,7 @@ cEw
 woc
 fwq
 hHN
-lRR
+hDS
 bpR
 skx
 gkY
@@ -250563,7 +250584,7 @@ aSe
 kFH
 aen
 hIA
-rBQ
+tTB
 fQc
 fQc
 noY

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5845,7 +5845,9 @@
 /area/station/medical/virology)
 "ccK" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 4
+	color = "#FFFF00";
+	dir = 4;
+	name = "plasma mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -8361,10 +8363,6 @@
 "daC" = (
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"daT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "dbh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21959,7 +21957,11 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "hTq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "no2 mixer"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hTE" = (
@@ -30082,9 +30084,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "kEe" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "air mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -38873,6 +38876,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"nMO" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Outlet Pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42968,10 +42978,7 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "plD" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Pure to Mix"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pma" = (
@@ -46264,8 +46271,10 @@
 /turf/open/floor/carpet,
 /area/station/command/corporate_showroom)
 "qua" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "oxygen mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -60451,8 +60460,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "vmx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "nitrogen mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -67615,6 +67626,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"xLX" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	color = "#FFFF00";
+	dir = 4;
+	name = "co2 mixer"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xMl" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=15-Court";
@@ -114434,7 +114453,7 @@ jms
 sCW
 fzM
 sCW
-qua
+xLX
 hnn
 kBh
 qKR
@@ -116488,8 +116507,8 @@ kgV
 hed
 jgt
 jZz
-jaq
-daT
+nnD
+cyW
 hTq
 dnW
 kBh
@@ -116745,8 +116764,8 @@ boD
 qwi
 jvj
 pul
-cyW
-cyW
+jaq
+nMO
 plD
 hyD
 oIM


### PR DESCRIPTION
## About The Pull Request

Puts a mixer infront every gas chamber like this
![image](https://github.com/user-attachments/assets/133d5c20-b257-41b5-9ba0-113f97fd4082)


## Why It's Good For The Game
Atmos core job content is mixing gasses and making their own the mixers will support this easier will still retaining normal functionality

## Changelog

:cl: ezel
map: Theres now a gas mixer infront every atmos gas chamber
/:cl: