### PR TITLE
Panacea Fix

### DIFF
--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -29,10 +29,11 @@
 		O.forceMove(get_turf(user))
 
 	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
-	user.reagents.add_reagent(/datum/reagent/medicine/pen_acid, 20)
+	user.reagents.add_reagent(/datum/reagent/medicine/neurine, 20)
+	user.reagents.add_reagent(/datum/reagent/medicine/c2/seiver, 20)
 	user.reagents.add_reagent(/datum/reagent/medicine/antihol, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/mannitol, 25)
-
+	user.reagents.add_reagent(/datum/reagent/medicine/ammoniated_mercury, 2)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)


### PR DESCRIPTION

## About The Pull Request
Removes Pentetic Acid that purged all of the chemicals(even beneficial) with Seiver and Ammoniated Mercury
## Why It's Good For The Game
The players that i asked for opinions on the panacea say that its really useless even at its cost because it purges beneficial chemicals and i made it useful
## Changelog
:cl:
add: Added Seiver and Ammoniated Mercury to Anatomic Panacea
del: Removed Pentetic Acid from Anatomic Panacea
/:cl:
