### PR TITLE
Fixes debug component printer

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -260,10 +260,11 @@
 		var/datum/design/design = SSresearch.techweb_design_by_id(id)
 		if((design.build_type & COMPONENT_PRINTER) && design.build_path)
 			all_circuit_designs[design.build_path] = list(
+				"id" = design.build_path,
+				"categories" = design.category,
+				"cost" = design.materials,
+				"desc" = design.desc,
 				"name" = design.name,
-				"description" = design.desc,
-				"materials" = design.materials,
-				"categories" = design.category
 			)
 
 	for(var/obj/item/circuit_component/component as anything in subtypesof(/obj/item/circuit_component))
@@ -272,10 +273,11 @@
 			categories = list("Admin")
 		if(!(component in all_circuit_designs))
 			all_circuit_designs[component] = list(
-				"name" = initial(component.display_name),
-				"description" = initial(component.desc),
-				"materials" = list(),
+				"id" = component.type,
 				"categories" = categories,
+				"cost" = list(),
+				"desc" = initial(component.desc),
+				"name" = initial(component.display_name),
 			)
 
 /obj/machinery/debug_component_printer/ui_interact(mob/user, datum/tgui/ui)
@@ -302,7 +304,7 @@
 				return TRUE
 
 			var/list/design = all_circuit_designs[build_path]
-			if(!design)
+			if (!design)
 				return TRUE
 
 			balloon_alert_to_viewers("printed [design["name"]]")
@@ -315,8 +317,10 @@
 /obj/machinery/debug_component_printer/ui_static_data(mob/user)
 	var/list/data = list()
 
-	data["materials"] = list()
+	data["debug"] = TRUE
 	data["designs"] = all_circuit_designs
+	data["materials"] = list()
+	data["SHEET_MATERIAL_AMOUNT"] = SHEET_MATERIAL_AMOUNT
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/ComponentPrinter.tsx
+++ b/tgui/packages/tgui/interfaces/ComponentPrinter.tsx
@@ -1,5 +1,5 @@
 import { Box, Icon, Section, Stack, Tooltip } from 'tgui-core/components';
-import { classes } from 'tgui-core/react';
+import { BooleanLike, classes } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
@@ -10,15 +10,16 @@ import { Material } from './Fabrication/Types';
 import { Design } from './Fabrication/Types';
 import { MaterialMap } from './Fabrication/Types';
 
-type ComponentPrinterData = {
+type Data = {
+  debug: BooleanLike;
   designs: Record<string, Design>;
   materials: Material[];
   SHEET_MATERIAL_AMOUNT: number;
 };
 
-export const ComponentPrinter = (props) => {
-  const { act, data } = useBackend<ComponentPrinterData>();
-  const { materials, designs, SHEET_MATERIAL_AMOUNT } = data;
+export function ComponentPrinter(props) {
+  const { act, data } = useBackend<Data>();
+  const { materials = [], designs, SHEET_MATERIAL_AMOUNT, debug } = data;
 
   // Reduce the material count array to a map of actually available materials.
   const availableMaterials: MaterialMap = {};
@@ -28,7 +29,12 @@ export const ComponentPrinter = (props) => {
   }
 
   return (
-    <Window title={'Component Printer'} width={670} height={600}>
+    <Window
+      title={`${debug && 'Debug '}Component Printer`}
+      width={670}
+      height={600}
+      theme={debug ? 'admin' : undefined}
+    >
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item grow>
@@ -39,19 +45,13 @@ export const ComponentPrinter = (props) => {
                 design,
                 availableMaterials,
                 _onPrintDesign,
-              ) => (
-                <Recipe
-                  design={design}
-                  available={availableMaterials}
-                  SHEET_MATERIAL_AMOUNT={SHEET_MATERIAL_AMOUNT}
-                />
-              )}
+              ) => <Recipe design={design} available={availableMaterials} />}
             />
           </Stack.Item>
           <Stack.Item>
             <Section>
               <MaterialAccessBar
-                availableMaterials={materials ?? []}
+                availableMaterials={materials}
                 SHEET_MATERIAL_AMOUNT={SHEET_MATERIAL_AMOUNT}
                 onEjectRequested={(material, amount) =>
                   act('remove_mat', { ref: material.ref, amount })
@@ -63,22 +63,28 @@ export const ComponentPrinter = (props) => {
       </Window.Content>
     </Window>
   );
-};
+}
 
 type RecipeProps = {
-  design: Design;
   available: MaterialMap;
-  SHEET_MATERIAL_AMOUNT: number;
+  design: Design;
 };
 
-const Recipe = (props: RecipeProps) => {
-  const { act } = useBackend<ComponentPrinterData>();
-  const { design, available, SHEET_MATERIAL_AMOUNT } = props;
+function Recipe(props: RecipeProps) {
+  const { available, design } = props;
 
-  const canPrint = !Object.entries(design.cost).some(
-    ([material, amount]) =>
-      !available[material] || amount > (available[material] ?? 0),
-  );
+  const { act, data } = useBackend<Data>();
+  const { SHEET_MATERIAL_AMOUNT, debug } = data;
+
+  const costs = Object.entries(design.cost);
+
+  const canPrint =
+    debug ||
+    !costs.some(([material, amount]) => {
+      const have = available[material];
+
+      return !have || amount > have;
+    });
 
   return (
     <div className="FabricatorRecipe">
@@ -114,8 +120,8 @@ const Recipe = (props: RecipeProps) => {
         >
           <div className="FabricatorRecipe__Icon">
             <Box
-              width={'32px'}
-              height={'32px'}
+              width="32px"
+              height="32px"
               className={classes(['design32x32', design.icon])}
             />
           </div>
@@ -124,4 +130,4 @@ const Recipe = (props: RecipeProps) => {
       </Tooltip>
     </div>
   );
-};
+}


### PR DESCRIPTION
## About The Pull Request
Seems this went under my radar. The backend was sending the wrong data. I also tuned up the UI a little bit to signify that it's the debug component printer. 

It will print anything listed, free.

<details>
<summary>Screenshots</summary>

![Screenshot 2025-07-07 162543](https://github.com/user-attachments/assets/de9b490d-66ee-4c67-8453-485769fd2ebd)

![Screenshot 2025-07-07 162550](https://github.com/user-attachments/assets/2a5a7cfd-3cd3-42af-aeea-3d83bb51ce9c)

</details>

## Why It's Good For The Game
Fixes #71511
## Changelog
:cl:
admin: The admin spawned component printer UI functions again
/:cl:
