### PR TITLE
Allows borgs to right-click their stored omnitools to pull out a specific tool

### DIFF
--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -248,6 +248,15 @@
 	update_appearance(UPDATE_ICON_STATE)
 	playsound(src, 'sound/items/tools/change_jaws.ogg', 50, TRUE)
 
+/obj/item/borg/cyborg_omnitool/Click(location, control, params)
+	var/list/modifiers = params2list(params)
+	if(!LAZYACCESS(modifiers, RIGHT_CLICK) || !iscyborg(usr))
+		return ..()
+	var/mob/living/silicon/robot/user = usr
+	if (!(src in user.held_items))
+		attack_self(user)
+	return ..()
+
 /obj/item/borg/cyborg_omnitool/update_icon_state()
 	if (reference)
 		icon_state = reference.icon_state

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -173,6 +173,10 @@
 	//is the toolset upgraded or not
 	var/upgraded = FALSE
 
+/obj/item/borg/cyborg_omnitool/Initialize(mapload)
+	. = ..()
+	register_context()
+
 /obj/item/borg/cyborg_omnitool/Destroy(force)
 	for(var/obj/item/tool_path as anything in atoms)
 		var/obj/item/tool = atoms[tool_path]
@@ -181,6 +185,15 @@
 	atoms.Cut()
 
 	return ..()
+
+/obj/item/borg/cyborg_omnitool/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if (!issilicon(user))
+		return
+	var/mob/living/silicon/robot/as_cyborg = user
+	if (!(src in as_cyborg.held_items))
+		context[SCREENTIP_CONTEXT_RMB] = "Select Tool"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /**
  * Sets the new internal tool to be used


### PR DESCRIPTION

## About The Pull Request

If you right-click a borg omnitool while its in the module storage, you'll get a radial and pull out the selected tool instead of having to use it in-hand again.

## Why It's Good For The Game

Basic QOL, should make engineering borgs' lives just a tiny bit easier.

## Changelog
:cl:
qol: Cyborgs can right-click their stored omnitools to pull out a specific tool instead of having to use it in-hand after selecting it to do so.
/:cl:
