### PR TITLE
Ninja stars rework

### DIFF
--- a/code/modules/antagonists/ninja/ninja_stars.dm
+++ b/code/modules/antagonists/ninja/ninja_stars.dm
@@ -1,18 +1,28 @@
-/**
- * # Ninja Throwing Star
- *
- * a throwing star which specifically makes sure you know it came from a real ninja.
- *
- * The most important item in the entire codebase, as without it we would all cease to exist.
- * Inherits everything that makes it interesting the stamina throwing star, but the most
- * important change made is that its name specifically has the prefix, 'ninja' in it.
- * This provides the detective role with information to play off of by ensuring that his
- * assumption that a space ninja is aboard the ship to be true when he find 20 of these in
- * the captain's back.  Along with this, its throwforce is 10 instead of the 5 of the stamina
- * throwing star, meaning it'll do a little more damage than the stamina throwing star does as well.
- * Changes to this item need to be approved by all maintainers, so if you do change it, make sure
- * you go through the proper channels, lest you get permabanned.  Do I make myself clear?
- */
 /obj/item/throwing_star/stamina/ninja
-	name = "ninja throwing star"
+	name = "energy throwing star"
 	throwforce = 10
+	var/datum/status_effect/energy_star/effect
+	embed_type = /datum/embedding/throwing_star/stamina/ninja
+
+/datum/embedding/throwing_star/stamina/ninja
+	var/effect
+
+/obj/item/throwing_star/stamina/ninja/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_UNCATCHABLE, TRAIT_GENERIC)
+
+/datum/status_effect/energy_star
+	id = "energystar_embed"
+	status_type = STATUS_EFFECT_MULTIPLE
+	tick_interval = 5 SECONDS
+
+/datum/status_effect/energy_star/tick(seconds_between_ticks)
+	owner.emp_act(EMP_HEAVY)
+
+/datum/embedding/throwing_star/stamina/ninja/on_successful_embed(mob/living/carbon/victim, obj/item/bodypart/target_limb)
+	effect = victim.apply_status_effect(/datum/status_effect/energy_star)
+
+/datum/embedding/throwing_star/stamina/ninja/stop_embedding()
+	if(effect)
+		QDEL_NULL(effect)
+


### PR DESCRIPTION
## About The Pull Request

This PR is going to rework ninja throwing stars and remake them into energy throwing stars. Now they will be uncatchable (just like energy bola) and will create EMP if embedded in someone's body.
![Eshurikeninhand](https://github.com/user-attachments/assets/fa26ae29-b9fb-4477-8bf2-b64a17e7f0b4)
![Eshuriken](https://github.com/user-attachments/assets/5e3fec82-5389-4f9c-9497-2d36e0b0dd6e)

Sprites by: Toriate

## Why It's Good For The Game

Current throwing stars are boring and unused, this PR makes whole module slot in ninja MODsuit actually useful.

## Changelog


:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
