### PR TITLE
Fixes 'note_path' var of 'airlock_note_placer' mapping helper

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1094,7 +1094,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_atoms_ontop)
 	if(locate(/obj/machinery/door/airlock) in turf)
 		var/obj/machinery/door/airlock/found_airlock = locate(/obj/machinery/door/airlock) in turf
 		if(note_path)
-			found_airlock.note = note_path
+			var/obj/item/paper/paper = new note_path(src)
+			found_airlock.note = paper
+			paper.forceMove(found_airlock)
 			found_airlock.update_appearance()
 			qdel(src)
 			return


### PR DESCRIPTION

## About The Pull Request

This old mapping helper had a problem with loading notes supplied via its 'note_path' variable.

## Why It's Good For The Game

The morgue memo note upon the morgue office door on Wawastation now appears.

Here's me testing it on runtime with a different note...
![image](https://github.com/user-attachments/assets/8d81a884-d0d4-4a75-941a-9f7273463e32)

## Changelog
:cl:
fix: fixed the 'note_path' var of the 'airlock_note_placer' mapping helper
/:cl:
