### PR TITLE
Borg omnitools cant drop the tool ref

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -31,7 +31,7 @@
 #define NOBLUDGEON (1<<7) // when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 /**
  * for all things that are technically items but don't want to be treated as such, given on a case-by-case basis
- * examples of use are hand items, omni-toolsets, non-limb limb items (hand eater, chainsaw), borg modules, bodyparts, organs, etc.
+ * examples of use are hand items, omni-toolsets, non-limb limbs (hand eater, mounted chainsaw, many null rods), borg modules, bodyparts, organs, etc.
  * This is used for general exclusion, such as preventing insertions into other items
  * Basically, these aren't "real" items. <= wow thanks for the fucking insight sherlock
 */

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -29,7 +29,13 @@
 #define NO_MAT_REDEMPTION (1<<5) // Stops you from putting things like an RCD or other items into an ORM or protolathe for materials.
 #define DROPDEL (1<<6) // When dropped, it calls qdel on itself
 #define NOBLUDGEON (1<<7) // when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
-#define ABSTRACT (1<<9) // for all things that are technically items but used for various different stuff <= wow thanks for the fucking insight sherlock
+/**
+ * for all things that are technically items but don't want to be treated as such, given on a case-by-case basis
+ * examples of use are hand items, omni-toolsets, non-limb limb items (hand eater, chainsaw), borg modules, bodyparts, organs, etc.
+ * This is used for general exclusion, such as preventing insertions into other items
+ * Basically, these aren't "real" items. <= wow thanks for the fucking insight sherlock
+*/
+#define ABSTRACT (1<<9)
 #define IMMUTABLE_SLOW (1<<10) // When players should not be able to change the slowdown of the item (Speed potions, etc)
 #define IN_STORAGE (1<<11) //is this item in the storage item, such as backpack? used for tooltips
 #define SURGICAL_TOOL (1<<12) //Tool commonly used for surgery: won't attack targets in an active surgical operation on help intent (in case of mistakes)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -224,8 +224,9 @@
 
 	//if all else fails just make a new one from scratch
 	tool = new reference(user)
-	//the internal tool is considered part of the tool itself.
+	//the internal tool is considered part of the tool itself, so don't let it be dropped.
 	tool.item_flags |= ABSTRACT
+	ADD_TRAIT(tool, TRAIT_NODROP, INNATE_TRAIT)
 	atoms[reference] = tool
 	return tool
 


### PR DESCRIPTION
## About The Pull Request

Borg omnitool is now nodrop so you can't drop the internal tool reference out of the omnitool

## Why It's Good For The Game

You can put them in closets & on conveyer belts because it doesn't check for ABSTRACT anywhere and ``doUnEquip`` doesn't prevent the dropping of items that isn't directly in your modules (so you can drop your beakers n stuff), so instead of fixing this one by one we're just gonna make them nodrop, they aren't ever in your actual hand anyway.

Fixes https://github.com/tgstation/tgstation/issues/91580

## Changelog

:cl:
fix: Borgs can't drop their omnitool's tools on conveyor belts & into closets.
/:cl: