### PR TITLE
Ensures that projectiles can embed even if there is armor mitigating the damage of the shot.

### DIFF
--- a/code/datums/embedding.dm
+++ b/code/datums/embedding.dm
@@ -142,7 +142,7 @@
 	if (pierce_hit)
 		return
 
-	if (blocked || !can_embed(source, hit))
+	if (blocked == 100 || !can_embed(source, hit))
 		failed_embed(hit, hit_zone)
 		return
 

--- a/code/datums/embedding.dm
+++ b/code/datums/embedding.dm
@@ -142,7 +142,7 @@
 	if (pierce_hit)
 		return
 
-	if (blocked == 100 || !can_embed(source, hit))
+	if (blocked >= 100 || !can_embed(source, hit))
 		failed_embed(hit, hit_zone)
 		return
 


### PR DESCRIPTION
## About The Pull Request

Currently, projectiles cannot embed if there is any armor present at all. This is due to the fact that the ``blocked`` argument passed to this proc isn't actually ``TRUE/FALSE``, as is expected of the typical embed proc and how the deceptively similarly named argument found on hitby would suggest. For projectiles, however, It is the value of armor that the mob being hit has when they were shot. Therefore, it will never embed unless that value being passed along is equal to 0, such as from being reduced by armour penetration (which is why flechettes work currently on live)

Now we only fail if the value is 100. Which means it was fully mitigated.

## Why It's Good For The Game

oughe

## Changelog
:cl:
fix: Projectiles can once again embed targets that are armoured.
/:cl:
