### PR TITLE
Makes psyker playable

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -65,7 +65,7 @@
 	echolocator.add_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), src.echo_group) //so they see all the tiles they echolocated, even if they are in the dark
 	if(blinding)
 		echolocator.become_blind(ECHOLOCATION_TRAIT)
-	echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
+		echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
 	START_PROCESSING(SSfastprocess, src)
 
 /datum/component/echolocation/Destroy(force)
@@ -75,7 +75,7 @@
 	echolocator.remove_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), echo_group)
 	if(blinding)
 		echolocator.cure_blind(ECHOLOCATION_TRAIT)
-	echolocator.clear_fullscreen("echo")
+		echolocator.clear_fullscreen("echo")
 	for(var/mob/living/echolocate_receiver as anything in receivers)
 		if(!echolocate_receiver.client)
 			continue
@@ -100,11 +100,19 @@
 		real_echo_range += 2
 	var/list/filtered = list()
 	var/list/seen = dview(real_echo_range, get_turf(echolocator.client?.eye || echolocator), invis_flags = echolocator.see_invisible)
-	for(var/atom/seen_atom as anything in seen)
-		if(!seen_atom.alpha)
-			continue
-		if(allowed_paths[seen_atom.type])
-			filtered += seen_atom
+	if(blinding)
+		for(var/atom/seen_atom as anything in seen)
+			if(!seen_atom.alpha)
+				continue
+			if(allowed_paths[seen_atom.type])
+				filtered += seen_atom
+	else
+		var/list/ranged_atoms = range(real_echo_range, get_turf(echolocator.client?.eye || echolocator))
+		for(var/atom/possible_atom as anything in ranged_atoms)
+			if(!possible_atom.alpha)
+				continue
+			if(allowed_paths[possible_atom.type])
+				filtered += possible_atom
 	if(!length(filtered))
 		return
 	var/current_time = "[world.time]"
@@ -119,7 +127,7 @@
 
 /datum/component/echolocation/proc/show_image(image/input_appearance, atom/input, current_time)
 	var/image/final_image = image(input_appearance)
-	final_image.layer += EFFECTS_LAYER
+	//final_image.layer += FOV_EFFECT_LAYER
 	final_image.plane = FULLSCREEN_PLANE
 	final_image.loc = images_are_static ? get_turf(input) : input
 	final_image.dir = input.dir

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -11,6 +11,8 @@
 	var/fade_out_time = 0.3 SECONDS
 	/// Are images static? If yes, spawns them on the turf and makes them not change location. Otherwise they change location and pixel shift with the original.
 	var/images_are_static = TRUE
+	/// Does this echolocation cause us to go blind?
+	var/blinding = TRUE
 	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images.
 	var/echo_group = null
 	/// This trait blocks us from receiving echolocation.
@@ -32,7 +34,7 @@
 	/// Cooldown for the echolocation.
 	COOLDOWN_DECLARE(cooldown_last)
 
-/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path)
+/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path, blinding)
 	. = ..()
 	var/mob/living/echolocator = parent
 	if(!istype(echolocator))
@@ -51,6 +53,8 @@
 		src.fade_in_time = fade_in_time
 	if(!isnull(fade_out_time))
 		src.fade_out_time = fade_out_time
+	if(!isnull(blinding))
+		src.blinding = blinding
 	if(!isnull(images_are_static))
 		src.images_are_static = images_are_static
 	if(!isnull(blocking_trait))
@@ -59,7 +63,8 @@
 	if(ispath(color_path))
 		client_colour = echolocator.add_client_colour(color_path, src.echo_group)
 	echolocator.add_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), src.echo_group) //so they see all the tiles they echolocated, even if they are in the dark
-	echolocator.become_blind(ECHOLOCATION_TRAIT)
+	if(blinding)
+		echolocator.become_blind(ECHOLOCATION_TRAIT)
 	echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
 	START_PROCESSING(SSfastprocess, src)
 
@@ -68,7 +73,8 @@
 	var/mob/living/echolocator = parent
 	QDEL_NULL(client_colour)
 	echolocator.remove_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), echo_group)
-	echolocator.cure_blind(ECHOLOCATION_TRAIT)
+	if(blinding)
+		echolocator.cure_blind(ECHOLOCATION_TRAIT)
 	echolocator.clear_fullscreen("echo")
 	for(var/mob/living/echolocate_receiver as anything in receivers)
 		if(!echolocate_receiver.client)

--- a/code/game/machinery/experimental_cloner/experimental_cloner_fuckup.dm
+++ b/code/game/machinery/experimental_cloner/experimental_cloner_fuckup.dm
@@ -143,7 +143,7 @@
 	weight = CLONER_FAILURE_RARE
 
 /datum/experimental_cloner_fuckup/total_failure/post_emerged(mob/living/carbon/human/victim)
-	victim.slow_psykerize()
+	victim.slow_psykerize(blind_them = TRUE)
 
 /// Just fuck me up
 /datum/experimental_cloner_fuckup/total_failure

--- a/code/modules/bitrunning/outfits.dm
+++ b/code/modules/bitrunning/outfits.dm
@@ -13,7 +13,7 @@
 
 /datum/outfit/echolocator/post_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
-	user.psykerize()
+	user.psykerize(is_blinding = TRUE)
 
 
 /datum/outfit/bitductor

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -13,7 +13,7 @@
 
 /obj/item/organ/brain/psyker/on_mob_insert(mob/living/carbon/inserted_into)
 	. = ..()
-	inserted_into.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DUMB, echo_group = "psyker", echo_icon = "psyker", color_path = /datum/client_colour/psyker, blinding = does_it_blind )
+	inserted_into.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DUMB, echo_group = "psyker", echo_icon = "psyker", color_path = /datum/client_colour/psyker, blinding = does_it_blind)
 	inserted_into.AddComponent(/datum/component/anti_magic, antimagic_flags = MAGIC_RESISTANCE_MIND)
 
 /obj/item/organ/brain/psyker/on_mob_remove(mob/living/carbon/removed_from)
@@ -33,7 +33,7 @@
 	apply_organ_damage(5 * seconds_per_tick, 199)
 
 /obj/organ/brain/psyker/blinding
-	does_it_blind = TRUE
+	var/does_it_blind = TRUE
 
 /obj/item/bodypart/head/psyker
 	limb_id = BODYPART_ID_PSYKER

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -32,8 +32,8 @@
 	owner.adjust_disgust(33 * seconds_per_tick)
 	apply_organ_damage(5 * seconds_per_tick, 199)
 
-/obj/organ/brain/psyker/blinding
-	var/does_it_blind = TRUE
+/obj/item/organ/brain/psyker/blinding
+	does_it_blind = TRUE
 
 /obj/item/bodypart/head/psyker
 	limb_id = BODYPART_ID_PSYKER
@@ -73,10 +73,10 @@
 	if(!psyker_head.replace_limb(src, special = TRUE))
 		return FALSE
 	qdel(old_head)
+	var/obj/item/organ/brain/psyker/psyker_brain = new() /// turns out if you make a flashing monochromatic outline against black background that refreshes on inconsistant intervals, it hurts peoples eyes. Who'da thunk.
 	if(is_blinding)
-		var/obj/item/organ/brain/psyker/blinding/psyker_brain = new() /// turns out if you make a flashing monochromatic outline against black background that refreshes on inconsistant intervals, it hurts peoples eyes. Who'da thunk.
-	else
-		var/obj/item/organ/brain/psyker/psyker_brain = new()
+		var/obj/item/organ/brain/psyker/blinding/dummy = new()
+		psyker_brain = dummy
 	old_brain.before_organ_replacement(psyker_brain)
 	old_brain.Remove(src, special = TRUE, movement_flags = NO_ID_TRANSFER)
 	qdel(old_brain)

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -43,7 +43,7 @@
 	head_flags = HEAD_DEBRAIN
 
 /// flavorful variant of psykerizing that deals damage and sends messages before calling psykerize()
-/mob/living/carbon/human/proc/slow_psykerize()
+/mob/living/carbon/human/proc/slow_psykerize(blind_them = FALSE)
 	if(stat == DEAD || !get_bodypart(BODY_ZONE_HEAD) || istype(get_bodypart(BODY_ZONE_HEAD), /obj/item/bodypart/head/psyker))
 		return
 	to_chat(src, span_userdanger("You feel unwell..."))
@@ -54,7 +54,7 @@
 	emote("scream")
 	apply_damage(30, BRUTE, BODY_ZONE_HEAD)
 	sleep(5 SECONDS)
-	if(!psykerize())
+	if(!psykerize(is_blinding = blind_them))
 		to_chat(src, span_warning("The transformation subsides..."))
 		return
 	apply_damage(50, BRUTE, BODY_ZONE_HEAD)

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -13,7 +13,7 @@
 
 /obj/item/organ/brain/psyker/on_mob_insert(mob/living/carbon/inserted_into)
 	. = ..()
-	inserted_into.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DUMB, echo_group = "psyker", echo_icon = "psyker", color_path = /datum/client_colour/psyker, blinding = does_it_blind)
+	inserted_into.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DUMB, echo_group = "psyker", echo_icon = "psyker", color_path = /datum/client_colour/psyker, blinding = does_it_blind )
 	inserted_into.AddComponent(/datum/component/anti_magic, antimagic_flags = MAGIC_RESISTANCE_MIND)
 
 /obj/item/organ/brain/psyker/on_mob_remove(mob/living/carbon/removed_from)


### PR DESCRIPTION
## About The Pull Request
-# so help me space jesus if this doesn't compile despite working fine on my local machine
Makes burdened chaplain and psyker pirates not blind, so that someone playing them isnt assaulted by irregularly flashing monochromatic lights on a black background. Instead the echolocation outlines will simply pulse to highlight nearby objects regardless of lighting conditions or other vision obscuring effects. adds support for if you want psykerization to blind people or not.
keeps bitrunner psykers blind, since that's the point of the domain. Just avoid those domains if you can't handle the effect, sorry.
## Why It's Good For The Game
A. It makes psyker an actual useful ability. I have personally seen, as a ghost, psyker pirates fail to navigate out of their ship for a full five minutes, and then die horribly because they are unable to actually do anything because they're **Worse than blinded** since blindness has a small radius of working vision.

B. In-game effects should not cause **real world eye pain and nausea** thank you very much.

neat fact: blind seers only really work when the seer-ing makes up for the blindness.

example of outline highlighting hidden underfloor objects (like that satchel!) while user is not horribly blinded
![image](https://github.com/user-attachments/assets/04ce713d-5e4a-434d-b41a-5206240a27ff)

## Changelog
:cl:
fix: blind psykers are not blinded twice by two different sources, head and brain.
qol: Psyker bounty hunters and chaplains are no longer blinded by default, so as to reduce the amount of eye strain from the echolocation effect. The echolocation virtual domains remain as they are.
/:cl:
