### PR TITLE
Fixes attack-equipping others triggering a self-equip timer with clothing that have `equip_delay_self`

### DIFF
--- a/code/datums/elements/attack_equip.dm
+++ b/code/datums/elements/attack_equip.dm
@@ -49,7 +49,7 @@
 		return
 
 	user.temporarilyRemoveItemFromInventory(attire)
-
-	sharp_dresser.equip_to_slot_if_possible(attire, attire.slot_flags)
+	//we've spent time based on the item's equip_delay_other already, so we don't need to wait more on a self-equip timer
+	sharp_dresser.equip_to_slot_if_possible(attire, attire.slot_flags, bypass_equip_delay_self = TRUE)
 
 	return finish_equip_mob(attire, sharp_dresser, user)


### PR DESCRIPTION
## About The Pull Request

The element wasn't making use of the flag in the `equip_to_slot_if_possible()` proc, which meant that you would spend time on a `do_after()` to attack-equip an item onto someone else just so the recipient would have to spend time equal to `equip_delay_self` to equip the item. This is weird, and it led to stuff like #73225 where you could magically make a jacket disappear into the recipient's contents. In theory this calls for a closer inspection of the equip pipeline's safety checks? but I might be a tad bit lazy to that. Funny how there are exactly 3 instances of an item with `equip_delay_self` in the entire game.

## Why It's Good For The Game

Closes #73225

## Changelog

:cl:
fix: fixed equipping straight jackets onto people with attack-equip then equipping another jacket through the equip window causing magical jacket consumption into the recipient's contents
/:cl: