### PR TITLE
Fixes space in Meta Central virtual domain not having NOTELEPORT

### DIFF
--- a/_maps/virtual_domains/meta_central.dmm
+++ b/_maps/virtual_domains/meta_central.dmm
@@ -3706,7 +3706,7 @@
 /area/virtual_domain)
 "Fd" = (
 /turf/open/space/basic,
-/area/space)
+/area/space/virtual_domain)
 "Ff" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/railing{


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/41a0837b-f64d-4df2-9d35-293f1b1745be)

Space had default area instead of virtdomain-specific one set, so you could teleport into and from it.

## Changelog
:cl:
fix: Fixed space in Meta Central virtual domain not having teleport prevention
/:cl:
