### PR TITLE
Now you don't need to have 1 unit of water on the mop to use it with other reagents

### DIFF
--- a/code/__DEFINES/cleaning.dm
+++ b/code/__DEFINES/cleaning.dm
@@ -12,6 +12,9 @@
 /// Return to stop cleaner component from blocking interaction chain further
 /// Only does anything if [CLEAN_BLOCKED] is also returned
 #define CLEAN_DONT_BLOCK_INTERACTION (1<<3)
+/// Return to do cleaning without actually cleaning anything
+/// Only does anything if [CLEAN_ALLOWED] is also returned
+#define CLEAN_NO_CLEANER_REAGENTS (1<<4)
 
 // Different kinds of things that can be cleaned.
 // Use these when overriding the wash proc or registering for the clean signals to check if your thing should be cleaned

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -89,6 +89,10 @@
  * * clean_target set this to false if the target should not be washed and if experience should not be awarded to the user
  */
 /datum/component/cleaner/proc/clean(datum/source, atom/target, mob/living/user, clean_target = TRUE)
+	//mops don't clean anything unless they're dipped in cleaning reagents
+	var/callback_return = pre_clean_callback.Invoke(source, target, user)
+	if(callback_return & CLEAN_NO_CLEANER_REAGENTS)
+		clean_target = FALSE
 	//make sure we don't attempt to clean something while it's already being cleaned
 	if(HAS_TRAIT(target, TRAIT_CURRENTLY_CLEANING) || (SEND_SIGNAL(target, COMSIG_ATOM_PRE_CLEAN, user) & COMSIG_ATOM_CANCEL_CLEAN))
 		return

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -52,6 +52,8 @@
 		return CLEAN_BLOCKED
 	if(reagents.has_reagent(amount = 1, chemical_flags = REAGENT_CLEANS))
 		return CLEAN_ALLOWED
+	else
+		return CLEAN_ALLOWED|CLEAN_NO_XP
 	return CLEAN_BLOCKED|CLEAN_NO_XP
 
 /**

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -52,7 +52,7 @@
 		return CLEAN_BLOCKED
 	if(reagents.has_reagent(amount = 1, chemical_flags = REAGENT_CLEANS))
 		return CLEAN_ALLOWED
-	return CLEAN_ALLOWED|CLEAN_NO_XP
+	return CLEAN_ALLOWED|CLEAN_NO_XP|CLEAN_NO_CLEANER_REAGENTS
 
 /**
  * Applies reagents to the cleaned floor and removes them from the mop.

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -52,9 +52,7 @@
 		return CLEAN_BLOCKED
 	if(reagents.has_reagent(amount = 1, chemical_flags = REAGENT_CLEANS))
 		return CLEAN_ALLOWED
-	else
-		return CLEAN_ALLOWED|CLEAN_NO_XP
-	return CLEAN_BLOCKED|CLEAN_NO_XP
+	return CLEAN_ALLOWED|CLEAN_NO_XP
 
 /**
  * Applies reagents to the cleaned floor and removes them from the mop.


### PR DESCRIPTION

Now you don't need to have at least 1 unit of water or other cleaning reagent on the mop to use it with other reagents
## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/91539
## Changelog
:cl:
fix: mops don't need to have 1 unit of water to be used with other reagents
/:cl:
