### PR TITLE
APC now either locates/makes the terminal

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -232,8 +232,7 @@
 		if(cell_type)
 			cell = new cell_type(src)
 			cell.charge = start_charge * cell.maxcharge / 100 // (convert percentage to actual value)
-		if(!locate(/obj/machinery/power/terminal) in loc)
-			make_terminal()
+		make_terminal()
 		///This is how we test to ensure that mappers use the directional subtypes of APCs, rather than use the parent and pixel-shift it themselves.
 		if(abs(offset_old) != APC_PIXEL_OFFSET)
 			log_mapping("APC: ([src]) at [AREACOORD(src)] with dir ([dir] | [uppertext(dir2text(dir))]) has pixel_[dir & (WEST|EAST) ? "x" : "y"] value [offset_old] - should be [dir & (SOUTH|EAST) ? "-" : ""][APC_PIXEL_OFFSET]. Use the directional/ helpers!")

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -8,9 +8,11 @@
 		terminal.connect_to_network()
 
 /obj/machinery/power/apc/proc/make_terminal(terminal_cable_layer = cable_layer)
+	//attempt to locate a terminal if mappers/map export placed it here
+	terminal = locate(/obj/machinery/power/terminal) in loc
 	// create a terminal object at the same position as original turf loc
-	// wires will attach to this
-	terminal = new /obj/machinery/power/terminal(loc)
+	if(QDELETED(terminal))
+		terminal = new /obj/machinery/power/terminal(loc)
 	terminal.cable_layer = terminal_cable_layer
 	terminal.setDir(dir)
 	terminal.master = src


### PR DESCRIPTION
## About The Pull Request
During map export both the APC & its terminal are exported. However, during import that terminal is not attached to the APC because it will only attempt to create a new one if one is not already present and not locate an existing terminal and re attach to it.

It now attempts to locate an existing terminal, from a previous map export so the APC charges again and stuff

## Changelog
:cl:
fix: map exported APC's now locate the terminals under them & attach to it thus enabling charging & stuff
/:cl:

