### PR TITLE
adds a notice span to gas pipe fasten

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -271,7 +271,7 @@ Buildable meters
 
 	wrench.play_tool_sound(src)
 	user.visible_message( \
-		"[user] fastens \the [src].", \
+		span_notice("[user] fastens \the [src]."), \
 		span_notice("You fasten \the [src]."), \
 		span_hear("You hear ratcheting."))
 


### PR DESCRIPTION
## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/91519
## Changelog
:cl:
qol: fasten pipes now has a nicer look to it in visible text message 
/:cl:
