### PR TITLE
regex for `for` loop anti pattern

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -702,9 +702,8 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 		var/list/flame_turf = flameturf
 		flameturf = list()
 		for(var/thing in flame_turf)
-			if(thing)
-				var/turf/T = thing
-				new /obj/effect/hotspot(T) //Mostly for ambience!
+			var/turf/T = thing
+			new /obj/effect/hotspot(T) //Mostly for ambience!
 		cost_flameturf = MC_AVERAGE(cost_flameturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		if (low_turf.len || med_turf.len || high_turf.len)

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -701,8 +701,7 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 		timer = TICK_USAGE_REAL
 		var/list/flame_turf = flameturf
 		flameturf = list()
-		for(var/thing in flame_turf)
-			var/turf/T = thing
+		for(var/turf/T as anything in flame_turf)
 			new /obj/effect/hotspot(T) //Mostly for ambience!
 		cost_flameturf = MC_AVERAGE(cost_flameturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -701,7 +701,7 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 		timer = TICK_USAGE_REAL
 		var/list/flame_turf = flameturf
 		flameturf = list()
-		for(var/turf/T as anything in flame_turf)
+		for(var/turf/T in flame_turf)
 			new /obj/effect/hotspot(T) //Mostly for ambience!
 		cost_flameturf = MC_AVERAGE(cost_flameturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 

--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -182,8 +182,7 @@ SUBSYSTEM_DEF(trading_card_game)
 			cardsByCount[id] += 1
 	var/toSend = "Out of [totalCards] cards"
 	for(var/id in sort_list(cardsByCount, GLOBAL_PROC_REF(cmp_num_string_asc)))
-		if(id)
-			var/datum/card/template = cached_cards[pack.series]["ALL"][id]
-			toSend += "\nID:[id] [template.name] [(cardsByCount[id] * 100) / totalCards]% Total:[cardsByCount[id]]"
+		var/datum/card/template = cached_cards[pack.series]["ALL"][id]
+		toSend += "\nID:[id] [template.name] [(cardsByCount[id] * 100) / totalCards]% Total:[cardsByCount[id]]"
 	message_admins(toSend)
 	qdel(pack)

--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -182,7 +182,8 @@ SUBSYSTEM_DEF(trading_card_game)
 			cardsByCount[id] += 1
 	var/toSend = "Out of [totalCards] cards"
 	for(var/id in sort_list(cardsByCount, GLOBAL_PROC_REF(cmp_num_string_asc)))
-		var/datum/card/template = cached_cards[pack.series]["ALL"][id]
-		toSend += "\nID:[id] [template.name] [(cardsByCount[id] * 100) / totalCards]% Total:[cardsByCount[id]]"
+		if(id)
+			var/datum/card/template = cached_cards[pack.series]["ALL"][id]
+			toSend += "\nID:[id] [template.name] [(cardsByCount[id] * 100) / totalCards]% Total:[cardsByCount[id]]"
 	message_admins(toSend)
 	qdel(pack)

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -211,12 +211,11 @@
 /obj/item/reagent_containers/borghypo/ui_data(mob/user)
 	var/list/available_reagents = list()
 	for(var/datum/reagent/reagent in stored_reagents.reagent_list)
-		if(reagent)
-			available_reagents.Add(list(list(
-				"name" = reagent.name,
-				"volume" = round(reagent.volume, 0.01) - 1,
-				"description" = reagent.description,
-			))) // list in a list because Byond merges the first list...
+		available_reagents.Add(list(list(
+			"name" = reagent.name,
+			"volume" = round(reagent.volume, 0.01) - 1,
+			"description" = reagent.description,
+		))) // list in a list because Byond merges the first list...
 
 	var/data = list()
 	data["theme"] = tgui_theme
@@ -443,12 +442,11 @@
 /obj/item/reagent_containers/borghypo/condiment_synthesizer/ui_data(mob/user)
 	var/list/condiments = list()
 	for(var/datum/reagent/reagent in stored_reagents.reagent_list)
-		if(reagent)
-			condiments.Add(list(list(
-				"name" = reagent.name,
-				"volume" = round(reagent.volume, 0.01) - 1,
-				"description" = reagent.description,
-			))) // list in a list because Byond merges the first list...
+		condiments.Add(list(list(
+			"name" = reagent.name,
+			"volume" = round(reagent.volume, 0.01) - 1,
+			"description" = reagent.description,
+		))) // list in a list because Byond merges the first list...
 
 	var/data = list()
 	data["theme"] = tgui_theme

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -220,16 +220,15 @@
 
 /obj/structure/spawner/nether/process(seconds_per_tick)
 	for(var/mob/living/living_mob in contents)
-		if(living_mob)
-			playsound(src, 'sound/effects/magic/demon_consume.ogg', 50, TRUE)
-			living_mob.adjustBruteLoss(60 * seconds_per_tick)
-			new /obj/effect/gibspawner/generic(get_turf(living_mob), living_mob)
-			if(living_mob.stat == DEAD)
-				var/mob/living/basic/blankbody/newmob = new(loc)
-				newmob.name = "[living_mob]"
-				newmob.desc = "It's [living_mob], but [living_mob.p_their()] flesh has an ashy texture, and [living_mob.p_their()] face is featureless save an eerie smile."
-				src.visible_message(span_warning("[living_mob] reemerges from the link!"))
-				qdel(living_mob)
+		playsound(src, 'sound/effects/magic/demon_consume.ogg', 50, TRUE)
+		living_mob.adjustBruteLoss(60 * seconds_per_tick)
+		new /obj/effect/gibspawner/generic(get_turf(living_mob), living_mob)
+		if(living_mob.stat == DEAD)
+			var/mob/living/basic/blankbody/newmob = new(loc)
+			newmob.name = "[living_mob]"
+			newmob.desc = "It's [living_mob], but [living_mob.p_their()] flesh has an ashy texture, and [living_mob.p_their()] face is featureless save an eerie smile."
+			src.visible_message(span_warning("[living_mob] reemerges from the link!"))
+			qdel(living_mob)
 
 /obj/structure/spawner/sentient
 	var/role_name = "A sentient mob"


### PR DESCRIPTION

## About The Pull Request
I made and metek improved this regex for finding instances if(itterator) in for loops because a downstream im working on does it an insane amount. Im fairly certin all these instaces have no reason to be running if checks here saying most of the for loops are typed so if it was null or something it shouldnt be iterated on
`for\s*\(var(/\w+)*/(\w+) .*\n\s+if\(\2\)`
## Why It's Good For The Game
just kinda bad practice. Its way way way worse on the downstream tho holy shit
<img width="1264" height="759" alt="image" src="https://github.com/user-attachments/assets/1d0f152d-372d-49d4-a9fa-6d8e4d27a816" />
## Changelog
N/A
