### PR TITLE
Makes sure that robot models cannot be spawned outside of the robot

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -112,7 +112,7 @@
 	human.hair_color = COLOR_PINK
 	human.update_body(is_creating = TRUE)
 
-// Slimes have both TRAIT_NOBLOOD and an exotic bloodtype set, so they need to be handled uniquely here.
+// Unique handling for slime blood here, it's got some unique properties that warrant a more detailed desc.
 // They may not be roundstart but in the unlikely event they become one might as well not leave a glaring issue open.
 /datum/species/jelly/create_pref_blood_perks()
 	var/list/to_add = list()

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -58,6 +58,10 @@
 /obj/item/robot_model/Initialize(mapload)
 	. = ..()
 	robot = loc
+	if(!istype(robot))
+		stack_trace("Robot model initialized outside of a robot at [AREACOORD(robot)]! \
+			This should never happen, make sure this item is never map-placed.")
+		return INITIALIZE_HINT_QDEL
 	create_storage(storage_type = /datum/storage/cyborg_internal_storage)
 	//src is what we store items visible to borgs, we'll store things in the bot itself otherwise.
 	for(var/path in basic_modules)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -59,7 +59,7 @@
 	. = ..()
 	robot = loc
 	if(!istype(robot))
-		stack_trace("Robot model initialized outside of a robot at [AREACOORD(robot)]! \
+		stack_trace("Robot model ([src]) initialized outside of a robot at [AREACOORD(robot)]! \
 			This should never happen, make sure this item is not map-placed.")
 		return INITIALIZE_HINT_QDEL
 	create_storage(storage_type = /datum/storage/cyborg_internal_storage)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -60,7 +60,7 @@
 	robot = loc
 	if(!istype(robot))
 		stack_trace("Robot model initialized outside of a robot at [AREACOORD(robot)]! \
-			This should never happen, make sure this item is never map-placed.")
+			This should never happen, make sure this item is not map-placed.")
 		return INITIALIZE_HINT_QDEL
 	create_storage(storage_type = /datum/storage/cyborg_internal_storage)
 	//src is what we store items visible to borgs, we'll store things in the bot itself otherwise.

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -277,7 +277,7 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 		//The abstract grown item expects a seed, but doesn't have one
 		/obj/item/food/grown,
 		///Single use case holder atom requiring a user
-		/atom/movable/looking_holder
+		/atom/movable/looking_holder,
 	)
 
 	// Everything that follows is a typesof() check.
@@ -356,6 +356,7 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	// Can't spawn openspace above nothing, it'll get pissy at me
 	returnable_list += typesof(/turf/open/space/openspace)
 	returnable_list += typesof(/turf/open/openspace)
+	returnable_list += typesof(/obj/item/robot_model) // These should never be spawned outside of a robot.
 
 	return returnable_list
 


### PR DESCRIPTION
## About The Pull Request

These are not coded to be spawned outside of a borg, and if they are, they will cause issues. (see: dropping the 'robot''s module in a pile on the ground).

## Why It's Good For The Game

This can cause issues such as hard dels if any of the spawned modules gets destroyed. 

## Changelog

Nothing player-facing