### PR TITLE
Fixing more dna console / mutation issues [NO GBP]

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -816,11 +816,13 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		if((!sequence || dna.mutation_in_sequence(mutation.type)) && !dna.get_mutation(mutation.type))
 			possible += mutation.type
 	possible -= excluded_mutations
-	return pick(possible)
+	return length(possible) ? pick(possible) : null //prevent runtimes from picking null
 
 ///Gives the mob a random mutation based on the given arguments.
 /mob/living/carbon/proc/easy_random_mutate(quality = POSITIVE|NEGATIVE|MINOR_NEGATIVE, scrambled = TRUE, sequence = TRUE, list/excluded_mutations = list(/datum/mutation/race))
 	var/mutation_path = get_random_mutation_path(quality, scrambled, sequence, excluded_mutations)
+	if(!mutation_path)
+		return
 	dna.add_mutation(mutation_path, MUTATION_SOURCE_ACTIVATED)
 	if(!scrambled)
 		return

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -110,7 +110,7 @@
 	copy.synchronizer_coeff = synchronizer_coeff
 	copy.power_coeff = power_coeff
 	copy.energy_coeff = energy_coeff
-	can_chromosome = can_chromosome
+	copy.can_chromosome = can_chromosome
 	copy.valid_chrom_list = valid_chrom_list
 	update_valid_chromosome_list()
 

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -979,7 +979,12 @@
 			if(!mutation.scrambled && !(MUTATION_SOURCE_MUTATOR in mutation.sources))
 				return
 
-			scanner_occupant.dna.remove_mutation(mutation.type, MUTATION_SOURCE_MUTATOR)
+			var/list/types_to_remove = list(MUTATION_SOURCE_MUTATOR)
+			if(mutation.scrambled)
+				types_to_remove += MUTATION_SOURCE_ACTIVATED
+			scanner_occupant.dna.remove_mutation(mutation.type, types_to_remove)
+			if(!QDELETED(mutation))
+				mutation.scrambled = FALSE
 			return
 
 		// Deletes saved mutation from console buffer.
@@ -1988,10 +1993,10 @@
 			// These will all be active mutations. They're added by injector and their
 			//  sequencing code can't be changed. They can only be nullified, which
 			//  completely removes them.
-			var/datum/mutation/active = GET_INITIALIZED_MUTATION(mutation.type)
-			var/mut_class = get_mutation_class(active)
+			var/datum/mutation/initialized = GET_INITIALIZED_MUTATION(mutation.type)
+			var/mut_class = get_mutation_class(mutation)
 
-			mutation_data["Alias"] = active.alias
+			mutation_data["Alias"] = initialized.alias
 			mutation_data["Sequence"] = text_sequence
 			mutation_data["Discovered"] = TRUE
 			mutation_data["Quality"] = mutation.quality

--- a/code/game/objects/items/chromosome.dm
+++ b/code/game/objects/items/chromosome.dm
@@ -31,13 +31,13 @@
 		return TRUE
 
 /obj/item/chromosome/proc/apply(datum/mutation/mutation)
-	if(mutation.stabilizer_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE)
+	if(mutation.stabilizer_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE && stabilizer_coeff)
 		mutation.stabilizer_coeff = stabilizer_coeff
-	if(mutation.synchronizer_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE)
+	if(mutation.synchronizer_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE && synchronizer_coeff)
 		mutation.synchronizer_coeff = synchronizer_coeff
-	if(mutation.power_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE)
+	if(mutation.power_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE && power_coeff)
 		mutation.power_coeff = power_coeff
-	if(mutation.energy_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE)
+	if(mutation.energy_coeff != MUTATION_COEFFICIENT_UNMODIFIABLE && energy_coeff)
 		mutation.energy_coeff = energy_coeff
 	mutation.can_chromosome = CHROMOSOME_USED
 	mutation.chromosome_name = name


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This will fix https://github.com/tgstation/tgstation/issues/91638.

## Changelog

:cl:
fix: You can nullify mutations that are either scrambled (mutagen etc.) or from a mutator (not activator) again.
fix: Mutations with applied chromosomes won't display "no chromosome applied" when saved or have zero instability among other things.
/:cl:
