### PR TITLE
Fixes TRAIT_MOVE_FLYING applying a double movement penalty

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -966,8 +966,10 @@
 	. = ..()
 	var/health_deficiency = max((maxHealth - health), staminaloss)
 	if(health_deficiency >= 40)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)
+		if(HAS_TRAIT(src, TRAIT_MOVE_FLYING))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)
+		else
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)


### PR DESCRIPTION
## About The Pull Request

Fixes an oversight that resulted in flying units to suffer from 2 different damage penalties.

## Why It's Good For The Game

# About the Pull Request
If you have TRAIT_MOVE_FLYING you only gain `damage_slowdown_flying` instead of gaining the slowdown for walking and for flying.

There isn't any reason as far as I'm aware why flying mobs should suffer from a double penalty, so I'm marking this as a fix.

## Changelog

:cl:
fix: fixes getting more slowdown than intended while flying.
/:cl:

