### PR TITLE
Fixes borg modules sometimes not breaking correctly.

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -52,7 +52,7 @@
 
 ///Helper for cyborgs unequipping things.
 /mob/living/silicon/robot/proc/deactivate_module(obj/item/item_module)
-	. = transferItemToLoc(item_module, newloc = model)
+	return transferItemToLoc(item_module, newloc = model)
 
 /mob/living/silicon/robot/doUnEquip(obj/item/item_dropping, force, atom/newloc, no_move, invdrop, silent)
 	//borgs can drop items that aren't part of the module (used for apparatus modules, the stored item isn't a module).

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -52,7 +52,7 @@
 
 ///Helper for cyborgs unequipping things.
 /mob/living/silicon/robot/proc/deactivate_module(obj/item/item_module)
-	transferItemToLoc(item_module, newloc = model)
+	. = transferItemToLoc(item_module, newloc = model)
 
 /mob/living/silicon/robot/doUnEquip(obj/item/item_dropping, force, atom/newloc, no_move, invdrop, silent)
 	//borgs can drop items that aren't part of the module (used for apparatus modules, the stored item isn't a module).


### PR DESCRIPTION
## About The Pull Request
Okay, so this is funny. When a borg takes damage and their health drops below a certain percentage, it tries to call a proc to break a module. The break-a-module proc checks if the module holds an item, and if it does, tries to drop the item. The drop item proc works, but returns nothing (IE, a falsely return). So the break-a-module proc sees this, thinks it didn't drop the item, and panic-quits.

So if you're fast enough to re-equip stuff, you can keep your modules from breaking and that's funny but also a bug. The fix is making the drop-item proc carry through a return value.
## Why It's Good For The Game
bugfix
## Changelog
closes #91851
:cl:
fix: Borg modules no longer fail to break if they were holding an item.

/:cl:
