### PR TITLE
Species with extra hands uses their species' arm

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -410,11 +410,11 @@
 	else if(amt > old_limbs)
 		hand_bodyparts.len = amt
 		for(var/i in old_limbs+1 to amt)
-			var/path = /obj/item/bodypart/arm/left
+			var/path = dna.species.bodypart_overrides[BODY_ZONE_L_ARM] || /obj/item/bodypart/arm/left
 			if(IS_RIGHT_INDEX(i))
-				path = /obj/item/bodypart/arm/right
+				path = dna.species.bodypart_overrides[BODY_ZONE_R_ARM] || /obj/item/bodypart/arm/right
 
-			var/obj/item/bodypart/BP = new path ()
+			var/obj/item/bodypart/BP = new path()
 			BP.held_index = i
 			BP.try_attach_limb(src, TRUE)
 			hand_bodyparts[i] = BP

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -409,13 +409,14 @@
 		hand_bodyparts.len = amt
 	else if(amt > old_limbs)
 		hand_bodyparts.len = amt
-		for(var/i in old_limbs+1 to amt)
-			var/path = dna.species.bodypart_overrides[BODY_ZONE_L_ARM] || /obj/item/bodypart/arm/left
+		for(var/i in old_limbs + 1 to amt)
+			var/obj/item/bodypart/new_bodypart
 			if(IS_RIGHT_INDEX(i))
-				path = dna.species.bodypart_overrides[BODY_ZONE_R_ARM] || /obj/item/bodypart/arm/right
+				new_bodypart = newBodyPart(BODY_ZONE_R_ARM)
+			else
+				new_bodypart = newBodyPart(BODY_ZONE_L_ARM)
 
-			var/obj/item/bodypart/BP = new path()
-			BP.held_index = i
-			BP.try_attach_limb(src, TRUE)
-			hand_bodyparts[i] = BP
+			new_bodypart.held_index = i
+			new_bodypart.try_attach_limb(src, TRUE)
+			hand_bodyparts[i] = new_bodypart
 	..() //Don't redraw hands until we have organs for them


### PR DESCRIPTION
## About The Pull Request

Species that get extra hands (currently through wizard stuff) gets their species' arm rather than base arm. This means ghosts no longer drop their extra arm when they go incorporeal.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/91820

## Changelog

:cl:
fix: Getting extra arms attached now gives you your species arms rather than human ones.
/:cl: