### PR TITLE
Airlock variable door delay fixes

### DIFF
--- a/code/__DEFINES/airlock.dm
+++ b/code/__DEFINES/airlock.dm
@@ -6,9 +6,8 @@
 #define AIRLOCK_LIGHT_OPENING "opening"
 
 // Airlock physical states
-#define AIRLOCK_CLOSED 1
-#define AIRLOCK_CLOSING 2
-#define AIRLOCK_OPEN 3
-#define AIRLOCK_OPENING 4
-#define AIRLOCK_DENY 5
-#define AIRLOCK_EMAG 6
+#define AIRLOCK_CLOSED "closed"
+#define AIRLOCK_CLOSING "closing"
+#define AIRLOCK_OPEN "open"
+#define AIRLOCK_OPENING "opening"
+#define AIRLOCK_DENY "deny"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -518,6 +518,12 @@
 	operating = FALSE
 	set_animation()
 
+/obj/machinery/door/airlock/update_icon(updates = ALL)
+	if(!airlock_state)
+		airlock_state = icon_state
+
+	return ..()
+
 /obj/machinery/door/airlock/update_icon_state()
 	. = ..()
 	if(animation)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -2542,19 +2542,17 @@
 // set_density on both open and close procs has a check and return builtin.
 
 /obj/machinery/door/airlock/instant/open(forced = DEFAULT_DOOR_CHECKS)
-	operating = TRUE
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN, forced)
+	operating = TRUE
 	set_density(FALSE)
-	operating = FALSE
-	update_appearance()
+	set_airlock_state(AIRLOCK_OPEN, animated = FALSE)
 	return TRUE
 
 /obj/machinery/door/airlock/instant/close(forced = DEFAULT_DOOR_CHECKS, force_crush = FALSE)
-	operating = TRUE
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
+	operating = TRUE
 	set_density(TRUE)
-	operating = FALSE
-	update_appearance()
+	set_airlock_state(AIRLOCK_CLOSED, animated = FALSE)
 	return TRUE
 
 /obj/machinery/door/airlock/instant/glass

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -76,6 +76,7 @@
 	name = "Airlock"
 	icon = 'icons/obj/doors/airlocks/station/public.dmi'
 	icon_state = "closed"
+	base_icon_state = null
 	max_integrity = 300
 	var/normal_integrity = AIRLOCK_INTEGRITY_N
 	integrity_failure = 0.25
@@ -502,30 +503,34 @@
 /obj/machinery/door/airlock/proc/is_secure()
 	return (security_level > 0)
 
-/obj/machinery/door/airlock/update_icon(updates=ALL, state=0, override=FALSE)
-	if(operating && !override)
+/obj/machinery/door/airlock/proc/set_airlock_state(new_state, animated = FALSE)
+	if(!new_state)
+		new_state = density ? AIRLOCK_CLOSED : AIRLOCK_OPEN
+	airlock_state = new_state
+	if(animated)
+		operating = TRUE
+		run_animation(airlock_state)
 		return
-
-	if(!state)
-		state = density ? AIRLOCK_CLOSED : AIRLOCK_OPEN
-	airlock_state = state
-
-	. = ..()
+	operating = FALSE
+	set_animation()
 
 /obj/machinery/door/airlock/update_icon_state()
 	. = ..()
-	switch(airlock_state)
-		if(AIRLOCK_OPEN, AIRLOCK_CLOSED)
-			icon_state = ""
-		if(AIRLOCK_DENY, AIRLOCK_OPENING, AIRLOCK_CLOSING, AIRLOCK_EMAG)
-			icon_state = "nonexistenticonstate" //MADNESS
+	if(animation)
+		icon_state = "[base_icon_state][animation]"
+	else if(airlock_state == AIRLOCK_OPEN)
+		icon_state = "[base_icon_state]open"
+	else
+		icon_state = "[base_icon_state]closed"
 
 /obj/machinery/door/airlock/update_overlays()
 	. = ..()
 
 	var/frame_state
 	var/light_state
-	switch(airlock_state)
+	if(machine_stat & MAINT)
+		frame_state = AIRLOCK_FRAME_CLOSED
+	else switch(airlock_state)
 		if(AIRLOCK_CLOSED)
 			frame_state = AIRLOCK_FRAME_CLOSED
 			if(locked)
@@ -535,8 +540,6 @@
 		if(AIRLOCK_DENY)
 			frame_state = AIRLOCK_FRAME_CLOSED
 			light_state = AIRLOCK_LIGHT_DENIED
-		if(AIRLOCK_EMAG)
-			frame_state = AIRLOCK_FRAME_CLOSED
 		if(AIRLOCK_CLOSING)
 			frame_state = AIRLOCK_FRAME_CLOSING
 			light_state = AIRLOCK_LIGHT_CLOSING
@@ -557,10 +560,11 @@
 
 	if(panel_open)
 		. += get_airlock_overlay("panel_[frame_state][security_level ? "_protected" : null]", overlays_file, src, em_block = TRUE)
+
 	if(frame_state == AIRLOCK_FRAME_CLOSED && welded)
 		. += get_airlock_overlay("welded", overlays_file, src, em_block = TRUE)
 
-	if(airlock_state == AIRLOCK_EMAG)
+	if(machine_stat & MAINT)
 		. += get_airlock_overlay("sparks", overlays_file, src, em_block = FALSE)
 
 	if(hasPower())
@@ -600,20 +604,21 @@
 			. += floorlight
 
 /obj/machinery/door/airlock/run_animation(animation)
-	switch(animation)
-		if(DOOR_OPENING_ANIMATION)
-			update_icon(ALL, AIRLOCK_OPENING)
-		if(DOOR_OPENING_ANIMATION)
-			update_icon(ALL, AIRLOCK_CLOSING)
-		if(DOOR_DENY_ANIMATION)
-			if(!machine_stat)
-				update_icon(ALL, AIRLOCK_DENY)
-				playsound(src,doorDeni,50,FALSE,3)
-				addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
+	if(animation == DOOR_DENY_ANIMATION)
+		if(machine_stat)
+			return
+		set_airlock_state(AIRLOCK_DENY, animated = FALSE)
+
+	return ..()
+
+/obj/machinery/door/airlock/animation_effects(animation)
+	if(animation == DOOR_DENY_ANIMATION)
+		playsound(src, doorDeni, 50, TRUE)
+		addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/proc/handle_deny_end()
 	if(airlock_state == AIRLOCK_DENY)
-		update_icon(ALL, AIRLOCK_CLOSED)
+		set_airlock_state(AIRLOCK_CLOSED, animated = FALSE)
 
 /obj/machinery/door/airlock/animation_length(animation)
 	switch(animation)
@@ -1279,8 +1284,7 @@
 				addtimer(CALLBACK(cyclelinkedairlock, PROC_REF(close)), BYPASS_DOOR_CHECKS)
 
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN, forced)
-	operating = TRUE
-	update_icon(ALL, AIRLOCK_OPENING, TRUE)
+	set_airlock_state(AIRLOCK_OPENING, animated = TRUE)
 	var/transparent_delay = animation_segment_delay(AIRLOCK_OPENING_TRANSPARENT)
 	sleep(transparent_delay)
 	set_opacity(0)
@@ -1297,7 +1301,7 @@
 	var/open_delay = animation_segment_delay(AIRLOCK_OPENING_FINISHED) - transparent_delay - passable_delay
 	sleep(open_delay)
 	layer = OPEN_DOOR_LAYER
-	update_icon(ALL, AIRLOCK_OPEN, TRUE)
+	set_airlock_state(AIRLOCK_OPEN, animated = FALSE)
 	operating = FALSE
 	if(delayed_close_requested)
 		delayed_close_requested = FALSE
@@ -1355,8 +1359,7 @@
 	if(killthis)
 		SSexplosions.med_mov_atom += killthis
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
-	operating = TRUE
-	update_icon(ALL, AIRLOCK_CLOSING, 1)
+	set_airlock_state(AIRLOCK_CLOSING, animated = TRUE)
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
 		set_density(TRUE)
@@ -1383,8 +1386,7 @@
 	update_freelook_sight()
 	var/close_delay = animation_segment_delay(AIRLOCK_CLOSING_FINISHED) - unpassable_delay - opaque_delay
 	sleep(close_delay)
-	update_icon(ALL, AIRLOCK_CLOSED, 1)
-	operating = FALSE
+	set_airlock_state(AIRLOCK_CLOSED, animated = FALSE)
 	delayed_close_requested = FALSE
 	if(!dangerous_close)
 		CheckForMobs()
@@ -1457,8 +1459,9 @@
 		if(istype(emag_card, /obj/item/card/emag/doorjack))
 			var/obj/item/card/emag/doorjack/doorjack_card = emag_card
 			doorjack_card.use_charge(user)
+		set_machine_stat(machine_stat | MAINT)
+		set_airlock_state(AIRLOCK_CLOSED)
 		operating = TRUE
-		update_icon(ALL, AIRLOCK_EMAG, 1)
 		addtimer(CALLBACK(src, PROC_REF(finish_emag_act)), 0.6 SECONDS)
 		return TRUE
 	return FALSE
@@ -1467,9 +1470,10 @@
 /obj/machinery/door/airlock/proc/finish_emag_act()
 	if(QDELETED(src))
 		return FALSE
+	set_machine_stat(machine_stat & ~MAINT)
 	operating = FALSE
 	if(!open())
-		update_icon(ALL, AIRLOCK_CLOSED, 1)
+		set_airlock_state(AIRLOCK_CLOSED)
 	obj_flags |= EMAGGED
 	lights = FALSE
 	locked = TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1469,7 +1469,7 @@
 		if(istype(emag_card, /obj/item/card/emag/doorjack))
 			var/obj/item/card/emag/doorjack/doorjack_card = emag_card
 			doorjack_card.use_charge(user)
-		set_machine_stat(machine_stat | MAINT)
+		set_machine_stat(machine_stat | MAINT) // flash the airlock lights and display some sparks
 		set_airlock_state(AIRLOCK_CLOSED)
 		operating = TRUE
 		addtimer(CALLBACK(src, PROC_REF(finish_emag_act)), 0.6 SECONDS)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1312,7 +1312,6 @@
 	sleep(open_delay)
 	layer = OPEN_DOOR_LAYER
 	set_airlock_state(AIRLOCK_OPEN, animated = FALSE)
-	operating = FALSE
 	if(delayed_close_requested)
 		delayed_close_requested = FALSE
 		addtimer(CALLBACK(src, PROC_REF(close)), FORCING_DOOR_CHECKS)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -503,6 +503,10 @@
 /obj/machinery/door/airlock/proc/is_secure()
 	return (security_level > 0)
 
+/**
+ * Set the airlock state to a new value, change the icon state
+ * and run the associated animation if required.
+ */
 /obj/machinery/door/airlock/proc/set_airlock_state(new_state, animated = FALSE)
 	if(!new_state)
 		new_state = density ? AIRLOCK_CLOSED : AIRLOCK_OPEN
@@ -528,7 +532,7 @@
 
 	var/frame_state
 	var/light_state
-	if(machine_stat & MAINT)
+	if(machine_stat & MAINT) // in the process of being emagged
 		frame_state = AIRLOCK_FRAME_CLOSED
 	else switch(airlock_state)
 		if(AIRLOCK_CLOSED)
@@ -564,7 +568,7 @@
 	if(frame_state == AIRLOCK_FRAME_CLOSED && welded)
 		. += get_airlock_overlay("welded", overlays_file, src, em_block = TRUE)
 
-	if(machine_stat & MAINT)
+	if(machine_stat & MAINT) // in the process of being emagged
 		. += get_airlock_overlay("sparks", overlays_file, src, em_block = FALSE)
 
 	if(hasPower())
@@ -613,7 +617,7 @@
 
 /obj/machinery/door/airlock/animation_effects(animation)
 	if(animation == DOOR_DENY_ANIMATION)
-		playsound(src, doorDeni, 50, TRUE)
+		playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
 		addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/proc/handle_deny_end()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -434,17 +434,17 @@
 	switch(animation)
 		if(DOOR_OPENING_ANIMATION)
 			if(panel_open)
-				icon_state = "o_door_opening"
+				icon_state = "o_[base_icon_state]_opening"
 			else
-				icon_state = "door_opening"
+				icon_state = "[base_icon_state]_opening"
 		if(DOOR_CLOSING_ANIMATION)
 			if(panel_open)
-				icon_state = "o_door_closing"
+				icon_state = "o_[base_icon_state]_closing"
 			else
-				icon_state = "door_closing"
+				icon_state = "[base_icon_state]_closing"
 		if(DOOR_DENY_ANIMATION)
 			if(!machine_stat)
-				icon_state = "door_deny"
+				icon_state = "[base_icon_state]_deny"
 		else
 			icon_state = "[base_icon_state]_[density ? "closed" : "open"]"
 


### PR DESCRIPTION
## About The Pull Request

- Fixes airlock's run_animation from having a duplicate open in the switch case instead of an open/closed.
- Completes the implementation of [Variable Door Delay](https://github.com/tgstation/tgstation/pull/84631) on airlocks. (The procs were made but never called in the airlock code.
- Implements a set_airlock_state that sets the airlock state as well as managing operating status and animations instead of calling it individually.

## Why It's Good For The Game

Fixes, less code duplication, airlocks use the new animation procs.

## Changelog

:cl: LT3
fix: Fixed incorrect opening case in variable door delay
code: Airlocks can have variable animation delay same as doors
/:cl: