### PR TITLE
Better Savefile Versioning (Define Macros Edition)

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -6,9 +6,6 @@
 /// The save data is below the accepted minimum and should be reset.
 #define SAVE_DATA_OBSOLETE -2
 
-#define IS_DATA_OBSOLETE(version) (version == SAVE_DATA_OBSOLETE)
-#define SHOULD_UPDATE_DATA(version) (version >= SAVE_DATA_NO_ERROR && version < SAVEFILE_VERSION_MAX)
-
 /// This is the lowest supported version, anything below this is completely obsolete and the entire savefile will be wiped.
 #define SAVEFILE_VERSION_MIN 32
 
@@ -17,6 +14,9 @@
 /// Only raise this value when changing the meaning/format/name/layout of an existing value
 /// where you would want the updater procs below to run
 #define SAVEFILE_VERSION_MAX 49
+
+#define IS_DATA_OBSOLETE(version) (version == SAVE_DATA_OBSOLETE)
+#define SHOULD_UPDATE_DATA(version) (version >= SAVE_DATA_NO_ERROR && version < SAVEFILE_VERSION_MAX)
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -12,19 +12,11 @@
 /// This is the lowest supported version, anything below this is completely obsolete and the entire savefile will be wiped.
 #define SAVEFILE_VERSION_MIN 32
 
-<<<<<<< Updated upstream
-//This is the current version, anything below this will attempt to update (if it's not obsolete)
-// You do not need to raise this if you are adding new values that have sane defaults.
-// Only raise this value when changing the meaning/format/name/layout of an existing value
-// where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 49
-=======
 /// This is the current version, anything below this will attempt to update (if it's not obsolete)
 /// You do not need to raise this if you are adding new values that have sane defaults.
 /// Only raise this value when changing the meaning/format/name/layout of an existing value
 /// where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 48
->>>>>>> Stashed changes
+#define SAVEFILE_VERSION_MAX 49
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn


### PR DESCRIPTION

## About The Pull Request

Savefile versioning is quite robust, but it relied a lot on comments to explain why exactly it worked (such as needing to explain that error/empty states were negative integers only because any valid savefile version would be a positive integer). Anyways, let's spell it out a lot more using `#define` values and dmdoccing said values in order to make the whole system a bit more cohesive.

This also corrects an issue that has irked me for a while, which is that we call and go through `update_preferences()` or `update_character()` _every single time_. `SAVEFILE_VERSION_MAX` is essentially just a placeholder, it's not checked against anything! Let's use that in one of the new macros we created so we can slim down on the proc call overhead (as well as whole branches of code) that we iterate through every single time we load a savefile. Like we were generating a backup json every single run without fail, let's trim that out when it's not necessary.
## Why It's Good For The Game

More clear for people operating on this code in the future as well as does a lot less work. Win win.
## Changelog
Tested it and it migrated my savefile from 48 -> 49 without any ill effect. Let me know if we want to have the redundancy behavior baked in where we call these procs/enter code branches every single time though- I would rather just bake the code in that way rather than live in a world of confusion on why it operates that way.

:cl:
server: Savefile migration has been tweaked a bit, though there realistically shouldn't be any issues with this. Keep a wary eye out though.
/:cl:
