### PR TITLE
Fixes rolling paper runtiming when trying to stuff a blunt

### DIFF
--- a/code/datums/components/ingredients_holder.dm
+++ b/code/datums/components/ingredients_holder.dm
@@ -45,7 +45,6 @@
 	if (!atom_parent.reagents && !replacement)
 		return COMPONENT_INCOMPATIBLE
 
-	atom_parent.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 
 	src.replacement = replacement
 	src.fill_type = fill_type
@@ -67,7 +66,8 @@
 	return ..()
 
 /datum/component/ingredients_holder/RegisterWithParent()
-	. = ..()
+	var/atom/atom_parent = parent
+	atom_parent.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(customizable_attack))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_ATOM_EXITED, PROC_REF(food_exited))
@@ -76,7 +76,6 @@
 	ADD_TRAIT(parent, TRAIT_INGREDIENTS_HOLDER, INNATE_TRAIT)
 
 /datum/component/ingredients_holder/UnregisterFromParent()
-	. = ..()
 	UnregisterSignal(parent, list(
 		COMSIG_ATOM_ATTACKBY,
 		COMSIG_ATOM_EXAMINE,
@@ -205,9 +204,9 @@
 		ingredient.forceMove(replacement_parent)
 		replacement = null
 		replacement_parent.TakeComponent(src)
-		atom_parent = parent
-		handle_reagents(atom_parent)
+		handle_reagents(parent)
 		qdel(atom_parent)
+		atom_parent = parent
 
 	handle_reagents(ingredient)
 


### PR DESCRIPTION
## About The Pull Request
The component was moving itself to, assigning as ``atom_parent`` and then deleting the joint it just made, runtiming and failing to do anything.
Closes #91665
Closes #91690

## Changelog
:cl:
fix: Fixed rolling paper runtiming when trying to stuff a blunt
/:cl:
