### PR TITLE
Removes Hos baton from their backpack and put them in their secbelt instead

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -269,6 +269,14 @@
 	new /obj/item/melee/baton/security/loaded(src)
 	update_appearance()
 
+/obj/item/storage/belt/security/hos/full/PopulateContents()
+	new /obj/item/reagent_containers/spray/pepper(src)
+	new /obj/item/restraints/handcuffs(src)
+	new /obj/item/grenade/flashbang(src)
+	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/melee/baton/security/loaded/hos(src)
+	update_appearance()
+
 /obj/item/storage/belt/security/webbing
 	name = "security webbing"
 	desc = "Unique and versatile chest rig, can hold security gear."

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -67,7 +67,7 @@
 	new /obj/item/storage/lockbox/loyalty(src)
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/shield/riot/tele(src)
-	new /obj/item/storage/belt/security/full(src)
+	new /obj/item/storage/belt/security/hos/full(src)
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 	new /obj/item/storage/photo_album/hos(src)
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -57,7 +57,6 @@
 	suit_store = /obj/item/gun/energy/e_gun
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
-		/obj/item/melee/baton/security/loaded/hos = 1,
 		)
 	belt = /obj/item/modular_computer/pda/heads/hos
 	ears = /obj/item/radio/headset/heads/hos/alt


### PR DESCRIPTION
## About The Pull Request
This PR removes the special baton that hos starts with and puts it in their locker secbelt instead

## Why It's Good For The Game

This is purely a knowledge check for hos players since their baton has a super cell battery, which means they penetrate more energy armour but if you don't know its a thing you usually just ditch one of the two batons or just carry them both, this adds it to their standard secbelt but they will lose out on their baton in their backpack which should be ok because before the pr that added it they didnt had a baton on spawn anyways just a energy gun

## Changelog
:cl: Ezel
qol: HoS special baton now just starts in their lockers secbelt.
/:cl:
