### PR TITLE
Fixes CatwalkStation armory not having energy guns

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -18026,7 +18026,14 @@
 "ftU" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/small/directional/west,
-/obj/structure/guncase/ecase,
+/obj/structure/guncase/ecase{
+	open = 0;
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "fua" = (


### PR DESCRIPTION

## About The Pull Request

Actually adds eguns to the gunlocker in armory, because I thought that it was a preset and not container-like in mapping.

## Why It's Good For The Game

In making of #91922, I noticed that the gunlocker in the armory didnt have any eguns in it, and since I was the one who made that change, I'll be the one to fix it before it inconveniences anyone.

## Changelog

:cl:

fix: Fixes CatwalkStation's armory not having eguns in the gunlocker.

/:cl:


