### PR TITLE
Non-abductors can yet again NOT use abductor batons

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -379,7 +379,7 @@ Return to step 11 of normal process."}
 
 /obj/item/melee/baton/abductor/can_baton(mob/living/target, mob/living/user)
 	if(!AbductorCheck(user))
-		return TRUE
+		return FALSE
 	return ..()
 
 /obj/item/melee/baton/abductor/baton_effect(mob/living/target, mob/living/user, modifiers, stun_override)


### PR DESCRIPTION
## About The Pull Request
Title. A proc returned TRUE instead of FALSE.

## Why It's Good For The Game
Easy fix.

## Changelog

:cl:
fix: Non-abductors can yet again NOT use abductor batons.
/:cl:
