### PR TITLE
Fixes a bunch of unarmed attack verbs' incorrect forms

### DIFF
--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -319,7 +319,7 @@
 	arm.unarmed_attack_verbs = list("slash")
 	arm.unarmed_attack_verbs_continuous = list("slashes")
 	arm.grappled_attack_verb = "lacerate"
-	arm.grappled_attack_verb_past = "lacerated"
+	arm.grappled_attack_verb_continuous = "lacerates"
 	arm.unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	arm.unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	arm.unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -344,7 +344,7 @@
 	arm.unarmed_attack_verbs = initial_unarmed_verbs[arm]
 	arm.unarmed_attack_verbs_continuous = initial_unarmed_verbs_past[arm]
 	arm.grappled_attack_verb = initial(arm.grappled_attack_verb)
-	arm.grappled_attack_verb_past = initial(arm.grappled_attack_verb_past)
+	arm.grappled_attack_verb_continuous = initial(arm.grappled_attack_verb_continuous)
 	arm.unarmed_attack_effect = initial(arm.unarmed_attack_effect)
 	arm.unarmed_attack_sound = initial(arm.unarmed_attack_sound)
 	arm.unarmed_miss_sound = initial(arm.unarmed_miss_sound)

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -315,9 +315,9 @@
 /// Make our arm do slashing effects
 /datum/status_effect/golem/diamond/proc/set_arm_fluff(obj/item/bodypart/arm/arm)
 	initial_unarmed_verbs[arm] = arm.unarmed_attack_verbs
-	initial_unarmed_verbs_past[arm] = arm.unarmed_attack_verbs_past
+	initial_unarmed_verbs_past[arm] = arm.unarmed_attack_verbs_continuous
 	arm.unarmed_attack_verbs = list("slash")
-	arm.unarmed_attack_verbs_past = list("slashed")
+	arm.unarmed_attack_verbs_continuous = list("slashes")
 	arm.grappled_attack_verb = "lacerate"
 	arm.grappled_attack_verb_past = "lacerated"
 	arm.unarmed_attack_effect = ATTACK_EFFECT_CLAW
@@ -342,7 +342,7 @@
 	if (!arm)
 		return
 	arm.unarmed_attack_verbs = initial_unarmed_verbs[arm]
-	arm.unarmed_attack_verbs_past = initial_unarmed_verbs_past[arm]
+	arm.unarmed_attack_verbs_continuous = initial_unarmed_verbs_past[arm]
 	arm.grappled_attack_verb = initial(arm.grappled_attack_verb)
 	arm.grappled_attack_verb_past = initial(arm.grappled_attack_verb_past)
 	arm.unarmed_attack_effect = initial(arm.unarmed_attack_effect)

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -311,7 +311,9 @@
 /// Make our arm do slashing effects
 /datum/status_effect/golem/diamond/proc/set_arm_fluff(obj/item/bodypart/arm/arm)
 	arm.unarmed_attack_verbs = list("slash")
+	arm.unarmed_attack_verbs_past = list("slashed")
 	arm.grappled_attack_verb = "lacerate"
+	arm.grappled_attack_verb_past = "lacerated"
 	arm.unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	arm.unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	arm.unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -332,6 +334,9 @@
 	if (!arm)
 		return
 	arm.unarmed_attack_verbs = initial(arm.unarmed_attack_verbs)
+	arm.unarmed_attack_verbs_past = initial(arm.unarmed_attack_verbs_past)
+	arm.grappled_attack_verb = initial(arm.grappled_attack_verb)
+	arm.grappled_attack_verb_past = initial(arm.grappled_attack_verb_past)
 	arm.unarmed_attack_effect = initial(arm.unarmed_attack_effect)
 	arm.unarmed_attack_sound = initial(arm.unarmed_attack_sound)
 	arm.unarmed_miss_sound = initial(arm.unarmed_miss_sound)

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -286,6 +286,10 @@
 	var/moving_alpha = 200
 	/// List of arms we have updated
 	var/list/modified_arms
+	/// Arm -> original attack verbs assoc list
+	var/list/initial_unarmed_verbs = list()
+	/// Arm -> original past attack verbs assocl ist
+	var/list/initial_unarmed_verbs_past = list()
 
 /datum/status_effect/golem/diamond/on_apply()
 	. = ..()
@@ -310,6 +314,8 @@
 
 /// Make our arm do slashing effects
 /datum/status_effect/golem/diamond/proc/set_arm_fluff(obj/item/bodypart/arm/arm)
+	initial_unarmed_verbs[arm] = arm.unarmed_attack_verbs
+	initial_unarmed_verbs_past[arm] = arm.unarmed_attack_verbs_past
 	arm.unarmed_attack_verbs = list("slash")
 	arm.unarmed_attack_verbs_past = list("slashed")
 	arm.grappled_attack_verb = "lacerate"
@@ -327,14 +333,16 @@
 	for (var/obj/item/bodypart/arm/arm as anything in modified_arms)
 		reset_arm_fluff(arm)
 	LAZYCLEARLIST(modified_arms)
+	initial_unarmed_verbs.Cut()
+	initial_unarmed_verbs_past.Cut()
 	return ..()
 
 /// Make our arm do whatever it originally did
 /datum/status_effect/golem/diamond/proc/reset_arm_fluff(obj/item/bodypart/arm/arm)
 	if (!arm)
 		return
-	arm.unarmed_attack_verbs = initial(arm.unarmed_attack_verbs)
-	arm.unarmed_attack_verbs_past = initial(arm.unarmed_attack_verbs_past)
+	arm.unarmed_attack_verbs = initial_unarmed_verbs[arm]
+	arm.unarmed_attack_verbs_past = initial_unarmed_verbs_past[arm]
 	arm.grappled_attack_verb = initial(arm.grappled_attack_verb)
 	arm.grappled_attack_verb_past = initial(arm.grappled_attack_verb_past)
 	arm.unarmed_attack_effect = initial(arm.unarmed_attack_effect)
@@ -346,6 +354,8 @@
 /datum/status_effect/golem/diamond/proc/on_arm_destroyed(obj/item/bodypart/arm/arm)
 	SIGNAL_HANDLER
 	modified_arms -= arm
+	initial_unarmed_verbs -= arm
+	initial_unarmed_verbs_past -= arm
 
 /// Makes you tougher
 /datum/status_effect/golem/titanium

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -837,7 +837,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Whether or not we get some protein for a successful attack. Nom.
 	var/biting = FALSE
 
-	var/atk_verb = pick(attacking_bodypart.unarmed_attack_verbs)
+	var/atk_verb_index = rand(1, length(attacking_bodypart.unarmed_attack_verbs))
+	var/atk_verb = attacking_bodypart.unarmed_attack_verbs[atk_verb_index]
+	var/atk_verb_past = "[atk_verb]ed"
+	if (length(attacking_bodypart.unarmed_attack_verbs_past) >= atk_verb_index) // Just in case
+		atk_verb_past = attacking_bodypart.unarmed_attack_verbs_past[atk_verb_index]
+
 	var/atk_effect = attacking_bodypart.unarmed_attack_effect
 
 	if(atk_effect == ATTACK_EFFECT_BITE)
@@ -845,7 +850,11 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			biting = TRUE
 		else if(user.get_active_hand()) //In the event we can't bite, emergency swap to see if we can attack with a hand.
 			attacking_bodypart = user.get_active_hand()
-			atk_verb = pick(attacking_bodypart.unarmed_attack_verbs)
+			atk_verb_index = rand(1, length(attacking_bodypart.unarmed_attack_verbs))
+			atk_verb = attacking_bodypart.unarmed_attack_verbs[atk_verb_index]
+			atk_verb_past = "[atk_verb]ed"
+			if (length(attacking_bodypart.unarmed_attack_verbs_past) >= atk_verb_index) // Just in case
+				atk_verb_past = attacking_bodypart.unarmed_attack_verbs_past[atk_verb_index]
 			atk_effect = attacking_bodypart.unarmed_attack_effect
 		else  //Nothing? Okay. Fail.
 			user.balloon_alert(user, "can't attack!")
@@ -883,7 +892,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			limb_accuracy += clamp(puncher_brute_and_burn / 2, 10, 200)
 			damage += damage * clamp(puncher_brute_and_burn / 100, 0.3, 2) //Basically a multiplier of how much extra damage you get based on how low your health is overall. A floor of about a 30%.
 			var/drunken_martial_descriptor = pick("Drunken", "Intoxicated", "Tipsy", "Inebriated", "Delirious", "Day-Drinker's", "Firegut", "Blackout")
-			atk_verb = "[drunken_martial_descriptor] [atk_verb]"
+			atk_verb = "[drunken_martial_descriptor] [capitalize(atk_verb)]"
+			atk_verb_past = "[drunken_martial_descriptor] [capitalize(atk_verb_past)]"
 
 		else if(user_drunkenness >= 60)
 			limb_accuracy = -limb_accuracy // good luck landing a punch now, you drunk fuck
@@ -932,8 +942,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	if(grappled && attacking_bodypart.grappled_attack_verb)
 		atk_verb = attacking_bodypart.grappled_attack_verb
-	target.visible_message(span_danger("[user] [atk_verb]ed [target]!"), \
-					span_userdanger("You're [atk_verb]ed by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+		atk_verb_past = attacking_bodypart.grappled_attack_verb_past
+
+	target.visible_message(span_danger("[user] [atk_verb_past] [target]!"), \
+					span_userdanger("You're [atk_verb_past] by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
 	to_chat(user, span_danger("You [atk_verb] [target]!"))
 
 	target.lastattacker = user.real_name

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -942,7 +942,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	if(grappled && attacking_bodypart.grappled_attack_verb)
 		atk_verb = attacking_bodypart.grappled_attack_verb
-		atk_verb_continuous = attacking_bodypart.grappled_attack_verb_past
+		atk_verb_continuous = attacking_bodypart.grappled_attack_verb_continuous
 
 	target.visible_message(span_danger("[user] [atk_verb_continuous] [target]!"), \
 					span_userdanger("[user] [atk_verb_continuous] you!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -839,9 +839,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	var/atk_verb_index = rand(1, length(attacking_bodypart.unarmed_attack_verbs))
 	var/atk_verb = attacking_bodypart.unarmed_attack_verbs[atk_verb_index]
-	var/atk_verb_past = "[atk_verb]ed"
-	if (length(attacking_bodypart.unarmed_attack_verbs_past) >= atk_verb_index) // Just in case
-		atk_verb_past = attacking_bodypart.unarmed_attack_verbs_past[atk_verb_index]
+	var/atk_verb_continuous = "[atk_verb]s"
+	if (length(attacking_bodypart.unarmed_attack_verbs_continuous) >= atk_verb_index) // Just in case
+		atk_verb_continuous = attacking_bodypart.unarmed_attack_verbs_continuous[atk_verb_index]
 
 	var/atk_effect = attacking_bodypart.unarmed_attack_effect
 
@@ -852,9 +852,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			attacking_bodypart = user.get_active_hand()
 			atk_verb_index = rand(1, length(attacking_bodypart.unarmed_attack_verbs))
 			atk_verb = attacking_bodypart.unarmed_attack_verbs[atk_verb_index]
-			atk_verb_past = "[atk_verb]ed"
-			if (length(attacking_bodypart.unarmed_attack_verbs_past) >= atk_verb_index) // Just in case
-				atk_verb_past = attacking_bodypart.unarmed_attack_verbs_past[atk_verb_index]
+			atk_verb_continuous = "[atk_verb]s"
+			if (length(attacking_bodypart.unarmed_attack_verbs_continuous) >= atk_verb_index) // Just in case
+				atk_verb_continuous = attacking_bodypart.unarmed_attack_verbs_continuous[atk_verb_index]
 			atk_effect = attacking_bodypart.unarmed_attack_effect
 		else  //Nothing? Okay. Fail.
 			user.balloon_alert(user, "can't attack!")
@@ -893,7 +893,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			damage += damage * clamp(puncher_brute_and_burn / 100, 0.3, 2) //Basically a multiplier of how much extra damage you get based on how low your health is overall. A floor of about a 30%.
 			var/drunken_martial_descriptor = pick("Drunken", "Intoxicated", "Tipsy", "Inebriated", "Delirious", "Day-Drinker's", "Firegut", "Blackout")
 			atk_verb = "[drunken_martial_descriptor] [capitalize(atk_verb)]"
-			atk_verb_past = "[drunken_martial_descriptor] [capitalize(atk_verb_past)]"
+			atk_verb_continuous = "[drunken_martial_descriptor] [capitalize(atk_verb_continuous)]"
 
 		else if(user_drunkenness >= 60)
 			limb_accuracy = -limb_accuracy // good luck landing a punch now, you drunk fuck
@@ -942,10 +942,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	if(grappled && attacking_bodypart.grappled_attack_verb)
 		atk_verb = attacking_bodypart.grappled_attack_verb
-		atk_verb_past = attacking_bodypart.grappled_attack_verb_past
+		atk_verb_continuous = attacking_bodypart.grappled_attack_verb_past
 
-	target.visible_message(span_danger("[user] [atk_verb_past] [target]!"), \
-					span_userdanger("You're [atk_verb_past] by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+	target.visible_message(span_danger("[user] [atk_verb_continuous] [target]!"), \
+					span_userdanger("[user] [atk_verb_continuous] you!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
 	to_chat(user, span_danger("You [atk_verb] [target]!"))
 
 	target.lastattacker = user.real_name

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -171,8 +171,12 @@
 	var/attack_type = BRUTE
 	/// the verbs used for an unarmed attack when using this limb, such as arm.unarmed_attack_verbs = list("punch")
 	var/list/unarmed_attack_verbs = list("bump")
+	/// Perfect tense attack verbs for successful attacks, called past because _perfect won't make much sense in isolation
+	var/list/unarmed_attack_verbs_past = list("bumped")
 	/// if we have a special attack verb for hitting someone who is grappled by us, it goes here.
 	var/grappled_attack_verb
+	/// Perfect tense grapple verb for successful attacks
+	var/grappled_attack_verb_past
 	/// what visual effect is used when this limb is used to strike someone.
 	var/unarmed_attack_effect = ATTACK_EFFECT_PUNCH
 	/// Sounds when this bodypart is used in an umarmed attack

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -171,12 +171,12 @@
 	var/attack_type = BRUTE
 	/// the verbs used for an unarmed attack when using this limb, such as arm.unarmed_attack_verbs = list("punch")
 	var/list/unarmed_attack_verbs = list("bump")
-	/// Continious tense attack verbs for successful attacks
+	/// Continuous tense attack verbs for successful attacks
 	var/list/unarmed_attack_verbs_continuous = list("bumps")
 	/// if we have a special attack verb for hitting someone who is grappled by us, it goes here.
 	var/grappled_attack_verb
-	/// Perfect tense grapple verb for successful attacks
-	var/grappled_attack_verb_past
+	/// Continuous tense grapple verb for successful attacks
+	var/grappled_attack_verb_continuous
 	/// what visual effect is used when this limb is used to strike someone.
 	var/unarmed_attack_effect = ATTACK_EFFECT_PUNCH
 	/// Sounds when this bodypart is used in an umarmed attack

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -171,8 +171,8 @@
 	var/attack_type = BRUTE
 	/// the verbs used for an unarmed attack when using this limb, such as arm.unarmed_attack_verbs = list("punch")
 	var/list/unarmed_attack_verbs = list("bump")
-	/// Perfect tense attack verbs for successful attacks, called past because _perfect won't make much sense in isolation
-	var/list/unarmed_attack_verbs_past = list("bumped")
+	/// Continious tense attack verbs for successful attacks
+	var/list/unarmed_attack_verbs_continuous = list("bumps")
 	/// if we have a special attack verb for hitting someone who is grappled by us, it goes here.
 	var/grappled_attack_verb
 	/// Perfect tense grapple verb for successful attacks

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -18,6 +18,7 @@
 	grind_results = null
 	is_dimorphic = TRUE
 	unarmed_attack_verbs = list("bite", "chomp")
+	unarmed_attack_verbs_past = list("bitten", "chomped")
 	unarmed_attack_effect = ATTACK_EFFECT_BITE
 	unarmed_attack_sound = 'sound/items/weapons/bite.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/bite.ogg'

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -18,7 +18,7 @@
 	grind_results = null
 	is_dimorphic = TRUE
 	unarmed_attack_verbs = list("bite", "chomp")
-	unarmed_attack_verbs_past = list("bitten", "chomped")
+	unarmed_attack_verbs_continuous = list("bites", "chomps")
 	unarmed_attack_effect = ATTACK_EFFECT_BITE
 	unarmed_attack_sound = 'sound/items/weapons/bite.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/bite.ogg'

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -142,7 +142,7 @@
 	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT
 	can_be_disabled = TRUE
 	unarmed_attack_verbs = list("punch") /// The classic punch, wonderfully classic and completely random
-	unarmed_attack_verbs_past = list("punched")
+	unarmed_attack_verbs_continuous = list("punches")
 	grappled_attack_verb = "pummel"
 	grappled_attack_verb_past = "pummeled"
 	unarmed_damage_low = 5
@@ -408,7 +408,7 @@
 	unarmed_attack_effect = ATTACK_EFFECT_KICK
 	body_zone = BODY_ZONE_L_LEG
 	unarmed_attack_verbs = list("kick") // The lovely kick, typically only accessable by attacking a grouded foe. 1.5 times better than the punch.
-	unarmed_attack_verbs_past = list("kicked")
+	unarmed_attack_verbs_continuous = list("kicks")
 	unarmed_damage_low = 7
 	unarmed_damage_high = 15
 	unarmed_effectiveness = 15

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -142,7 +142,9 @@
 	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT
 	can_be_disabled = TRUE
 	unarmed_attack_verbs = list("punch") /// The classic punch, wonderfully classic and completely random
+	unarmed_attack_verbs_past = list("punched")
 	grappled_attack_verb = "pummel"
+	grappled_attack_verb_past = "pummeled"
 	unarmed_damage_low = 5
 	unarmed_damage_high = 10
 	unarmed_pummeling_bonus = 1.5
@@ -406,6 +408,7 @@
 	unarmed_attack_effect = ATTACK_EFFECT_KICK
 	body_zone = BODY_ZONE_L_LEG
 	unarmed_attack_verbs = list("kick") // The lovely kick, typically only accessable by attacking a grouded foe. 1.5 times better than the punch.
+	unarmed_attack_verbs_past = list("kicked")
 	unarmed_damage_low = 7
 	unarmed_damage_high = 15
 	unarmed_effectiveness = 15

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -144,7 +144,7 @@
 	unarmed_attack_verbs = list("punch") /// The classic punch, wonderfully classic and completely random
 	unarmed_attack_verbs_continuous = list("punches")
 	grappled_attack_verb = "pummel"
-	grappled_attack_verb_past = "pummeled"
+	grappled_attack_verb_continuous = "pummels"
 	unarmed_damage_low = 5
 	unarmed_damage_high = 10
 	unarmed_pummeling_bonus = 1.5

--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -38,7 +38,7 @@
 	dmg_overlay_type = null
 	attack_type = BURN //burn bish
 	unarmed_attack_verbs = list("burn", "sear")
-	unarmed_attack_verbs_past = list("burnt", "seared")
+	unarmed_attack_verbs_continuous = list("burns", "sears")
 	grappled_attack_verb = "scorch"
 	grappled_attack_verb_past = "scorched"
 	unarmed_attack_sound = 'sound/items/weapons/etherealhit.ogg'
@@ -58,7 +58,7 @@
 	dmg_overlay_type = null
 	attack_type = BURN // bish buzz
 	unarmed_attack_verbs = list("burn", "sear")
-	unarmed_attack_verbs_past = list("burnt", "seared")
+	unarmed_attack_verbs_continuous = list("burns", "sears")
 	grappled_attack_verb = "scorch"
 	grappled_attack_verb_past = "scorched"
 	unarmed_attack_sound = 'sound/items/weapons/etherealhit.ogg'

--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -40,7 +40,7 @@
 	unarmed_attack_verbs = list("burn", "sear")
 	unarmed_attack_verbs_continuous = list("burns", "sears")
 	grappled_attack_verb = "scorch"
-	grappled_attack_verb_past = "scorched"
+	grappled_attack_verb_continuous = "scorches"
 	unarmed_attack_sound = 'sound/items/weapons/etherealhit.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/etherealmiss.ogg'
 	brute_modifier = 1.25 //ethereal are weak to brute damage
@@ -60,7 +60,7 @@
 	unarmed_attack_verbs = list("burn", "sear")
 	unarmed_attack_verbs_continuous = list("burns", "sears")
 	grappled_attack_verb = "scorch"
-	grappled_attack_verb_past = "scorched"
+	grappled_attack_verb_continuous = "scorches"
 	unarmed_attack_sound = 'sound/items/weapons/etherealhit.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/etherealmiss.ogg'
 	brute_modifier = 1.25 //ethereal are weak to brute damage

--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -38,7 +38,9 @@
 	dmg_overlay_type = null
 	attack_type = BURN //burn bish
 	unarmed_attack_verbs = list("burn", "sear")
+	unarmed_attack_verbs_past = list("burnt", "seared")
 	grappled_attack_verb = "scorch"
+	grappled_attack_verb_past = "scorched"
 	unarmed_attack_sound = 'sound/items/weapons/etherealhit.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/etherealmiss.ogg'
 	brute_modifier = 1.25 //ethereal are weak to brute damage
@@ -56,7 +58,9 @@
 	dmg_overlay_type = null
 	attack_type = BURN // bish buzz
 	unarmed_attack_verbs = list("burn", "sear")
+	unarmed_attack_verbs_past = list("burnt", "seared")
 	grappled_attack_verb = "scorch"
+	grappled_attack_verb_past = "scorched"
 	unarmed_attack_sound = 'sound/items/weapons/etherealhit.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/etherealmiss.ogg'
 	brute_modifier = 1.25 //ethereal are weak to brute damage

--- a/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
@@ -21,7 +21,7 @@
 	unarmed_attack_verbs = list("slash", "scratch", "claw")
 	unarmed_attack_verbs = list("slashed", "scratched", "clawed")
 	grappled_attack_verb = "lacerate"
-	grappled_attack_verb_past = "lacerated"
+	grappled_attack_verb_continuous = "lacerates"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -32,7 +32,7 @@
 	unarmed_attack_verbs = list("slash", "scratch", "claw")
 	unarmed_attack_verbs = list("slashed", "scratched", "clawed")
 	grappled_attack_verb = "lacerate"
-	grappled_attack_verb_past = "lacerated"
+	grappled_attack_verb_continuous = "lacerates"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'

--- a/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
@@ -19,7 +19,9 @@
 	icon_greyscale = 'icons/mob/human/species/lizard/bodyparts.dmi'
 	limb_id = SPECIES_LIZARD
 	unarmed_attack_verbs = list("slash", "scratch", "claw")
+	unarmed_attack_verbs = list("slashed", "scratched", "clawed")
 	grappled_attack_verb = "lacerate"
+	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -28,7 +30,9 @@
 	icon_greyscale = 'icons/mob/human/species/lizard/bodyparts.dmi'
 	limb_id = SPECIES_LIZARD
 	unarmed_attack_verbs = list("slash", "scratch", "claw")
+	unarmed_attack_verbs = list("slashed", "scratched", "clawed")
 	grappled_attack_verb = "lacerate"
+	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -234,7 +234,7 @@
 	unarmed_attack_verbs = list("slash", "lash")
 	unarmed_attack_verbs_continuous = list("slashes", "lashes")
 	grappled_attack_verb = "lacerate"
-	grappled_attack_verb_past = "lacerated"
+	grappled_attack_verb_continuous = "lacerates"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slice.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -248,7 +248,7 @@
 	unarmed_attack_verbs = list("slash", "lash")
 	unarmed_attack_verbs_continuous = list("slashes", "lashes")
 	grappled_attack_verb = "lacerate"
-	grappled_attack_verb_past = "lacerated"
+	grappled_attack_verb_continuous = "lacerates"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slice.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -17,6 +17,7 @@
 /obj/item/bodypart/arm/left/snail
 	limb_id = SPECIES_SNAIL
 	unarmed_attack_verbs = list("slap")
+	unarmed_attack_verbs_past = list("slapped")
 	unarmed_attack_effect = ATTACK_EFFECT_DISARM
 	unarmed_damage_low = 1
 	unarmed_damage_high = 2 //snails are soft and squishy
@@ -26,6 +27,7 @@
 /obj/item/bodypart/arm/right/snail
 	limb_id = SPECIES_SNAIL
 	unarmed_attack_verbs = list("slap")
+	unarmed_attack_verbs_past = list("slapped")
 	unarmed_attack_effect = ATTACK_EFFECT_DISARM
 	unarmed_damage_low = 1
 	unarmed_damage_high = 2 //snails are soft and squishy
@@ -230,7 +232,9 @@
 /obj/item/bodypart/arm/left/pod
 	limb_id = SPECIES_PODPERSON
 	unarmed_attack_verbs = list("slash", "lash")
+	unarmed_attack_verbs_past = list("slashed", "lashed")
 	grappled_attack_verb = "lacerate"
+	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slice.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -242,7 +246,9 @@
 /obj/item/bodypart/arm/right/pod
 	limb_id = SPECIES_PODPERSON
 	unarmed_attack_verbs = list("slash", "lash")
+	unarmed_attack_verbs_past = list("slashed", "lashed")
 	grappled_attack_verb = "lacerate"
+	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slice.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -17,7 +17,7 @@
 /obj/item/bodypart/arm/left/snail
 	limb_id = SPECIES_SNAIL
 	unarmed_attack_verbs = list("slap")
-	unarmed_attack_verbs_past = list("slapped")
+	unarmed_attack_verbs_continuous = list("slaps")
 	unarmed_attack_effect = ATTACK_EFFECT_DISARM
 	unarmed_damage_low = 1
 	unarmed_damage_high = 2 //snails are soft and squishy
@@ -27,7 +27,7 @@
 /obj/item/bodypart/arm/right/snail
 	limb_id = SPECIES_SNAIL
 	unarmed_attack_verbs = list("slap")
-	unarmed_attack_verbs_past = list("slapped")
+	unarmed_attack_verbs_continuous = list("slaps")
 	unarmed_attack_effect = ATTACK_EFFECT_DISARM
 	unarmed_damage_low = 1
 	unarmed_damage_high = 2 //snails are soft and squishy
@@ -232,7 +232,7 @@
 /obj/item/bodypart/arm/left/pod
 	limb_id = SPECIES_PODPERSON
 	unarmed_attack_verbs = list("slash", "lash")
-	unarmed_attack_verbs_past = list("slashed", "lashed")
+	unarmed_attack_verbs_continuous = list("slashes", "lashes")
 	grappled_attack_verb = "lacerate"
 	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
@@ -246,7 +246,7 @@
 /obj/item/bodypart/arm/right/pod
 	limb_id = SPECIES_PODPERSON
 	unarmed_attack_verbs = list("slash", "lash")
-	unarmed_attack_verbs_past = list("slashed", "lashed")
+	unarmed_attack_verbs_continuous = list("slashes", "lashes")
 	grappled_attack_verb = "lacerate"
 	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW

--- a/code/modules/surgery/bodyparts/species_parts/moth_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/moth_bodyparts.dm
@@ -29,7 +29,7 @@
 	limb_id = SPECIES_MOTH
 	should_draw_greyscale = FALSE
 	unarmed_attack_verbs = list("slash")
-	unarmed_attack_verbs_past = list("slashed")
+	unarmed_attack_verbs_continuous = list("slashes")
 	grappled_attack_verb = "lacerate"
 	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
@@ -43,7 +43,7 @@
 	limb_id = SPECIES_MOTH
 	should_draw_greyscale = FALSE
 	unarmed_attack_verbs = list("slash")
-	unarmed_attack_verbs_past = list("slashed")
+	unarmed_attack_verbs_continuous = list("slashes")
 	grappled_attack_verb = "lacerate"
 	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW

--- a/code/modules/surgery/bodyparts/species_parts/moth_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/moth_bodyparts.dm
@@ -31,7 +31,7 @@
 	unarmed_attack_verbs = list("slash")
 	unarmed_attack_verbs_continuous = list("slashes")
 	grappled_attack_verb = "lacerate"
-	grappled_attack_verb_past = "lacerated"
+	grappled_attack_verb_continuous = "lacerates"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -45,7 +45,7 @@
 	unarmed_attack_verbs = list("slash")
 	unarmed_attack_verbs_continuous = list("slashes")
 	grappled_attack_verb = "lacerate"
-	grappled_attack_verb_past = "lacerated"
+	grappled_attack_verb_continuous = "lacerates"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'

--- a/code/modules/surgery/bodyparts/species_parts/moth_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/moth_bodyparts.dm
@@ -29,7 +29,9 @@
 	limb_id = SPECIES_MOTH
 	should_draw_greyscale = FALSE
 	unarmed_attack_verbs = list("slash")
+	unarmed_attack_verbs_past = list("slashed")
 	grappled_attack_verb = "lacerate"
+	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'
@@ -41,7 +43,9 @@
 	limb_id = SPECIES_MOTH
 	should_draw_greyscale = FALSE
 	unarmed_attack_verbs = list("slash")
+	unarmed_attack_verbs_past = list("slashed")
 	grappled_attack_verb = "lacerate"
+	grappled_attack_verb_past = "lacerated"
 	unarmed_attack_effect = ATTACK_EFFECT_CLAW
 	unarmed_attack_sound = 'sound/items/weapons/slash.ogg'
 	unarmed_miss_sound = 'sound/items/weapons/slashmiss.ogg'


### PR DESCRIPTION

## About The Pull Request

Introduces perfect tense attack verbs for all of our limbs, as just adding ``ed`` to the end doesn't work in about half the cases. 
- Closes #90573

## Changelog
:cl:
fix: Fixed incorrect perfect tense forms of some unarmed attacks like felinid bites
/:cl:
