### PR TITLE
fixes create_mob and create_turf, in line with create_object

### DIFF
--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -6,7 +6,7 @@
 		mobjs = jointext(typesof(/mob), ";")
 		create_mob_html = file2text('html/create_object.html')
 		create_mob_html = replacetext(create_mob_html, "Create Object", "Create Mob")
-		create_mob_html = replacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
+		create_mob_html = replacetext(create_mob_html, "null; /* object types */", "\"[mobjs]\";")
 
 	user << browse(create_panel_helper(create_mob_html), "window=create_mob;size=425x475")
 

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -5,6 +5,6 @@
 		turfjs = jointext(typesof(/turf), ";")
 		create_turf_html = file2text('html/create_object.html')
 		create_turf_html = replacetext(create_turf_html, "Create Object", "Create Turf")
-		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
+		create_turf_html = replacetext(create_turf_html, "null; /* object types */", "\"[turfjs]\";")
 
 	user << browse(create_panel_helper(create_turf_html), "window=create_turf;size=425x475")


### PR DESCRIPTION

## About The Pull Request
As detailed in #91431, PR #91379 misplaced a few semicolons and broke the functionality for these three admin tools. Only the object panel was fixed, but the mob and turf panels remain broken. This fixes it, the exact same issue was/is the problem.


## Why It's Good For The Game
Restores admin functionality that is currently missing.

## Changelog
:cl:
fix: create mob and create turf both function correctly again.
/:cl:
