### PR TITLE
Fix a runtime with the lobby screen info

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -11,10 +11,7 @@
 /datum/hud/new_player/New(mob/owner)
 	. = ..()
 
-	if (!owner || !owner.client)
-		return
-
-	if (owner.client.interviewee)
+	if (!owner?.client || owner.client.interviewee)
 		return
 
 	var/list/buttons = subtypesof(/atom/movable/screen/lobby)
@@ -767,7 +764,7 @@
 		else
 			time_remaining = "SOON"
 
-		if(hud.mymob.client.holder)
+		if(hud.mymob.client?.holder)
 			new_maptext = "<span style='text-align: center; vertical-align: middle'>Starting in [time_remaining]<br /> \
 				[LAZYLEN(GLOB.clients)] player\s<br /> \
 				[SSticker.totalPlayersReady] players ready<br /> \


### PR DESCRIPTION
## About The Pull Request

Clients are fickle things and can go _poof!_ at just about any moment... so let's kinda just use a `?.` when checking to see if the client has a holder (... is there even a reason that's a holder check and not `is_admin`, out of curiosity?)

```
[01:37:06] Runtime in code/_onclick/hud/new_player.dm, line 770: Cannot read null.holder
proc name: update text (/atom/movable/screen/lobby/new_player_info/proc/update_text)
src: New Player Info (/atom/movable/screen/lobby/new_player_info)
src.loc: null
call stack:
  New Player Info (/atom/movable/screen/lobby/new_player_info): update text()
  New Player Info (/atom/movable/screen/lobby/new_player_info): process(1)
  New Player Info (/datum/controller/subsystem/processing/newplayer_info): fire(0)
  New Player Info (/datum/controller/subsystem/processing/newplayer_info): fire(0)
  New Player Info (/datum/controller/subsystem/processing/newplayer_info): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop(4)
  Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game

one less annoying runtime

## Changelog

No player-facing changes.