### PR TITLE
doubles the speed of some projectiles

### DIFF
--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -17,4 +17,4 @@ PROCESSING_SUBSYSTEM_DEF(projectiles)
 	 * assume that 1 speed = 1 tile per decisecond, but this is a variable so that admins/debuggers can edit
 	 * in order to debug projectile behavior by evenly slowing or speeding all of them up.
 	 */
-	var/pixels_per_decisecond = ICON_SIZE_ALL
+	var/pixels_per_decisecond = ICON_SIZE_ALL * 2

--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -17,4 +17,4 @@ PROCESSING_SUBSYSTEM_DEF(projectiles)
 	 * assume that 1 speed = 1 tile per decisecond, but this is a variable so that admins/debuggers can edit
 	 * in order to debug projectile behavior by evenly slowing or speeding all of them up.
 	 */
-	var/pixels_per_decisecond = ICON_SIZE_ALL * 2
+	var/pixels_per_decisecond = ICON_SIZE_ALL

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -18,7 +18,7 @@
 	reflectable = TRUE
 	wound_bonus = -20
 	bare_wound_bonus = 10
-
+	speed = 2.5
 
 /obj/projectile/beam/laser
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -45,7 +45,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	damage = 9
 	wound_bonus = -40
-	speed = 0.9
+	speed = 1.8
 
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
@@ -53,7 +53,7 @@
 	icon_state = "hellfire"
 	wound_bonus = 0
 	damage = 30
-	speed = 1.6
+	speed = 3.2
 	light_color = "#FF969D"
 
 /obj/projectile/beam/laser/heavylaser
@@ -150,7 +150,7 @@
 	icon_state = "scatterdisabler"
 	damage = 5.5
 	damage_falloff_tile = -0.5
-	speed = 1.2
+	speed = 2.4
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	tracer_type = /obj/effect/projectile/tracer/xray
 	muzzle_type = /obj/effect/projectile/muzzle/xray

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -12,6 +12,7 @@
 	wound_bonus = 0
 	wound_falloff_tile = -5
 	embed_falloff_tile = -3
+	speed = 2
 
 /obj/projectile/bullet/smite
 	name = "divine retribution"

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -35,7 +35,7 @@
 	suppressed = SUPPRESSED_VERY
 	damage_type = BURN
 	armor_flag = BOMB
-	speed = 0.8
+	speed = 1.6
 	wound_bonus = 30
 	bare_wound_bonus = 30
 	wound_falloff_tile = -4

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -84,7 +84,7 @@
 	damage = 5
 	wound_bonus = 5
 	bare_wound_bonus = 5
-	speed = 1.1
+	speed = 2
 	wound_falloff_tile = -0.5 //We would very much like this to cause wounds despite the low damage, so the drop off is relatively slow
 	sharpness = SHARP_EDGED
 
@@ -107,7 +107,7 @@
 	stamina = 10
 	sharpness = NONE
 	embed_type = null
-	speed = 0.8
+	speed = 1.8
 	stamina_falloff_tile = -0.25
 	ricochets_max = 4
 	ricochet_chance = 120
@@ -139,7 +139,7 @@
 	armour_penetration = 30
 	damage_falloff_tile = -0.2
 	wound_falloff_tile = -0.5
-	speed = 1.2
+	speed = 2
 	sharpness = SHARP_POINTY
 	embed_type = /datum/embedding/bullet/flechette
 


### PR DESCRIPTION
## About The Pull Request

wip and it's not going anywhere unless maintainers think it's a good idea basically

## Why It's Good For The Game

melee combat is too prevalent and too strong. a gun should be a powerful tool, it shouldn't be subservient to melee weapons. energy weapons in particular are very very easy to dodge when running away. rather than making melee weapons weaker, or ranged weapons deal more damage, or making spacemen slower, we simply buff the proj speed. the point of this is more to be TESTED because we've talked about doing this a bunch of times and never actually went thru with testing it. it's not hitscan and it's still possible to dodge. this doesn't affect lavaland mobs or anything like that who could probably have their proj speed reduced tbqhf

## Changelog

:cl:
balance: laser and disabler projectiles are now twice as fast
balance: bullets are about 1.5x as fast
/:cl: