### PR TITLE
Fix stat panel background color

### DIFF
--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -1,4 +1,5 @@
 .light:root {
+  --color-base: #ffffff;
   --scrollbar-base: #f2f2f2;
   --scrollbar-thumb: #a7a7a7;
 }
@@ -196,6 +197,7 @@ img {
  * MARK: Dark theme colors
  */
 .dark:root {
+  --color-base: #151515;
   --scrollbar-base: #151515;
   --scrollbar-thumb: #363636;
 }
@@ -203,13 +205,6 @@ img {
 body.dark {
   background-color: #151515;
   color: #b2c4dd;
-  scrollbar-base-color: #1c1c1c;
-  scrollbar-face-color: #3b3b3b;
-  scrollbar-3dlight-color: #252525;
-  scrollbar-highlight-color: #252525;
-  scrollbar-track-color: #1c1c1c;
-  scrollbar-arrow-color: #929292;
-  scrollbar-shadow-color: #3b3b3b;
 }
 
 .dark a {

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -746,11 +746,9 @@ function set_theme(which) {
   if (which == "light") {
     document.body.className = "";
     document.documentElement.className = "light";
-    set_style_sheet("browserOutput_white");
   } else if (which == "dark") {
     document.body.className = "dark";
     document.documentElement.className = "dark";
-    set_style_sheet("browserOutput");
   }
 }
 
@@ -769,21 +767,6 @@ function set_tabs_style(style) {
     menu.classList.remove("menu-wrap");
     menu.classList.remove("tabs-classic");
   }
-}
-
-function set_style_sheet(sheet) {
-  if (document.getElementById("goonStyle")) {
-    var currentSheet = document.getElementById("goonStyle");
-    currentSheet.parentElement.removeChild(currentSheet);
-  }
-  var head = document.getElementsByTagName("head")[0];
-  var sheetElement = document.createElement("link");
-  sheetElement.id = "goonStyle";
-  sheetElement.rel = "stylesheet";
-  sheetElement.type = "text/css";
-  sheetElement.href = sheet + ".css";
-  sheetElement.media = "all";
-  head.appendChild(sheetElement);
 }
 
 function restoreFocus() {

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -12,7 +12,7 @@
     <!-- tgui:ntos-error -->
     <!-- tgui:inline-css -->
   </head>
-  <body style="background-color: #333">
+  <body style="background-color: var(--color-base)">
     <!-- tgui:assets -->
     <!-- tgui:inline-html-start -->
     <!-- tgui:inline-html -->


### PR DESCRIPTION
## About The Pull Request
Just a fix for a stat panel background color, was broken after -  https://github.com/tgstation/tgstation/pull/92004
Also removed unused goonStyle from it. There is no browserOutput.css in repo

Still works

https://github.com/user-attachments/assets/2e4158cd-f6a1-498b-90d7-c65c738853c9


## Why It's Good For The Game
No dark background in stat panel, even on light theme

## Changelog

:cl:
fix: Stat panel background no longer be... dark in both themes
/:cl:
