### PR TITLE
Fixes lathes breaking on ore silo deletion

### DIFF
--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -122,7 +122,7 @@ handles linking back and forth.
  * old_silo- The silo we are trying to disconnect from
  */
 /datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
-	if (QDELETED(old_silo) || silo != old_silo)
+	if (silo != old_silo)
 		return
 
 	UnregisterSignal(parent, list(COMSIG_ATOM_ITEM_INTERACTION, COMSIG_ATOM_ITEM_INTERACTION_SECONDARY))

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -121,8 +121,8 @@ handles linking back and forth.
  * Arguments
  * old_silo- The silo we are trying to disconnect from
  */
-/datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
-	if (silo != old_silo)
+/datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo = silo)
+	if (isnull(old_silo) || silo != old_silo)
 		return
 
 	UnregisterSignal(parent, list(COMSIG_ATOM_ITEM_INTERACTION, COMSIG_ATOM_ITEM_INTERACTION_SECONDARY))

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -75,7 +75,7 @@ handles linking back and forth.
 /datum/component/remote_materials/Destroy()
 	if(silo)
 		allow_standalone = FALSE
-		disconnect_from(silo)
+		disconnect()
 	mat_container = null
 
 	return ..()
@@ -115,14 +115,9 @@ handles linking back and forth.
 	if (!silo && mat_container)
 		mat_container.max_amount = size
 
-/**
- * Disconnect this component from the remote silo
- *
- * Arguments
- * old_silo- The silo we are trying to disconnect from
- */
-/datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo = silo)
-	if (isnull(old_silo) || silo != old_silo)
+///Disconnects this component from the silo
+/datum/component/remote_materials/proc/disconnect()
+	if(isnull(silo))
 		return
 
 	UnregisterSignal(parent, list(COMSIG_ATOM_ITEM_INTERACTION, COMSIG_ATOM_ITEM_INTERACTION_SECONDARY))

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -38,7 +38,7 @@
 		GLOB.ore_silo_default = null
 
 	for(var/datum/component/remote_materials/mats as anything in ore_connected_machines)
-		mats.disconnect_from(src)
+		mats.disconnect()
 
 	ore_connected_machines = null
 	materials = null
@@ -162,7 +162,7 @@
 			if(isnull(remote))
 				return
 
-			remote.disconnect_from(src)
+			remote.disconnect()
 			return TRUE
 
 		if("hold")


### PR DESCRIPTION
## About The Pull Request
- Fixes #91494
- Fixes #91479
- Fixes #90533

The ORM disconnects the machines from its `Destroy()` proc by which time its deleted flag has already been set to TRUE leading to an early return, thus causing the silo to not disconnect properly

## Changelog
:cl:
fix: lathes don't break on ore silo deletion
/:cl:

