### PR TITLE
Kiss skillchip added to Chipped quirk as an option

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -121,4 +121,5 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 	"\"Space Station 13: The Musical\"" = /obj/item/skillchip/musical,
 	"Mast-Angl-Er" = /obj/item/skillchip/master_angler,
 	"Kommand" = /obj/item/skillchip/big_pointer,
+	"K1SS" = /obj/item/skillchip/chefs_kiss,
 ))


### PR DESCRIPTION
## About The Pull Request

Very simple PR, adds the K1SS skillchip to the options for the chipped quirk

## Why It's Good For The Game

Lets chefs or other players express that they are quite good at cooking at round start. Now that random scientist or engineer who doesn't formally work as a chef could actually demonstrate that they actually are a pretty darn good cook by taking this quirk.

## Changelog

:cl:
add: Can now select the K1SS skillchip for the Chipped quirk.
/:cl: