### PR TITLE
Fixes BPM setting on synth circuit interface not doing anything

### DIFF
--- a/code/modules/instruments/piano_synth.dm
+++ b/code/modules/instruments/piano_synth.dm
@@ -144,6 +144,8 @@
 	SIGNAL_HANDLER
 	is_playing.set_output(TRUE)
 	started_playing.set_output(COMPONENT_SIGNAL)
+	if (beats_per_min.value)
+		synth.song.set_bpm(beats_per_min.value)
 
 /obj/item/circuit_component/synth/proc/continue_if_autoplaying(datum/source, atom/music_player)
 	SIGNAL_HANDLER
@@ -165,7 +167,8 @@
 	synth.song.set_repeats(repetitions.value)
 
 /obj/item/circuit_component/synth/proc/set_bpm()
-	synth.song.sanitize_tempo(BPM_TO_TEMPO_SETTING(beats_per_min.value))
+	if (beats_per_min.value)
+		synth.song.set_bpm(beats_per_min.value)
 
 /obj/item/circuit_component/synth/proc/set_instrument()
 	synth.song.set_instrument(selected_instrument.value)


### PR DESCRIPTION

## About The Pull Request

Also it no longer runtimes constantly so there's that
- Closes #91981

## Changelog
:cl:
fix: Fixed BPM setting on synth circuit interface not doing anything
/:cl:
