### PR TITLE
progress bars are no longer part of your hitbox

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -46,6 +46,7 @@
 	bar = image('icons/effects/progressbar.dmi', bar_loc, "prog_bar_0", pixel_x = offset_x)
 	SET_PLANE_EXPLICIT(bar, ABOVE_HUD_PLANE, User)
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	bar.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	user = User
 
 	LAZYADDASSOCLIST(user.progressbars, bar_loc, src)


### PR DESCRIPTION

## About The Pull Request
gave mouse transparency to the do_after progress bar
## Why It's Good For The Game
it's pretty annoying to hit yourself when it can't be reasonably expected that a progress bar is part of your hitbox
## Changelog
:cl:
qol: progress bars are no longer part of your hitbox
/:cl:
