### PR TITLE
Removes the red crowbar from shaft miners

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -74,7 +74,6 @@
 
 /obj/item/storage/box/survival/mining/PopulateContents()
 	..()
-	new /obj/item/crowbar/red(src)
 	new /obj/item/healthanalyzer/simple/miner(src)
 
 // Engineer survival box


### PR DESCRIPTION

## About The Pull Request
Removes the crowbar that was added in https://github.com/tgstation/tgstation/commit/3da17776ca8a83f4d0a318579bcf774f8f6af535
## Why It's Good For The Game
Shaft miners dont really need a roundstart crowbar.
## Changelog
:cl:
del: Removes the shaft miner from the shaft miners' survival box
/:cl:
