### PR TITLE
Mindswap knocks wizard unconcious for a duration depending on spell level

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
@@ -2,7 +2,7 @@
 // Wizard spells that aid mobiilty(or stealth?)
 /datum/spellbook_entry/mindswap
 	name = "Mindswap"
-	desc = "Allows you to switch bodies with a target next to you. You will both fall asleep when this happens, and it will be quite obvious that you are the target's body if someone watches you do it."
+	desc = "Allows you to switch bodies with a target next to you. Your old body will fall unconcious when this happens, and it will be quite obvious that you are the target's body if someone watches you do it."
 	spell_type = /datum/action/cooldown/spell/pointed/mind_transfer
 	category = SPELLBOOK_CATEGORY_MOBILITY
 

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
@@ -2,7 +2,7 @@
 // Wizard spells that aid mobiilty(or stealth?)
 /datum/spellbook_entry/mindswap
 	name = "Mindswap"
-	desc = "Allows you to switch bodies with a target next to you. Your old body will fall unconcious when this happens, and it will be quite obvious that you are the target's body if someone watches you do it."
+	desc = "Allows you to switch bodies with a target next to you. You will both fall asleep when this happens, and it will be quite obvious that you are the target's body if someone watches you do it. Each level reduces the time you spend stunned."
 	spell_type = /datum/action/cooldown/spell/pointed/mind_transfer
 	category = SPELLBOOK_CATEGORY_MOBILITY
 

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -135,7 +135,7 @@
 
 	// only knock out the victim
 	caster.Unconscious(unconscious_amount_caster)
-	to_swap.Unconscious(unconscious_amount_victim / (spell_level * 2))
+	to_swap.Unconscious(unconscious_amount_victim / (spell_level * spell_level))
 
 	// Only the caster and victim hear the sounds,
 	// that way no one knows for sure if the swap happened

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -135,7 +135,7 @@
 
 	// only knock out the victim
 	caster.Unconscious(unconscious_amount_caster)
-	//to_swap.Unconscious(unconscious_amount_victim)
+	to_swap.Unconscious(unconscious_amount_victim / (spell_level * 2))
 
 	// Only the caster and victim hear the sounds,
 	// that way no one knows for sure if the swap happened

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -134,8 +134,8 @@
 	// MIND TRANSFER END
 
 	// only knock out the victim
-	//caster.Unconscious(unconscious_amount_caster)
-	to_swap.Unconscious(unconscious_amount_victim)
+	caster.Unconscious(unconscious_amount_caster)
+	//to_swap.Unconscious(unconscious_amount_victim)
 
 	// Only the caster and victim hear the sounds,
 	// that way no one knows for sure if the swap happened

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -133,8 +133,8 @@
 
 	// MIND TRANSFER END
 
-	// Now we knock both mobs out for a time.
-	caster.Unconscious(unconscious_amount_caster)
+	// only knock out the victim
+	//caster.Unconscious(unconscious_amount_caster)
 	to_swap.Unconscious(unconscious_amount_victim)
 
 	// Only the caster and victim hear the sounds,

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -25,10 +25,8 @@
 	/// You may be wondering "What's the point of mindswap if the target has no mind"?
 	/// Primarily for debugging - targets hit with this set to FALSE will init a mind, then do the swap.
 	var/target_requires_mind = TRUE
-	/// For how long is the caster stunned for after the spell
-	var/unconscious_amount_caster = 40 SECONDS
-	/// For how long is the victim stunned for after the spell
-	var/unconscious_amount_victim = 40 SECONDS
+	/// For how long is the caster or victim stunned for after the spell
+	var/unconscious_amount_base = 20 SECONDS
 	/// List of mobs we cannot mindswap into.
 	var/static/list/mob/living/blacklisted_mobs = typecacheof(list(
 		/mob/living/basic/demon/slaughter,
@@ -133,9 +131,10 @@
 
 	// MIND TRANSFER END
 
-	// only knock out the victim
-	caster.Unconscious(unconscious_amount_caster)
-	to_swap.Unconscious(unconscious_amount_victim / (spell_level * spell_level))
+	// knocks out the victim, and the caster for a duration depending on spell level.
+	caster.Unconscious(unconscious_amount_base) //applied to the body the wizard is leaving behind
+	to_swap.Unconscious(unconscious_amount_base / (spell_level * spell_level)) //applied to the body the wizard is taking over
+	priority_announce("[unconscious_amount_base / (spell_level * spell_level)]")
 
 	// Only the caster and victim hear the sounds,
 	// that way no one knows for sure if the swap happened


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Each level spent in mind transfer reduces the time the wizard is stunned. Calculated as;

BASE_STUN_TIME / (spell_level^2)

Level 1; 40 seconds
Level 2; 10 seconds
Level 3; 4.44444 seconds
Level 4; 2.5 seconds
Level 5; 1.6 seconds

The time the victim is stunned is unaffected.

## Why It's Good For The Game
Current mindswap knocks the wizard unconcious for 40 seconds, which they have to spend completely helpless. This spell in its current state is underpowered and spending additional levels only reduces the cooldown of casting it. 

This change aims to buff it by reducing the stun significantly with each level spent.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
change: mindswap now knocks the wizard unconscious for a duration depending on spell level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
