### PR TITLE
Extinguisher changes: Now bulky, higher force, with a new attack

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -117,7 +117,7 @@
 	var/min_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_SEVERE, return_value_if_no_wound = 30, wound_source = src)
 	var/max_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 50, wound_source = src)
 
-	wallopee.apply_damage(src.force * 2, src.damtype, head_to_bash, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = src)
+	wallopee.apply_damage(src.force * 3, src.damtype, head_to_bash, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = src)
 	wallopee.emote("scream")
 	log_combat(user, wallopee, "bashed [wallopee]'s [head_name]")
 	user.do_attack_animation(wallopee, used_item = src)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -88,24 +88,21 @@
 	if(w_class < WEIGHT_CLASS_BULKY)
 		return SECONDARY_ATTACK_CALL_NORMAL
 
-	if(!iscarbon(victim) || user.combat_mode)
-		return SECONDARY_ATTACK_CALL_NORMAL
-
-	if(user.zone_selected != BODY_ZONE_HEAD)
+	if(!iscarbon(victim))
 		return SECONDARY_ATTACK_CALL_NORMAL
 
 	var/mob/living/carbon/wallopee = victim
-	var/obj/item/bodypart/head/head_to_bash = wallopee.get_bodypart(check_zone(user.zone_selected))
-	var/head_name = head_to_bash.name
+	var/obj/item/bodypart/head/head_to_bash = wallopee.get_bodypart(BODY_ZONE_HEAD)
 
 	if(!head_to_bash)
-		to_chat(user, span_warning("There is no head to bash."))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return SECONDARY_ATTACK_CALL_NORMAL
+
+	var/head_name = head_to_bash.name
 
 	if(fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)
 		playsound(src, fire_extinguisher_reagent_sloshing_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)
 
-	log_combat(user, wallopee, "prepared to use [src] to bash [wallopee]'s [head_name]")
+	log_combat(user, wallopee, "prepared to use a bash attack with a [src] against [wallopee]")
 
 	wallopee.visible_message(span_danger("[user] begins to raise [src] above [wallopee]'s [head_name]."), span_userdanger("[user] begins to raise [src], aiming to cave in your [head_name]!"))
 
@@ -119,7 +116,7 @@
 
 	wallopee.apply_damage(src.force * 3, src.damtype, head_to_bash, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = src)
 	wallopee.emote("scream")
-	log_combat(user, wallopee, "bashed [wallopee]'s [head_name]")
+	log_combat(user, wallopee, "used a bash attack with a [src] against [wallopee]")
 	user.do_attack_animation(wallopee, used_item = src)
 
 	if(fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -88,6 +88,9 @@
 	if(w_class < WEIGHT_CLASS_BULKY)
 		return SECONDARY_ATTACK_CALL_NORMAL
 
+	if(issilicon(user))
+		return SECONDARY_ATTACK_CALL_NORMAL
+
 	if(!iscarbon(victim))
 		return SECONDARY_ATTACK_CALL_NORMAL
 

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -194,6 +194,9 @@
 	inhand_icon_state = "foam_extinguisher"
 	tank_holder_icon_state = "holder_foam_extinguisher"
 	dog_fashion = null
+	throwforce = 10
+	w_class = WEIGHT_CLASS_NORMAL
+	force = 10
 	chem = /datum/reagent/firefighting_foam
 	tanktypes = list(
 		/obj/structure/reagent_dispensers/foamtank,

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -10,11 +10,11 @@
 	pickup_sound = 'sound/items/handling/gas_tank/gas_tank_pick_up.ogg'
 	drop_sound = 'sound/items/handling/gas_tank/gas_tank_drop.ogg'
 	obj_flags = CONDUCTS_ELECTRICITY
-	throwforce = 10
-	w_class = WEIGHT_CLASS_NORMAL
+	throwforce = 13
+	w_class = WEIGHT_CLASS_BULKY
 	throw_speed = 2
 	throw_range = 7
-	force = 10
+	force = 13
 	demolition_mod = 1.25
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 0.9)
 	attack_verb_continuous = list("slams", "whacks", "bashes", "thunks", "batters", "bludgeons", "thrashes")
@@ -82,6 +82,50 @@
 	if((slot & ITEM_SLOT_HANDS) && fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)
 		playsound(src, fire_extinguisher_reagent_sloshing_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)
 
+// A secondary attack letting you wind up the extinguisher for a real wallopping to your targets head
+/obj/item/extinguisher/attack_secondary(mob/living/victim, mob/living/user, params)
+	// This only makes sense for heavier extinguishers
+	if(w_class < WEIGHT_CLASS_BULKY)
+		return SECONDARY_ATTACK_CALL_NORMAL
+
+	if(!iscarbon(victim) || user.combat_mode)
+		return SECONDARY_ATTACK_CALL_NORMAL
+
+	if(user.zone_selected != BODY_ZONE_HEAD)
+		return SECONDARY_ATTACK_CALL_NORMAL
+
+	var/mob/living/carbon/wallopee = victim
+	var/obj/item/bodypart/head/head_to_bash = wallopee.get_bodypart(check_zone(user.zone_selected))
+	var/head_name = head_to_bash.name
+
+	if(!head_to_bash)
+		to_chat(user, span_warning("There is no head to bash."))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)
+		playsound(src, fire_extinguisher_reagent_sloshing_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)
+
+	log_combat(user, wallopee, "prepared to use [src] to bash [wallopee]'s [head_name]")
+
+	wallopee.visible_message(span_danger("[user] begins to raise [src] above [wallopee]'s [head_name]."), span_userdanger("[user] begins to raise [src], aiming to cave in your [head_name]!"))
+
+	if(do_after(user,  2 SECONDS, target = wallopee))
+		wallopee.visible_message(span_danger("[user] brings [src] heavily down on [wallopee]'s [head_name]."), span_userdanger("[user] brings [src] heavily down on your [head_name]!"))
+
+		var/min_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_SEVERE, return_value_if_no_wound = 20, wound_source = src)
+		var/max_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 40, wound_source = src)
+
+		wallopee.apply_damage(src.force * 2, src.damtype, head_to_bash, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = src)
+		wallopee.emote("scream")
+		log_combat(user, wallopee, "bashed [wallopee]'s [head_name]")
+		user.do_attack_animation(wallopee, used_item = src)
+
+		if(fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)
+			playsound(src, fire_extinguisher_reagent_sloshing_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)
+
+		playsound(source = src, soundin = src.hitsound, vol = src.get_clamped_volume(), vary = TRUE)
+
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/extinguisher/empty
 	starting_water = FALSE

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -109,21 +109,23 @@
 
 	wallopee.visible_message(span_danger("[user] begins to raise [src] above [wallopee]'s [head_name]."), span_userdanger("[user] begins to raise [src], aiming to cave in your [head_name]!"))
 
-	if(do_after(user,  2 SECONDS, target = wallopee))
-		wallopee.visible_message(span_danger("[user] brings [src] heavily down on [wallopee]'s [head_name]."), span_userdanger("[user] brings [src] heavily down on your [head_name]!"))
+	if(!do_after(user,  2 SECONDS, target = wallopee))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-		var/min_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_SEVERE, return_value_if_no_wound = 20, wound_source = src)
-		var/max_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 40, wound_source = src)
+	wallopee.visible_message(span_danger("[user] brings [src] heavily down on [wallopee]'s [head_name]."), span_userdanger("[user] brings [src] heavily down on your [head_name]!"))
 
-		wallopee.apply_damage(src.force * 2, src.damtype, head_to_bash, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = src)
-		wallopee.emote("scream")
-		log_combat(user, wallopee, "bashed [wallopee]'s [head_name]")
-		user.do_attack_animation(wallopee, used_item = src)
+	var/min_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_SEVERE, return_value_if_no_wound = 30, wound_source = src)
+	var/max_wound = head_to_bash.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 50, wound_source = src)
 
-		if(fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)
-			playsound(src, fire_extinguisher_reagent_sloshing_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)
+	wallopee.apply_damage(src.force * 2, src.damtype, head_to_bash, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = src)
+	wallopee.emote("scream")
+	log_combat(user, wallopee, "bashed [wallopee]'s [head_name]")
+	user.do_attack_animation(wallopee, used_item = src)
 
-		playsound(source = src, soundin = src.hitsound, vol = src.get_clamped_volume(), vary = TRUE)
+	if(fire_extinguisher_reagent_sloshing_sound && reagents.total_volume > 0)
+		playsound(src, fire_extinguisher_reagent_sloshing_sound, LIQUID_SLOSHING_SOUND_VOLUME, vary = TRUE, ignore_walls = FALSE)
+
+	playsound(source = src, soundin = src.hitsound, vol = src.get_clamped_volume(), vary = TRUE)
 
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 


### PR DESCRIPTION
## About The Pull Request
Changes the weight of the fire extinguisher to bulky.
Changes its force to 13.
Adds a brand new alt attack, when you rightclick on the head of a target you will wind up your extinguisher for 2 seconds and then smash it down doing 39 damage with a wound bonus. This may need better telegraphing, if you have any idea on how to implement this please reach out or make a pr to this branch.
## Why It's Good For The Game
Fire extinguisher to bulky and force increase, I feel as if the regular fire extinguisher fits better as a heavy improvised weapon / fire fighting tool rather than just the latter, and in order to justify the changes to increase the force of the fire extinguisher so it can act as a fairly good improvised weapon (around the same strength as a toolbox) its weight had to be changed. A fire extinguisher should be a superior option to just fighting with fists and I believe that in its former state it really wasnt. The bulky extinguisher change also comes as a result of people repeatedly stealing and bagging the fire extinguishers which often leaves common areas without them, greatly reducing the capacity for fire fighting.

The alt attack, I felt like it was pretty cool and flavorful to be able to "charge" up a hit with a fire extinguisher and be able to just smash it down on someone, it also lends it a niche for finishers. [Also this](https://www.youtube.com/watch?v=IhPTUog6DWc&t=180s)
## Changelog
:cl:
add: Fire extinguishers now have an alternate attack, usable with right click
balance: Fire extinguishers force: 10 -> 13
balance: Fire extinguishers weight: Normal -> Bulky
/:cl:
