### PR TITLE
painting fixes

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -233,6 +233,10 @@
 			show_grid = !show_grid
 		if("finalize")
 			. = TRUE
+			if(isobserver(user)) // Ghosts cant finalize
+				return FALSE
+			if(istype(user, /mob/living/silicon) && !Adjacent(user, src)) // Silicons cant finalize unless adjacent
+				return FALSE
 			finalize(user)
 		if("patronage")
 			. = TRUE


### PR DESCRIPTION

## About The Pull Request

mirrors https://github.com/Bubberstation/Bubberstation/pull/4136

ghosts can no longer finalize paintings.
silicons now must be adjacent to a painting to finalize it.

## Why It's Good For The Game

bug fix

## Changelog

:cl:
fix: ghosts can no longer finalize paintings.
fix: silicons now must be adjacent to a painting to finalize it.
/:cl:

