### PR TITLE
Fix meteor announce runtime

### DIFF
--- a/code/modules/events/meteors/stray_meteor_event.dm
+++ b/code/modules/events/meteors/stray_meteor_event.dm
@@ -27,7 +27,7 @@
 		spawn_meteor(GLOB.meteors_stray)
 
 /datum/round_event/stray_meteor/announce(fake)
-	if(GLOB.meteor_list)
+	if(length(GLOB.meteor_list))
 		var/obj/effect/meteor/detected_meteor = pick(GLOB.meteor_list) //If we accidentally pick a meteor not spawned by the event, we're still technically not wrong
 		var/sensor_name = detected_meteor.signature
 		priority_announce("Our [sensor_name] sensors have detected an incoming signature approaching [GLOB.station_name]. Please brace for impact.", "Meteor Alert")


### PR DESCRIPTION
## About The Pull Request

`if(GLOB.meteor_list)` will always pass because it's always a list, it should be checking for length. At least from what I can tell.