### PR TITLE
[no gbp] Fixes build cache issue

### DIFF
--- a/tools/bootstrap/javascript_.ps1
+++ b/tools/bootstrap/javascript_.ps1
@@ -37,6 +37,11 @@ function Get-Bun {
         $BunTag = " (baseline)"
     }
 
+    if (Test-Path $BunTargetDir -PathType Container) {
+        Write-Output "Bun target directory exists but bun.exe is missing. Re-downloading."
+        Remove-Item $BunTargetDir -Recurse -Force
+    }
+
     $BunSource = "https://github.com/oven-sh/bun/releases/download/bun-v$BunVersion/$BunRelease.zip"
 
     Write-Output "Downloading Bun v$BunVersion$BunTag"


### PR DESCRIPTION

## About The Pull Request
If the bootstrap tool did not properly download bun for whatever reason, it would error on subsequent downloads because the directory already existsed
## Why It's Good For The Game
Bug fix reported a couple times in discord
## Changelog
