### PR TITLE
Balance changes to the Wizard MOD and energy shields.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -147,12 +147,7 @@
 	if(!user.dropItemToGround(user.wear_suit) || !user.dropItemToGround(user.head))
 		return
 	mod.quick_activation()
-
-/datum/spellbook_entry/item/battlemage_charge
-	name = "Battlemage Armour Charges"
-	desc = "A powerful defensive rune, it will grant eight additional charges to a battlemage shield."
-	item_path = /obj/item/wizard_armour_charge
-	category = SPELLBOOK_CATEGORY_DEFENSIVE
-	cost = 1
+	var/obj/item/mod/module/eradication_lock/lock_module = locate() in mod.modules
+	lock_module.used()
 
 #undef SPELLBOOK_CATEGORY_DEFENSIVE

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -299,11 +299,3 @@
 	stickman.faction |= summoner.faction - FACTION_NEUTRAL //These bad boys shouldn't inherit the neutral faction from the crew
 
 	COOLDOWN_START(src, summoning_cooldown, 3 SECONDS)
-
-
-// The actual code for this is handled in the shielded component, see [/datum/component/shielded/proc/check_recharge_rune]
-/obj/item/wizard_armour_charge
-	name = "battlemage shield charges"
-	desc = "A powerful rune that will increase the number of hits a suit of battlemage armour can take before failing.."
-	icon = 'icons/effects/anomalies.dmi'
-	icon_state = "flux"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1494,8 +1494,8 @@
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	slowdown_deployed = 0.25
+	complexity_max = DEFAULT_MAX_COMPLEXITY
+	slowdown_deployed = 0
 	ui_theme = "wizard"
 	inbuilt_modules = list(/obj/item/mod/module/anti_magic/wizard)
 	allowed_suit_storage = list(

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -396,6 +396,9 @@
 		/obj/item/mod/module/energy_shield/wizard,
 		/obj/item/mod/module/emp_shield/advanced,
 		/obj/item/mod/module/quick_cuff,
+		/obj/item/mod/module/noslip,
+		/obj/item/mod/module/rad_protection,
+		/obj/item/mod/module/eradication_lock,
 	)
 
 /obj/item/mod/control/pre_equipped/ninja

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -397,6 +397,7 @@
 		/obj/item/mod/module/emp_shield/advanced,
 		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/noslip,
+		/obj/item/mod/module/welding,
 		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/eradication_lock,
 	)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -140,8 +140,6 @@
 	var/charge_recovery = 1
 	/// Whether or not this shield can lose multiple charges.
 	var/lose_multiple_charges = FALSE
-	/// The item path to recharge this shielkd.
-	var/recharge_path = null
 	/// The icon file of the shield.
 	var/shield_icon_file = 'icons/effects/effects.dmi'
 	/// The icon_state of the shield.
@@ -154,8 +152,16 @@
 	charges = max_charges
 
 /obj/item/mod/module/energy_shield/on_part_activation()
-	mod.AddComponent(/datum/component/shielded, max_charges = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
-	charge_recovery = charge_recovery, lose_multiple_charges = lose_multiple_charges, recharge_path = recharge_path, starting_charges = charges, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
+	mod.AddComponent(\
+		/datum/component/shielded, \
+		max_charges = max_charges, \
+		recharge_start_delay = recharge_start_delay, \
+		charge_increment_delay = charge_increment_delay, \
+		charge_recovery = charge_recovery, \
+		lose_multiple_charges = lose_multiple_charges, \
+		starting_charges = charges, \
+		shield_icon_file = shield_icon_file, \
+		shield_icon = shield_icon)
 	RegisterSignal(mod.wearer, COMSIG_LIVING_CHECK_BLOCK, PROC_REF(shield_reaction))
 
 /obj/item/mod/module/energy_shield/on_part_deactivation(deleting = FALSE)
@@ -188,12 +194,9 @@
 	icon_state = "battlemage_shield"
 	idle_power_cost = 0 //magic
 	use_energy_cost = 0 //magic too
-	max_charges = 15
-	recharge_start_delay = 0 SECONDS
-	charge_recovery = 8
+	max_charges = 5
 	shield_icon_file = 'icons/effects/magic.dmi'
 	shield_icon = "mageshield"
-	recharge_path = /obj/item/wizard_armour_charge
 	required_slots = list()
 
 ///Magic Nullifier - Protects you from magic.


### PR DESCRIPTION
## About The Pull Request

Wizard MOD is now bio,flash proof, and comes with the no slips module , and the Hilbert DNA lock module installed.

Energy shield charges on the battle shield module have been reduced from 15 to 5 but now regenerate over time.

energy shield charges are now only consumed if at least 3 damage is dealt to the bubble.


## Why It's Good For The Game

atomization of this PR: https://github.com/tgstation/tgstation/pull/91702 so I'm just gonna copypaste the same reasoning.

**Wiz Modsuit changes**

Despite being the Mod given to arguably the highest possible threat a station should face, this thing is insanely underwhelming.

It doesn't come packaged with even some basic immunities we would grant to our common antagonists, the charges are limited and once they expire this suit has nothing to offer besides basic space protection and some decent armor.

The suit has been rebalanced to offer a wide array of protections and have the Shield charges regenerate overtime to a maximum of 5, and it no longer has any slowdown.

You might also want to reconsider using this as crew....

"That's a lot of stuff Jake, won't this make the suit overpowered?"

You can bet your spessman arse it will, Wizard is not supposed to be a balanced antagonist in any way shape or form, but an absolute force of chaos.

 Given how everything else in the game has been powercept over the Years, we left this poor dude behind, it's time to address that.

**Energy Shield MOD changes**

I don't think the Shield should expire if no damage (or a pitiful amount of) hits the bubble, these have already been nerfed to only have 1 charge, it shouldn't require so little firepower (or none of) to destroy.

## Changelog

:cl:
balance: Wiz suit is now bio,flash proof, comes with the no slip and Hilbert dna module installed, slowdown was removed.
balance: Energy shield charges on the battlemage module have been reduced to 5 but now regenerate over time.
balance: energy shield charges now require a minimum of 3 total damage to be consumed.
removal: you can no longer buy additional shield charges for the suit using the spellbook.
/:cl:

