### PR TITLE
fix blood brothers amount

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -187,7 +187,6 @@
 /datum/antagonist/brother/admin_add(datum/mind/new_owner,mob/admin)
 	var/datum/team/brother_team/team = new
 	team.add_member(new_owner)
-	new_owner.add_antag_datum(/datum/antagonist/brother, team)
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] into a blood brother.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] into a blood brother.")
 
@@ -218,6 +217,8 @@
 		forge_brother_objectives()
 	if (!new_member.has_antag_datum(/datum/antagonist/brother))
 		add_brother(new_member.current)
+	else
+		set_brothers_left(brothers_left - 1)
 
 /datum/team/brother_team/remove_member(datum/mind/member)
 	if (!(member in members))


### PR DESCRIPTION
## About The Pull Request

Adding members with blood brother antag datum to Blood Brothers team didn't respect amount of brothers in team.

## Why It's Good For The Game

Bugs bad. 3 bb's 100% of time is also bad (not really, but it is)

## Changelog

:cl:
fix: Blood Brother with existing antag datum now properly added to Blood Brothers team, which fixes bug with 3 blood brothers in team 100% of time
/:cl:
