### PR TITLE
`md5asfile` now uses rust-g to get a file hash

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -105,10 +105,6 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 /proc/pathflatten(path)
 	return replacetext(path, "/", "_")
 
-/// Returns the md5 of a file at a given path.
-/proc/md5filepath(path)
-	. = md5(file(path))
-
 /// Save file as an external file then md5 it.
 /// Used because md5ing files stored in the rsc sometimes gives incorrect md5 results.
 /// https://www.byond.com/forum/post/2611357
@@ -118,7 +114,7 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 	var/filename = "tmp/md5asfile.[world.realtime].[world.timeofday].[world.time].[world.tick_usage].[notch]"
 	notch = WRAP(notch+1, 0, 2**15)
 	fcopy(file, filename)
-	. = md5filepath(filename)
+	. = rustg_hash_file(RUSTG_HASH_MD5, filename)
 	fdel(filename)
 
 /**


### PR DESCRIPTION
## About The Pull Request

This removes the `md5filepath` proc, which was only used in `md5asfile`.

Instead, `md5asfile` will just directly use `rustg_hash_file`, so we avoid having to read the file that we *just* wrote to disk right back into BYOND to MD5 it, and we can use rust-g to hash that file instead.

in theory, this should be even more performant if https://github.com/tgstation/rust-g/pull/228 is ~~merged~~ released

## Why It's Good For The Game

avoids an unneeded round-trip and hopefully improves performance.

## Changelog

no user-facing changes
