### PR TITLE
Power gaming phobia

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -42,6 +42,7 @@ GLOBAL_LIST_INIT(phobia_regexes, list(
 	"insects" = construct_phobia_regex("insects"),
 	"lizards" = construct_phobia_regex("lizards"),
 	"ocky icky" = construct_phobia_regex("ocky icky"),
+	"power gaming" = construct_phobia_regex("power gaming"),
 	"robots" = construct_phobia_regex("robots"),
 	"security" = construct_phobia_regex("security"),
 	"skeletons" = construct_phobia_regex("skeletons"),
@@ -448,6 +449,17 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/item/banhammer,
 		/obj/item/toy/plush/awakenedplushie,
 	)),
+	"power gaming" = typecacheof(list(
+		/obj/item/extinguisher/mini,
+		/obj/item/clothing/glasses/meson,
+		/obj/item/soap,
+		/obj/item/screwdriver,
+		/obj/item/wrench,
+		/obj/item/crowbar,
+		/obj/item/wirecutters,
+		/obj/item/weldingtool,
+		/obj/item/multitool,
+	)),
 	"robots" = typecacheof(list(
 		/obj/item/ai_module,
 		/obj/item/aicard,
@@ -578,6 +590,12 @@ GLOBAL_LIST_INIT(phobia_species, list(
 	"skeletons" = typecacheof(list(
 		/datum/species/plasmaman,
 		/datum/species/skeleton,
+	)),
+))
+GLOBAL_LIST_INIT(phobia_reagents, list(
+	"power gaming" = typecacheof(list(
+		/datum/reagent/consumable/ethanol/quadruple_sec,
+		/datum/reagent/medicine/c2/multiver,
 	)),
 ))
 

--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -459,6 +459,13 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/item/wirecutters,
 		/obj/item/weldingtool,
 		/obj/item/multitool,
+		/obj/item/clothing/gloves/color/yellow,
+		/obj/item/storage/box/papersack,
+		/obj/item/reagent_containers/cup/glass/sillycup,
+		/obj/item/storage/wallet,
+		/obj/item/storage/backpack/satchel/flat,
+		/obj/item/food/powercrepe,
+
 	)),
 	"robots" = typecacheof(list(
 		/obj/item/ai_module,
@@ -596,6 +603,7 @@ GLOBAL_LIST_INIT(phobia_reagents, list(
 	"power gaming" = typecacheof(list(
 		/datum/reagent/consumable/ethanol/quadruple_sec,
 		/datum/reagent/medicine/c2/multiver,
+		/datum/reagent/consumable/pwr_game,
 	)),
 ))
 

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -19,6 +19,7 @@
 	var/list/trigger_objs //also checked in mob equipment
 	var/list/trigger_turfs
 	var/list/trigger_species
+	var/list/trigger_reagents
 
 /datum/brain_trauma/mild/phobia/New(new_phobia_type)
 	if(new_phobia_type)
@@ -35,6 +36,7 @@
 	trigger_objs = GLOB.phobia_objs[phobia_type]
 	trigger_turfs = GLOB.phobia_turfs[phobia_type]
 	trigger_species = GLOB.phobia_species[phobia_type]
+	trigger_reagents = GLOB.phobia_reagents[phobia_type]
 	..()
 
 /datum/brain_trauma/mild/phobia/on_lose(silent)
@@ -65,6 +67,13 @@
 				freak_out(checked)
 				return
 
+	if(LAZYLEN(trigger_reagents))
+		for(var/obj/item/reagent_containers/seen_container in seen_atoms)
+			for(var/datum/reagent/seen_reagent in seen_container.reagents.reagent_list)
+				if(is_scary_reagent(seen_reagent))
+					freak_out(seen_reagent)
+					return
+
 	seen_atoms -= owner //make sure they aren't afraid of themselves.
 	if(LAZYLEN(trigger_mobs) || LAZYLEN(trigger_species) || LAZYLEN(trigger_objs))
 		for(var/mob/living/checked in seen_atoms)
@@ -80,6 +89,14 @@
 		return TRUE
 	var/obj/item/checked_item = checked
 	return !HAS_TRAIT(checked_item, TRAIT_EXAMINE_SKIP)
+
+/datum/brain_trauma/mild/phobia/proc/is_scary_reagent(datum/checked)
+	if (QDELETED(checked) || !is_type_in_typecache(checked, trigger_reagents))
+		return FALSE
+	if (!isdatum(checked))
+		return TRUE
+	var/datum/reagent/checked_reagent = checked
+	return !HAS_TRAIT(checked_reagent, TRAIT_EXAMINE_SKIP)
 
 /datum/brain_trauma/mild/phobia/proc/is_scary_mob(mob/living/checked)
 	if(is_type_in_typecache(checked, trigger_mobs))
@@ -222,6 +239,10 @@
 
 /datum/brain_trauma/mild/phobia/ocky_icky
 	phobia_type = "ocky icky"
+	random_gain = FALSE
+
+/datum/brain_trauma/mild/phobia/power_gaming
+	phobia_type = "power gaming"
 	random_gain = FALSE
 
 /datum/brain_trauma/mild/phobia/robots

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -71,7 +71,7 @@
 		for(var/obj/item/reagent_containers/seen_container in seen_atoms)
 			for(var/datum/reagent/seen_reagent in seen_container.reagents.reagent_list)
 				if(is_scary_reagent(seen_reagent))
-					freak_out(seen_reagent)
+					freak_out(seen_container)
 					return
 
 	seen_atoms -= owner //make sure they aren't afraid of themselves.

--- a/code/modules/admin/smites/phobia_ocky_icky.dm
+++ b/code/modules/admin/smites/phobia_ocky_icky.dm
@@ -6,4 +6,3 @@
 	. = ..()
 	var/mob/living/carbon/ocker = target
 	ocker.gain_trauma(/datum/brain_trauma/mild/phobia/ocky_icky, TRAUMA_RESILIENCE_LOBOTOMY)
-	

--- a/code/modules/admin/smites/phobia_power_gaming.dm
+++ b/code/modules/admin/smites/phobia_power_gaming.dm
@@ -1,9 +1,8 @@
 /// POWER GAMING ON MY SERVER??? MAKE THEM QUIVER IN THE MERE PRESENCE OF POWER
-/datum/smite/ocky_icky
+/datum/smite/power_gaming
 	name = "Power Gaming phobia"
 
-/datum/smite/ocky_icky/effect(client/user, mob/living/target)
+/datum/smite/power_gaming/effect(client/user, mob/living/target)
 	. = ..()
 	var/mob/living/carbon/gamer = target
 	gamer.gain_trauma(/datum/brain_trauma/mild/phobia/power_gaming, TRAUMA_RESILIENCE_LOBOTOMY)
-

--- a/code/modules/admin/smites/phobia_power_gaming.dm
+++ b/code/modules/admin/smites/phobia_power_gaming.dm
@@ -1,0 +1,9 @@
+/// POWER GAMING ON MY SERVER??? MAKE THEM QUIVER IN THE MERE PRESENCE OF POWER
+/datum/smite/ocky_icky
+	name = "Power Gaming phobia"
+
+/datum/smite/ocky_icky/effect(client/user, mob/living/target)
+	. = ..()
+	var/mob/living/carbon/gamer = target
+	gamer.gain_trauma(/datum/brain_trauma/mild/phobia/power_gaming, TRAUMA_RESILIENCE_LOBOTOMY)
+

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -411,7 +411,16 @@
 		"y",
 		"5head"
 	],
-
+	"power gaming": [
+		"extinguisher",
+		"gaming",
+		"menson",
+		"multiver",
+		"power",
+		"quadsec",
+		"soap",
+		"tool"
+	],
 	"robots": [
 		"ai",
 		"android",

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3059,6 +3059,7 @@
 #include "code\modules\admin\smites\nugget.dm"
 #include "code\modules\admin\smites\petrify.dm"
 #include "code\modules\admin\smites\phobia_ocky_icky.dm"
+#include "code\modules\admin\smites\phobia_power_gaming.dm"
 #include "code\modules\admin\smites\puzzgrid.dm"
 #include "code\modules\admin\smites\puzzle.dm"
 #include "code\modules\admin\smites\retcon.dm"


### PR DESCRIPTION

## About The Pull Request

Power gamers have gone TOO FAR. admins need an appropriate response to the rampant power gaming on Manuel. this PR will fix Manuel and restore it to the glory days were we can bar RP in peace

Adds a power gaming phobia, which makes you afraid of dangerous power gaming tactics (such as meson goggles, quadsec, multiver, crowbars, pocket extinguishers and more)
## Why It's Good For The Game

Im saving RP
## Changelog

Adds a power gaming phobia and power gaming admin smite
:cl:
add: power gaming phobia and smite
/:cl:
