### PR TITLE
Fix some new dreamchecker lints

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -224,7 +224,6 @@
 		amount_of_lunatics++
 
 /datum/heretic_knowledge/ultimate/moon_final/proc/on_life(mob/living/source, seconds_per_tick, times_fired)
-	var/obj/effect/moon_effect = /obj/effect/temp_visual/moon_ringleader
 	SIGNAL_HANDLER
 
 	visible_hallucination_pulse(
@@ -240,7 +239,7 @@
 			continue
 		if(carbon_view.can_block_magic(MAGIC_RESISTANCE_MIND)) //Somehow a shitty piece of tinfoil is STILL able to hold out against the power of an ascended heretic.
 			continue
-		new moon_effect(get_turf(carbon_view))
+		new /obj/effect/temp_visual/moon_ringleader(get_turf(carbon_view))
 		carbon_view.adjust_confusion(2 SECONDS)
 		carbon_view.mob_mood.adjust_sanity(-5)
 		var/carbon_sanity = carbon_view.mob_mood.sanity

--- a/code/modules/fishing/fish/fish_evolution.dm
+++ b/code/modules/fishing/fish/fish_evolution.dm
@@ -32,8 +32,8 @@ GLOBAL_LIST_EMPTY(fishes_by_fish_evolution)
 	var/show_result_on_wiki = TRUE
 
 /datum/fish_evolution/New()
-	..()
 	SHOULD_CALL_PARENT(TRUE)
+	..()
 	if(!ispath(new_fish_type, /obj/item/fish))
 		stack_trace("[type] instantiated with a new fish type of [new_fish_type]. That's not a fish, hun, things will break.")
 	if(!name)

--- a/code/modules/mob/living/basic/cult/constructs/harvester.dm
+++ b/code/modules/mob/living/basic/cult/constructs/harvester.dm
@@ -162,9 +162,9 @@
 	RegisterSignal(src, COMSIG_MOB_ENSLAVED_TO, PROC_REF(link_master))
 
 /mob/living/basic/construct/harvester/heretic/proc/link_master(mob/self, mob/master)
+	SIGNAL_HANDLER
 	src.construct_master = master
 	RegisterSignal(construct_master, COMSIG_LIVING_DEATH, PROC_REF(on_master_death))
-	SIGNAL_HANDLER
 
 /mob/living/basic/construct/harvester/heretic/proc/on_master_death(mob/self, mob/master)
 	SIGNAL_HANDLER

--- a/code/modules/modular_computers/file_system/program_circuit.dm
+++ b/code/modules/modular_computers/file_system/program_circuit.dm
@@ -53,8 +53,8 @@
 	return ..()
 
 /obj/item/circuit_component/mod_program/populate_ports()
-	. = ..()
 	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
 	start = add_input_port("Start", PORT_TYPE_SIGNAL, trigger = PROC_REF(start_prog))
 	kill = add_input_port("Kill", PORT_TYPE_SIGNAL, trigger = PROC_REF(kill_prog))
 	running = add_output_port("Running", PORT_TYPE_NUMBER)


### PR DESCRIPTION

## About The Pull Request

https://github.com/SpaceManiac/SpacemanDMM/pull/435 added a new dreamchecker lint, for SDMM `set` statements not at the top of the proc.

While this lint isn't in the current SDMM _release_, I was testing it out earlier and saw these issues, so might as well fix them before they even become an issue.

i also fixed a useless variable in moon heretic code that was right next to the incorrectly placed `SIGNAL_HANDLER`

## Why It's Good For The Game

https://github.com/user-attachments/assets/5b063f41-32f3-490a-b0a3-199ca8147ec3

## Changelog

No player-facing changes.