### PR TITLE
Doubles time between mail shipments and blocks mail on red / delta alert (the amount of mail is not changing don't worry)

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -65,6 +65,8 @@ SUBSYSTEM_DEF(economy)
 	/// Tracks a temporary sum of all money in the system
 	/// We need this on the subsystem because of yielding and such
 	var/temporary_total = 0
+	/// Determines how many ticks it takes to restock mail
+	var/ticks_per_mail = 2
 
 /datum/controller/subsystem/economy/Initialize()
 	//removes cargo from the split
@@ -90,7 +92,6 @@ SUBSYSTEM_DEF(economy)
 
 /datum/controller/subsystem/economy/fire(resumed = 0)
 	var/seconds_per_tick = wait / (5 MINUTES)
-
 	if(!resumed)
 		temporary_total = 0
 		processing_part = ECON_DEPARTMENT_STEP
@@ -116,8 +117,9 @@ SUBSYSTEM_DEF(economy)
 		if(!HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING) && !price_update())
 			return
 
-	var/effective_mailcount = round(living_player_count()/(inflation_value - 0.5)) //More mail at low inflation, and vis versa.
-	mail_waiting += clamp(effective_mailcount, 1, MAX_MAIL_PER_MINUTE * seconds_per_tick)
+	if(times_fired % ticks_per_mail == 0)
+		var/effective_mailcount = round(living_player_count() / (inflation_value - 0.5)) //More mail at low inflation, and vis versa.
+		mail_waiting += clamp(effective_mailcount, 1, ticks_per_mail * MAX_MAIL_PER_MINUTE * seconds_per_tick)
 
 	SSstock_market.news_string = ""
 

--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -35,6 +35,8 @@
 	var/lowering_to_configuration_key
 	/// Our configuration key for elevating to text, if set, will override the default elevating to announcement.
 	var/elevating_to_configuration_key
+	/// if TRUE, stops mail shipments from being sent during this security level
+	var/disables_mail = FALSE
 
 /datum/security_level/New()
 	. = ..()
@@ -92,7 +94,7 @@
 	lowering_to_configuration_key = /datum/config_entry/string/alert_red_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_red_upto
 	shuttle_call_time_mod = ALERT_COEFF_RED
-
+	disables_mail = TRUE
 /**
  * DELTA
  *
@@ -108,3 +110,4 @@
 	fire_alarm_light_color = LIGHT_COLOR_INTENSE_RED
 	elevating_to_configuration_key = /datum/config_entry/string/alert_delta
 	shuttle_call_time_mod = ALERT_COEFF_DELTA
+	disables_mail = TRUE

--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -306,7 +306,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 */
 /obj/docking_port/mobile/supply/proc/create_mail()
 	//Early return if there's no mail waiting to prevent taking up a slot. We also don't send mails on sundays or holidays.
-	if(!SSeconomy.mail_waiting || SSeconomy.mail_blocked)
+	if(!SSeconomy.mail_waiting || SSeconomy.mail_blocked || SSsecurity_level.current_security_level.disables_mail)
 		return
 
 	//spawn crate


### PR DESCRIPTION
## About The Pull Request

1. Mail is now shipped every 2 SSeconomy ticks, rather than every SSeconomy ticks. The amount of mail per round will not change.

2. Mail is not shipped during Red or Delta alert. Mail will still continue to pile up for if the station returns to blue alert.

## Why It's Good For The Game

1. The time between cargo shipments is like five minutes. This means you get mail practically every cargo shipment, if only a few pieces. I think it's a bit spammy, so doubling time between shipments means you actually get substantial shipments of mail and you don't have to pay attention to mail constantly.

2. In the event of an emergency and the cargo shuttle has to fly back and forth for emergency supplies (like guns for a blob), being blocked because of mail is annoying. It's also reasonable from an in character perspective that they would hold your mail until the emergency is resolved.

## Changelog

:cl: Melbert
qol: Mail is now shipped every 10 minutes rather than every 5 minutes. The amount of mail remains unchanged (so you get 1 crate with 6 mail instead of 2 crates with 3 mail each).
qol: Mail is no longer shipped while the station is on red alert - mail held will be sent if the station returns to blue alert.
/:cl: