### PR TITLE
Adds the `MAPLOADED_1` flag for map loaded stuff

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define IGNORE_TURF_PIXEL_OFFSET_1 (1<<18)
 /// This atom does not need to generate its own preview icon for GAGS
 #define NO_NEW_GAGS_PREVIEW_1 (1<<19)
-/// This atom was maploaded. atoms created during round start don't have this flag
+/// This atom was maploaded. atoms created after round start don't have this flag
 #define MAPLOADED_1 (1<<20)
 
 // Update flags for [/atom/proc/update_appearance]

--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -60,6 +60,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define IGNORE_TURF_PIXEL_OFFSET_1 (1<<18)
 /// This atom does not need to generate its own preview icon for GAGS
 #define NO_NEW_GAGS_PREVIEW_1 (1<<19)
+/// This atom was maploaded. atoms created during round start don't have this flag
+#define MAPLOADED_1 (1<<20)
 
 // Update flags for [/atom/proc/update_appearance]
 /// Update the atom's name

--- a/code/game/atom/atoms_initializing_EXPENSIVE.dm
+++ b/code/game/atom/atoms_initializing_EXPENSIVE.dm
@@ -119,6 +119,8 @@
 	if(flags_1 & INITIALIZED_1)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1
+	if(mapload)
+		flags_1 |= MAPLOADED_1
 
 	SET_PLANE_IMPLICIT(src, plane)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -76,8 +76,6 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	var/secure = FALSE
 	var/can_install_electronics = TRUE
 
-	var/is_maploaded = FALSE
-
 	var/contents_initialized = FALSE
 	/// is this closet locked by an exclusive id, i.e. your own personal locker
 	var/datum/weakref/id_card = null
@@ -154,8 +152,6 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		add_to_roundstart_list()
 
 	// if closed, any item at the crate's loc is put in the contents
-	if (mapload)
-		is_maploaded = TRUE
 	. = INITIALIZE_HINT_LATELOAD
 
 	populate_contents_immediate()
@@ -173,6 +169,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	update_appearance()
 
 /obj/structure/closet/LateInitialize()
+	var/is_maploaded = flags_1 & MAPLOADED_1
 	if(!opened && is_maploaded)
 		take_contents()
 

--- a/code/modules/mob/living/basic/boss/thing/thing.dm
+++ b/code/modules/mob/living/basic/boss/thing/thing.dm
@@ -36,8 +36,6 @@
 
 	// ruin logic
 
-	/// if true, this boss may only be killed proper in its ruin by the associated machines as part of the bossfight.
-	var/maploaded = TRUE
 	/// where we spawned. not set if not maploaded
 	var/turf/spawn_loc
 	/// return timer
@@ -56,8 +54,7 @@
 	grant_actions_by_list(innate_actions)
 	AddElement(/datum/element/relay_attackers) // used to immediately aggro if shot from outside aggro range
 	RegisterSignal(src, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(immediate_aggro))
-	maploaded = mapload
-	if(maploaded)
+	if(mapload)
 		spawn_loc = loc
 		RegisterSignal(src, COMSIG_AI_BLACKBOARD_KEY_SET(BB_BASIC_MOB_CURRENT_TARGET), PROC_REF(target_gained))
 		RegisterSignal(src, COMSIG_AI_BLACKBOARD_KEY_CLEARED(BB_BASIC_MOB_CURRENT_TARGET), PROC_REF(target_lost))
@@ -89,7 +86,7 @@
 	if(phase_invulnerability_timer)
 		return //wtf?
 
-	if(!maploaded || client)
+	if(!(flags_1 & MAPLOADED_1) || client)
 		phase_successfully_depleted()
 		return
 	if(!client && istype(get_area(src), /area/station)) //retreat to station if AI controlled

--- a/code/modules/transport/elevator/elev_panel.dm
+++ b/code/modules/transport/elevator/elev_panel.dm
@@ -24,9 +24,6 @@
 	// Indestructible until someone wants to make these constructible, with all the chaos that implies
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-	/// Were we instantiated at mapload? Used to determine when we should link / throw errors
-	var/maploaded = FALSE
-
 	/// A weakref to the transport_controller datum we control
 	var/datum/weakref/lift_weakref
 	/// What specific_transport_id do we link with?
@@ -61,7 +58,6 @@
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 	AddElement(/datum/element/contextual_screentip_bare_hands, lmb_text = "Send Elevator")
 
-	maploaded = mapload
 	// Maploaded panels link in post_machine_initialize...
 	if(mapload)
 		return
@@ -72,7 +68,7 @@
 /obj/machinery/elevator_control_panel/post_machine_initialize()
 	. = ..()
 	// If we weren't maploaded, we probably already linked (or tried to link) in Initialize().
-	if(!maploaded)
+	if(!(flags_1 & MAPLOADED_1))
 		return
 
 	// This is exclusively for linking in mapload, just to ensure all elevator parts are created,


### PR DESCRIPTION
## About The Pull Request
Now to know if an atom was created during map load you can do `if(flags_1 & MAPLOADED_1)` instead of creating a var to keep track of it yourself.

Atoms created after round start don't have this flag. That's what a map loaded atom is

## Changelog
:cl:
code: added the `MAPLOAD_1` flag for `flags_1` var to know if an atom was map loaded
/:cl:

