### PR TITLE
[tm only] doubles the speed of some gun-released projectiles

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -18,7 +18,7 @@
 	reflectable = TRUE
 	wound_bonus = -20
 	exposed_wound_bonus = 10
-
+	speed = 2.5
 
 /obj/projectile/beam/laser
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -45,7 +45,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	damage = 9
 	wound_bonus = -40
-	speed = 0.9
+	speed = 1.8
 
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
@@ -53,7 +53,7 @@
 	icon_state = "hellfire"
 	wound_bonus = 0
 	damage = 30
-	speed = 1.6
+	speed = 3.2
 	light_color = "#FF969D"
 
 /obj/projectile/beam/laser/heavylaser
@@ -150,7 +150,7 @@
 	icon_state = "scatterdisabler"
 	damage = 5.5
 	damage_falloff_tile = -0.5
-	speed = 1.2
+	speed = 2.4
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	tracer_type = /obj/effect/projectile/tracer/xray
 	muzzle_type = /obj/effect/projectile/muzzle/xray

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -12,6 +12,7 @@
 	wound_bonus = 0
 	wound_falloff_tile = -5
 	embed_falloff_tile = -3
+	speed = 2
 
 /obj/projectile/bullet/smite
 	name = "divine retribution"

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -35,7 +35,7 @@
 	suppressed = SUPPRESSED_VERY
 	damage_type = BURN
 	armor_flag = BOMB
-	speed = 0.8
+	speed = 1.6
 	wound_bonus = 30
 	exposed_wound_bonus = 30
 	wound_falloff_tile = -4

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -84,7 +84,7 @@
 	damage = 5
 	wound_bonus = 5
 	exposed_wound_bonus = 5
-	speed = 1.1
+	speed = 2
 	wound_falloff_tile = -0.5 //We would very much like this to cause wounds despite the low damage, so the drop off is relatively slow
 	sharpness = SHARP_EDGED
 
@@ -107,7 +107,7 @@
 	stamina = 10
 	sharpness = NONE
 	embed_type = null
-	speed = 0.8
+	speed = 1.8
 	stamina_falloff_tile = -0.25
 	ricochets_max = 4
 	ricochet_chance = 120
@@ -139,7 +139,7 @@
 	armour_penetration = 30
 	damage_falloff_tile = -0.2
 	wound_falloff_tile = -0.5
-	speed = 1.2
+	speed = 2
 	sharpness = SHARP_POINTY
 	embed_type = /datum/embedding/bullet/flechette
 


### PR DESCRIPTION
## About The Pull Request
revival of https://github.com/tgstation/tgstation/pull/91649
lasers and ballistics
doubles the speed of most projectiles released by guns 
This pr is for gathering information, thus it is TM ONLY.
## Why It's Good For The Game
it's a bit ridiculous how a minor speed buff can allow you to outrun bullets or high-concentrated beams of light that could sear your insides, this makes it nigh-impossible to catch anyone huffed up on ephedrine or any other movespeed altering reagent, I'm interested in seeing what happens if we buff the projectile speed.
## Changelog
### TM ONLY
