### PR TITLE
Medsci headset nuked on Meta and Catwalk, but doubled on IceBox and Delta

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -4858,10 +4858,6 @@
 	pixel_x = -6;
 	pixel_y = 2
 	},
-/obj/item/radio/headset/headset_medsci{
-	pixel_x = -5;
-	pixel_y = 12
-	},
 /obj/item/storage/pill_bottle/mutadone{
 	pixel_x = 8;
 	pixel_y = 16

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -45561,10 +45561,14 @@
 	},
 /obj/item/radio/headset/headset_medsci{
 	pixel_x = -7;
-	pixel_y = 4
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
+	},
+/obj/item/radio/headset/headset_medsci{
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -31217,6 +31217,10 @@
 /obj/machinery/firealarm/directional/south,
 /obj/item/radio/headset/headset_medsci{
 	pixel_x = 16;
+	pixel_y = 3
+	},
+/obj/item/radio/headset/headset_medsci{
+	pixel_x = 16;
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62856,10 +62856,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/item/radio/headset/headset_medsci{
-	pixel_x = -7;
-	pixel_y = 4
-	},
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 6;
 	pixel_y = 9


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

Medsci is long-gone so we better keep as much references to it as possible. (not a thing for maps that still have medsci layout, such as IceBox and DeltaStation)

## Changelog

:cl:
map: removed medsci headset from MetaStation and CatwalkStation. Added one more on DeltaStation and IceBox instead.
/:cl:

