### PR TITLE
Removes a debugging statement that was left in

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -129,7 +129,6 @@
 		if(item_stack == src || QDELING(item_stack) || (item_stack.amount >= item_stack.max_amount))
 			continue
 		if(!(item_stack.flags_1 & INITIALIZED_1))
-			stack_trace("find_other_stack found uninitialized stack in loc? skipping for now")
 			continue
 		var/stack_ref = REF(item_stack)
 		if(already_found[stack_ref])


### PR DESCRIPTION
## About The Pull Request

Tin, this debug statement was left in.

See https://github.com/tgstation/tgstation/pull/91015#discussion_r2115260199

## Why It's Good For The Game

It's causing spurious CI failures for no reason which is annoying.

## Changelog

:cl:
fix: stops stack merging from causing spurious CI runtimes
/:cl: