### PR TITLE
the default linux `PreCompile.sh` now copies .so files instead of moving them

### DIFF
--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -29,7 +29,7 @@ fi
 echo "Deploying rust-g..."
 git checkout "$RUST_G_VERSION"
 env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
+cp -f target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd ..
 
 #
@@ -50,7 +50,7 @@ fi
 echo "Deploying Dreamlaua..."
 git checkout "$DREAMLUAU_VERSION"
 env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-mv target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
+cp -f target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 cd ..
 
 # compile tgui


### PR DESCRIPTION
## About The Pull Request

by changing the `mv` commands in the `PreCompile.sh` preset for rust-g and dreamluau to `cp -f`, we can avoid having to re-link the so files every compile if nothing has changed, meaning that this step is practically instant if the rust-g and compiler versions were the same as last time.

tested downstream and this does not seem to cause any issues in production

## Why It's Good For The Game

Improves compile times.

## Changelog

no player-facing changes
