### PR TITLE
Adds the Mind Batterer

### DIFF
--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -11,8 +11,9 @@
  * * what_done - is a verb describing the action (e.g. punched, throwed, kicked, etc.)
  * * atom/object - is a tool with which the action was made (usually an item)
  * * addition - is any additional text, which will be appended to the rest of the log line
+ * * log_user - Whether the user should get a log, FALSE to log just the target.
  */
-/proc/log_combat(atom/user, atom/target, what_done, atom/object=null, addition=null)
+/proc/log_combat(atom/user, atom/target, what_done, atom/object=null, addition=null, log_user = TRUE)
 	var/ssource = key_name(user)
 	var/starget = key_name(target)
 
@@ -28,8 +29,9 @@
 
 	var/postfix = "[sobject][saddition][hp]"
 
-	var/message = "[what_done] [starget][postfix]"
-	user.log_message(message, LOG_ATTACK, color="red")
+	if(log_user)
+		var/message = "[what_done] [starget][postfix]"
+		user.log_message(message, LOG_ATTACK, color="red")
 
 	if(user != target)
 		var/reverse_message = "was [what_done] by [ssource][postfix]"

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -17,7 +17,7 @@
  * to make your own getaway.
  * Can be charged for additional uses with 2TC per use.
  */
-/obj/item/batterer
+/obj/item/mind_batterer
 	name = "mind batterer"
 	desc = "A strange device with twin antennas."
 	icon = 'icons/obj/devices/syndie_gadget.dmi'
@@ -37,11 +37,11 @@
 	///The cooldown between uses so you can't use both immediately.
 	COOLDOWN_DECLARE(mind_batterer_cooldown)
 
-/obj/item/batterer/Initialize(mapload)
+/obj/item/mind_batterer/Initialize(mapload)
 	. = ..()
 	register_context()
 
-/obj/item/batterer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+/obj/item/mind_batterer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	if(isnull(held_item) && uses_left)
 		context[SCREENTIP_CONTEXT_LMB] = "Bat Minds"
 		return CONTEXTUAL_SCREENTIP_SET
@@ -50,7 +50,7 @@
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE
 
-/obj/item/batterer/update_desc(updates)
+/obj/item/mind_batterer/update_desc(updates)
 	. = ..()
 	desc = initial(desc)
 	if(uses_left)
@@ -58,14 +58,14 @@
 	else
 		desc += " It appears to have burned out. It can be repaired with some [EXAMINE_HINT("telecrystals")]."
 
-/obj/item/batterer/update_icon_state()
+/obj/item/mind_batterer/update_icon_state()
 	. = ..()
 	if(!uses_left)
 		icon_state = "[base_icon_state]burnt"
 	else
 		icon_state = base_icon_state
 
-/obj/item/batterer/item_interaction(mob/living/user, obj/item/interacting_item, list/modifiers)
+/obj/item/mind_batterer/item_interaction(mob/living/user, obj/item/interacting_item, list/modifiers)
 	if(!istype(interacting_item, /obj/item/stack/telecrystal))
 		return NONE
 	var/obj/item/stack/telecrystal/crystals = interacting_item
@@ -78,7 +78,7 @@
 	update_appearance(UPDATE_ICON)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/item/batterer/attack_self(mob/user, modifiers)
+/obj/item/mind_batterer/attack_self(mob/user, modifiers)
 	. = ..()
 	if(.)
 		return TRUE

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -104,7 +104,7 @@
 		//instead we'll batch it up and send one log for user below.
 		log_combat(user, affected, "knocked down", src, log_user = FALSE)
 		if(isnull(log_message))
-			log_message = "Used [src], affecting: [affected]"
+			log_message = "Knocked down: [affected]"
 		else
 			log_message += ", [affected]"
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -92,7 +92,7 @@
 
 	//knocking & logging everyone knocked.
 	var/log_message
-	for(var/mob/living/affected in get_hear(CONFIG_GET(string/default_view), user) - user)
+	for(var/mob/living/affected in hearers(7, get_turf(user)) - user)
 		if(HAS_TRAIT(affected, TRAIT_DEAF))
 			continue
 		affected.Knockdown(

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -179,7 +179,7 @@
 	name = "Mind Batterer"
 	desc = "A device with antennaes and a speaker that emits a specific frequency meant to disorient everyone nearby, \
 			with inconsistent functionality to each person it affects. Has a cooldown of 20 seconds between each use, \
-			coming with 2 charges by default, but can be recharged with 2 TC for each additional use."
+			coming with 2 charges by default, but can be charged up with more telecrystals."
 	item = /obj/item/mind_batterer
 	cost = 4
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -175,6 +175,15 @@
 	cost = 1
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 
+/datum/uplink_item/device_tools/mind_batterer
+	name = "Mind Batterer"
+	desc = "A device with antennaes and a speaker that emits a specific frequency meant to disorient everyone nearby, \
+			with inconsistent functionality to each person it affects. Has a cooldown of 20 seconds between each use, \
+			coming with 2 charges by default, but can be recharged with 2 TC for each additional use."
+	item = /obj/item/batterer
+	cost = 4
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
+
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"
 	desc = "A radioactive microlaser disguised as a standard Nanotrasen health analyzer. When used, it emits a \

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -180,7 +180,7 @@
 	desc = "A device with antennaes and a speaker that emits a specific frequency meant to disorient everyone nearby, \
 			with inconsistent functionality to each person it affects. Has a cooldown of 20 seconds between each use, \
 			coming with 2 charges by default, but can be recharged with 2 TC for each additional use."
-	item = /obj/item/batterer
+	item = /obj/item/mind_batterer
 	cost = 4
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 


### PR DESCRIPTION
## About The Pull Request

We've had an unused "Mind Batterer" item in the code for about 12 years now, with a comment saying it's a "future traitor item", so I thought why not add it? So now it's in the uplink for 4 TC.

Changes:
- Now has context tips
- Can now be reloaded with TC to get more uses out of it (1TC = 1 use)
- Removes RNG, but causes Knockdown for 10-20 seconds & staggering, rather than Paralyze for 20-40 seconds. This was picked arbitrarily and I don't mind changing them if it's considered to weak or too strong.
- Has a 20 second cooldown between uses
- Doesn't affect Deaf mobs anymore.

Also changed the logging to be easier to understand, this is how it looks like for the user
![image](https://github.com/user-attachments/assets/b7c96df4-9f50-44f0-b635-6642d16c7f61)

And for those affected by it
![image](https://github.com/user-attachments/assets/06d50d41-e528-4173-b4f7-4c0b36fba4bc)

## So what does it actually do?

https://github.com/user-attachments/assets/3ed99c42-f58a-4a76-afb7-99f82941d3f3

## Why It's Good For The Game

This is like a Traitor variant of the flashbang, better in some ways and worse in others, but it makes it a good tool to make a group of people fall to the floor and drop the items in their hands.

## Changelog

:cl:
add: Added the Mind Batterer to the traitor uplink and reworked how it behaves. It's now a decent, reloadable, traitor variant of flashbangs.
/:cl: