### PR TITLE
Replaces some cells with megacells in space ruins reliant on APC cell replacements

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
@@ -48,7 +48,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "l" = (
-/obj/item/stock_parts/power_store/cell,
+/obj/item/stock_parts/power_store/battery,
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "m" = (

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -49,7 +49,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/tcommsat_oldaisat)
 "am" = (
-/obj/item/stock_parts/power_store/cell,
+/obj/item/stock_parts/power_store/battery,
 /turf/open/floor/plating/airless,
 /area/ruin/space/tcommsat_oldaisat)
 "an" = (

--- a/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
@@ -44,7 +44,7 @@
 /area/ruin/space/oldteleporter)
 "l" = (
 /obj/structure/table,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/battery/high,
 /turf/open/floor/iron/airless,
 /area/ruin/space/oldteleporter)
 "n" = (


### PR DESCRIPTION
## About The Pull Request
Updates some space ruin's "cells for shoving into APCs" into "batteries for shoving into APCs".

There are probably more I've forgotten, but these were the ones that jumped out at me. Tell me if there's others I've forgotten so I can shove them in this PR.

<details>
<summary>Updated maps and StrongDMM screenshots:</summary>

"Old AI Sat" (the one with the NASA spacesuits)
![image](https://github.com/user-attachments/assets/34e6a7d0-2005-4cef-8729-7e442e1e6b85)

"Old Teleporter"
![image](https://github.com/user-attachments/assets/98e084c3-495d-4e24-b9b9-cd434142ff95)

"Abandoned Teleporter" (the one you have to fix)
![image](https://github.com/user-attachments/assets/24964247-cdbe-4d32-a49a-b050867aa71a)

</details>

## Why It's Good For The Game
These space ruins (and probably more that I've forgotten) are pretty reliant on the battery in the APC not dying instantly. The cells, a holdover from before the cell-battery split... kinda-sorta can't perform.

## Changelog

:cl:
fix: Some old cells in space ruins reliant on replacing an APC's power cell have been replaced with their megacell counterparts.
/:cl:
