### PR TITLE
borgs cant drop again

### DIFF
--- a/code/datums/elements/slapcrafting.dm
+++ b/code/datums/elements/slapcrafting.dm
@@ -41,9 +41,10 @@
 	if(isnull(slapcraft_recipes))
 		CRASH("NULL SLAPCRAFT RECIPES?")
 
+	//mobs that can't craft (ex: borgs) can't slapcraft.
 	var/datum/component/personal_crafting/craft_sheet = user.GetComponent(/datum/component/personal_crafting)
 	if(!craft_sheet)
-		CRASH("No craft sheet on user ??")
+		return
 
 	var/list/valid_recipes
 	for(var/datum/crafting_recipe/recipe as anything in slapcraft_recipes)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -110,7 +110,7 @@
 		added_module.forceMove(src)
 	modules += added_module
 	added_module.mouse_opacity = MOUSE_OPACITY_OPAQUE
-	added_module.obj_flags |= ABSTRACT
+	added_module.item_flags |= ABSTRACT
 	if(nonstandard)
 		added_modules += added_module
 	if(requires_rebuild)


### PR DESCRIPTION
## About The Pull Request

ABSTRACT is an ``item_flags`` not an ``obj_flags`` which was fucking up making the items abstract, this fixes that, and removes a runtime for slapcraft for non-craft users (it was causing a runtime when borgs were trying to use one of their items on another one of their items).

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/91736

## Changelog

:cl:
fix: Borgs can't put their models in other storage items.
/:cl: