### PR TITLE
Reverts colorful reagent (and other coloring agents) behavior back to old one.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2162,6 +2162,9 @@
 	if (!can_color_mobs)
 		return
 
+	exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY) //BUBBERSTATION ADDITION: REVERTS TO OLD COLORING BEHAVIOR
+
+	/* BUBBERSTATION CHANGE: REMOVES UPSTREAM COLORING BEHAVIOR BECAUSE OF HOW OVERLAYS WORK.
 	if (!iscarbon(exposed_mob))
 		exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 		return
@@ -2173,6 +2176,7 @@
 
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
+	BUBBERSTATION EDIT END. */
 
 /datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Reverts colorful reagent (and other coloring agents) behavior back to old one.

## Why It's Good For The Game

So for some reason someone thought it was a good idea to make colorful reagent also color organs, external and internal.

All organs can't be washed off of their color with how current washing mechanics works, and requires you to literally dismember someone to clean an organ. While SAD fixes external organs, they don't touch internal organs which means your insides would still be colored, leaving your eyes to be stuck a certain color because of how it works.

Even if they could be washed off, they still conflict with species sprites and custom overlays, leading to wonky looking characters.

This PR reverts that behavior and just makes it so that just your mob object is colored (something that can easily be washed off)


## Changelog

:cl: BurgerBB
del: Reverts colorful reagent (and other coloring agents) behavior back to old one.
/:cl:
