### PR TITLE
Adds config for roundstart blue alert

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -178,6 +178,9 @@
 /datum/config_entry/string/alert_delta
 	default = "Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
 
+/datum/config_entry/flag/roundstart_blue_alert
+	default = TRUE
+
 /datum/config_entry/flag/revival_pod_plants
 
 /datum/config_entry/number/revival_brain_life

--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -118,7 +118,7 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 			SSstation.announcer.get_rand_report_sound(),
 			color_override = "green",
 		)
-	else
+	else if(CONFIG_GET(flag/roundstart_blue_alert))
 		if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_BLUE)
 			SSsecurity_level.set_level(SEC_LEVEL_BLUE, announce = FALSE)
 		priority_announce(
@@ -128,6 +128,13 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 			ANNOUNCER_INTERCEPT,
 			color_override = SSsecurity_level.current_security_level.announcement_color,
 		)
+	else
+		priority_announce(
+			"A summary of the station's situation has been copied and printed to all communications consoles.",
+			"Security Report",
+			SSstation.announcer.get_rand_report_sound(),
+		)
+
 #endif
 
 	return .

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -81,6 +81,11 @@ ALERT_DELTA Destruction of the station is imminent. All crew are instructed to o
 ## The total weight of station goals possible for a round (allows multiple goals)
 STATION_GOAL_BUDGET 1
 
+## If TRUE / 1, station is raised to blue alert at roundstart.
+## If FALSE / 0, station remains at green alert.
+## Roundstart command report and greendshift announcements are unaffected.
+ROUNDSTART_BLUE_ALERT 1
+
 ## GAME MODES ###
 
 ## Uncomment to not send a roundstart intercept report. Gamemodes may override this.


### PR DESCRIPTION
## About The Pull Request

Adds a config option `roundstart_blue_alert` which determines if the station is put on blue alert on roundstart.

**Greenshifts** are unaffected, they will still have a unique announcement indicating it's a greenshift

**Roundstart reports** are unaffected, they will be sent regardless. 

## Why It's Good For The Game

Some servers put more player agency on command to control the report level, some servers re-theme the levels so blue is more of an involved thing, some servers put more weight on the current level, etc. Giving the option of staying on green until someone decides to up it is neat I guess.

Before doing this I tried to find when this was even added - to see what the justification was and make sure I wasn't violating it - and wasn't successful. R4407 had "`Security Level Elevated`" in their reports but didn't have security levels implemented, so it was purely fluff.

## Changelog

:cl: Melbert
config: Adds "roundstart_blue_alert", allowing you to disable roundstart blue alert. Defaults to "on".
/:cl:
