### PR TITLE
Moves breathe_water() from /obj/item/organ/lungs/fish to parent

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -276,7 +276,6 @@
 
 /obj/item/organ/lungs/fish/Initialize(mapload)
 	. = ..()
-	add_gas_reaction(/datum/gas/water_vapor, always = PROC_REF(breathe_water))
 	respiration_type |= RESPIRATION_OXYGEN //after all, we get oxygen from water
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/fish)
 	if(has_gills)

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -267,6 +267,7 @@
 	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
 	food_tastes = list("gross fish" = 1)
 	safe_oxygen_min = 0 //We don't breathe this
+	safe_water_level = 16 //We breathe this
 
 	/// Bodypart overlay applied to the chest where the lungs are in
 	var/datum/bodypart_overlay/simple/gills/gills

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -267,8 +267,6 @@
 	foodtype_flags = RAW | SEAFOOD | GORE | GROSS
 	food_tastes = list("gross fish" = 1)
 	safe_oxygen_min = 0 //We don't breathe this
-	///The required partial pressure of water_vapor for not suffocating.
-	var/safe_water_level = parent_type::safe_oxygen_min
 
 	/// Bodypart overlay applied to the chest where the lungs are in
 	var/datum/bodypart_overlay/simple/gills/gills
@@ -303,30 +301,6 @@
 /obj/item/organ/lungs/fish/on_mob_remove(mob/living/carbon/owner)
 	. = ..()
 	owner.clear_alert(ALERT_NOT_ENOUGH_WATER)
-
-/// Requires the spaceman to have either water vapor or be wet.
-/obj/item/organ/lungs/fish/proc/breathe_water(mob/living/carbon/breather, datum/gas_mixture/breath, water_pp, old_water_pp)
-	var/need_to_breathe = !HAS_TRAIT(src, TRAIT_SPACEBREATHING) && !HAS_TRAIT(breather, TRAIT_IS_WET)
-	if(water_pp < safe_water_level && need_to_breathe)
-		on_low_water(breather, breath, water_pp)
-		return
-
-	if(old_water_pp < safe_water_level || breather.failed_last_breath)
-		breather.failed_last_breath = FALSE
-		breather.clear_alert(ALERT_NOT_ENOUGH_WATER)
-
-	if(need_to_breathe)
-		breathe_gas_volume(breath, /datum/gas/water_vapor, /datum/gas/carbon_dioxide)
-	// Heal mob if not in crit.
-	if(breather.health >= breather.crit_threshold && breather.oxyloss)
-		breather.adjustOxyLoss(-5)
-
-/// Called when there isn't enough water to breath
-/obj/item/organ/lungs/fish/proc/on_low_water(mob/living/carbon/breather, datum/gas_mixture/breath, water_pp)
-	breather.throw_alert(ALERT_NOT_ENOUGH_WATER, /atom/movable/screen/alert/not_enough_water)
-	var/gas_breathed = handle_suffocation(breather, water_pp, safe_water_level, breath.gases[/datum/gas/water_vapor][MOLES])
-	if(water_pp)
-		breathe_gas_volume(breath, /datum/gas/water_vapor, /datum/gas/carbon_dioxide, volume = gas_breathed)
 
 // Simple overlay so we can add gills to those with fish lungs
 /datum/bodypart_overlay/simple/gills

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -48,7 +48,7 @@
 	///How much breath partial pressure is a safe amount of plasma. 0 means that we are immune to plasma.
 	var/safe_plasma_max = 0.05
 	///The required partial pressure of water_vapor for not suffocating.
-	var/safe_water_level = 16 // same as oxygen
+	var/safe_water_level = 0
 	var/n2o_detect_min = 0.08 //Minimum n2o for effects
 	var/n2o_para_min = 1 //Sleeping agent
 	var/n2o_sleep_min = 5 //Sleeping agent
@@ -142,6 +142,8 @@
 		add_gas_reaction(/datum/gas/plasma, always = PROC_REF(breathe_plasma))
 	if(safe_plasma_max)
 		add_gas_reaction(/datum/gas/plasma, while_present = PROC_REF(too_much_plasma), on_loss = PROC_REF(safe_plasma))
+	if(safe_water_level)
+		add_gas_reaction(/datum/gas/water_vapor, always = PROC_REF(breathe_water))
 	add_gas_reaction(/datum/gas/bz, while_present = PROC_REF(too_much_bz))
 	add_gas_reaction(/datum/gas/freon, while_present = PROC_REF(too_much_freon))
 	add_gas_reaction(/datum/gas/halon, while_present = PROC_REF(too_much_halon))


### PR DESCRIPTION
## About The Pull Request

Moves the breathe_water() behavior from fish sub type to parent type.

## Why It's Good For The Game

Makes breathing water/water vapor accessible to all lungs without requiring a subtyped organ. Leaves the gills overlay handling on the fish subtype.

## Changelog
No player facing changes
