### PR TITLE
`map_export` now saves welded airlocks and paper on noticeboards

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -86,7 +86,7 @@
 	var/data
 
 	if(welded)
-		data += "[data ? ",\n" : ""][/obj/effect/mapping_helpers/airlock/welded::type]"
+		data += "[data ? ",\n" : ""][/obj/effect/mapping_helpers/airlock/welded]"
 
 	return data
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -82,10 +82,13 @@
 	fire = 80
 	acid = 70
 
-/obj/machinery/door/get_save_vars()
-	. = ..()
-	. += NAMEOF(src, welded)
-	return .
+/obj/machinery/door/on_object_saved()
+	var/data
+
+	if(welded)
+		data += "[data ? ",\n" : ""][/obj/effect/mapping_helpers/airlock/welded::type]"
+
+	return data
 
 /obj/machinery/door/Initialize(mapload)
 	AddElement(/datum/element/blocks_explosives)

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -13,18 +13,27 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/noticeboard, 32)
 
+/obj/structure/noticeboard/on_object_saved()
+	var/data
+
+	for(var/obj/item/paper/paper in contents)
+		var/metadata = generate_tgm_metadata(paper)
+		data += "[data ? ",\n" : ""][paper.type][metadata]"
+
+	return data
+
 /obj/structure/noticeboard/Initialize(mapload)
 	. = ..()
 
 	if(!mapload)
 		return
 
-	for(var/obj/item/I in loc)
+	for(var/obj/item/paper/paper in loc)
 		if(notices >= MAX_NOTICES)
 			break
-		if(istype(I, /obj/item/paper))
-			I.forceMove(src)
-			notices++
+
+		paper.forceMove(src)
+		notices++
 	update_appearance(UPDATE_ICON)
 	find_and_hang_on_wall()
 

--- a/code/modules/admin/verbs/map_export.dm
+++ b/code/modules/admin/verbs/map_export.dm
@@ -45,7 +45,10 @@ ADMIN_VERB(map_export, R_DEBUG, "Map Export", "Select a part of the map by coord
 
 /**
  * A procedure for saving non-standard properties of an object.
- * For example, saving ore into a silo, and further spavn by coordinates of metal stacks objects
+ * Examples:
+ * Saving material stacks (ie. ore in a silo)
+ * Saving variables that can be shown as mapping helpers (ie. welded airlock mapping helper)
+ * Saving objects inside of another object (ie. paper inside a noticeboard)
  */
 /obj/proc/on_object_saved()
 	return null


### PR DESCRIPTION

## About The Pull Request
When using `map-export`:
- Exports the welded state of an airlock to the welded airlock mapping helper
- Exports the paper inside of a noticeboard to pop out and be saved on the same turf

Both `airlocks` and `noticeboards` handle the outside objects already in their `Initialization()` procs so I didn't have to change anything. Also I cleaned up the paper code and added some better code documentation to `on_object_saved()`.

We convert this:
![dreamseeker_h4gQeOTaSC](https://github.com/user-attachments/assets/356b976f-b597-4492-96b0-7169b22e1845)

To this:
![StrongDMM_lQ5B1i8lH5](https://github.com/user-attachments/assets/b5360967-3e36-4e32-b94d-a51245eab867)

## Why It's Good For The Game
There weren't any good examples of using `on_object_saved()` and the documentation was lacking so I wanted to include some proof of concept for a few objects. Also airlocks already save their welded state, but I think it looks better to have it as a mapping helper since it shows up in StrongDMM instead of being a VV edit.

## Changelog
:cl:
add: Welded airlocks are saved as welded airlock mapping helpers when using the `map_export` admin verb
add: Paper on noticeboards are saved when using the `map_export` admin verb
/:cl:
