### PR TITLE
Adds ability to exclude air vent's and scrubber's setting from being changed by switching air alarm modes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -120,9 +120,13 @@
 
 	/// List of all air vents in the area
 	var/list/obj/machinery/atmospherics/components/unary/vent_pump/air_vents = list()
+	/// List of air vents in the area, that shouldn't be touched by air alarm modes
+	var/list/obj/machinery/atmospherics/components/unary/vent_pump/excluded_vents = list()
 
 	/// List of all air scrubbers in the area
 	var/list/obj/machinery/atmospherics/components/unary/vent_scrubber/air_scrubbers = list()
+	/// List of air scrubbers in the area, that shouldn't be touched by air alarm modes
+	var/list/obj/machinery/atmospherics/components/unary/vent_scrubber/excluded_scrubbers = list()
 
 	/// Are shuttles allowed to dock in this area
 	var/allow_shuttle_docking = FALSE
@@ -367,7 +371,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	//atmos cleanup
 	firealarms = null
 	air_vents = null
+	excluded_vents = null
 	air_scrubbers = null
+	excluded_scrubbers = null
 	//turf cleanup
 	turfs_by_zlevel = null
 	turfs_to_uncontain_by_zlevel = null

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -326,7 +326,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 				"external" = vent.external_pressure_bound,
 				"internal" = vent.internal_pressure_bound,
 				"extdefault" = (vent.external_pressure_bound == ONE_ATMOSPHERE),
-				"intdefault" = (vent.internal_pressure_bound == 0)
+				"intdefault" = (vent.internal_pressure_bound == 0),
+				"allow_automation" = !(vent in my_area.excluded_vents),
 			))
 		data["scrubbers"] = list()
 		for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in my_area.air_scrubbers)
@@ -341,6 +342,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 				"scrubbing" = scrubber.scrubbing,
 				"widenet" = scrubber.widenet,
 				"filter_types" = filter_types,
+				"allow_automation" = !(scrubber in my_area.excluded_scrubbers),
 			))
 
 		data["selectedModePath"] = selected_mode.type
@@ -473,6 +475,15 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 				return TRUE
 
 			scrubber.toggle_filters(params["val"])
+		if ("automation")
+			if (!isnull(vent))
+				vent.toggle_automation()
+				return TRUE
+
+			if (!isnull(scrubber))
+				scrubber.toggle_automation()
+				return TRUE
+
 		if ("mode")
 			select_mode(user, text2path(params["mode"]))
 			investigate_log("was turned to [selected_mode.name] mode by [key_name(user)]", INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
@@ -37,14 +37,14 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = FALSE
 
 /datum/air_alarm_mode/filtering/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = ATMOS_EXTERNAL_BOUND
 		vent.external_pressure_bound = ONE_ATMOSPHERE
 		vent.pump_direction = ATMOS_DIRECTION_RELEASING
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.filter_types = list(/datum/gas/carbon_dioxide)
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SCRUBBING)
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = FALSE
 
 /datum/air_alarm_mode/contaminated/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = ATMOS_EXTERNAL_BOUND
 		vent.external_pressure_bound = ONE_ATMOSPHERE
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 
 	var/list/filtered = subtypesof(/datum/gas)
 	filtered -= list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/pluoxium)
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.filter_types = filtered.Copy()
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SCRUBBING)
@@ -77,14 +77,14 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = FALSE
 
 /datum/air_alarm_mode/draught/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = ATMOS_EXTERNAL_BOUND
 		vent.external_pressure_bound = ONE_ATMOSPHERE * 2
 		vent.pump_direction = ATMOS_DIRECTION_RELEASING
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.set_widenet(FALSE)
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SIPHONING)
@@ -95,14 +95,14 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = TRUE
 
 /datum/air_alarm_mode/refill/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = ATMOS_EXTERNAL_BOUND
 		vent.external_pressure_bound = ONE_ATMOSPHERE * 3
 		vent.pump_direction = ATMOS_DIRECTION_RELEASING
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 
 		scrubber.filter_types = list(/datum/gas/carbon_dioxide)
@@ -116,11 +116,11 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 
 /// Same as [/datum/air_alarm_mode/siphon/apply]
 /datum/air_alarm_mode/cycle/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = FALSE
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.set_widenet(TRUE)
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SIPHONING)
@@ -131,14 +131,14 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	if(pressure >= ONE_ATMOSPHERE * 0.05)
 		return
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = ATMOS_EXTERNAL_BOUND
 		vent.external_pressure_bound = ONE_ATMOSPHERE
 		vent.pump_direction = ATMOS_DIRECTION_RELEASING
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.filter_types = list(/datum/gas/carbon_dioxide)
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SCRUBBING)
@@ -150,11 +150,11 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = TRUE
 
 /datum/air_alarm_mode/siphon/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = FALSE
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.set_widenet(FALSE)
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SIPHONING)
@@ -165,11 +165,11 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = TRUE
 
 /datum/air_alarm_mode/panic_siphon/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = FALSE
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = TRUE
 		scrubber.set_widenet(TRUE)
 		scrubber.set_scrubbing(ATMOS_DIRECTION_SIPHONING)
@@ -180,11 +180,11 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	danger = FALSE
 
 /datum/air_alarm_mode/off/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = FALSE
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = FALSE
 		scrubber.update_appearance(UPDATE_ICON)
 
@@ -195,14 +195,14 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	emag = TRUE
 
 /datum/air_alarm_mode/flood/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = ATMOS_INTERNAL_BOUND
 		vent.internal_pressure_bound = 0
 		vent.pump_direction = ATMOS_DIRECTION_RELEASING
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = FALSE
 		scrubber.update_appearance(UPDATE_ICON)
 
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	emag = TRUE // siphoning things with vents can horribly fuck up distro, even if its surprisingly fast
 
 /datum/air_alarm_mode/vent_siphon/apply(area/applied)
-	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
+	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in (applied.air_vents - applied.excluded_vents))
 		vent.on = TRUE
 		vent.pressure_checks = NONE
 		vent.internal_pressure_bound = 0
@@ -221,6 +221,6 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 		vent.pump_direction = ATMOS_DIRECTION_SIPHONING
 		vent.update_appearance(UPDATE_ICON)
 
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)
+	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in (applied.air_scrubbers - applied.excluded_scrubbers))
 		scrubber.on = FALSE
 		scrubber.update_appearance(UPDATE_ICON)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -169,8 +169,19 @@
 	//you cannot unassign from an area we never were assigned to
 	if(isnull(target_area) || assigned_area != target_area)
 		return
+	if(src in assigned_area.excluded_vents)
+		assigned_area.excluded_vents -= src
 	assigned_area.air_vents -= src
 	assigned_area = null
+
+/obj/machinery/atmospherics/components/unary/vent_pump/proc/toggle_automation()
+	var/area/target_area = get_area(src)
+	if(isnull(target_area) || assigned_area != target_area)
+		return
+	if(src in assigned_area.excluded_vents)
+		assigned_area.excluded_vents -= src
+		return
+	assigned_area.excluded_vents += src
 
 /obj/machinery/atmospherics/components/unary/vent_pump/on_exit_area(datum/source, area/area_to_unregister)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -169,8 +169,7 @@
 	//you cannot unassign from an area we never were assigned to
 	if(isnull(target_area) || assigned_area != target_area)
 		return
-	if(src in assigned_area.excluded_vents)
-		assigned_area.excluded_vents -= src
+	assigned_area.excluded_vents -= src
 	assigned_area.air_vents -= src
 	assigned_area = null
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -79,8 +79,19 @@
 	//you cannot unassign from an area we never were assigned to
 	if(isnull(target_area) || assigned_area != target_area)
 		return
+	if(src in assigned_area.excluded_scrubbers)
+		assigned_area.excluded_scrubbers -= src
 	assigned_area.air_scrubbers -= src
 	assigned_area = null
+
+/obj/machinery/atmospherics/components/unary/vent_scrubber/proc/toggle_automation()
+	var/area/target_area = get_area(src)
+	if(isnull(target_area) || assigned_area != target_area)
+		return
+	if(src in assigned_area.excluded_scrubbers)
+		assigned_area.excluded_scrubbers -= src
+		return
+	assigned_area.excluded_scrubbers += src
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on_exit_area(datum/source, area/area_to_unregister)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -79,8 +79,7 @@
 	//you cannot unassign from an area we never were assigned to
 	if(isnull(target_area) || assigned_area != target_area)
 		return
-	if(src in assigned_area.excluded_scrubbers)
-		assigned_area.excluded_scrubbers -= src
+	assigned_area.excluded_scrubbers -= src
 	assigned_area.air_scrubbers -= src
 	assigned_area = null
 

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
@@ -24,6 +24,7 @@ export type VentProps = {
   internal: number;
   extdefault: number;
   intdefault: number;
+  allow_automation: BooleanLike;
 };
 
 export type ScrubberProps = {
@@ -32,6 +33,7 @@ export type ScrubberProps = {
   power: BooleanLike;
   scrubbing: BooleanLike;
   widenet: BooleanLike;
+  allow_automation: BooleanLike;
   filter_types: {
     gas_id: string;
     gas_name: string;
@@ -55,6 +57,7 @@ export const Vent = (props: VentProps) => {
     internal,
     extdefault,
     intdefault,
+    allow_automation,
   } = props;
   return (
     <Section
@@ -70,6 +73,16 @@ export const Vent = (props: VentProps) => {
               act('power', {
                 ref: refID,
                 val: Number(!power),
+              })
+            }
+          />
+          <Button
+            icon={allow_automation ? 'check-square-o' : 'square-o'}
+            selected={allow_automation}
+            tooltip={`${allow_automation ? 'Disable' : 'Enable'} mode automation`}
+            onClick={() =>
+              act('automation', {
+                ref: refID,
               })
             }
           />
@@ -197,22 +210,42 @@ export const Vent = (props: VentProps) => {
 
 export const Scrubber = (props: ScrubberProps) => {
   const { act } = useBackend();
-  const { long_name, power, scrubbing, refID, widenet, filter_types } = props;
+  const {
+    long_name,
+    power,
+    scrubbing,
+    refID,
+    widenet,
+    allow_automation,
+    filter_types,
+  } = props;
   return (
     <Section
       title={decodeHtmlEntities(long_name)}
       buttons={
-        <Button
-          icon={power ? 'power-off' : 'times'}
-          content={power ? 'On' : 'Off'}
-          selected={power}
-          onClick={() =>
-            act('power', {
-              ref: refID,
-              val: Number(!power),
-            })
-          }
-        />
+        <>
+          <Button
+            icon={power ? 'power-off' : 'times'}
+            content={power ? 'On' : 'Off'}
+            selected={power}
+            onClick={() =>
+              act('power', {
+                ref: refID,
+                val: Number(!power),
+              })
+            }
+          />
+          <Button
+            icon={allow_automation ? 'check-square-o' : 'square-o'}
+            selected={allow_automation}
+            tooltip={`${allow_automation ? 'Disable' : 'Enable'} mode automation`}
+            onClick={() =>
+              act('automation', {
+                ref: refID,
+              })
+            }
+          />
+        </>
       }
     >
       <LabeledList>


### PR DESCRIPTION

## About The Pull Request
Just adds a small button near the power one upon pressing on which component in question will be excluded from air alarm automation. Helpful for custom synthesis chambers and whatsnot to prevent gases flowing where they dont supposed to be.

![image](https://github.com/user-attachments/assets/68553359-8365-4809-86d4-6f43d084c2a7)

![image](https://github.com/user-attachments/assets/16d7217b-647c-43d2-b5ab-80693d976c10)
## Why It's Good For The Game
Its always sucks to get a leak in atmos, run towards the airalarm to turn the contaminated or some other mode and facepalm yourself afterward as your beautiful turf bz chamber now sucked every gas its not supposed to suck
## Changelog
:cl:
qol: Added ability to prevent atmos vents and scrubber settings from being touched by changing air alarm modes
/:cl:
