### PR TITLE
Fix maid headband GAGS preview

### DIFF
--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -55,7 +55,7 @@
 	desc = "Just like from one of those chinese cartoons!"
 	greyscale_colors = "#494955#EEEEEE"
 	icon = 'icons/map_icons/clothing/head/_head.dmi'
-	icon_state = "/obj/item/clothing/head/costume/maid"
+	icon_state = "/obj/item/clothing/head/costume/maid_headband"
 	post_init_icon_state = "maid"
 	greyscale_config = /datum/greyscale_config/maid_headband
 	greyscale_config_worn = /datum/greyscale_config/maid_headband/worn


### PR DESCRIPTION

## About The Pull Request

items with GAGS customization need `icon_state` set to their type path because that's the name of the preview icon generated for them in the `map_icons` folder, this fixes an incorrect instance of that

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed icon preview for maid headband
/:cl:
