### PR TITLE
Replaces the traitor Toy AI module with the real toy on Wawa

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -33975,10 +33975,6 @@
 	pixel_x = 1;
 	pixel_y = -2
 	},
-/obj/item/ai_module/toy_ai{
-	pixel_x = -13;
-	pixel_y = 9
-	},
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "AI Upload Chamber - Lower";
 	network = list("aiupload")
@@ -33986,6 +33982,10 @@
 /obj/machinery/airalarm/directional/south,
 /obj/item/phone{
 	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/toy/talking/ai{
+	pixel_x = -13;
 	pixel_y = 9
 	},
 /turf/open/floor/carpet,

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -33984,7 +33984,7 @@
 	pixel_x = 9;
 	pixel_y = 9
 	},
-/obj/item/toy/talking/ai{
+/obj/item/ai_module/toy_ai{
 	pixel_x = -13;
 	pixel_y = 9
 	},

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -25695,14 +25695,14 @@
 "jbM" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
-/obj/item/ai_module/toy_ai{
-	pixel_x = 16;
-	pixel_y = 8
-	},
 /obj/item/paper_bin/construction{
 	pixel_y = 6
 	},
 /obj/item/pen,
+/obj/item/toy/talking/ai{
+	pixel_x = 18;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jbP" = (
@@ -60303,13 +60303,13 @@
 /area/station/maintenance/department/science)
 "uOs" = (
 /obj/structure/table/wood,
-/obj/item/ai_module/toy_ai{
-	pixel_x = 9;
-	pixel_y = -6
-	},
 /obj/item/food/carneburrito{
 	pixel_x = -2;
 	pixel_y = 5
+	},
+/obj/item/toy/talking/ai{
+	pixel_x = 9;
+	pixel_y = -6
 	},
 /turf/open/floor/carpet/executive,
 /area/station/command/meeting_room)


### PR DESCRIPTION
## About The Pull Request
Replaces 2 instances of the traitor AI toy with the real toy on Wawa
Resolves https://github.com/tgstation/tgstation/issues/91468

## Why It's Good For The Game

Probaly shouldnt be putting free traitor gear around the map 

## Changelog
:cl: Ezel
fix: Replaces 2 instances of the traitor AI toy with the real toy on Wawastation
/:cl:
