### PR TITLE
Implements colored bloom for emissives

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -59,30 +59,42 @@
 #define EMISSIVE_SPACE_LAYER 3
 #define EMISSIVE_WALL_LAYER 4
 
-#define RENDER_PLANE_LIGHTING 15
+#define EMISSIVE_BLOOM_PLATE 15
+
+//-------------------- Game plane assembly ---------------------
+
+#define RENDER_PLANE_GAME 16
+/// If fov is enabled we'll draw game to this and do shit to it
+#define RENDER_PLANE_GAME_MASKED 17
+/// The bit of the game plane that is let alone is sent here
+#define RENDER_PLANE_GAME_UNMASKED 18
+
+//-------------------- Lighting ---------------------
+
+#define RENDER_PLANE_LIGHTING 20
 
 /// Masks the lighting plane with turfs, so we never light up the void
 /// Failing that, masks emissives and the overlay lighting plane
-#define LIGHT_MASK_PLANE 16
+#define LIGHT_MASK_PLANE 21
 #define LIGHT_MASK_RENDER_TARGET "*LIGHT_MASK_PLANE"
 
 ///Things that should render ignoring lighting
-#define ABOVE_LIGHTING_PLANE 17
+#define ABOVE_LIGHTING_PLANE 22
 
-#define WEATHER_GLOW_PLANE 18
+#define WEATHER_GLOW_PLANE 23
 
 ///---------------- MISC -----------------------
 
 ///Pipecrawling images
-#define PIPECRAWL_IMAGES_PLANE 20
+#define PIPECRAWL_IMAGES_PLANE 24
 
 ///AI Camera Static
-#define CAMERA_STATIC_PLANE 21
+#define CAMERA_STATIC_PLANE 25
 
 ///Anything that wants to be part of the game plane, but also wants to draw above literally everything else
-#define HIGH_GAME_PLANE 22
+#define HIGH_GAME_PLANE 26
 
-#define FULLSCREEN_PLANE 23
+#define FULLSCREEN_PLANE 27
 
 ///--------------- FULLSCREEN RUNECHAT BUBBLES ------------
 
@@ -102,11 +114,7 @@
 // The largest plane here must still be less than RENDER_PLANE_GAME
 
 //-------------------- Rendering ---------------------
-#define RENDER_PLANE_GAME 40
-/// If fov is enabled we'll draw game to this and do shit to it
-#define RENDER_PLANE_GAME_MASKED 41
-/// The bit of the game plane that is let alone is sent here
-#define RENDER_PLANE_GAME_UNMASKED 42
+#define LIT_GAME_RENDER_PLATE 40
 #define RENDER_PLANE_NON_GAME 45
 
 // Only VERY special planes should be here, as they are above not just the game, but the UI planes as well.

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -78,11 +78,14 @@
 /// Don't block any emissives. Useful for things like, pieces of paper?
 #define EMISSIVE_BLOCK_NONE 2
 
-#define _EMISSIVE_COLOR(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, val,val,val,0)
+#define _EMISSIVE_COLOR(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, val,0,0,0)
+#define _EMISSIVE_COLOR_NO_BLOOM(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,val,0,0)
 /// The color matrix applied to all emissive overlays. Should be solely dependent on alpha and not have RGB overlap with [EM_BLOCK_COLOR].
 #define EMISSIVE_COLOR _EMISSIVE_COLOR(1)
+#define EMISSIVE_COLOR_NO_BLOOM _EMISSIVE_COLOR_NO_BLOOM(1)
 /// A globally cached version of [EMISSIVE_COLOR] for quick access.
 GLOBAL_LIST_INIT(emissive_color, EMISSIVE_COLOR)
+GLOBAL_LIST_INIT(emissive_color_no_bloom, EMISSIVE_COLOR_NO_BLOOM)
 
 #define _EM_BLOCK_COLOR(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,val, 0,0,0,0)
 /// The color matrix applied to all emissive blockers. Should be solely dependent on alpha and not have RGB overlap with [EMISSIVE_COLOR].

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -22,6 +22,14 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"size" = 1
 		)
 	),
+	"bloom" = list(
+		"defaults" = list(
+			"threshold" = COLOR_BLACK,
+			"size" = 1,
+			"offset" = 0,
+			"alpha" = 255
+		)
+	),
 	// Not implemented, but if this isn't uncommented some windows will just error
 	// Needs either a proper matrix editor, or just a hook to our existing one
 	// Issue is filterrific assumes variables will have the same value type if they share the same name, which this violates
@@ -199,6 +207,17 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 	. = list("type" = "blur")
 	if(!isnull(size))
 		.["size"] = size
+
+/proc/bloom_filter(threshold, size, offset, alpha)
+	. = list("type" = "bloom")
+	if(!isnull(threshold))
+		.["threshold"] = threshold
+	if(!isnull(size))
+		.["size"] = size
+	if(!isnull(offset))
+		.["offset"] = offset
+	if(!isnull(alpha))
+		.["alpha"] = alpha
 
 /proc/layering_filter(icon, render_source, x, y, flags, color, transform, blend_mode)
 	. = list("type" = "layer")

--- a/code/__HELPERS/lighting.dm
+++ b/code/__HELPERS/lighting.dm
@@ -1,11 +1,17 @@
 /// Produces a mutable appearance glued to the [EMISSIVE_PLANE] dyed to be the [EMISSIVE_COLOR].
-/proc/emissive_appearance(icon, icon_state = "", atom/offset_spokesman, layer = FLOAT_LAYER, alpha = 255, appearance_flags = NONE, offset_const)
+/proc/emissive_appearance(icon, icon_state = "", atom/offset_spokesman, layer = FLOAT_LAYER, alpha = 255, appearance_flags = NONE, offset_const, apply_bloom = TRUE)
 	var/mutable_appearance/appearance = mutable_appearance(icon, icon_state, layer, offset_spokesman, EMISSIVE_PLANE, 255, appearance_flags | EMISSIVE_APPEARANCE_FLAGS, offset_const)
 	if(alpha == 255)
-		appearance.color = GLOB.emissive_color
+		if (apply_bloom)
+			appearance.color = GLOB.emissive_color
+		else
+			appearance.color = GLOB.emissive_color_no_bloom
 	else
 		var/alpha_ratio = alpha/255
-		appearance.color = _EMISSIVE_COLOR(alpha_ratio)
+		if (apply_bloom)
+			appearance.color = _EMISSIVE_COLOR(alpha_ratio)
+		else
+			appearance.color = _EMISSIVE_COLOR_NO_BLOOM(alpha_ratio)
 
 	//Test to make sure emissives with broken or missing icon states are created
 	if(PERFORM_ALL_TESTS(focus_only/invalid_emissives))

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -341,7 +341,10 @@
 
 /atom/movable/screen/plane_master/emissive/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
+	/// Okay, so what we're doing here is making all emissives convert to white for actual emissive masking (i.e. adding light so objects glow)
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_color = list(1,1,1,0, 1,1,1,0, 1,1,1,0, 0,0,0,1, 0,0,0,0))
+	/// But for the bloom plate we convert only the red color into full white, this way we can have emissives in green channel unaffected by bloom
+	/// which allows us to selectively bloom only a part of our emissives
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), relay_color = list(1,1,1,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0))
 
 /atom/movable/screen/plane_master/pipecrawl

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -309,6 +309,7 @@
 	plane = ABOVE_LIGHTING_PLANE
 	documentation = "Anything on the game plane that needs a space to draw on that will be above the lighting plane.\
 		<br>Mostly little alerts and effects, also sometimes contains things that are meant to look as if they glow."
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/weather_glow
 	name = "Weather Glow"
@@ -316,6 +317,7 @@
 	plane = WEATHER_GLOW_PLANE
 	start_hidden = TRUE
 	critical = PLANE_CRITICAL_DISPLAY
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/weather_glow/set_home(datum/plane_master_group/home)
 	. = ..()
@@ -334,7 +336,7 @@
 	plane = EMISSIVE_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	render_relay_planes = list(EMISSIVE_RENDER_PLATE)
+	render_relay_planes = list(EMISSIVE_RENDER_PLATE, EMISSIVE_BLOOM_PLATE)
 	critical = PLANE_CRITICAL_DISPLAY
 
 /atom/movable/screen/plane_master/pipecrawl
@@ -343,6 +345,7 @@
 		<br>Has a few effects and a funky color matrix designed to make things a bit more visually readable."
 	plane = PIPECRAWL_IMAGES_PLANE
 	start_hidden = TRUE
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/pipecrawl/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
@@ -358,6 +361,7 @@
 	documentation = "Holds camera static images. Usually only visible to people who can well, see static.\
 		<br>We use images rather then vis contents because they're lighter on maptick, and maptick sucks butt."
 	plane = CAMERA_STATIC_PLANE
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/camera_static/show_to(mob/mymob)
 	. = ..()
@@ -396,6 +400,7 @@
 		<br>Really only exists for its layering potential, we don't use this for any vfx"
 	plane = HIGH_GAME_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/ghost
 	name = "Ghost"

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -336,8 +336,13 @@
 	plane = EMISSIVE_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	render_relay_planes = list(EMISSIVE_RENDER_PLATE, EMISSIVE_BLOOM_PLATE)
+	render_relay_planes = list()
 	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/emissive/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_color = list(1,1,1,0, 1,1,1,0, 1,1,1,0, 0,0,0,1, 0,0,0,0))
+	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), relay_color = list(1,1,1,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0))
 
 /atom/movable/screen/plane_master/pipecrawl
 	name = "Pipecrawl"

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -379,9 +379,9 @@
 /atom/movable/screen/plane_master/rendering_plate/emissive_bloom
 	name = "Emissive bloom plate"
 	documentation = "Plate used to bloom emissives before adding them onto the overlay lighting plane. This relies on game rendering plate,\
-		 which assembles all in-world planes affected by lighting, is above the emissive plane - which allows us to bypass having to fullbright\
-		 the emissive plane on a separate plate before alpha masking the rendering plate copy via multiplying fullbright emissive created here\
-		 with the game plate, which technically achieves the same effect. Odd, but it works, and is significantly graphically cheaper."
+		which assembles all in-world planes affected by lighting, is above the emissive plane - which allows us to bypass having to fullbright\
+		the emissive plane on a separate plate before alpha masking the rendering plate copy via multiplying fullbright emissive created here\
+		with the game plate, which technically achieves the same effect. Odd, but it works, and is significantly graphically cheaper."
 	plane = EMISSIVE_BLOOM_PLATE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -75,11 +75,12 @@
 		<br>We apply a displacement effect from the gravity pulse plane too, so we can warp the game world.\
 		<br>If we have fov enabled we'll relay this onto two different rendering plates to apply fov effects to only a portion. If not, we just draw straight to master"
 	plane = RENDER_PLANE_GAME
-	render_relay_planes = list(RENDER_PLANE_MASTER)
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
+	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), blend_override = BLEND_MULTIPLY)
 
 /atom/movable/screen/plane_master/rendering_plate/game_plate/show_to(mob/mymob)
 	. = ..()
@@ -96,13 +97,13 @@
 	SIGNAL_HANDLER
 	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_UNMASKED, offset))
 	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_MASKED, offset))
-	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_MASTER, offset))
+	remove_relay_from(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
 
 /atom/movable/screen/plane_master/rendering_plate/game_plate/proc/fov_disabled(mob/source)
 	SIGNAL_HANDLER
 	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME_UNMASKED, offset))
 	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME_MASKED, offset))
-	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_MASTER, offset))
+	add_relay_to(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
 
 ///renders the parts of the plate unmasked by fov
 /atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate
@@ -110,7 +111,7 @@
 	documentation = "Holds the bits of the game plate that aren't impacted by fov.\
 		<br>We use an alpha mask to cut out the bits we plan on dealing with elsewhere"
 	plane = RENDER_PLANE_GAME_UNMASKED
-	render_relay_planes = list(RENDER_PLANE_MASTER)
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
@@ -143,7 +144,7 @@
 	documentation = "Contains the bits of the game plate that are hidden by some form of fov\
 		<br>Applies a color matrix to dim and create contrast, alongside a blur. Goal is only half being able to see stuff"
 	plane = RENDER_PLANE_GAME_MASKED
-	render_relay_planes = list(RENDER_PLANE_MASTER)
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/rendering_plate/masked_game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
@@ -219,6 +220,7 @@
 	blend_mode_override = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	critical = PLANE_CRITICAL_DISPLAY
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 	/// A list of light cutoffs we're actively using, (mass, r, g, b) to avoid filter churn
 	var/list/light_cutoffs
 
@@ -336,7 +338,7 @@
 	render_target = LIGHT_MASK_RENDER_TARGET
 	// We blend against the game plane, so she's gotta multiply!
 	blend_mode = BLEND_MULTIPLY
-	render_relay_planes = list(RENDER_PLANE_GAME)
+	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
 
 /atom/movable/screen/plane_master/rendering_plate/light_mask/show_to(mob/mymob)
 	. = ..()
@@ -350,7 +352,7 @@
 	. = ..()
 	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset))
 	emissive.remove_filter("lighting_mask")
-	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME, offset))
+	remove_relay_from(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
 	UnregisterSignal(oldmob, COMSIG_MOB_SIGHT_CHANGE)
 
 /atom/movable/screen/plane_master/rendering_plate/light_mask/proc/handle_sight(datum/source, new_sight, old_sight)
@@ -358,14 +360,14 @@
 	// And instead mask JUST the overlay lighting plane, since that will look fuckin wrong
 	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset))
 	if(new_sight & SEE_AVOID_TURF_BLACKNESS && !(new_sight & SEE_TURFS))
-		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME, offset))
+		remove_relay_from(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
 		emissive.add_filter("lighting_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(LIGHT_MASK_RENDER_TARGET, offset)))
 	// If we CAN'T see through the black, then draw er down brother!
 	else
 		emissive.remove_filter("lighting_mask")
 		// We max alpha here, so our darkness is actually.. dark
 		// Can't do it before cause it fucks with the filter
-		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME, offset), relay_color = list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,1))
+		add_relay_to(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset), relay_color = list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,1))
 
 ///render plate for OOC stuff like ghosts, hud-screen effects, etc
 /atom/movable/screen/plane_master/rendering_plate/non_game
@@ -374,12 +376,36 @@
 	plane = RENDER_PLANE_NON_GAME
 	render_relay_planes = list(RENDER_PLANE_MASTER)
 
+/atom/movable/screen/plane_master/rendering_plate/emissive_bloom
+	name = "Emissive bloom plate"
+	documentation = "Plate used to bloom emissives before adding them onto the overlay lighting plane. This relies on game rendering plate,\
+		 which assembles all in-world planes affected by lighting, is above the emissive plane - which allows us to bypass having to fullbright\
+		 the emissive plane on a separate plate before alpha masking the rendering plate copy via multiplying fullbright emissive created here\
+		 with the game plate, which technically achieves the same effect. Odd, but it works, and is significantly graphically cheaper."
+	plane = EMISSIVE_BLOOM_PLATE
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	blend_mode = BLEND_ADD
+	render_relay_planes = list(O_LIGHTING_VISUAL_PLANE)
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/emissive_bloom/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	add_filter("emissive_bloom", 1, bloom_filter(threshold = COLOR_BLACK, size = 2, offset = 1))
+
 /atom/movable/screen/plane_master/rendering_plate/turf_lighting
 	name = "Turf lighting post-processing plate"
 	documentation = "Used by overlay lighting, and possibly over plates, to mask out turf lighting."
 	plane = TURF_LIGHTING_PLATE
 	render_relay_planes = list(RENDER_PLANE_LIGHTING)
 	blend_mode = BLEND_ADD
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/lit_game
+	name = "Lit game rendering plate"
+	documentation = "Plate which is used to multiply the game rendering plate by lighting visuals and rendering fullbright stuff. Exists so we can fetch fullbright game plate for emissive VFX."
+	plane = LIT_GAME_RENDER_PLATE
+	render_relay_planes = list(RENDER_PLANE_MASTER)
 	critical = PLANE_CRITICAL_DISPLAY
 
 /**

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -196,7 +196,7 @@
 /obj/item/clothing/suit/hazardvest/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
 	if(!isinhands)
-		. += emissive_appearance(icon_file, "[icon_state]-emissive", src, alpha = src.alpha)
+		. += emissive_appearance(icon_file, "[icon_state]-emissive", src, alpha = src.alpha, apply_bloom = FALSE)
 
 /obj/item/clothing/suit/hazardvest/press // Variant used by the Curator
 	name = "press hazard vest"


### PR DESCRIPTION
## About The Pull Request

Emissive sprites now bloom out a bit (3 pixels, to be specific)

![dreamseeker_R8B30ELsSi](https://github.com/user-attachments/assets/77a9b955-b4ca-4f66-aadb-6ecbf0796244)
![dreamseeker_r6cnRUq7Hp](https://github.com/user-attachments/assets/0fcd0b09-bfe9-4fc8-9c8a-0fa8fbaff61e)

This is done by rendering emissives onto a plate, multiplying them by unlit game rendering plate to color them, then blooming all non-black pixels (1 offset, 2 size, so 100/66/33% brightness) on it and rendering it onto the overlay lighting plane. We use overlay lighting because it slightly detracts from the static lighting plane, so our emissives color their surroundings a bit even in fully lit rooms.

![dreamseeker_i3RG3WjEfK](https://github.com/user-attachments/assets/d2a5d91c-b511-45e7-88f1-d25d3f4f3876)

You can make emissives not emit light by setting ``apply_bloom`` to FALSE in ``emissive_appearance()``. This is done by storing bloom in the red color channel and converting bloomless emissives to green, then having both render targets have color matrixes which convert them back to white.

## Why It's Good For The Game

Fancy visuals, goes hard.

## Changelog
:cl:
add: Emissive objects now have a bit of a colored bloom around them.
/:cl:
