### PR TITLE
Ghost lighting now updates prefs

### DIFF
--- a/code/__DEFINES/observers.dm
+++ b/code/__DEFINES/observers.dm
@@ -10,3 +10,11 @@
 #define NOTIFY_CATEGORY_DEFAULT (GHOST_NOTIFY_FLASH_WINDOW | GHOST_NOTIFY_IGNORE_MAPLOAD | GHOST_NOTIFY_NOTIFY_SUICIDERS)
 /// The default set of flags, without the flash_window flag.
 #define NOTIFY_CATEGORY_NOFLASH (NOTIFY_CATEGORY_DEFAULT & ~GHOST_NOTIFY_FLASH_WINDOW)
+
+///Assoc List of types of ghost lightings & the player-facing name.
+GLOBAL_LIST_INIT(ghost_lightings, list(
+	"[LIGHTING_CUTOFF_VISIBLE]" = "Normal",
+	"[LIGHTING_CUTOFF_MEDIUM]" = "Darker",
+	"[LIGHTING_CUTOFF_HIGH]" = "Night Vision",
+	"[LIGHTING_CUTOFF_FULLBRIGHT]" = "Fullbright",
+))

--- a/code/__DEFINES/observers.dm
+++ b/code/__DEFINES/observers.dm
@@ -13,8 +13,8 @@
 
 ///Assoc List of types of ghost lightings & the player-facing name.
 GLOBAL_LIST_INIT(ghost_lightings, list(
-	"[LIGHTING_CUTOFF_VISIBLE]" = "Normal",
-	"[LIGHTING_CUTOFF_MEDIUM]" = "Darker",
-	"[LIGHTING_CUTOFF_HIGH]" = "Night Vision",
-	"[LIGHTING_CUTOFF_FULLBRIGHT]" = "Fullbright",
+	"Normal" = LIGHTING_CUTOFF_VISIBLE,
+	"Darker" = LIGHTING_CUTOFF_MEDIUM,
+	"Night Vision" = LIGHTING_CUTOFF_HIGH,
+	"Fullbright" = LIGHTING_CUTOFF_FULLBRIGHT,
 ))

--- a/code/modules/client/preferences/ghost_lighting.dm
+++ b/code/modules/client/preferences/ghost_lighting.dm
@@ -10,7 +10,7 @@
 /datum/preference/choiced/ghost_lighting/init_possible_values()
 	var/list/values = list()
 	for(var/option_name in GLOB.ghost_lightings)
-		values += GLOB.ghost_lightings[option_name]
+		values += option_name
 	return values
 
 /datum/preference/choiced/ghost_lighting/apply_to_client(client/client, value)

--- a/code/modules/client/preferences/ghost_lighting.dm
+++ b/code/modules/client/preferences/ghost_lighting.dm
@@ -1,10 +1,3 @@
-GLOBAL_LIST_INIT(ghost_lighting_options, list(
-	"Fullbright" = LIGHTING_CUTOFF_FULLBRIGHT,
-	"Night Vision" = LIGHTING_CUTOFF_HIGH,
-	"Darker" = LIGHTING_CUTOFF_MEDIUM,
-	"Normal" = LIGHTING_CUTOFF_VISIBLE,
-))
-
 /// How bright a ghost's lighting plane is
 /datum/preference/choiced/ghost_lighting
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
@@ -16,8 +9,8 @@ GLOBAL_LIST_INIT(ghost_lighting_options, list(
 
 /datum/preference/choiced/ghost_lighting/init_possible_values()
 	var/list/values = list()
-	for(var/option_name in GLOB.ghost_lighting_options)
-		values += option_name
+	for(var/option_name in GLOB.ghost_lightings)
+		values += GLOB.ghost_lightings[option_name]
 	return values
 
 /datum/preference/choiced/ghost_lighting/apply_to_client(client/client, value)

--- a/code/modules/mob/dead/observer/ghost_menu.dm
+++ b/code/modules/mob/dead/observer/ghost_menu.dm
@@ -1,13 +1,6 @@
 GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 
 /datum/ghost_menu
-	///Static assoc list of all types of lightings ghosts can use & names shown in the UI.
-	var/static/list/ghost_lightings = list(
-		"[LIGHTING_CUTOFF_VISIBLE]" = "Mob Vision",
-		"[LIGHTING_CUTOFF_MEDIUM]" = "Slight Night Vision",
-		"[LIGHTING_CUTOFF_HIGH]" = "Night Vision",
-		"[LIGHTING_CUTOFF_FULLBRIGHT]" = "Fullbright",
-	)
 
 /datum/ghost_menu/ui_state(mob/user)
 	return GLOB.observer_state
@@ -57,10 +50,13 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 			var/darkness_type = params["darkness_level"]
 			if(isnull(darkness_type))
 				return FALSE
-			for(var/lighting_types in ghost_lightings)
-				if(darkness_type != ghost_lightings[lighting_types])
+			for(var/lighting_types in GLOB.ghost_lightings)
+				if(darkness_type != GLOB.ghost_lightings[lighting_types])
 					continue
-				toggle_darkness(dead_user, lighting_types)
+				//our selected one is the one we already have enabled.
+				if(dead_user.lighting_cutoff == GLOB.ghost_lightings[lighting_types])
+					return FALSE
+				toggle_darkness(dead_user, darkness_type)
 				return TRUE
 		if("toggle_visibility")
 			var/to_toggle = params["toggling"]
@@ -95,8 +91,8 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 
 	data["can_boo"] = COOLDOWN_FINISHED(user, bootime)
 	data["has_fun"] = user.fun_verbs
-	data["body_name"] = user.can_reenter_corpse ? user.mind.current.real_name : FALSE
-	data["current_darkness"] = ghost_lightings["[user.lighting_cutoff]"]
+	data["body_name"] = (user.mind.current && user.can_reenter_corpse) ? user.mind.current.real_name : FALSE
+	data["current_darkness"] = GLOB.ghost_lightings["[user.lighting_cutoff]"]
 	data["notification_data"] = list()
 	for(var/key in GLOB.poll_ignore_desc)
 		data["notification_data"] += list(list(
@@ -144,8 +140,8 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 	var/list/data = list()
 	data["max_extra_view"] = (user.client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT) - GHOST_MIN_VIEW_RANGE
 	data["darkness_levels"] = list()
-	for(var/level in ghost_lightings)
-		data["darkness_levels"] += ghost_lightings[level]
+	for(var/level in GLOB.ghost_lightings)
+		data["darkness_levels"] += GLOB.ghost_lightings[level]
 	data["lag_switch_on"] = !!(SSlag_switch.measures[DISABLE_GHOST_ZOOM_TRAY] && !user.client?.holder)
 	return data
 
@@ -156,9 +152,8 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 	t_ray_scan(user)
 
 /datum/ghost_menu/proc/toggle_darkness(mob/dead/observer/user, darkness_type)
-	if(user.lighting_cutoff == darkness_type)
-		return
-	user.lighting_cutoff = text2num(darkness_type)
+	user.client.prefs.write_preference(GLOB.preference_entries[/datum/preference/choiced/ghost_lighting], darkness_type)
+	user.lighting_cutoff = user.default_lighting_cutoff()
 	user.update_sight()
 
 /datum/ghost_menu/proc/toggle_hud_type(mob/dead/observer/user, hud_type)

--- a/code/modules/mob/dead/observer/ghost_menu.dm
+++ b/code/modules/mob/dead/observer/ghost_menu.dm
@@ -51,10 +51,10 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 			if(isnull(darkness_type))
 				return FALSE
 			for(var/lighting_types in GLOB.ghost_lightings)
-				if(darkness_type != GLOB.ghost_lightings[lighting_types])
+				if(darkness_type != lighting_types)
 					continue
 				//our selected one is the one we already have enabled.
-				if(dead_user.lighting_cutoff == GLOB.ghost_lightings[lighting_types])
+				if(dead_user.lighting_cutoff == GLOB.ghost_lightings[darkness_type])
 					return FALSE
 				toggle_darkness(dead_user, darkness_type)
 				return TRUE
@@ -92,7 +92,9 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 	data["can_boo"] = COOLDOWN_FINISHED(user, bootime)
 	data["has_fun"] = user.fun_verbs
 	data["body_name"] = (user.mind.current && user.can_reenter_corpse) ? user.mind.current.real_name : FALSE
-	data["current_darkness"] = GLOB.ghost_lightings["[user.lighting_cutoff]"]
+	for(var/level in GLOB.ghost_lightings)
+		if(GLOB.ghost_lightings[level] == user.lighting_cutoff)
+			data["current_darkness"] = level
 	data["notification_data"] = list()
 	for(var/key in GLOB.poll_ignore_desc)
 		data["notification_data"] += list(list(
@@ -141,7 +143,7 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 	data["max_extra_view"] = (user.client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT) - GHOST_MIN_VIEW_RANGE
 	data["darkness_levels"] = list()
 	for(var/level in GLOB.ghost_lightings)
-		data["darkness_levels"] += GLOB.ghost_lightings[level]
+		data["darkness_levels"] += level
 	data["lag_switch_on"] = !!(SSlag_switch.measures[DISABLE_GHOST_ZOOM_TRAY] && !user.client?.holder)
 	return data
 

--- a/code/modules/mob/dead/observer/ghost_menu.dm
+++ b/code/modules/mob/dead/observer/ghost_menu.dm
@@ -91,7 +91,7 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 
 	data["can_boo"] = COOLDOWN_FINISHED(user, bootime)
 	data["has_fun"] = user.fun_verbs
-	data["body_name"] = (user.mind.current && user.can_reenter_corpse) ? user.mind.current.real_name : FALSE
+	data["body_name"] = (user.can_reenter_corpse && user?.mind.current) ? user.mind.current.real_name : FALSE
 	for(var/level in GLOB.ghost_lightings)
 		if(GLOB.ghost_lightings[level] == user.lighting_cutoff)
 			data["current_darkness"] = level

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -805,8 +805,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/datum/preferences/prefs = client?.prefs
 	if(!prefs || (client?.combo_hud_enabled && prefs.toggles & COMBOHUD_LIGHTING))
 		return ..()
-	return GLOB.ghost_lighting_options[prefs.read_preference(/datum/preference/choiced/ghost_lighting)]
-
+	var/pref_level = prefs.read_preference(/datum/preference/choiced/ghost_lighting)
+	for(var/level in GLOB.ghost_lightings)
+		if(GLOB.ghost_lightings[level] == pref_level)
+			return text2num(level)
 
 /// Called when we exit the orbiting state
 /mob/dead/observer/proc/on_deorbit(datum/source)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -805,10 +805,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/datum/preferences/prefs = client?.prefs
 	if(!prefs || (client?.combo_hud_enabled && prefs.toggles & COMBOHUD_LIGHTING))
 		return ..()
-	var/pref_level = prefs.read_preference(/datum/preference/choiced/ghost_lighting)
-	for(var/level in GLOB.ghost_lightings)
-		if(GLOB.ghost_lightings[level] == pref_level)
-			return text2num(level)
+	return GLOB.ghost_lightings[prefs.read_preference(/datum/preference/choiced/ghost_lighting)]
 
 /// Called when we exit the orbiting state
 /mob/dead/observer/proc/on_deorbit(datum/source)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -429,7 +429,7 @@
 
 /// Returns this mob's default lighting alpha
 /mob/proc/default_lighting_cutoff()
-	if(client?.combo_hud_enabled && client?.prefs?.toggles & COMBOHUD_LIGHTING)
+	if(client?.combo_hud_enabled && (client?.prefs?.toggles & COMBOHUD_LIGHTING))
 		return LIGHTING_CUTOFF_FULLBRIGHT
 	return initial(lighting_cutoff)
 


### PR DESCRIPTION
## About The Pull Request

Changing your ghost lighting in the observer menu now updates its respective preference, meaning it follows you through rounds. When I made the UI I wasn't aware that it was also a preference, and I'd assume many others think the same.

## Why It's Good For The Game

It's nice when things you do in game save between rounds without having to manually re-do it, for most of us who haven't scrolled through the long ass settings page through every setting.

## Changelog

:cl:
qol: Changing your ghost lighting in the ghost menu now saves between rounds.
/:cl: