### PR TITLE
Fixes movespeed glitch on holy hoverboards

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -236,21 +236,26 @@
 
 /datum/component/riding/vehicle/scooter/skateboard/vehicle_mob_buckle(datum/source, mob/living/rider, force = FALSE)
 	. = ..()
-	if(can_slow_down)
-		RegisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED, PROC_REF(toggle_move_delay))
-		toggle_move_delay(rider)
+	if(!can_slow_down)
+		return
+	RegisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED, PROC_REF(toggle_move_delay))
+	if(rider.move_intent == MOVE_INTENT_WALK)
+		vehicle_move_delay += 0.6
 
 /datum/component/riding/vehicle/scooter/skateboard/handle_unbuckle(mob/living/rider)
 	. = ..()
-	if(can_slow_down)
-		toggle_move_delay(rider)
-		UnregisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED)
+	if(!can_slow_down)
+		return
+	UnregisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED)
+	if(rider.move_intent == MOVE_INTENT_WALK)
+		vehicle_move_delay -= 0.6
 
 /datum/component/riding/vehicle/scooter/skateboard/proc/toggle_move_delay(mob/living/rider)
 	SIGNAL_HANDLER
-	vehicle_move_delay = initial(vehicle_move_delay)
 	if(rider.move_intent == MOVE_INTENT_WALK)
 		vehicle_move_delay += 0.6
+	else
+		vehicle_move_delay -= 0.6
 
 /datum/component/riding/vehicle/scooter/skateboard/pro
 	vehicle_move_delay = 1


### PR DESCRIPTION

## About The Pull Request

Caused by ``initial()`` usage on the base type, and speed modification on the holy child. Since move_intent can only be run or walk, we're good to just +- on the base type instead.
Closes #91492

## Changelog
:cl:
fix: Fixed holy hoverboards being able to gain speed boosts via move intent changing while in space
/:cl:
