### PR TITLE
Makes zone targeted feedback more useful

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -348,7 +348,7 @@
 
 	if(ishuman(src) || client) // istype(src) is kinda bad, but it's to avoid spamming the blackbox
 		SSblackbox.record_feedback("nested tally", "item_used_for_combat", 1, list("[attacking_item.force]", "[attacking_item.type]"))
-		SSblackbox.record_feedback("tally", "zone_targeted", 1, targeting_human_readable)
+		SSblackbox.record_feedback("tally", "zone_targeted", 1, user.zone_selected)
 
 	var/damage_done = apply_damage(
 		damage = final_force,


### PR DESCRIPTION
## About The Pull Request

RN this feedback records the **hit zone**, rather than the **targeted zone**

This is kinda useless because the hit zone has a 20% chance to be a random zone instead of the targeted zone. We can't really discover anything about zone targeting stats when our results just shows "everything is being hit"

So I just changed it to the targeted zone. You know what they're aiming at, not what they ultimately hit