### PR TITLE
[NO GBP] Some flatpack & machine fixes

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -164,7 +164,7 @@
 /obj/machinery/New(loc, obj/item/circuitboard/board, ...)
 	if(istype(board))
 		circuit = board
-		//we don't want machines that override Initialize() to have the board passed as a param e.g. atmos
+		//we don't want machines that override Initialize() have the board passed as a param e.g. atmos
 		var/list/arguments = list(args)
 		for(var/i in arguments)
 			if(arguments[i] == board)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -164,6 +164,13 @@
 /obj/machinery/New(loc, obj/item/circuitboard/board, ...)
 	if(istype(board))
 		circuit = board
+		//we don't want machines that override Initialize() to have the board passed as a param e.g. atmos
+		var/list/arguments = list(args)
+		for(var/i in arguments)
+			if(arguments[i] == board)
+				arguments -= i
+				break
+		return ..(arglist(arguments))
 
 	return ..()
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -165,12 +165,7 @@
 	if(istype(board))
 		circuit = board
 		//we don't want machines that override Initialize() have the board passed as a param e.g. atmos
-		var/list/arguments = list(args)
-		for(var/i in arguments)
-			if(arguments[i] == board)
-				arguments -= i
-				break
-		return ..(arglist(arguments))
+		return ..(loc)
 
 	return ..()
 

--- a/code/game/machinery/flatpacker.dm
+++ b/code/game/machinery/flatpacker.dm
@@ -114,7 +114,7 @@
 /obj/machinery/flatpacker/proc/get_flatpack_component_name(obj/item/component)
 	PRIVATE_PROC(TRUE)
 
-	if(ispath(type, /obj/item/vending_refill))
+	if(ispath(component, /obj/item/vending_refill))
 		var/obj/item/vending_refill/canister = component
 
 		return "\improper [canister::machine_name] restocking unit"

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -68,9 +68,6 @@
 	///keeps the name of the object from being overridden if it's vareditted.
 	var/override_naming
 
-	///If we should init and immediately start processing
-	var/init_processing = FALSE
-
 	armor_type = /datum/armor/machinery_atmospherics
 
 /datum/armor/machinery_atmospherics
@@ -87,7 +84,6 @@
 	if(pipe_flags & PIPING_CARDINAL_AUTONORMALIZE)
 		normalize_cardinal_directions()
 	nodes = new(device_type)
-	init_processing = process
 	set_init_directions(init_dir)
 
 	if(mapload && name != initial(name))
@@ -102,7 +98,7 @@
 
 	SSspatial_grid.add_grid_awareness(src, SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
 	SSspatial_grid.add_grid_membership(src, turf_loc, SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-	if(init_processing)
+	if(process)
 		SSair.start_processing_machine(src)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
- Machines constructed from flatpack boxes & machine frames now don't pass the circuit board arg don't to its `Initialize()` proc, this resulted in for e.g. the thermomachine getting it's `process` arg set to the circuit board instead of `TRUE/FALSE` which isn't ideal
- Flatpack machines display the correct names of its custom components

## Changelog
:cl:
fix: flatpack machine shows correct names for custom components
fix: correct args gets passed to machine `Initialize()` proc when constructed from machine frames & flatpack boxes
/:cl:

