### PR TITLE
Presistent clients now actually properly track clients between reloads

### DIFF
--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -52,17 +52,14 @@
 	src.key = "[key]_[mock_client_uid++]"
 	ckey = ckey(key)
 
-#ifdef UNIT_TESTS // otherwise this shit can leak into production servers which is drather bad
+#ifdef UNIT_TESTS // otherwise this shit can leak into production servers which is drather dbad
 	GLOB.directory[ckey] = src
 
 	if(GLOB.persistent_clients_by_ckey[ckey])
 		persistent_client = GLOB.persistent_clients_by_ckey[ckey]
-		persistent_client.byond_build = byond_build
-		persistent_client.byond_version = byond_version
 	else
 		persistent_client = new(ckey)
-		persistent_client.byond_build = byond_build
-		persistent_client.byond_version = byond_version
+	persistent_client.set_client(src)
 #endif
 
 	fully_created = TRUE
@@ -70,7 +67,7 @@
 /datum/client_interface/Destroy(force)
 	GLOB.directory -= ckey
 	if(persistent_client?.client == src)
-		persistent_client.client = null
+		persistent_client.set_client(null)
 	persistent_client = null
 	return ..()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -260,12 +260,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(GLOB.persistent_clients_by_ckey[ckey])
 		reconnecting = TRUE
 		persistent_client = GLOB.persistent_clients_by_ckey[ckey]
-		persistent_client.byond_build = byond_build
-		persistent_client.byond_version = byond_version
 	else
 		persistent_client = new(ckey)
-		persistent_client.byond_build = byond_build
-		persistent_client.byond_version = byond_version
+	persistent_client.set_client(src)
 
 	if(byond_version >= 516)
 		winset(src, null, list("browser-options" = "find,refresh,byondstorage"))
@@ -595,7 +592,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	GLOB.clients -= src
 	GLOB.directory -= ckey
-	persistent_client.client = null
+	persistent_client.set_client(null)
 
 	log_access("Logout: [key_name(src)]")
 	GLOB.ahelp_tickets.ClientLogout(src)

--- a/code/modules/client/persistent_client.dm
+++ b/code/modules/client/persistent_client.dm
@@ -11,9 +11,9 @@ GLOBAL_LIST_EMPTY_TYPED(persistent_clients, /datum/persistent_client)
 	/// The mob this persistent client is currently bound to.
 	var/mob/mob
 
-	/// Major version of BYOND this client is using.
+	/// Major version of BYOND this client was last using.
 	var/byond_version
-	/// Build number of BYOND this client is using.
+	/// Build number of BYOND this client was last using.
 	var/byond_build
 
 	/// Action datums assigned to this player
@@ -39,8 +39,7 @@ GLOBAL_LIST_EMPTY_TYPED(persistent_clients, /datum/persistent_client)
 	/// World.time this player last died
 	var/time_of_death = 0
 
-/datum/persistent_client/New(ckey, client)
-	src.client = client
+/datum/persistent_client/New(ckey)
 	achievements = new(ckey)
 	GLOB.persistent_clients_by_ckey[ckey] = src
 	GLOB.persistent_clients += src
@@ -49,6 +48,19 @@ GLOBAL_LIST_EMPTY_TYPED(persistent_clients, /datum/persistent_client)
 	SHOULD_CALL_PARENT(FALSE)
 	. = QDEL_HINT_LETMELIVE
 	CRASH("Who the FUCK tried to delete a persistent client? Get your head checked you leadskull.")
+
+/// Setter for the client var, updates any vars we have that might be dependent on client state
+/datum/persistent_client/proc/set_client(client/new_client)
+	if(client == new_client)
+		return
+	
+	if(client)
+		client.persistent_client = null
+	client = new_client
+	if(client)
+		client.persistent_client = src
+		byond_build = client.byond_build
+		byond_version = client.byond_version
 
 /// Setter for the mob var, handles both references.
 /datum/persistent_client/proc/set_mob(mob/new_mob)


### PR DESCRIPTION

## About The Pull Request

KAPUUUUUUUUUUUU

Also, client interfaces are now stored in the client var of persistent clients. @Absolucy was this intentionally ommitted from your pr?