### PR TITLE
Fixes xenomorphs being able to infinitely vomit out the same person

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -192,6 +192,7 @@
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, PROC_REF(content_died))
 
 /obj/item/organ/stomach/alien/content_moved(atom/movable/source)
+	. = ..()
 	if(source.loc == src || source.loc == owner)
 		return
 	UnregisterSignal(source, COMSIG_LIVING_DEATH)


### PR DESCRIPTION

## About The Pull Request

Didn't call parent, thus didn't unreg the mob.
Closes #91557

## Changelog
:cl:
fix: Fixed xenomorphs being able to infinitely vomit out the same person
/:cl:
