### PR TITLE
Adds shuttle parts to Catwalk tech storage

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -13169,10 +13169,8 @@
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
 "dVM" = (
-/obj/structure/table,
-/obj/item/t_scanner{
-	pixel_y = 8
-	},
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "dVO" = (
@@ -24132,6 +24130,9 @@
 	},
 /obj/item/multitool{
 	pixel_x = 5
+	},
+/obj/item/t_scanner{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)


### PR DESCRIPTION
## About The Pull Request

These parts were never added to catwalk tech storage. I put the rack with them in the place of the table that only had a single t-ray, and moved the t-ray to the table with the multitools.

## Why It's Good For The Game

Shuttle parts were meant to be a standard fixture of tech storages across all maps. This PR resolves this inconcistency.

## Changelog

:cl:
map: Catwalk Station's tech storage now has the same collection of shuttle parts that other stations do.
/:cl: