### PR TITLE
Rebalances the Paddy: Weaker armor, but moves fast if the siren is on.

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -59,6 +59,9 @@
 /obj/vehicle/sealed/mecha/ripley/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/armor_plate, 3, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_plate_ripley_goliath)
+	movedelay = CONFIG_GET(number/movedelay/run_delay)
+	fast_pressure_step_in = CONFIG_GET(number/movedelay/run_delay)
+	slow_pressure_step_in = CONFIG_GET(number/movedelay/run_delay) + 0.5
 
 /datum/armor/armor_plate_ripley_goliath
 	melee = 10
@@ -156,9 +159,9 @@
 		weewooloop.stop()
 		siren = FALSE
 	else
-		movedelay = 1.5
-		slow_pressure_step_in = 2
-		fast_pressure_step_in = 1.5
+		movedelay = CONFIG_GET(number/movedelay/run_delay)
+		fast_pressure_step_in = CONFIG_GET(number/movedelay/run_delay)
+		slow_pressure_step_in = CONFIG_GET(number/movedelay/run_delay) + 0.5
 		weewooloop.start()
 		siren = TRUE
 	for(var/mob/occupant as anything in occupants)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -123,7 +123,7 @@
 	bullet = 0
 	laser = 0
 	energy = 0
-	bomb = 20
+	bomb = -20
 	fire = 100
 	acid = 100
 

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -42,6 +42,8 @@
 	var/fast_pressure_step_in = 1.5
 	/// How fast the mech is in normal pressure
 	var/slow_pressure_step_in = 2
+	/// Should we update our move delay to the config on init?
+	var/mirror_config_speed_init = TRUE
 
 /datum/armor/mecha_ripley
 	melee = 40
@@ -59,9 +61,10 @@
 /obj/vehicle/sealed/mecha/ripley/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/armor_plate, 3, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_plate_ripley_goliath)
-	movedelay = CONFIG_GET(number/movedelay/run_delay)
-	fast_pressure_step_in = CONFIG_GET(number/movedelay/run_delay)
-	slow_pressure_step_in = CONFIG_GET(number/movedelay/run_delay) + 0.5
+	if(mirror_config_speed_init)
+		movedelay = CONFIG_GET(number/movedelay/run_delay)
+		fast_pressure_step_in = CONFIG_GET(number/movedelay/run_delay)
+		slow_pressure_step_in = CONFIG_GET(number/movedelay/run_delay) + 0.5
 
 /datum/armor/armor_plate_ripley_goliath
 	melee = 10
@@ -75,6 +78,7 @@
 	base_icon_state = "ripleymkii"
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
+	mirror_config_speed_init = FALSE
 	movedelay = 4
 	max_temperature = 30000
 	max_integrity = 250
@@ -105,6 +109,7 @@
 	movedelay = 5
 	slow_pressure_step_in = 5
 	fast_pressure_step_in = 3
+	mirror_config_speed_init = FALSE
 	possible_int_damage = MECHA_INT_FIRE|MECHA_INT_CONTROL_LOST|MECHA_INT_SHORT_CIRCUIT
 	accesses = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
 	armor_type = /datum/armor/mecha_paddy

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -96,9 +96,6 @@
 	name = "\improper APLU \"Paddy\""
 	icon_state = "paddy"
 	base_icon_state = "paddy"
-	movedelay = 5
-	slow_pressure_step_in = 5
-	fast_pressure_step_in = 3
 	max_temperature = 20000
 	max_integrity = 250
 	mech_type = EXOSUIT_MODULE_PADDY
@@ -122,11 +119,11 @@
 	var/datum/looping_sound/siren/weewooloop
 
 /datum/armor/mecha_paddy
-	melee = 40
-	bullet = 20
-	laser = 10
-	energy = 20
-	bomb = 40
+	melee = 30
+	bullet = 0
+	laser = 0
+	energy = 0
+	bomb = 20
 	fire = 100
 	acid = 100
 
@@ -134,6 +131,8 @@
 	. = ..()
 	weewooloop = new(src, FALSE, FALSE)
 	weewooloop.volume = 100
+	weewooloop.extra_range = 14 // 2 additional screens away
+	weewooloop.falloff_exponent = 3
 
 /obj/vehicle/sealed/mecha/ripley/paddy/generate_actions()
 	. = ..()
@@ -148,9 +147,15 @@
 
 /obj/vehicle/sealed/mecha/ripley/paddy/proc/togglesiren(force_off = FALSE)
 	if(force_off || siren)
+		movedelay = 5
+		slow_pressure_step_in = 5
+		fast_pressure_step_in = 3
 		weewooloop.stop()
 		siren = FALSE
 	else
+		movedelay = 1.5
+		slow_pressure_step_in = 2
+		fast_pressure_step_in = 1.5
 		weewooloop.start()
 		siren = TRUE
 	for(var/mob/occupant as anything in occupants)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -158,9 +158,9 @@
 
 /obj/vehicle/sealed/mecha/ripley/paddy/proc/togglesiren(force_off = FALSE)
 	if(force_off || siren)
-		movedelay = 5
-		slow_pressure_step_in = 5
-		fast_pressure_step_in = 3
+		movedelay = initial(move_delay)
+		slow_pressure_step_in = initial(slow_pressure_step_in)
+		fast_pressure_step_in = initial(fast_pressure_step_in)
 		weewooloop.stop()
 		siren = FALSE
 	else

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -158,7 +158,7 @@
 
 /obj/vehicle/sealed/mecha/ripley/paddy/proc/togglesiren(force_off = FALSE)
 	if(force_off || siren)
-		movedelay = initial(move_delay)
+		movedelay = initial(movedelay)
 		slow_pressure_step_in = initial(slow_pressure_step_in)
 		fast_pressure_step_in = initial(fast_pressure_step_in)
 		weewooloop.stop()

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -99,6 +99,9 @@
 	max_temperature = 20000
 	max_integrity = 250
 	mech_type = EXOSUIT_MODULE_PADDY
+	movedelay = 5
+	slow_pressure_step_in = 5
+	fast_pressure_step_in = 3
 	possible_int_damage = MECHA_INT_FIRE|MECHA_INT_CONTROL_LOST|MECHA_INT_SHORT_CIRCUIT
 	accesses = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
 	armor_type = /datum/armor/mecha_paddy


### PR DESCRIPTION
## About The Pull Request

Closes #91593

The PADDY and RIPLEY now properly move at the correct speeds; default config-human run speed, and will respect changes to those configs.
The PADDY now moves fast again, but only if the Siren is enabled.
The PADDY now only has 30% melee armor; it no longer has bullet, energy, or laser armor.
The PADDY now has a weakness to bomb damage and is thus more vulnerable to explosives like IED soda cans.
The PADDY's sirens are now audible from a much further distance and fall off slower.

## Why It's Good For The Game

The current PADDY balance was done to make it a non-viable mecha that's completely useless as the result of a kneejerk revert. This change makes it a vehicle that has to announce itself to get anywhere at a reasonable speed, with the annoying siren providing a reason to not leave it at fast speed at all times, along with providing a tell that it's on the way.
Fixes the PADDY being able to run down humans if the configs for human speed is changed.

## Changelog
:cl:
fix: The PADDY and RIPLEY now properly move at the correct speeds; default config-human run speed, and will respect changes to those configs.
balance: The PADDY now moves fast again, but only if the Siren is enabled.
balance: The PADDY now only has 30% melee armor; it no longer has bullet, energy, or laser armor.
balance: The PADDY now has a weakness to bomb damage and is thus more vulnerable to explosives like IED soda cans.
balance: The PADDY's sirens are now audible from a much further distance and fall off slower.
/:cl: