### PR TITLE
Fixes dna consoles [NO GBP]

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -734,7 +734,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	var/datum/mutation/mutation = get_mutation(mutation_path)
 	if(check_block_string(mutation_path))
 		if(!mutation)
-			. = add_mutation(mutation_path, MUTATION_SOURCE_ACTIVATED)
+			add_mutation(mutation_path, MUTATION_SOURCE_ACTIVATED)
 		return
 	if(MUTATION_SOURCE_ACTIVATED in mutation?.sources)
 		remove_mutation(mutation, MUTATION_SOURCE_ACTIVATED)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -1949,7 +1949,7 @@
 				mutation_data["Scrambled"] = stored.scrambled
 				mut_class = get_mutation_class(stored)
 				mutation_data["CanChromo"] = stored.can_chromosome
-				mutation_data["ByondRef"] = REF(mutation)
+				mutation_data["ByondRef"] = REF(stored)
 				mutation_data["Type"] = stored.type
 				if(stored.can_chromosome)
 					mutation_data["ValidChromos"] = jointext(stored.valid_chrom_list, ", ")


### PR DESCRIPTION
## About The Pull Request
The value of the "ByondRef" key referenced the dummy mutation used for alias and sequence and not the one actually from the mutations list of the dna datum.

## Why It's Good For The Game
This will fix #91532.

## Changelog

:cl:
fix: Fixed DNA consoles.
/:cl:
