### PR TITLE
change an `istype` terenary to an `astype`

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1359,7 +1359,7 @@
 		if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 			to_chat(src, span_warning("You hands are blocked for this action!"))
 			return FALSE
-		if(!can_hold_items(isitem(target) ? target : null)) // almost redundant if it weren't for mobs
+		if(!can_hold_items(astype(target, /obj/item))) // almost redundant if it weren't for mobs
 			to_chat(src, span_warning("You don't have the hands for this action!"))
 			return FALSE
 


### PR DESCRIPTION
## About The Pull Request

someone posted this snippet in discord and my code-rotted brain immediately blurted out this potential improvement, so i thought i'd pr it while why not

basically, `istype(x, y) ? x : null` is the same thing as `astype(x, y)` now, but it's a single builtin

i am **incredibly** bored, alright???

<details>
<summary><h3>low-level comparison if literally anyone cares</h3></summary>

`return istype(thing, /mob/cat) ? thing : null`
```
0000: 00000033 0000FFD9 00000000  GetVar arg(0)
0003: 00000060 00000008 00000000  PushVal /mob/cat
0006: 0000007D                    IsType
0007: 0000000D                    Test
0008: 00000011 0000000F           Jz LAB_000F
000A: 00000033 0000FFD9 00000000  GetVar arg(0)
000D: 0000000F 00000011           Jmp LAB_0011
LAB_000F:
000F: 00000033 0000FFE6           GetVar null
LAB_0011:
0011: 00000012                    Ret
0012: 00000000                    End
```

`return astype(thing, /mob/cat)`
```
0000: 00000033 0000FFD9 00000000  GetVar arg(0)
0003: 00000060 00000008 00000000  PushVal /mob/cat
0006: 00000185                    AsType
0007: 00000012                    Ret
0008: 00000000                    End
```

</details>

## Why It's Good For The Game

idk, microscopically better performance but even i can recognize it certainly doesn't matter (also doesn't hurt tho)

## Changelog

no player-facing changes
