### PR TITLE
Void Torch: The Torchening

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -813,7 +813,7 @@ Striking a noncultist, however, will tear their flesh."}
 
 /obj/item/flashlight/flare/culttorch
 	name = "void torch"
-	desc = "Used by veteran cultists to instantly transport items to their needful brethren."
+	desc = "Used by savvy cultists to instantly transport equipment into the hands of their needful brethren."
 	w_class = WEIGHT_CLASS_SMALL
 	light_range = 1
 	icon_state = "torch"
@@ -864,6 +864,7 @@ Striking a noncultist, however, will tear their flesh."}
 		but through the torch's flames you see that [interacting_with] has reached [cultist_to_receive]!"))
 	user.log_message("teleported [interacting_with] to [cultist_to_receive] with [src].", LOG_GAME)
 	cultist_to_receive.put_in_hands(interacting_with)
+	to_chat(cultist_to_receive, span_notice("A fellow cultist has teleported [interacting_with] to you via Void Torch!"))
 	charges--
 	to_chat(user, span_notice("[src] now has [charges] charge\s."))
 	if(charges <= 0)

--- a/code/modules/antagonists/cult/cult_structure_archives.dm
+++ b/code/modules/antagonists/cult/cult_structure_archives.dm
@@ -63,3 +63,4 @@
 #undef CURSE_ORB
 #undef VEIL_WALKER
 #undef CRIMSON_MEDALLION
+#undef VOID_TORCH

--- a/code/modules/antagonists/cult/cult_structure_archives.dm
+++ b/code/modules/antagonists/cult/cult_structure_archives.dm
@@ -3,7 +3,7 @@
 #define CURSE_ORB "Shuttle Curse"
 #define VEIL_WALKER "Veil Walker"
 #define CRIMSON_MEDALLION "Crimson Medallion"
-#define VOID_TORCH "Void Torch"
+#define VOID_TORCH "Two Void Torches"
 
 // Cult archives. Gives out utility items.
 /obj/structure/destructible/cult/item_dispenser/archives
@@ -32,7 +32,7 @@
 			),
 		VOID_TORCH = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/lighting.dmi', icon_state = "torch"),
-			OUTPUT_ITEMS = list(/obj/item/flashlight/flare/culttorch),
+			OUTPUT_ITEMS = list(/obj/item/flashlight/flare/culttorch, /obj/item/flashlight/flare/culttorch),
 			),
 	)
 

--- a/code/modules/antagonists/cult/cult_structure_archives.dm
+++ b/code/modules/antagonists/cult/cult_structure_archives.dm
@@ -1,14 +1,15 @@
 /// Some defines for items the cult archives can create.
 #define CULT_BLINDFOLD "Zealot's Blindfold"
 #define CURSE_ORB "Shuttle Curse"
-#define VEIL_WALKER "Veil Walker Set"
+#define VEIL_WALKER "Veil Walker"
 #define CRIMSON_MEDALLION "Crimson Medallion"
+#define VOID_TORCH "Void Torch"
 
 // Cult archives. Gives out utility items.
 /obj/structure/destructible/cult/item_dispenser/archives
 	name = "archives"
 	desc = "A desk covered in arcane manuscripts and tomes in unknown languages. Looking at the text makes your skin crawl."
-	cult_examine_tip = "Can be used to create zealot's blindfolds, shuttle curse orbs, and veil walker equipment."
+	cult_examine_tip = "Can be used to create zealot's blindfolds, shuttle curse orbs, and teleportation equipment."
 	icon_state = "tomealtar"
 	light_range = 1.5
 	light_color = LIGHT_COLOR_FIRE
@@ -27,7 +28,11 @@
 			),
 		VEIL_WALKER = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/antags/cult/items.dmi', icon_state = "shifter"),
-			OUTPUT_ITEMS = list(/obj/item/cult_shift, /obj/item/flashlight/flare/culttorch),
+			OUTPUT_ITEMS = list(/obj/item/cult_shift),
+			),
+		VOID_TORCH = list(
+			PREVIEW_IMAGE = image(icon = 'icons/obj/lighting.dmi', icon_state = "torch"),
+			OUTPUT_ITEMS = list(/obj/item/flashlight/flare/culttorch),
 			),
 	)
 


### PR DESCRIPTION

## About The Pull Request
So basically, they're their own item in the archive, you get two of them per archive use, and they notify the guy you teleport the item to.
## Why It's Good For The Game
I am like the only person who uses it, a lot of people don't know what it is or how it works, and it's generally not regarded very highly if the comments of #92075  are anything to go by. Some small buffs and QOL should help elevate it a bit.
## Changelog
:cl:
qol: Void Torch now notifies the guy you teleport things to.
balance: Void torch is now it's own archive craft. You get two per, for buddy cop (buddy cultist?) action.
/:cl:
