### PR TITLE
[NO GBP] Supermatter-spawned hallucination anomalies don't spawn decoys

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomalies_hallucination.dm
@@ -14,6 +14,8 @@
 		span_warning("Something's wispering around you!"),
 		span_warning("You are going insane!"),
 	)
+	///Do we spawn misleading decoys?
+	var/spawn_decoys = TRUE
 
 /obj/effect/anomaly/hallucination/Initialize(mapload, new_lifespan)
 	. = ..()
@@ -50,6 +52,9 @@
 	)
 
 /obj/effect/anomaly/hallucination/proc/generate_decoys()
+	if(!spawn_decoys)
+		return
+
 	for(var/turf/floor in orange(1, src))
 		if(prob(35))
 			new /obj/effect/anomaly/hallucination/decoy(floor)
@@ -100,3 +105,7 @@
 
 /obj/effect/anomaly/hallucination/decoy/generate_decoys()
 	return
+
+///Subtype for the SM that doesn't spawn decoys, because otherwise the whole area gets flooded with dummies.
+/obj/effect/anomaly/hallucination/supermatter
+	spawn_decoys = FALSE

--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -172,7 +172,7 @@
 		if(PYRO_ANOMALY)
 			new /obj/effect/anomaly/pyro(local_turf, has_changed_lifespan ? rand(15 SECONDS, 25 SECONDS) : null, FALSE)
 		if(HALLUCINATION_ANOMALY)
-			new /obj/effect/anomaly/hallucination(local_turf, has_changed_lifespan ? rand(15 SECONDS, 25 SECONDS) : null, FALSE)
+			new /obj/effect/anomaly/hallucination/supermatter(local_turf, has_changed_lifespan ? rand(15 SECONDS, 25 SECONDS) : null, FALSE)
 		if(VORTEX_ANOMALY)
 			new /obj/effect/anomaly/bhole(local_turf, 2 SECONDS, FALSE)
 		if(BIOSCRAMBLER_ANOMALY)


### PR DESCRIPTION

## About The Pull Request

Supermatter hallucination anomalies no longer spawn decoys.
## Why It's Good For The Game

When a delam hits there's way too many of these flying around. It looks ridiculous. I don't like it.

They're not getting defused anyways. The decoys aren't really misleading anyone from anything so why have them at all?
## Changelog
:cl: Rhials
qol: Supermatter hallucinatory anomalies no longer spawn decoys.
/:cl:
