### PR TITLE
add config for food values

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -500,3 +500,6 @@
 
 /datum/config_entry/number/max_shuttle_size
 	default = 250
+
+/datum/config_entry/number/food_order_value_multiplier
+	default = 5

--- a/code/datums/elements/food/venue_price.dm
+++ b/code/datums/elements/food/venue_price.dm
@@ -29,7 +29,7 @@
 
 /datum/element/venue_price/proc/reagent_sold(datum/reagent/reagent_sold, mob/living/basic/robot_customer/sold_to, obj/item/container)
 	SIGNAL_HANDLER
-
+	venue_price = venue_price * CONFIG_GET(number/food_order_value_multiplier)
 	produce_cash(sold_to, container)
 	return TRANSACTION_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request
Adds a config to modify the value of food outcomes for bots coming to the bar

## Why It's Good For The Game
At the moment, prices are WAAAY too low compared to cargo bounty prices. The game is more fun if players are incentivised to pay the bots that come to the bar rather than fucking off to cargo every minute. 

I've set it as a config value because I don't know what is the correct number, it might need some balancing.

## Changelog
:cl:
balance: Kitchen and bar bots have had their wallets loosened and aren't so stingy anymore!
/:cl:
