### PR TITLE
Allows malfunctioning AI's to once again dominate unbeaconed mechs.

### DIFF
--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -14,7 +14,7 @@
 		control_tracker = B
 		break
 
-	if(!data_tracker)
+	if(!data_tracker && !user.can_dominate_mechs)
 		to_chat(user, span_warning("You cannot interface this exosuit without tracking beacons installed."))
 		return
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

## Why It's Good For The Game

Mech domination is intended to allow a malfunctioning AI to dominate any mech, with or without a tracker beacon.

I have no idea whether or not this was an accident (some of the checks seem to hint as such), or the PR was misleading, but this was introduced in what was supposedly a chat display improvement PR https://github.com/tgstation/tgstation/pull/90565. The body of the PR seems to hint it was probably a deceptive nerf, as they acknowledged this would happen, even though the code changed would not require these checks to take place or, more importantly, early return if the AI in question could dominate mechs. Which is a complete behaviour change worth acknowledging.

Lets not do that in the future, okay?

## Changelog
:cl:
fix: Malfunctioning AI's can once again dominate mechs without a beacon.
/:cl:
