### PR TITLE
Ripley goliath plating now takes up an armor slot on the mech

### DIFF
--- a/code/datums/components/armor_plate.dm
+++ b/code/datums/components/armor_plate.dm
@@ -3,9 +3,9 @@
 	var/amount = 0
 	/// The maximum number of upgarde items that can be applied. Once var/amount reaches this value, no more upgrades can be applied
 	var/maxamount = 3
-	/// THe path for our upgrade item. Each one is expended to improve the parent's armor values.
+	/// The path for our upgrade item. Each one is expended to improve the parent's armor values.
 	var/upgrade_item = /obj/item/stack/sheet/animalhide/goliath_hide
-	/// THe armor datum path for our upgrade values. This value is added per upgrade item applied
+	/// The armor datum path for our upgrade values. This value is added per upgrade item applied
 	var/datum/armor/armor_mod = /datum/armor/armor_plate
 	/// The name of the upgrade item.
 	var/upgrade_name
@@ -13,6 +13,8 @@
 	var/upgrade_prefix = "reinforced"
 	/// Tracks whether or not we've received an upgrade or not.
 	var/have_upgraded = FALSE
+	/// Abstract armor equipment we're using to take up the slot and show up in the mech UI
+	var/obj/item/mecha_parts/mecha_equipment/armor/armor_plate/plate_component = null
 
 /datum/armor/armor_plate
 	melee = 10
@@ -38,6 +40,10 @@
 	var/obj/item/typecast = src.upgrade_item
 	src.upgrade_name = initial(typecast.name)
 
+/datum/component/armor_plate/Destroy(force)
+	QDEL_NULL(plate_component)
+	return ..()
+
 /datum/component/armor_plate/proc/examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
@@ -61,11 +67,18 @@
 
 	if(!istype(our_upgrade_item, upgrade_item))
 		return
+
 	if(amount >= maxamount)
 		to_chat(user, span_warning("You can't improve [parent] any further!"))
 		return
 
-	if(istype(our_upgrade_item, /obj/item/stack))
+	if(ismecha(parent) && !plate_component)
+		var/obj/vehicle/sealed/mecha/as_mecha = parent
+		if (LAZYLEN(as_mecha.equip_by_category[MECHA_ARMOR]) >= as_mecha.max_equip_by_category[MECHA_ARMOR])
+			to_chat(user, span_warning("[as_mecha] doesn't have any availible armor slots!"))
+			return
+
+	if(isstack(our_upgrade_item))
 		our_upgrade_item.use(1)
 	else
 		if(length(our_upgrade_item.contents))
@@ -76,17 +89,26 @@
 	var/obj/target_for_upgrading = parent
 	amount++
 	target_for_upgrading.set_armor(target_for_upgrading.get_armor().add_other_armor(armor_mod))
+	SEND_SIGNAL(target_for_upgrading, COMSIG_ARMOR_PLATED, amount, maxamount)
 
-	if(ismecha(target_for_upgrading))
-		var/obj/vehicle/sealed/mecha/mecha_for_upgrading = target_for_upgrading
-		mecha_for_upgrading.update_appearance()
-		to_chat(user, span_info("You strengthen [mecha_for_upgrading], improving its resistance against attacks."))
-	else
-		SEND_SIGNAL(target_for_upgrading, COMSIG_ARMOR_PLATED, amount, maxamount)
+	if(!ismecha(target_for_upgrading))
 		if(upgrade_prefix && !have_upgraded)
 			target_for_upgrading.name = "[upgrade_prefix] [target_for_upgrading.name]"
 			have_upgraded = TRUE
 		to_chat(user, span_info("You strengthen [target_for_upgrading], improving its resistance against attacks."))
+		return
+
+	var/obj/vehicle/sealed/mecha/mecha_for_upgrading = target_for_upgrading
+	mecha_for_upgrading.update_appearance()
+	to_chat(user, span_info("You strengthen [mecha_for_upgrading], improving its resistance against attacks."))
+	if (plate_component)
+		return
+	plate_component = new(mecha_for_upgrading)
+	plate_component.name = our_upgrade_item.name
+	plate_component.desc = our_upgrade_item.desc
+	plate_component.icon = our_upgrade_item.icon
+	plate_component.icon_state = our_upgrade_item.icon_state
+	plate_component.attach(mecha_for_upgrading)
 
 /datum/component/armor_plate/proc/dropplates(datum/source, force)
 	SIGNAL_HANDLER
@@ -105,3 +127,9 @@
 		if(!LAZYLEN(mech.occupants))
 			overlay_string += "-open"
 		overlays += overlay_string
+
+/// Abstract armor module used just to occupy a slot and show up in the UI
+/obj/item/mecha_parts/mecha_equipment/armor/armor_plate
+	name = "abstract armor"
+	desc = "Report this to a coder if you see this!"
+	detachable = FALSE

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -149,27 +149,23 @@
 //////////////////////////// ARMOR BOOSTER MODULES //////////////////////////////////////////////////////////
 /obj/item/mecha_parts/mecha_equipment/armor
 	equipment_slot = MECHA_ARMOR
-	///short protection name to display in the UI
-	var/protect_name = "you're mome"
-	///icon in armor.dmi that shows in the UI
-	var/iconstate_name
 	//how much the armor of the mech is modified by
 	var/datum/armor/armor_mod
 
 /obj/item/mecha_parts/mecha_equipment/armor/attach(obj/vehicle/sealed/mecha/new_mecha, attach_right)
 	. = ..()
-	chassis.set_armor(chassis.get_armor().add_other_armor(armor_mod))
+	if (armor_mod)
+		chassis.set_armor(chassis.get_armor().add_other_armor(armor_mod))
 
 /obj/item/mecha_parts/mecha_equipment/armor/detach(atom/moveto)
-	chassis.set_armor(chassis.get_armor().subtract_other_armor(armor_mod))
+	if (armor_mod)
+		chassis.set_armor(chassis.get_armor().subtract_other_armor(armor_mod))
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/armor/anticcw_armor_booster
 	name = "exosuit impact cushion plates"
 	desc = "Boosts exosuit armor against melee attacks"
 	icon_state = "mecha_abooster_ccw"
-	iconstate_name = "melee"
-	protect_name = "Melee Armor"
 	armor_mod = /datum/armor/mecha_equipment_ccw_boost
 
 /datum/armor/mecha_equipment_ccw_boost
@@ -179,8 +175,6 @@
 	name = "exosuit projectile shielding"
 	desc = "Boosts exosuit armor against ranged kinetic and energy projectiles. Completely blocks taser shots."
 	icon_state = "mecha_abooster_proj"
-	iconstate_name = "range"
-	protect_name = "Ranged Armor"
 	armor_mod = /datum/armor/mecha_equipment_ranged_boost
 
 /datum/armor/mecha_equipment_ranged_boost
@@ -192,8 +186,6 @@
 	desc = "Boosts exosuit armor against energy-based attacks. Also shields the exosuit's internal wiring from hostile EMP attacks. However, this may leave the \
 		exosuit slightly more vulnerable to kinetic blows due to taking up valuable hull cushioning."
 	icon_state = "mecha_abooster_emp"
-	iconstate_name = "range"
-	protect_name = "EMP and Energy Armor"
 	armor_mod = /datum/armor/mecha_equipment_energy_boost
 
 /datum/armor/mecha_equipment_energy_boost


### PR DESCRIPTION

## About The Pull Request
Attaching goliath plating to mechs now requires and takes up an armor slot.

![image](https://github.com/user-attachments/assets/cb2c6b97-95a5-4a82-b935-9ca7412fea03)

Also removed some now-unused values on armor modules

##### This is a comission for Ezel/Improvedname

## Why It's Good For The Game

Currently you can get to melee armor cap on Ripley or Paddy by stacking an armor booster with goliath armor (20 + 30 + nat 40 = 90) which is a bit absurd. While its strong enough on ripley, a lot of both antagonist and crew weapons (most, in fact) are melee and thus become absolutely useless against an already very oppressive roundstart mech that Paddy is. This makes goliath plates a better option than an armor booster that you have to go down to lavaland to while preventing it from being stacked to reach absurd numbers. Also could possibly lead to allowing attachment of those to other mechs which I think could be neat.

## Changelog
:cl:
balance: Ripley goliath plating now takes up an armor slot on the mech
/:cl:
