### PR TITLE
[NO GBP] Fix: Support for a light theme for standard radio channels

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -320,9 +320,11 @@
 						if(num2text(channel["freq"]) != freq && channel["name"] == new_name)
 							return
 				info["name"] = new_name
-				var/new_color = input(usr, "Choose color for frequency", "Modifying Frequency Information", info["color"]) as color|null
-				if(new_color)
-					info["color"] = new_color
+				// No color changing for channels with theme settings
+				if(!GLOB.freqtospan["[freq]"])
+					var/new_color = input(usr, "Choose color for frequency", "Modifying Frequency Information", info["color"]) as color|null
+					if(new_color)
+						info["color"] = new_color
 				frequency_infos[params["freq"]] = info
 				. = TRUE
 		if("add_freq_info")

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -4,6 +4,7 @@ This file has the basic atom/movable level speech procs.
 And the base of the send_speech() proc, which is the core of saycode.
 */
 GLOBAL_LIST_INIT(freqtospan, list(
+	"[FREQ_COMMON]" = "radio",
 	"[FREQ_SCIENCE]" = "sciradio",
 	"[FREQ_MEDICAL]" = "medradio",
 	"[FREQ_ENGINEERING]" = "engradio",
@@ -296,6 +297,12 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 /proc/get_radio_color(freq, freq_color)
 	if(freq)
+		// No custom colors for channels with theme settings
+		if(GLOB.freqtospan["[freq]"])
+			return ""
+		// No color overrides for commonn channel color (for freqs like 145.3)
+		if(freq_color == RADIO_COLOR_COMMON)
+			return ""
 		if(freq_color)
 			return freq_color
 		var/color = GLOB.reserved_radio_colors[get_radio_name(freq, null)]

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -334,6 +334,43 @@ em {
 
 /* RADIO COLORS */
 /* IF YOU CHANGE THIS KEEP IT IN SYNC WITH TGUI CONSTANTS */
+
+.radio {
+  color: hsl(132.8, 74.4%, 45.9%);
+}
+
+.sciradio {
+  color: hsl(271.6, 91.7%, 76.5%);
+}
+
+.comradio {
+  color: hsl(53, 97.6%, 50%);
+}
+
+.secradio {
+  color: hsl(0, 71.2%, 53.7%);
+}
+
+.medradio {
+  color: hsl(202, 83.6%, 64.1%);
+}
+
+.engradio {
+  color: hsl(17, 87.8%, 61.4%);
+}
+
+.suppradio {
+  color: hsl(33.7, 44.9%, 49.8%);
+}
+
+.servradio {
+  color: hsl(88.1, 60.6%, 40.8%);
+}
+
+.enteradio {
+  color: hsl(157.1, 39.6%, 62.4%);
+}
+
 .syndradio {
   color: hsl(359.1, 31.8%, 42.5%);
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -342,6 +342,42 @@ em {
   color: hsl(120, 100%, 76.7%);
 }
 
+.radio {
+  color: hsl(120, 100%, 25.1%);
+}
+
+.sciradio {
+  color: hsl(300, 50%, 40%);
+}
+
+.comradio {
+  color: hsl(57.9, 97.3%, 29.4%);
+}
+
+.secradio {
+  color: hsl(0, 100%, 32%);
+}
+
+.medradio {
+  color: hsl(201.8, 49.3%, 39.4%);
+}
+
+.engradio {
+  color: hsl(17.3, 96.7%, 52.9%);
+}
+
+.suppradio {
+  color: hsl(34.6, 59.2%, 41.4%);
+}
+
+.servradio {
+  color: hsl(88.6, 58.9%, 42%);
+}
+
+.enteradio {
+  color: hsl(176.1, 20%, 45.1%);
+}
+
 .syndradio {
   color: hsl(358.7, 26.7%, 33.7%);
 }


### PR DESCRIPTION

## About The Pull Request

Fix of https://github.com/tgstation/tgstation/issues/91881
What has changed? Now you can't set custom colors for channels that have color settings in the chat based on the theme (freqspans), but the color will be displayed correctly in different themes

It is still possible to change the channel name for all types (custom and standard). It is also possible to change the color of your channels (without support for the light theme)

I hope this will be a temporary solution, as I would like to return full customization of channels based on the user's chosen theme.

## Why It's Good For The Game

Fans of the light theme will be pleased.

## Changelog

:cl: FeudeyTF
fix: added light theme support for standard radio channels
/:cl: