### PR TITLE
"You have died" text no longer refers to ghost tab

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -36,7 +36,8 @@ GLOBAL_LIST_EMPTY(dead_players_during_shift)
 				<b>Brain damage</b>: [src.get_organ_loss(ORGAN_SLOT_BRAIN) || "0"]<br>\
 				<b>[get_bloodtype()?.get_blood_name() || "Blood"] volume</b>: [src.blood_volume]cl ([round((src.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 0.1)]%)<br>\
 				<b>Reagents</b>:<br>[reagents_readout()]", INVESTIGATE_DEATHS)
-	to_chat(src, span_warning("You have died. Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab."))
+	to_chat(src, span_warning("You have died. Barring complete bodyloss, you can in most cases be revived by other players. \
+		If you do not wish to be brought back, type \"Do Not Resuscitate\" in the command bar or press the ghost button twice in the ghost menu."))
 
 /mob/living/carbon/human/proc/reagents_readout()
 	var/readout = "[get_bloodtype()?.get_blood_name() || "Blood"]stream:"


### PR DESCRIPTION
## About The Pull Request

"You have died" text no longer refers to ghost tab in telling you how to DNR

## Why It's Good For The Game

It don't exist no more!!

## Changelog

:cl: Melbert
qol: "You have died" text no longer refers to ghost tab
/:cl:
