### PR TITLE
Fix unlinking the briefcase launchpad remote not working

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -385,6 +385,7 @@
 	if(!our_pad)
 		pad = null
 		return TRUE
+	var/mob/user = ui.user
 	switch(action)
 		if("set_pos")
 			var/new_x = text2num(params["x"])
@@ -409,15 +410,15 @@
 			our_pad.display_name = new_name
 		if("remove")
 			. = TRUE
-			if(usr && tgui_alert(usr, "Are you sure?", "Unlink Launchpad", list("Confirm", "Abort")) == "I'm Sure")
+			if(tgui_alert(user, "Are you sure?", "Unlink Launchpad", list("I'm Sure", "Abort")) == "I'm Sure")
 				our_pad = null
 		if("launch")
 			sending = TRUE
-			teleport(usr, our_pad)
+			teleport(user, our_pad)
 			. = TRUE
 		if("pull")
 			sending = FALSE
-			teleport(usr, our_pad)
+			teleport(user, our_pad)
 			. = TRUE
 
 #undef BEAM_FADE_TIME

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -315,7 +315,7 @@
 /obj/machinery/launchpad/briefcase/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
 	if(istype(item, /obj/item/launchpad_remote))
 		var/obj/item/launchpad_remote/launch = item
-		if(launch.pad == WEAKREF(src)) //do not attempt to link when already linked
+		if(IS_WEAKREF_OF(src, launch.pad)) //do not attempt to link when already linked
 			return ..()
 		launch.pad = WEAKREF(src)
 		to_chat(user, span_notice("You link [src] to [launch]."))

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -354,7 +354,7 @@
 
 /obj/item/launchpad_remote/ui_data(mob/user)
 	var/list/data = list()
-	var/obj/machinery/launchpad/briefcase/our_pad = pad.resolve()
+	var/obj/machinery/launchpad/briefcase/our_pad = pad?.resolve()
 	data["has_pad"] = our_pad ? TRUE : FALSE
 	if(our_pad)
 		data["pad_closed"] = our_pad.closed
@@ -381,7 +381,7 @@
 	. = ..()
 	if(.)
 		return
-	var/obj/machinery/launchpad/briefcase/our_pad = pad.resolve()
+	var/obj/machinery/launchpad/briefcase/our_pad = pad?.resolve()
 	if(!our_pad)
 		pad = null
 		return TRUE
@@ -411,7 +411,7 @@
 		if("remove")
 			. = TRUE
 			if(tgui_alert(user, "Are you sure?", "Unlink Launchpad", list("I'm Sure", "Abort")) == "I'm Sure")
-				our_pad = null
+				pad = null
 		if("launch")
 			sending = TRUE
 			teleport(user, our_pad)


### PR DESCRIPTION
## About The Pull Request

port of my fix from https://github.com/Monkestation/Monkestation2.0/pull/7110, credit to @Xander3359 for pointing the issue out

the "Unlink Launchpad" tgui alert gave the options "Confirm" or "Abort"... but it only unlinked if the result was "I'm Sure", so it would never actually unlink. so I changed "Confirm" to "I'm Sure".

and even besides that, it set the local variable `our_pad` to null, rather than the remote's `pad` variable

also made it use `ui.user` instead of `usr`

## Why It's Good For The Game

things working is nice

## Changelog
:cl:
fix: You can now actually unlink the remote from a briefcase launchpad.
/:cl:
