### PR TITLE
Remove mysql insecure warning in CI

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -49,6 +49,7 @@ jobs:
           mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} tg_ci < SQL/tgstation_schema.sql
           mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} -e 'CREATE DATABASE tg_ci_prefixed;'
           mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
+          echo "Sucessful MySQL Database Setup"
       - name: Install rust-g
         run: |
           bash tools/ci/install_rust_g.sh

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -46,10 +46,10 @@ jobs:
           MYSQL_CREDENTIALS: --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }}
         run: |
           sudo systemctl start mysql
-          mysql MYSQL_CREDENTIALS -e 'CREATE DATABASE tg_ci;'
-          mysql MYSQL_CREDENTIALS tg_ci < SQL/tgstation_schema.sql
-          mysql MYSQL_CREDENTIALS -e 'CREATE DATABASE tg_ci_prefixed;'
-          mysql MYSQL_CREDENTIALS tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
+          mysql ${{ env.MYSQL_CREDENTIALS }} -e 'CREATE DATABASE tg_ci;'
+          mysql ${{ env.MYSQL_CREDENTIALS }} tg_ci < SQL/tgstation_schema.sql
+          mysql ${{ env.MYSQL_CREDENTIALS }} -e 'CREATE DATABASE tg_ci_prefixed;'
+          mysql ${{ env.MYSQL_CREDENTIALS }} tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
       - name: Install rust-g
         run: |
           bash tools/ci/install_rust_g.sh

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -41,12 +41,15 @@ jobs:
           name: build-artifact-${{ inputs.major || env.BYOND_MAJOR }}-${{ inputs.minor || env.BYOND_MINOR}}
           path: ./
       - name: Setup database
+        env:
+          MYSQL_CONFIG_FILE: tools/ci/mysql_config.cnf
+          MYSQL_CREDENTIALS: --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }}
         run: |
           sudo systemctl start mysql
-          mysql -u root -proot -e 'CREATE DATABASE tg_ci;'
-          mysql -u root -proot tg_ci < SQL/tgstation_schema.sql
-          mysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'
-          mysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
+          mysql MYSQL_CREDENTIALS -e 'CREATE DATABASE tg_ci;'
+          mysql MYSQL_CREDENTIALS tg_ci < SQL/tgstation_schema.sql
+          mysql MYSQL_CREDENTIALS -e 'CREATE DATABASE tg_ci_prefixed;'
+          mysql MYSQL_CREDENTIALS tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
       - name: Install rust-g
         run: |
           bash tools/ci/install_rust_g.sh

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -43,13 +43,12 @@ jobs:
       - name: Setup database
         env:
           MYSQL_CONFIG_FILE: tools/ci/mysql_config.cnf
-          MYSQL_CREDENTIALS: --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }}
         run: |
           sudo systemctl start mysql
-          mysql ${{ env.MYSQL_CREDENTIALS }} -e 'CREATE DATABASE tg_ci;'
-          mysql ${{ env.MYSQL_CREDENTIALS }} tg_ci < SQL/tgstation_schema.sql
-          mysql ${{ env.MYSQL_CREDENTIALS }} -e 'CREATE DATABASE tg_ci_prefixed;'
-          mysql ${{ env.MYSQL_CREDENTIALS }} tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} -e 'CREATE DATABASE tg_ci;'
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} tg_ci < SQL/tgstation_schema.sql
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} -e 'CREATE DATABASE tg_ci_prefixed;'
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
       - name: Install rust-g
         run: |
           bash tools/ci/install_rust_g.sh

--- a/tools/ci/mysql_config.cnf
+++ b/tools/ci/mysql_config.cnf
@@ -1,0 +1,3 @@
+[client]
+user = "root"
+password = "root"


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/e8007e11-fc54-4f31-905e-2249481cd0a0)

This warning thing has been annoying me for a while when I scour CI logs looking for oranges/reds, let's remove this needless emission by confabulating a `.cfg` file and using that to run any necessary commands. This worked on my local repository and should pass CI without any issues on this repo as well.
## Why It's Good For The Game

In case we really wanna start cracking down on failing due to warnings in CI it's helpful to ensure that the standard case is normal. Also just cleaner in general.
## Changelog
Not needed.
