### PR TITLE
Reduces ghost poll time for blackout drunk

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -13,6 +13,8 @@
 	var/mob/living/split_personality/owner_backseat
 	///The role to display when polling ghost
 	var/poll_role = "split personality"
+	///How long do we give ghosts to respond?
+	var/poll_time = 20 SECONDS
 
 /datum/brain_trauma/severe/split_personality/on_gain()
 	var/mob/living/brain_owner = owner
@@ -41,7 +43,7 @@
 	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
 		question = "Do you want to play as [span_danger("[owner.real_name]'s")] [span_notice(poll_role)]?",
 		check_jobban = ROLE_PAI,
-		poll_time = 20 SECONDS,
+		poll_time = poll_time,
 		checked_target = owner,
 		ignore_category = POLL_IGNORE_SPLITPERSONALITY,
 		alert_pic = owner,
@@ -264,6 +266,7 @@
 	lose_text = "You wake up very, very confused and hungover. All you can remember is drinking a lot of alcohol... what happened?"
 	poll_role = "blacked out drunkard"
 	random_gain = FALSE
+	poll_time = 10 SECONDS
 	/// Duration of effect, tracked in seconds, not deciseconds. qdels when reaching 0.
 	var/duration_in_seconds = 180
 


### PR DESCRIPTION
## About The Pull Request

Reduces the time spent selecting ghosts for the "blackout drunk" effect from 20 seconds to 10

## Why It's Good For The Game

Your average person who triggers the "Blackout Drunk" effect (where another player is put in control of their character) is roughly 45 seconds away from dying of liver failure (number I pulled out of my ass) or at least getting knocked out for a long time due to the amount of alcohol in their blood
20 of those seconds are spent polling for ghosts, meaning that the length of time between someone else assuming direct control and the character becoming permanently unconscious is frequently not really long enough for them to do anything funny

You know when clicking this role that you're signing up for a good time not a long time, but I think that also means people probably don't need to think too long about whether they want to play it or not, so halving the selection time gives you a full 10 seconds more time to tell everyone in the bar that they're your best friends

Regular Split Personality traumas aren't so time critical and can continue to enjoy a lengthier selection process to possibly gather more candidates

## Changelog

:cl:
qol: ghost candidates for blackout drunk are selected more quickly
/:cl:
