### PR TITLE
fixes examine message for canister shot

### DIFF
--- a/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
+++ b/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
@@ -185,3 +185,4 @@
 	obj_flags = CONDUCTS_ELECTRICITY
 	throwforce = 0
 	w_class = WEIGHT_CLASS_BULKY
+	projectile_type = /obj/projectile/bullet/shrapnel

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -52,7 +52,7 @@
 
 ///Helper for cyborgs unequipping things.
 /mob/living/silicon/robot/proc/deactivate_module(obj/item/item_module)
-	transferItemToLoc(item_module, newloc = model)
+	return transferItemToLoc(item_module, newloc = model)
 
 /mob/living/silicon/robot/doUnEquip(obj/item/item_dropping, force, atom/newloc, no_move, invdrop, silent)
 	//borgs can drop items that aren't part of the module (used for apparatus modules, the stored item isn't a module).

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -52,7 +52,7 @@
 
 ///Helper for cyborgs unequipping things.
 /mob/living/silicon/robot/proc/deactivate_module(obj/item/item_module)
-	return transferItemToLoc(item_module, newloc = model)
+	transferItemToLoc(item_module, newloc = model)
 
 /mob/living/silicon/robot/doUnEquip(obj/item/item_dropping, force, atom/newloc, no_move, invdrop, silent)
 	//borgs can drop items that aren't part of the module (used for apparatus modules, the stored item isn't a module).


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/91805

the guns are hardcoded to fire projectiles and the projectiles are not inherited from the ammo type that's put in, which is a bit annoying but the mentioned bug is fixed.
## Changelog
:cl:
fix: canister shots are no longer always "spent"
/:cl:
