### PR TITLE
Fire alarm attackby + screentips + new wires

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -97,6 +97,9 @@
 #define WIRE_ENVIRONMENT "Environment"
 #define WIRE_LOOP_MODE "Loop mode"
 #define WIRE_REPLAY_MODE "Replay mode"
+#define WIRE_FIRE_DETECT "Automatic Detection"
+#define WIRE_FIRE_TRIGGER "Alarm Trigger"
+#define WIRE_FIRE_RESET "Alarm Reset"
 
 // Wire states for the AI
 #define AI_WIRE_NORMAL 0

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -176,7 +176,7 @@
 /datum/wires/proc/is_dud_color(color)
 	return is_dud(get_wire(color))
 
-/datum/wires/proc/cut(wire, source)
+/datum/wires/proc/cut(wire, mob/living/source)
 	if(is_cut(wire))
 		cut_wires -= wire
 		SEND_SIGNAL(src, COMSIG_MEND_WIRE(wire), wire)
@@ -186,7 +186,7 @@
 		SEND_SIGNAL(src, COMSIG_CUT_WIRE(wire), wire)
 		on_cut(wire, mend = FALSE, source = source)
 
-/datum/wires/proc/cut_color(color, source)
+/datum/wires/proc/cut_color(color, mob/living/source)
 	cut(get_wire(color), source)
 
 /datum/wires/proc/cut_random(source)
@@ -196,7 +196,7 @@
 	for(var/wire in wires)
 		cut(wire, source)
 
-/datum/wires/proc/pulse(wire, user, force=FALSE)
+/datum/wires/proc/pulse(wire, mob/living/user, force=FALSE)
 	if(!force && is_cut(wire))
 		return
 	SEND_SIGNAL(src, COMSIG_PULSE_WIRE, wire, user)
@@ -248,10 +248,10 @@
 /datum/wires/proc/get_status()
 	return list()
 
-/datum/wires/proc/on_cut(wire, mend = FALSE, source = null)
+/datum/wires/proc/on_cut(wire, mend = FALSE, mob/living/source = null)
 	return
 
-/datum/wires/proc/on_pulse(wire, user)
+/datum/wires/proc/on_pulse(wire, mob/living/user)
 	return
 // End Overridable Procs
 

--- a/code/datums/wires/firealarm.dm
+++ b/code/datums/wires/firealarm.dm
@@ -1,0 +1,59 @@
+/datum/wires/firealarm
+	holder_type = /obj/machinery/firealarm
+	proper_name = "Fire Alarm"
+
+/datum/wires/firealarm/New(atom/holder)
+	wires = list(
+		WIRE_FIRE_DETECT, // toggles whether it can activate automatically
+		WIRE_FIRE_RESET, // resets fire alarm
+		WIRE_FIRE_TRIGGER, // triggers fire alarm
+	)
+	add_duds(1)
+	return ..()
+
+/datum/wires/firealarm/interactable(mob/user)
+	var/obj/machinery/firealarm/alarm = holder
+	return ..() && alarm.panel_open && alarm.buildstage == FIRE_ALARM_BUILD_SECURED
+
+/datum/wires/firealarm/get_status()
+	var/obj/machinery/airalarm/alarm = holder
+	var/list/status = list()
+	status += "The thermal sensor light is [alarm.my_area?.fire_detect ? "on" : "off"]."
+	return status
+
+/datum/wires/firealarm/on_pulse(wire, mob/living/user)
+	var/obj/machinery/firealarm/alarm = holder
+	switch(wire)
+		if(WIRE_FIRE_DETECT)
+			alarm.toggle_fire_detect(user, silent = TRUE)
+		if(WIRE_FIRE_TRIGGER)
+			alarm.alarm(user, silent = TRUE)
+		if(WIRE_FIRE_RESET)
+			alarm.reset(user, silent = TRUE)
+
+/datum/wires/firealarm/on_cut(wire, mend, mob/living/source)
+	var/obj/machinery/firealarm/alarm = holder
+	switch(wire)
+		if(WIRE_FIRE_DETECT)
+			// blocks multitool toggle, though wirecutter toggle "bypasses" this
+			alarm.can_toggle_detection = !mend
+			var/num_cut = 0
+			for(var/obj/machinery/firealarm/firealarm in alarm.my_area?.firealarms)
+				if(WIRE_FIRE_DETECT in firealarm.wires?.cut_wires)
+					num_cut += 1
+			// if mending, restore fire detection
+			if(mend)
+				alarm.enable_fire_detect(source)
+			// or if cutting and all fire alarms in the area are cut, disable fire detection
+			else if(length(alarm.my_area?.firealarms) == num_cut)
+				alarm.disable_fire_detect(source)
+		if(WIRE_FIRE_TRIGGER)
+			// does not reset() or alarm() - it's now stuck on or off
+			alarm.can_trigger = !mend
+		if(WIRE_FIRE_RESET)
+			// does not reset() or alarm() - it's now stuck on or off
+			alarm.can_reset = !mend
+
+/datum/wires/firealarm/always_reveal_wire(color)
+	// to maintain previous behavior of "anyone can multitool a fire alarm to disable it"
+	return get_color_of_wire(WIRE_FIRE_DETECT) == color

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -291,6 +291,7 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || buildstage != FIRE_ALARM_BUILD_SECURED)
 		return .
+	add_fingerprint(user)
 	reset(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -37,6 +37,14 @@
 	///looping sound datum for our fire alarm siren.
 	var/datum/looping_sound/firealarm/soundloop
 
+	// Set by wires, not meant for subtypes
+	/// If FALSE, the fire alarm can never be reset().
+	VAR_FINAL/can_reset = TRUE
+	/// If FALSE, the fire alarm can never be alarm()ed.
+	VAR_FINAL/can_trigger = TRUE
+	/// If FALSE, a multitool or borg can't disable the sensor.
+	VAR_FINAL/can_toggle_detection = TRUE
+
 /datum/armor/machinery_firealarm
 	fire = 90
 	acid = 30
@@ -55,16 +63,11 @@
 	AddElement(/datum/element/atmos_sensitive, mapload)
 	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(check_security_level))
 	soundloop = new(src, FALSE)
+	set_wires(new /datum/wires/firealarm(src))
 
 	AddComponent(/datum/component/usb_port, list(
 		/obj/item/circuit_component/firealarm,
 	))
-
-	AddElement( \
-		/datum/element/contextual_screentip_bare_hands, \
-		lmb_text = "Turn on", \
-		rmb_text = "Turn off", \
-	)
 
 	AddComponent( \
 		/datum/component/redirect_attack_hand_from_turf, \
@@ -74,12 +77,7 @@
 		), \
 	)
 
-	var/static/list/hovering_mob_typechecks = list(
-		/mob/living/silicon = list(
-			SCREENTIP_CONTEXT_CTRL_LMB = "Toggle thermal sensors, which control auto-deploy",
-		)
-	)
-	AddElement(/datum/element/contextual_screentip_mob_typechecks, hovering_mob_typechecks)
+	register_context()
 	find_and_hang_on_wall()
 	update_appearance()
 
@@ -146,10 +144,12 @@
 
 /obj/machinery/firealarm/update_appearance(updates)
 	. = ..()
-	if((my_area?.fire || LAZYLEN(my_area?.active_firelocks)) && !(obj_flags & EMAGGED) && !(machine_stat & (BROKEN|NOPOWER)))
-		set_light(l_range = 2.5, l_power = 1.5)
+	if(buildstage != FIRE_ALARM_BUILD_SECURED)
+		set_light(l_on = FALSE)
+	else if((my_area?.fire || LAZYLEN(my_area?.active_firelocks)) && !(obj_flags & EMAGGED) && !(machine_stat & (BROKEN|NOPOWER)))
+		set_light(l_on = TRUE, l_range = 2.5, l_power = 1.5)
 	else
-		set_light(l_range = 1.6, l_power = 1)
+		set_light(l_on = TRUE, l_range = 1.6, l_power = 1)
 
 /obj/machinery/firealarm/update_icon_state()
 	if(panel_open)
@@ -208,6 +208,7 @@
 	if(prob(50 / severity))
 		alarm()
 
+// Stops AI from toggling auto-fire detection, also disables the sound and lighting
 /obj/machinery/firealarm/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
 		return FALSE
@@ -215,7 +216,7 @@
 	update_appearance()
 	visible_message(span_warning("Sparks fly out of [src]!"))
 	if(user)
-		balloon_alert(user, "speaker disabled")
+		balloon_alert(user, "circuitry fried")
 		user.log_message("emagged [src].", LOG_ATTACK)
 	playsound(src, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	set_status()
@@ -240,18 +241,16 @@
  * Arguments:
  * * mob/user is the user that pulled the alarm.
  */
-/obj/machinery/firealarm/proc/alarm(mob/user)
-	if(!is_operational)
+/obj/machinery/firealarm/proc/alarm(mob/user, silent = FALSE)
+	if(!is_operational || !can_trigger || my_area?.fire)
 		return
-
-	if(my_area.fire)
-		return //area alarm already active
 	my_area.alarm_manager.send_alarm(ALARM_FIRE, my_area)
 	// This'll setup our visual effects, so we only need to worry about the alarm
 	for(var/obj/machinery/door/firedoor/firelock in my_area.firedoors)
 		firelock.activate(FIRELOCK_ALARM_TYPE_GENERIC)
 	if(user)
-		balloon_alert(user, "triggered alarm!")
+		if(!silent)
+			balloon_alert(user, "triggered alarm!")
 		user.log_message("triggered a fire alarm.", LOG_GAME)
 	my_area.fault_status = AREA_FAULT_MANUAL
 	my_area.fault_location = name
@@ -265,8 +264,8 @@
  * Arguments:
  * * mob/user is the user that reset the alarm.
  */
-/obj/machinery/firealarm/proc/reset(mob/user)
-	if(!is_operational)
+/obj/machinery/firealarm/proc/reset(mob/user, silent = FALSE)
+	if(!is_operational || !can_reset)
 		return
 	my_area.alarm_manager.clear_alarm(ALARM_FIRE, my_area)
 	// Clears all fire doors and their effects for now
@@ -274,23 +273,24 @@
 	for(var/obj/machinery/door/firedoor/firelock in my_area.firedoors)
 		firelock.crack_open()
 	if(user)
-		balloon_alert(user, "reset alarm")
+		if(!silent)
+			balloon_alert(user, "reset alarm")
 		user.log_message("reset a fire alarm.", LOG_GAME)
 	soundloop.stop()
 	SEND_SIGNAL(src, COMSIG_FIREALARM_ON_RESET)
 	update_use_power(IDLE_POWER_USE)
 
 /obj/machinery/firealarm/attack_hand(mob/user, list/modifiers)
-	if(buildstage != FIRE_ALARM_BUILD_SECURED)
-		return
 	. = ..()
-	add_fingerprint(user)
+	if(. || buildstage != FIRE_ALARM_BUILD_SECURED)
+		return .
 	alarm(user)
+	return TRUE
 
 /obj/machinery/firealarm/attack_hand_secondary(mob/user, list/modifiers)
-	if(buildstage != FIRE_ALARM_BUILD_SECURED)
-		return ..()
-	add_fingerprint(user)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || buildstage != FIRE_ALARM_BUILD_SECURED)
+		return .
 	reset(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
@@ -306,104 +306,180 @@
 /obj/machinery/firealarm/attack_robot_secondary(mob/user)
 	return attack_hand_secondary(user)
 
-/obj/machinery/firealarm/attackby(obj/item/tool, mob/living/user, list/modifiers, list/attack_modifiers)
-	add_fingerprint(user)
+/obj/machinery/firealarm/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	if(issilicon(user))
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle automatic fire detection"
+		return CONTEXTUAL_SCREENTIP_SET
 
-	if(tool.tool_behaviour == TOOL_SCREWDRIVER && buildstage == FIRE_ALARM_BUILD_SECURED)
-		tool.play_tool_sound(src)
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Turn on"
+		context[SCREENTIP_CONTEXT_RMB] = "Turn off"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	switch(held_item.tool_behaviour)
+		if(TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_RMB] = "[panel_open ? "Unexpose" : "Expose"] wires"
+			. = CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_WELDER)
+			if(panel_open)
+				context[SCREENTIP_CONTEXT_LMB] = "Repair"
+				. = CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_WIRECUTTER)
+			if(panel_open && buildstage == FIRE_ALARM_BUILD_SECURED)
+				context[SCREENTIP_CONTEXT_LMB] = "Examine wires"
+				context[SCREENTIP_CONTEXT_RMB] = "Remove wires"
+				. = CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_MULTITOOL)
+			if(panel_open && buildstage == FIRE_ALARM_BUILD_SECURED)
+				context[SCREENTIP_CONTEXT_LMB] = "Examine wires"
+				. = CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_CROWBAR)
+			if(panel_open && buildstage == FIRE_ALARM_BUILD_NO_WIRES)
+				context[SCREENTIP_CONTEXT_RMB] = "Remove circuit"
+				. = CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_WRENCH)
+			if(panel_open && buildstage == FIRE_ALARM_BUILD_NO_CIRCUIT)
+				context[SCREENTIP_CONTEXT_RMB] = "Remove fire alarm"
+				. = CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/stack/cable_coil) && panel_open && buildstage == FIRE_ALARM_BUILD_NO_WIRES)
+		context[SCREENTIP_CONTEXT_LMB] = "Install wires"
+		. = CONTEXTUAL_SCREENTIP_SET
+
+	if((istype(held_item, /obj/item/electronics/firealarm) || istype(held_item, /obj/item/electroadaptive_pseudocircuit)) && panel_open && buildstage == FIRE_ALARM_BUILD_NO_CIRCUIT)
+		context[SCREENTIP_CONTEXT_LMB] = "Install circuit"
+		. = CONTEXTUAL_SCREENTIP_SET
+
+	return .
+
+/obj/machinery/firealarm/screwdriver_act(mob/living/user, obj/item/tool)
+	if(buildstage == FIRE_ALARM_BUILD_SECURED)
 		toggle_panel_open()
-		to_chat(user, span_notice("The wires have been [panel_open ? "exposed" : "unexposed"]."))
+		tool.play_tool_sound(src)
+		balloon_alert(user, "wires [panel_open ? "exposed" : "unexposed"]")
 		update_appearance()
-		return
+		return ITEM_INTERACT_SUCCESS
+	return NONE
 
-	if(panel_open)
+/obj/machinery/firealarm/screwdriver_act_secondary(mob/living/user, obj/item/tool)
+	return screwdriver_act(user, tool)
 
-		if(tool.tool_behaviour == TOOL_WELDER && !user.combat_mode)
-			if(atom_integrity < max_integrity)
-				if(!tool.tool_start_check(user, amount=1))
-					return
+/obj/machinery/firealarm/welder_act(mob/living/user, obj/item/tool)
+	if(!panel_open)
+		return NONE
+	if(atom_integrity >= max_integrity)
+		balloon_alert(user, "already in good condition!")
+		return ITEM_INTERACT_BLOCKING
+	if(!tool.tool_start_check(user, amount = 1))
+		return ITEM_INTERACT_BLOCKING
+	balloon_alert(user, "repairing...")
+	if(!tool.use_tool(src, user, 4 SECONDS, amount = 1, volume = 50, extra_checks = CALLBACK(src, PROC_REF(state_callback), null, TRUE)))
+		return ITEM_INTERACT_BLOCKING
+	repair_damage(INFINITY)
+	balloon_alert(user, "repaired")
+	return ITEM_INTERACT_SUCCESS
 
-				to_chat(user, span_notice("You begin repairing [src]..."))
-				if(tool.use_tool(src, user, 40, volume=50))
-					atom_integrity = max_integrity
-					to_chat(user, span_notice("You repair [src]."))
-			else
-				to_chat(user, span_warning("[src] is already in good condition!"))
-			return
+/obj/machinery/firealarm/wirecutter_act_secondary(mob/living/user, obj/item/tool)
+	if(!panel_open)
+		return NONE
+	if(buildstage != FIRE_ALARM_BUILD_SECURED)
+		balloon_alert(user, "expose the wires first!")
+		return ITEM_INTERACT_BLOCKING
 
-		switch(buildstage)
-			if(2)
-				if(tool.tool_behaviour == TOOL_MULTITOOL)
-					toggle_fire_detect(user)
-					return
-				if(tool.tool_behaviour == TOOL_WIRECUTTER)
-					buildstage = FIRE_ALARM_BUILD_NO_WIRES
-					tool.play_tool_sound(src)
-					new /obj/item/stack/cable_coil(user.loc, 5)
-					to_chat(user, span_notice("You cut the wires from \the [src]."))
-					update_appearance()
-					return
+	buildstage = FIRE_ALARM_BUILD_NO_WIRES
+	tool.play_tool_sound(src)
+	new /obj/item/stack/cable_coil(user.loc, 5)
+	balloon_alert(user, "wires removed")
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
-				else if(tool.force) //hit and turn it on
-					..()
-					var/area/area = get_area(src)
-					if(!area.fire)
-						alarm()
-					return
+/obj/machinery/firealarm/crowbar_act(mob/living/user, obj/item/tool)
+	if(!panel_open)
+		return NONE
+	if(buildstage != FIRE_ALARM_BUILD_NO_WIRES)
+		return NONE
 
-			if(1)
-				if(istype(tool, /obj/item/stack/cable_coil))
-					var/obj/item/stack/cable_coil/coil = tool
-					if(coil.get_amount() < 5)
-						to_chat(user, span_warning("You need more cable for this!"))
-					else
-						coil.use(5)
-						buildstage = FIRE_ALARM_BUILD_SECURED
-						to_chat(user, span_notice("You wire \the [src]."))
-						update_appearance()
-					return
+	loc.balloon_alert_to_viewers("removing circuit...")
+	if(!tool.use_tool(src, user, 2 SECONDS, volume = 50, extra_checks = CALLBACK(src, PROC_REF(state_callback), FIRE_ALARM_BUILD_NO_WIRES, TRUE)))
+		return ITEM_INTERACT_BLOCKING
+	if(machine_stat & BROKEN)
+		balloon_alert(user, "broken circuit removed")
+		set_machine_stat(machine_stat & ~BROKEN)
+	else
+		balloon_alert(user, "circuit removed")
+		new /obj/item/electronics/firealarm(user.drop_location())
+	buildstage = FIRE_ALARM_BUILD_NO_CIRCUIT
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
-				else if(tool.tool_behaviour == TOOL_CROWBAR)
-					user.visible_message(span_notice("[user.name] removes the electronics from [src.name]."), \
-										span_notice("You start prying out the circuit..."))
-					if(tool.use_tool(src, user, 20, volume=50))
-						if(buildstage == FIRE_ALARM_BUILD_NO_WIRES)
-							if(machine_stat & BROKEN)
-								to_chat(user, span_notice("You remove the destroyed circuit."))
-								set_machine_stat(machine_stat & ~BROKEN)
-							else
-								to_chat(user, span_notice("You pry out the circuit."))
-								new /obj/item/electronics/firealarm(user.loc)
-							buildstage = FIRE_ALARM_BUILD_NO_CIRCUIT
-							update_appearance()
-					return
-			if(0)
-				if(istype(tool, /obj/item/electronics/firealarm))
-					to_chat(user, span_notice("You insert the circuit."))
-					qdel(tool)
-					buildstage = FIRE_ALARM_BUILD_NO_WIRES
-					update_appearance()
-					return
+/obj/machinery/firealarm/crowbar_act_secondary(mob/living/user, obj/item/tool)
+	return crowbar_act(user, tool)
 
-				else if(istype(tool, /obj/item/electroadaptive_pseudocircuit))
-					var/obj/item/electroadaptive_pseudocircuit/pseudoc = tool
-					if(!pseudoc.adapt_circuit(user, circuit_cost = 0.015 * STANDARD_CELL_CHARGE))
-						return
-					user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
-					span_notice("You adapt a fire alarm circuit and slot it into the assembly."))
-					buildstage = FIRE_ALARM_BUILD_NO_WIRES
-					update_appearance()
-					return
+/obj/machinery/firealarm/wrench_act(mob/living/user, obj/item/tool)
+	if(!panel_open)
+		return NONE
+	if(buildstage != FIRE_ALARM_BUILD_NO_CIRCUIT)
+		return NONE
 
-				else if(tool.tool_behaviour == TOOL_WRENCH)
-					user.visible_message(span_notice("[user] removes the fire alarm assembly from the wall."), \
-						span_notice("You remove the fire alarm assembly from the wall."))
-					var/obj/item/wallframe/firealarm/frame = new /obj/item/wallframe/firealarm()
-					frame.forceMove(user.drop_location())
-					tool.play_tool_sound(src)
-					qdel(src)
-					return
-	return ..()
+	loc.balloon_alert_to_viewers("[/obj/item/wallframe/firealarm::name] removed")
+	new /obj/item/wallframe/firealarm(user.drop_location())
+	tool.play_tool_sound(loc)
+	qdel(src)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/firealarm/wrench_act_secondary(mob/living/user, obj/item/tool)
+	return wrench_act(user, tool)
+
+/obj/machinery/firealarm/tool_act(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(. & ITEM_INTERACT_ANY_BLOCKER)
+		return .
+	if(is_wire_tool(tool))
+		if(panel_open)
+			wires.interact(user)
+			return ITEM_INTERACT_SUCCESS
+
+		balloon_alert(user, "expose the wires first!")
+		return ITEM_INTERACT_BLOCKING
+	return NONE
+
+/obj/machinery/firealarm/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!panel_open)
+		return NONE
+
+	if(buildstage == FIRE_ALARM_BUILD_NO_WIRES)
+		if(istype(tool, /obj/item/stack/cable_coil))
+			var/obj/item/stack/cable_coil/coil = tool
+			if(!coil.use(5))
+				balloon_alert(user, "need 5 cables!")
+				return ITEM_INTERACT_BLOCKING
+			buildstage = FIRE_ALARM_BUILD_SECURED
+			balloon_alert(user, "wires installed")
+			update_appearance()
+			return ITEM_INTERACT_SUCCESS
+
+	if(buildstage == FIRE_ALARM_BUILD_NO_CIRCUIT)
+		if(istype(tool, /obj/item/electronics/firealarm))
+			balloon_alert(user, "circuit installed")
+			qdel(tool)
+			buildstage = FIRE_ALARM_BUILD_NO_WIRES
+			update_appearance()
+			return ITEM_INTERACT_SUCCESS
+
+		if(istype(tool, /obj/item/electroadaptive_pseudocircuit))
+			var/obj/item/electroadaptive_pseudocircuit/pseudoc = tool
+			if(!pseudoc.adapt_circuit(user, circuit_cost = 0.015 * STANDARD_CELL_CHARGE))
+				return ITEM_INTERACT_BLOCKING
+			balloon_alert(user, "circuit installed")
+			buildstage = FIRE_ALARM_BUILD_NO_WIRES
+			update_appearance()
+			return ITEM_INTERACT_SUCCESS
+
+	return NONE
+
+/obj/machinery/firealarm/proc/state_callback(desired_build_state, desired_panel_state)
+	return (isnull(desired_build_state) || buildstage == desired_build_state) \
+		&& (isnull(desired_panel_state) || panel_open == desired_panel_state)
 
 /obj/machinery/firealarm/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if((buildstage == FIRE_ALARM_BUILD_NO_CIRCUIT) && (the_rcd.construction_upgrades & RCD_UPGRADE_SIMPLE_CIRCUITS))
@@ -419,12 +495,22 @@
 			return TRUE
 	return FALSE
 
+// Taking melee damage always triggers the alarm if panel is open
+/obj/machinery/firealarm/attacked_by(obj/item/attacking_item, mob/living/user, list/modifiers, list/attack_modifiers)
+	. = ..()
+	if(!. || !panel_open || buildstage != FIRE_ALARM_BUILD_SECURED)
+		return
+	alarm()
+
+// Taking any damage has a rng chance of triggering the alarm regardless of panel state
 /obj/machinery/firealarm/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
-	if(.) //damage received
-		if(atom_integrity > 0 && !(machine_stat & BROKEN) && buildstage != FIRE_ALARM_BUILD_NO_CIRCUIT)
-			if(prob(33) && buildstage == FIRE_ALARM_BUILD_SECURED) //require fully wired electronics to set of the alarms
-				alarm()
+	if(!.) //damage received
+		return
+	if(atom_integrity <= 0 || buildstage != FIRE_ALARM_BUILD_SECURED)
+		return
+	if(prob(damage_amount * 3))
+		alarm()
 
 /obj/machinery/firealarm/singularity_pull(atom/singularity, current_size)
 	if (current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects, the fire alarm experiences integrity failure
@@ -470,20 +556,46 @@
 
 /obj/machinery/firealarm/AICtrlClick(mob/living/silicon/robot/user)
 	if(obj_flags & EMAGGED)
-		to_chat(user, span_warning("The control circuitry of [src] appears to be malfunctioning."))
+		balloon_alert(user, "control circuitry malfunctioning!")
 		return
 	toggle_fire_detect(user)
 
-/obj/machinery/firealarm/proc/toggle_fire_detect(mob/user)
-	my_area.fire_detect = !my_area.fire_detect
-	for(var/obj/machinery/firealarm/fire_panel in my_area.firealarms)
-		fire_panel.update_icon()
-	// Used to force all the firelocks to update, if the zone is not manually activated
-	if (my_area.fault_status != AREA_FAULT_MANUAL)
-		reset() // Don't send user to prevent double balloon_alert() and the action is already logged in this proc.
-	if (user)
+/// Toggles automatic fire detection on or off
+/obj/machinery/firealarm/proc/toggle_fire_detect(mob/user, silent = FALSE)
+	if(!can_toggle_detection)
+		if(user && !silent)
+			balloon_alert(user, "thermal sensors unresponsive!")
+		return
+	if(my_area.fire_detect)
+		disable_fire_detect(user)
+	else
+		enable_fire_detect(user)
+	if (user && !silent)
 		balloon_alert(user, "thermal sensors [my_area.fire_detect ? "enabled" : "disabled"]")
-		user.log_message("[ my_area.fire_detect ? "enabled" : "disabled" ] firelock sensors using [src].", LOG_GAME)
+
+/// Stops the area from automatically activating firelocks
+/obj/machinery/firealarm/proc/disable_fire_detect(mob/user)
+	if(!my_area.fire_detect)
+		return
+	my_area.fire_detect = FALSE
+	for(var/obj/machinery/firealarm/fire_panel in my_area.firealarms)
+		fire_panel.update_appearance()
+	// Used to force all the firelocks to update, if the zone is not manually activated
+	if(my_area.fault_status != AREA_FAULT_MANUAL)
+		reset()
+	user?.log_message("disabled firelock sensors using [src].", LOG_GAME)
+
+/// Enables the area to automatically activate firelocks
+/obj/machinery/firealarm/proc/enable_fire_detect(mob/user)
+	if(my_area.fire_detect)
+		return
+	my_area.fire_detect = TRUE
+	for(var/obj/machinery/firealarm/fire_panel in my_area.firealarms)
+		fire_panel.update_appearance()
+	// See above
+	if(my_area.fault_status != AREA_FAULT_MANUAL)
+		reset()
+	user?.log_message("enabled firelock sensors using [src].", LOG_GAME)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
 
@@ -499,25 +611,23 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
 	desc = "Cuban Pete is in the house!"
 	var/static/party_overlay
 
-/obj/machinery/firealarm/partyalarm/reset()
-	if (machine_stat & (NOPOWER|BROKEN))
+/obj/machinery/firealarm/partyalarm/reset(mob/user, silent = FALSE)
+	if (!is_operational || !can_reset)
 		return
 	var/area/area = get_area(src)
 	if (!area || !area.party)
 		return
-	area.party = FALSE
-	area.cut_overlay(party_overlay)
+	my_area.party = FALSE
+	my_area.cut_overlay(party_overlay)
 
-/obj/machinery/firealarm/partyalarm/alarm()
-	if (machine_stat & (NOPOWER|BROKEN))
+/obj/machinery/firealarm/partyalarm/alarm(mob/user, silent = FALSE)
+	if (!is_operational || !can_trigger)
 		return
-	var/area/area = get_area(src)
-	if (!area || area.party || area.name == "Space")
+	if (my_area.party || is_area_nearby_station(my_area))
 		return
-	area.party = TRUE
-	if (!party_overlay)
-		party_overlay = iconstate2appearance('icons/area/areas_misc.dmi', "party")
-	area.add_overlay(party_overlay)
+	party_overlay ||= iconstate2appearance('icons/area/areas_misc.dmi', "party")
+	my_area.party = TRUE
+	my_area.add_overlay(party_overlay)
 
 /obj/item/circuit_component/firealarm
 	display_name = "Fire Alarm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2041,6 +2041,7 @@
 #include "code\datums\wires\emitter.dm"
 #include "code\datums\wires\explosive.dm"
 #include "code\datums\wires\fax.dm"
+#include "code\datums\wires\firealarm.dm"
 #include "code\datums\wires\holopad.dm"
 #include "code\datums\wires\mass_driver.dm"
 #include "code\datums\wires\mecha.dm"


### PR DESCRIPTION
## About The Pull Request

1. Adds 4 wires to fire alarms

trigger - triggers the fire alarm on pulse, disables trigger on cut
reset - resets the fire alarm on pulse, disables reset on cut
toggle - takes the old multitool act on pulse (toggling auto fire detection), does similar on cut
dud - does nothing

2. Fire alarm attackby -> tool and item interactions

3. Fire alarm screentips

4. Changed fire alarm trigger on damage from flat 33% to (3 * damage)%

## Why It's Good For The Game

1. Allows for more assembly shenanigans - maybe cutting the reset wire and having a signaller on pulse

2. Cleaner

3. Helpful

4. allows you to consistently rely on the behavior by using higher force weapons (such as guns) (this was a request)

## Changelog

:cl: Melbert
add: Fire alarms now has wires
add: Fire alarm trigger on damage now scales based on damage dealt, rather than being a flat 33%
qol: Fire alarm screentips
refactor: Refactored fire alarms de/assembly, report any oddities
/:cl:
