### PR TITLE
Fix hard deletes related to escape menu

### DIFF
--- a/code/modules/escape_menu/escape_menu.dm
+++ b/code/modules/escape_menu/escape_menu.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_EMPTY(escape_menus)
 /datum/escape_menu/Destroy(force)
 	QDEL_NULL(base_holder)
 	QDEL_NULL(page_holder)
+	resource_panels = null // list contents were already qdeled in QDEL_NULL(page_holder), so we can safely null this
 
 	var/datum/our_hud = our_hud_ref?.resolve()
 	if(our_hud)


### PR DESCRIPTION

## About The Pull Request

`resource_panels` is only emptied if the user collapses the panel by clicking the expand button again, if they just close the escape menu with it expanded then refs to all the buttons linger and hard delete

## Why It's Good For The Game

Fix for several hard deletes
```
RUNTIME: ## TESTING: GC: -- [0x2002d13] | /atom/movable/screen/escape_menu/lobby_button/small/collapsible was unable to be GC'd -- (ref count of 3)
RUNTIME: ## TESTING: GC: -- [0x2002259] | /atom/movable/screen/escape_menu/lobby_button/small/collapsible was unable to be GC'd -- (ref count of 3)
RUNTIME: ## TESTING: GC: -- [0x2002414] | /atom/movable/screen/escape_menu/lobby_button/small/collapsible was unable to be GC'd -- (ref count of 3)
RUNTIME: ## TESTING: GC: -- [0x2001e36] | /atom/movable/screen/escape_menu/lobby_button/small/collapsible was unable to be GC'd -- (ref count of 3)
RUNTIME: ## TESTING: GC: -- [0x2007b3b] | /atom/movable/screen/escape_menu/lobby_button/small/collapsible was unable to be GC'd -- (ref count of 3)
RUNTIME: ## TESTING: GC: -- [0x200216d] | /atom/movable/screen/escape_menu/lobby_button/small/collapsible was unable to be GC'd -- (ref count of 3)
```

## Changelog

N/A
