### PR TITLE
Infinite credit dupe trick patch [100% working] [June 2025] [No download] [Link in video description]

### DIFF
--- a/code/modules/modular_computers/file_system/programs/betting.dm
+++ b/code/modules/modular_computers/file_system/programs/betting.dm
@@ -241,12 +241,11 @@ GLOBAL_LIST_EMPTY_TYPED(active_bets, /datum/active_bet)
 				else
 					//putting more money in
 					if(text2num(existing_bets[2]) < money_betting)
-						if(better.account_balance < money_betting)
-							return
 						var/money_adding_in = money_betting - text2num(existing_bets[2])
+						if(!better.adjust_money(-money_adding_in, "Gambling on [name]."))
+							return
 						total_amount_bet += money_adding_in
 						better.bank_card_talk("Additional [money_adding_in]cr deducted for your bet on [name].")
-						better.adjust_money(-money_adding_in, "Gambling on [name].")
 						existing_bets[2] = "[money_betting]"
 						return
 					//taking it all out, we remove them from the list so they aren't a winner with bets of 0.
@@ -265,11 +264,10 @@ GLOBAL_LIST_EMPTY_TYPED(active_bets, /datum/active_bet)
 						existing_bets[2] = "[money_betting]"
 						return
 
-	if(better.account_balance < money_betting)
+	if(!better.adjust_money(-money_betting, "Gambling on [name]"))
 		return
 	total_amount_bet += money_betting
 	options[option_betting] += list(list(better, "[money_betting]"))
-	better.adjust_money(-money_betting, "Gambling on [name]")
 	better.bank_card_talk("Deducted [money_betting]cr for your bet on [name].")
 
 ///Cancels your bet, removing your bet and refunding your money.

--- a/code/modules/modular_computers/file_system/programs/betting.dm
+++ b/code/modules/modular_computers/file_system/programs/betting.dm
@@ -265,6 +265,8 @@ GLOBAL_LIST_EMPTY_TYPED(active_bets, /datum/active_bet)
 						existing_bets[2] = "[money_betting]"
 						return
 
+	if(better.account_balance < money_betting)
+		return
 	total_amount_bet += money_betting
 	options[option_betting] += list(list(better, "[money_betting]"))
 	better.adjust_money(-money_betting, "Gambling on [name]")


### PR DESCRIPTION
## About The Pull Request

So it turns out the spacebet app verifies that the user has the money to make a bet only if they already have an active bet and they're increasing the amount of money it is, with a fresh bet this is never checked. This means someone can bet 10k credits on an option, it will place the bet with no regard for their account balance, then they can set their bet back to zero and the app will happily refund them 10k. Now they have 10k. They can do this as fast as they can type the numbers

## Why It's Good For The Game

UH OHHH (Fixes #91117)

## Changelog
:cl:
fix: fixed infinite credit exploit in spacebet app
/:cl:
