### PR TITLE
Ebow changes: You have to pull back the string. It's still lethal. It's also gonna make you take a nap with a soporific bolt in you.

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -99,7 +99,7 @@
 
 /datum/crafting_recipe/ebow
 	name = "Energy Crossbow"
-	result = /obj/item/gun/energy/recharge/ebow/large
+	result = /obj/item/gun/energy/ebow/large
 	reqs = list(
 		/obj/item/gun/energy/recharge/kinetic_accelerator = 1,
 		/obj/item/weaponcrafting/gunkit/ebow = 1,

--- a/code/datums/components/crank_recharge.dm
+++ b/code/datums/components/crank_recharge.dm
@@ -16,9 +16,11 @@
 	var/is_charging = FALSE
 	/// Should you be able to move while charging, use IGNORE_USER_LOC_CHANGE if you want to move and crank
 	var/charge_move = NONE
+	/// Should our do_after() to crank the gun show the cogwheel effect? If TRUE, will hide the cogwheel.
+	var/crank_hidden = FALSE
 	COOLDOWN_DECLARE(charge_sound_cooldown)
 
-/datum/component/crank_recharge/Initialize(charging_cell, spin_to_win = FALSE, charge_amount = 500, cooldown_time = 2 SECONDS, charge_sound = 'sound/items/weapons/laser_crank.ogg', charge_sound_cooldown_time = 1.8 SECONDS, charge_move = NONE)
+/datum/component/crank_recharge/Initialize(charging_cell, spin_to_win = FALSE, charge_amount = 500, cooldown_time = 2 SECONDS, charge_sound = 'sound/items/weapons/laser_crank.ogg', charge_sound_cooldown_time = 1.8 SECONDS, charge_move = NONE, crank_hidden = FALSE)
 	. = ..()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -31,6 +33,7 @@
 	src.charge_sound = charge_sound
 	src.charge_sound_cooldown_time = charge_sound_cooldown_time
 	src.charge_move = charge_move
+	src.crank_hidden = crank_hidden
 /datum/component/crank_recharge/RegisterWithParent()
 	. = ..()
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_attack_self))
@@ -59,7 +62,7 @@
 		COOLDOWN_START(src, charge_sound_cooldown, charge_sound_cooldown_time)
 		playsound(source, charge_sound, 40)
 	source.balloon_alert(user, "charging...")
-	if(!do_after(user, cooldown_time, source, interaction_key = DOAFTER_SOURCE_CHARGE_CRANKRECHARGE, timed_action_flags = charge_move))
+	if(!do_after(user, cooldown_time, source, interaction_key = DOAFTER_SOURCE_CHARGE_CRANKRECHARGE, timed_action_flags = charge_move, hidden = crank_hidden))
 		is_charging = FALSE
 		return
 	charging_cell.give(charge_amount)

--- a/code/datums/storage/subtypes/holsters.dm
+++ b/code/datums/storage/subtypes/holsters.dm
@@ -10,7 +10,7 @@
 	if(length(holdables))
 		set_holdable(holdables)
 		return
-		
+
 	set_holdable(list(
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
@@ -35,7 +35,7 @@
 		/obj/item/gun/energy/dueling,
 		/obj/item/food/grown/banana,
 		/obj/item/gun/energy/laser/thermal,
-		/obj/item/gun/energy/recharge/ebow,
+		/obj/item/gun/energy/ebow,
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
 	)
@@ -88,7 +88,7 @@
 		/obj/item/ammo_box/a357,
 		/obj/item/ammo_box/strilka310,
 		/obj/item/ammo_box/magazine/toy/pistol,
-		/obj/item/gun/energy/recharge/ebow,
+		/obj/item/gun/energy/ebow,
 		/obj/item/gun/energy/e_gun/mini,
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/energy/dueling,

--- a/code/game/objects/items/shrapnel.dm
+++ b/code/game/objects/items/shrapnel.dm
@@ -27,6 +27,11 @@
 	sharpness = SHARP_EDGED
 	embed_type = /datum/embedding/shrapnel
 
+/obj/item/shrapnel/energy_bolt
+	name = "glowing green bolt"
+	custom_materials = list(/datum/material/uranium = SMALL_MATERIAL_AMOUNT * 0.5)
+	embed_type = /datum/embedding/energy_bolt
+
 /obj/projectile/bullet/shrapnel
 	name = "flying shrapnel shard"
 	damage = 14

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -68,7 +68,7 @@
 			new /obj/item/implanter/storage(src) // 6 tc
 
 		if(KIT_STEALTHY)
-			new /obj/item/gun/energy/recharge/ebow(src) // 10 tc
+			new /obj/item/gun/energy/ebow(src) // 10 tc
 			new /obj/item/pen/sleepy(src) // 4 tc
 			new /obj/item/healthanalyzer/rad_laser(src) // 3 tc
 			new /obj/item/chameleon(src) // 7 tc

--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -19,7 +19,7 @@
 #define MBOX_DURATION_STANDBY (2.7 SECONDS)
 
 GLOBAL_LIST_INIT(mystery_box_guns, list(
-	/obj/item/gun/energy/recharge/ebow/large,
+	/obj/item/gun/energy/ebow/large,
 	/obj/item/gun/energy/e_gun,
 	/obj/item/gun/energy/e_gun/nuclear,
 	/obj/item/gun/energy/laser,

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -324,7 +324,7 @@
 	gloves = /obj/item/clothing/gloves/color/yellow
 	mask = /obj/item/clothing/mask/gas
 	l_hand = /obj/item/melee/energy/sword
-	r_hand = /obj/item/gun/energy/recharge/ebow
+	r_hand = /obj/item/gun/energy/ebow
 	shoes = /obj/item/clothing/shoes/magboots/advance
 
 /datum/outfit/traitor/post_equip(mob/living/carbon/human/H, visuals_only)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -110,7 +110,7 @@
 	mask = /obj/item/clothing/mask/gas
 	belt = /obj/item/storage/belt
 	l_hand = /obj/item/melee/energy/sword/saber/red
-	r_hand = /obj/item/gun/energy/recharge/ebow
+	r_hand = /obj/item/gun/energy/ebow
 	shoes = /obj/item/clothing/shoes/magboots/advance
 
 /datum/outfit/heretic_hallucination
@@ -219,7 +219,7 @@
 		qdel(briefcase_item)
 	for(var/i = 3 to 0 step -1)
 		sec_briefcase.contents += new /obj/item/stack/spacecash/c1000
-	sec_briefcase.contents += new /obj/item/gun/energy/recharge/ebow
+	sec_briefcase.contents += new /obj/item/gun/energy/ebow
 	sec_briefcase.contents += new /obj/item/gun/ballistic/revolver/mateba
 	sec_briefcase.contents += new /obj/item/ammo_box/a357
 	sec_briefcase.contents += new /obj/item/grenade/c4/x4

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -602,7 +602,7 @@
 	shoes = /obj/item/clothing/shoes/chameleon/noslip
 	glasses = /obj/item/clothing/glasses/thermal/syndi
 	gloves = /obj/item/clothing/gloves/combat
-	suit_store = /obj/item/gun/energy/recharge/ebow
+	suit_store = /obj/item/gun/energy/ebow
 	l_hand = /obj/item/melee/energy/sword
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/stimulants
 	l_pocket = /obj/item/soap/syndie

--- a/code/modules/hallucination/fake_message.dm
+++ b/code/modules/hallucination/fake_message.dm
@@ -36,7 +36,7 @@
 				/obj/item/gun/ballistic/revolver,
 				/obj/item/gun/energy/e_gun/hos,
 				/obj/item/gun/energy/laser/captain,
-				/obj/item/gun/energy/recharge/ebow,
+				/obj/item/gun/energy/ebow,
 				/obj/item/gun/syringe/syndicate,
 				/obj/item/hand_tele,
 				/obj/item/melee/baton/security,

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -243,7 +243,7 @@
 		apply_damage(stamina, STAMINA, null, blocked)
 
 	if(drowsy)
-		adjust_drowsiness(drowsy)
+		adjust_drowsiness_up_to(drowsy, drowsy * 2)
 	if(eyeblur)
 		adjust_eye_blur_up_to(eyeblur, eyeblur)
 	if(jitter && !check_stun_immunity(CANSTUN))

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/energy/bolt
 	projectile_type = /obj/projectile/energy/bolt
 	select_name = "bolt"
-	e_cost = LASER_SHOTS(1, STANDARD_CELL_CHARGE * 0.5)
+	e_cost = LASER_SHOTS(1, STANDARD_CELL_CHARGE)
 	fire_sound = 'sound/items/weapons/gun/general/heavy_shot_suppressed.ogg' // Even for non-suppressed crossbows, this is the most appropriate sound
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect
 

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -153,7 +153,7 @@
 		charging_cell = get_cell(), \
 		charge_amount = STANDARD_CELL_CHARGE, \
 		cooldown_time = recharge_time, \
-		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound = 'sound/items/weapons/kinetic_reload.ogg', \
 		charge_sound_cooldown_time = recharge_time, \
 		charge_move = IGNORE_USER_LOC_CHANGE, \
 		crank_hidden = suppressed, \

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -135,6 +135,7 @@
 	inhand_icon_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
+	automatic_charge_overlays = FALSE
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	/// How long it takes for our gun to be recharged.

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -138,7 +138,7 @@
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	/// How long it takes for our gun to be recharged.
-	var/recharge_time = 1.5 SECONDS
+	var/recharge_time = 2 SECONDS
 	/// instead of an overlay, sets the icon_state directly.
 	var/no_charge_state = "crossbow_empty"
 
@@ -184,4 +184,4 @@
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
 	suppressed = FALSE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
-	recharge_time = 0.5 SECONDS
+	recharge_time = 1 SECONDS

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -126,3 +126,62 @@
 		ammunition by manually spinning the weapon's nanite canister."
 	icon_state = "cryopistol"
 	ammo_type = list(/obj/item/ammo_casing/energy/nanite/cryo)
+
+/obj/item/gun/energy/ebow
+	name = "mini energy crossbow"
+	desc = "A weapon favored by syndicate stealth specialists."
+	icon_state = "crossbow"
+	base_icon_state = "crossbow"
+	inhand_icon_state = "crossbow"
+	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
+	suppressed = TRUE
+	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
+	/// How long it takes for our gun to be recharged.
+	var/recharge_time = 1.5 SECONDS
+	/// instead of an overlay, sets the icon_state directly.
+	var/no_charge_state = "crossbow_empty"
+
+/obj/item/gun/energy/ebow/add_bayonet_point()
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 20, offset_y = 12)
+
+/obj/item/gun/energy/ebow/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = STANDARD_CELL_CHARGE, \
+		cooldown_time = recharge_time, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = recharge_time, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+		crank_hidden = suppressed, \
+	)
+
+/obj/item/gun/energy/ebow/update_icon_state()
+	. = ..()
+	if(no_charge_state && !can_shoot())
+		icon_state = no_charge_state
+	else
+		icon_state = base_icon_state
+
+/obj/item/gun/energy/ebow/halloween
+	name = "candy corn crossbow"
+	desc = "A weapon favored by Syndicate trick-or-treaters."
+	icon_state = "crossbow_halloween"
+	base_icon_state = "crossbow_halloween"
+	no_charge_state = "crossbow_halloween_empty"
+	ammo_type = list(/obj/item/ammo_casing/energy/bolt/halloween)
+
+/obj/item/gun/energy/ebow/large
+	name = "energy crossbow"
+	desc = "A reverse engineered weapon using syndicate technology."
+	icon_state = "crossbowlarge"
+	base_icon_state = "crossbowlarge"
+	no_charge_state = "crossbowlarge_empty"
+	w_class = WEIGHT_CLASS_BULKY
+	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
+	suppressed = FALSE
+	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
+	recharge_time = 0.5 SECONDS

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -139,7 +139,7 @@
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	/// How long it takes for our gun to be recharged.
-	var/recharge_time = 2 SECONDS
+	var/recharge_time = 1 SECONDS
 	/// instead of an overlay, sets the icon_state directly.
 	var/no_charge_state = "crossbow_empty"
 
@@ -185,4 +185,4 @@
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
 	suppressed = FALSE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
-	recharge_time = 1 SECONDS
+	recharge_time = 0.5 SECONDS

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -139,7 +139,7 @@
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	/// How long it takes for our gun to be recharged.
-	var/recharge_time = 1 SECONDS
+	var/recharge_time = 2 SECONDS
 	/// instead of an overlay, sets the icon_state directly.
 	var/no_charge_state = "crossbow_empty"
 
@@ -185,4 +185,4 @@
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
 	suppressed = FALSE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
-	recharge_time = 0.5 SECONDS
+	recharge_time = 2.5 SECONDS

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -97,43 +97,6 @@
 	if(no_charge_state && !can_shoot())
 		icon_state = no_charge_state
 
-/obj/item/gun/energy/recharge/ebow
-	name = "mini energy crossbow"
-	desc = "A weapon favored by syndicate stealth specialists."
-	icon_state = "crossbow"
-	base_icon_state = "crossbow"
-	inhand_icon_state = "crossbow"
-	no_charge_state = "crossbow_empty"
-	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
-	suppressed = TRUE
-	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
-	recharge_time = 2 SECONDS
-	holds_charge = TRUE
-	unique_frequency = TRUE
-
-/obj/item/gun/energy/recharge/ebow/add_bayonet_point()
-	AddComponent(/datum/component/bayonet_attachable, offset_x = 20, offset_y = 12)
-
-/obj/item/gun/energy/recharge/ebow/halloween
-	name = "candy corn crossbow"
-	desc = "A weapon favored by Syndicate trick-or-treaters."
-	icon_state = "crossbow_halloween"
-	base_icon_state = "crossbow_halloween"
-	no_charge_state = "crossbow_halloween_empty"
-	ammo_type = list(/obj/item/ammo_casing/energy/bolt/halloween)
-
-/obj/item/gun/energy/recharge/ebow/large
-	name = "energy crossbow"
-	desc = "A reverse engineered weapon using syndicate technology."
-	icon_state = "crossbowlarge"
-	base_icon_state = "crossbowlarge"
-	no_charge_state = "crossbowlarge_empty"
-	w_class = WEIGHT_CLASS_BULKY
-	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
-	suppressed = null
-	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
-
 /// A silly gun that does literally zero damage, but disrupts electrical sources of light, like flashlights.
 /obj/item/gun/energy/recharge/fisher
 	name = "\improper SC/FISHER disruptor"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -7,6 +7,7 @@
 	knockdown = 1 SECONDS
 	slur = 10 SECONDS
 	speed = 2
+	shrapnel_type = /obj/item/shrapnel/energy_bolt
 	embed_type = /datum/embedding/energy_bolt
 
 /datum/embedding/energy_bolt

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,12 +1,21 @@
 /obj/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
-	damage_type = TOX
-	stamina = 60
+	damage = 60
+	damage_type = STAMINA
 	eyeblur = 20 SECONDS
-	knockdown = 10
+	knockdown = 1 SECONDS
 	slur = 10 SECONDS
+	drowsy = 10 SECONDS
+	speed = 2
+
+/obj/projectile/energy/bolt/on_hit(atom/target, blocked, pierce_hit)
+	. = ..()
+	if(ishuman(target))
+		var/mob/living/carbon/human/the_snoozer = target
+		the_snoozer.adjust_silence_up_to(1 SECONDS, 2 SECONDS)
+		if(HAS_TRAIT_FROM(the_snoozer, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(the_snoozer, TRAIT_KNOCKEDOUT))
+			the_snoozer.AdjustSleeping(drowsy)
 
 /obj/projectile/energy/bolt/halloween
 	name = "candy corn"
@@ -14,4 +23,6 @@
 	icon = 'icons/obj/food/food.dmi'
 
 /obj/projectile/energy/bolt/large
-	damage = 20
+	damage = 80
+	knockdown = 2 SECONDS
+	drowsy = 30 SECONDS

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -6,16 +6,29 @@
 	eyeblur = 20 SECONDS
 	knockdown = 1 SECONDS
 	slur = 10 SECONDS
-	drowsy = 10 SECONDS
 	speed = 2
+	embed_type = /datum/embedding/energy_bolt
 
-/obj/projectile/energy/bolt/on_hit(atom/target, blocked, pierce_hit)
+/datum/embedding/energy_bolt
+	embed_chance = 100
+	fall_chance = 1
+	jostle_chance = 5
+	jostle_pain_mult = 0.2
+	pain_stam_pct = 0.2
+	ignore_throwspeed_threshold = TRUE
+	rip_time = 1.5 SECONDS
+
+/datum/embedding/energy_bolt/process(seconds_per_tick)
 	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/the_snoozer = target
-		the_snoozer.adjust_silence_up_to(1 SECONDS, 2 SECONDS)
-		if(HAS_TRAIT_FROM(the_snoozer, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(the_snoozer, TRAIT_KNOCKEDOUT))
-			the_snoozer.AdjustSleeping(drowsy)
+
+	if(!(owner.mob_biotypes & MOB_ORGANIC))
+		return
+
+	owner.set_silence_if_lower(2 SECONDS)
+	owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
+	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(the_snoozer, TRAIT_KNOCKEDOUT))
+		owner.AdjustSleeping(10 SECONDS)
+		fall_chance = 50
 
 /obj/projectile/energy/bolt/halloween
 	name = "candy corn"
@@ -25,4 +38,3 @@
 /obj/projectile/energy/bolt/large
 	damage = 80
 	knockdown = 2 SECONDS
-	drowsy = 30 SECONDS

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -20,23 +20,19 @@
 	ignore_throwspeed_threshold = TRUE
 	rip_time = 1.5 SECONDS
 
-/datum/embedding/energy_bolt/process(seconds_per_tick)
-	. = ..()
-
+/datum/embedding/energy_bolt/process_effect(seconds_per_tick)
 	if(!isliving(owner))
 		return
 
-	var/mob/living/living_owner = owner
-
-	if(!(living_owner.mob_biotypes & MOB_ORGANIC))
+	if(!(owner.mob_biotypes & MOB_ORGANIC))
 		return
 
-	living_owner.set_silence_if_lower(2 SECONDS)
-	living_owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
-	if(HAS_TRAIT_FROM(living_owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(living_owner, TRAIT_KNOCKEDOUT))
-		living_owner.AdjustSleeping(10 SECONDS)
+	owner.set_silence_if_lower(2 SECONDS)
+	owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
+	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
+		owner.AdjustSleeping(10 SECONDS)
 
-	if(HAS_TRAIT(living_owner, TRAIT_KNOCKEDOUT))
+	if(HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
 		fall_chance = clamp(fall_chance + 30, 0, 100)
 
 /obj/projectile/energy/bolt/halloween

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -27,7 +27,7 @@
 
 	owner.set_silence_if_lower(2 SECONDS)
 	owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
-	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(the_snoozer, TRAIT_KNOCKEDOUT))
+	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
 		owner.AdjustSleeping(10 SECONDS)
 		fall_chance = 50
 

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,8 +1,9 @@
 /obj/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 60
-	damage_type = STAMINA
+	damage = 15
+	stamina = 60
+	damage_type = TOX
 	eyeblur = 20 SECONDS
 	knockdown = 1 SECONDS
 	slur = 10 SECONDS
@@ -22,15 +23,20 @@
 /datum/embedding/energy_bolt/process(seconds_per_tick)
 	. = ..()
 
-	if(!(owner.mob_biotypes & MOB_ORGANIC))
+	if(!isliving(owner))
 		return
 
-	owner.set_silence_if_lower(2 SECONDS)
-	owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
-	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
-		owner.AdjustSleeping(10 SECONDS)
+	var/mob/living/living_owner = owner
 
-	if(HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
+	if(!(living_owner.mob_biotypes & MOB_ORGANIC))
+		return
+
+	living_owner.set_silence_if_lower(2 SECONDS)
+	living_owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
+	if(HAS_TRAIT_FROM(living_owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(living_owner, TRAIT_KNOCKEDOUT))
+		living_owner.AdjustSleeping(10 SECONDS)
+
+	if(HAS_TRAIT(living_owner, TRAIT_KNOCKEDOUT))
 		fall_chance = clamp(fall_chance + 30, 0, 100)
 
 /obj/projectile/energy/bolt/halloween
@@ -39,5 +45,6 @@
 	icon = 'icons/obj/food/food.dmi'
 
 /obj/projectile/energy/bolt/large
-	damage = 80
+	damage = 20
+	stamina = 80
 	knockdown = 2 SECONDS

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -29,7 +29,9 @@
 	owner.adjust_drowsiness_up_to(1 SECONDS, 60 SECONDS)
 	if(HAS_TRAIT_FROM(owner, TRAIT_INCAPACITATED, STAMINA) && !HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
 		owner.AdjustSleeping(10 SECONDS)
-		fall_chance = 50
+
+	if(HAS_TRAIT(owner, TRAIT_KNOCKEDOUT))
+		fall_chance = clamp(fall_chance + 30, 0, 100)
 
 /obj/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/spells/spell_types/right_and_wrong.dm
+++ b/code/modules/spells/spell_types/right_and_wrong.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/ballistic/rifle/boltaction/harpoon,
 	/obj/item/gun/ballistic/automatic/mini_uzi,
 	/obj/item/gun/energy/lasercannon,
-	/obj/item/gun/energy/recharge/ebow/large,
+	/obj/item/gun/energy/ebow/large,
 	/obj/item/gun/energy/e_gun/nuclear,
 	/obj/item/gun/ballistic/automatic/proto,
 	/obj/item/gun/ballistic/automatic/c20r,

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -99,7 +99,7 @@
 	slur as if inebriated. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
 	item = /obj/item/gun/energy/ebow
-	cost = 10
+	cost = 8
 	surplus = 50
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -98,7 +98,7 @@
 	toxin that will damage and disorient targets, causing them to \
 	slur as if inebriated. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
-	item = /obj/item/gun/energy/recharge/ebow
+	item = /obj/item/gun/energy/ebow
 	cost = 10
 	surplus = 50
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS

--- a/tools/UpdatePaths/Scripts/91680_ebows_recharge_to_crank.txt
+++ b/tools/UpdatePaths/Scripts/91680_ebows_recharge_to_crank.txt
@@ -1,0 +1,3 @@
+/obj/item/gun/energy/ebow : /obj/item/gun/energy/recharge/ebow{@OLD}
+/obj/item/gun/energy/ebow/halloween : /obj/item/gun/energy/recharge/ebow/halloween{@OLD}
+/obj/item/gun/energy/ebow/large : /obj/item/gun/energy/recharge/ebow/large{@OLD}


### PR DESCRIPTION
## About The Pull Request

The mini energy crossbow and energy crossbow are now crank guns, requiring you to pull back the bow manually. This is not interrupted by moving, but is interrupted by dropping the weapon. It takes 2 seconds to crank the mini energy crossbow (its current recharge time) and 2.5 seconds to crank the energy crossbow.

The mini energy crossbow bolt still does 60 damage, while the energy crossbow bolt does 80. It still does 15 toxin for the mini and 20 for the large.

The bolt embeds. While embedded, it starts to inflict jostle stamina damage, mutes and increases drowsiness. If the target enters stamina crit, it sleeps the target and increases the chance the bolt falls out of the target.

It costs 8 TC.

## Why It's Good For The Game

~~I find the weapon can be a little at odds with itself at times, which I think is a single target disabling tool.~~

~~Repeat applications can potentially kill a target, even though to keep someone stamcrit you will need to shoot them several times.~~

**A few folk really argued for the soul of killing people with the piddly toxin damage the bolt does, so I've walked this decision back. I do think it would be better if nonlethal but whatever floats your boats. The sleeping effect does help at least.**

While it is a stealth weapon, it doesn't attack fast enough nor does it do enough to prevent callouts on its own to be an effective stealth tool. You either need to hope the slurring is strong enough to scramble a callout, or you need to invest in additional tools.

It already costs half your budget, so additional investments are a continued sore point.

It is mostly valued for its skirmishing power, but I think its kidnapping power a bit neglected. As a reliable tool for putting distance and putting someone out of commission, I think this is reasonably solid as an adjustment. I think the manual crank also makes it a touch less powerful for skirmishing.

## Changelog
:cl:
balance: The mini energy crossbow and energy crossbow need to be manually cranked to fire. Now the energy crossbow is like a REAL crossbow! Good for it.
balance: The energy bolt of these guns can embed, which mutes the target, makes them sleepy, and does additional stamina damage whenever the bolt jostles. If the target enters stamina crit while it is embedded, they fall asleep.
balance: The mini energy crossbow costs 8 TC.
/:cl:
