### PR TITLE
Removes the Justice's RNG damage block

### DIFF
--- a/code/modules/vehicles/mecha/combat/justice.dm
+++ b/code/modules/vehicles/mecha/combat/justice.dm
@@ -142,14 +142,6 @@
 	animate(src, alpha = 255, time = 0.5 SECONDS)
 	playsound(src, 'sound/vehicles/mecha/mech_stealth_effect.ogg' , 75, FALSE)
 
-/obj/vehicle/sealed/mecha/justice/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
-	if(LAZYLEN(occupants))
-		if(prob(60))
-			new /obj/effect/temp_visual/mech_sparks(get_turf(src))
-			playsound(src, 'sound/vehicles/mecha/mech_stealth_effect.ogg' , 75, FALSE)
-			return
-	return ..()
-
 /datum/action/vehicle/sealed/mecha/invisibility
 	name = "Invisibility"
 	button_icon_state = "mech_stealth_off"


### PR DESCRIPTION

## About The Pull Request
Completely removes the damage blocking mechanic of the Justice mech.
Probably also negates some of #91434
## Why It's Good For The Game
This thing is so laughably overtuned in so many aspects that make it unfun to engage with in any situation. For those unaware it can currently:
- Crit in two hits with its 60 force punches
- Turn completely invisible and move silently while doing so
- Instantly kill anyone with its dash attack which ALSO beheads (Something that's usually only reserved for surgery and the chainsaw with a do_after)
- And finally, blocks 60% of all incoming damage

Its a real pain to deal with and there's no good way to engage one since EMP's aren't as effective as people make them out to be. So I'm cutting out its ability to negate damage entirely, which mind you still doesn't make it a pushover. This thing can shift invisible and gut you before you can get half of its integrity down if you're facing it front on.

I'm aware the creator is trying to address this with a rebalance of how the defence works, but I feel their plan will make it even worse to deal with, so I'm sticking with the simplest solution.
## Changelog
:cl:
balance: The Justice mech has had its damage negation removed
/:cl:
