### PR TITLE
Fix `map_export` including projectiles in saved maps

### DIFF
--- a/code/modules/admin/verbs/map_export.dm
+++ b/code/modules/admin/verbs/map_export.dm
@@ -1,9 +1,3 @@
-/// Blacklist of mapping objects we don't want saved
-GLOBAL_LIST_INIT(map_export_blacklist, typecacheof(list(
-	/obj/effect,
-	/obj/projectile,
-)))
-
 ADMIN_VERB(map_export, R_DEBUG, "Map Export", "Select a part of the map by coordinates and download it.", ADMIN_CATEGORY_DEBUG)
 	var/user_x = user.mob.x
 	var/user_y = user.mob.y
@@ -208,20 +202,20 @@ GLOBAL_LIST_INIT(save_file_chars, list(
 	maxz,
 	save_flag = ALL,
 	shuttle_area_flag = SAVE_SHUTTLEAREA_DONTCARE,
-	list/obj_blacklist = GLOB.map_export_blacklist,
+	list/obj_blacklist,
 )
 	var/width = maxx - minx
 	var/height = maxy - miny
 	var/depth = maxz - minz
 
-	if(!islist(obj_blacklist))
+	if(obj_blacklist && !islist(obj_blacklist))
 		CRASH("Non-list being used as object blacklist for map writing")
 
-	// we want to keep crayon writings, blood splatters, cobwebs, etc.
-	obj_blacklist -= typecacheof(/obj/effect/decal)
-	obj_blacklist -= typecacheof(/obj/effect/turf_decal)
-	obj_blacklist -= typecacheof(/obj/effect/landmark) // most landmarks get deleted except for latejoin arrivals shuttle
-
+	// we want to keep decals from crayon writings, blood splatters, cobwebs, etc.
+	// most landmarks get deleted except for latejoin arrivals shuttle
+	var/static/list/default_blacklist = typecacheof(list(/obj/effect, /obj/projectile)) - typecacheof(list(/obj/effect/decal, /obj/effect/turf_decal, /obj/effect/landmark))
+	if(!obj_blacklist)
+		obj_blacklist = default_blacklist
 
 	//Step 0: Calculate the amount of letters we need (26 ^ n > turf count)
 	var/turfs_needed = width * height

--- a/code/modules/admin/verbs/map_export.dm
+++ b/code/modules/admin/verbs/map_export.dm
@@ -1,3 +1,9 @@
+/// Blacklist of mapping objects we don't want saved
+GLOBAL_LIST_INIT(map_export_blacklist, typecacheof(list(
+	/obj/effect,
+	/obj/projectile,
+)))
+
 ADMIN_VERB(map_export, R_DEBUG, "Map Export", "Select a part of the map by coordinates and download it.", ADMIN_CATEGORY_DEBUG)
 	var/user_x = user.mob.x
 	var/user_y = user.mob.y
@@ -202,7 +208,7 @@ GLOBAL_LIST_INIT(save_file_chars, list(
 	maxz,
 	save_flag = ALL,
 	shuttle_area_flag = SAVE_SHUTTLEAREA_DONTCARE,
-	list/obj_blacklist = typecacheof(/obj/effect),
+	list/obj_blacklist = GLOB.map_export_blacklist,
 )
 	var/width = maxx - minx
 	var/height = maxy - miny
@@ -215,6 +221,7 @@ GLOBAL_LIST_INIT(save_file_chars, list(
 	obj_blacklist -= typecacheof(/obj/effect/decal)
 	obj_blacklist -= typecacheof(/obj/effect/turf_decal)
 	obj_blacklist -= typecacheof(/obj/effect/landmark) // most landmarks get deleted except for latejoin arrivals shuttle
+
 
 	//Step 0: Calculate the amount of letters we need (26 ^ n > turf count)
 	var/turfs_needed = width * height


### PR DESCRIPTION

## About The Pull Request
The map export verb was including fired projectiles from guns/lasers/magic/etc. if a map was saved at the exact time the projectile was on the screen. This is bad because when the map is loaded, the projectile is just stationary and doesn't disappear.

## Why It's Good For The Game
Mapping consistency.

## Changelog
:cl:
fix: Fix map export including projectiles in saved maps
/:cl:
