### PR TITLE
Deletes knockdown while buckled from shuttle movement 

### DIFF
--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -326,8 +326,6 @@ All ShuttleMove procs go here
 		return
 	if(knockdown > 0)
 		if(buckled)
-			// If we're buckled, no stun but we'll still be floored and frozen
-			Knockdown(knockdown)
 			Immobilize(knockdown * 0.5)
 			return
 		Paralyze(knockdown)


### PR DESCRIPTION
## About The Pull Request

Deletes the knockdown part of "on shuttle move while buckled", leaves just immobilize.

## Why It's Good For The Game

I added this not long ago but it didn't really end up working as I expected and causes issues like randomly losing your cigarette during shuttle launch, so... eh. It can go.

## Changelog
:cl: Melbert
del: If buckled during a violent shuttle launch, you'll no longer be knocked down + immobilized, instead just immobilized. Unbuckled effects are unchanged.
/:cl:
