### PR TITLE
Cyborgs can no longer shatter glass while no glass is stored in the synthesizer + TK glass shatter fix

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -73,14 +73,22 @@
 	var/list/shards = list()
 	for(var/datum/material/mat in custom_materials)
 		if(mat.shard_type)
-			var/obj/item/new_shard = new mat.shard_type(user.loc)
-			new_shard.add_fingerprint(user)
-			shards += "\a [new_shard.name]"
+			shards += mat.shard_type
 	if(!shards.len)
+		return FALSE
+	if(!use(1))
+		to_chat(user, is_cyborg ? span_warning("There is not enough material in the synthesizer to produce a shard!") : span_warning("Somehow, there is not enough of [src] to shatter!"))
+		if(!is_cyborg)
+			stack_trace("A stack of sheet material was attempted to be shattered into shards while having less than 1 sheets remaining.")
 		return FALSE
 	user.do_attack_animation(src, ATTACK_EFFECT_BOOP)
 	playsound(src, SFX_SHATTER, 70, TRUE)
-	use(1)
-	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving [english_list(shards)]."), \
-		span_notice("You shatter the sheet of [name] on the floor, leaving [english_list(shards)]."))
+	var/list/shards_created = list()
+	for(var/shard_to_create in shards)
+		var/obj/item/new_shard = new shard_to_create(drop_location())
+		new_shard.add_fingerprint(user)
+		shards_created += "[new_shard.name]"
+	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving [english_list(shards_created)]."), \
+		span_notice("You shatter the sheet of [name] on the floor, leaving [english_list(shards_created)]."))
 	return TRUE
+


### PR DESCRIPTION
## About The Pull Request

Title; also introduces a stack trace in case a non-borg tries to shatter a <1 sheet stack. Moves shard creation to `drop_location()` instead of `user.loc` so shattering glass with TK won't magic shards under your feet.

## Why It's Good For The Game

no issue opened for this one apparently, weird
anyway, less bug good

## Changelog

:cl:
fix: fixed borgs being able to shatter glass into shards when there's no glass in the synthesizer
fix: shattering sheets into shards with telekinesis will place the shards at the stack, not at the user's feet
/:cl: