### PR TITLE
Adds back a couple ghost verbs

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -966,12 +966,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	GLOB.observer_default_invisibility = amount
 
 /mob/dead/observer/proc/open_spawners_menu()
+	set name = "Spawners Menu"
 	if(!spawners_menu)
 		spawners_menu = new(src)
 
 	spawners_menu.ui_interact(src)
 
 /mob/dead/observer/proc/open_minigames_menu()
+	set name = "Minigames Menu"
 	if(!client)
 		return
 	if(!isobserver(src))

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -57,7 +57,6 @@
 /client/verb/reportissue()
 	set name = "report-issue"
 	set desc = "Report an issue"
-	set hidden = TRUE
 
 	var/githuburl = CONFIG_GET(string/githuburl)
 	if(!githuburl)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/91619 missed a couple that I use and I want them back!!

Also unhides the report-issue verb as it's kind of a pain to get to now with the removal of the ever present button above stat panel.

## Why It's Good For The Game

Reee give me back my verbs

## Changelog

:cl:
qol: "Spawners Menu" and "Minigames Menu" are back as chat verbs for power users
qol: report-issue is now a verb that can be used in chat to open the issue report prompt for power users
/:cl: