### PR TITLE
Remove dos2unix install from compile changelogs CI

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
-          sudo apt-get install  dos2unix
 
       - name: "Checkout"
         if: steps.value_holder.outputs.ACTIONS_ENABLED


### PR DESCRIPTION

## About The Pull Request

Remove `sudo apt-get install dos2unix` from compile changelogs workflow

## Why It's Good For The Game

The step using it was deleted in https://github.com/tgstation/tgstation/commit/e378552368c538c47d8718d9e230e7ae7d663f04 but the dependency install step remains

## Changelog

No
