### PR TITLE
Fix tgui-dev-server crash when reloading after connected client closes

### DIFF
--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -7,7 +7,7 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 
 import { createLogger } from './logging.js';
 
@@ -45,7 +45,15 @@ export class DreamSeeker {
     logger.log(
       `topic call at ${this.client.defaults.baseURL}/dummy.htm?${query}`,
     );
-    return this.client.get('/dummy.htm?' + query);
+    return this.client.get('/dummy.htm?' + query).catch((e) => {
+      if (isAxiosError(e) && e.code === 'ECONNREFUSED') {
+        // Client exited, remove from list
+        instanceByPid.delete(this.pid);
+        logger.log(`client disconnected`);
+      } else {
+        throw e;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION

## About The Pull Request
Added a catch handler to the dreamseeker.js topic call which removes the client from the global register if the topic call results in `ECONNREFUSED` (i.e. the client closed). Allows the dev server to be left open in the background between game restarts
## Why It's Good For The Game
Better developer experience
