### PR TITLE
Removes honey from the produce order console.

### DIFF
--- a/code/game/machinery/computer/orders/order_items/cook/order_reagents.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_reagents.dm
@@ -96,11 +96,6 @@
 	purchase_path = /obj/item/reagent_containers/condiment/grounding_solution
 	cost_per_order = 30
 
-/datum/orderable_item/reagents/honey
-	name = "Honey"
-	purchase_path = /obj/item/reagent_containers/condiment/honey
-	cost_per_order = 125 //its high quality honey :)
-
 /datum/orderable_item/reagents/mayonnaise
 	name = "Mayonnaise"
 	purchase_path = /obj/item/reagent_containers/condiment/mayonnaise


### PR DESCRIPTION
## About The Pull Request

This PR removes the ability to order honey using the chefs produce console.

## Why It's Good For The Game

Honey is supposed to be a premium reagent.

This is not only appropriate flavour, it is reinforced mechanically in several ways.

It has substantial gameplay impact by being the strongest sterilizer in the game and used in powerful chemistry reactions like royal jelly and beesplosion. 

It has its own submechanic; apiculture, dedicated to producing it.

It is also a possible option for the advanced chemical cargo bounties.

It should not be obtainable in a trivial and effortless manner because you managed to click on a machine.

Having it be orderable roundstart like this just serves to cheapen honey dishes and devalue bees.

### Update: Honey Buff PR open

I have opened a PR to make surgical sterilisers more powerful which honey would be the great benefactor from, it should complement this PR by helping to incentivise apiculture. 
 
https://github.com/tgstation/tgstation/pull/91861

## Changelog

:cl:
del: Honey is no longer orderable from the produce console.
/:cl:

