### PR TITLE
Fixed cockroach spawners not doing anything

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -360,4 +360,6 @@
 /obj/effect/mob_spawn/cockroach/Initialize(mapload)
 	if(prob(bloodroach_chance))
 		mob_type = /mob/living/basic/cockroach/bloodroach
-	return ..()
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(create))
+	qdel(src)


### PR DESCRIPTION
## About The Pull Request

In my infinite hubris and sloth, I foolishly assumed mob spawners 'spawn' 'mobs'. In truth, they actually do Absolutely Nothing and it's just the ghost_role and corpse subtypes that actually do anything. It's still my bad but,  bruh. bruh uruhurb,,,

## Why It's Good For The Game

closes #91575

Cock 
Roach

## Changelog

:cl:
fix: Fixed cockroach spawners not doing anything
/:cl:

