### PR TITLE
Inexorable no longer provides softcrit immunity in hardcrit

### DIFF
--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -320,3 +320,4 @@
 
 /// Permanent trait from an overdose effect
 #define OVERDOSE_TRAIT "overdose"
+#define MEMENTO_MORI_TRAIT "memento_mori"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -675,7 +675,7 @@
 	text_lose_indication = span_notice("You suddenly feel more human.")
 	difficulty = 24
 	synchronizer_coeff = 1
-	mutation_traits = list(TRAIT_NOSOFTCRIT, TRAIT_ANALGESIA)
+	mutation_traits = list(TRAIT_ANALGESIA)
 
 /datum/mutation/inexorable/on_acquiring(mob/living/carbon/human/acquirer)
 	. = ..()
@@ -697,6 +697,14 @@
 		REMOVE_TRAIT(owner, TRAIT_SOFTSPOKEN, REF(src))
 	else
 		ADD_TRAIT(owner, TRAIT_SOFTSPOKEN, REF(src))
+	if(owner.health <= owner.hardcrit_threshold)
+		if(HAS_TRAIT(owner, TRAIT_NOSOFTCRIT))
+			REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, REF(src))
+			owner.update_stat()
+	else
+		if(!HAS_TRAIT(owner, TRAIT_NOSOFTCRIT))
+			ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, REF(src))
+			owner.update_stat()
 
 /datum/mutation/inexorable/on_life(seconds_per_tick, times_fired)
 	if(owner.health > owner.crit_threshold || owner.stat != CONSCIOUS || HAS_TRAIT(owner, TRAIT_STASIS))

--- a/code/modules/mining/lavaland/mining_loot/clothing.dm
+++ b/code/modules/mining/lavaland/mining_loot/clothing.dm
@@ -38,7 +38,7 @@
 /obj/item/clothing/neck/necklace/memento_mori/proc/mori()
 	icon_state = "memento_mori"
 	if (!active_owner)
-		returnssss
+		return
 	UnregisterSignal(active_owner, COMSIG_LIVING_HEALTH_UPDATE)
 	var/mob/living/carbon/human/stored_owner = active_owner //to avoid infinite looping when dust unequips the pendant
 	active_owner = null
@@ -48,8 +48,6 @@
 /obj/item/clothing/neck/necklace/memento_mori/proc/check_health(mob/living/source)
 	SIGNAL_HANDLER
 
-	if(HAS_TRAIT_NOT_FROM(source, TRAIT_NOSOFTCRIT, MEMENTO_MORI_TRAIT))
-		REMOVE_TRAIT_NOT_FROM(source, TRAIT_NOSOFTCRIT, MEMENTO_MORI_TRAIT)
 	var/list/guardians = source.get_all_linked_holoparasites()
 	if (!length(guardians))
 		return

--- a/code/modules/mining/lavaland/mining_loot/clothing.dm
+++ b/code/modules/mining/lavaland/mining_loot/clothing.dm
@@ -26,18 +26,19 @@
 /obj/item/clothing/neck/necklace/memento_mori/proc/memento(mob/living/carbon/human/user)
 	to_chat(user, span_warning("You feel your life being drained by the pendant..."))
 	if (!do_after(user, 4 SECONDS, target = user))
-		return
+		return FALSE
 
 	to_chat(user, span_notice("Your lifeforce is now linked to the pendant! You feel like removing it would kill you, and yet you instinctively know that until then, you won't die."))
-	user.add_traits(list(TRAIT_NODEATH, TRAIT_NOHARDCRIT, TRAIT_NOCRITDAMAGE), CLOTHING_TRAIT)
+	user.add_traits(list(TRAIT_NODEATH, TRAIT_NOHARDCRIT, TRAIT_NOCRITDAMAGE), MEMENTO_MORI_TRAIT)
 	RegisterSignal(user, COMSIG_LIVING_HEALTH_UPDATE, PROC_REF(check_health))
 	icon_state = "memento_mori_active"
 	active_owner = user
+	return TRUE
 
 /obj/item/clothing/neck/necklace/memento_mori/proc/mori()
 	icon_state = "memento_mori"
 	if (!active_owner)
-		return
+		returnssss
 	UnregisterSignal(active_owner, COMSIG_LIVING_HEALTH_UPDATE)
 	var/mob/living/carbon/human/stored_owner = active_owner //to avoid infinite looping when dust unequips the pendant
 	active_owner = null
@@ -47,6 +48,8 @@
 /obj/item/clothing/neck/necklace/memento_mori/proc/check_health(mob/living/source)
 	SIGNAL_HANDLER
 
+	if(HAS_TRAIT_NOT_FROM(source, TRAIT_NOSOFTCRIT, MEMENTO_MORI_TRAIT))
+		REMOVE_TRAIT_NOT_FROM(source, TRAIT_NOSOFTCRIT, MEMENTO_MORI_TRAIT)
 	var/list/guardians = source.get_all_linked_holoparasites()
 	if (!length(guardians))
 		return
@@ -83,7 +86,8 @@
 	var/obj/item/clothing/neck/necklace/memento_mori/memento = target
 	if(memento.active_owner || !ishuman(owner))
 		return FALSE
-	memento.memento(owner)
+	if(!memento.memento(owner))
+		return FALSE
 	Remove(memento.active_owner) //Remove the action button, since there's no real use in having it now.
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
i didn't wanna fix this but i was asked to. Inexorable removes softcrit if in deepcrit. Also fixes a runtime if you cancel the do_after
## Why It's Good For The Game
Inexorable provides softcrit immunity, but memento mori provides hardcrit and death resistance, these combo extremely well letting you walk around at your damage cap with no problems
## Changelog
:cl:
balance: Inexorable now removes softcrit immunity in hardcrit
fix: runtime with the memento mori action's do_after
/:cl:
