### PR TITLE
disable OpenDream linting complaining about `world.IsSubscribed` and `client.IsByondMember`

### DIFF
--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -24,6 +24,7 @@
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
 #pragma ProcArgumentGlobal error
+#pragma UnsupportedAccess disabled
 
 //3000-3999
 #pragma EmptyBlock error


### PR DESCRIPTION
## About The Pull Request

this disables the `UnsupportedAccess` warning in opendream linting, so we stop getting these warnings for every opendream lint:
```
Warning: OD2801: /world.IsSubscribed() is unsupported: OpenDream does not have a premium tier
Warning: OD2801: /client.IsByondMember() is unsupported: OpenDream has no premium tier.
Warning: OD2801: /client.IsByondMember() is unsupported: OpenDream has no premium tier.
Warning: OD2801: /client.IsByondMember() is unsupported: OpenDream has no premium tier.
```

## Why It's Good For The Game

![jiggly](https://github.com/user-attachments/assets/19e926ce-93a2-45f6-b4ef-76cd0724268f)

## Changelog

no player-facing changes