### PR TITLE
Adds autopsy scanner to morgue surgery tray

### DIFF
--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -203,6 +203,7 @@
 		/obj/item/stack/sticky_tape/surgical,
 		/obj/item/surgical_drapes,
 		/obj/item/surgicaldrill/cruel,
+		/obj/item/autopsy_scanner,
 	)
 
 /obj/item/surgery_tray/full/morgue/deployed


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

Allows doctors to skip the 200 credits tradeoff in coroner vend (or wait for research to print scanners) and perform autopsies. However, you'll still need to hack the coroner's office or have the AI ​​open the door. This is a good change, as autopsy is now required for most medical experiments, and most rounds delay this process due to the lack of a coroner or research to print the scanner itself.

## Changelog

:cl:
add: Added autopsy scanner to morgue surgery tray
/:cl:
