### PR TITLE
Bluespace crystals take a 1.5 second do_after to blink with, their description reflects this

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -18,7 +18,7 @@
 
 /obj/item/stack/ore/bluespace_crystal/examine(mob/user)
 	. = ..()
-	. += span_notice("When crushed by high-velocity -- such as THROWING -- or USEd in-hand, this ")
+	. += span_notice("When crushed by high-velocity -- such as THROWING -- or USEd in-hand, this  ")
 
 /obj/item/stack/ore/bluespace_crystal/refined
 	name = "refined bluespace crystal"
@@ -38,7 +38,7 @@
 
 /obj/item/stack/ore/bluespace_crystal/attack_self(mob/user)
 	user.visible_message("[user] takes [src] in-hand and squeezes with obvious effort...")
-	if(!do_after(user, 2 SECONDS))
+	if(!do_after(user, 1.5 SECONDS))
 		balloon_alert(user, "crushing interrupted")
 		return
 	user.visible_message(span_warning("[user] crushes [src]!"), span_danger("You crush [src]!"))

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -1,7 +1,7 @@
 //Bluespace crystals, used in telescience and when crushed it will blink you to a random turf.
 /obj/item/stack/ore/bluespace_crystal
 	name = "bluespace crystal"
-	desc = "A glowing bluespace crystal, not much is known about how they work. It looks very delicate."
+	desc = "A glowing bluespace crystal, not much is known about how they work. It feels delicate and brittle, but the inner fractals give a dizzying, non-dimensional sense of density."
 	icon = 'icons/obj/ore.dmi'
 	icon_state = "bluespace_crystal"
 	singular_name = "bluespace crystal"
@@ -15,6 +15,10 @@
 	merge_type = /obj/item/stack/ore/bluespace_crystal
 	/// The teleport range when crushed/thrown at someone.
 	var/blink_range = 8
+
+/obj/item/stack/ore/bluespace_crystal/examine(mob/user)
+	. = ..()
+	. += span_notice("When crushed by high-velocity -- such as THROWING -- or USEd in-hand, this ")
 
 /obj/item/stack/ore/bluespace_crystal/refined
 	name = "refined bluespace crystal"
@@ -33,6 +37,10 @@
 	return 1
 
 /obj/item/stack/ore/bluespace_crystal/attack_self(mob/user)
+	user.visible_message("[user] takes [src] in-hand and squeezes with obvious effort...")
+	if(!do_after(user, 2 SECONDS))
+		balloon_alert(user, "crushing interrupted")
+		return
 	user.visible_message(span_warning("[user] crushes [src]!"), span_danger("You crush [src]!"))
 	new /obj/effect/particle_effect/sparks(loc)
 	playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
@@ -55,7 +63,7 @@
 //Artificial bluespace crystal, doesn't give you much research.
 /obj/item/stack/ore/bluespace_crystal/artificial
 	name = "artificial bluespace crystal"
-	desc = "An artificially made bluespace crystal, it looks delicate."
+	desc = "An artificially made bluespace crystal; it looks infinitely-dense, but feels quite brittle."
 	mats_per_unit = list(/datum/material/bluespace=SHEET_MATERIAL_AMOUNT*0.5)
 	blink_range = 4 // Not as good as the organic stuff!
 	points = 0 //nice try
@@ -73,7 +81,7 @@
 	inhand_icon_state = null
 	gulag_valid = TRUE
 	singular_name = "bluespace polycrystal"
-	desc = "A stable polycrystal, made of fused-together bluespace crystals. You could probably break one off."
+	desc = "A stable polycrystal, made of fused-together bluespace crystals. You could probably break one off; though stable crystals are known to have had their super-positional density and brittleness stabilized."
 	mats_per_unit = list(/datum/material/bluespace=SHEET_MATERIAL_AMOUNT)
 	attack_verb_continuous = list("bluespace polybashes", "bluespace polybatters", "bluespace polybludgeons", "bluespace polythrashes", "bluespace polysmashes")
 	attack_verb_simple = list("bluespace polybash", "bluespace polybatter", "bluespace polybludgeon", "bluespace polythrash", "bluespace polysmash")


### PR DESCRIPTION

## About The Pull Request
This adds a 2 second do_after to use a crystal in-hand to crush it for a teleport; it also modifies the description of bluespace crystals to give hints about crushing them, and to spit some scifi woowoo about them being superpositioned as dense and brittle, I don't know, it's the future, I don't gotta explain shit

The effect on throwing remains the same.

## Why It's Good For The Game
Bluespace crystals being <x> number of tries of get-out-of-jail free cards depending on how many you steal from the ore silo is out of tune with our other teleport options; there are only two hand teles in any given round, the portal gun requires an anomaly core, so does the MOD teleporter, and other teleports are relegated to magical antagonists or traitor gear. Bluespace crystals, on the other hand, will blink you as quickly as you can press your hotkey macro, with no downside besides POSSIBLY ending up in a bad spot if you run out during your spamming of the 'use self' button.

Adding a do_after gives at least a brief opportunity of counterplay.

## Changelog
:cl: Bisar
balance: Bluespace crystal blinking when used in-hand now requires a 2 second do_after.
/:cl:
