### PR TITLE
Fix the lobby art not fading out

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -470,7 +470,7 @@ SUBSYSTEM_DEF(ticker)
 			qdel(player)
 			ADD_TRAIT(living, TRAIT_NO_TRANSFORM, SS_TICKER_TRAIT)
 			if(living.client)
-				var/atom/movable/screen/splash/fade_out = new(null, living.client, TRUE)
+				var/atom/movable/screen/splash/fade_out = new(null, null, living.client, TRUE)
 				fade_out.Fade(TRUE)
 				living.client.init_verbs()
 			livings += living

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -58,7 +58,7 @@ SUBSYSTEM_DEF(title)
 	for(var/thing in GLOB.clients)
 		if(!thing)
 			continue
-		var/atom/movable/screen/splash/S = new(null, thing, FALSE)
+		var/atom/movable/screen/splash/S = new(null, null, thing, FALSE)
 		S.Fade(FALSE,FALSE)
 
 /datum/controller/subsystem/title/Recover()

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -128,7 +128,7 @@
 
 /area/shuttle/arrival/on_joining_game(mob/living/boarder)
 	if(SSshuttle.arrivals?.mode == SHUTTLE_CALL)
-		var/atom/movable/screen/splash/Spl = new(null, boarder.client, TRUE)
+		var/atom/movable/screen/splash/Spl = new(null, null, boarder.client, TRUE)
 		Spl.Fade(TRUE)
 		boarder.playsound_local(get_turf(boarder), 'sound/announcer/ApproachingTG.ogg', 25)
 	boarder.update_parallax_teleport()

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -59,7 +59,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	var/client/hopper = client
 	to_chat(hopper, span_notice("Sending you to [pick]."))
-	var/atom/movable/screen/splash/fade_in = new(null, src, hopper, FALSE)
+	var/atom/movable/screen/splash/fade_in = new(null, null, src, hopper, FALSE)
 	fade_in.Fade(FALSE)
 
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)


### PR DESCRIPTION

## About The Pull Request

ports a fix from https://github.com/Monkestation/Monkestation2.0/pull/6991

https://github.com/tgstation/tgstation/pull/76772 accidentally broke most instances of using `/atom/movable/screen/splash`, bc now the client needs to be third instead of second argument to `new /atom/movable/screen/splash`... yeah.

<details>
<summary><h3>pre-fix video clip</h3></summary>

https://github.com/user-attachments/assets/87015373-de72-4753-bf6e-55c3d9ffa207

</details>

<details>
<summary><h3>post-fix video clip</h3></summary>

https://github.com/user-attachments/assets/3dc80c68-f4a5-44a7-95fe-d590affc273d

</details>

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: The lobby art properly fades out during roundstart, latejoin, and server restart again.
/:cl:
