### PR TITLE
Fixes some cases of dynamic reading defined values over config values

### DIFF
--- a/code/controllers/subsystem/dynamic/__dynamic_defines.dm
+++ b/code/controllers/subsystem/dynamic/__dynamic_defines.dm
@@ -53,3 +53,6 @@
 ]"
 
 #define RULESET_CONFIG_CANCEL "Cancel"
+
+/// Used to easily get a config entry for a dynamic ruleset or tier
+#define GET_DYNAMIC_CONFIG(some_typepath, var_name) SSdynamic.get_config_value(some_typepath, NAMEOF(some_typepath, ##var_name), some_typepath::##var_name)

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -76,6 +76,29 @@ SUBSYSTEM_DEF(dynamic)
 		load_config()
 	return dynamic_config
 
+/// Used to get a config entry for some variable on some typepath
+/// Can be passed a default value.
+/datum/controller/subsystem/dynamic/proc/get_config_value(datum/some_typepath, var_name, default_value)
+	var/config_tag
+	if(ispath(some_typepath, /datum/dynamic_ruleset))
+		var/datum/dynamic_ruleset/ruleset_type = some_typepath
+		config_tag = ruleset_type::config_tag
+	else if(ispath(some_typepath, /datum/dynamic_tier))
+		var/datum/dynamic_tier/tier_type = some_typepath
+		config_tag = tier_type::config_tag
+	else
+		stack_trace("Dynamic get_config_value called with invalid typepath: [some_typepath]")
+		return default_value
+
+	if(isnull(config_tag)) // Technically valid
+		return default_value
+
+	if(!length(dynamic_config))
+		load_config()
+
+	var/config_value = dynamic_config?[config_tag]?[var_name]
+	return isnull(config_value) ? default_value : config_value
+
 /**
  * Selects which rulesets are to run at roundstart, and sets them up
  *
@@ -180,13 +203,11 @@ SUBSYSTEM_DEF(dynamic)
 
 	var/list/tier_weighted = list()
 	for(var/datum/dynamic_tier/tier_datum as anything in subtypesof(/datum/dynamic_tier))
-		var/min_players_config = dynamic_config[tier_datum::config_tag]?[NAMEOF(tier_datum, min_pop)]
-		var/min_players = isnull(min_players_config) ? tier_datum::min_pop : min_players_config
-		if(roundstart_population < min_players)
+		var/tier_pop = GET_DYNAMIC_CONFIG(tier_datum, min_pop)
+		if(roundstart_population < tier_pop)
 			continue
 
-		var/tier_config_weight = dynamic_config[tier_datum::config_tag]?[NAMEOF(tier_datum, weight)]
-		var/tier_weight = isnull(tier_config_weight) ? tier_datum::weight : tier_config_weight
+		var/tier_weight = GET_DYNAMIC_CONFIG(tier_datum, weight)
 		if(tier_weight <= 0)
 			continue
 
@@ -290,7 +311,7 @@ SUBSYSTEM_DEF(dynamic)
 
 	for(var/datum/dynamic_tier/tier_datum as anything in subtypesof(/datum/dynamic_tier))
 		if(tier_datum::tier == shown_tier)
-			return tier_datum::advisory_report
+			return GET_DYNAMIC_CONFIG(tier_datum, advisory_report)
 
 	return null
 

--- a/code/controllers/subsystem/dynamic/dynamic_admin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_admin.dm
@@ -184,12 +184,12 @@ ADMIN_VERB(dynamic_panel, R_ADMIN, "Dynamic Panel", "Mess with dynamic.", ADMIN_
 				return TRUE
 			var/list/tiers = list()
 			for(var/datum/dynamic_tier/tier as anything in subtypesof(/datum/dynamic_tier))
-				tiers[initial(tier.name)] = tier
-			var/datum/dynamic_tier/picked = tgui_input_list(ui.user, "Pick a dynamic tier before the game starts", "Pick tier", tiers, ui_state = ADMIN_STATE(R_ADMIN))
+				tiers[tier::config_tag] = tier
+			var/picked = tgui_input_list(ui.user, "Pick a dynamic tier before the game starts", "Pick tier", tiers, ui_state = ADMIN_STATE(R_ADMIN))
 			if(picked && !SSticker.HasRoundStarted())
 				SSdynamic.set_tier(tiers[picked])
-				message_admins("[key_name_admin(ui.user)] set the dynamic tier to [initial(picked.tier)].")
-				log_admin("[key_name_admin(ui.user)] set the dynamic tier to [initial(picked.tier)].")
+				message_admins("[key_name_admin(ui.user)] set the dynamic tier to [picked].")
+				log_admin("[key_name_admin(ui.user)] set the dynamic tier to [picked].")
 			return TRUE
 		if("max_light_chance")
 			SSdynamic.admin_forcing_next_light = !SSdynamic.admin_forcing_next_light

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -129,8 +129,7 @@ GLOBAL_LIST_INIT(non_ruleset_antagonists, list(
 		antag_time_limits = list()
 		for(var/datum/dynamic_ruleset/ruleset as anything in subtypesof(/datum/dynamic_ruleset))
 			var/antag_flag = initial(ruleset.pref_flag)
-			var/config_min_days = SSdynamic.dynamic_config[initial(ruleset.config_tag)]?[NAMEOF(ruleset, minimum_required_age)]
-			var/min_days = isnull(config_min_days) ? initial(ruleset.minimum_required_age) : config_min_days
+			var/min_days = GET_DYNAMIC_CONFIG(ruleset, minimum_required_age)
 
 			antag_time_limits[antag_flag] = min_days
 


### PR DESCRIPTION
## About The Pull Request

Fixes #92125

Very simple, when working without an instantiated datum we would read from the config manually, but some places neglected to do that. 

So I added a macro to help in the future.

## Changelog

:cl: Melbert
fix: Fixes some places where dynamic configs were not being read correctly
/:cl:
