### PR TITLE
Tweaks to biddler malf

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -451,3 +451,5 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 
 /// Camera net used by battle royale objective
 #define BATTLE_ROYALE_CAMERA_NET "battle_royale_camera_net"
+
+#define MALF_MAX_PP 400

--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -168,6 +168,7 @@
 	var/list/data = list()
 	data["processingTime"] = malf_ai.malf_picker.processing_time
 	data["compactMode"] = module_picker_compactmode
+	data["hackedAPCs"] = malf_ai.hacked_apcs.len
 	return data
 
 /datum/antagonist/malf_ai/ui_static_data(mob/living/silicon/ai/malf_ai)
@@ -199,6 +200,7 @@
 					"name" = mod.name,
 					"cost" = mod.cost,
 					"desc" = mod.description,
+					"minimum_apcs" = mod.minimum_apcs,
 				))
 			data["categories"] += list(cat)
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -594,7 +594,7 @@
 		hacked_flicker_counter = hacked_flicker_counter - 1
 		if(hacked_flicker_counter <= 0)
 			flicker_hacked_icon()
-		if(COOLDOWN_FINISHED(src, malf_ai_pt_generation) && cell.use(30 KILO JOULES)>0) // Over time generation of malf points for the ai controlling it, costs a bit of power
+		if(COOLDOWN_FINISHED(src, malf_ai_pt_generation) && cell.use(60 KILO JOULES)>0 && malfai.malf_picker.processing_time<MALF_MAX_PP) // Over time generation of malf points for the ai controlling it, costs a bit of power
 			COOLDOWN_START(src, malf_ai_pt_generation, 30 SECONDS)
 			malfai.malf_picker.processing_time += 1
 

--- a/tgui/packages/tgui/interfaces/common/MalfAiModules.tsx
+++ b/tgui/packages/tgui/interfaces/common/MalfAiModules.tsx
@@ -12,14 +12,14 @@ type MalfItem = Item & {
 
 type Data = {
   processingTime: string;
-  apcsHacked: number;
+  hackedAPCs: number;
   categories: Category[];
 };
 
 /** Common ui for selecting malf ai modules */
 export function MalfAiModules(props) {
   const { act, data } = useBackend<Data>();
-  const { processingTime, apcsHacked, categories = [] } = data;
+  const { processingTime, hackedAPCs, categories = [] } = data;
 
   const categoriesList: string[] = [];
   const items: MalfItem[] = [];
@@ -35,10 +35,10 @@ export function MalfAiModules(props) {
         cost: `${item.cost} PT`,
         desc:
           item.desc +
-          (item.minimum_apcs
+          (item.minimum_apcs > 0
             ? ` Requires at least ${item.minimum_apcs} APCs hacked.`
             : ''),
-        disabled: processingTime < item.cost || apcsHacked < item.minimum_apcs,
+        disabled: processingTime < item.cost || hackedAPCs < item.minimum_apcs,
         icon_state: item.icon_state,
         icon: item.icon,
         id: item.name,


### PR DESCRIPTION

## About The Pull Request
Fixes the bugged malf ai descriptions, properly describing which modules need minimum number of hacked apcs
Adds a processing power limit to discourage just sitting on your ass for 2 hours to stack up infinite points
Increases the power draw of hacked APCs to increase the phantom drain on powernet brought by malf hacking a lot
## Why It's Good For The Game
Discourages hacking two apcs and waiting for next two hours. Also having working descriptions is cool.
## Changelog
:cl:
balance: Adds a upper limit for malf ai points, currently at 400
balance: Increases hacked apc power draw to 2 kW
fix: Fixed bugged malf ai module descriptions
/:cl:
