### PR TITLE
Buffs sterilizing agents and makes them easier to understand.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -103,9 +103,9 @@
 
 	if(methods & (TOUCH|VAPOR|PATCH))
 		exposed_mob.adjust_fire_stacks(reac_volume / 15)
-		var/power_multiplier = boozepwr / 65 // Weak alcohol has less sterilizing power
+		var/sterilizing_power = boozepwr / 650 // Weak alcohol has less sterilizing power
 		for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
-			surgery.speed_modifier = max(0.1 * power_multiplier, surgery.speed_modifier)
+			surgery.speed_modifier = min(1 - sterilizing_power, surgery.speed_modifier)
 
 /datum/reagent/consumable/ethanol/beer
 	name = "Beer"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -835,7 +835,7 @@
 
 	var/mob/living/carbon/exposed_carbon = exposed_mob
 	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(0.6, surgery.speed_modifier)
+		surgery.speed_modifier = min(0.4, surgery.speed_modifier)
 
 /datum/reagent/consumable/mayonnaise
 	name = "Mayonnaise"

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -954,7 +954,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		return
 
 	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(0.3, surgery.speed_modifier)
+		surgery.speed_modifier = min(0.7, surgery.speed_modifier)
 
 /datum/reagent/inverse/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -369,7 +369,7 @@
 	if(methods & (PATCH|TOUCH))
 		var/mob/living/carbon/exposed_carbon = exposed_mob
 		for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-			surgery.speed_modifier = max(0.1, surgery.speed_modifier)
+			surgery.speed_modifier = min(0.9, surgery.speed_modifier)
 
 		if(show_message)
 			to_chat(exposed_carbon, span_danger("You feel your injuries fade away to nothing!") )
@@ -1225,7 +1225,7 @@
 		return
 
 	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(surgery.speed_modifier  - 0.1, -0.9)
+		surgery.speed_modifier = min(surgery.speed_modifier  +  0.1, 1.1)
 
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -33,7 +33,7 @@
 	var/requires_bodypart_type = BODYTYPE_ORGANIC
 
 	///The speed modifier given to the surgery through external means.
-	var/speed_modifier = 0
+	var/speed_modifier = 1
 	///Whether the surgery requires research to do. You need to add a design if using this!
 	var/requires_tech = FALSE
 	///typepath of a surgery that will, once researched, replace this surgery in the operating menu.

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -126,7 +126,10 @@
 	if(implement_type) //this means it isn't a require hand or any item step.
 		implement_speed_mod = implements[implement_type] / 100.0
 
-	speed_mod /= (get_location_modifier(target) * (1 + surgery.speed_modifier) * implement_speed_mod) * target.mob_surgery_speed_mod
+	//multiply speed_mod by sterilizer modifier
+	speed_mod *= surgery.speed_modifier
+
+	speed_mod /= (get_location_modifier(target) * implement_speed_mod) * target.mob_surgery_speed_mod
 	var/modded_time = time * speed_mod
 
 


### PR DESCRIPTION

## About The Pull Request

This PR changes how the speed boost from sterilizing agents is assigned and calculated.

from:

 surgery_time /= (1 + sterilizer_bonus) 

to

surgery_time *= sterilizer_bonus

All sterilizing agents agents have their sterilizer values changed to 1 -  "old value" 

## Why It's Good For The Game

There is a lot of confusion about how these reagents work. 

I've always been told sterilizine reduces surgery time by 20% and that honey reduces it by a whooping 60%.

Recently a new inverse krokodil reagent was added that designed to reduce surgery times by 30%.

Due to the way these modifiers were calculated none of these reagents actually offered these surgery do_after reductions, until now!

They are now calculated by simple multiplication like toolspeed and other common modifiers.

sterilizine 16.6% -> 20%
honey 37,5% -> 60%
permonid 23% -> 30%

I haven't been able to track down what the intended time savings were when all of these reagents were added, but for some of these the low effciency seems to be unintentional.

And I think it is nice to reward the doctors for putting in the work to get better gear, especially when it involved departmental cooperation like baccus and honey.

## Changelog

:cl:
balance: sterilizing reagents like sterilizine, honey and alcohols now improve surgery speed more. 
/:cl:

