### PR TITLE
Updates the mech ammo duffel bags into two separate types for each kind of mech. Each with equivalent ammunition and the toolbelt.

### DIFF
--- a/code/game/objects/items/storage/dufflebags.dm
+++ b/code/game/objects/items/storage/dufflebags.dm
@@ -293,10 +293,13 @@
 	icon_state = "duffel-syndieammo"
 	inhand_icon_state = "duffel-syndieammo"
 
-/obj/item/storage/backpack/duffelbag/syndie/ammo/mech
-	desc = "A large duffel bag, packed to the brim with various exosuit ammo."
+/obj/item/storage/backpack/duffelbag/syndie/ammo/darkgygax
+	name = "\improper Dark Gygax ammunition duffel bag"
+	desc = "A large duffel bag, packed to the brim with ammunition for the scattershot exosuit weapon. Suited to equipping the standard loadout of a Dark Gygax."
 
-/obj/item/storage/backpack/duffelbag/syndie/ammo/mech/PopulateContents()
+/obj/item/storage/backpack/duffelbag/syndie/ammo/darkgygax/PopulateContents()
+	new /obj/item/mecha_ammo/scattershot(src)
+	new /obj/item/mecha_ammo/scattershot(src)
 	new /obj/item/mecha_ammo/scattershot(src)
 	new /obj/item/mecha_ammo/scattershot(src)
 	new /obj/item/mecha_ammo/scattershot(src)
@@ -304,18 +307,17 @@
 	new /obj/item/storage/belt/utility/syndicate(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo/mauler
-	desc = "A large duffel bag, packed to the brim with various exosuit ammo."
+	name = "\improper Mauler ammunition duffel bag"
+	desc = "A large duffel bag, packed to the brim with various exosuit ammo. Suited to equipping the standard loadout of a Dark Gygax."
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo/mauler/PopulateContents()
 	new /obj/item/mecha_ammo/lmg(src)
 	new /obj/item/mecha_ammo/lmg(src)
 	new /obj/item/mecha_ammo/lmg(src)
-	new /obj/item/mecha_ammo/scattershot(src)
-	new /obj/item/mecha_ammo/scattershot(src)
-	new /obj/item/mecha_ammo/scattershot(src)
 	new /obj/item/mecha_ammo/missiles_srm(src)
 	new /obj/item/mecha_ammo/missiles_srm(src)
 	new /obj/item/mecha_ammo/missiles_srm(src)
+	new /obj/item/storage/belt/utility/syndicate(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle
 	desc = "A large duffel bag containing a medical equipment, a Donksoft LMG, a big jumbo box of riot darts, and a magboot MODsuit module."

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -592,15 +592,15 @@
 // ~~ Mech Support ~~
 
 /datum/uplink_item/mech/support_bag
-	name = "Mech Support Kit Bag"
-	desc = "A duffel bag containing ammo for four full reloads of the scattershot carbine which is equipped on standard Dark Gygax and Mauler exosuits. Also comes with some support equipment for maintaining the mech, including tools and an inducer."
-	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/mech
+	name = "Dark Gygax Support Duffel Bag"
+	desc = "A duffel bag containing ammo for isx full reloads of the scattershot exosuit weapon, which is equipped on standard Dark Gygax exosuits. Also comes with some support equipment for maintaining the mech, including tools and an inducer."
+	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/darkgygax
 	cost = 4
 	purchasable_from = UPLINK_SERIOUS_OPS
 
 /datum/uplink_item/mech/support_bag/mauler
-	name = "Mauler Ammo Bag"
-	desc = "A duffel bag containing ammo for three full reloads of the LMG, scattershot carbine, and SRM-8 missile launcher that are equipped on a standard Mauler exosuit."
+	name = "Mauler Support Duffel Bag"
+	desc = "A duffel bag containing ammo for three full reloads of the LMG and SRM-8 missile launcher that are equipped on a standard Mauler exosuit. Also comes with some support equipment for maintaining the mech, including tools and an inducer."
 	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/mauler
 	cost = 6
 	purchasable_from = UPLINK_SERIOUS_OPS


### PR DESCRIPTION

## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/91707

What is says on the tin. Rather than the previous setup which was a duffelbag with less ammo and a supposrt belt, and a duffelbag with all the ammo shared across the mech types, we've made the two duffel bags a distinctly marked bag for each mech, both containing the same amount of ammunition, and containing a belt.

## Why It's Good For The Game

Mech equipment changed quite a bit ago, which resulted in various issues with the nukie mechs that never seemingly got addressed at all. One such problem is that the dark gygax only has one gun and an empty arm slot. We'll deal with that later.

The most glaring issue is that these ammo packs never got updated. And it is not only deceptively marked, but for a mauler user to get the support items in the other duffelbag, they otherwise have useless ammo they cannot use.

We've equalized the bag contents now to make up for the fact that our nukie mech loadouts are separated out. Both bags provide the necessary support equipment for the mech.

## Changelog
:cl:
qol: Nuclear Operatives can now purchase support bags for their specific kind of mech; Dark Gygax or Mauler. No need to buy useless amoo just to get a toolbelt!
/:cl:
