### PR TITLE
heavily change catwalk station science

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -201,6 +201,9 @@
 /obj/item/taperecorder,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "ade" = (
@@ -20157,7 +20160,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
+/obj/structure/disposalpipe/sorting,
 /turf/open/floor/iron,
 /area/station/science/research)
 "fZP" = (
@@ -22136,9 +22140,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "gEv" = (
@@ -38286,7 +38287,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/yjunction,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "ltW" = (
@@ -54165,7 +54168,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "qhE" = (
@@ -58106,6 +58111,9 @@
 "rrT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/sign/poster/official/work_for_a_future/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "rrY" = (
@@ -76726,6 +76734,9 @@
 /obj/item/disk/tech_disk{
 	pixel_x = 12
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/research)
 "wSW" = (
@@ -77017,7 +77028,6 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
-/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
 /turf/open/floor/engine,
 /area/station/science/lab)
 "wXD" = (
@@ -181102,7 +181112,7 @@ wEJ
 jLs
 jes
 mRE
-vsK
+orJ
 wSA
 tNP
 oEi
@@ -181359,7 +181369,7 @@ jJX
 jes
 jes
 bvT
-vsK
+orJ
 acV
 jkr
 qyM
@@ -181616,7 +181626,7 @@ cwP
 cwP
 xWT
 dTc
-vsK
+orJ
 rrT
 soU
 qSk

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -20924,13 +20924,6 @@
 "gkI" = (
 /obj/structure/sign/poster/official/safety_report/directional/south,
 /obj/effect/turf_decal/trimline/purple/end,
-/obj/item/pushbroom{
-	pixel_y = 10
-	},
-/obj/item/pushbroom,
-/obj/item/pushbroom{
-	pixel_y = 5
-	},
 /obj/structure/mop_bucket/janitorialcart,
 /turf/open/floor/plastic,
 /area/station/science/research)
@@ -23041,9 +23034,7 @@
 /area/station/maintenance/disposal/incinerator)
 "gRZ" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/textured,
 /area/station/science/robotics/augments)
 "gSg" = (
@@ -26353,6 +26344,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/welded,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "hPQ" = (
@@ -26426,13 +26418,6 @@
 /area/station/maintenance/disposal/incinerator)
 "hQD" = (
 /obj/machinery/holopad,
-/obj/item/pushbroom,
-/obj/item/pushbroom{
-	pixel_y = 5
-	},
-/obj/item/pushbroom{
-	pixel_y = 10
-	},
 /turf/open/floor/plastic,
 /area/station/science/research)
 "hQE" = (
@@ -36269,6 +36254,7 @@
 /obj/item/pushbroom{
 	pixel_y = 10
 	},
+/obj/structure/rack,
 /turf/open/floor/plastic,
 /area/station/science/research)
 "kMj" = (
@@ -54669,13 +54655,6 @@
 /area/station/medical/break_room)
 "qpy" = (
 /obj/effect/turf_decal/trimline/purple,
-/obj/item/pushbroom{
-	pixel_y = 5
-	},
-/obj/item/staff/broom{
-	pixel_y = 10
-	},
-/obj/item/pushbroom,
 /mob/living/basic/bot/cleanbot,
 /turf/open/floor/plastic,
 /area/station/science/research)
@@ -62897,7 +62876,9 @@
 "sOn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = s
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
@@ -70164,6 +70145,7 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/remains/human,
+/obj/structure/rack,
 /turf/open/floor/plastic,
 /area/station/science/research)
 "uVX" = (
@@ -71627,13 +71609,14 @@
 /obj/effect/turf_decal/trimline/purple/end{
 	dir = 1
 	},
-/obj/item/pushbroom,
+/obj/structure/rack,
+/obj/item/staff/broom{
+	pixel_y = 10
+	},
 /obj/item/pushbroom{
 	pixel_y = 5
 	},
-/obj/item/pushbroom{
-	pixel_y = 10
-	},
+/obj/item/pushbroom,
 /turf/open/floor/plastic,
 /area/station/science/research)
 "vrx" = (
@@ -182932,7 +182915,7 @@ aBO
 jLl
 orJ
 vsC
-lqg
+soU
 uVV
 kMb
 soU
@@ -183446,7 +183429,7 @@ qSk
 tuY
 pKA
 kny
-lqg
+soU
 vrw
 gkI
 soU
@@ -183704,8 +183687,8 @@ fpm
 iEq
 fpm
 arT
-fpm
-fpm
+vFA
+vFA
 arT
 arT
 arT

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -62877,7 +62877,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = s
+	dir = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -20161,7 +20161,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
-/obj/structure/disposalpipe/sorting,
+/obj/structure/disposalpipe/sorting/mail,
 /turf/open/floor/iron,
 /area/station/science/research)
 "fZP" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -5157,9 +5157,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "bEB" = (
@@ -5958,6 +5955,7 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics/lab)
 "bPW" = (
@@ -6743,9 +6741,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
@@ -12382,7 +12377,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
 "dKs" = (
-/obj/structure/disposalpipe/sorting/mail{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -13683,7 +13678,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ecw" = (
@@ -17419,9 +17413,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "fmj" = (
@@ -25484,7 +25479,9 @@
 "hDf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip,
+/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "hDg" = (
@@ -28770,14 +28767,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "iCa" = (
-/obj/effect/turf_decal/siding/purple{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "iCd" = (
 /obj/structure/table/reinforced,
@@ -29647,8 +29640,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "iNI" = (
@@ -35454,7 +35449,6 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "kxE" = (
@@ -36408,7 +36402,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
+/obj/structure/disposalpipe/junction{
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
@@ -38504,6 +38498,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "lys" = (
@@ -41284,7 +41279,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "mmN" = (
@@ -43942,7 +43936,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "nec" = (
@@ -48596,9 +48589,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2
-	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/iron,
 /area/station/science/research)
 "ozw" = (
@@ -52633,7 +52624,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/research,
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "pKp" = (
@@ -54000,7 +53990,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip,
+/obj/structure/disposalpipe/sorting/mail/flip,
+/obj/effect/mapping_helpers/mail_sorting/science/research,
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "qeG" = (
@@ -62876,9 +62867,7 @@
 "sOn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
@@ -69233,7 +69222,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "uHe" = (
@@ -70372,6 +70360,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "uZV" = (
@@ -70693,7 +70682,6 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "veS" = (
@@ -117132,7 +117120,7 @@ jFH
 jFH
 uGP
 kxo
-iCa
+idj
 lbe
 idj
 idj
@@ -117903,7 +117891,7 @@ akq
 tsJ
 viD
 hYO
-rrF
+iCa
 bEw
 rOk
 rrF

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -135,11 +135,14 @@
 /turf/closed/wall,
 /area/station/science/cytology)
 "abY" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/robotics)
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/lobby)
 "acl" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -187,12 +190,10 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/end{
 	dir = 8
 	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/misc/asteroid,
-/area/station/science/robotics)
+/area/station/science/lower)
 "acV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/table,
@@ -214,18 +215,7 @@
 /turf/open/openspace,
 /area/station/maintenance/hallway/abandoned_recreation)
 "adM" = (
-/obj/structure/table/glass,
-/obj/item/hand_labeler_refill{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/hand_labeler{
-	pixel_y = 13
-	},
-/obj/item/universal_scanner{
-	pixel_x = 7;
-	pixel_y = 6
-	},
+/obj/machinery/computer/rdconsole,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "adU" = (
@@ -516,7 +506,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "aiP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
@@ -1044,25 +1034,18 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "arv" = (
-/obj/structure/table,
-/obj/item/healthanalyzer{
-	pixel_x = -7;
-	pixel_y = 13
+/obj/structure/closet/crate/science{
+	name = "circuits crate"
 	},
-/obj/effect/turf_decal/tile/dark_blue/anticorner{
-	dir = 4
-	},
-/obj/item/clothing/mask/breath/medical{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/storage/belt/utility/full{
-	pixel_y = 1
-	},
-/turf/open/floor/iron/white/textured_corner{
-	dir = 8
-	},
-/area/station/science/robotics)
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit,
+/obj/item/compact_remote,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/hello_world,
+/obj/item/compact_remote,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "arw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1588,7 +1571,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "azT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
@@ -1640,7 +1623,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "aBl" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/large,
@@ -1713,7 +1696,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/iron,
 /area/station/science/research)
 "aBR" = (
@@ -1805,16 +1787,10 @@
 /area/station/medical/morgue)
 "aDF" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/turf/open/floor/engine,
+/area/station/science/lab)
 "aDI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
@@ -1863,7 +1839,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "aEO" = (
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
@@ -2078,7 +2054,7 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "aIE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -2518,7 +2494,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "aPg" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table,
@@ -2547,7 +2523,7 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "aPF" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -3121,7 +3097,6 @@
 "aYG" = (
 /obj/structure/table,
 /obj/machinery/recharger{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -3424,7 +3399,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "bdy" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3776,7 +3751,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "biZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3801,13 +3776,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bki" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/east{
-	req_access = list("robotics")
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/robotics)
+/area/station/science/lower)
 "bkt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
@@ -4012,7 +3983,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "bmQ" = (
 /obj/structure/musician/piano,
 /turf/open/floor/plating,
@@ -4873,12 +4844,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
 "bzs" = (
-/obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "bzB" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics)
@@ -5015,7 +4985,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/station/science/robotics)
+/area/station/science/lower)
 "bBy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5044,7 +5014,7 @@
 "bBV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/openspace,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "bCa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -5056,7 +5026,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "bCh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5191,7 +5161,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "bEB" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -5561,7 +5531,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "bJs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -5686,9 +5656,10 @@
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/fore)
 "bLh" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/obj/structure/lattice,
+/obj/machinery/door/window/left/directional/east,
+/turf/open/openspace,
+/area/station/command/heads_quarters/rd)
 "bLu" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/autoname/directional/east,
@@ -5898,8 +5869,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "bOO" = (
@@ -5965,15 +5936,30 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/surgery)
 "bPN" = (
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
+/obj/item/circuitboard/mecha/ripley/peripherals{
+	pixel_x = -3
+	},
+/obj/item/circuitboard/mecha/ripley/main{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/item/borg/upgrade/rename{
+	pixel_x = -14;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/utility/welding{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/clothing/glasses/welding,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "bPW" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -6586,7 +6572,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "bYT" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/random/structure/grille,
@@ -6616,7 +6602,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "bZm" = (
 /obj/machinery/door/airlock{
 	id_tag = "commissarydoor";
@@ -6762,9 +6748,9 @@
 	dir = 9
 	},
 /obj/machinery/camera/autoname/directional/east,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/fireaxecabinet/mechremoval/directional/east,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "cam" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch,
@@ -7243,9 +7229,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai)
 "chr" = (
-/obj/machinery/holopad,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "chu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7541,10 +7526,8 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "cmh" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/turf/open/openspace,
 /area/station/science/robotics/lab)
 "cmp" = (
 /obj/effect/turf_decal/siding/white/corner{
@@ -7665,8 +7648,7 @@
 "coP" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/large/style_2{
-	pixel_x = -29;
-	pixel_y = -12
+	pixel_x = -29
 	},
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
@@ -7765,8 +7747,7 @@
 	pixel_y = 5
 	},
 /obj/item/stack/sheet/iron/ten{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
@@ -8745,20 +8726,9 @@
 /area/station/cargo/storage)
 "cCX" = (
 /obj/structure/table/reinforced,
-/obj/item/circuitboard/mecha/ripley/peripherals{
-	pixel_x = -3
-	},
-/obj/item/circuitboard/mecha/ripley/main{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/obj/item/borg/upgrade/rename{
-	pixel_x = -14;
-	pixel_y = 10
-	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "cDf" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
@@ -8923,12 +8893,9 @@
 /turf/closed/wall,
 /area/station/science/ordnance/storage)
 "cFH" = (
-/obj/structure/transport/linear,
-/obj/effect/landmark/transport/transport_id{
-	specific_transport_id = "catwalk_robo"
-	},
-/turf/open/openspace,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/robotics)
 "cFL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Hall Maintenance Access"
@@ -9122,7 +9089,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "cIw" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -9539,20 +9506,11 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
 "cPz" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/turf/open/floor/engine,
+/area/station/science/lab)
 "cPH" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/item/wrench{
@@ -9576,9 +9534,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "cPY" = (
-/obj/machinery/door/airlock/research{
-	name = "Research and Development Lab"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9587,9 +9542,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Workshop"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "roboticsprivacy";
+	name = "Robotics Shutters"
+	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "cQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance,
@@ -9748,7 +9711,7 @@
 /obj/effect/turf_decal/siding/purple/corner,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "cSN" = (
 /obj/structure/table,
 /obj/item/clothing/head/utility/welding{
@@ -9961,10 +9924,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "cVE" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "cVG" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -10158,7 +10120,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
 	},
-/area/station/science/lab)
+/area/station/science/robotics)
 "cZh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -10182,6 +10144,7 @@
 /area/station/commons/storage/tools)
 "cZl" = (
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/lattice,
 /turf/open/openspace,
 /area/station/command/heads_quarters/rd)
 "cZo" = (
@@ -10286,7 +10249,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "dbw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -10556,7 +10519,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "dgB" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11563,7 +11526,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "dwb" = (
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
@@ -11862,7 +11825,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "dBm" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central)
@@ -12419,9 +12382,8 @@
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "dKt" = (
 /obj/structure/closet/crate/hydroponics{
 	name = "hydroponics supplies crate"
@@ -12514,11 +12476,10 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "dLs" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "dLy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12695,7 +12656,7 @@
 "dNW" = (
 /obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "dNZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -12835,7 +12796,7 @@
 "dQV" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "dRj" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard{
@@ -12868,7 +12829,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "dRo" = (
 /obj/effect/decal/cleanable/glitter/pink,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -12998,12 +12959,19 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/closet/crate/mod,
-/obj/item/mod/module/longfall,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "dTv" = (
 /obj/structure/table/reinforced,
+/obj/item/computer_disk{
+	pixel_y = 6
+	},
+/obj/item/computer_disk{
+	pixel_x = -6
+	},
+/obj/item/computer_disk{
+	pixel_x = 6
+	},
 /obj/machinery/newscaster/directional/east,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -13404,7 +13372,7 @@
 "dYB" = (
 /obj/machinery/computer/mechpad,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "dYN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -13412,7 +13380,7 @@
 /obj/effect/turf_decal/siding/purple,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "dYQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13542,13 +13510,10 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "eab" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "eaf" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/openspace,
@@ -13715,6 +13680,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ecw" = (
@@ -13746,18 +13712,8 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ecJ" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner/end,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "ecL" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -14227,7 +14183,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/station/science/robotics)
+/area/station/science/lower)
 "ekk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -14437,9 +14393,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "emR" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -14871,9 +14826,9 @@
 /turf/open/floor/plating,
 /area/station/security/detectives_office/private_investigators_office)
 "euD" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/science/robotics)
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "euG" = (
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
@@ -15038,7 +14993,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "exM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15127,13 +15082,17 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ezP" = (
-/obj/structure/training_machine,
 /obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 2
 	},
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/station/science/robotics/augments)
 "ezT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -16344,8 +16303,9 @@
 	},
 /obj/machinery/newscaster/directional/east,
 /obj/structure/disposalpipe/segment,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "eTS" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
@@ -16549,16 +16509,13 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/abandoned)
 "eXw" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/white/textured_half{
-	dir = 1
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 8
 	},
-/area/station/science/robotics)
+/turf/open/floor/iron,
+/area/station/science/lower)
 "eXF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -16862,7 +16819,7 @@
 	},
 /obj/structure/sign/directions/science/directional/south,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "fdl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17009,21 +16966,14 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "ffR" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ffT" = (
-/obj/structure/railing/corner/end/flip,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/turf/closed/wall,
+/area/station/science/lower)
 "fgb" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -17215,14 +17165,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fjf" = (
-/obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/disk/tech_disk{
-	pixel_x = -9;
-	pixel_y = 7
-	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "fji" = (
@@ -17356,6 +17302,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/universal_scanner{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/storage/box/shipping{
+	pixel_x = 4;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "fkH" = (
@@ -17462,7 +17420,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "fmj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -17760,18 +17718,9 @@
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "fqD" = (
-/obj/structure/table,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/effect/turf_decal/tile/dark_blue/anticorner,
-/obj/item/borg/upgrade/rename{
-	pixel_y = 14
-	},
-/turf/open/floor/iron/white/textured_corner{
-	dir = 1
-	},
-/area/station/science/robotics)
+/obj/machinery/module_duplicator,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "fqK" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -18035,16 +17984,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "fut" = (
-/obj/machinery/door/airlock/research{
-	name = "Testing Labs"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Workshop"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -18135,26 +18085,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "fwn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/assembly/flash/handheld{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/science/robotics/augments)
 "fwp" = (
-/obj/structure/table,
-/obj/item/disk/tech_disk{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/disk/tech_disk,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -10
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/openspace,
 /area/station/science/lab)
 "fwx" = (
 /obj/machinery/airalarm/directional/east,
@@ -18439,8 +18385,7 @@
 	dir = 8
 	},
 /obj/machinery/airlock_controller/incinerator_atmos{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -18791,7 +18736,7 @@
 	},
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "fFA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -18898,16 +18843,30 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
 "fGV" = (
-/obj/structure/rack,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/gloves,
-/obj/item/healthanalyzer,
-/obj/effect/turf_decal/tile/dark_blue/anticorner{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/white/textured_corner,
-/area/station/science/robotics)
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 13
+	},
+/obj/structure/table,
+/obj/item/stock_parts/servo,
+/obj/item/stock_parts/capacitor{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/capacitor{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/capacitor{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/turf/open/floor/iron,
+/area/station/science/lower)
 "fHc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -19511,15 +19470,15 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "fQI" = (
-/obj/structure/table,
 /obj/machinery/cell_charger{
 	pixel_y = 12
 	},
 /obj/item/stock_parts/power_store/cell/high,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "fQL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20071,18 +20030,15 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "fXN" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/airlock/research/glass{
-	name = "Robotics Workshop"
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "fXO" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -20267,8 +20223,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
+/obj/item/robot_suit,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "gaL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20384,10 +20342,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
 "gce" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "gcf" = (
@@ -20478,13 +20436,11 @@
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
 "gde" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "gdf" = (
@@ -20579,10 +20535,19 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "gfz" = (
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/machinery/shower/directional/west,
+/obj/structure/fluff/shower_drain,
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/machinery/door/window/left/directional/west{
+	name = "Shower"
+	},
+/turf/open/floor/noslip/tram{
+	color = "#52B4E9";
+	name = "high-traction tile"
+	},
+/area/station/science/robotics/augments)
 "gfC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20955,9 +20920,16 @@
 /area/station/security/lockers)
 "gkI" = (
 /obj/structure/sign/poster/official/safety_report/directional/south,
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/trimline/purple/end,
-/turf/open/floor/iron/white/textured,
+/obj/item/pushbroom{
+	pixel_y = 10
+	},
+/obj/item/pushbroom,
+/obj/item/pushbroom{
+	pixel_y = 5
+	},
+/obj/structure/mop_bucket/janitorialcart,
+/turf/open/floor/plastic,
 /area/station/science/research)
 "gkN" = (
 /obj/structure/closet/crate/trashcart/filled,
@@ -21433,8 +21405,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "grl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21526,7 +21499,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "gtt" = (
 /obj/structure/railing{
 	dir = 8
@@ -21954,11 +21927,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "gAd" = (
-/obj/structure/table,
 /obj/item/folder/white,
 /obj/structure/disposalpipe/segment,
+/obj/item/toy/crayon/spraycan/roboticist{
+	pixel_x = 10;
+	pixel_y = 20
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "gAf" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -22017,13 +21994,11 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/end{
 	dir = 4
 	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/misc/asteroid,
-/area/station/science/robotics)
+/area/station/science/lower)
 "gBp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -22316,13 +22291,11 @@
 /area/station/command/heads_quarters/cmo)
 "gGO" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/spawner/random/food_or_drink/donuts,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "gHa" = (
@@ -22589,7 +22562,7 @@
 "gLN" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "gLQ" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -22806,11 +22779,12 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "gPd" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/drone_dispenser,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/obj/structure/lattice,
+/obj/structure/musician/piano/unanchored{
+	name = "comedy piano"
+	},
+/turf/open/openspace,
+/area/station/command/heads_quarters/rd)
 "gPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23063,10 +23037,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "gRZ" = (
-/obj/effect/turf_decal/bot,
-/obj/item/robot_suit,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/science/robotics/augments)
 "gSg" = (
 /obj/structure/closet/secure_closet{
 	name = "contraband locker"
@@ -23618,6 +23591,17 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"hac" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/white/textured_corner{
+	dir = 4
+	},
+/area/station/science/robotics/augments)
 "hag" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/start/hangover,
@@ -24084,7 +24068,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "hhT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -24195,14 +24179,21 @@
 /turf/open/openspace,
 /area/station/commons/fitness/recreation)
 "hkD" = (
-/obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = 14;
 	pixel_y = 8
 	},
 /obj/item/pen,
+/obj/item/storage/belt/utility/full/engi{
+	pixel_y = 4
+	},
+/obj/item/multitool{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "hkM" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -24234,16 +24225,11 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "hlg" = (
-/obj/structure/table,
-/obj/item/stock_parts/matter_bin{
-	pixel_y = 9
+/obj/item/surgery_tray/full/deployed,
+/turf/open/floor/iron/white/textured_corner{
+	dir = 8
 	},
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics/augments)
 "hlh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/filingcabinet,
@@ -24622,14 +24608,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/chair/sofa/right/brown{
+/obj/machinery/light/warm/directional/east,
+/obj/machinery/camera/autoname/directional/east,
+/obj/structure/chair/sofa/middle/brown{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
-/obj/effect/landmark/start/roboticist,
-/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "hqz" = (
 /turf/closed/wall,
 /area/station/medical/abandoned)
@@ -24714,9 +24699,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
 "hsx" = (
-/obj/effect/landmark/start/roboticist,
-/turf/open/floor/iron/white/textured_large,
-/area/station/science/robotics)
+/obj/effect/landmark/start/scientist,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/lower)
 "hsB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/punching_bag,
@@ -24762,7 +24750,7 @@
 	},
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "hti" = (
 /obj/structure/table/glass,
 /obj/item/modular_computer/laptop/preset/civilian{
@@ -25396,7 +25384,7 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "hBS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
@@ -25501,7 +25489,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "hDg" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
@@ -26094,13 +26082,19 @@
 "hMs" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "hMw" = (
 /obj/effect/turf_decal/trimline/dark/arrow_cw,
 /obj/effect/turf_decal/trimline/dark/arrow_cw,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hMC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "hMD" = (
@@ -26348,10 +26342,11 @@
 /area/station/commons/dorms)
 "hPP" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/airlock/research/glass{
-	name = "Science Console Access"
+	name = "Broom Closet"
 	},
+/obj/effect/mapping_helpers/airlock/welded,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "hPQ" = (
@@ -26425,7 +26420,14 @@
 /area/station/maintenance/disposal/incinerator)
 "hQD" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron/white/textured,
+/obj/item/pushbroom,
+/obj/item/pushbroom{
+	pixel_y = 5
+	},
+/obj/item/pushbroom{
+	pixel_y = 10
+	},
+/turf/open/floor/plastic,
 /area/station/science/research)
 "hQE" = (
 /obj/structure/railing{
@@ -26620,15 +26622,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hSy" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/welding{
-	pixel_y = 5
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "scistores";
+	name = "Science Store Shutters"
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 1
+/obj/item/hand_labeler{
+	pixel_y = 13
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/obj/item/hand_labeler_refill{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/lobby)
 "hSz" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -26841,14 +26851,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "hXg" = (
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "hXm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26964,8 +26974,11 @@
 /area/station/medical/chemistry)
 "hYO" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_white{
+	color = 003879
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "hZa" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/engine/hull,
@@ -27253,7 +27266,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "idq" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 8
@@ -27359,7 +27372,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "igc" = (
 /obj/machinery/computer/records/security,
 /obj/structure/lattice/catwalk,
@@ -27722,8 +27735,9 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/structure/training_machine,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "imL" = (
 /obj/structure/table/wood,
 /obj/item/hand_labeler{
@@ -28239,7 +28253,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "itK" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera/autoname/directional/north,
@@ -28667,15 +28681,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iAo" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/roboticist,
+/obj/machinery/drone_dispenser,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "iAp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28778,7 +28789,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "iCd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/left/directional/east{
@@ -28927,9 +28938,15 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "iDR" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/door/window/left/directional/south{
+	name = "Augmentation Theatre";
+	req_access = list("robotics")
+	},
+/turf/open/floor/iron/white/textured_edge,
+/area/station/science/robotics/augments)
 "iEf" = (
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
@@ -29060,7 +29077,7 @@
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "iFw" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -29159,20 +29176,10 @@
 /area/station/maintenance/disposal/incinerator)
 "iGD" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/briefcase/secure{
-	pixel_y = 8;
-	pixel_x = 1
-	},
+/obj/item/storage/briefcase/secure,
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
-/obj/item/computer_disk{
-	pixel_x = -6
-	},
-/obj/item/computer_disk,
-/obj/item/computer_disk{
-	pixel_x = 6
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "iGH" = (
@@ -29533,12 +29540,10 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/end{
 	dir = 8
 	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/misc/asteroid,
-/area/station/science/robotics)
+/area/station/science/lower)
 "iLL" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/transit_tube/horizontal,
@@ -29654,8 +29659,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "iNI" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -29746,12 +29752,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "iPq" = (
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "iPt" = (
 /obj/item/binoculars,
 /obj/item/toy/basketball,
@@ -30564,7 +30570,7 @@
 	},
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "jdk" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -31160,12 +31166,6 @@
 /area/station/hallway/secondary/command)
 "jlE" = (
 /obj/structure/cable/multilayer/multiz,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "jlK" = (
@@ -31989,7 +31989,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "jxU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -32448,9 +32448,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jDj" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
@@ -32459,7 +32456,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "jDq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/trunk/multiz/down{
@@ -32600,7 +32597,7 @@
 "jFH" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "jFI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -33277,6 +33274,16 @@
 	},
 /turf/open/openspace,
 /area/station/hallway/primary/central)
+"jQx" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/roboticist,
+/turf/open/floor/iron/white/textured,
+/area/station/science/robotics/augments)
 "jQL" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -33902,7 +33909,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "kcs" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34169,6 +34176,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/chapel)
+"kfz" = (
+/obj/structure/table,
+/obj/machinery/coffeemaker{
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/science/lower)
 "kfA" = (
 /obj/effect/turf_decal/siding/white,
 /obj/item/kirbyplants/organic/plant21{
@@ -34488,7 +34505,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/computer/security/telescreen/rd/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "kkM" = (
@@ -34677,7 +34693,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "kmL" = (
 /obj/item/clothing/head/soft/grey{
 	pixel_x = -2;
@@ -34738,21 +34754,17 @@
 	},
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /obj/item/stack/sheet/iron/fifty{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/stack/sheet/iron/fifty{
-	pixel_x = 8;
-	pixel_y = 0
+	pixel_x = 8
 	},
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -34770,7 +34782,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "knM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -34816,7 +34828,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "kow" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -35091,13 +35103,28 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "ktf" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/directional/north{
+	c_tag = "Jim Norton's Quebecois Coffee"
+	},
+/obj/item/reagent_containers/condiment/sugar{
+	pixel_y = 4
+	},
+/obj/item/storage/pill_bottle/happinesspsych{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/storage/box/coffeepack,
+/obj/item/storage/box/coffeepack/robusta,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/structure/closet/secure_closet/freezer/empty/open,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "kto" = (
@@ -35199,15 +35226,11 @@
 /area/station/commons/storage/tools)
 "kue" = (
 /obj/structure/rack,
-/obj/item/clothing/head/utility/welding{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/clothing/glasses/welding,
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "kui" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35442,7 +35465,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "kxE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
@@ -35940,6 +35963,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/flatpacker,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "kFC" = (
@@ -36231,11 +36255,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/starboard/lesser)
 "kMb" = (
-/obj/machinery/rnd/production/protolathe/department/science,
 /obj/effect/turf_decal/trimline/purple/end,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white/textured,
+/obj/item/pushbroom,
+/obj/item/borg/upgrade/broomer,
+/obj/item/pushbroom{
+	pixel_y = 10
+	},
+/turf/open/floor/plastic,
 /area/station/science/research)
 "kMj" = (
 /turf/closed/wall/r_wall,
@@ -36388,12 +36416,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "kPd" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -36412,7 +36439,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "kPq" = (
 /obj/structure/chair{
 	dir = 1
@@ -36753,7 +36780,7 @@
 	dir = 1
 	},
 /turf/closed/wall,
-/area/station/science/robotics)
+/area/station/science/lower)
 "kTL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -36833,8 +36860,14 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/abandoned)
 "kVQ" = (
-/turf/closed/wall/r_wall,
-/area/station/science/explab)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "roboticsprivacy";
+	name = "Robotics Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics)
 "kVS" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -36882,7 +36915,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "kWv" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 6
@@ -36964,20 +36997,19 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/cryo)
 "kXQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/purple,
-/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "kYd" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "kYe" = (
 /obj/structure/railing{
 	dir = 8
@@ -36991,7 +37023,7 @@
 "kYi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "kYK" = (
 /obj/structure/closet/crate/science,
 /obj/structure/railing{
@@ -37186,6 +37218,7 @@
 /obj/item/vending_refill/custom,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/item/circuitboard/machine/vendor,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "laK" = (
@@ -37222,7 +37255,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "lbh" = (
 /obj/structure/chair{
 	dir = 8
@@ -37365,17 +37398,18 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "lei" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = -2;
-	pixel_y = 12
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/obj/effect/landmark/start/roboticist,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics)
 "lep" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -37479,13 +37513,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/starboard/aft)
 "lga" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/shipping{
-	pixel_x = 4;
-	pixel_y = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/modular_computer/preset/cargochat/science{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
@@ -37600,9 +37632,8 @@
 "lig" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/plasma,
-/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "lim" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
@@ -37671,7 +37702,7 @@
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "ljW" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -37809,7 +37840,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "lmt" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -38390,9 +38421,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "lwG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38426,26 +38459,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "lxs" = (
-/obj/effect/turf_decal/trimline/yellow/corner,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -4;
-	pixel_y = 15
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/west,
-/obj/item/toy/crayon/spraycan/roboticist{
-	pixel_x = 10;
-	pixel_y = 20
-	},
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "lxz" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/power/smes{
@@ -38488,13 +38508,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "lxY" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/bot_white{
+	color = 003879
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "lys" = (
 /obj/machinery/vatgrower,
 /obj/machinery/camera/autoname/directional/west,
@@ -38823,13 +38844,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "lCM" = (
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/effect/turf_decal/loading_area{
-	dir = 1
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = -2;
+	pixel_y = 12
 	},
-/obj/item/surgery_tray,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -10
+	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "lCO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
@@ -39212,7 +39240,6 @@
 /area/station/maintenance/starboard/lesser)
 "lJe" = (
 /obj/effect/turf_decal/siding/thinplating_new/light/corner,
-/obj/effect/turf_decal/trimline/purple/corner,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 23;
@@ -39222,7 +39249,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "lJf" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/cup/bowl,
@@ -39405,12 +39432,11 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "lLY" = (
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/effect/turf_decal/loading_area{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 3
 	},
-/turf/open/floor/iron,
-/area/station/science/robotics)
+/turf/open/floor/iron/dark,
+/area/station/science/lobby)
 "lMe" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/structure/railing,
@@ -39887,7 +39913,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "lSH" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -40457,8 +40483,9 @@
 /area/station/security/eva)
 "mat" = (
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "may" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/clothing/suit/hooded/wintercoat/medical{
@@ -40582,7 +40609,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "mcl" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -41047,7 +41074,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "mip" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -41090,7 +41117,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "miT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -41267,6 +41294,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "mmN" = (
@@ -41549,7 +41577,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "mrg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -41633,15 +41661,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/kirbyplants/organic/plant4,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "msb" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/structure/railing/corner,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "msm" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -42083,7 +42111,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "mzR" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
@@ -42172,6 +42200,9 @@
 	},
 /obj/structure/rack,
 /obj/item/electronics/airlock,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "mBK" = (
@@ -42406,7 +42437,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/power_store/cell/high,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "mFg" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -42558,7 +42589,7 @@
 "mHi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "mHt" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -43692,7 +43723,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "mZH" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -43814,7 +43845,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "nbo" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
@@ -43923,7 +43954,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "nec" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/cable,
@@ -44196,7 +44227,7 @@
 	},
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "nhR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44607,35 +44638,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "noJ" = (
-/obj/structure/table,
-/obj/item/stock_parts/servo,
-/obj/item/stock_parts/servo,
-/obj/item/stock_parts/capacitor{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/capacitor{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/capacitor{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/turf/closed/wall/r_wall,
+/area/station/science/lower)
 "noQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -44942,7 +44946,7 @@
 	},
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "nts" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44968,15 +44972,28 @@
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
 "ntN" = (
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "ntP" = (
-/obj/structure/table,
 /obj/item/reagent_containers/dropper{
 	pixel_y = -7
 	},
+/obj/item/book/manual/wiki/robotics_cyborgs{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -4;
+	pixel_y = 15
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "nuw" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -45524,8 +45541,9 @@
 /obj/machinery/light_switch/directional/west{
 	pixel_y = 6
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "nCg" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown/fourcorners,
@@ -45583,10 +45601,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "nCI" = (
-/obj/machinery/component_printer,
-/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/plastic,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "nCM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -45762,19 +45779,8 @@
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office/private_investigators_office)
 "nFY" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/mob/living/basic/bot/medbot/derelict,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "nFZ" = (
 /obj/structure/lattice/catwalk,
@@ -45811,20 +45817,12 @@
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison/rec)
 "nGu" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "nGv" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/spawner/random/trash/grime,
@@ -45948,18 +45946,12 @@
 /turf/open/floor/glass,
 /area/station/maintenance/starboard/fore)
 "nIu" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
 /obj/structure/cable,
+/mob/living/simple_animal/bot/secbot/beepsky/armsky{
+	name = "Shinji"
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "nIA" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -46154,14 +46146,10 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "nLN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mod/module/longfall{
-	pixel_x = -8;
-	pixel_y = 18
-	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "nLQ" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/r_wall,
@@ -46280,7 +46268,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "nNM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -46598,7 +46586,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "nTj" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/siding/dark{
@@ -46660,8 +46648,9 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "nTM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -46784,7 +46773,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "nVm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/prison/directional/north,
@@ -46817,7 +46806,7 @@
 "nWm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "nWs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -46881,7 +46870,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "nWV" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/lattice/catwalk,
@@ -47395,7 +47384,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "oeF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47671,10 +47660,9 @@
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
-/obj/effect/landmark/start/roboticist,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "ojU" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/airlock/maintenance,
@@ -47809,7 +47797,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "omG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
 	},
@@ -47819,8 +47806,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "omX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -47903,10 +47891,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
 "oof" = (
-/obj/machinery/module_duplicator,
-/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/loading_area/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "ooo" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/frame/machine,
@@ -47982,7 +47969,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "opB" = (
 /obj/structure/rack,
 /obj/item/mop,
@@ -48084,19 +48071,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ora" = (
-/obj/structure/railing/corner/end,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "orb" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
@@ -48109,15 +48091,13 @@
 "orv" = (
 /obj/structure/flora/rock/pile,
 /obj/structure/flora/bush/jungle/a/style_2,
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark/end{
 	dir = 4
 	},
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/misc/asteroid,
-/area/station/science/robotics)
+/area/station/science/lower)
 "orx" = (
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/wood,
@@ -48629,7 +48609,6 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/research,
 /turf/open/floor/iron,
 /area/station/science/research)
 "ozw" = (
@@ -48719,7 +48698,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "oBh" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -48931,7 +48910,7 @@
 "oEi" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "oEw" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -49371,7 +49350,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "oKI" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
@@ -49472,9 +49451,8 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "oLN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
@@ -50136,8 +50114,12 @@
 /area/station/science/genetics)
 "oVp" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "oVt" = (
@@ -50909,12 +50891,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/scientist,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "pgu" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -50957,6 +50938,11 @@
 	},
 /turf/open/openspace,
 /area/station/medical/cryo)
+"pgK" = (
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/science/robotics)
 "pgM" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -51148,11 +51134,12 @@
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
 /obj/structure/sign/poster/official/anniversary_vintage_reprint/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/random/structure/crate_loot,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "plp" = (
@@ -51343,7 +51330,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "pnS" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
@@ -51691,8 +51678,9 @@
 	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/camera/autoname/directional/north,
+/obj/structure/chair/sofa/right,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "puR" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/directional/south,
@@ -52045,7 +52033,7 @@
 "pBB" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "pBC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52215,10 +52203,6 @@
 /area/station/service/chapel)
 "pEW" = (
 /obj/structure/table/reinforced,
-/obj/machinery/ecto_sniffer{
-	pixel_x = -6;
-	pixel_y = -4
-	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 3;
 	pixel_y = 11
@@ -52244,7 +52228,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "pFb" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -52383,9 +52367,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "pHc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
@@ -52395,8 +52376,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "pHd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -52508,9 +52492,23 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/lesser)
 "pJi" = (
-/obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/item/book/manual/wiki/robotics_cyborgs{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/ecto_sniffer{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/mmi{
+	pixel_x = 7
+	},
+/turf/open/floor/iron/white/textured_corner,
+/area/station/science/robotics/augments)
 "pJn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -52541,7 +52539,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "pJs" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -52644,6 +52642,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/mail_sorting/science/research,
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "pKp" = (
@@ -52670,7 +52669,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "pKC" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -53057,9 +53056,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pOR" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/structure/table/optable,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/station/science/robotics/augments)
 "pOW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -54022,22 +54023,10 @@
 /area/station/tcommsat/server)
 "qeP" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "qeX" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
@@ -54103,8 +54092,9 @@
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/structure/chair/sofa/left,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "qgr" = (
 /obj/structure/table,
 /obj/item/dest_tagger{
@@ -54328,7 +54318,7 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/lesser)
 "qju" = (
-/obj/structure/table/glass,
+/obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "qjy" = (
@@ -54429,8 +54419,7 @@
 	pixel_y = 5
 	},
 /obj/effect/spawner/random/maintenance{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
@@ -54675,7 +54664,15 @@
 /area/station/medical/break_room)
 "qpy" = (
 /obj/effect/turf_decal/trimline/purple,
-/turf/open/floor/iron/white/textured,
+/obj/item/pushbroom{
+	pixel_y = 5
+	},
+/obj/item/staff/broom{
+	pixel_y = 10
+	},
+/obj/item/pushbroom,
+/mob/living/basic/bot/cleanbot,
+/turf/open/floor/plastic,
 /area/station/science/research)
 "qpG" = (
 /obj/structure/railing{
@@ -55173,7 +55170,7 @@
 	},
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "qyM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility/full{
@@ -55182,7 +55179,7 @@
 	},
 /obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/iron/dark/textured_corner,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "qyU" = (
 /obj/structure/chair{
 	dir = 1
@@ -55881,7 +55878,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "qIF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -56409,7 +56406,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "qRy" = (
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 4
@@ -56688,7 +56685,7 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "qWc" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -57581,9 +57578,9 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "rkW" = (
-/obj/effect/turf_decal/bot_white,
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "rkY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57627,6 +57624,18 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
+"rlz" = (
+/obj/item/storage/belt/utility/full/engi{
+	pixel_y = 4
+	},
+/obj/machinery/ecto_sniffer{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/welding,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/robotics)
 "rlR" = (
 /obj/item/storage/box/snappops{
 	pixel_x = 6;
@@ -57671,7 +57680,7 @@
 "rmq" = (
 /obj/machinery/mechpad,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "rms" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -58005,6 +58014,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/chair/office{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "rqq" = (
@@ -58114,11 +58126,8 @@
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "rrF" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "rrT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/sign/poster/official/work_for_a_future/directional/south,
@@ -58630,10 +58639,9 @@
 /obj/effect/turf_decal/trimline/purple/arrow_cw{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ryW" = (
@@ -58664,7 +58672,6 @@
 	},
 /obj/item/holosign_creator/atmos,
 /obj/item/holosign_creator/atmos{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/machinery/light_switch/directional/north,
@@ -59446,9 +59453,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/fireaxecabinet/mechremoval/directional/east,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "rKO" = (
 /obj/machinery/computer/station_alert{
 	dir = 1
@@ -59618,11 +59624,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/eva)
 "rOk" = (
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 13
+/obj/effect/turf_decal/bot_white{
+	color = 003879
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "rOn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59662,7 +59668,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "rPn" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld{
@@ -59880,8 +59886,9 @@
 	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/light_switch/directional/north,
+/obj/structure/chair/sofa/middle,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "rRW" = (
 /obj/item/ammo_casing/spent{
 	pixel_x = 7;
@@ -59929,8 +59936,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "rTp" = (
@@ -60909,7 +60914,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "shL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -61015,7 +61020,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "sjO" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
@@ -61207,11 +61212,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
 "snd" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "sns" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -61674,7 +61676,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "stR" = (
 /obj/effect/turf_decal/siding{
 	dir = 5
@@ -62190,7 +62192,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "sEn" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 4
@@ -62462,7 +62464,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "sHG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -62890,8 +62892,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sOn" = (
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/station/science/robotics/augments)
 "sOv" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
@@ -62924,7 +62930,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "sPk" = (
@@ -62957,7 +62962,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
 "sPx" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -63038,7 +63043,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "sQJ" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -63098,16 +63103,8 @@
 /area/station/maintenance/port)
 "sRn" = (
 /obj/structure/table/reinforced,
-/obj/item/multitool{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/book/manual/wiki/robotics_cyborgs{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "sRo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64049,13 +64046,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "thd" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured_half{
-	dir = 1
-	},
-/area/station/science/robotics)
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "thf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -64063,8 +64056,9 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
+/obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "thk" = (
 /obj/item/trash/can{
 	pixel_x = -8
@@ -64214,8 +64208,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "tjU" = (
@@ -64540,8 +64532,9 @@
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "toE" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -64886,7 +64879,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/machinery/modular_computer/preset/cargochat/science,
 /turf/open/floor/iron,
 /area/station/science/research)
 "tvs" = (
@@ -65102,20 +65094,16 @@
 	pixel_x = -5
 	},
 /obj/item/transfer_valve{
-	pixel_x = -9;
-	pixel_y = 0
+	pixel_x = -9
 	},
 /obj/item/transfer_valve{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /obj/item/transfer_valve{
-	pixel_x = -1;
-	pixel_y = 0
+	pixel_x = -1
 	},
 /obj/item/transfer_valve{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -65396,7 +65384,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "tDx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/button/flasher{
@@ -66130,6 +66118,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"tOU" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/glasses/welding{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "tOW" = (
 /obj/effect/spawner/random/trash/graffiti,
 /obj/structure/disposalpipe/segment{
@@ -66447,7 +66449,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
 	},
-/area/station/science/robotics)
+/area/station/science/lower)
 "tTD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -66996,8 +66998,6 @@
 /area/station/maintenance/department/medical)
 "ucb" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "ucd" = (
@@ -67421,15 +67421,31 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "uiy" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 10
 	},
-/obj/item/surgery_tray/full,
-/turf/open/floor/iron/white/textured_half,
-/area/station/science/robotics)
+/obj/item/stock_parts/matter_bin{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_y = 9
+	},
+/obj/item/stock_parts/servo,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/turf/open/floor/iron,
+/area/station/science/lower)
 "uiH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67488,8 +67504,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ujI" = (
+/obj/structure/lattice,
 /turf/open/openspace,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "ujS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -67518,18 +67535,10 @@
 /turf/open/floor/plating/elevatorshaft,
 /area/station/commons/lounge)
 "ukk" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/flatpack/flatpacker{
-	pixel_x = 4;
-	pixel_y = 14
-	},
-/obj/item/flatpack/flatpacker{
-	pixel_y = 7
-	},
+/obj/machinery/cell_charger,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "ukm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -67587,7 +67596,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "ukP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/warning/vacuum/directional/west,
@@ -67928,7 +67937,7 @@
 /obj/machinery/photocopier/prebuilt,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "upS" = (
 /obj/structure/railing{
 	dir = 8
@@ -68088,7 +68097,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "urG" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
@@ -68098,7 +68107,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "urV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68412,8 +68421,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/closet/crate/mod{
+	name = "Robotics Supply crate"
+	},
+/obj/item/mod/module/longfall,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3
+	},
+/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "uwh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor/auto{
@@ -68623,15 +68649,15 @@
 /area/station/maintenance/starboard/fore)
 "uyc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Robotics Workshop"
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/airlock/research{
+	name = "Testing Labs"
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "uyn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -68680,7 +68706,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/station/science/robotics)
+/area/station/science/lower)
 "uza" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68783,7 +68809,7 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "uAE" = (
 /turf/open/floor/iron/dark,
 /area/station/security/range)
@@ -69223,7 +69249,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "uHe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69769,19 +69795,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uPL" = (
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/integrated_circuit/loaded/hello_world,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/item/compact_remote,
-/obj/structure/closet/crate/science{
-	name = "circuits crate"
-	},
-/obj/item/multitool/circuit,
-/obj/item/multitool/circuit,
-/obj/item/multitool/circuit,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/obj/structure/lattice,
+/turf/open/openspace,
+/area/station/command/heads_quarters/rd)
 "uQv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -69997,10 +70013,13 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uTY" = (
-/obj/structure/fake_stairs/directional/north,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Testing Labs"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "uUe" = (
 /obj/structure/railing{
 	dir = 8
@@ -70059,9 +70078,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "uUT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70128,7 +70146,21 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/tile,
-/area/station/science/robotics)
+/area/station/science/lower)
+"uVV" = (
+/obj/effect/turf_decal/trimline/purple/end{
+	dir = 1
+	},
+/obj/item/pushbroom,
+/obj/item/pushbroom{
+	pixel_y = 5
+	},
+/obj/item/pushbroom{
+	pixel_y = 10
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plastic,
+/area/station/science/research)
 "uVX" = (
 /obj/structure/railing{
 	dir = 4
@@ -70354,7 +70386,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "uZV" = (
 /obj/machinery/door/window/left/directional/north{
 	req_access = list("medical")
@@ -70524,7 +70556,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
 	},
-/area/station/science/robotics)
+/area/station/science/lower)
 "vcR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
@@ -70674,8 +70706,9 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "veS" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/artistic{
@@ -70932,7 +70965,7 @@
 	},
 /obj/structure/sign/departments/rndserver/directional/north,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "viI" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 4
@@ -71252,9 +71285,11 @@
 /area/station/medical/medbay/central)
 "vmZ" = (
 /obj/structure/table/reinforced,
-/obj/item/circuitboard/machine/vendor,
-/obj/item/screwdriver{
-	pixel_y = 10
+/obj/machinery/fax{
+	fax_name = "Research Division";
+	name = "Research Division Fax Machine";
+	pixel_x = 1;
+	pixel_y = 4
 	},
 /turf/open/floor/iron,
 /area/station/science/lobby)
@@ -71467,9 +71502,8 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/lesser)
 "vpz" = (
-/obj/structure/transport/linear,
-/turf/open/openspace,
-/area/station/science/robotics/lab)
+/turf/open/floor/engine,
+/area/station/science/lab)
 "vqa" = (
 /obj/structure/transport/linear,
 /turf/open/openspace,
@@ -71585,13 +71619,17 @@
 /turf/open/floor/iron/recharge_floor,
 /area/station/maintenance/starboard/lesser)
 "vrw" = (
-/obj/machinery/computer/rdconsole{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/end{
 	dir = 1
 	},
-/turf/open/floor/iron/white/textured,
+/obj/item/pushbroom,
+/obj/item/pushbroom{
+	pixel_y = 5
+	},
+/obj/item/pushbroom{
+	pixel_y = 10
+	},
+/turf/open/floor/plastic,
 /area/station/science/research)
 "vrx" = (
 /obj/machinery/shower/directional/west,
@@ -71826,9 +71864,19 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "vvD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("robotics");
+	name = "Robotics"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "roboticsprivacy";
+	name = "Robotics Shutters"
+	},
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/robotics)
 "vvE" = (
 /obj/machinery/plumbing/input,
 /obj/effect/decal/cleanable/dirt,
@@ -72224,13 +72272,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vBv" = (
-/obj/structure/fake_stairs/directional/north,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/research{
+	name = "Testing Labs"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "vBx" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
 /obj/item/reagent_containers/syringe,
@@ -72461,6 +72512,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"vFs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/iron/dark,
+/area/station/science/lobby)
 "vFA" = (
 /turf/closed/wall,
 /area/station/science/xenobiology)
@@ -72949,11 +73007,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "vMR" = (
-/obj/machinery/modular_computer/preset/civilian{
+/obj/machinery/mecha_part_fabricator{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "vNc" = (
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -73128,7 +73186,7 @@
 	},
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "vPU" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
@@ -73285,6 +73343,10 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
+/obj/item/storage/fancy/coffee_condi_display{
+	pixel_x = 12;
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "vRF" = (
@@ -73334,7 +73396,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "vSn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -73378,15 +73440,18 @@
 "vSx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/scientist,
+/obj/effect/landmark/start/roboticist,
+/obj/structure/chair/office{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "vSz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "vSC" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	name = "euthanization chamber freezer"
@@ -73568,10 +73633,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/port)
 "vWv" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/item/robot_suit,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lab)
+/area/station/science/robotics)
 "vWI" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/bottle/fluorine{
@@ -73622,8 +73687,29 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
+/obj/machinery/button/door/directional/north{
+	id = "roboticsprivacy";
+	name = "Robotics Privacy Controls";
+	req_access = list("robotics");
+	pixel_y = 0;
+	pixel_x = 24
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/effect/spawner/random/food_or_drink/donuts,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "vXU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73678,13 +73764,13 @@
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
 "vYT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/door/airlock/research{
+	name = "Research and Development Lab"
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/iron,
-/area/station/science/breakroom)
+/area/station/science/robotics)
 "vYV" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
@@ -73769,7 +73855,7 @@
 	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "wag" = (
 /obj/item/cigbutt{
 	pixel_x = -11;
@@ -73917,7 +74003,7 @@
 "wcN" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "wcT" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/autoname/directional/west,
@@ -74007,13 +74093,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "weg" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "weh" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -76247,11 +76330,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "wMe" = (
-/obj/effect/turf_decal/trimline/purple/end{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/iron/white/textured,
-/area/station/science/research)
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/structure/tank_holder/anesthetic,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/station/science/robotics/augments)
 "wMn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76355,7 +76442,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "wNu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -76450,17 +76537,21 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "wPb" = (
-/obj/machinery/door/airlock/research{
-	name = "R&D's Backdoor"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Workshop"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "roboticsprivacy";
+	name = "Robotics Shutters"
+	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "wPf" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/landmark/event_spawn,
@@ -76782,11 +76873,11 @@
 /turf/open/floor/glass/reinforced/airless,
 /area/station/solars/starboard/aft)
 "wVA" = (
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/engine,
-/area/station/science/auxlab/firing_range)
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "wVD" = (
 /obj/structure/railing{
 	dir = 8
@@ -76938,27 +77029,19 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wXr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
-/obj/structure/railing{
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/machinery/elevator_control_panel/directional/south{
-	linked_elevator_id = "catwalk_robo";
-	preset_destination_names = list("2"="Lower  Robotics","3"="Upper  Robotics")
-	},
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "wXD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -77187,24 +77270,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
 "xau" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/elevator_control_panel/directional/south{
-	linked_elevator_id = "catwalk_robo";
-	preset_destination_names = list("2"="Lower  Robotics","3"="Upper  Robotics")
-	},
+/obj/structure/table,
 /turf/open/floor/iron,
-/area/station/science/robotics)
+/area/station/science/lower)
 "xaz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -77414,7 +77485,7 @@
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "xdU" = (
 /obj/structure/railing/corner,
 /obj/structure/table/glass,
@@ -77584,7 +77655,7 @@
 	pixel_y = -6
 	},
 /turf/closed/wall,
-/area/station/science/robotics)
+/area/station/science/lower)
 "xgD" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet2";
@@ -77707,8 +77778,9 @@
 /area/station/maintenance/port)
 "xjc" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/lattice,
 /turf/open/openspace,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "xjq" = (
 /obj/structure/table/reinforced,
 /obj/item/rcl/pre_loaded{
@@ -77749,8 +77821,19 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "xjz" = (
-/turf/open/floor/plating/elevatorshaft,
-/area/station/science/robotics)
+/obj/item/disk/tech_disk,
+/obj/item/disk/tech_disk{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/structure/table,
+/obj/item/controller,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "xjK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/filingcabinet,
@@ -77965,7 +78048,7 @@
 "xnW" = (
 /obj/machinery/light/directional/south,
 /turf/open/openspace,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "xnZ" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/chapel{
@@ -78291,7 +78374,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "xsP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78522,7 +78605,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/science/robotics)
+/area/station/science/lower)
 "xwF" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass/reinforced,
@@ -78654,11 +78737,10 @@
 	},
 /area/station/science/ordnance/storage)
 "xzG" = (
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "xzX" = (
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
@@ -79163,7 +79245,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "xGR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/structure/window/reinforced,
@@ -79520,7 +79602,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "xNr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79825,7 +79907,6 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/clothing/ears/earmuffs{
@@ -79841,8 +79922,7 @@
 /obj/item/crowbar,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -79932,7 +80012,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/explab)
+/area/station/science/robotics/lab)
 "xTX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80375,13 +80455,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xYS" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/half,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white/textured_half,
-/area/station/science/robotics)
+/turf/open/floor/iron,
+/area/station/science/lower)
 "xZp" = (
 /obj/machinery/computer/rdconsole,
 /turf/open/floor/carpet,
@@ -80561,7 +80637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured_half,
-/area/station/science/robotics/lab)
+/area/station/science/lab)
 "ybW" = (
 /obj/item/melee/flyswatter{
 	pixel_x = 10
@@ -80803,8 +80879,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "yfm" = (
-/turf/closed/wall,
-/area/station/science/explab)
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/engine,
+/area/station/science/lab)
 "yfs" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/blood/oil,
@@ -80828,7 +80905,7 @@
 	},
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/robotics)
 "yfM" = (
 /obj/structure/table,
 /obj/item/gavelhammer{
@@ -80913,9 +80990,7 @@
 /area/station/hallway/primary/central)
 "ygN" = (
 /obj/structure/table,
-/obj/item/disk/tech_disk{
-	pixel_x = 5
-	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "ygW" = (
@@ -81173,14 +81248,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "ylI" = (
-/obj/structure/tank_holder/anesthetic,
-/obj/effect/turf_decal/tile/dark_blue/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured_corner{
-	dir = 4
-	},
-/area/station/science/robotics)
+/obj/machinery/component_printer,
+/turf/open/floor/iron,
+/area/station/science/lower)
 "ylO" = (
 /turf/open/floor/glass,
 /area/station/commons/fitness/recreation)
@@ -114231,11 +114301,11 @@ pMS
 pMS
 pMS
 gNK
-bzB
+noJ
 bBv
 uyT
 ekj
-bzB
+noJ
 atV
 ebY
 ebY
@@ -114488,26 +114558,26 @@ jJX
 jJX
 jJX
 jes
-bzB
+noJ
 dbt
 knI
 knI
-bzB
-bzB
+noJ
+noJ
 bki
-jZc
+bki
 uyc
-jZc
+bki
+noJ
+noJ
 bzB
 bzB
-fAl
-fAl
-tNP
+kVQ
 cPY
-tNP
-tNP
-fAl
-jkr
+kVQ
+vvD
+bzB
+gXG
 ruK
 szy
 djL
@@ -114745,26 +114815,26 @@ rVs
 cNS
 hGR
 tAK
-jZc
+bki
 dYB
 nWm
 hXe
 htc
 acN
 iAo
-abY
+ecJ
 vSz
 lCM
+tOU
 xjz
-xjz
-jkr
+bzB
 nCd
-thf
+hMC
 pHc
 thf
-thf
+lei
 vXQ
-fAl
+bzB
 tUH
 nLp
 nLp
@@ -115002,7 +115072,7 @@ dmi
 vhJ
 nRK
 mhI
-jZc
+bki
 rmq
 qIz
 dRl
@@ -115011,17 +115081,17 @@ orv
 tDv
 sjN
 aAI
-lLY
-xjz
-xjz
-jkr
+ecJ
+ecJ
+ecJ
+vYT
 kXQ
-ntN
-gal
-ntN
-ntN
+rrF
+pgp
+rrF
+nFY
 nTK
-fAl
+bzB
 tVo
 nLp
 nLp
@@ -115247,7 +115317,7 @@ fLr
 aZs
 fLr
 vUS
-afL
+vFs
 quJ
 wmR
 quJ
@@ -115259,7 +115329,7 @@ xhn
 vhJ
 xhn
 sns
-jZc
+bki
 uAB
 mHi
 mZA
@@ -115269,16 +115339,16 @@ lSl
 cIq
 lJe
 ecJ
-nFY
+ecJ
 xau
-jkr
+bzB
 puF
-hlg
-gal
-ntN
+rrF
+pgp
+rrF
 rrF
 lmc
-fAl
+bzB
 lGy
 nLp
 hFi
@@ -115516,7 +115586,7 @@ aUV
 qEY
 dwl
 dUW
-bzB
+noJ
 ton
 uUQ
 mZA
@@ -115528,14 +115598,14 @@ xgC
 fGV
 thd
 ylI
-jkr
+bzB
 rRQ
-noJ
+rrF
 pgp
-ntN
-hSy
+nCI
+rrF
 sDY
-fAl
+bzB
 vdl
 hFi
 sQJ
@@ -115763,7 +115833,7 @@ fLr
 gNZ
 sfM
 guk
-wmR
+abY
 quJ
 quJ
 vCB
@@ -115773,7 +115843,7 @@ jJX
 btw
 jJX
 jes
-bzB
+noJ
 fFx
 mcj
 mzq
@@ -115781,18 +115851,18 @@ nWU
 gBg
 kYd
 vPQ
-gXG
+ffT
 uiy
 hsx
 xYS
-jkr
+bzB
 qgj
 nIu
-gal
-fwp
-lei
+pgp
+rrF
+rrF
 fdi
-fAl
+bzB
 lGy
 ajB
 uxt
@@ -116030,19 +116100,19 @@ bDv
 rLt
 ktf
 gGO
-gXG
+ffT
 ntn
 bYA
 xwB
 mrV
-gXG
+ffT
 pnG
 qRs
 tTl
 arv
 eXw
 fqD
-jkr
+bzB
 cSL
 ffO
 miO
@@ -116287,26 +116357,26 @@ vRD
 sOz
 leS
 oVp
-euD
+kfz
 bdw
 uVP
 kOV
 opA
 uTY
-hMC
+ecJ
 qRs
 vcJ
-gXG
-gXG
-gXG
-jkr
+noJ
+noJ
+noJ
+bzB
 dYN
-ntN
+rlz
 grd
-ntN
-rkW
+rrF
+cFH
 lmc
-fAl
+bzB
 pcR
 pTp
 sQJ
@@ -116531,9 +116601,9 @@ nGH
 fLr
 aZs
 fLr
-xKq
+hSy
 nfG
-quJ
+lLY
 lga
 adM
 rqn
@@ -116543,7 +116613,7 @@ cHz
 ygN
 nWi
 aEZ
-vYT
+aEZ
 euD
 kPg
 chr
@@ -116553,17 +116623,17 @@ vBv
 rKN
 stL
 iFn
-bzB
+noJ
 qWb
 cZa
-tNP
+jZc
 yfK
 rkW
-gal
+pgp
 ntN
-gPd
+rrF
 qyA
-fAl
+bzB
 pcR
 tgL
 nLp
@@ -116811,16 +116881,16 @@ tsJ
 tsJ
 tsJ
 tsJ
-jFH
+pgK
 xdT
-tNP
+jZc
 yfK
 ukk
 gal
-vWv
+rrF
 vWv
 lmc
-fAl
+bzB
 mgh
 pTp
 cOe
@@ -117058,7 +117128,7 @@ ucb
 xSD
 acI
 nqP
-gXG
+ffT
 lwB
 hqr
 ojS
@@ -117077,7 +117147,7 @@ lbe
 idj
 idj
 uix
-fAl
+bzB
 wnJ
 izU
 dxN
@@ -117328,13 +117398,13 @@ tsJ
 tsJ
 tsJ
 ndY
-vWv
-hYO
+vMR
+oof
 uZS
 vMR
 oof
 exo
-fAl
+bzB
 pcR
 pTp
 xaz
@@ -117588,10 +117658,10 @@ mqY
 lxY
 hDf
 fme
-bLh
-nCI
+rOk
+rrF
 ifV
-fAl
+bzB
 lGy
 tgL
 xaz
@@ -117825,7 +117895,7 @@ fzT
 rOA
 qle
 dbb
-fwn
+kEw
 jlE
 kEw
 lPm
@@ -117843,12 +117913,12 @@ akq
 tsJ
 viD
 hYO
-ntN
+rrF
 bEw
 rOk
-uPL
+rrF
 exo
-fAl
+bzB
 pcR
 fAI
 jpp
@@ -118105,7 +118175,7 @@ cai
 waf
 vSd
 azS
-fAl
+bzB
 xIp
 fCk
 jlc
@@ -118355,9 +118425,9 @@ mJp
 qxI
 wps
 arT
-vFA
-vFA
-vFA
+arT
+arT
+arT
 arT
 arT
 arT
@@ -179771,22 +179841,22 @@ kBF
 kBF
 kBF
 kBF
+fAl
+tNP
+tNP
+tNP
+fAl
+tNP
+tNP
+tNP
+fAl
+wcN
+wcN
+wcN
+wcN
+wcN
+wcN
 fCV
-fTs
-fTs
-fTs
-fCV
-fTs
-fTs
-fTs
-fCV
-wcN
-wcN
-wcN
-wcN
-wcN
-wcN
-kVQ
 mQh
 mQh
 mQh
@@ -180028,22 +180098,22 @@ jes
 kBF
 kBF
 kBF
-fCV
+fAl
 weg
 pEW
 snd
 lxs
-ffT
+eab
 cPz
 aDF
-lAl
-kVQ
+jkr
+fCV
 bBV
-kVQ
+fCV
 bBV
 bBV
-kVQ
-kVQ
+fCV
+fCV
 ubs
 ubs
 uKt
@@ -180285,22 +180355,22 @@ jJX
 rpn
 fDQ
 rmS
-fTs
+tNP
 nLN
 pBB
 xzG
 bzs
 eab
+yfm
 vpz
-cFH
-fTs
-ujI
-ujI
-ujI
-ujI
-ujI
+tNP
+rXL
+rXL
+rXL
+rXL
+rXL
 xnW
-kVQ
+fCV
 ubs
 ubs
 uKt
@@ -180542,7 +180612,7 @@ jJX
 kzL
 nQL
 dvn
-fTs
+tNP
 lig
 gLN
 oEi
@@ -180550,14 +180620,14 @@ bzs
 dLs
 vpz
 vpz
-fTs
+tNP
 ujI
 ujI
 ujI
 xjc
 ujI
 ujI
-kVQ
+fCV
 ubs
 ubs
 uKt
@@ -180807,14 +180877,14 @@ jDj
 ora
 nGu
 wXr
-lAl
+jkr
+rXL
 ujI
+rXL
+rXL
 ujI
-ujI
-ujI
-ujI
-ujI
-kVQ
+rXL
+fCV
 uKt
 ubs
 uKt
@@ -181040,12 +181110,12 @@ mJl
 mJl
 mJl
 iHy
-dyN
-dyN
-dyN
-dyN
-dyN
-dyN
+uPL
+uPL
+uPL
+gPd
+uPL
+uPL
 vMt
 fgb
 bEB
@@ -181056,22 +181126,22 @@ jes
 mRE
 vsK
 wSA
-fTs
-gRZ
+tNP
+oEi
 kYi
 nbj
-cmh
+bzs
 dQV
 xNo
 kue
-lAl
+jkr
+rXL
 ujI
+rXL
+rXL
 ujI
-ujI
-ujI
-ujI
-ujI
-kVQ
+rXL
+fCV
 uKt
 uKt
 uKt
@@ -181301,7 +181371,7 @@ cZl
 cZl
 cZl
 cZl
-cZl
+bLh
 cZl
 vMt
 jes
@@ -181313,7 +181383,7 @@ jes
 bvT
 vsK
 acV
-lAl
+jkr
 qyM
 oAS
 msb
@@ -181321,14 +181391,14 @@ bJl
 imJ
 emM
 sRn
-fTs
+tNP
+rXL
 ujI
+rXL
+rXL
 ujI
-ujI
-ujI
-ujI
-ujI
-kVQ
+rXL
+fCV
 uKt
 ubs
 uKt
@@ -181574,18 +181644,18 @@ soU
 qSk
 qSk
 qSk
-rXL
+fwp
 dTr
 qeP
 cCX
-fTs
+tNP
 ujI
 ujI
 ujI
 ujI
 ujI
 ujI
-kVQ
+fCV
 uKt
 ubs
 ubs
@@ -181831,18 +181901,18 @@ vpn
 lqj
 gDw
 qSk
+fwp
+jkr
+jkr
+jkr
+jkr
 rXL
-lAl
-lAl
-lAl
-lAl
 ujI
+rXL
+rXL
 ujI
-ujI
-ujI
-ujI
-ujI
-kVQ
+rXL
+fCV
 uKt
 ubs
 ubs
@@ -182088,10 +182158,10 @@ soU
 bOx
 pkQ
 qSk
-yfm
-yfm
-ujI
-ujI
+lAl
+lAl
+cmh
+rXL
 sQC
 shG
 shG
@@ -182099,7 +182169,7 @@ bmP
 shG
 shG
 biP
-kVQ
+fCV
 rey
 ubs
 ubs
@@ -182356,7 +182426,7 @@ xGL
 pJq
 oLJ
 upR
-kVQ
+fCV
 uKt
 ubs
 uKt
@@ -182613,7 +182683,7 @@ dKs
 ukO
 aOQ
 xTT
-vvD
+fTs
 gsm
 gsm
 gsm
@@ -182856,13 +182926,13 @@ jLl
 orJ
 vsC
 lqg
-vrw
+uVV
 kMb
 soU
 pJi
 sOn
-sOn
-sOn
+wMe
+hac
 kWr
 dNW
 vSx
@@ -183116,9 +183186,9 @@ hPP
 hQD
 qpy
 soU
-sOn
-sOn
-sOn
+fwn
+gRZ
+jQx
 iDR
 kWr
 hkD
@@ -183127,7 +183197,7 @@ kou
 hMs
 nTe
 ljx
-vvD
+fTs
 ubs
 ubs
 gsm
@@ -183370,10 +183440,10 @@ tuY
 pKA
 kny
 lqg
-wMe
+vrw
 gkI
 soU
-sOn
+hlg
 pOR
 ezP
 gfz
@@ -183384,7 +183454,7 @@ oKD
 hMs
 nTe
 dgy
-kVQ
+fCV
 ubs
 ubs
 gsm
@@ -183641,7 +183711,7 @@ jdi
 nNJ
 urG
 mik
-kVQ
+fCV
 ubs
 ubs
 gsm

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -54651,7 +54651,9 @@
 /area/station/medical/break_room)
 "qpy" = (
 /obj/effect/turf_decal/trimline/purple,
-/mob/living/basic/bot/cleanbot,
+/mob/living/basic/bot/cleanbot{
+	name = "Stanley"
+	},
 /turf/open/floor/plastic,
 /area/station/science/research)
 "qpG" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -9925,6 +9925,9 @@
 /area/station/hallway/primary/central)
 "cVE" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "cVG" = (
@@ -23038,6 +23041,9 @@
 /area/station/maintenance/disposal/incinerator)
 "gRZ" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/robotics/augments)
 "gSg" = (
@@ -26853,10 +26859,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/science/lower)
 "hXg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "hXm" = (
@@ -29750,10 +29756,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "iPq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "iPt" = (
@@ -33280,6 +33286,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/roboticist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
 /area/station/science/robotics/augments)
 "jQL" = (
@@ -52503,6 +52511,7 @@
 /obj/item/mmi{
 	pixel_x = 7
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_corner,
 /area/station/science/robotics/augments)
 "pJn" = (
@@ -62888,6 +62897,8 @@
 "sOn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -76329,6 +76340,9 @@
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/tank_holder/anesthetic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -76867,7 +76881,6 @@
 /turf/open/floor/glass/reinforced/airless,
 /area/station/solars/starboard/aft)
 "wVA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/iron,

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -26974,9 +26974,7 @@
 /area/station/medical/chemistry)
 "hYO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_white{
-	color = 003879
-	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "hZa" = (
@@ -38511,9 +38509,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/bot_white{
-	color = 003879
-	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "lys" = (
@@ -59624,9 +59620,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/eva)
 "rOk" = (
-/obj/effect/turf_decal/bot_white{
-	color = 003879
-	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics)
 "rOn" = (


### PR DESCRIPTION
## About The Pull Request
Heavily change catwalk station science, as a broom closet sized fab room is kinda small innit?
Map edits by [NanoCats](https://github.com/NanoCats)
![image](https://github.com/user-attachments/assets/77410b53-208b-404e-92b5-91d77a67826f)
![image](https://github.com/user-attachments/assets/b538da4e-91be-4598-81ea-9f893424fcde)
![image](https://github.com/user-attachments/assets/d9ac943d-1db0-4e7f-ae60-c55df7298e95)
![image](https://github.com/user-attachments/assets/f667eaf8-39b8-40c9-ade2-8448269e21d8)


## Why It's Good For The Game
I love the idea of catwalkstation and i'd love if it was made a bit better for the hope of keeping it for good and becoming a classic map.

## Changelog

:cl: NanoCats, Arturlang
map: Heavily changes catwalkstation's science department, including moving the protolathe downstairs and north of the cupboard it is currently in, and adds a second exofabber for robotics.
/:cl:

