### PR TITLE
Removes buy limit on traitor discounts

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -82,7 +82,7 @@
 				if((uplink_handler.assigned_role in item.restricted_roles) || (uplink_handler.assigned_species in item.restricted_species))
 					uplink_items += item
 					continue
-		uplink_handler.extra_purchasable += create_uplink_sales(rand(uplink_sales_min, uplink_sales_max), /datum/uplink_category/discounts, 1, uplink_items)
+		uplink_handler.extra_purchasable += create_uplink_sales(rand(uplink_sales_min, uplink_sales_max), /datum/uplink_category/discounts, -1, uplink_items)
 
 	if(give_objectives)
 		forge_traitor_objectives()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -30,14 +30,14 @@
 			"16% sales tax will be charged for orders originating within Space Nebraska.",
 		)
 
-		//override the item stock limit passed into the function
-		if (limited_stock > 0) {
-			uplink_item.limited_stock = limited_stock
-		}
-
 		//We want to limit the purchase amount of some items without adjusting the pricing.
 		if (uplink_item.limited_discount_stock > 0) {
 			uplink_item.limited_stock = uplink_item.limited_discount_stock
+		}
+
+		//if stock limited is passed into the function, we'll override whatever is set
+		if (limited_stock > 0) {
+			uplink_item.limited_stock = limited_stock
 		}
 
 		if(uplink_item.cost >= 20) //Tough love for nuke ops

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -35,7 +35,7 @@
 			uplink_item.limited_stock = uplink_item.limited_discount_stock
 		}
 
-		//if stock limited is passed into the function, we'll override whatever is set
+		//if stock limited is passed into the function, we'll override everything
 		if (limited_stock > 0) {
 			uplink_item.limited_stock = limited_stock
 		}

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -29,7 +29,13 @@
 			"Use only as directed.",
 			"16% sales tax will be charged for orders originating within Space Nebraska.",
 		)
-		uplink_item.limited_stock = limited_stock
+
+		if (limited_stock > 0) {
+			uplink_item.limited_stock = limited_stock
+		} else if (uplink_item.limited_stock > 0) {	//we do not want to bypass the hard limit on certain items. but they can have an some extra, as a treat.
+			uplink_item.limited_stock *= 2
+		}
+
 		if(uplink_item.cost >= 20) //Tough love for nuke ops
 			discount *= 0.5
 		uplink_item.stock_key = WEAKREF(uplink_item)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -30,10 +30,14 @@
 			"16% sales tax will be charged for orders originating within Space Nebraska.",
 		)
 
+		//override the item stock limit passed into the function
 		if (limited_stock > 0) {
 			uplink_item.limited_stock = limited_stock
-		} else if (uplink_item.limited_stock > 0) {	//we do not want to bypass the hard limit on certain items. but they can have an some extra, as a treat.
-			uplink_item.limited_stock *= 2
+		}
+
+		//We want to limit the purchase amount of some items without adjusting the pricing.
+		if (uplink_item.limited_discount_stock > 0) {
+			uplink_item.limited_stock = uplink_item.limited_discount_stock
 		}
 
 		if(uplink_item.cost >= 20) //Tough love for nuke ops
@@ -79,6 +83,8 @@
 	var/stock_key = UPLINK_SHARED_STOCK_UNIQUE
 	/// How many items of this stock can be purchased.
 	var/limited_stock = -1 //Setting this above zero limits how many times this item can be bought by the same traitor in a round, -1 is unlimited
+	/// How many items of this stock can be purchased from the discount tab.
+	var/limited_discount_stock = -1
 	/// A bitfield to represent what uplinks can purchase this item.
 	/// See [`code/__DEFINES/uplink.dm`].
 	var/purchasable_from = ALL

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -266,6 +266,7 @@
 	progression_minimum = 20 MINUTES
 	item = /obj/item/powersink
 	cost = 11
+	limited_stock = 1
 
 /datum/uplink_item/device_tools/syndicate_contacts
 	name = "Polarized Contact Lenses"

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -85,20 +85,12 @@
 	desc = "A variation of the syndicate bomb designed to produce a large EMP effect."
 	item = /obj/item/sbeacondrop/emp
 	cost = 7
+	limited_discount_stock = 4
 
 /datum/uplink_item/explosives/syndicate_bomb/emp/New()
 	..()
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
 		cost *= 2
-
-/datum/uplink_item/explosives/syndicate_bomb/emp/get_discount_value(discount_type)
-	switch(discount_type)
-		if(TRAITOR_DISCOUNT_BIG)
-			return 0.4	//4 TC
-		if(TRAITOR_DISCOUNT_AVERAGE)
-			return 0.25	//5 TC
-		else
-			return 0.1	//6 TC
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
@@ -111,16 +103,8 @@
 	progression_minimum = 30 MINUTES
 	item = /obj/item/sbeacondrop/bomb
 	cost = 11
+	limited_discount_stock = 4
 
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()
 	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
-
-/datum/uplink_item/explosives/syndicate_bomb/get_discount_value(discount_type)
-	switch(discount_type)
-		if(TRAITOR_DISCOUNT_BIG)
-			return 0.5	//5 TC
-		if(TRAITOR_DISCOUNT_AVERAGE)
-			return 0.35	//7 TC
-		else
-			return 0.15	//9 TC

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -91,6 +91,15 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
 		cost *= 2
 
+/datum/uplink_item/explosives/syndicate_bomb/emp/get_discount_value(discount_type)
+	switch(discount_type)
+		if(TRAITOR_DISCOUNT_BIG)
+			return 0.4	//4 TC
+		if(TRAITOR_DISCOUNT_AVERAGE)
+			return 0.25	//5 TC
+		else
+			return 0.1	//6 TC
+
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
@@ -106,3 +115,12 @@
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()
 	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
+
+/datum/uplink_item/explosives/syndicate_bomb/get_discount_value(discount_type)
+	switch(discount_type)
+		if(TRAITOR_DISCOUNT_BIG)
+			return 0.5	//5 TC
+		if(TRAITOR_DISCOUNT_AVERAGE)
+			return 0.35	//7 TC
+		else
+			return 0.15	//9 TC


### PR DESCRIPTION
## About The Pull Request

Removes the buy limit on items in traitor uplink discount tab.

Purchase limits are kept on a few problematic items
A purchase limit was added to powersink

## Why It's Good For The Game

Traitor is a great role for doing interesting things. I'm loving the removal of progtot as it has encouraged players to think of interesting things to do instead of purely game. I want to further encourage interesting things by removing the buy limit on the discounts for traitor uplink.
Unfortunately this does add a bit of power to traitors through certain discounts like syndicate bomb, but it doesn't add too much. Apart from a few niche items, what is a traitor going to do with 7 syndicate modsuits or 4 revolvers? One purchase generally gives them enough power to succeed.
I'm hoping this encourages more traitors to team up or do something funny with 20 e-daggers.

also enables general griefsky

## Changelog

:cl:
balance: Removes buy limit on traitor discounts
balance: Purchase limit was added to powersink
/:cl:

