### PR TITLE
cleanable decals are mouse transparent (except for blood)

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -15,6 +15,8 @@
 	/// If TRUE, gains TRAIT_MOPABLE on init - thus this cleanable will cleaned if its turf is cleaned
 	/// Set to FALSE for things that hang high on the walls or things which generally shouldn't be mopped up
 	var/is_mopped = TRUE
+	// overriden on blood, so it can be clicked.
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/decal/cleanable/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -7,6 +7,7 @@
 	beauty = -100
 	clean_type = CLEAN_TYPE_BLOOD
 	color = BLOOD_COLOR_RED
+	mouse_opacity = MOUSE_OPACITY_ICON
 
 	/// Amount of blood, in units, in this decal
 	/// Spent when drying or making footprints


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
Every time an advanced fire extinguisher is used, it spawns a bunch of stabilised plasma cleanable decals which intercept your click on the turf, which stops you from placing pipes, crowbaring the tile, etc. .

This isn't the only decal that does this, in fact EVERY cleanable decal that spans the whole tile completely intercepts your click, so let's fix that.
## Changelog
:cl:
qol: you can now click a turf on which cleanable decals are placed on
/:cl:
