### PR TITLE
gravity fields are effect types and can't be moved by tram

### DIFF
--- a/code/datums/proximity_monitor/fields/gravity.dm
+++ b/code/datums/proximity_monitor/fields/gravity.dm
@@ -64,14 +64,11 @@
 /datum/proximity_monitor/advanced/gravity/warns_on_entrance/proc/clear_recent_warning(mob_ref_key)
 	LAZYREMOVE(recently_warned, mob_ref_key)
 
-/obj/gravity_fluff_field
+/obj/effect/gravity_fluff_field
 	icon = 'icons/obj/smooth_structures/grav_field.dmi'
 	icon_state = "grav_field-0"
 	base_icon_state = "grav_field"
-	obj_flags = NONE
 	anchored = TRUE
-	move_resist = INFINITY
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags_self = LETPASSCLICKS
 	smoothing_flags = SMOOTH_BITMASK
@@ -82,7 +79,7 @@
 	var/mutable_appearance/emissive
 	var/particles/particle_type
 
-/obj/gravity_fluff_field/Initialize(mapload, strength)
+/obj/effect/gravity_fluff_field/Initialize(mapload, strength)
 	. = ..()
 	if(isnull(strength))
 		return INITIALIZE_HINT_QDEL
@@ -102,12 +99,12 @@
 		color = particle_type::color
 	RegisterSignal(src, COMSIG_ATOM_SMOOTHED_ICON, PROC_REF(smoothed))
 
-/obj/gravity_fluff_field/Destroy(force)
+/obj/effect/gravity_fluff_field/Destroy(force)
 	remove_shared_particles(particle_type)
 	emissive = null
 	return ..()
 
-/obj/gravity_fluff_field/proc/smoothed(datum/source)
+/obj/effect/gravity_fluff_field/proc/smoothed(datum/source)
 	SIGNAL_HANDLER
 	cut_overlay(emissive)
 	// because it uses a different name
@@ -121,8 +118,8 @@
 	. = ..()
 	if(!isopenturf(target))
 		return
-	new /obj/gravity_fluff_field(target, gravity_value)
+	new /obj/effect/gravity_fluff_field(target, gravity_value)
 
 /datum/proximity_monitor/advanced/gravity/subtle_effect/cleanup_field_turf(turf/target)
 	. = ..()
-	qdel(locate(/obj/gravity_fluff_field) in target)
+	qdel(locate(/obj/effect/gravity_fluff_field) in target)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -136,7 +136,7 @@
 
 /obj/structure/transport/linear/proc/add_item_on_transport(datum/source, atom/movable/new_transport_contents)
 	SIGNAL_HANDLER
-	var/static/list/blacklisted_types = typecacheof(list(/obj/structure/fluff/tram_rail, /obj/effect/decal/cleanable, /obj/structure/transport/linear, /mob/eye))
+	var/static/list/blacklisted_types = typecacheof(list(/obj/structure/fluff/tram_rail, /obj/effect/decal/cleanable, /obj/structure/transport/linear, /mob/eye, /obj/effect/gravity_fluff_field))
 	if(is_type_in_typecache(new_transport_contents, blacklisted_types) || new_transport_contents.invisibility == INVISIBILITY_ABSTRACT || HAS_TRAIT(new_transport_contents, TRAIT_UNDERFLOOR)) //prevents the tram from stealing things like landmarks
 		return FALSE
 	if(new_transport_contents in transport_contents)


### PR DESCRIPTION
## About The Pull Request
they are not attackable or clickable
fixes https://github.com/tgstation/tgstation/issues/90155
## Why It's Good For The Game
less likely to break things 
## Changelog
:cl:
fix: portable grav gen effects can't be moved by tram
code: portable grav gen effects are actually a subtype of effect now
/:cl:
