### PR TITLE
Removes Piercing syringes from RND

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -105,18 +105,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/piercesyringe
-	name = "Piercing Syringe"
-	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
-	id = "piercesyringe"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/glass =SHEET_MATERIAL_AMOUNT, /datum/material/diamond =HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/reagent_containers/syringe/piercing
-	category = list(
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_CHEMISTRY
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
-
 /datum/design/bluespacebodybag
 	name = "Bluespace Body Bag"
 	desc = "A bluespace body bag, powered by experimental bluespace technology. It can hold loads of bodies and the largest of creatures."

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -79,7 +79,6 @@
 		"defibrillator_compact",
 		"defibmount",
 		"medicalbed_emergency",
-		"piercesyringe",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	required_experiments = list(/datum/experiment/scanning/reagent/haloperidol)


### PR DESCRIPTION
## About The Pull Request
This PR removes piercing syringes from RND 

## Why It's Good For The Game

Piercing syringes are very oppresive and they also negate the special armor made to negate normal syringes/rock hard skin at the mininum cost of 1 metal and 0.20 diamonds(at tier 1) they're are also very very early in the research tree

Normally armor like firesuits/biosuits/modsuits (or any clothing with THICKMATERIAL tag) would deflect normal shot syringes, piercing syringes completely would negate that and at a cheap price which is kinda boring

People who argue 10 units is low, you can make a deathmix in less let people be able to use more specialized armour VS a threat then some min/maxing chemist creeep

## Changelog
:cl: Ezel
del: You can no longer print piercing syringes from medlathes
/:cl:
