### PR TITLE
fixes infinite recursion with surgery gas masks

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -1239,7 +1239,6 @@
 		if (breath_mask != tool)
 			breath_mask = tool
 			RegisterSignal(breath_mask, COMSIG_MOVABLE_MOVED, PROC_REF(on_mask_moved))
-			RegisterSignal(breath_mask, COMSIG_ITEM_DROPPED, PROC_REF(check_mask_range))
 
 		balloon_alert(user, "mask attached")
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)


### PR DESCRIPTION

## About The Pull Request
there was an infinite recursion with masks being dropped over and over again so the 'move' signal wasnt being unregistered from the mob holding the mask. i figured the unequip signal wasnt needed anyway since we're already registering a moved signal on the mask, which already handles clearing signals from the holding mob upon being removed from their inventory.

## Why It's Good For The Game
fixes #91607

## Changelog
:cl:
fix: moving away from the surgery table with its mask no longer causes lag
/:cl:
