### PR TITLE
Fixes digi legs on the new maid costume

### DIFF
--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -127,6 +127,7 @@
 	flags_1 = IS_PLAYER_COLORABLE_1
 	body_parts_covered = CHEST|GROIN
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	alternate_worn_layer = UNDER_SUIT_LAYER
 	can_adjust = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Re adds the NO_NEW_ICON flag that got removed on accident.
## Why It's Good For The Game
Maid outfit magically summons pants onto your deliciously digitigrade legs now and its not supposed to do that, also things working properly is good.
## Changelog
:cl:
fix: The maid costume will no longer summon interdimensional pants onto your digitigrade legs.
/:cl:
