### PR TITLE
Removes stacks of plasteel from atmos maps that don't start with a crystalizer pre-setup

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -43481,11 +43481,8 @@
 	pixel_y = 7
 	},
 /obj/item/stack/sheet/glass/fifty{
-	pixel_y = 7
-	},
-/obj/item/stack/sheet/plasteel/fifty{
-	pixel_x = 7;
-	pixel_y = 7
+	pixel_y = 7;
+	pixel_x = 6
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5517,7 +5517,6 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/obj/item/stack/sheet/plasteel/twenty,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -67797,11 +67796,14 @@
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/south,
-/obj/item/stack/sheet/plasteel/fifty,
 /obj/item/stack/sheet/rglass{
 	amount = 20;
 	pixel_x = 2;
 	pixel_y = -2
+	},
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = 2;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -17567,10 +17567,6 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/stack/sheet/plasteel/twenty{
-	pixel_x = 3;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68909,7 +68909,6 @@
 /area/station/medical/pharmacy)
 "xJK" = (
 /obj/structure/table,
-/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "xJQ" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -23238,6 +23238,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = -3
+	},
 /obj/item/circuitboard/machine/crystallizer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -49588,7 +49588,6 @@
 /area/station/security/prison/shower)
 "rkp" = (
 /obj/effect/turf_decal/stripes,
-/obj/item/stack/sheet/plasteel/fifty,
 /obj/item/stack/cable_coil{
 	pixel_x = -1;
 	pixel_y = -3


### PR DESCRIPTION
## About The Pull Request

Removes plasteel from maps that already have a pre-setup crystalizer otherwise 20 plasteel

## Why It's Good For The Game

Atmos has 120 Plasteel in total.
50 coming from the hfr boxes
50 coming in raw material laying in the hfr chamber
and 20 coming from the crystalizer
And this PR reduces that amount to make material economy matter to much, atmos doesn't ever have real uses for 50 plasteel besides at max reinforcing a floor which they can just can use engineering/miner materials.

## Changelog
:cl: Ezel
Map:Removes the stack of plasteel from maps that don't have crystalizer pre-setup otherwise it has 20 plasteel instead
/:cl:
