### PR TITLE
Minor clean-up of Science, and adds tagger-attached disposal bins to Catwalk Station

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -109197,7 +109197,7 @@ riD
 cSy
 eNb
 sAG
-wTk
+riD
 pkc
 psQ
 riD

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -24742,6 +24742,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"hrh" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "hri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/snackvend,
@@ -74834,6 +74840,14 @@
 /obj/item/grenade/chem_grenade/cleaner,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"wjv" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "wjw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -104534,7 +104548,7 @@ jhu
 tTO
 tDy
 tDy
-fgH
+wjv
 tTO
 tDy
 bUQ
@@ -107621,7 +107635,7 @@ fXf
 fWY
 bNt
 bUQ
-fgH
+hrh
 tpj
 tTO
 tDy

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -3810,6 +3810,7 @@
 /obj/machinery/door/window/left/directional/east{
 	req_access = list("robotics")
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/science/robotics)
 "bkj" = (
@@ -6299,7 +6300,7 @@
 /area/station/engineering/atmos/upper)
 "bTU" = (
 /obj/effect/turf_decal/siding/green/corner,
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -13775,6 +13776,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ecw" = (
@@ -17722,11 +17724,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/research)
 "foN" = (
@@ -19573,10 +19576,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "fRd" = (
-/obj/machinery/disposal/bin{
-	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
-	name = "corpse disposal"
-	},
+/obj/machinery/disposal/bin/tagger,
 /obj/machinery/button/door/directional/north{
 	id = "main_surgery";
 	name = "privacy shutters control"
@@ -25685,7 +25685,7 @@
 "hFf" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -25876,10 +25876,7 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "hHF" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 2;
-	pixel_y = 2
-	},
+/obj/machinery/disposal/bin/tagger,
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -27595,9 +27592,14 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
-/obj/structure/tank_holder/anesthetic{
-	pixel_y = 21;
-	pixel_x = 2
+/obj/structure/rack,
+/obj/item/storage/box/gloves{
+	pixel_y = 4
+	},
+/obj/item/storage/box/bodybags,
+/obj/item/healthanalyzer{
+	pixel_x = 5;
+	pixel_y = -4
 	},
 /turf/open/floor/iron/white/textured_corner,
 /area/station/science/robotics)
@@ -31882,7 +31884,8 @@
 /area/station/tcommsat/server)
 "juz" = (
 /obj/machinery/mecha_part_fabricator/maint{
-	name = "forgotten exosuit fabricator"
+	name = "forgotten exosuit fabricator";
+	drop_direction = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -33390,6 +33393,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "jPs" = (
@@ -35900,7 +35904,7 @@
 	dir = 1
 	},
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research)
 "kzX" = (
@@ -39720,8 +39724,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
+/obj/machinery/disposal/bin/tagger,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -40190,7 +40194,7 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -42321,9 +42325,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/research/glass{
-	name = "Xenobiology Access"
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
 "mzR" = (
@@ -45173,11 +45174,11 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/wood/tile,
 /area/station/science/robotics)
 "nts" = (
@@ -46448,8 +46449,11 @@
 	pixel_x = -8;
 	pixel_y = 18
 	},
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_edge{
-	dir = 8
+	dir = 4
 	},
 /area/station/science/robotics/lab)
 "nLQ" = (
@@ -51448,10 +51452,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pjt" = (
-/obj/machinery/disposal/bin{
-	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
-	name = "corpse disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -51719,7 +51720,7 @@
 "por" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
@@ -52391,7 +52392,9 @@
 /area/station/maintenance/starboard/aft)
 "pBB" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/science/robotics/lab)
 "pBC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52962,7 +52965,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -53763,13 +53766,8 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/obj/structure/rack,
-/obj/item/storage/box/gloves{
-	pixel_y = 4
-	},
-/obj/item/healthanalyzer{
-	pixel_x = 5;
-	pixel_y = -4
+/obj/structure/tank_holder/anesthetic{
+	anchored = 1
 	},
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
@@ -57293,11 +57291,12 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "qYs" = (
@@ -61640,7 +61639,7 @@
 /area/station/engineering/break_room)
 "snd" = (
 /obj/machinery/mecha_part_fabricator{
-	dir = 4
+	drop_direction = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/robotics/lab)
@@ -74399,7 +74398,7 @@
 /area/station/cargo/storage)
 "weg" = (
 /obj/machinery/mecha_part_fabricator{
-	dir = 4
+	drop_direction = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/warm/directional/north,
@@ -77386,7 +77385,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
 /obj/machinery/elevator_control_panel/directional/south{
 	linked_elevator_id = "catwalk_robo";
 	preset_destination_names = list("2"="Lower  Robotics","3"="Upper  Robotics")
@@ -78473,13 +78471,10 @@
 "xqa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/disposal/bin{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "xqd" = (
@@ -79080,8 +79075,11 @@
 /area/station/science/ordnance/storage)
 "xzG" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_edge{
-	dir = 8
+	dir = 4
 	},
 /area/station/science/robotics/lab)
 "xzX" = (
@@ -80356,6 +80354,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "xTX" = (


### PR DESCRIPTION
## About The Pull Request

Cleans up a few things in Catwalk Robotics: Adds a desk bell to the Robotics desk; cleans up the surgery area so it doesn't become inaccessible at roundstart when a Roboticist runs in to the tank holder; adds in a body bag box; adjusts floor decals. There is no longer an annoying extra misplaced airlock inside Xenobiology.

![image](https://github.com/user-attachments/assets/0648a6c1-e504-4de4-aa44-4ac34b6e819b)

Adjusts Catwalk's disposal deliveries: Security now has their tag helper appropriately mapped in so they can receive deliveries; adds tagger-attached disposal bins to every general department area, Dorms, Kitchen, Custodial Closet, and one in the Public Hallway; adjusts various decal markers from "bot" to "delivery" where they are set to receive deliveries, and removes them where they don't; replaces the renamed corpse disposal bins with regular bins, as there isn't a corpse disposal set-up on this map.

Catwalk's Exosuit Fabricators no longer print in the wrong direction.
## Why It's Good For The Game

Anchoring the tank holder should make the Robotics surgery table not become blocked every single round. The desk bell probably isn't going to do much, but it's at least something to help when your view of the front desk is blocked from up top. Having things you try to send to Security not do an endless loop forever around the station is also nice, I guess, maybe, perhaps a bit of a controversial opinion, unless it's a bomb. You want your bombs arriving in time after all, not getting lost in the Deliveries Office.
## Changelog
:cl:
map: Catwalk Science has gotten a minor clean-up of Robotics' Surgery area.
map: Adds destination taggers to various disposal bins on Catwalk where appropriate.
fix: Catwalk Station: exosuit fabricators no longer print in the wrong direction, removal of a stray airlock in Xenobiology, Security department now has their missing delivery tag set properly for disposal mail, and adds a missing wall near medical virology hallway.
/:cl:
