### PR TITLE
[NO GBP] Fixes cleanable decal merging not working and flypeople not being able to drink vomit

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -78,6 +78,7 @@
 
 /// Returns reagents datum if it exists, or lazyloads one if it doesn't
 /obj/effect/decal/cleanable/proc/lazy_init_reagents()
+	RETURN_TYPE(/datum/reagents)
 	if (reagents)
 		return reagents
 
@@ -86,6 +87,7 @@
 
 	create_reagents(reagent_amount)
 	reagents.add_reagent(decal_reagent, reagent_amount)
+	return reagents
 
 /obj/effect/decal/cleanable/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	// Why are rags cups???

--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -459,11 +459,11 @@
 	/// Beyond a threshold we change to a bloodier icon state
 	var/very_bloody = FALSE
 
-/obj/effect/decal/cleanable/blood/update_desc(updates)
+/obj/effect/decal/cleanable/blood/trail/update_desc(updates)
 	. = ..()
 	desc = "A [dried ? "dried " : ""]trail of [get_blood_string()]."
 
-/obj/effect/decal/cleanable/blood/lazy_init_reagents()
+/obj/effect/decal/cleanable/blood/trail/lazy_init_reagents()
 	if(!istype(loc, /obj/effect/decal/cleanable/blood/trail_holder))
 		return ..()
 

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -191,15 +191,15 @@
 
 /obj/effect/decal/cleanable/vomit/attack_hand(mob/user, list/modifiers)
 	. = ..()
-	if(.)
+	if(. || !ishuman(user))
 		return
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(isflyperson(H))
-			playsound(get_turf(src), 'sound/items/drink.ogg', 50, TRUE) //slurp
-			H.visible_message(span_alert("[H] extends a small proboscis into the vomit pool, sucking it with a slurping sound."))
-			reagents.trans_to(H, reagents.total_volume, transferred_by = user, methods = INGEST)
-			qdel(src)
+	var/mob/living/carbon/human/as_human = user
+	if(!isflyperson(as_human))
+		return
+	playsound(get_turf(src), 'sound/items/drink.ogg', 50, TRUE) //slurp
+	as_human.visible_message(span_alert("[as_human] extends a small proboscis into the vomit pool, sucking it with a slurping sound."))
+	lazy_init_reagents()?.trans_to(as_human, reagents.total_volume, transferred_by = user, methods = INGEST)
+	qdel(src)
 
 /obj/effect/decal/cleanable/vomit/toxic // this has a more toned-down color palette, which may be why it's used as the default in so many spots
 	icon_state = "vomittox_1"


### PR DESCRIPTION

## About The Pull Request

Flypeople vomit drinking didn't lazy init the reagents which caused it to runtime, and reagent init did not return anything on successful init which means that init code would be required to be ran twice to work - but as this was overriden by blood, it wasn't spotted in testing (or by anyone so far, most likely)
Also fixed wrong typepaths for trail proc overrides which caused all blood to have trails' description

Closes #91568

## Changelog
:cl:
fix: Fixed flypeople not being able to drink vomit
fix: Random blood decals no longer claim to be trails, only actual trails do.
/:cl:
