### PR TITLE
Fix holopad calls keeping off-camera turfs static even after you leave the call.

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -10,8 +10,6 @@
 	var/mob/eye/camera/remote/eye = user.remote_control
 	if(!istype(eye))
 		CRASH("Attempted to remove eye control from non-camera eye. Something has gone horribly wrong.")
-	for(var/datum/camerachunk/camerachunk_left as anything in eye.visibleCameraChunks)
-		camerachunk_left.remove(eye)
 	eye.assign_user(null)
 
 //this datum manages its own references

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -10,6 +10,8 @@
 	var/mob/eye/camera/remote/eye = user.remote_control
 	if(!istype(eye))
 		CRASH("Attempted to remove eye control from non-camera eye. Something has gone horribly wrong.")
+	for(var/datum/camerachunk/camerachunks_gone as anything in eye.visibleCameraChunks)
+		camerachunks_gone.remove(eye)
 	eye.assign_user(null)
 
 //this datum manages its own references

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -10,8 +10,8 @@
 	var/mob/eye/camera/remote/eye = user.remote_control
 	if(!istype(eye))
 		CRASH("Attempted to remove eye control from non-camera eye. Something has gone horribly wrong.")
-	for(var/datum/camerachunk/camerachunks_gone as anything in eye.visibleCameraChunks)
-		camerachunks_gone.remove(eye)
+	for(var/datum/camerachunk/camerachunk_left as anything in eye.visibleCameraChunks)
+		camerachunk_left.remove(eye)
 	eye.assign_user(null)
 
 //this datum manages its own references

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -124,8 +124,6 @@
 
 	for(var/datum/action/actions_removed as anything in actions)
 		actions_removed.Remove(user)
-	for(var/datum/camerachunk/camerachunks_gone as anything in eyeobj.visibleCameraChunks)
-		camerachunks_gone.remove(eyeobj)
 
 	eyeobj.assign_user(null)
 	current_user = null

--- a/code/modules/mob/eye/camera/camera.dm
+++ b/code/modules/mob/eye/camera/camera.dm
@@ -22,10 +22,14 @@
 	GLOB.camera_eyes += src
 
 /mob/eye/camera/Destroy()
-	for(var/datum/camerachunk/chunk in visibleCameraChunks)
-		chunk.remove(src)
+	clear_camera_chunks()
 	GLOB.camera_eyes -= src
 	return ..()
+
+/// Clears us from any visible camera chunks.
+/mob/eye/camera/proc/clear_camera_chunks()
+	for(var/datum/camerachunk/chunk in visibleCameraChunks)
+		chunk.remove(src)
 
 /**
  * Getter proc for getting the current user's client.

--- a/code/modules/mob/eye/camera/remote.dm
+++ b/code/modules/mob/eye/camera/remote.dm
@@ -60,6 +60,7 @@
 		var/client/old_user_client = GetViewerClient()
 		if(user_image && old_user_client)
 			old_user_client.images -= user_image
+		clear_camera_chunks()
 
 	user_ref = WEAKREF(new_user) //The user_ref can still be null!
 


### PR DESCRIPTION

## About The Pull Request

It seems that we weren't properly cleaning up the static after removing the user.
We do clear it when the eye gets _destroyed_, but we don't properly clear it when a user gets removed or re-assigned.
...Well, advanced camera eyes clear it when the user gets removed...
So this just makes a new `clear_camera_chunks()` proc, and makes remote eyes call it when clearing or assigning a new user if we had an old user, making sure we've cleared the static from our past user.
## Why It's Good For The Game

Fixes #90151.
Fixes #90435.
Fixes #90636.
## Changelog
:cl:
fix: The static from holocalls no longer stays even after exiting the holocall.
/:cl:
