### PR TITLE
Cult music only plays on first scribe

### DIFF
--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -370,12 +370,14 @@
 	if(!check_if_in_ritual_site(cultist, cult_team))
 		return FALSE
 	var/area/summon_location = get_area(cultist)
+	var/static/cult_music_played = FALSE
 	priority_announce(
 		text = "Figments from an eldritch god are being summoned by [cultist.real_name] into [summon_location.get_original_area_name()] from an unknown dimension. Disrupt the ritual at all costs!",
-		sound = 'sound/music/antag/bloodcult/bloodcult_scribe.ogg',
+		sound = cult_music_played ? 'sound/announcer/notice/notice3.ogg' : 'sound/music/antag/bloodcult/bloodcult_scribe.ogg',
 		sender_override = "[command_name()] Higher Dimensional Affairs",
 		has_important_message = TRUE,
 	)
+	cult_music_played = TRUE
 	for(var/shielded_turf in spiral_range_turfs(1, cultist, 1))
 		LAZYADD(shields, new /obj/structure/emergency_shield/cult/narsie(shielded_turf))
 


### PR DESCRIPTION
## About The Pull Request

First rune scribe plays the cult music stinger, all following ones just use the sound for red alert.

I'd use airraid.ogg but that's used when Nar'sie is actually summoned.

## Why It's Good For The Game

Cool song but it's really loud and really long and really spammable

## Changelog

:cl: Melbert
qol: Cult's music stinger is only played on first attempt at scribing a Nar'sie rune, following attempts will use the sound for red alert.
/:cl:
