### PR TITLE
OpenDream's version of `qdel()`

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -268,7 +268,7 @@ SUBSYSTEM_DEF(garbage)
 		return
 
 #ifdef OPENDREAM
-	spawn(1) //so many things use after del, holy shit
+	spawn(world.tick_lag) //so many things use after del, holy shit
 		HardDelete(D) //OpenDream hard deletes are instant, and the dotnet GC cleans up in a seperate thread
 	return
 #endif

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -266,6 +266,13 @@ SUBSYSTEM_DEF(garbage)
 /datum/controller/subsystem/garbage/proc/Queue(datum/D, level = GC_QUEUE_FILTER)
 	if (isnull(D))
 		return
+
+#ifdef OPENDREAM
+	spawn(1) //so many things use after del, holy shit
+		HardDelete(D) //OpenDream hard deletes are instant, and the dotnet GC cleans up in a seperate thread
+	return
+#endif
+
 	if (level > GC_QUEUE_COUNT)
 		HardDelete(D)
 		return


### PR DESCRIPTION

## About The Pull Request

Adds an `#ifdef` in the GC subsytem's `Queue()`  for OpenDream causing all `qdel()` calls to hard delete after one tick.

## Why It's Good For The Game

OpenDream's hard dels are instant, and rely on the dotnet GC's cleanup instead. This is much faster and doesn't require DM side GC handling. As a result of this though, `refcount()` doesn't work in OpenDream and so TG's GC subsystem gets very angry and confused. 

The `spawn()` is because a bunch of stuff relies on dels not being *instant* instant.

## Changelog
:cl:
code: adds better handling for `qdel()` in OpenDream
/:cl:
