### PR TITLE
Fix two runtimes related to decal lazy init reagents

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2978,6 +2978,7 @@
 		return
 
 	var/spilled_ants = (round(reac_volume,1) - 5) // To account for ant decals giving 3-5 ants on initialize.
+	pests.lazy_init_reagents()
 	pests.reagents.add_reagent(type, spilled_ants)
 	pests.update_ant_damage()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1183,6 +1183,7 @@
 
 	var/obj/effect/decal/cleanable/greenglow/glow = exposed_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/greenglow)
 	if(!QDELETED(glow))
+		glow.lazy_init_reagents()
 		glow.reagents.add_reagent(type, reac_volume)
 
 //Mutagenic chem side-effects.

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1182,7 +1182,7 @@
 		return
 
 	var/obj/effect/decal/cleanable/greenglow/glow = exposed_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/greenglow)
-	if(!glow)
+	if(QDELETED(glow))
 		return
 
 	glow.decal_reagent = type
@@ -2981,7 +2981,7 @@
 		return
 
 	var/obj/effect/decal/cleanable/ants/pests = exposed_turf.spawn_unique_cleanable(ants_decal)
-	if(!pests)
+	if(QDELETED(pests))
 		return
 
 	pests.decal_reagent = type

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1182,9 +1182,15 @@
 		return
 
 	var/obj/effect/decal/cleanable/greenglow/glow = exposed_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/greenglow)
-	if(!QDELETED(glow))
-		glow.lazy_init_reagents()
-		glow.reagents.add_reagent(type, reac_volume)
+	if(!glow)
+		return
+
+	glow.decal_reagent = type
+	var/rounded_volume = round(reac_volume, 1)
+	glow.reagent_amount = rounded_volume
+	if(glow.lazy_init_reagents()) // Decal already has reagents inited, add instead
+		glow.reagents.maximum_volume = min(glow.reagents.maximum_volume + rounded_volume, 300) // Increase reagent holder volume up to a max of 300
+		glow.reagents.add_reagent(type, rounded_volume)
 
 //Mutagenic chem side-effects.
 /datum/reagent/uranium/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
@@ -2978,9 +2984,12 @@
 	if(!pests)
 		return
 
-	var/spilled_ants = (round(reac_volume,1) - 5) // To account for ant decals giving 3-5 ants on initialize.
-	pests.lazy_init_reagents()
-	pests.reagents.add_reagent(type, spilled_ants)
+	pests.decal_reagent = type
+	var/rounded_volume = round(reac_volume, 1)
+	pests.reagent_amount = rounded_volume
+	if(pests.lazy_init_reagents()) // Decal already has reagents inited, add instead
+		pests.reagents.maximum_volume = min(pests.reagents.maximum_volume + rounded_volume, 300) // Increase reagent holder volume up to a max of 300
+		pests.reagents.add_reagent(type, rounded_volume)
 	pests.update_ant_damage()
 
 /datum/reagent/ants/fire


### PR DESCRIPTION

## About The Pull Request

#91054 changed decals so they no longer init reagent holders on `Initialize`, which means these `expose_turf` reactions were runtiming because the reagent holder didn't exist when they tried to `add_reagent`. This rewrites their code to make sure init is handled, but also to take advantage of the fact that there won't be existing reagents (like in the case of ants where it does - 5). It was also necessary to add code to increase the max volume of the reagent holder because `lazy_init_reagents` sets max volume to `reagent_amount` instead of 300 like the old code

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed runtimes with splashing ants and uranium onto tiles
/:cl:
