### PR TITLE
Mild acrobatics skillchip buff. Added item descriptions to other chips

### DIFF
--- a/code/modules/library/skill_learning/generic_skillchips/acrobatics.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/acrobatics.dm
@@ -13,19 +13,22 @@
 	/// list of emotes whose cd is overridden by this skillchip. can be edited in mapping or ingame
 	var/list/affected_emotes = list("spin", "flip")
 	var/datum/effect_system/spark_spread/sparks
-	// you can use this without lowering integrity! let's be honest. nobody's doing that
-	var/allowed_usage = 3
+	/// you can use this without lowering integrity! let's be honest. nobody's doing that
+	var/allowed_usage = 5
+	/// How many seconds does it take for it to recover one allowed usage
 	var/reload_charge = 10 SECONDS
-	// current particle effect used for smoking brain
+	/// current particle effect used for smoking brain
 	var/obj/effect/abstract/particle_holder/particle_effect
 
 /obj/item/skillchip/acrobatics/on_activate(mob/living/carbon/user, silent = FALSE)
 	. = ..()
 	RegisterSignal(user, COMSIG_MOB_EMOTE_COOLDOWN_CHECK, PROC_REF(whowee))
+	AddElement(/datum/element/obj_regen, 0.01) // 1% regen per SSobj tick.
 
 /obj/item/skillchip/acrobatics/on_deactivate(mob/living/carbon/user, silent)
 	. = ..()
 	UnregisterSignal(user, COMSIG_MOB_EMOTE_COOLDOWN_CHECK)
+	RemoveElement(/datum/element/obj_regen, 0.01)
 
 /obj/item/skillchip/acrobatics/Destroy(force)
 	QDEL_NULL(sparks)
@@ -41,8 +44,9 @@
 	if(allowed_usage)
 		allowed_usage--
 		addtimer(CALLBACK(src, PROC_REF(charge)), reload_charge)
-	else
-		take_damage(1, sound_effect = FALSE)
+		return COMPONENT_EMOTE_COOLDOWN_BYPASS
+
+	take_damage(1, sound_effect = FALSE)
 
 	if(!sparks)
 		sparks = new(src)

--- a/code/modules/library/skill_learning/generic_skillchips/matrix_taunt.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/matrix_taunt.dm
@@ -2,6 +2,8 @@
 
 /obj/item/skillchip/matrix_taunt
 	name = "BULLET_DODGER skillchip"
+	desc = "Overclock, override and overload your kinesthesic senses, proprioception and reflexes for a small window of time to \
+		automatically dodge fired projectiles. Activated by performing a taunt."
 	skill_name = "Taunt 2 Dodge"
 	skill_description = "At the cost of stamina, your taunts can also be used to dodge incoming projectiles."
 	skill_icon = FA_ICON_SPINNER

--- a/code/modules/library/skill_learning/generic_skillchips/misc.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/misc.dm
@@ -22,6 +22,7 @@
 
 /obj/item/skillchip/bonsai
 	name = "Hedge 3 skillchip"
+	desc = "\"Learn how to trim hedges and potted plants into new shapes. Third edition.\""
 	auto_traits = list(TRAIT_BONSAI)
 	skill_name = "Hedgetrimming"
 	skill_description = "Trim hedges and potted plants into marvelous new shapes with any old knife. Not applicable to plastic plants."
@@ -31,6 +32,7 @@
 
 /obj/item/skillchip/useless_adapter
 	name = "Skillchip adapter"
+	desc = "Yo dawg, heard you like skillchips so we put a skillchip in your skillchip so you can... uuuh..."
 	skill_name = "Useless adapter"
 	skill_description = "Allows you to insert another skillchip into this adapter after it has been inserted into your brain..."
 	skill_icon = "plug"
@@ -43,6 +45,7 @@
 
 /obj/item/skillchip/light_remover
 	name = "N16H7M4R3 skillchip"
+	desc = "A skillchip about safe lightbulb removal. Whoever came up with that awful name should be fired."
 	auto_traits = list(TRAIT_LIGHTBULB_REMOVER)
 	skill_name = "Lightbulb Removing"
 	skill_description = "Stop failing taking out lightbulbs today, no gloves needed!"
@@ -52,6 +55,7 @@
 
 /obj/item/skillchip/disk_verifier
 	name = "K33P-TH4T-D15K skillchip"
+	desc = "A skillchip with a tiny print of a nuclear authentification disk stamped onto it."
 	auto_traits = list(TRAIT_DISK_VERIFIER)
 	skill_name = "Nuclear Disk Verification"
 	skill_description = "Nuclear authentication disks have an extremely long serial number for verification. This skillchip stores that number, which allows the user to automatically spot forgeries."
@@ -70,6 +74,7 @@
 
 /obj/item/skillchip/appraiser
 	name = "GENUINE ID Appraisal Now! skillchip"
+	desc = "The name couldn't be any more desperate and self-explainatory, by skillchip naming standards."
 	auto_traits = list(TRAIT_ID_APPRAISER)
 	skill_name = "ID Appraisal"
 	skill_description = "Appraise an ID and see if it's issued from centcom, or just a cruddy station-printed one."
@@ -79,6 +84,7 @@
 
 /obj/item/skillchip/sabrage
 	name = "Le S48R4G3 skillchip"
+	desc = "A skillchip faintly smelling of alcohol. Best used in conjuction with a sabre or otherwise a sharp blade."
 	auto_traits = list(TRAIT_SABRAGE_PRO)
 	skill_name = "Sabrage Proficiency"
 	skill_description = "Grants the user knowledge of the intricate structure of a champagne bottle's structural weakness at the neck, \
@@ -107,6 +113,7 @@
 
 /obj/item/skillchip/chefs_kiss
 	name = "K1SS skillchip"
+	desc = "This skillchip faintly smells of apple pie, how lovely. Consult a dietician before use."
 	auto_traits = list(TRAIT_CHEF_KISS)
 	skill_name = "Chef's Kiss"
 	skill_description = "Allows you to kiss food you've created to make them with love."
@@ -125,6 +132,7 @@
 
 /obj/item/skillchip/drunken_brawler
 	name = "F0RC3 4DD1CT10N skillchip"
+	desc = "A skillchip reeking of alcohol, said to improve one's fighting prowess while inebriated, as if that can" save you from liver cirrhosis."
 	auto_traits = list(TRAIT_DRUNKEN_BRAWLER)
 	skill_name = "Drunken Unarmed Proficiency"
 	skill_description = "When intoxicated, you gain increased unarmed effectiveness."
@@ -134,6 +142,7 @@
 
 /obj/item/skillchip/master_angler
 	name = "Mast-Angl-Er skillchip"
+	desc = "A skillchip brimmed with encyclopedic excerpts and factoids about fishing and fishes."
 	auto_traits = list(TRAIT_REVEAL_FISH, TRAIT_EXAMINE_FISHING_SPOT, TRAIT_EXAMINE_FISH, TRAIT_EXAMINE_DEEPER_FISH)
 	skill_name = "Fisherman's Discernment"
 	skill_description = "Lists fishes when examining a fishing spot, gives a hint of whatever thing's biting the hook and more."

--- a/code/modules/library/skill_learning/generic_skillchips/misc.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/misc.dm
@@ -132,7 +132,7 @@
 
 /obj/item/skillchip/drunken_brawler
 	name = "F0RC3 4DD1CT10N skillchip"
-	desc = "A skillchip reeking of alcohol, said to improve one's fighting prowess while inebriated, as if that can" save you from liver cirrhosis."
+	desc = "A skillchip reeking of alcohol, said to improve one's fighting prowess while inebriated, as if that will save you from liver cirrhosis."
 	auto_traits = list(TRAIT_DRUNKEN_BRAWLER)
 	skill_name = "Drunken Unarmed Proficiency"
 	skill_description = "When intoxicated, you gain increased unarmed effectiveness."


### PR DESCRIPTION
## About The Pull Request
There is no way to repair the acrobatics skillchip, and the allowed usages only prevent it from taking damage, not the user. This PR ups that amount to 5 and makes it repair 1% of its integrity every 2 seconds.

Also assigns a `desc` to other chips that were using the generic one, which is really not in the slightest helpful, especially if you're buying the skillchip from a vending machine.

## Why It's Good For The Game
Better acrobatics skillchip (It's just flipping and spinning, there's little mechanical advantage to that), and more descriptive chips.

## Changelog

:cl:
balance: Buffed the acrobatics skillchip (the one that disables spinning and flipping cooldowns). Gave new item descriptions to skillchips that were missing one.
/:cl:
