### PR TITLE
Un-hardcode door ID on derelict vault door computer

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
@@ -1,3 +1,5 @@
+#define DERELICT_VAULT_ID "derelictvault"
+
 /////////// thederelict items
 
 /obj/item/paper/fluff/ruins/thederelict/equipment
@@ -49,6 +51,7 @@
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
+	var/door_id = DERELICT_VAULT_ID
 	var/obj/structure/cable/attached_cable
 	var/obj/machinery/door/airlock/vault/derelict/door1
 	var/obj/machinery/door/airlock/vault/derelict/door2
@@ -76,7 +79,7 @@
 ///Initializes airlock links.
 /obj/machinery/computer/vaultcontroller/proc/find_airlocks()
 	for(var/obj/machinery/door/airlock/A as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/airlock))
-		if(A.id_tag == "derelictvault")
+		if(A.id_tag == door_id)
 			if(!door1)
 				door1 = A
 				continue
@@ -161,7 +164,7 @@
 	move_resist = INFINITY
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	id_tag = "derelictvault"
+	id_tag = DERELICT_VAULT_ID
 	has_access_panel = FALSE
 
 ///Overrides screwdriver act to prevent all deconstruction and hacking. Override for extra tuff fluff
@@ -312,3 +315,5 @@
 /obj/item/tape/captains_log/Initialize(mapload)
 	. = ..()
 	unspool() // the tape spawns damaged
+
+#undef DERELICT_VAULT_ID


### PR DESCRIPTION
## About The Pull Request

Change the code for the Russian derelict vault to use a var instead of having a hardcoded value for the door ID to link to, also change the default value to a define

## Why It's Good For The Game

Enables mappers and var editors to make use of these things for shenanigans

## Changelog

:cl:
code: the russian derelict vault computer now uses a variable for the door id
/:cl:
