### PR TITLE
fix duffelbag speedup bug

### DIFF
--- a/code/game/objects/items/storage/dufflebags.dm
+++ b/code/game/objects/items/storage/dufflebags.dm
@@ -22,6 +22,7 @@
 
 /obj/item/storage/backpack/duffelbag/Initialize(mapload)
 	. = ..()
+	slowdown += zip_slowdown
 	set_zipper(TRUE)
 	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, PROC_REF(on_speed_potioned))
 


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/91415 changed how zip_slowdown is incremented and decremented, but did not test their changes or consider that set_zipper runs on init to zip it, reducing slowdown, thus reducing slowdown to negative numbers.

## Why It's Good For The Game
speedy duffels bad

## Changelog

:cl:
fix: fix duffels making you fast as fuck
/:cl:

