### PR TITLE
Fix crude shuttle blueprints being uncraftable

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -104,7 +104,7 @@
 	for(var/obj/item/toy/crayon/crayon in collected_tools)
 		if(!is_type_in_typecache(crayon, valid_types))
 			continue
-		if(final_check ? crayon.use_charges(user, 10) : crayon.check_empty(user, 10))
+		if(final_check ? crayon.use_charges(user, 10) : !crayon.check_empty(user, 10))
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION

## About The Pull Request

`check_empty` returns TRUE if the crayon is empty, which means we want to be checking for FALSE in this check, not TRUE

## Why It's Good For The Game

Fixes #91939 

## Changelog
:cl:
fix: fixed crude shuttle blueprints being uncraftable
/:cl:
