### PR TITLE
Kills the impostor infinite pizza and fixes the actual infinite pizza

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -229,7 +229,8 @@
 	var/randomize_pizza = pick_weight(rng_pizza_list)
 	rng_pizza_list -= randomize_pizza
 	var/obj/item/pizzabox/new_pizza_box = new(new_crate)
-	new_pizza_box.pizza = new randomize_pizza
+	new_pizza_box.pizza = new randomize_pizza(new_pizza_box)
+	new_pizza_box.pizza.slice()
 	new_pizza_box.boxtag = new_pizza_box.pizza.boxtag
 	new_pizza_box.boxtag_set = TRUE
 	new_pizza_box.update_appearance(UPDATE_ICON | UPDATE_DESC)

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -422,7 +422,8 @@
 			return
 
 	var/obj/item/food/pizza/favourite_pizza_type = pizza_preferences[nommer.ckey]
-	pizza = new favourite_pizza_type
+	pizza = new favourite_pizza_type(src)
+	pizza.slice()
 	boxtag_set = FALSE
 	update_appearance() //update our boxtag to match our new pizza
 	pizza.foodtypes = nommer.get_liked_foodtypes() //it's our favorite!


### PR DESCRIPTION
## About The Pull Request

Box slicing was fucking up on pizzaboxes from cargo because the pizza from those boxes weren't actually placed in the pizzabox contents. Ghost pizza. What's more, slicing a pizza spawned in a infinite pizzabox would brick the funny property of said box since you would only ever get one type of slice that's bound to not be someone's favorite. Also the way the cargo order populates the boxes works in such a way that it would not pre-slice the pizza, unlike pre-built pathed pizza boxes that do, in fact, pre-slice their pizza.

So all that's fixed.

## Why It's Good For The Game

Fixes #91688
Fixes infinite pizza box getting stuck on the type that was sliced in the box.

## Changelog

:cl:
fix: killed the impostor infinite pizza
fix: the One True infinite pizza no longer gets stuck on a single pizza type if the pizza conjured by the box gets sliced
fix: the cargo pizza order now pre-slices the pizza, because that's what all pizza places have been doing since the dawn of time and our favorite supplier PizzNTe has been forcefully convinced to not break this sacred tradition
/:cl: