### PR TITLE
Spacebilly Elegy. Moonshine rework

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
+++ b/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
@@ -31,6 +31,11 @@
 	required_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/sugar = 5)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
+/datum/chemical_reaction/drink/moonshine_extra_patriotic
+	results = list(/datum/reagent/consumable/ethanol/moonshine = 10)
+	required_reagents = list(/datum/reagent/consumable/cornmeal = 7, /datum/reagent/consumable/corn_syrup = 3)
+	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
+
 /datum/chemical_reaction/drink/spacebeer
 	results = list(/datum/reagent/consumable/ethanol/beer = 10)
 	required_reagents = list(/datum/reagent/consumable/flour = 10)
@@ -498,7 +503,7 @@
 
 /datum/chemical_reaction/drink/turbo
 	results = list(/datum/reagent/consumable/ethanol/turbo = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol/moonshine = 2, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/ethanol/sugar_rush = 1, /datum/reagent/consumable/pwr_game = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/moonshine = 2, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/pwr_game = 1)
 	reaction_tags = REACTION_TAG_DRINK | REACTION_TAG_EASY | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/drink/old_timer

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -838,10 +838,23 @@
 /datum/reagent/consumable/ethanol/moonshine
 	name = "Moonshine"
 	description = "You've really hit rock bottom now... your liver packed its bags and left last night."
-	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha) (like water)
-	boozepwr = 95
-	taste_description = "bitterness"
+	color = "#fff4c37e"
+	boozepwr = 120
+	taste_description = "white lightning"
+	quality = DRINK_NICE
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
+	. = ..()
+
+	if(prob(10)) //prob to make it more spiky and prevent a constant microdrip of methanol
+		drinker.reagents.add_reagent(/datum/reagent/impurity/methanol, metabolization_rate * (1 - purity))
+
+	if(HAS_TRAIT(drinker, TRAIT_ROUGHRIDER) || drinker.mind?.get_skill_level(/datum/skill/mining) > SKILL_LEVEL_APPRENTICE) //No fancy city folk, they can try healin from their latte crapuccino and leaf salads or whatever they be eatin over there
+		var/need_mob_update
+		need_mob_update = drinker.adjustBruteLoss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjustToxLoss(-1 * REM * seconds_per_tick, updating_health = FALSE)
+		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/b52
 	name = "B-52"


### PR DESCRIPTION

## About The Pull Request


### Moonshine Changes

Moonshine now has 120 boozepower, making it one of the stronger alcohols. 

Moonshine now has a chance to convert into methanol in the users body if impure. 

Moonshine now has an alternate cornmeal and corn syrup based recipe.

Moonshine now heals rough riders(this includes settlers) and experienced miners 1 brute and 1 tox per cycle.

Moonshine now taste like white lightning instead of bitterness. 

Moonshine is now a DRINK_GOOD, which is still low when consider the effort involved, but we at least get a little mood boost for our work.

### Related change

The moonshine drink Turbo is now easier to make, no longer requires sugar rush.

## Why It's Good For The Game

The common man of the heartlands will be ignored no longer.

## Changelog

:cl:
add:  Moonshine now heals salt of the earth folk like settlers, rough riders and experienced miners.
add: Moonshine now has a chance to convert into metanol if impure.
add: Moonshine has an alternate recipe; cornmeal + corn syrup, catalyzed by enzyme.
balance: Turbo no longer requires sugar rush.
/:cl:

