### PR TITLE
Improves the PR announcement message grammar

### DIFF
--- a/tools/Tgstation.PRAnnouncer/PRAnnounceQuery.cs
+++ b/tools/Tgstation.PRAnnouncer/PRAnnounceQuery.cs
@@ -46,7 +46,13 @@ namespace Tgstation.PRAnnouncer
 				PullRequest = new PRAnnouncePayloadPullRequest(pullRequestEvent.PullRequest),
 			};
 
-			announce = $"[{pullRequestEvent.PullRequest.Base.Repo.FullName}] Pull Request {(pullRequestEvent.PullRequest.Merged == true ? "merged" : (pullRequestEvent.Action ?? "(NULL ACTION)"))} {HtmlEncoder.Default.Encode(pullRequestEvent.Sender?.Login ?? "(NULL)")}: <a href=\"{pullRequestEvent.PullRequest.HtmlUrl}\"> #{pullRequestEvent.PullRequest.Number} {HtmlEncoder.Default.Encode($"{pullRequestEvent.PullRequest.User.Login} - {pullRequestEvent.PullRequest.Title}")}";
+            var action = pullRequestEvent.PullRequest.Merged == true ? "merged" : pullRequestEvent.Action;
+            if (action != null && pullRequestEvent.Sender?.Login != null)
+            {
+                action += $" by {HtmlEncoder.Default.Encode(pullRequestEvent.Sender.Login)}";
+            }
+
+			announce = $"[{pullRequestEvent.PullRequest.Base.Repo.FullName}] Pull Request {action ?? "(NULL ACTION)"}: <a href=\"{pullRequestEvent.PullRequest.HtmlUrl}\">#{pullRequestEvent.PullRequest.Number} {HtmlEncoder.Default.Encode($"{pullRequestEvent.PullRequest.User.Login} - {pullRequestEvent.PullRequest.Title}")}</a>";
 		}
 
 		/// <summary>


### PR DESCRIPTION
## About The Pull Request

This makes it so the PR announcements have better grammar: they'll actually say "Pull Request merged by [user]: ..." instead of the current "Pull Request merged [user]: ..."

also got rid of a weird extra space

i've barely coded C# in a while so this prolly sucks, sorry.

## Why It's Good For The Game

because "Pull Request merged Absolucy" annoys me.

## Changelog
:cl:
spellcheck: PR announcements should now say "X merged by Y: ..." instead of "X merged Y: ..."
/:cl:
