### PR TITLE
[NO GBP] Fixes the beacon stacking blocking throwing a runtime. Cleans up the attachment failure messages.

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -202,6 +202,7 @@
 			if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
 				thegun.equip_cooldown = 8
 		equip_cooldown = 8
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno/try_attach_part(mob/user, obj/vehicle/sealed/mecha/themech, attach_right)
 	var/has_cryo = FALSE

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -120,10 +120,13 @@
 
 /obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/mecha_to_attach, attach_right = FALSE)
 	if(!(mecha_to_attach.mecha_flags & flag_to_check))
+		to_chat(usr, span_notice("[src] is incompatible with [mecha_to_attach]."))
 		return
-	for(var/obj/item/mecha_parts/mecha_tracking/tracker in chassis.trackers)
-		if(tracker.flag_to_check == flag_to_check)
-			return //there can only be one...type of this tracker
+
+	if(!mecha_to_attach.check_tracker(flag_to_check))
+		to_chat(usr, span_notice("There already exists a version of [src] attached to [mecha_to_attach]."))
+		return
+
 	if(!..())
 		return
 	mecha_to_attach.trackers += src

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -120,11 +120,11 @@
 
 /obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/mecha_to_attach, attach_right = FALSE)
 	if(!(mecha_to_attach.mecha_flags & flag_to_check))
-		to_chat(usr, span_notice("[src] is incompatible with [mecha_to_attach]."))
+		to_chat(user, span_notice("[src] is incompatible with [mecha_to_attach]."))
 		return
 
 	if(!mecha_to_attach.check_tracker(flag_to_check))
-		to_chat(usr, span_notice("There already exists a version of [src] attached to [mecha_to_attach]."))
+		to_chat(user, span_notice("There already exists a version of [src] attached to [mecha_to_attach]."))
 		return
 
 	if(!..())

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -123,9 +123,10 @@
 		to_chat(user, span_notice("[src] is incompatible with [mecha_to_attach]."))
 		return
 
-	if(!mecha_to_attach.check_tracker(flag_to_check))
-		to_chat(user, span_notice("There already exists a version of [src] attached to [mecha_to_attach]."))
-		return
+	for(var/obj/item/mecha_parts/mecha_tracking/tracker as anything in mecha_to_attach.trackers)
+		if(tracker.flag_to_check == flag_to_check)
+			to_chat(user, span_notice("There already exists a version of [src] attached to [mecha_to_attach]."))
+			return
 
 	if(!..())
 		return

--- a/code/modules/vehicles/mecha/mecha_helpers.dm
+++ b/code/modules/vehicles/mecha/mecha_helpers.dm
@@ -29,13 +29,3 @@
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
 			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = I
 			gun.projectiles_cache = gun.projectiles_cache_max
-
-/////////////////////////////
-///// Tracker Blocking /////
-///////////////////////////
-
-/obj/vehicle/sealed/mecha/proc/check_tracker(flag_to_check)
-	for(var/obj/item/mecha_parts/mecha_tracking/tracker in trackers)
-		if(tracker.flag_to_check == flag_to_check)
-			return FALSE //there can only be one...type of this tracker
-	return TRUE

--- a/code/modules/vehicles/mecha/mecha_helpers.dm
+++ b/code/modules/vehicles/mecha/mecha_helpers.dm
@@ -29,3 +29,13 @@
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
 			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = I
 			gun.projectiles_cache = gun.projectiles_cache_max
+
+/////////////////////////////
+///// Tracker Blocking /////
+///////////////////////////
+
+/obj/vehicle/sealed/mecha/proc/check_tracker(flag_to_check)
+	for(var/obj/item/mecha_parts/mecha_tracking/tracker in trackers)
+		if(tracker.flag_to_check == flag_to_check)
+			return FALSE //there can only be one...type of this tracker
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. closes https://github.com/tgstation/tgstation/issues/91965

Edit: I'm also fixing this in this pr as well. Closes https://github.com/tgstation/tgstation/issues/91957

## Why It's Good For The Game

glorped it 
![421132658-5fa6bfe9-2803-4401-877d-83aedee21dcf](https://github.com/user-attachments/assets/f4ad4588-3061-4e91-9f33-f297e624b35b)

## Changelog
:cl:
fix: Mech beacons actually attach again.
fix: You'll get a message about why a beacon failed to attach, if it failed to attach
fix: Cryo cannons can not be attached to mechs.
/:cl:
