### PR TITLE
Emergency suture is kill. Replaced with bandage.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -1073,7 +1073,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/dangerous_research/lab)
 "oJ" = (
-/obj/item/stack/medical/suture/emergency,
+/obj/item/stack/medical/bandage,
 /obj/item/stack/medical/gauze/twelve,
 /obj/item/reagent_containers/hypospray/medipen/blood_loss,
 /obj/effect/spawner/random/medical/injector,

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -558,14 +558,6 @@
 	heal_continuous_sound = SFX_SUTURE_CONTINUOUS
 	heal_end_sound = SFX_SUTURE_END
 
-/obj/item/stack/medical/suture/emergency
-	name = "emergency suture"
-	desc = "A value pack of cheap sutures, not very good at repairing damage, but still decent at stopping bleeding."
-	heal_brute = 5
-	amount = 5
-	max_amount = 5
-	merge_type = /obj/item/stack/medical/suture/emergency
-
 /obj/item/stack/medical/suture/medicated
 	name = "medicated suture"
 	icon_state = "suture_purp"

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -59,7 +59,8 @@
 	var/static/items_inside = list(
 		/obj/item/healthanalyzer/simple = 1,
 		/obj/item/stack/medical/gauze = 1,
-		/obj/item/stack/medical/suture/emergency = 1,
+		/obj/item/stack/medical/bandage = 1,
+		/obj/item/stack/medical/bandage = 1,
 		/obj/item/stack/medical/ointment = 1,
 		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
 		/obj/item/storage/pill_bottle/iron = 1,

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -60,7 +60,6 @@
 		/obj/item/healthanalyzer/simple = 1,
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bandage = 1,
-		/obj/item/stack/medical/bandage = 1,
 		/obj/item/stack/medical/ointment = 1,
 		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
 		/obj/item/storage/pill_bottle/iron = 1,

--- a/tools/UpdatePaths/Scripts/91854_emergency_suture.txt
+++ b/tools/UpdatePaths/Scripts/91854_emergency_suture.txt
@@ -1,0 +1,3 @@
+#comment This replaces the old emergency sutures with bandages. 
+
+/obj/item/stack/medical/bandage : /obj/item/stack/medical/suture/emergency{@OLD}


### PR DESCRIPTION
## About The Pull Request

This PR removes the suture/emergency item and replaces it with a bandage in all instances.

Provides as much brute healing overall(25), but in one big chunk.

## Why It's Good For The Game

### Flavour

Suturing is a specialised medical skill and not typically something you'd expect to find a standard workplace first aid kit.

The emergency suture also shared a sprite with the regular suture causing confusion.

### Healing Glut

Like when I first added sutures and mesh six year ago, one of the main reasons for making this change is also to start making a dent in the glut of free easy healing available to the crew. 

While medical is in a much better place than before we started the grand medical revitalisation project¹ 6 or so years ago, we have been backsliding by turbo powercreeping chems, letting plumbing churn out ungodly amounts of heal mix patches, nerfing organ damage and wounds and adding more free healing items to maps.

While these bandages provide the same amount of healing, the healing is less granular as such some of it will likely be wasted, leading to a modest reduction of free heal points available to the crew under real world conditions.

#### Wound Treatment

The bandages are worse for treating bleeds, but the kit already contains a super ez bleed fixing pen and gauze, so the kit is still very robust for dealing with bleeds.

Hopefully the minor reduction in bleed treating power will encourage players to engage more with the expansive and robust system we have for ghetto treatment of bleeds.  

While this doesn't address the multiple elephants in the room, it reduces the free item glut slightly. 

1. (cloning removal, organ damage, trek meds removal, sleeper removal, bruise pack removal, surgery expansion etc) 

## Changelog

:cl:
del: Del removed the emergency sutures.
balance: Emergency medkits now have a bandage instead of an emergency suture stack.
/:cl:

