### PR TITLE
Fixes ai and cyborgs not being able to open windoors

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -446,7 +446,8 @@
 	qdel(src)
 	return TRUE
 
-/obj/machinery/door/window/interact(mob/user) //for sillycones
+/obj/machinery/door/window/attack_ai(mob/user) //for sillycones
+	. = ..()
 	try_to_activate_door(user)
 
 /obj/machinery/door/window/try_to_activate_door(mob/user, access_bypass = FALSE)


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/91790
## Changelog
:cl:
fix: silicons can open windoors again
/:cl:
