### PR TITLE
Heavily changes catwalk security, nearly completely altering the brig.

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -596,7 +596,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "akh" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -950,7 +950,6 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/bed/dogbed/mcgriff,
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -961,6 +960,7 @@
 	req_access = list("armory")
 	},
 /obj/structure/cable,
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "aqj" = (
@@ -1029,7 +1029,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "ars" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2289,14 +2289,13 @@
 /turf/open/openspace,
 /area/station/service/library)
 "aLI" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "aLJ" = (
 /turf/open/floor/carpet,
 /area/station/security/courtroom)
@@ -2307,6 +2306,12 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"aLL" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/small/directional/west,
+/obj/structure/guncase/ecase,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "aLT" = (
 /obj/machinery/computer/records/medical{
 	dir = 1
@@ -2324,16 +2329,13 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "aLX" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "aLY" = (
 /obj/item/stack/cable_coil{
 	pixel_y = -12
@@ -2477,7 +2479,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "aOj" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -2716,6 +2718,14 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"aTg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "aTt" = (
 /turf/open/floor/wood/large,
 /area/station/service/library)
@@ -2745,6 +2755,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"aTB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "aTH" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/window/spawner/directional/west,
@@ -2945,7 +2964,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "aWk" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/autoname/directional/west{
@@ -3064,8 +3083,7 @@
 /turf/open/floor/engine/hull/air,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aXU" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "aXW" = (
@@ -3119,13 +3137,8 @@
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "aYG" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 0;
-	pixel_y = 5
-	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "aYR" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch/directional/south,
@@ -4033,14 +4046,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "bnu" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -4048,8 +4061,8 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/stripes/end,
 /obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "bnO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
@@ -4092,6 +4105,18 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/storage/satellite)
+"bop" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/food_or_drink/donuts{
+	pixel_x = -4;
+	pixel_y = 38
+	},
+/obj/item/lighter{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "boq" = (
 /obj/item/toy/snappop,
 /turf/open/floor/plating,
@@ -4330,14 +4355,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/box/zipties{
-	pixel_x = -15;
-	pixel_y = 8
-	},
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "bsx" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -4620,15 +4643,23 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "bvU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/vending/security,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "armory";
+	name = "Armory Shutters"
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "bvZ" = (
 /obj/structure/railing{
 	dir = 8
@@ -6285,13 +6316,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bTJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable{
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/brig)
 "bTN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6593,13 +6629,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bYW" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "bYZ" = (
 /obj/item/toy/crayon/spraycan{
 	pixel_x = -8;
@@ -6968,6 +7004,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"cdb" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "cdc" = (
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
@@ -7347,14 +7392,14 @@
 "ciN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage"
 	},
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "ciS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -7471,6 +7516,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"clj" = (
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/fax{
+	fax_name = "Security Office";
+	name = "Security Office Fax Machine"
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "clk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -7557,6 +7610,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "cmK" = (
@@ -7682,12 +7738,9 @@
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
 "cpi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/brig)
 "cpy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -8663,7 +8716,6 @@
 "cBW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -8793,6 +8845,16 @@
 	dir = 4
 	},
 /area/station/medical/surgery)
+"cDX" = (
+/obj/structure/cable,
+/obj/machinery/computer/records/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "cDZ" = (
 /obj/machinery/computer/security/mining,
 /obj/structure/lattice/catwalk,
@@ -8963,6 +9025,14 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"cGg" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "cGp" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
@@ -9101,8 +9171,9 @@
 "cIa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "cIl" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera/autoname/directional/south,
@@ -9922,6 +9993,10 @@
 /obj/effect/turf_decal/tile/dark_blue,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"cUM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/medical)
 "cUX" = (
 /obj/structure/railing,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -10082,7 +10157,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "cXJ" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
@@ -10328,9 +10403,6 @@
 /turf/open/space/basic,
 /area/space)
 "dcJ" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light_switch/directional/north,
@@ -10630,7 +10702,8 @@
 /area/station/commons/dorms)
 "dhT" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/openspace,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/glass,
 /area/station/security/brig)
 "dic" = (
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -11432,20 +11505,14 @@
 /turf/open/openspace,
 /area/station/construction/storage_wing)
 "duf" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "dul" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/sign/warning/radiation/rad_area/directional/north,
@@ -11565,8 +11632,16 @@
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "dwb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/glass,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "dwf" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/pale/style_random,
@@ -11746,8 +11821,13 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
 "dzh" = (
-/turf/closed/wall,
-/area/station/security/office)
+/obj/structure/chair/sofa/corp/right{
+	desc = "Looks like someone threw it out. Covered in donut crumbs.";
+	dir = 1;
+	name = "couch"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "dzj" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/east{
 	id = "Cell 1";
@@ -12116,7 +12196,11 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
 "dFQ" = (
-/obj/structure/chair,
+/obj/structure/cable,
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "dFT" = (
@@ -12267,12 +12351,10 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/computer/security/labor{
-	dir = 8
-	},
 /obj/machinery/camera/directional/east,
+/obj/machinery/gulag_teleporter,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "dHK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12344,6 +12426,22 @@
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/floor/plating,
 /area/station/construction/storage_wing)
+"dIY" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/mod/module/plasma_stabilizer{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/mod/module/signlang_radio{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/mod/module/thermal_regulator{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "dJb" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
@@ -12709,6 +12807,11 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"dOi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "dOk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -12875,8 +12978,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dRJ" = (
-/obj/effect/spawner/random/structure/grille,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "dRU" = (
@@ -12964,6 +13071,16 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"dSZ" = (
+/obj/structure/lattice,
+/obj/item/toy/figure/ninja{
+	name = "Space Ninja";
+	desc = "How did he get there??";
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dTb" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/booze,
@@ -13160,11 +13277,9 @@
 /turf/open/openspace,
 /area/station/engineering/lobby)
 "dVE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/port)
 "dVL" = (
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
@@ -13412,13 +13527,11 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "dYQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/computer/records/security,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "dYY" = (
@@ -13579,12 +13692,8 @@
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
 "eat" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13776,7 +13885,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "edf" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -13890,9 +13999,6 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port)
 "efm" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -14032,7 +14138,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
 "egL" = (
-/obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -14165,15 +14270,14 @@
 /turf/closed/wall,
 /area/station/science/xenobiology/hallway)
 "ejJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ejP" = (
@@ -14505,6 +14609,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"eof" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/office)
 "eoq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -14943,7 +15050,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "ewf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -15114,10 +15221,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "ezx" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/turf/closed/wall,
+/area/station/security/medical)
 "ezL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -15236,6 +15341,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"eBk" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/closet/secure_closet/warden,
+/obj/item/binoculars,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "eBt" = (
 /obj/structure/tank_dispenser/oxygen{
 	pixel_x = -1;
@@ -15497,9 +15613,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "eGJ" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/port/fore)
+/obj/effect/turf_decal/tile/red/fourcorners,
+/turf/closed/wall/r_wall,
+/area/station/security/brig)
 "eGM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -15846,16 +15962,13 @@
 /area/station/security/brig)
 "eML" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "eNb" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -16713,7 +16826,7 @@
 /obj/effect/turf_decal/box/corners,
 /obj/item/reagent_containers/cup/bottle/morphine,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "faR" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/engine_access,
@@ -16820,14 +16933,8 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "fcJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/turf/closed/wall/r_wall,
+/area/station/security/processing)
 "fcK" = (
 /turf/closed/wall/r_wall,
 /area/station/security/detectives_office/private_investigators_office)
@@ -17247,16 +17354,16 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "fju" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	name = "Security Requests Console";
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/disablers,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/ai_monitored/security/armory)
 "fjy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -17594,6 +17701,18 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/science/research)
+"foz" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/briefcase/secure{
+	pixel_x = -3;
+	pixel_y = -32
+	},
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "foN" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -17899,9 +18018,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "fsH" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "fsM" = (
@@ -17933,12 +18051,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/port)
 "fsP" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory - Space";
-	dir = 4
-	},
-/turf/open/space/openspace,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "fsQ" = (
 /obj/structure/reflector/single{
 	dir = 9
@@ -17946,13 +18063,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "fsR" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/photocopier,
+/turf/open/floor/glass,
 /area/station/security/brig)
 "fsS" = (
 /obj/structure/lattice/catwalk,
@@ -18198,6 +18310,13 @@
 /obj/item/radio/off,
 /turf/open/floor/wood,
 /area/station/command/teleporter)
+"fwO" = (
+/obj/machinery/light/directional,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "fwP" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -18367,7 +18486,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "fzd" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -18457,28 +18576,7 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
 "fAH" = (
-/obj/structure/table,
-/obj/item/dragnet_beacon{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses{
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses{
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses{
-	pixel_y = -1
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/security/armory)
 "fAI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18511,14 +18609,16 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "fBf" = (
-/obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Security Office";
-	name = "Security Office Fax Machine"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/table,
+/obj/machinery/coffeemaker{
+	pixel_x = 0;
+	pixel_y = 9
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/brig)
 "fBm" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -18680,17 +18780,14 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "fDY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -19267,9 +19364,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fMt" = (
-/obj/item/food/cake/wedding,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/machinery/vending/wallmed/directional/east,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "fMu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -19390,6 +19491,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
+"fOd" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/megaphone/sec{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "fOe" = (
 /obj/structure/railing{
 	dir = 1
@@ -19417,11 +19526,11 @@
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/modular_computer/preset/cargochat/security,
 /obj/item/clothing/head/soft/sec{
-	pixel_x = -5;
+	pixel_x = 0;
 	pixel_y = 11
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "fOX" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/stripes/line,
@@ -20920,14 +21029,8 @@
 /area/station/hallway/primary/central)
 "gkk" = (
 /obj/structure/cable,
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "gkn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20945,11 +21048,15 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gkH" = (
-/obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "gkI" = (
 /obj/structure/sign/poster/official/safety_report/directional/south,
@@ -21322,16 +21429,39 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gpy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/structure/closet/secure_closet/warden,
-/obj/item/binoculars,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/machinery/button/door{
+	id = "briglockdown";
+	name = "Prison Wing Lockdown";
+	pixel_x = 9;
+	pixel_y = 10;
+	req_access = list("security")
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = 9;
+	pixel_y = 2;
+	req_access = list("security")
+	},
+/obj/machinery/recharger{
+	pixel_x = -1;
+	pixel_y = 7
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "gpI" = (
@@ -21438,7 +21568,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "grr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21492,25 +21622,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gtj" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec{
-	pixel_y = 15
-	},
-/obj/item/storage/backpack/duffelbag/sec{
-	pixel_y = 8
-	},
-/obj/item/inspector{
-	pixel_x = 4;
-	pixel_y = -6
-	},
-/obj/item/inspector{
-	pixel_x = -1;
-	pixel_y = -12
-	},
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/chair/sofa/corp/left{
+	desc = "Looks like someone threw it out. Covered in donut crumbs.";
+	dir = 4;
+	name = "couch"
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/brig)
 "gtk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -21887,16 +22009,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "gzl" = (
-/obj/structure/table,
-/obj/item/gun/energy/temperature/security{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/item/gun/energy/ionrifle{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -22471,15 +22583,6 @@
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/megaphone/sec{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/megaphone/sec{
-	pixel_x = 4;
-	pixel_y = -3
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -22517,14 +22620,12 @@
 /area/station/engineering/supermatter/room)
 "gKx" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe{
-	pixel_x = -7;
-	pixel_y = 10
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet{
+	name = "evidence closet 2"
 	},
-/obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "gKL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -22634,11 +22735,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison/safe)
 "gMv" = (
-/obj/item/target/syndicate,
-/obj/structure/training_machine,
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
@@ -23066,11 +23162,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/robotics/lab)
 "gSg" = (
-/obj/structure/closet/secure_closet{
-	name = "contraband locker"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
@@ -23260,13 +23357,22 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "gWi" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
 /obj/structure/sign/poster/contraband/communist_state/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/item/storage/box/prisoner{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/storage/box/prisoner{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/structure/table,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "gWm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/duct,
@@ -23707,13 +23813,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "hbM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "hci" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24099,16 +24205,15 @@
 /turf/open/floor/engine/hull/air,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hix" = (
+/obj/machinery/newscaster/directional/west,
 /obj/structure/rack,
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	name = "Security Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/battle_rifle{
+	pixel_y = 3
 	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/spawner/random/armory/e_gun,
+/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "hiK" = (
@@ -24177,8 +24282,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "hkm" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
@@ -24356,7 +24463,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "hmG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -24713,7 +24820,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "hsx" = (
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/white/textured_large,
@@ -24843,10 +24950,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "hug" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/machinery/computer/records/security,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "hui" = (
@@ -25141,6 +25245,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
+"hzd" = (
+/obj/machinery/camera/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "hzo" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -25200,17 +25313,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "hzT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/warden)
 "hzY" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 10
@@ -26008,7 +26124,10 @@
 /area/station/security/eva)
 "hKK" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/gulag_teleporter,
+/obj/machinery/vending/security,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "hKP" = (
@@ -27750,9 +27869,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/disposalpipe/sorting/mail/flip,
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ina" = (
@@ -27801,13 +27922,13 @@
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
 "inH" = (
-/obj/structure/rack,
-/obj/machinery/newscaster/directional/west,
 /obj/machinery/camera/motion{
 	c_tag = "Armory - Internal";
 	dir = 8
 	},
-/obj/effect/spawner/random/armory/laser_gun,
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "inK" = (
@@ -28143,12 +28264,12 @@
 "isD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "isG" = (
 /obj/structure/railing{
 	dir = 8
@@ -28355,21 +28476,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
 "iwe" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/pen{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet/l3closet/security,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "iwp" = (
@@ -28607,17 +28716,21 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
 "izs" = (
-/obj/structure/rack,
-/obj/item/storage/box/evidence{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 2
 	},
-/obj/item/storage/box/deputy{
-	pixel_x = 3
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/item/radio{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/glass,
+/area/station/security/brig)
 "izF" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -28732,7 +28845,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "iBG" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/floor/plating,
@@ -29438,7 +29551,7 @@
 "iKO" = (
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "iKT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -30364,7 +30477,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "jai" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -30533,12 +30646,11 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
 "jcK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/glass,
+/area/station/security/brig)
 "jcQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -31038,7 +31150,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "jkx" = (
 /obj/structure/closet/crate/wooden{
 	desc = "Used for storing props for a stage play!.";
@@ -31128,6 +31240,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
+"jlk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "jlo" = (
 /obj/structure/rack,
 /obj/item/encryptionkey/headset_com{
@@ -31187,6 +31309,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"jlT" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/lighter,
+/turf/closed/wall,
+/area/station/security/warden)
 "jma" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31358,7 +31485,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "jqd" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Community Center"
@@ -31839,6 +31966,14 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
+"jwr" = (
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "jwt" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy{
@@ -31975,7 +32110,7 @@
 /area/station/science/xenobiology)
 "jxI" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "jxL" = (
@@ -32540,8 +32675,10 @@
 /area/station/science/xenobiology)
 "jEB" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "jEG" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -32723,6 +32860,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
+"jHk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "jHq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -33227,15 +33371,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
 "jPU" = (
-/obj/structure/table,
 /obj/machinery/light_switch/directional/south,
-/obj/effect/spawner/random/armory/riot_shield,
-/obj/effect/spawner/random/armory/riot_helmet,
-/obj/effect/spawner/random/armory/riot_armor,
 /obj/machinery/light/directional/south,
-/obj/item/storage/belt/grenade{
-	pixel_y = 11
+/obj/machinery/button/door/directional/south{
+	id = "armory";
+	name = "Armory Shutters"
 	},
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/riot_shield,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "jPW" = (
@@ -34268,6 +34412,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/medbay/central)
+"khD" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "khE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -34447,19 +34601,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "kkv" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet{
+	name = "evidence closet 3"
 	},
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = -18;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -15
-	},
+/obj/effect/spawner/random/contraband/permabrig_weapon,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "kkC" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
@@ -35173,7 +35321,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/warning,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "ktL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -35550,11 +35698,10 @@
 /area/station/hallway/secondary/command)
 "kyS" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/office)
 "kyZ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/sign/warning/vacuum/external/directional/south,
@@ -35671,6 +35818,12 @@
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 10
 	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/office)
+"kAT" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/shotgun,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "kAV" = (
@@ -36093,15 +36246,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "kJp" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/turf/closed/wall,
+/area/station/security/warden)
 "kJw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36696,13 +36844,13 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
 "kSX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/status_display/ai/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/status_display/ai/directional/east,
-/obj/structure/bed/medical/emergency,
+/obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "kSY" = (
 /obj/structure/table,
 /obj/item/blood_filter{
@@ -36919,12 +37067,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
 "kWS" = (
-/obj/item/bouquet/sunflower,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/structure/cable,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "kWX" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
 	dir = 1
@@ -36948,6 +37097,7 @@
 /obj/effect/turf_decal/caution,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "kXG" = (
@@ -37091,15 +37241,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/tcommsat/server)
 "lae" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/sorting/mail,
-/obj/effect/mapping_helpers/mail_sorting/security/general,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "laf" = (
@@ -37382,7 +37531,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "leu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37657,7 +37806,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "ljt" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -37673,6 +37822,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/station/science/explab)
+"ljy" = (
+/obj/structure/secure_safe/directional/north{
+	name = "armory safe A";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/laser_gun,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "ljW" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -37706,7 +37865,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "lkt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -37747,6 +37906,7 @@
 /obj/machinery/door/window/right/directional/east{
 	name = "Warden's Place"
 	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "lkP" = (
@@ -37833,16 +37993,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "lmx" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lmz" = (
@@ -37931,7 +38087,7 @@
 	pixel_y = -1
 	},
 /mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/security/armory)
 "lnM" = (
 /obj/machinery/light/directional/north,
@@ -38076,7 +38232,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "lqr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38257,6 +38413,12 @@
 	},
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
+"ltn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "ltC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -39262,15 +39424,9 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "lJk" = (
 /obj/machinery/newscaster/directional/west,
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "lJo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4{
@@ -39665,8 +39821,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lON" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lPc" = (
@@ -39717,11 +39875,17 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "lPK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/structure/table/reinforced/rglass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/machinery/rnd/production/techfab/department/security,
-/turf/open/floor/iron/dark,
+/obj/item/inspector,
+/obj/item/inspector{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/turf/open/floor/glass,
 /area/station/security/brig)
 "lPS" = (
 /obj/machinery/holopad,
@@ -39815,6 +39979,27 @@
 /obj/structure/stairs/west,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"lRo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -15
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "lRp" = (
 /obj/item/storage/box/lights/mixed,
 /obj/structure/cable,
@@ -40386,6 +40571,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"lZb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/rnd/production/techfab/department/security,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "lZj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/poster/contraband/clown/directional/south,
@@ -40492,12 +40684,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "mbg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
-/area/station/security/range)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "mbk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -40559,13 +40750,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "mca" = (
-/obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/glass,
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/regular{
+	pixel_x = 0;
+	pixel_y = 5
 	},
-/obj/machinery/camera/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "mcb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -40916,14 +41110,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "mgj" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/under/rank/medical/scrubs/purple,
-/obj/item/clothing/under/rank/medical/scrubs/purple,
-/obj/item/healthanalyzer,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/obj/item/poster/random_contraband,
+/obj/effect/spawner/random/maintenance/no_decals/five,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "mgu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41138,17 +41332,9 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
 "mjZ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "mke" = (
 /obj/structure/table,
 /obj/item/binoculars,
@@ -41160,21 +41346,12 @@
 /turf/open/floor/glass,
 /area/station/commons/fitness/recreation)
 "mkG" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/closet/secure_closet{
-	name = "contraband locker"
+/obj/structure/bed/medical/emergency,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/spawner/random/maintenance/three,
-/obj/item/toy/figure/hos{
-	name = "Mismade HoS' Action Figure";
-	toysay = "Honk!"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "mkI" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
@@ -41796,12 +41973,11 @@
 "muE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/vending/wallmed/directional/west,
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "muF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/north,
@@ -42264,15 +42440,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "mDq" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "mDv" = (
@@ -42422,20 +42592,9 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "mFO" = (
-/obj/structure/table,
 /obj/item/radio/intercom/directional/south,
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/item/implanter{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 17;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "mFR" = (
@@ -42543,9 +42702,11 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/computer/records/security{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "mHd" = (
@@ -42760,6 +42921,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"mJK" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "mJL" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating/airless,
@@ -42847,10 +43014,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "mKZ" = (
@@ -42939,6 +43102,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
+"mMU" = (
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/light/directional/west,
+/obj/machinery/computer/prisoner/management{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "mMV" = (
 /obj/structure/railing{
 	dir = 6
@@ -43004,7 +43179,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "mNN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -43111,13 +43286,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "mPg" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "mPn" = (
@@ -43383,8 +43558,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass,
 /area/station/security/brig)
 "mUv" = (
 /obj/structure/lattice/catwalk,
@@ -43710,7 +43884,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "mZV" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43865,14 +44039,10 @@
 /area/station/command/heads_quarters/cmo)
 "ndf" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/landmark/secequipment,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "ndl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/autoname/directional/north,
@@ -44052,13 +44222,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "nfx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/computer/records/security{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "nfB" = (
@@ -44642,15 +44807,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
 "noQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/red,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/closet{
+	name = "evidence closet 4"
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "noR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -45188,7 +45354,7 @@
 "nwZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/security/lockers)
+/area/station/security/processing)
 "nxa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -45257,6 +45423,10 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/closet/secure_closet/injection{
+	name = "educational injections";
+	pixel_x = 2
+	},
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "nxR" = (
@@ -45440,6 +45610,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
+"nAZ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "nBg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45975,14 +46163,13 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "nIK" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass,
 /area/station/security/brig)
 "nIL" = (
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -46914,7 +47101,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
 "nXf" = (
-/obj/structure/railing,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -47517,7 +47703,7 @@
 "ohe" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "ohh" = (
 /turf/open/floor/grass,
 /area/station/science/cytology)
@@ -48360,6 +48546,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"ovN" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/box/deputy{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/implanter{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "ovQ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -48805,7 +49007,7 @@
 "oCb" = (
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "oCe" = (
 /turf/closed/wall,
 /area/station/hallway/primary/starboard)
@@ -49159,7 +49361,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "oHE" = (
 /obj/machinery/holopad/secure,
 /obj/structure/disposalpipe/segment,
@@ -49505,8 +49707,18 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port)
 "oLY" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/storage/box/prisoner{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
@@ -50036,7 +50248,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "oTU" = (
-/obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
 "oTZ" = (
@@ -50435,8 +50647,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass,
 /area/station/security/brig)
 "pac" = (
 /obj/machinery/door/airlock/security{
@@ -50590,7 +50801,7 @@
 /obj/machinery/light/directional/west,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "pbU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -51390,9 +51601,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "pow" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/closed/wall/r_wall,
+/area/station/security/office)
 "poZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51415,7 +51625,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "ppp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue,
@@ -51430,16 +51640,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/upper)
 "ppM" = (
-/obj/structure/closet/secure_closet{
-	name = "contraband locker"
-	},
-/obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/spawner/random/contraband/grenades/lethal,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "pqj" = (
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
@@ -52089,6 +52294,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"pBR" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "pBU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -52264,14 +52473,20 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "pFP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/box/evidence{
+	pixel_x = -5;
+	pixel_y = 12
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/item/folder/red{
+	pixel_x = 7
+	},
+/obj/item/toy/crayon/white{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "pFR" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
@@ -52496,8 +52711,9 @@
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "pIP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -53630,29 +53846,21 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/abandoned)
 "pWM" = (
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/airalarm/directional/south,
-/obj/item/toy/crayon/white{
-	pixel_x = -5;
-	pixel_y = 6
-	},
 /obj/item/toy/crayon/white{
 	pixel_x = -1;
 	pixel_y = 4
 	},
-/obj/item/toy/crayon/white{
-	pixel_x = -8;
-	pixel_y = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/item/paper_bin{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/structure/chair/sofa/corp/corner{
+	desc = "Looks like someone threw it out. Covered in donut crumbs.";
+	dir = 1;
+	name = "couch"
 	},
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/brig)
 "pWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -54283,6 +54491,13 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/station/engineering/main)
+"qiJ" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory - Space";
+	dir = 4
+	},
+/turf/open/space/openspace,
+/area/space)
 "qiU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -54786,8 +55001,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "qqY" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -54944,8 +55160,8 @@
 /area/station/construction/storage_wing)
 "qtA" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "qtM" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/camera/autoname/directional/north,
@@ -55049,6 +55265,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
+"qvR" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "qvU" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -55442,21 +55663,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qBw" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/brig)
 "qBx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -55510,12 +55722,11 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "qCp" = (
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/structure/transport/linear/public,
-/turf/open/openspace,
-/area/station/security/brig)
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "qCN" = (
 /obj/structure/railing{
 	dir = 1
@@ -56636,7 +56847,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "qVm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57605,6 +57816,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "rlk" = (
@@ -57946,8 +58159,10 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig - Infirmary"
 	},
+/obj/structure/closet/secure_closet/evidence,
+/obj/effect/spawner/random/contraband/narcotics,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "rpB" = (
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
@@ -58264,26 +58479,8 @@
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/box/deputy{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/storage/backpack/duffelbag/sec{
-	pixel_y = 2
-	},
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/dragnet,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "ruc" = (
@@ -58458,9 +58655,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rwf" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -58540,7 +58734,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "rxc" = (
 /obj/structure/table,
 /obj/machinery/fax{
@@ -58646,7 +58840,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "rze" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garbage Closet"
@@ -58991,6 +59185,9 @@
 "rED" = (
 /turf/closed/wall,
 /area/station/security/prison/shower)
+"rEE" = (
+/turf/open/floor/glass,
+/area/station/security/brig)
 "rEG" = (
 /obj/structure/mirror/directional/north,
 /obj/item/cigbutt,
@@ -59187,7 +59384,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rHm" = (
-/turf/closed/wall,
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/turf/open/floor/glass,
 /area/station/security/brig)
 "rHo" = (
 /obj/structure/disposalpipe/segment{
@@ -59270,12 +59470,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rIo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/camera/autoname/directional/south,
+/obj/structure/table,
+/obj/machinery/syndicatebomb/training{
+	pixel_x = 0;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
+/obj/item/wirecutters,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "rIq" = (
@@ -60370,9 +60575,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "saD" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -60419,6 +60621,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"sbf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "sbh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61750,9 +61958,6 @@
 /turf/open/floor/plating,
 /area/station/solars/starboard/aft)
 "svo" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -62066,24 +62271,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "briglockdown";
-	name = "Prison Wing Lockdown";
-	pixel_x = 5;
-	pixel_y = 7;
-	req_access = list("security")
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = 5;
-	pixel_y = -1;
-	req_access = list("security")
-	},
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
+/obj/machinery/computer/crew{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -62477,20 +62666,13 @@
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
 "sHK" = (
-/obj/structure/closet/crate/robust,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/item/toy/singlecard,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "sHR" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Custodial"
@@ -62806,13 +62988,10 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/main)
 "sMX" = (
-/obj/machinery/door/airlock/security{
-	name = "Gulag Processing"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "sNa" = (
@@ -62991,9 +63170,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "sQe" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -63069,17 +63245,14 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "sRe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "sRg" = (
@@ -64198,7 +64371,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "tjv" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -64633,7 +64805,7 @@
 	},
 /obj/item/vending_refill/security,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "tpU" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -64968,6 +65140,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
+"twQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "twX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -65086,7 +65265,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "tzO" = (
 /obj/structure/chair/office/light,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65260,6 +65439,14 @@
 /obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
+"tBR" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "tCb" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -65976,9 +66163,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tMn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/office)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "tMo" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured_large,
@@ -66004,8 +66191,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "tMS" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -66120,10 +66308,14 @@
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office/private_investigators_office)
 "tOE" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -66452,6 +66644,22 @@
 	dir = 4
 	},
 /area/station/science/robotics)
+"tTq" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/food/donut/berry{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "tTD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -67258,9 +67466,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "ugl" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
@@ -67934,9 +68146,6 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "upS" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/warning{
@@ -67964,16 +68173,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "upW" = (
-/obj/structure/table,
-/obj/machinery/syndicatebomb/training{
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_x = 1;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/camera/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet/bombcloset/security,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "uqb" = (
@@ -68055,8 +68256,9 @@
 "urc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "urh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -68103,6 +68305,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/science/explab)
+"urH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/range)
 "urV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68702,15 +68912,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "uzp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/evidence)
 "uzs" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -69625,9 +69837,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uNd" = (
-/obj/machinery/light/directional,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/security,
 /turf/open/floor/iron/dark,
-/area/station/security/range)
+/area/station/security/office)
 "uNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -69807,13 +70022,19 @@
 /turf/open/openspace,
 /area/station/maintenance/port/fore)
 "uRg" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/machinery/light/directional/west,
 /obj/structure/rack,
-/obj/structure/secure_safe/directional/north{
-	name = "armory safe A";
-	pixel_x = -22;
+/obj/effect/spawner/random/armory/riot_helmet{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/spawner/random/armory/bulletproof_helmet{
+	pixel_x = 8;
 	pixel_y = 0
 	},
-/obj/effect/spawner/random/armory/disablers,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "uRk" = (
@@ -69972,17 +70193,12 @@
 /turf/open/space/basic,
 /area/space)
 "uTu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
+/obj/machinery/light/directional/north,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "uTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
@@ -70006,11 +70222,8 @@
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "uUe" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
-/area/station/security/range)
+/area/station/security/medical)
 "uUj" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -70211,17 +70424,7 @@
 /area/station/medical/abandoned)
 "uXo" = (
 /obj/machinery/newscaster/directional/west,
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/machinery/recharger{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/machinery/camera/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/closed/wall/r_wall,
 /area/station/security/lockers)
 "uXz" = (
 /obj/structure/bed{
@@ -71941,13 +72144,9 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "vxH" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vxJ" = (
@@ -72240,6 +72439,12 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"vBB" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "vBM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -73097,19 +73302,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vPH" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "vPJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/port)
 "vPN" = (
 /obj/structure/cable,
@@ -73495,12 +73693,9 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "vUx" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 8
-	},
-/obj/structure/transport/linear/public,
-/turf/open/openspace,
-/area/station/security/brig)
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
 "vUQ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/wood,
@@ -73787,7 +73982,7 @@
 	},
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "waq" = (
 /obj/machinery/newscaster/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -73902,14 +74097,17 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "wcf" = (
-/obj/structure/table,
 /obj/machinery/firealarm/directional/south,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/effect/spawner/random/armory/bulletproof_helmet,
-/obj/effect/spawner/random/armory/bulletproof_helmet,
-/obj/effect/spawner/random/armory/bulletproof_armor,
-/obj/effect/spawner/random/armory/bulletproof_armor,
-/obj/machinery/light/directional/west,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/riot_armor{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/effect/spawner/random/armory/bulletproof_armor{
+	pixel_x = 11;
+	pixel_y = 2
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "wcL" = (
@@ -74205,11 +74403,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/office)
 "wgp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 4
@@ -74400,7 +74600,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/area/station/security/processing)
 "wiK" = (
 /obj/structure/cable,
 /turf/open/floor/wood/large,
@@ -74558,11 +74758,8 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
 "wlJ" = (
-/obj/structure/rack,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/spawner/random/armory/shotgun,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "wlL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -75028,6 +75225,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/cafeteria)
+"wsI" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "wsR" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -75732,7 +75940,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "wDP" = (
-/obj/structure/railing,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -76081,15 +76288,12 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "wIN" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/structure/cable,
+/turf/closed/wall,
+/area/station/security/evidence)
 "wIW" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -77320,6 +77524,14 @@
 /obj/machinery/light/warm/dim/directional/west,
 /turf/open/openspace,
 /area/station/hallway/primary/central)
+"xch" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "xci" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/openspace,
@@ -77511,11 +77723,13 @@
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/lesser)
 "xfc" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "xfn" = (
@@ -77553,6 +77767,17 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos/upper)
+"xfQ" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/sec{
+	pixel_y = 7
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "xfV" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -77594,14 +77819,14 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "xgS" = (
 /obj/machinery/airalarm/directional/west,
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/rack,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/under/rank/medical/scrubs/purple,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "xgV" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/turf_decal/tile/dark/full,
@@ -77733,18 +77958,16 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/item/clothing/suit/hooded/ablative{
-	pixel_x = 1
-	},
-/obj/structure/rack,
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Ablative Trenchcoat"
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access = list("armory")
+	},
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/maintenance/three,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -77901,9 +78124,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "xmL" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/security/medical)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "xmQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -78558,9 +78785,8 @@
 /turf/open/openspace,
 /area/station/hallway/primary/fore)
 "xxf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "xxv" = (
@@ -78918,7 +79144,7 @@
 	},
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "xDM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -79577,7 +79803,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/office)
 "xOh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -80421,10 +80647,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "yap" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/ai_monitored/security/armory)
+/turf/closed/wall/r_wall,
+/area/station/security/office)
 "yav" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
@@ -80480,14 +80705,6 @@
 /turf/open/openspace,
 /area/station/medical/storage)
 "ybe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/computer/prisoner/management{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "ybg" = (
@@ -80949,15 +81166,9 @@
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "yhF" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/secure_safe/directional/east{
-	name = "evidence safe"
-	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
-/area/station/security/evidence)
+/area/station/security/medical)
 "yhH" = (
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos/upper)
@@ -80982,6 +81193,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
+"yhV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/lockers)
 "yhW" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver{
@@ -162270,11 +162486,11 @@ nlm
 xIe
 nlm
 nlm
-yap
-yap
-yap
-yap
-yap
+mae
+mae
+mae
+mae
+mae
 mDG
 mDG
 mDG
@@ -162526,13 +162742,13 @@ nlm
 nlm
 xIe
 nlm
-yap
-yap
+mae
+mae
 aWd
-stm
+eof
 xOa
-yap
-yap
+mae
+mae
 mDG
 mDG
 dDL
@@ -162783,13 +162999,13 @@ nlm
 nlm
 xIe
 nlm
-yap
+mae
 xDI
 mZL
 fyZ
 kAI
 oHC
-yap
+mae
 mDG
 mDG
 nlm
@@ -163040,13 +163256,13 @@ xIe
 xIe
 xIe
 nlm
-yap
+mae
 oCb
 lqq
 grl
 ktI
 tpI
-yap
+mae
 mDG
 mDG
 nlm
@@ -163297,13 +163513,13 @@ dDL
 nlm
 nlm
 nlm
-yap
+mae
 wao
 edd
 mNI
 cXx
 faJ
-yap
+mae
 mDG
 nlm
 nlm
@@ -163551,16 +163767,16 @@ nlm
 nlm
 nlm
 dDL
-nlm
-nlm
-nlm
-yap
-yap
+qiJ
+dcE
+dcE
+mae
+mae
 jpJ
 akb
 iKO
-yap
-yap
+mae
+mae
 mDG
 nlm
 nlm
@@ -163804,19 +164020,19 @@ nlm
 nlm
 nlm
 nlm
-nlm
-nlm
-nlm
-dDL
-fsP
-nlm
-nlm
-nlm
+gRG
+gRG
+gRG
+vUx
+gRG
+gRG
+gRG
+dSZ
 yap
 arf
 tzC
 ewb
-yap
+mae
 mDG
 mDG
 nlm
@@ -164062,18 +164278,18 @@ nlm
 nlm
 nlm
 gRG
+fju
+hix
+aLL
+ljy
+kAT
 gRG
 gRG
-gRG
-gRG
-gRG
-gRG
-gRG
-gRG
-gRG
+pow
+pow
 tMB
-gRG
-gRG
+pow
+pow
 mDG
 mDG
 nlm
@@ -164319,30 +164535,30 @@ nlm
 nlm
 gRG
 gRG
-hix
+uof
 inH
 gzl
+uof
+uof
 uRg
-wlJ
 gRG
-gRG
-bwH
+pow
 ndf
-cnP
+ltn
 vPH
 bwH
 bwH
-nwZ
+yhV
 bwH
-nwZ
+yhV
 bwH
 nwZ
 hmB
-bwH
+fcJ
 nwZ
-bwH
+fcJ
 wiI
-bwH
+fcJ
 nlm
 nlm
 nlm
@@ -164576,29 +164792,29 @@ eBw
 eBw
 gRG
 dkw
-uof
-uof
+stm
 fAH
-uof
-uof
+fAH
+fAH
+stm
 wcf
 gRG
 fON
-aWm
-cnP
-aWm
+vPH
+ltn
+vPH
 uXo
 hKK
 oLY
-nwZ
+aLX
 dFQ
-aWm
+hzd
 nwZ
-aWm
+aYG
 nwZ
 ozN
 nwZ
-aWm
+aYG
 nwZ
 nlm
 nlm
@@ -164834,29 +165050,29 @@ hKJ
 gRG
 dqH
 stm
-stm
+fAH
 lnK
-stm
+fAH
 stm
 jPU
 gRG
 bnF
-tXJ
-cnP
+pBR
+jHk
 qtA
 xxf
 aWm
+tXJ
 aWm
-nwZ
 tjv
 rlb
-bwH
+fcJ
 jag
-bwH
+fcJ
 nwZ
-bwH
+fcJ
 ljl
-bwH
+fcJ
 nlm
 nlm
 nlm
@@ -165091,29 +165307,29 @@ fdd
 kto
 stm
 aqk
-stm
-stm
-stm
+fAH
+fAH
+fAH
 tAs
-stm
+mjZ
 gif
-aWm
-pow
-dVE
+vPH
+aXU
+mKX
+ltn
+gkH
 cnP
-gkH
-gkH
 kXE
 sMX
-cnP
+aTg
 cnP
 qqW
-cnP
+fsP
 pIy
 lke
 pbQ
 ohe
-bwH
+fcJ
 nlm
 nlm
 nlm
@@ -165355,21 +165571,21 @@ nBw
 xju
 gRG
 bvU
-fju
+vPH
 duf
-xpj
+cdb
 sRe
 bdT
 xpj
-bwH
+khD
 gSg
 ugl
-bwH
+fcJ
 aLI
-jcK
-urc
+gkk
+dOi
 ppi
-aWm
+aYG
 nwZ
 nlm
 nlm
@@ -165611,18 +165827,18 @@ usO
 dUN
 gRG
 gRG
-dzh
-mae
+dYQ
+pBR
 mDq
-mae
-mwr
-lji
-lji
-lji
+lZb
+ezx
+rwh
+rwh
+rwh
 kUq
 kUq
 kUq
-kUq
+xch
 gkk
 urc
 lep
@@ -165867,24 +166083,24 @@ qWc
 cmt
 cRn
 mGW
-aLX
-tMn
+fsH
+uNd
 aXU
-fcJ
+mKX
 rIo
-mwr
+ezx
 eML
 lJk
 xgS
 kUq
-sHK
 uJi
+cGg
 bYW
 gWi
 aOa
 dHv
 bsq
-bwH
+fcJ
 nlm
 nlm
 nlm
@@ -166122,26 +166338,26 @@ rwf
 lmx
 lmx
 lmx
-mjZ
+lmx
 bnu
-kyS
-tMn
-izs
-dYQ
-pFP
+fsH
+wsI
+vPH
+mKX
+pJp
 ciN
 isD
 cIa
 hjS
 kUq
-wTk
 uJi
-kUq
-bwH
+dVE
+fcJ
+fcJ
 iBv
-bwH
-bwH
-bwH
+fcJ
+fcJ
+fcJ
 nlm
 nlm
 nlm
@@ -166375,18 +166591,18 @@ wKD
 lFm
 ggl
 nXf
-jfA
-jfA
-jfA
-jfA
-jfA
-mPg
-kyS
-tMn
+lPK
+tTq
+rEE
+fsR
+rEE
+bTJ
+fsH
+mbg
 hug
 mKX
 upW
-mwr
+cUM
 ppM
 jkw
 dwb
@@ -166624,26 +166840,26 @@ xut
 fzd
 xut
 xut
-tUX
-apK
+hYF
+urH
 oTU
-uAE
-uNd
+oTU
+oTU
 lFm
 bmx
-vUx
-jfA
-jfA
-jfA
-jfA
-jfA
+bmx
+fOd
+jcK
+rEE
+pFP
+mJK
 mPg
 wgf
-uTu
 rOq
-pJp
+mKX
+mKX
 iwe
-mwr
+cUM
 mkG
 yhF
 mca
@@ -166881,29 +167097,29 @@ nSx
 ihv
 dhx
 xut
-uCF
-mbg
-uAE
-uAE
-uAE
+hGg
+apK
+uTu
+sHK
+fwO
 lFm
 jSY
 bmx
-jfA
-jfA
+ovN
+jcK
 dhT
-jfA
-jfA
+xfQ
+vBB
 mPg
 kyS
-tMn
+mae
 fsH
 vxH
 mFO
-kUq
-kUq
-kUq
-kUq
+rwh
+jwr
+uUe
+lRo
 kUq
 uJi
 kUq
@@ -167140,24 +167356,24 @@ hpz
 xut
 nec
 apK
-uUe
+uAE
 gMv
-uUe
+uAE
 lFm
 bmx
-qCp
-jfA
-jfA
-jfA
-jfA
-jfA
-mPg
+bmx
+izs
+jcK
+rEE
+dIY
+rHm
+jlk
 xfc
-tMn
+nAZ
 fBf
 gtj
 pWM
-kUq
+rwh
 fMt
 kWS
 jEB
@@ -167403,21 +167619,21 @@ lFm
 lFm
 efN
 wDP
-jfA
-jfA
-jfA
-jfA
-jfA
-mPg
-xfc
-tMn
-tMn
+foz
+bop
+rEE
+clj
+rEE
+twQ
+sbf
+wlJ
+wlJ
 tMn
 dzh
-kUq
-kUq
+lji
+mwr
 wIN
-kUq
+mwr
 kUq
 dEu
 riD
@@ -167653,15 +167869,15 @@ oKt
 xut
 xut
 rFA
-hGg
-rFA
+tBR
+cpi
 cpi
 ewi
 ocQ
 auF
-fsR
+egL
 upS
-ejJ
+aTB
 ejJ
 efm
 efm
@@ -167911,14 +168127,14 @@ dnj
 hGg
 tXf
 eGJ
-kTw
-kTw
+qvR
+bOI
 dDS
-rHm
-lPK
+uKa
+uKa
 hzT
-wxT
-wxT
+jlT
+qCp
 kJp
 ktp
 wxT
@@ -167928,7 +168144,7 @@ lON
 imW
 tOE
 xmL
-bTJ
+lji
 qVh
 hsr
 gKx
@@ -168167,15 +168383,15 @@ bMg
 bOk
 kHU
 kTw
-kTw
-kTw
-ezx
+eGJ
+jxI
+bOI
 oPa
 uKa
-uKa
+eBk
 fDY
-uKa
-qXK
+mMU
+cDX
 uKa
 cJs
 dxB
@@ -168185,7 +168401,7 @@ jII
 bqm
 jII
 bpK
-rwh
+lji
 rpy
 ryW
 kkv
@@ -168425,7 +168641,7 @@ uRd
 aiY
 kTw
 psn
-jxI
+bOI
 xOt
 dDS
 uKa
@@ -168442,7 +168658,7 @@ hLC
 ihP
 fTi
 bxH
-rwh
+lji
 kSX
 hbM
 noQ
@@ -168699,7 +168915,7 @@ vmv
 ihP
 aZA
 nJB
-rwh
+bpK
 kUq
 kUq
 kUq

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -12329,10 +12329,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
-"dHu" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
 "dHv" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -67433,17 +67429,6 @@
 /obj/effect/mapping_helpers/dead_body_placer,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
-"ugl" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
 "ugn" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood/large,
@@ -72125,7 +72110,6 @@
 "vxH" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vxJ" = (
@@ -73285,11 +73269,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"vPJ" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port)
 "vPN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73676,14 +73655,11 @@
 "vUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable{
-	pixel_x = 0;
-	pixel_y = 0
-	},
 /obj/effect/turf_decal/trimline/red/warning,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "vUQ" = (
@@ -164023,7 +163999,7 @@ nlm
 gRG
 gRG
 gRG
-dHu
+gRG
 gRG
 gRG
 gRG
@@ -165579,7 +165555,7 @@ bdT
 xpj
 nUU
 gSg
-ugl
+gSg
 fcJ
 aLI
 gkk
@@ -166606,7 +166582,7 @@ vke
 ppM
 jkw
 dwb
-vPJ
+kUq
 uJi
 dwB
 kUq

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -16600,6 +16600,11 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/openspace,
 /area/station/science/genetics)
+"eWU" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "eWW" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -43984,7 +43989,6 @@
 /area/station/command/heads_quarters/cmo)
 "ndf" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -70165,7 +70169,6 @@
 "uUe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -164521,7 +164524,7 @@ gRG
 wpQ
 ndf
 xPo
-izs
+eWU
 bwH
 bwH
 nwZ

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -27519,12 +27519,13 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "ihw" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory - Space";
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/camera/directional/east{
+	pixel_x = 0;
+	pixel_y = -10
 	},
 /turf/open/space/openspace,
-/area/space)
+/area/space/nearstation)
 "ihE" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/burial,
@@ -77922,7 +77923,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
 	},
@@ -163742,8 +163742,8 @@ nlm
 nlm
 nlm
 nlm
-dDL
 ihw
+nlm
 dcE
 dcE
 mae

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -815,6 +815,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"ank" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/shotgun,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "anm" = (
 /turf/closed/wall,
 /area/station/service/library/printer)
@@ -1405,6 +1411,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"axf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "axn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1496,6 +1508,14 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
+"ayO" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "ayR" = (
 /obj/structure/table,
 /obj/item/storage/crayons{
@@ -1967,6 +1987,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/hallway/secondary/entry)
+"aGg" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
+"aGx" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "aGR" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
@@ -2306,12 +2340,6 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"aLL" = (
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/light/small/directional/west,
-/obj/structure/guncase/ecase,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
 "aLT" = (
 /obj/machinery/computer/records/medical{
 	dir = 1
@@ -2329,13 +2357,13 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "aLX" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "aLY" = (
 /obj/item/stack/cable_coil{
 	pixel_y = -12
@@ -2718,14 +2746,6 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"aTg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/security_officer,
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
 "aTt" = (
 /turf/open/floor/wood/large,
 /area/station/service/library)
@@ -2755,15 +2775,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
-"aTB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "aTH" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/window/spawner/directional/west,
@@ -3083,9 +3094,15 @@
 /turf/open/floor/engine/hull/air,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aXU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/structure/secure_safe/directional/north{
+	name = "armory safe A";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/laser_gun,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "aXW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ladder,
@@ -4105,18 +4122,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/storage/satellite)
-"bop" = (
-/obj/structure/table/reinforced/rglass,
-/obj/effect/spawner/random/food_or_drink/donuts{
-	pixel_x = -4;
-	pixel_y = 38
-	},
-/obj/item/lighter{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "boq" = (
 /obj/item/toy/snappop,
 /turf/open/floor/plating,
@@ -6316,18 +6321,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bTJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/warning,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/computer/security,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/office)
 "bTN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7004,15 +7003,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"cdb" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4;
-	pixel_x = 0
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "cdc" = (
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
@@ -7516,14 +7506,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"clj" = (
-/obj/structure/table/reinforced/rglass,
-/obj/machinery/fax{
-	fax_name = "Security Office";
-	name = "Security Office Fax Machine"
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "clk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -7951,6 +7933,9 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/space/basic,
 /area/station/maintenance/solars/port/aft)
+"crx" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/office)
 "crB" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -8220,6 +8205,18 @@
 /obj/effect/landmark/navigate_destination/dockescpod,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"cvq" = (
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/light/directional/west,
+/obj/machinery/computer/prisoner/management{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "cvv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -8703,6 +8700,14 @@
 	dir = 1
 	},
 /area/station/maintenance/port/aft)
+"cBO" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/megaphone/sec{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "cBT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -8845,16 +8850,6 @@
 	dir = 4
 	},
 /area/station/medical/surgery)
-"cDX" = (
-/obj/structure/cable,
-/obj/machinery/computer/records/security{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/warden)
 "cDZ" = (
 /obj/machinery/computer/security/mining,
 /obj/structure/lattice/catwalk,
@@ -9025,14 +9020,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"cGg" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "cGp" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
@@ -9993,10 +9980,6 @@
 /obj/effect/turf_decal/tile/dark_blue,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
-"cUM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/medical)
 "cUX" = (
 /obj/structure/railing,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -11821,13 +11804,13 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
 "dzh" = (
-/obj/structure/chair/sofa/corp/right{
-	desc = "Looks like someone threw it out. Covered in donut crumbs.";
-	dir = 1;
-	name = "couch"
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
+/obj/machinery/computer/records/security,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/office)
 "dzj" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/east{
 	id = "Cell 1";
@@ -12346,6 +12329,10 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
+"dHu" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
 "dHv" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -12426,22 +12413,6 @@
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/floor/plating,
 /area/station/construction/storage_wing)
-"dIY" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/mod/module/plasma_stabilizer{
-	pixel_x = 0;
-	pixel_y = -1
-	},
-/obj/item/mod/module/signlang_radio{
-	pixel_x = 0;
-	pixel_y = -1
-	},
-/obj/item/mod/module/thermal_regulator{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "dJb" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
@@ -12807,11 +12778,6 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
-"dOi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/processing)
 "dOk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -13071,16 +13037,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"dSZ" = (
-/obj/structure/lattice,
-/obj/item/toy/figure/ninja{
-	name = "Space Ninja";
-	desc = "How did he get there??";
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dTb" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/booze,
@@ -13278,8 +13234,8 @@
 /area/station/engineering/lobby)
 "dVE" = (
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "dVL" = (
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
@@ -13527,13 +13483,14 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "dYQ" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/computer/records/security,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "dYY" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -14138,10 +14095,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
 "egL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/turf/open/floor/plating,
 /area/station/security/brig)
 "egU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14276,8 +14235,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ejP" = (
@@ -14609,9 +14566,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
-"eof" = (
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/office)
 "eoq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -15221,8 +15175,23 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "ezx" = (
-/turf/closed/wall,
-/area/station/security/medical)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "ezL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -15341,17 +15310,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"eBk" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/closet/secure_closet/warden,
-/obj/item/binoculars,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/dark,
-/area/station/security/warden)
 "eBt" = (
 /obj/structure/tank_dispenser/oxygen{
 	pixel_x = -1;
@@ -16354,6 +16312,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/cytology)
+"eSq" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "eSu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -17354,16 +17317,12 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "fju" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	name = "Security Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/disablers,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "fjy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -17701,18 +17660,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/science/research)
-"foz" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/briefcase/secure{
-	pixel_x = -3;
-	pixel_y = -32
-	},
-/obj/item/storage/fancy/cigarettes{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "foN" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -18018,10 +17965,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "fsH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "fsM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18051,11 +17999,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/port)
 "fsP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/processing)
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "fsQ" = (
 /obj/structure/reflector/single{
 	dir = 9
@@ -18063,8 +18008,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "fsR" = (
-/obj/machinery/photocopier,
-/turf/open/floor/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/security/brig)
 "fsS" = (
 /obj/structure/lattice/catwalk,
@@ -18310,13 +18257,6 @@
 /obj/item/radio/off,
 /turf/open/floor/wood,
 /area/station/command/teleporter)
-"fwO" = (
-/obj/machinery/light/directional,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "fwP" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -19491,14 +19431,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
-"fOd" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/megaphone/sec{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "fOe" = (
 /obj/structure/railing{
 	dir = 1
@@ -19537,6 +19469,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"fOZ" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/port)
 "fPf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/openspace,
@@ -19788,6 +19724,22 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"fSS" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/riot_helmet{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/spawner/random/armory/bulletproof_helmet{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "fSW" = (
 /obj/machinery/netpod,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23518,6 +23470,10 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
+"gXS" = (
+/obj/machinery/photocopier,
+/turf/open/floor/glass,
+/area/station/security/brig)
 "gXT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24205,15 +24161,9 @@
 /turf/open/floor/engine/hull/air,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hix" = (
-/obj/machinery/newscaster/directional/west,
-/obj/structure/rack,
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/battle_rifle{
-	pixel_y = 3
-	},
-/obj/item/gun/energy/temperature/security,
-/obj/item/gun/energy/ionrifle,
-/obj/item/clothing/suit/hooded/ablative,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/small/directional/west,
+/obj/structure/guncase/ecase,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "hiK" = (
@@ -24286,6 +24236,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
+"hjX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "hkm" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
@@ -25245,15 +25206,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
-"hzd" = (
-/obj/machinery/camera/directional/west,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
 "hzo" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -26352,6 +26304,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
+"hNY" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "hNZ" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -27564,6 +27522,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"ihw" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory - Space";
+	dir = 4
+	},
+/turf/open/space/openspace,
+/area/space)
 "ihE" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/burial,
@@ -28716,21 +28681,8 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
 "izs" = (
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/radio{
-	pixel_x = 0;
-	pixel_y = 2
-	},
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/glass,
-/area/station/security/brig)
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "izF" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -29377,6 +29329,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
+"iIg" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "iIi" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
@@ -30646,11 +30604,11 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
 "jcK" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "jcQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -31240,16 +31198,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
-"jlk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/warning,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "jlo" = (
 /obj/structure/rack,
 /obj/item/encryptionkey/headset_com{
@@ -31309,11 +31257,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
-"jlT" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/lighter,
-/turf/closed/wall,
-/area/station/security/warden)
 "jma" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31966,14 +31909,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
-"jwr" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/medical)
 "jwt" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy{
@@ -32109,9 +32044,20 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "jxI" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark,
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/radio{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/glass,
 /area/station/security/brig)
 "jxL" = (
 /obj/machinery/door/firedoor,
@@ -32860,13 +32806,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
-"jHk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "jHq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -33516,6 +33455,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"jSQ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/range)
 "jSV" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -34214,6 +34161,12 @@
 /obj/item/cigbutt,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/cargo/bitrunning/den)
+"keo" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "keq" = (
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark/smooth_large,
@@ -34322,6 +34275,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
+"kfF" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "kfG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -34412,16 +34373,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/medbay/central)
-"khD" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/lockers)
 "khE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -35138,6 +35089,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"krI" = (
+/obj/structure/chair/sofa/corp/right{
+	desc = "Looks like someone threw it out. Covered in donut crumbs.";
+	dir = 1;
+	name = "couch"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "krQ" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box{
@@ -35697,7 +35656,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
 "kyS" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -35820,12 +35778,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/office)
-"kAT" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/shotgun,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
 "kAV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -36419,6 +36371,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"kMH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "kMI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/fax{
@@ -37209,6 +37168,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
+"kZp" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/briefcase/secure{
+	pixel_x = -3;
+	pixel_y = -32
+	},
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "kZv" = (
 /obj/structure/broken_flooring/pile/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -37822,16 +37793,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/station/science/explab)
-"ljy" = (
-/obj/structure/secure_safe/directional/north{
-	name = "armory safe A";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/laser_gun,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
 "ljW" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -37993,14 +37954,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "lmx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 8
+/obj/machinery/newscaster/directional/west,
+/obj/structure/rack,
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/battle_rifle{
+	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "lmz" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -38413,12 +38377,6 @@
 	},
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
-"ltn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "ltC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -39128,6 +39086,18 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"lEH" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/food_or_drink/donuts{
+	pixel_x = -4;
+	pixel_y = 38
+	},
+/obj/item/lighter{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "lEO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -39876,14 +39846,17 @@
 /area/station/hallway/primary/central)
 "lPK" = (
 /obj/structure/table/reinforced/rglass,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/inspector,
-/obj/item/inspector{
-	pixel_x = -5;
+/obj/item/storage/box/deputy{
+	pixel_x = 6;
 	pixel_y = 12
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/implanter{
+	pixel_x = -1;
+	pixel_y = 0
 	},
 /turf/open/floor/glass,
 /area/station/security/brig)
@@ -39979,27 +39952,6 @@
 /obj/structure/stairs/west,
 /turf/open/floor/plating,
 /area/station/security/brig)
-"lRo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -15
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -7;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/medical)
 "lRp" = (
 /obj/item/storage/box/lights/mixed,
 /obj/structure/cable,
@@ -40571,13 +40523,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"lZb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/rnd/production/techfab/department/security,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "lZj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/poster/contraband/clown/directional/south,
@@ -40684,11 +40629,20 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "mbg" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/box/evidence{
+	pixel_x = -5;
+	pixel_y = 12
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/item/folder/red{
+	pixel_x = 7
+	},
+/obj/item/toy/crayon/white{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "mbk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -41332,9 +41286,14 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
 "mjZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "mke" = (
 /obj/structure/table,
 /obj/item/binoculars,
@@ -41421,6 +41380,10 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/station/commons/vacant_room/office)
+"mlX" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "mmb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -42921,12 +42884,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"mJK" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "mJL" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating/airless,
@@ -43102,18 +43059,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
-"mMU" = (
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/light/directional/west,
-/obj/machinery/computer/prisoner/management{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/warden)
 "mMV" = (
 /obj/structure/railing{
 	dir = 6
@@ -43750,6 +43695,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"mXD" = (
+/turf/open/floor/glass,
+/area/station/security/brig)
 "mXL" = (
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
@@ -45353,8 +45301,9 @@
 /area/space/nearstation)
 "nwZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/security/processing)
+/area/station/security/lockers)
 "nxa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -45610,24 +45559,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
-"nAZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = 7;
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "nBg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -46344,6 +46275,12 @@
 /obj/structure/stairs/north,
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
+"nLM" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "nLN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mod/module/longfall{
@@ -46946,6 +46883,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"nUU" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "nUV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -48546,22 +48493,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
-"ovN" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/deputy{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/item/storage/box/evidence{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/item/implanter{
-	pixel_x = -1;
-	pixel_y = 0
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "ovQ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -49216,6 +49147,27 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
+"oFs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -15
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "oFw" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -50028,6 +49980,12 @@
 "oRp" = (
 /turf/open/floor/iron/textured_large,
 /area/space/nearstation)
+"oRq" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "oRs" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -50340,6 +50298,14 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"oUW" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "oVg" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
@@ -51313,6 +51279,14 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/port)
+"pjA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "pjC" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/cigar,
@@ -51601,7 +51575,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "pow" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
 /area/station/security/office)
 "poZ" = (
 /obj/structure/cable,
@@ -52294,10 +52269,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"pBR" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "pBU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -52473,20 +52444,10 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "pFP" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/evidence{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/folder/red{
-	pixel_x = 7
-	},
-/obj/item/toy/crayon/white{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
+/obj/structure/disposalpipe/segment,
+/obj/item/lighter,
+/turf/closed/wall,
+/area/station/security/warden)
 "pFR" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
@@ -54491,13 +54452,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/station/engineering/main)
-"qiJ" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory - Space";
-	dir = 4
-	},
-/turf/open/space/openspace,
-/area/space)
 "qiU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -55265,11 +55219,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
-"qvR" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "qvU" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -55722,11 +55671,13 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
 "qCp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/warden)
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/fax{
+	fax_name = "Security Office";
+	name = "Security Office Fax Machine"
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "qCN" = (
 /obj/structure/railing{
 	dir = 1
@@ -56482,6 +56433,12 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"qPK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "qPM" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 1
@@ -58443,6 +58400,22 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"rtq" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/mod/module/plasma_stabilizer{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/mod/module/signlang_radio{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/mod/module/thermal_regulator{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "rtx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -58454,6 +58427,17 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
+"rtA" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/closet/secure_closet/warden,
+/obj/item/binoculars,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "rtD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59185,9 +59169,6 @@
 "rED" = (
 /turf/closed/wall,
 /area/station/security/prison/shower)
-"rEE" = (
-/turf/open/floor/glass,
-/area/station/security/brig)
 "rEG" = (
 /obj/structure/mirror/directional/north,
 /obj/item/cigbutt,
@@ -59384,11 +59365,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rHm" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/structure/lattice,
+/obj/item/toy/figure/ninja{
+	name = "Space Ninja";
+	desc = "How did he get there??";
+	pixel_x = -8;
+	pixel_y = 7
 	},
-/turf/open/floor/glass,
-/area/station/security/brig)
+/turf/open/space/basic,
+/area/space/nearstation)
 "rHo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60621,12 +60606,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"sbf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "sbh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62666,13 +62645,16 @@
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
 "sHK" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/sec{
+	pixel_y = 7
 	},
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "sHR" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Custodial"
@@ -62912,6 +62894,16 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"sKR" = (
+/obj/structure/cable,
+/obj/machinery/computer/records/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "sKT" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
@@ -63082,6 +63074,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"sOy" = (
+/obj/machinery/light/directional,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "sOz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65140,13 +65139,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
-"twQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/warning,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "twX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -65439,14 +65431,6 @@
 /obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
-"tBR" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "tCb" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -66644,22 +66628,6 @@
 	dir = 4
 	},
 /area/station/science/robotics)
-"tTq" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/food/donut/berry{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "tTD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -68256,7 +68224,6 @@
 "urc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/processing)
 "urh" = (
@@ -68305,14 +68272,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/science/explab)
-"urH" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/range)
 "urV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69172,6 +69131,9 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/central)
+"uDi" = (
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "uDo" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/fire{
@@ -69837,12 +69799,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uNd" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/computer/security,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/brig)
 "uNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -70022,21 +69987,12 @@
 /turf/open/openspace,
 /area/station/maintenance/port/fore)
 "uRg" = (
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/machinery/light/directional/west,
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/riot_helmet{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/machinery/light/directional/north,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/spawner/random/armory/bulletproof_helmet{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "uRk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random/directional/south,
@@ -70193,12 +70149,11 @@
 /turf/open/space/basic,
 /area/space)
 "uTu" = (
-/obj/machinery/light/directional/north,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/range)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/processing)
 "uTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
@@ -70222,8 +70177,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "uUe" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
-/area/station/security/medical)
+/area/station/security/office)
 "uUj" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -70814,6 +70773,22 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron/stairs/medium,
 /area/station/medical/medbay/central)
+"vdX" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/food/donut/berry{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "vef" = (
 /obj/machinery/door/airlock{
 	name = "Coffin Storage"
@@ -71232,6 +71207,10 @@
 "vkd" = (
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"vke" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/medical)
 "vkl" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -72439,12 +72418,6 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"vBB" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "vBM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -73302,6 +73275,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vPH" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box{
+	pixel_x = 0;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vPJ" = (
@@ -73693,9 +73674,18 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "vUx" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "vUQ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/wood,
@@ -74758,8 +74748,9 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
 "wlJ" = (
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/processing)
 "wlL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -75071,6 +75062,9 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"wpQ" = (
+/turf/closed/wall/r_wall,
+/area/station/security/office)
 "wpW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/red/dim/directional/north,
@@ -75225,17 +75219,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/cafeteria)
-"wsI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = 0;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "wsR" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -75260,6 +75243,17 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
+"wtg" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	name = "Security Requests Console";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/disablers,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "wti" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/spawner/directional/north,
@@ -77524,14 +77518,6 @@
 /obj/machinery/light/warm/dim/directional/west,
 /turf/open/openspace,
 /area/station/hallway/primary/central)
-"xch" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/processing)
 "xci" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/openspace,
@@ -77705,6 +77691,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"xeV" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/inspector,
+/obj/item/inspector{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/turf/open/floor/glass,
+/area/station/security/brig)
 "xeW" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark/smooth_large,
@@ -77767,17 +77766,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos/upper)
-"xfQ" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/sec{
-	pixel_y = 7
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/glass,
-/area/station/security/brig)
 "xfV" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -78801,6 +78789,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"xxK" = (
+/turf/closed/wall,
+/area/station/security/medical)
 "xxZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
@@ -79873,6 +79864,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
+"xPo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "xPB" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -80942,6 +80939,14 @@
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
+"yek" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/lockers)
 "yem" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -81193,11 +81198,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
-"yhV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/lockers)
 "yhW" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver{
@@ -162745,7 +162745,7 @@ nlm
 mae
 mae
 aWd
-eof
+crx
 xOa
 mae
 mae
@@ -163767,7 +163767,7 @@ nlm
 nlm
 nlm
 dDL
-qiJ
+ihw
 dcE
 dcE
 mae
@@ -164023,11 +164023,11 @@ nlm
 gRG
 gRG
 gRG
-vUx
+dHu
 gRG
 gRG
 gRG
-dSZ
+rHm
 yap
 arf
 tzC
@@ -164278,18 +164278,18 @@ nlm
 nlm
 nlm
 gRG
-fju
+wtg
+lmx
 hix
-aLL
-ljy
-kAT
+aXU
+ank
 gRG
 gRG
-pow
-pow
+wpQ
+wpQ
 tMB
-pow
-pow
+wpQ
+wpQ
 mDG
 mDG
 nlm
@@ -164540,22 +164540,22 @@ inH
 gzl
 uof
 uof
-uRg
+fSS
 gRG
-pow
+wpQ
 ndf
-ltn
-vPH
+xPo
+izs
 bwH
-bwH
-yhV
-bwH
-yhV
 bwH
 nwZ
+bwH
+nwZ
+bwH
+wlJ
 hmB
 fcJ
-nwZ
+wlJ
 fcJ
 wiI
 fcJ
@@ -164800,22 +164800,22 @@ stm
 wcf
 gRG
 fON
-vPH
-ltn
-vPH
+izs
+xPo
+izs
 uXo
 hKK
 oLY
-aLX
+ayO
 dFQ
-hzd
-nwZ
+dYQ
+wlJ
 aYG
-nwZ
+wlJ
 ozN
-nwZ
+wlJ
 aYG
-nwZ
+wlJ
 nlm
 nlm
 nlm
@@ -165057,8 +165057,8 @@ stm
 jPU
 gRG
 bnF
-pBR
-jHk
+mlX
+kMH
 qtA
 xxf
 aWm
@@ -165069,7 +165069,7 @@ rlb
 fcJ
 jag
 fcJ
-nwZ
+wlJ
 fcJ
 ljl
 fcJ
@@ -165311,20 +165311,20 @@ fAH
 fAH
 fAH
 tAs
-mjZ
+dVE
 gif
-vPH
-aXU
+izs
+pow
 mKX
-ltn
+xPo
 gkH
 cnP
 kXE
 sMX
-aTg
+yek
 cnP
 qqW
-fsP
+qPK
 pIy
 lke
 pbQ
@@ -165571,22 +165571,22 @@ nBw
 xju
 gRG
 bvU
-vPH
+izs
 duf
-cdb
+aGg
 sRe
 bdT
 xpj
-khD
+nUU
 gSg
 ugl
 fcJ
 aLI
 gkk
-dOi
+urc
 ppi
 aYG
-nwZ
+wlJ
 nlm
 nlm
 nlm
@@ -165827,23 +165827,23 @@ usO
 dUN
 gRG
 gRG
-dYQ
-pBR
+dzh
+mlX
 mDq
-lZb
-ezx
+uUe
+xxK
 rwh
 rwh
 rwh
 kUq
 kUq
 kUq
-xch
+pjA
 gkk
-urc
+uTu
 lep
 aYG
-nwZ
+wlJ
 nlm
 nlm
 nlm
@@ -166083,18 +166083,18 @@ qWc
 cmt
 cRn
 mGW
-fsH
-uNd
-aXU
+kyS
+bTJ
+pow
 mKX
 rIo
-ezx
+xxK
 eML
 lJk
 xgS
 kUq
 uJi
-cGg
+oUW
 bYW
 gWi
 aOa
@@ -166333,16 +166333,16 @@ svo
 sQe
 uvF
 auF
-egL
+fsR
 rwf
-lmx
-lmx
-lmx
-lmx
+mjZ
+mjZ
+mjZ
+mjZ
 bnu
-fsH
-wsI
+kyS
 vPH
+izs
 mKX
 pJp
 ciN
@@ -166351,7 +166351,7 @@ cIa
 hjS
 kUq
 uJi
-dVE
+fOZ
 fcJ
 fcJ
 iBv
@@ -166591,18 +166591,18 @@ wKD
 lFm
 ggl
 nXf
-lPK
-tTq
-rEE
-fsR
-rEE
-bTJ
-fsH
-mbg
+xeV
+vdX
+mXD
+gXS
+mXD
+vUx
+kyS
+iIg
 hug
 mKX
 upW
-cUM
+vke
 ppM
 jkw
 dwb
@@ -166841,25 +166841,25 @@ fzd
 xut
 xut
 hYF
-urH
+jSQ
 oTU
 oTU
 oTU
 lFm
 bmx
 bmx
-fOd
-jcK
-rEE
-pFP
-mJK
+cBO
+fsH
+mXD
+mbg
+hNY
 mPg
 wgf
 rOq
 mKX
 mKX
 iwe
-cUM
+vke
 mkG
 yhF
 mca
@@ -167099,27 +167099,27 @@ dhx
 xut
 hGg
 apK
-uTu
-sHK
-fwO
+uRg
+kfF
+sOy
 lFm
 jSY
 bmx
-ovN
-jcK
-dhT
-xfQ
-vBB
-mPg
-kyS
-mae
+lPK
 fsH
+dhT
+sHK
+oRq
+mPg
+keo
+mae
+kyS
 vxH
 mFO
 rwh
-jwr
-uUe
-lRo
+aLX
+uDi
+oFs
 kUq
 uJi
 kUq
@@ -167362,14 +167362,14 @@ uAE
 lFm
 bmx
 bmx
-izs
-jcK
-rEE
-dIY
-rHm
-jlk
+jxI
+fsH
+mXD
+rtq
+nLM
+uNd
 xfc
-nAZ
+ezx
 fBf
 gtj
 pWM
@@ -167619,17 +167619,17 @@ lFm
 lFm
 efN
 wDP
-foz
-bop
-rEE
-clj
-rEE
-twQ
-sbf
-wlJ
-wlJ
+kZp
+lEH
+mXD
+qCp
+mXD
+fju
+axf
+fsP
+fsP
 tMn
-dzh
+krI
 lji
 mwr
 wIN
@@ -167869,16 +167869,16 @@ oKt
 xut
 xut
 rFA
-tBR
+egL
 cpi
 cpi
 ewi
 ocQ
 auF
-egL
+fsR
 upS
-aTB
 ejJ
+hjX
 efm
 efm
 saD
@@ -168127,14 +168127,14 @@ dnj
 hGg
 tXf
 eGJ
-qvR
+aGx
 bOI
 dDS
 uKa
 uKa
 hzT
-jlT
-qCp
+pFP
+jcK
 kJp
 ktp
 wxT
@@ -168384,14 +168384,14 @@ bOk
 kHU
 kTw
 eGJ
-jxI
+eSq
 bOI
 oPa
 uKa
-eBk
+rtA
 fDY
-mMU
-cDX
+cvq
+sKR
 uKa
 cJs
 dxB


### PR DESCRIPTION

## About The Pull Request

Almost completely changes the brig on Catwalk Station, pictures included.
Evidence storage and secmed are switched to give secmed more room, as evidence storage isnt really used that much to begin with. 
Gulag teleporter was moved into the actual gulag room, which im not really sure why they didnt share the same room to begin with, as well as editing the area to say gulag processing, since it was just flagged as the locker room.
Warden's office was made one tile wider to give them more room to breathe, as well as giving them a crew sensor monitor in their office. 
Armory shutter buttons were added, as well as just re-arranging the contents and adding a BR and contraband locker, present in the other map's armories.
Added a 5th secoff locker into the locker room.

Warden's office
![image](https://github.com/user-attachments/assets/08f655c2-5f5b-46f5-a3d2-bb1603b0315a)
Armory
![image](https://github.com/user-attachments/assets/dbc19b8f-803c-4b6d-a56a-08b5c77c75f4)
The main Brig
![image](https://github.com/user-attachments/assets/dc622501-d05b-4602-95ca-2182823284ba)
Security office + Secure Gear storage
![image](https://github.com/user-attachments/assets/38c6161e-8e6e-4f00-b625-ca0e5ac4270c)
Security Locker room
![image](https://github.com/user-attachments/assets/9a278e87-5d07-4cc2-a36e-210be4e91391)
Security medbay + Evidence storage
![image](https://github.com/user-attachments/assets/23cec295-17ca-4aba-9318-9bc9bb20f445)
Gulag processing + Security Mech Storage
![image](https://github.com/user-attachments/assets/50b29ad9-90fa-465f-baac-8a66db682b25)
I have tested the map in-game, It has worked, but I have yet to take pictures of it ingame, but I will soon, as well as a video demonstration, too.
If you have any suggestions or requested changes, let me know.



## Why It's Good For The Game

As of now, the current Catwalk brig just feels cramped- I'm also not the only person who felt this way, after asking. The armory didnt have a shutter button (atleast not one you can use in the armory), the lathe was in a random corner, the wardens office was 3 tiles wide, and the observation took up most of the brig. It felt cramped, and especially hard to move stuff around the map. I saw pr #91438, and went "huh, why dont I refurbish the department I play in the most." And thats what I did.



:cl: Kuricityy
map: Heavily changes Catwalk Station's security department; almost completely altering the brig.
/:cl:
