### PR TITLE
Doubles the rate of all airlock pumps, faster external airlock cycling

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -51,7 +51,7 @@
 	///Which pressure holds docked vessel\station for override of external_pressure_target
 	var/docked_side_pressure
 	///Rate of the pump to remove gases from the air
-	var/volume_rate = 1000
+	var/volume_rate = 2000
 	///The start time of the current cycle to calculate cycle duration
 	var/cycle_start_time
 	///Max duration of cycle, after which the pump will unlock the airlocks with a warning


### PR DESCRIPTION
## About The Pull Request

This changes the volume pump speed from 1000 to 2000

## Why It's Good For The Game

People often use space as a way to escape, but they also find themselves often caught on the cycling where officers get 10 seconds to throw lasers disablers at them which causes them to caught pretty much instantly. and some more of the issues are explained in https://forums.tgstation13.org/viewtopic.php?p=780423#p780423

## Changelog
:cl: Ezel
qol: The volume of all airlock pumps are now doubled resulting in faster cycling
/:cl:

