### PR TITLE
Swarming mobs spread out immediately

### DIFF
--- a/code/datums/components/swarming.dm
+++ b/code/datums/components/swarming.dm
@@ -5,7 +5,8 @@
 	var/list/swarm_members = list()
 	var/static/list/swarming_loc_connections = list(
 		COMSIG_ATOM_EXITED = PROC_REF(leave_swarm),
-		COMSIG_ATOM_ENTERED = PROC_REF(join_swarm)
+		COMSIG_ATOM_ENTERED = PROC_REF(join_swarm),
+		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(join_swarm)
 	)
 
 
@@ -26,7 +27,7 @@
 	swarm_members = null
 	return ..()
 
-/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived)
 	SIGNAL_HANDLER
 
 	var/datum/component/swarming/other_swarm = arrived.GetComponent(/datum/component/swarming)


### PR DESCRIPTION
## About The Pull Request

Mobs will check for swarming when an atom inits on their tile as well as when one enters it

## Why It's Good For The Game

I was fucking around with the Hive Head changeling power and noticed that the bees it spawns tend to stack up instead of spread out nicely, and I didn't like that.
![image](https://github.com/user-attachments/assets/0c42ffbb-0183-4d56-bcd7-2352c1e16efd)

## Changelog

:cl:
fix: Small stacking mobs like mice and bees will attempt to spread out visually within their tile as soon as they spawn rather than just when moving
/:cl:
