### PR TITLE
Renames jackboots to boots

### DIFF
--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -66,7 +66,7 @@
 	slowdown = -1
 
 /obj/item/clothing/shoes/jackboots/sec
-	name = "security boots"
+	name = "security jackboots"
 	desc = "Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "jackboots_sec"
 

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -42,8 +42,8 @@
 	acid = 50
 
 /obj/item/clothing/shoes/jackboots
-	name = "jackboots"
-	desc = "Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time."
+	name = "boots"
+	desc = "Nanotrasen-issue boots for costumed scenarios or dress-up situations. All fashion, all the time."
 	icon_state = "jackboots"
 	inhand_icon_state = "jackboots"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_MASK
@@ -66,10 +66,12 @@
 	slowdown = -1
 
 /obj/item/clothing/shoes/jackboots/sec
+	name = "security boots"
+	desc = "Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "jackboots_sec"
 
 /obj/item/clothing/shoes/jackboots/floortile
-	name = "floortile camouflage jackboots"
+	name = "floortile camouflage boots"
 	desc = "Is it just me or is there a pair of jackboots on the floor?"
 	icon_state = "ftc_boots"
 	inhand_icon_state = null


### PR DESCRIPTION
## About The Pull Request

Renames jackboots to boots
Fixes the non-security boots saying they're security gear in the description when they're in the autodrobe/clothesmate.

## Why It's Good For The Game

Fixes a bug with the non-security boots being labelled as security boots in the description.

## Changelog

:cl:
spellcheck: Renames jackboots to boots
fix: Fixes the non-security boots saying they're security gear in the description when they're in the autodrobe/clothesmate.
/:cl: