### PR TITLE
The Material Stock Market will now showcase the current elastic modifier of materials.

### DIFF
--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -195,7 +195,7 @@
 				continue
 			var/datum/export/material/export_est = i
 			if(export_est.material_id == traded_mat)
-				elastic_mult = export_est.cost
+				elastic_mult = (export_est.cost / export_est.init_cost) * 100
 
 		material_data += list(list(
 			"name" = initial(traded_mat.name),

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -151,6 +151,7 @@
 	var/sheet_to_buy
 	var/requested_amount
 	var/minimum_value_threshold = 0
+	var/elastic_mult = 1
 	for(var/datum/material/traded_mat as anything in SSstock_market.materials_prices)
 		//convert trend into text
 		switch(SSstock_market.materials_trends[traded_mat])
@@ -188,7 +189,14 @@
 		else
 			minimum_value_threshold = round(initial(traded_mat.value_per_unit) * SHEET_MATERIAL_AMOUNT * 0.5)
 
-		//send data
+		//Pulling elastic modifier into data.
+		for(var/i as anything in GLOB.exports_list)
+			if(!istype(i, /datum/export/material/market))
+				continue
+			var/datum/export/material/export_est = i
+			if(export_est.material_id == traded_mat)
+				elastic_mult = export_est.cost
+
 		material_data += list(list(
 			"name" = initial(traded_mat.name),
 			"price" = SSstock_market.materials_prices[traded_mat],
@@ -197,7 +205,8 @@
 			"quantity" = SSstock_market.materials_quantity[traded_mat],
 			"trend" = trend_string,
 			"color" = color_string,
-			"requested" = requested_amount
+			"requested" = requested_amount,
+			"elastic" = elastic_mult
 			))
 
 	//get account balance

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -190,10 +190,7 @@
 			minimum_value_threshold = round(initial(traded_mat.value_per_unit) * SHEET_MATERIAL_AMOUNT * 0.5)
 
 		//Pulling elastic modifier into data.
-		for(var/i as anything in GLOB.exports_list)
-			if(!istype(i, /datum/export/material/market))
-				continue
-			var/datum/export/material/export_est = i
+		for(var/datum/export/material/market/export_est in GLOB.exports_list)
 			if(export_est.material_id == traded_mat)
 				elastic_mult = (export_est.cost / export_est.init_cost) * 100
 
@@ -206,7 +203,7 @@
 			"trend" = trend_string,
 			"color" = color_string,
 			"requested" = requested_amount,
-			"elastic" = elastic_mult
+			"elastic" = elastic_mult,
 			))
 
 	//get account balance

--- a/tgui/packages/tgui/interfaces/MatMarket.tsx
+++ b/tgui/packages/tgui/interfaces/MatMarket.tsx
@@ -140,9 +140,15 @@ export const MatMarket = (props) => {
                     <Stack.Item
                       width="10%"
                       pr="2%"
-                      textColor={material.elastic < 0.33 ? 'red' : material.elastic < 0.66 ? 'orange' : 'green'}
+                      textColor={
+                        material.elastic < 33
+                          ? 'red'
+                          : material.elastic < 66
+                            ? 'orange'
+                            : 'green'
+                      }
                     >
-                      Elasticity: <b>{Math.round(material.elastic * 100)}</b>%
+                      Elasticity: <b>{Math.round(material.elastic)}</b>%
                     </Stack.Item>
 
                     <Stack.Item width="15%" pr="2%">

--- a/tgui/packages/tgui/interfaces/MatMarket.tsx
+++ b/tgui/packages/tgui/interfaces/MatMarket.tsx
@@ -23,6 +23,7 @@ type Material = {
   threshold: number;
   color: string;
   requested: number;
+  elastic: number;
 };
 
 type Data = {
@@ -132,6 +133,13 @@ export const MatMarket = (props) => {
                       pr="3%"
                     >
                       {toTitleCase(material.name)}
+                    </Stack.Item>
+                    <Stack.Item
+                      width="10%"
+                      pr="2%"
+                      textColor={material.elastic < 0.33 ? 'red' : material.elastic < 0.66 ? 'orange' : 'green'}
+                    >
+                      Elasticity: <b>{Math.round(material.elastic * 100)}</b>%
                     </Stack.Item>
 
                     <Stack.Item width="15%" pr="2%">

--- a/tgui/packages/tgui/interfaces/MatMarket.tsx
+++ b/tgui/packages/tgui/interfaces/MatMarket.tsx
@@ -88,6 +88,9 @@ export const MatMarket = (props) => {
               time. To prevent market manipulation, all registered traders can
               buy a total of 10 full stacks of materials at a time.
               <br /> <br />
+              When selling materials, prices will be decreased based on the
+              elastic modifier of the material, which will recover over time.
+              <br /> <br />
               All new purchases will include the cost of the shipped crate,
               which may be recycled afterwards.
             </Collapsible>


### PR DESCRIPTION
## About The Pull Request

The GMM Material stock market now informs the player about the elastic modifier which that material currently has, namely for avoiding funny situations where someone sells hundreds of units of a material and doesn't quite follow why their perfectly priced material has sold for nothing.

![image](https://github.com/user-attachments/assets/87ab1987-769e-44b8-919c-9b06fcffa6d2)

Additionally, I've added a note to the instructions dropdown describing how elasticity works. In hindsight, that drop down only gets more ugly by the day, and should probably be co-opted by a modal all things considered, but for this 3 seconds I think this is fine as a stopgap.

## Why It's Good For The Game

The elasticity feature on the GMM has been REALLY poorly handled all things considered, and it's not very clear that elasticity even effects stock market sales. This adds at least a UI element describing how the sale price has decreased, so that cargo can better coordinate on how to work around different material elasticities.

This also pairs well with the other fix PR syncit dropped, in the case that we can clear up a bit about how this mechanic works overall.

## Changelog

:cl:
qol: The GMM Stock market now shows material elasticity, AKA the sale price reduction caused by selling a material, which will steadily recover after a sale.
/:cl:

