### PR TITLE
Fix admin immersion buttons scaling incorrectly with UI

### DIFF
--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -576,7 +576,7 @@ const FunForYouTab = (props) => {
       </Stack.Item>
       <Stack.Item>
         <Stack>
-          <Stack.Item grow>
+          <Stack.Item>
             <NoticeBox danger width={19.6} mb={0}>
               <Button
                 color="red"
@@ -587,7 +587,7 @@ const FunForYouTab = (props) => {
               />
             </NoticeBox>
           </Stack.Item>
-          <Stack.Item grow>
+          <Stack.Item>
             <NoticeBox info width={19.6} mb={0}>
               <Button
                 color="blue"


### PR DESCRIPTION

## About The Pull Request
Fixes some buttons on the admin secrets menu that scale incorrectly when the UI is stretched.

## Why It's Good For The Game
Better UI.

## Changelog
:cl:
fix: Fix admin immersion buttons scaling incorrectly when UI is stretched.
/:cl:
