### PR TITLE
Add updatepaths script for maid uniform resprite

### DIFF
--- a/tools/UpdatePaths/Scripts/91885_maid_uniform_resprite.txt
+++ b/tools/UpdatePaths/Scripts/91885_maid_uniform_resprite.txt
@@ -2,3 +2,5 @@
 
 /obj/item/clothing/gloves/maid : @DELETE
 /obj/item/clothing/neck/maid : @DELETE
+
+/obj/item/clothing/head/costume/maidheadband : /obj/item/clothing/head/costume/maid_headband{@OLD}

--- a/tools/UpdatePaths/Scripts/91885_maid_uniform_resprite.txt
+++ b/tools/UpdatePaths/Scripts/91885_maid_uniform_resprite.txt
@@ -1,0 +1,4 @@
+# Neck and gloves were merged into main sprite
+
+/obj/item/clothing/gloves/maid : @DELETE
+/obj/item/clothing/neck/maid : @DELETE


### PR DESCRIPTION
## About The Pull Request

#91885 deleted the hand and neck items and repathed the headband during the re-sprite and those could have been mapped in somewhere... on a downstream far away

## Why It's Good For The Game

Deleting/repathing items likely to be on maps should have updatepaths script

## Changelog

No player facing changes
