### PR TITLE
adds some more SDQL2/Lua wrappers

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -302,3 +302,14 @@
 
 /proc/_is_type_in_typecache(thing_to_check, typecache)
 	return is_type_in_typecache(thing_to_check, typecache)
+
+/proc/_floor(a)
+	return floor(a)
+
+/proc/_ceil(a)
+	return ceil(a)
+
+/proc/_typesof(a, subtypes_only = FALSE)
+	. = typesof(a)
+	if(subtypes_only)
+		. -= a

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -86,6 +86,9 @@
 /proc/_log(X, Y)
 	return log(X, Y)
 
+/proc/_uppertext(T)
+	return uppertext(T)
+
 /proc/_LOWER_TEXT(T)
 	return LOWER_TEXT(T)
 
@@ -313,3 +316,15 @@
 	. = typesof(a)
 	if(subtypes_only)
 		. -= a
+
+/proc/_html_encode(text)
+	return html_encode(text)
+
+/proc/_html_decode(text)
+	return html_decode(text)
+
+/proc/_url_encode(text)
+	return url_encode(text)
+
+/proc/_url_decode(text)
+	return url_decode(text)

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -51,6 +51,10 @@ function SS13.is_type_in_typecache(thing, typecache)
 	return dm.global_procs._is_type_in_typecache(thing, typecache) == 1
 end
 
+function SS13.typesof(type, subtypes_only)
+	return dm.global_procs._typesof(SS13.type(type), subtypes_only)
+end
+
 function SS13.get_turf(thing)
 	return dm.global_procs._get_step(thing, 0)
 end


### PR DESCRIPTION
## About The Pull Request

This adds ~~3~~ 8 wrappers for SDQL2/Lua: `_floor(x)`, `_ceil(x)` (we already had `_round(a, b = 1)`), and `_typesof(a, subtypes_only)`

`_typesof` has a second argument, `subtypes_only` (default false), which makes it act like `subtypesof` instead, to save from having to manually remove the base type (especially since removing by value is kind of annoying in Lua)

the Lua SS13 library has had a `SS13.typesof` function added, which does exactly what it says on the tin (also with the second `subtypes_only` argument)

also added `_uppertext`, `_html_encode`, `_html_decode`, `_url_encode`, and `_url_decode`. these should all be selfexplanatory

## Why It's Good For The Game

more utility for Lua and SDQL2

## Changelog
:cl:
admin: Added some more Lua/SDQL2 wrappers: _floor(), _ceil(), _typesof(), _uppertext(), _html_encode(), _html_decode(), _url_encode(), and _url_decode()
/:cl:
