### PR TITLE
Adds collar bombs to cargo (for security)

### DIFF
--- a/code/game/objects/items/storage/boxes/clothes_boxes.dm
+++ b/code/game/objects/items/storage/boxes/clothes_boxes.dm
@@ -254,6 +254,9 @@
 	var/obj/item/collar_bomb_button/button = new(src)
 	new /obj/item/clothing/neck/collar_bomb(src, button)
 
+/obj/item/storage/box/collar_bomb/security
+	desc = "Contains a bomb collar and its associated button."
+
 /obj/item/storage/box/itemset/crusader/blue/PopulateContents()
 	new /obj/item/clothing/suit/chaplainsuit/armor/crusader/blue(src)
 	new /obj/item/clothing/head/helmet/plate/crusader/blue(src)

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -391,3 +391,13 @@
 		/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno,
 	)
 	crate_name = "thermal cannons crate"
+
+/datum/supply_pack/security/collar_bombs
+	name = "Collar Bombs Crate"
+	desc = "Contains three collar bombs with their associated boxes, along with a spare."
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(
+		/obj/item/clothing/neck/collar_bomb = 1,
+		/obj/item/storage/box/collar_bomb/security = 3,
+	)
+	crate_name = "collar bombs crate"

--- a/code/modules/clothing/neck/collar_bomb.dm
+++ b/code/modules/clothing/neck/collar_bomb.dm
@@ -111,7 +111,6 @@
 	if(brian.get_item_by_slot(ITEM_SLOT_NECK) == collar)
 		brian.investigate_log("has had their [collar] triggered by [user] via yellow button.", INVESTIGATE_DEATHS)
 
-
 /obj/item/collar_bomb_button/Destroy()
 	collar?.button = null
 	collar = null


### PR DESCRIPTION

## About The Pull Request
Lets security buy bomb collars from cargo. The pack contains:
- 3 collar boxes 
  - 1 collar bomb
  - 1 associated collar bomb button
- 1 spare collar bomb

## Why It's Good For The Game

Terry, this one's for you.

You have three options when you capture an antagonist: 
- **Perma:** This only really works for traitors and blood brothers. Other antagonists have internal abilities that makes containing them unviable. You're also risking them just... breaking out. Anyone determined enough will be able to escape. 
- **Execution:** Everyone's favorite method of dealing with antagonists. Dead antagonists can't take revenge on you and can't perform a retaliatory plasmaflood. 
- **Parole:** Very rare. Usually only done for very new players who aren't much of a threat, for metafriends or with the hypnosis chamber (seen exactly once, but really funny). There's a lot of problems with letting them run around free, even with pacification surgery.

Now, letting antagonists out on parole is actually viable! They could still melt it slowly, or the button holder gets killed, or they convince a medical doctor to help remove it, etc,  but it is now not an insane option. Having a murderer walk around with a bomb around their neck is also just really good vibes. 

You can also attach voice analyzers to the collar. Set it to the TCH'TCH'CH sound heretics make when using their mansus hand to effectively neuter them! Now you can actually contain them! Or keep them around as some sort of attack dog

It is feature creeping black market content though, sorry @Ghommie 
## Changelog
:cl:
add: Adds bomb collars to cargo for security
/:cl:
