### PR TITLE
reduces the volume of all emergency internals tanks by 3 times

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -44,6 +44,7 @@
 //TANKS
 /// The volume of the standard handheld gas tanks on the station.
 #define TANK_STANDARD_VOLUME 70
+#define TANK_EMERGENCY_STANDARD_VOLUME 1
 /// The minimum pressure an gas tanks release valve can be set to.
 #define TANK_MIN_RELEASE_PRESSURE 0
 /// The maximum pressure an gas tanks release valve can be set to.

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -154,7 +154,7 @@
 	worn_icon = null
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
-	volume = 6 //same size as the engineering ones but plasmamen have special lungs that consume less plasma per breath
+	volume = TANK_EMERGENCY_STANDARD_VOLUME * 2 //same size as the engineering ones but plasmamen have special lungs that consume less plasma per breath
 	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
 /obj/item/tank/internals/plasmaman/belt/full/populate_gas()
@@ -182,7 +182,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
-	volume = 3 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
+	volume = TANK_EMERGENCY_STANDARD_VOLUME //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 
 /obj/item/tank/internals/emergency_oxygen/populate_gas()
@@ -200,7 +200,7 @@
 	worn_icon_state = "emergency_engi"
 	tank_holder_icon_state = "holder_emergency_engi"
 	worn_icon = null
-	volume = 6 // should last 24 minutes if full
+	volume = TANK_EMERGENCY_STANDARD_VOLUME * 2
 
 /obj/item/tank/internals/emergency_oxygen/engi/empty/populate_gas()
 	return
@@ -210,7 +210,7 @@
 	icon_state = "emergency_double"
 	worn_icon_state = "emergency_engi"
 	tank_holder_icon_state = "holder_emergency_engi"
-	volume = 12 //If it's double of the above, shouldn't it be double the volume??
+	volume = TANK_EMERGENCY_STANDARD_VOLUME * 4
 
 /obj/item/tank/internals/emergency_oxygen/double/empty/populate_gas()
 	return


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
filling an **emergency** internals tank with a canister sets you for the rest of the game, with this change it will be for emergency use ONLY, making the big internals tanks actually useful and making space more dangerous.
## Changelog
:cl:
balance: reduced volume of all emergency internals tanks by 3 times
/:cl:
