### PR TITLE
Sanitizes ghost spawners' names when adding them to `GLOB.mob_spawners` because `\improper` is still a pain in the ass

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -141,13 +141,13 @@
 /obj/effect/mob_spawn/ghost_role/Initialize(mapload)
 	. = ..()
 	SSpoints_of_interest.make_point_of_interest(src)
-	LAZYADD(GLOB.mob_spawners[name], src)
+	LAZYADD(GLOB.mob_spawners[format_text(name)], src)
 
 /obj/effect/mob_spawn/ghost_role/Destroy()
-	var/list/spawners = GLOB.mob_spawners[name]
+	var/list/spawners = GLOB.mob_spawners[format_text(name)]
 	LAZYREMOVE(spawners, src)
 	if(!LAZYLEN(spawners))
-		GLOB.mob_spawners -= name
+		GLOB.mob_spawners -= format_text(name)
 	return ..()
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE


### PR DESCRIPTION
## About The Pull Request

#79567 basically did the trick because `\improper` leaves one or two fucky symbols (see: #64429), which easily messes up ghosts' spawner menu - it would show the spawners' entries but won't let you use **Jump To** or **Spawn** buttons because it was trying to do that to non-existent spawners with corrupted names.

## Why It's Good For The Game

Fixes #79480

## Changelog

:cl:
fix: fixed certain pirate spawners having broken Jump to/Spawn buttons in the ghost spawners menu (greytide, space IRS, Interdyne)
/:cl: