### PR TITLE
Fixes overlay lighting failing to remove if power is set to 0

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -391,12 +391,10 @@
 	var/new_power = source.light_power
 	set_lum_power(new_power >= 0 ? 0.5 : -0.5)
 	set_alpha = min(230, (abs(new_power) * 120) + 30)
-	visible_mask.blend_mode = new_power > 0 ? BLEND_ADD : BLEND_SUBTRACT
-	if(directional)
-		cone.blend_mode = new_power > 0 ? BLEND_ADD : BLEND_SUBTRACT
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= visible_mask
 	visible_mask.alpha = set_alpha
+	visible_mask.blend_mode = new_power > 0 ? BLEND_ADD : BLEND_SUBTRACT
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += visible_mask
 	if(!directional)
@@ -404,6 +402,7 @@
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= cone
 	cone.alpha = min(120, (abs(new_power) * 60) + 15)
+	cone.blend_mode = new_power > 0 ? BLEND_ADD : BLEND_SUBTRACT
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += cone
 


### PR DESCRIPTION

## About The Pull Request

These things are overlays, so if we modify them before we try and remove them, we'll be trying to remove a different appearance, and it'll fail.

This means if you set power to 0 before any other light arg, you will create a stuck underlay

## Why It's Good For The Game
Closes #91764
Enables #91726

## Changelog
:cl:
fix: Hitting lit things with the light_eater will no longer sometimes cause them to stay stuck, lit
/:cl:
