### PR TITLE
Repurposed Glands is now Gene Stim; it now simply doses you with 4 units of Changeling Adrenaline on use and cannot be used if you're on fire

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/adrenaline
 	name = "Gene Stim"
 	desc = "We concentrate our chemicals into a potent stimulant, rendering our form stupendously robust against being incapacitated. Costs 25 chemicals."
-	helptext = "Disregard any condition that has stunned us and suffuse our form with FOUR units of Changeling Adrenaline; our form recovers massive stamina and plainly disregards any pain or fatigue during its effects."
+	helptext = "Disregard any condition that has stunned us and suffuse our form with FOUR units of Changeling Adrenaline; our form recovers massive stamina and simply disregards any pain or fatigue during its effects."
 	button_icon_state = "adrenaline"
 	chemical_cost = 25 // similar cost to biodegrade, as they serve similar purposes
 	dna_cost = 2

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -18,7 +18,7 @@
 	user.setStaminaLoss(0)
 	user.set_resting(FALSE, instant = TRUE)
 
-	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 4) //20 seconds
+	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 4) //Tank 5 consecutive baton hits
 
 	to_chat(user, span_changeling("The staggering rush of a stimulant honed precisely to our biology is INVIGORATING. We will not be subdued."))
 

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,50 +1,17 @@
 /datum/action/changeling/adrenaline
-	name = "Repurposed Glands"
-	desc = "We shift almost all available muscle mass from the arms to the legs, disabling the former but making us unable to be downed for 20 seconds. Costs 25 chemicals."
-	helptext = "Disables your arms and retracts bioweaponry, but regenerates your legs, grants you speed, and wakes you up from any stun."
+	name = "Gene Stim"
+	desc = "We concentrate our chemicals into a potent stimulant, rendering our form stupendously robust against being incapacitated. Costs 25 chemicals."
+	helptext = "Doses you with Changeling Adrenaline: Restore a massive amount of stamina per tick, and no-sell stamcrit while the reagent is inside you."
 	button_icon_state = "adrenaline"
 	chemical_cost = 25 // similar cost to biodegrade, as they serve similar purposes
 	dna_cost = 2
 	req_human = FALSE
 	req_stat = CONSCIOUS
-	disabled_by_fire = FALSE
-
-/datum/action/changeling/adrenaline/can_sting(mob/living/user, mob/living/target)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	if(HAS_TRAIT_FROM(user, TRAIT_PARALYSIS_L_ARM, CHANGELING_TRAIT) || HAS_TRAIT_FROM(user, TRAIT_PARALYSIS_R_ARM, CHANGELING_TRAIT))
-		user.balloon_alert(user, "already boosted!")
-		return FALSE
-
-	return .
+	disabled_by_fire = TRUE
 
 //Recover from stuns.
 /datum/action/changeling/adrenaline/sting_action(mob/living/carbon/user)
 	..()
-	to_chat(user, span_changeling("Our arms feel weak, but our legs become unstoppable!"))
-
-	for(var/datum/action/changeling/weapon/weapon_ability in user.actions)
-		weapon_ability.unequip_held(user)
-
-	// Destroy legcuffs with our IMMENSE LEG STRENGTH.
-	if(istype(user.legcuffed))
-		user.visible_message(
-			span_warning("[user]'s legs suddenly rip [user.legcuffed] apart!"),
-			span_warning("We rip apart our leg restraints!"),
-		)
-		qdel(user.legcuffed)
-
-	// Regenerate our legs only.
-	var/our_leg_zones = (GLOB.all_body_zones - GLOB.leg_zones)
-	user.regenerate_limbs(excluded_zones = our_leg_zones) // why is this exclusive rather than inclusive
-
-	user.add_traits(list(TRAIT_PARALYSIS_L_ARM, TRAIT_PARALYSIS_R_ARM), CHANGELING_TRAIT)
-	user.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-
-	// Revert above mob changes.
-	addtimer(CALLBACK(src, PROC_REF(unsting_action), user), 20 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 	// Get us standing up.
 	user.SetAllImmobility(0)
@@ -55,8 +22,3 @@
 	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 4) //20 seconds
 
 	return TRUE
-
-/datum/action/changeling/adrenaline/proc/unsting_action(mob/living/user)
-	to_chat(user, span_changeling("The muscles in our limbs shift back to their usual places."))
-	user.remove_traits(list(TRAIT_PARALYSIS_L_ARM, TRAIT_PARALYSIS_R_ARM), CHANGELING_TRAIT)
-	user.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/adrenaline
 	name = "Gene Stim"
 	desc = "We concentrate our chemicals into a potent stimulant, rendering our form stupendously robust against being incapacitated. Costs 25 chemicals."
-	helptext = "Resets your stun/knockdown state and doses you with Changeling Adrenaline: Restore a massive amount of stamina per tick, resist batons and damage slowdown, and no-sell stamcrit while the reagent is inside you. Be aware: Only four units per use!"
+	helptext = "Disregard any condition that has stunned us and suffuse our form with FOUR units of Changeling Adrenaline; our form recovers massive stamina and plainly disregards any pain or fatigue during its effects."
 	button_icon_state = "adrenaline"
 	chemical_cost = 25 // similar cost to biodegrade, as they serve similar purposes
 	dna_cost = 2

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/adrenaline
 	name = "Gene Stim"
 	desc = "We concentrate our chemicals into a potent stimulant, rendering our form stupendously robust against being incapacitated. Costs 25 chemicals."
-	helptext = "Doses you with Changeling Adrenaline: Restore a massive amount of stamina per tick, and no-sell stamcrit while the reagent is inside you."
+	helptext = "Resets your stun/knockdown state and doses you with Changeling Adrenaline: Restore a massive amount of stamina per tick, resist batons and damage slowdown, and no-sell stamcrit while the reagent is inside you. Be aware: Only four units per use!"
 	button_icon_state = "adrenaline"
 	chemical_cost = 25 // similar cost to biodegrade, as they serve similar purposes
 	dna_cost = 2
@@ -18,7 +18,8 @@
 	user.setStaminaLoss(0)
 	user.set_resting(FALSE, instant = TRUE)
 
-	// Add fast reagents to go fast.
 	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 4) //20 seconds
+
+	to_chat(user, span_changeling("The staggering rush of a stimulant honed precisely to our biology is INVIGORATING. We will not be subdued."))
 
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1447,7 +1447,7 @@
 	description = "Reduces the duration of unconsciousness, knockdown and stuns. Restores stamina, but deals toxin damage when overdosed."
 	color = "#C1151D"
 	overdose_threshold = 30
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Changeling Adrenaline was part of a big to-do I did to reagents back in yonder ancient history to make stamina-restoring drugs actually restore stamina in a way that impacted gameplay. At the same time, there was a lot of muck happening around how much ass changeling sucked, and someone reworked their adrenaline ability to be a "run away fast" ability and included completely disabling their arms as what I assume was intent to balance it.

I think this is a stupendously poor design decision and changeling is staggeringly worse for it. So instead, I semi-reverted it to my intent for changeling adrenaline at the time; a very small amount of a very powerful reagent per use of the ability. Incidentally around that time, handling for changeling abilities being crippled by fire was also introduced, and I adjusted this ability to not be usable while you're on fire.

Final note: Changeling Adrenaline cannot be synthesized (and as such, can't be rolled in botany plants)

## Why It's Good For The Game

Changeling being an inhumanly tough monstrosity that just doesn't go down in the face of pain and fatigue seems right in their wheelhouse, and having the ability crippled by fire plays to the intent of throwing a molotov at a changeling being a hard counter to them.
## Changelog
:cl: Bisar
balance: Repurposed Glands is now instead Gene Stim; simply put, your stuns are reset and you are dosed with 4 units of Changeling Adrenaline on use. This ability cannot be used while on fire. /:cl:
