### PR TITLE
Slimes which split with a 0% mutation chance only make slimes with a 0% mutation chance insuring true copies

### DIFF
--- a/code/modules/mob/living/basic/slime/actions.dm
+++ b/code/modules/mob/living/basic/slime/actions.dm
@@ -142,7 +142,10 @@
 			baby.befriend(slime_friend)
 
 		babies += baby
-		baby.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
+		if(mutation_chance == 0)
+			baby.mutation_chance = 0
+		else
+			baby.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
 		SSblackbox.record_feedback("tally", "slime_babies_born", 1, baby.slime_type.colour)
 
 	var/mob/living/basic/slime/new_slime = pick(babies) // slime that the OG slime will move into.


### PR DESCRIPTION

## About The Pull Request

Slimes that are at 0% mutation chance cant gain mutation chance upon splitting

I also tried a pr like this 3 months or so ago, and didnt want to or know how to fix the error that popped up.
Hoping it doesnt come back to haunt me 😨 
## Why It's Good For The Game

If you put in the effort to get a slime to 0% mutation chance, you should be able to keep them at 0%. 
## Changelog

Slimes dont gain mutation chance while at 0%
:cl:
qol: slimes at 0% mutation chance stay at 0% upon splitting
/:cl:
