### PR TITLE
Changes the description of the Modular Console machine

### DIFF
--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -3,7 +3,7 @@
 // Modular Computer - A machinery that is mostly just a host to the Modular Computer item.
 /obj/machinery/modular_computer
 	name = "modular computer"
-	desc = "You shouldn't see this. If you do, report it." //they should be examining the processor instead
+	desc = "The frame of an advanced computer" //This should only show up when building a computer, it should examine the processor instead
 	icon = 'icons/obj/machines/modular_console.dmi'
 	icon_state = "console"
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.025


### PR DESCRIPTION

## About The Pull Request

Fixes #91501
This text was expected to never be seen, but when modular computer parts got removed it shows up when crafting one from the menu

## Why It's Good For The Game

Having report messages on things that aren't really bugs isn't desirable

## Changelog

:cl:
fix: Fixed the description of the modular console frame on the crafting menu
/:cl:

