### PR TITLE
Fixes plasmaman limbs still igniting the person if they were removed

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -57,7 +57,7 @@
 #define COMSIG_CARBON_REMOVE_LIMB "carbon_remove_limb"
 /// Called from carbon losing a limb /obj/item/bodypart/proc/drop_limb(obj/item/bodypart/lost_limb, special, dismembered)
 #define COMSIG_CARBON_POST_REMOVE_LIMB "carbon_post_remove_limb"
-/// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(mob/living/carbon/old_owner, obj/item/bodypart/removed_part, special, dismembered)
+/// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(obj/item/bodypart/removed_part, special, dismembered)
 #define COMSIG_BODYPART_REMOVED "bodypart_removed"
 
 ///from base of mob/living/carbon/soundbang_act(): (list(intensity))

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -57,7 +57,7 @@
 #define COMSIG_CARBON_REMOVE_LIMB "carbon_remove_limb"
 /// Called from carbon losing a limb /obj/item/bodypart/proc/drop_limb(obj/item/bodypart/lost_limb, special, dismembered)
 #define COMSIG_CARBON_POST_REMOVE_LIMB "carbon_post_remove_limb"
-/// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(obj/item/bodypart/removed_part, special, dismembered)
+/// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(mob/living/carbon/old_owner, special, dismembered)
 #define COMSIG_BODYPART_REMOVED "bodypart_removed"
 
 ///from base of mob/living/carbon/soundbang_act(): (list(intensity))

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -57,7 +57,7 @@
 #define COMSIG_CARBON_REMOVE_LIMB "carbon_remove_limb"
 /// Called from carbon losing a limb /obj/item/bodypart/proc/drop_limb(obj/item/bodypart/lost_limb, special, dismembered)
 #define COMSIG_CARBON_POST_REMOVE_LIMB "carbon_post_remove_limb"
-/// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(mob/living/carbon/old_owner, special, dismembered)
+/// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(mob/living/carbon/old_owner, obj/item/bodypart/removed_part, special, dismembered)
 #define COMSIG_BODYPART_REMOVED "bodypart_removed"
 
 ///from base of mob/living/carbon/soundbang_act(): (list(intensity))

--- a/code/modules/surgery/bodyparts/bodypart_effects.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects.dm
@@ -30,7 +30,7 @@
 		activate()
 
 /// Remove a bodypart from the effect. Deleting = TRUE is used during clean-up phase
-/datum/status_effect/grouped/bodypart_effect/proc/remove_bodypart(obj/item/bodypart/bodypart, deleting = FALSE)
+/datum/status_effect/grouped/bodypart_effect/proc/remove_bodypart(mob/living/carbon/old_owner, obj/item/bodypart/bodypart, deleting = FALSE)
 	UnregisterSignal(bodypart, COMSIG_BODYPART_REMOVED)
 
 	bodyparts.Remove(bodypart)

--- a/code/modules/surgery/bodyparts/bodypart_effects.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects.dm
@@ -30,7 +30,7 @@
 		activate()
 
 /// Remove a bodypart from the effect. Deleting = TRUE is used during clean-up phase
-/datum/status_effect/grouped/bodypart_effect/proc/remove_bodypart(mob/living/carbon/old_owner, obj/item/bodypart/bodypart, deleting = FALSE)
+/datum/status_effect/grouped/bodypart_effect/proc/remove_bodypart(mob/living/carbon/old_owner, obj/item/bodypart/bodypart, deleting)
 	UnregisterSignal(bodypart, COMSIG_BODYPART_REMOVED)
 
 	bodyparts.Remove(bodypart)
@@ -38,14 +38,14 @@
 	if(deleting)
 		return
 
-	if(bodyparts.len == 0)
+	if(bodyparts.len == 0 && !QDELETED(old_owner))
 		qdel(src)
 
 	else if(is_active && bodyparts.len < minimum_bodyparts)
 		deactivate()
 
 /// Signal called when a bodypart is removed
-/datum/status_effect/grouped/bodypart_effect/proc/on_bodypart_removed(obj/item/bodypart/bodypart)
+/datum/status_effect/grouped/bodypart_effect/proc/on_bodypart_removed(obj/item/bodypart/bodypart, special)
 	SIGNAL_HANDLER
 
 	remove_bodypart(owner, bodypart)
@@ -54,7 +54,7 @@
 /datum/status_effect/grouped/bodypart_effect/proc/on_bodypart_destroyed(obj/item/bodypart/bodypart)
 	SIGNAL_HANDLER
 
-	remove_bodypart(bodypart)
+	remove_bodypart(bodypart.owner, bodypart)
 
 /// Activate some sort of effect when a threshold is reached
 /datum/status_effect/grouped/bodypart_effect/proc/activate()
@@ -75,7 +75,7 @@
 /datum/status_effect/grouped/bodypart_effect/Destroy()
 	deactivate()
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
-		remove_bodypart(bodypart, deleting = TRUE)
+		remove_bodypart(bodypart.owner, bodypart, deleting = TRUE)
 
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
They only removed the effects on the specific limbs, and didn't clear the status effect. 
In my defense, the signal documentation literally lied to me and thus I used the wrong argument
(Tested and works)

:cl: 
fix: Removing plasmaman limbs now doesnt leave you burning for eternity
/:cl: