### PR TITLE
mech clamp do_afters now also check for adjacency because of strafing shenanigans

### DIFF
--- a/code/__DEFINES/mecha.dm
+++ b/code/__DEFINES/mecha.dm
@@ -72,3 +72,7 @@
 /// Values to determine the effects on a mech should it suffer an EMP
 #define MECH_EMP_DAMAGE_LOWER 100
 #define MECH_EMP_DAMAGE_UPPER 180
+
+/// bitflags for do_after checks on mechs
+#define MECH_DO_AFTER_DIR_CHANGE_FLAG (1 << 0)
+#define MECH_DO_AFTER_ADJACENCY_FLAG (1 << 1)

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -126,20 +126,30 @@
  * * target: targeted atom for action activation
  * * user: occupant to display do after for
  * * interaction_key: interaction key to pass to [/proc/do_after]
+ * * flags: bitfield for different checks on do_after_checks
  */
-/obj/item/mecha_parts/mecha_equipment/proc/do_after_cooldown(atom/target, mob/user, interaction_key)
+/obj/item/mecha_parts/mecha_equipment/proc/do_after_cooldown(atom/target, mob/user, interaction_key, flags)
 	if(!chassis)
 		return FALSE
 	chassis.use_energy(energy_drain)
-	return do_after(user, equip_cooldown, target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target), interaction_key = interaction_key)
+	return do_after(user, equip_cooldown, target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target, flags), interaction_key = interaction_key)
 
 ///Do after wrapper for mecha equipment
-/obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, mob/user, delay)
-	return do_after(user, delay, target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target))
+/obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, mob/user, delay, flags)
+	return do_after(user, delay, target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target, flags))
 
 /// do after checks for the mecha equipment do afters
-/obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target)
-	return chassis && (get_dir(chassis, target) & chassis.dir)
+/obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target, flags = MECH_DO_AFTER_DIR_CHANGE_FLAG)
+	. = TRUE
+
+	if(!chassis)
+		return FALSE
+
+	if(flags & MECH_DO_AFTER_DIR_CHANGE_FLAG && !(get_dir(chassis, target) & chassis.dir))
+		return FALSE
+
+	if(flags & MECH_DO_AFTER_ADJACENCY_FLAG && !(chassis.Adjacent(target)))
+		return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/proc/can_attach(obj/vehicle/sealed/mecha/M, attach_right = FALSE, mob/user)
 	return default_can_attach(M, attach_right, user)

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -78,7 +78,7 @@
 		playsound(chassis, clampsound, 50, FALSE, -6)
 		chassis.visible_message(span_notice("[chassis] lifts [target] and starts to load it into cargo compartment."))
 		clamptarget.set_anchored(TRUE)
-		if(!do_after_cooldown(target, source))
+		if(!do_after_cooldown(target, source, flags = MECH_DO_AFTER_DIR_CHANGE_FLAG|MECH_DO_AFTER_ADJACENCY_FLAG))
 			clamptarget.set_anchored(FALSE)
 			return
 		clamptarget.set_anchored(FALSE)

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -658,7 +658,7 @@
 
 		playsound(chassis, clampsound, 50, FALSE, -6)
 		mobtarget.visible_message(span_notice("[chassis] lifts [mobtarget] into its internal holding cell."),span_userdanger("[chassis] grips you with [src] and prepares to load you into [secmech.cargo_hold]!"))
-		if(!do_after_cooldown(mobtarget, source))
+		if(!do_after_cooldown(mobtarget, source, flags = MECH_DO_AFTER_DIR_CHANGE_FLAG|MECH_DO_AFTER_ADJACENCY_FLAG))
 			return
 		mobtarget.forceMove(secmech.cargo_hold)
 		log_message("Loaded [mobtarget]. Cargo compartment capacity: [secmech.cargo_hold.cargo_capacity - secmech.cargo_hold.contents.len]", LOG_MECHA)


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/90904

if you have strafing on your dir doesn't actually change, making this do_after abusable 
## Changelog
:cl:
fix: moving out of range of a target you are clamping while strafing will halt the do_after of mechs
/:cl:
