### PR TITLE
Adds surgery computer and advanced surgery disk to nukie base

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -693,6 +693,7 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
+/obj/item/disk/surgery/forgottenship,
 /turf/open/floor/iron/white,
 /area/shuttle/syndicate/medical)
 "pd" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -693,7 +693,6 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
-/obj/item/disk/surgery/forgottenship,
 /turf/open/floor/iron/white,
 /area/shuttle/syndicate/medical)
 "pd" = (

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -113,11 +113,8 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
 	},
-/obj/structure/table/reinforced/plasmarglass,
-/obj/effect/spawner/surgery_tray/full{
-	pixel_y = -11
-	},
-/obj/item/storage/belt/medical,
+/obj/machinery/computer/operating,
+/obj/item/disk/surgery/forgottenship,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/centcom/syndicate_mothership/control)
 "bF" = (
@@ -634,13 +631,10 @@
 	dir = 6
 	},
 /obj/structure/table/reinforced/plasmarglass,
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
+/obj/effect/spawner/surgery_tray/full{
+	pixel_y = -11
 	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = 15
-	},
+/obj/item/storage/belt/medical,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/centcom/syndicate_mothership/control)
 "gS" = (
@@ -2190,6 +2184,13 @@
 	dir = 1
 	},
 /obj/item/storage/medkit/regular,
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_y = 15
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "yP" = (

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -794,6 +794,8 @@
 	},
 /obj/structure/table/optable,
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/defibrillator_mount/directional/north,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/centcom/syndicate_mothership/control)
 "iG" = (


### PR DESCRIPTION

## About The Pull Request

Adds a surgery computer, defib and an advanced surgery disk to the Nukie base. 

## Why It's Good For The Game

The nukie base lacked surgery computers despite having a corner and room for one. Additionally, giving the nukies their own research disk means they won't rely on the stations research when it comes to advanced surgeries.

## Changelog
:cl:
add: Surgery computer and defib to Nukie base
add: Advanced Surgery Disk to Nukie base
/:cl:
