### PR TITLE
HARS cannot roll as an innate mutation until your DNA has been scrambled once

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -283,12 +283,18 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	for(var/blocknum in 1 to DNA_FEATURE_BLOCKS)
 		. += L[blocknum] || random_string(GET_UI_BLOCK_LEN(blocknum), GLOB.hex_characters)
 
-/datum/dna/proc/generate_dna_blocks()
-	var/bonus
+/**
+ * Picks what mutations this DNA has innate and generates DNA blocks for them
+ *
+ * * mutation_blacklist - Optional list of mutation typepaths to exclude from generation.
+ */
+/datum/dna/proc/generate_dna_blocks(list/mutation_blacklist)
+	var/list/mutations_temp = list() + GLOB.good_mutations + GLOB.bad_mutations + GLOB.not_good_mutations
 	if(species?.inert_mutation)
-		bonus = GET_INITIALIZED_MUTATION(species.inert_mutation)
-	var/list/mutations_temp = GLOB.good_mutations + GLOB.bad_mutations + GLOB.not_good_mutations + bonus
-	if(!LAZYLEN(mutations_temp))
+		mutations_temp |= GET_INITIALIZED_MUTATION(species.inert_mutation)
+	for(var/mutation_type in mutation_blacklist)
+		mutations_temp -= GET_INITIALIZED_MUTATION(mutation_type)
+	if(!length(mutations_temp))
 		return
 	mutation_index.Cut()
 	default_mutation_genes.Cut()
@@ -489,7 +495,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(newblood_type)
 		blood_type = newblood_type
 	if(create_mutation_blocks) //I hate this
-		generate_dna_blocks()
+		generate_dna_blocks(mutation_blacklist = list(/datum/mutation/headless))
 	if(randomize_features)
 		for(var/species_type in GLOB.species_prototypes)
 			var/list/new_features = GLOB.species_prototypes[species_type].randomize_features()


### PR DESCRIPTION
## About The Pull Request

No humanoid spawns with HARS as an innate mutation.

However, if your DNA is scrambled, HARS can show up as an innate mutation. 

## Why It's Good For The Game

Radiation can
- Randomly make you blind
- Randomly make you deaf
- Randomly make you mute

Independently.

Each of these alone is pretty bad, I think most people would agree. But not overly punishing. If you're blind or deaf, you can still call for help, and if you're mute, you can write on a piece of paper.

But then we have HARS. Which applies all of these maluses at once (and more) and can be bestowed upon you if you are unlucky enough to have it as an innate gene. Calling for help is difficult since you have no tongue and no radio, knowing if anyone is *coming* to help is impossible due to lacking ears, and you can't even write on paper because you're blind. 

This is suuuper punishing compared to any other gene - As funny as it is that you can have your head removed by standing in a radiation storm for a second, it ramps the lethality of it up too aggressively. 

And there is precedent for preventing rads and whatnot from mutating genes deemed too punishing - you can't mutate into a monkey from radiation*.

Thus, this PR completely prevents players from having HARS as an innate mutation. HARS can still be obtained by scrambling the genes of someone, such as via the DNA console in genetics, meaning traitor geneticists can still use it for evil acts and whatnot.

**If the common consensus is that removing it from innate mutations outright is too excessive, it can always be added to the blacklist of `easy_random_mutate`, the same way Monkified is blacklisted.*

## Changelog

:cl: Melbert
balance: HARS cannot spawn as an innate gene - it will only show up in scrambled DNA (such as from the DNA console)
/:cl:
