### PR TITLE
Fix the dozen or so lingering spritesheet errors caused by GAGS map icons

### DIFF
--- a/code/modules/asset_cache/assets/crafting.dm
+++ b/code/modules/asset_cache/assets/crafting.dm
@@ -36,13 +36,8 @@
 			icon_file = style.icon
 			icon_state = style.icon_state
 
-	if(preview_item.greyscale_config)
-		var/datum/greyscale_config/greyscale_config = preview_item::greyscale_config
-		icon_file ||= preview_item::icon_preview || greyscale_config::icon_file
-		icon_state ||= preview_item::icon_state_preview || preview_item::post_init_icon_state || preview_item::icon_state
-	else
-		icon_file ||= preview_item::icon_preview || preview_item::icon
-		icon_state ||= preview_item::icon_state_preview || preview_item::icon_state
+	icon_file ||= preview_item::icon_preview || preview_item::icon
+	icon_state ||= preview_item::icon_state_preview || preview_item::icon_state
 
 	if(PERFORM_ALL_TESTS(focus_only/bad_cooking_crafting_icons))
 		if(!icon_exists_or_scream(icon_file, icon_state))


### PR DESCRIPTION

## About The Pull Request

It turns out this additional code is not only not needed but actually breaks the spritesheet because the whole point is icon and icon_state are set to the generated icon that you use in stuff like spritesheets. Testing this change made all the errors go away and the proper icons appear in the crafting menu

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed broken GAGS icons in the crafting menu
/:cl:
