### PR TITLE
Makes vendors created from flatpacks start empty to prevent duping

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1194,7 +1194,7 @@
 		. += display_parts(user, TRUE)
 
 //called on machinery construction (i.e from frame to machinery) but not on initialization
-/obj/machinery/proc/on_construction(mob/user)
+/obj/machinery/proc/on_construction(mob/user, from_flatpack = FALSE)
 	return
 
 /**

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -17,7 +17,7 @@
 	link_alerts()
 	return ..()
 
-/obj/machinery/computer/station_alert/on_construction(mob/user)
+/obj/machinery/computer/station_alert/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	link_alerts()
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -57,7 +57,7 @@
 		GLOB.navbeacons["[new_turf?.z]"] += src
 	return ..()
 
-/obj/machinery/navbeacon/on_construction(mob/user)
+/obj/machinery/navbeacon/on_construction(mob/user, from_flatpack = FALSE)
 	var/turf/our_turf = loc
 	if(!isfloorturf(our_turf))
 		return

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -79,7 +79,7 @@
 	QDEL_NULL(cell)
 	return..()
 
-/obj/machinery/space_heater/on_construction()
+/obj/machinery/space_heater/on_construction(mob/user, from_flatpack = FALSE)
 	set_panel_open(TRUE)
 	QDEL_NULL(cell)
 

--- a/code/game/objects/items/flatpacks.dm
+++ b/code/game/objects/items/flatpacks.dm
@@ -75,7 +75,7 @@
 	var/obj/machinery/new_machine = new board.build_path(loc)
 	loc.visible_message(span_warning("[src] deploys!"))
 	playsound(src, 'sound/machines/terminal/terminal_eject.ogg', 70, TRUE)
-	new_machine.on_construction(user)
+	new_machine.on_construction(user, from_flatpack = TRUE)
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -43,7 +43,7 @@
 		engine_state = ENGINE_UNWRENCHED
 		anchored = FALSE
 
-/obj/machinery/power/shuttle_engine/on_construction(mob/user)
+/obj/machinery/power/shuttle_engine/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	if(anchored)
 		connect_to_shuttle(port = SSshuttle.get_containing_shuttle(src)) //connect to a new ship, if needed

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -543,7 +543,7 @@
 		PIPING_FORWARD_SHIFT(pipe_overlay, piping_layer, 2)
 	return pipe_overlay
 
-/obj/machinery/atmospherics/on_construction(mob/user, obj_color, set_layer = PIPING_LAYER_DEFAULT)
+/obj/machinery/atmospherics/on_construction(mob/user, obj_color, set_layer = PIPING_LAYER_DEFAULT, from_flatpack = FALSE)
 	if(can_unwrench)
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		set_pipe_color(obj_color)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -127,7 +127,7 @@
 	airs[i] = null
 	return ..()
 
-/obj/machinery/atmospherics/components/on_construction(mob/user)
+/obj/machinery/atmospherics/components/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	update_parents()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -68,7 +68,7 @@
 		return FALSE
 	. = ..()
 
-/obj/machinery/atmospherics/components/unary/thermomachine/on_construction(mob/user, obj_color, set_layer)
+/obj/machinery/atmospherics/components/unary/thermomachine/on_construction(mob/user, obj_color, set_layer, from_flatpack = FALSE)
 	var/obj/item/circuitboard/machine/thermomachine/board = circuit
 	if(board)
 		piping_layer = board.pipe_layer

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -13,7 +13,7 @@
 /obj/machinery/atmospherics/components/unary/set_init_directions()
 	initialize_directions = dir
 
-/obj/machinery/atmospherics/components/unary/on_construction(mob/user)
+/obj/machinery/atmospherics/components/unary/on_construction(mob/user, from_flatpack = FALSE)
 	..()
 	update_appearance()
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -64,7 +64,7 @@
 	AddElement(/datum/element/elevation, pixel_shift = 8)
 	register_context()
 
-/obj/machinery/portable_atmospherics/on_construction(mob/user)
+/obj/machinery/portable_atmospherics/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	set_anchored(FALSE)
 

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -37,7 +37,7 @@
 		WARNING("[src] couldnt find a Quartermaster/Storage (aka cargobay) area on the station, and as such it has set the supplypod landingzone to the area it resides in.")
 		landingzone = get_area(src)
 
-/obj/machinery/computer/cargo/express/on_construction(mob/user)
+/obj/machinery/computer/cargo/express/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	packin_up()
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -69,7 +69,7 @@
 	update_static_data(user)
 	return TRUE
 
-/obj/machinery/computer/cargo/on_construction(mob/user)
+/obj/machinery/computer/cargo/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	circuit.configure_machine(src)
 

--- a/code/modules/food_and_drinks/restaurant/_venue.dm
+++ b/code/modules/food_and_drinks/restaurant/_venue.dm
@@ -201,7 +201,7 @@
 	linked_venue = null
 	return ..()
 
-/obj/machinery/restaurant_portal/on_construction(mob/user)
+/obj/machinery/restaurant_portal/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	circuit.configure_machine(src)
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -102,7 +102,7 @@
 	DropFuel()
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/on_construction(mob/user)
+/obj/machinery/power/port_gen/pacman/on_construction(mob/user, from_flatpack = FALSE)
 	var/obj/item/circuitboard/machine/pacman/our_board = circuit
 	if(our_board.high_production_profile)
 		icon_state = "portgen1_0"

--- a/code/modules/power/smes_portable.dm
+++ b/code/modules/power/smes_portable.dm
@@ -118,7 +118,7 @@
 	/// The port this is connected to.
 	var/obj/machinery/power/smes/connector/connected_port
 
-/obj/machinery/power/smesbank/on_construction(mob/user)
+/obj/machinery/power/smesbank/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	set_anchored(FALSE)
 

--- a/code/modules/shuttle/mobile_port/variants/custom/custom_consoles.dm
+++ b/code/modules/shuttle/mobile_port/variants/custom/custom_consoles.dm
@@ -5,7 +5,7 @@
 	circuit = /obj/item/circuitboard/computer/shuttle/flight_control
 	var/static/list/connections = list(COMSIG_TURF_ADDED_TO_SHUTTLE = PROC_REF(on_loc_added_to_shuttle))
 
-/obj/machinery/computer/shuttle/custom_shuttle/on_construction(mob/user)
+/obj/machinery/computer/shuttle/custom_shuttle/on_construction(mob/user, from_flatpack = FALSE)
 	circuit.configure_machine(src)
 	if(!shuttleId)
 		AddElement(/datum/element/connect_loc, connections)
@@ -47,7 +47,7 @@
 	zlink_range = 1
 	var/static/list/connections = list(COMSIG_TURF_ADDED_TO_SHUTTLE = PROC_REF(on_loc_added_to_shuttle))
 
-/obj/machinery/computer/camera_advanced/shuttle_docker/custom/on_construction(mob/user)
+/obj/machinery/computer/camera_advanced/shuttle_docker/custom/on_construction(mob/user, from_flatpack = FALSE)
 	circuit.configure_machine(src)
 	if(!shuttleId)
 		AddElement(/datum/element/connect_loc, connections)

--- a/code/modules/transport/tram/tram_controls.dm
+++ b/code/modules/transport/tram/tram_controls.dm
@@ -183,7 +183,7 @@
 
 	update_appearance()
 
-/obj/machinery/computer/tram_controls/on_construction(mob/user)
+/obj/machinery/computer/tram_controls/on_construction(mob/user, from_flatpack = FALSE)
 	. = ..()
 	var/obj/item/circuitboard/computer/tram_controls/my_circuit = circuit
 	split_mode = my_circuit.split_mode

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -323,6 +323,19 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	for(var/obj/item/vending_refill/installed_refill in component_parts)
 		restock(installed_refill)
 
+/obj/machinery/vending/on_construction(mob/user, from_flatpack = FALSE)
+	if (!from_flatpack)
+		return
+	// When built from a flatpack, empty our canister upon construction
+	for(var/obj/item/vending_refill/installed_refill in component_parts)
+		for (var/item_sold in installed_refill.products)
+			installed_refill.products[item_sold] = 0
+		for (var/item_sold in installed_refill.contraband)
+			installed_refill.contraband[item_sold] = 0
+		for (var/item_sold in installed_refill.premium)
+			installed_refill.premium[item_sold] = 0
+	RefreshParts()
+
 /obj/machinery/vending/on_deconstruction(disassembled)
 	if(refill_canister)
 		return ..()


### PR DESCRIPTION

## About The Pull Request

Flatpacks pass an arg into ``on_construction`` which makes vendors wipe their inventory to prevent duping by repeatedly flatpacking a vendor to refill its inventory.
Closes #91615

## Changelog
:cl:
fix: Flatpacked vendors start empty to prevent duping
/:cl:
