### PR TITLE
Make psyker more playable.

### DIFF
--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -11,6 +11,8 @@
 	var/fade_out_time = 0.3 SECONDS
 	/// Are images static? If yes, spawns them on the turf and makes them not change location. Otherwise they change location and pixel shift with the original.
 	var/images_are_static = TRUE
+	/// Does this echolocation cause us to go blind?
+	var/blinding = TRUE
 	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images.
 	var/echo_group = null
 	/// This trait blocks us from receiving echolocation.
@@ -32,7 +34,7 @@
 	/// Cooldown for the echolocation.
 	COOLDOWN_DECLARE(cooldown_last)
 
-/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path)
+/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path, blinding)
 	. = ..()
 	var/mob/living/echolocator = parent
 	if(!istype(echolocator))
@@ -51,6 +53,8 @@
 		src.fade_in_time = fade_in_time
 	if(!isnull(fade_out_time))
 		src.fade_out_time = fade_out_time
+	if(!isnull(blinding))
+		src.blinding = blinding
 	if(!isnull(images_are_static))
 		src.images_are_static = images_are_static
 	if(!isnull(blocking_trait))
@@ -59,7 +63,8 @@
 	if(ispath(color_path))
 		client_colour = echolocator.add_client_colour(color_path, src.echo_group)
 	echolocator.add_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), src.echo_group) //so they see all the tiles they echolocated, even if they are in the dark
-	echolocator.become_blind(ECHOLOCATION_TRAIT)
+	if(blinding)
+		echolocator.become_blind(ECHOLOCATION_TRAIT)
 	echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
 	START_PROCESSING(SSfastprocess, src)
 
@@ -68,7 +73,8 @@
 	var/mob/living/echolocator = parent
 	QDEL_NULL(client_colour)
 	echolocator.remove_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), echo_group)
-	echolocator.cure_blind(ECHOLOCATION_TRAIT)
+	if(blinding)
+		echolocator.cure_blind(ECHOLOCATION_TRAIT)
 	echolocator.clear_fullscreen("echo")
 	for(var/mob/living/echolocate_receiver as anything in receivers)
 		if(!echolocate_receiver.client)

--- a/code/game/machinery/experimental_cloner/experimental_cloner_fuckup.dm
+++ b/code/game/machinery/experimental_cloner/experimental_cloner_fuckup.dm
@@ -143,7 +143,7 @@
 	weight = CLONER_FAILURE_RARE
 
 /datum/experimental_cloner_fuckup/total_failure/post_emerged(mob/living/carbon/human/victim)
-	victim.slow_psykerize()
+	victim.slow_psykerize(blind_them = TRUE)
 
 /// Just fuck me up
 /datum/experimental_cloner_fuckup/total_failure

--- a/code/modules/bitrunning/outfits.dm
+++ b/code/modules/bitrunning/outfits.dm
@@ -13,7 +13,7 @@
 
 /datum/outfit/echolocator/post_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
-	user.psykerize()
+	user.psykerize(is_blinding = TRUE)
 
 
 /datum/outfit/bitductor

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -43,7 +43,7 @@
 	head_flags = HEAD_DEBRAIN
 
 /// flavorful variant of psykerizing that deals damage and sends messages before calling psykerize()
-/mob/living/carbon/human/proc/slow_psykerize()
+/mob/living/carbon/human/proc/slow_psykerize(blind_them = FALSE)
 	if(stat == DEAD || !get_bodypart(BODY_ZONE_HEAD) || istype(get_bodypart(BODY_ZONE_HEAD), /obj/item/bodypart/head/psyker))
 		return
 	to_chat(src, span_userdanger("You feel unwell..."))
@@ -54,7 +54,7 @@
 	emote("scream")
 	apply_damage(30, BRUTE, BODY_ZONE_HEAD)
 	sleep(5 SECONDS)
-	if(!psykerize())
+	if(!psykerize(is_blinding = blind_them))
 		to_chat(src, span_warning("The transformation subsides..."))
 		return
 	apply_damage(50, BRUTE, BODY_ZONE_HEAD)


### PR DESCRIPTION

## About The Pull Request
yes i know its webedits its small just gimmie like a couple hours and i'll post testing results on local machine okay? okay thanks

Makes burdened chaplain and psyker pirates not blind, so that someone playing them isnt assaulted by irregularly flashing monochromatic lights on a black background. adds support for if you want psykerization to blind people or not.
keeps bitrunner psykers blind, since that's the point of the domain. Just avoid those specific ones if you can't handle the effect, sorry.
## Why It's Good For The Game
A. It makes psyker an actual useful ability. I have personally seen, as a ghost, psyker pirates fail to navigate out of their ship for a full five minutes, and then die horribly because they are unable to actually do anything because they're **Worse than blinded** since blindness has a small radius of working vision.

B. In-game effects should not cause **real world eye pain and nausea** thank you very much.

neat fact: blind seers only really work when the seer-ing makes up for the blindness.
## Changelog
:cl:
fix: blind psykers are not blinded twice by two different sources.
qol: Psyker pirates and chaplains are no longer blinded by default, so as to reduce the amount of eye strain from the echolocation effect. The echolocation virtual domains remain as they are.
/:cl:
