### PR TITLE
Fixes ancient bug on share()

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -422,9 +422,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(temperature_delta > MINIMUM_TEMPERATURE_TO_MOVE || abs(moved_moles) > MINIMUM_MOLES_DELTA_TO_MOVE)
 		var/our_moles
 		TOTAL_MOLES(cached_gases,our_moles)
-		var/their_moles
-		TOTAL_MOLES(sharer_gases,their_moles)
-		return (temperature_archived*(our_moles + moved_moles) - sharer.temperature_archived*(their_moles - moved_moles)) * R_IDEAL_GAS_EQUATION / volume
+		return (temperature_archived*((our_moles + moved_moles) - our_moles)) * R_IDEAL_GAS_EQUATION / volume //return the change in pressure of our gas mix bc this is the pressure that is doing the work to push
 
 ///Performs temperature sharing calculations (via conduction) between two gas_mixtures assuming only 1 boundary length
 ///Returns: new temperature of the sharer


### PR DESCRIPTION
## About The Pull Request
So share() returns the initial pressure delta between the turfs before equalizing. The problem is that since we resserve portions for other turfs as to not lead to over sharing it creates discrepancies where the tiles changes pressure a little but the spacewind acting on the mob/obj has much higher pressure. Now it is the change in pressure of the turf calling share() that will determine the spacewind pressure since this change in pressure is accurate with the amount of pressure actually moving. This as a consequence will make spacewind pressure lower and might not be as impactful. I kinda need this to have future space wind models accurately with the pressure direction. CCing @LemonInTheDark as we discuessed about this in discord. 

Fun fact: this bug has been around pre listmost 
## Why It's Good For The Game
This will decrease the spacewind impact which can be good when you are trying to enter the station. It might also make atmos less impactful.

Did some play testing fire seems to move mob around less, space still pull nearby tiles and opening door to high pressure area still push you back.
## To-do
- [x] Test the impact near spacetiles, fire and door opening
- [ ] Change mob/obj space wind resistance depending on how much less impact this makes
## Demo videos

https://github.com/user-attachments/assets/58cf6a2e-3093-4d41-9c42-ecfa6390c170

Seems space wind isnt too bad for now
## Changelog
:cl:
fix: fixed share() pressure returns that makes spacewind at least 2x more powerful
/:cl:
