### PR TITLE
Move unzip install to InstallDeps.sh

### DIFF
--- a/tools/tgs_scripts/InstallDeps.sh
+++ b/tools/tgs_scripts/InstallDeps.sh
@@ -8,28 +8,29 @@ has_cargo="$(command -v ~/.cargo/bin/cargo)"
 has_sudo="$(command -v sudo)"
 has_ytdlp="$(command -v yt-dlp)"
 has_pip3="$(command -v pip3)"
+has_unzip="$(command -v unzip)"
 set -e
 set -x
 
 # apt packages, libssl needed by rust-g but not included in TGS barebones install
-if ! ( [ -x "$has_git" ] && [ -x "$has_curl" ] && [ -x "$has_pip3" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] ); then
+if ! ( [ -x "$has_git" ] && [ -x "$has_curl" ] && [ -x "$has_pip3" ] && [ -x "$has_unzip" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] ); then
 	echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	echo "!!! HEY YOU THERE, READING THE TGS LOGS READ THIS!!!"
 	echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	echo "We are about to try installing native dependencies, we will use 'sudo' if possible for this, but it may fail because the tgstation-server user doesn't have passwordless sudo."
 	echo "WE DO NOT RECOMMEND GRANTING PASSWORDLESS SUDO!!! Instead, install all the dependencies yourself with the following command:"
-	echo "............................................................................................................................................"
-	echo "sudo apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl libclang-dev g++-multilib python3 python3-pip"
-	echo "............................................................................................................................................"
+	echo ".................................................................................................................................................."
+	echo "sudo apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl libclang-dev g++-multilib python3 python3-pip unzip"
+	echo ".................................................................................................................................................."
 	echo "Attempting to install apt dependencies..."
 	if ! [ -x "$has_sudo" ]; then
 		dpkg --add-architecture i386
 		apt-get update
-		apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl libclang-dev g++-multilib python3 python3-pip
+		apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl libclang-dev g++-multilib python3 python3-pip unzip
 	else
 		sudo dpkg --add-architecture i386
 		sudo apt-get update
-		sudo apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl libclang-dev g++-multilib python3 python3-pip
+		sudo apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl libclang-dev g++-multilib python3 python3-pip unzip
 	fi
 fi
 

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -53,9 +53,6 @@ env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --ignore-rust-version --re
 mv target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 cd ..
 
-# Get unzip
-apt-get install -y unzip
-
 # compile tgui
 echo "Compiling tgui..."
 cd "$1"


### PR DESCRIPTION

## About The Pull Request

Move the line to install `unzip` from `PreCompile.sh` to `InstallDeps.sh` so it only runs if you're actually missing unzip, and gives a warning that you'll need to install it manually if it fails to passwordless sudo install it

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/22feeb16-17d2-4343-956b-859034568975)
Deployments are now failing if your TGS system user isn't root because it's trying to install this every time with no sudo, `InstallDeps.sh` is a more appropriate place for it

## Changelog
:cl:
server: TGS deployments should no longer fail to install unzip
/:cl:
