### PR TITLE
HoP traitors may get an objective to kill the Captain and steal their ID

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -334,6 +334,8 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define DESTROY_AI_PROB(denominator) (100 / denominator)
 /// If the destroy AI objective doesn't roll, chance that we'll get a maroon instead. If this prob fails, they will get a generic assassinate objective instead.
 #define MAROON_PROB 30
+/// Probability that any job related objective is picked
+#define JOB_PROB 40
 
 /// How many telecrystals a normal traitor starts with
 #define TELECRYSTALS_DEFAULT 20

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -136,11 +136,10 @@
 	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
 	// This does not give them 1 fewer objectives than intended.
 	for(var/i in objective_count to objective_limit - 1)
-		if(job_objective)
-			objectives += job_objective
-			job_objective = null // Only one job objective per traitor.
-			continue
-		objectives += forge_single_generic_objective()
+		var/generated = forge_single_generic_objective(job_objective)
+		if(generated == job_objective)
+			job_objective = null
+		objectives += generated
 
 /**
  * ## forge_ending_objective
@@ -170,7 +169,10 @@
 	ending_objective.owner = owner
 	objectives += ending_objective
 
-/datum/antagonist/traitor/proc/forge_single_generic_objective()
+/datum/antagonist/traitor/proc/forge_single_generic_objective(job_objective)
+	if(prob(JOB_PROB) && job_objective)
+		return job_objective
+
 	if(prob(KILL_PROB))
 		var/list/active_ais = active_ais(skip_syndicate = TRUE)
 		if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
@@ -196,10 +198,8 @@
 	return steal_objective
 
 /datum/antagonist/traitor/proc/forge_job_objective()
-	var/datum/objective/job_objective = owner.assigned_role.generate_traitor_objective()
-	if(isnull(job_objective))
-		return null
-	job_objective.owner = owner
+	var/datum/objective/job_objective = owner.assigned_role.generate_traitor_objective() // can return null
+	job_objective?.owner = owner
 	return job_objective
 
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -132,10 +132,14 @@
 		objective_count++
 
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
-
+	var/datum/objective/job_objective = forge_job_objective()
 	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
 	// This does not give them 1 fewer objectives than intended.
 	for(var/i in objective_count to objective_limit - 1)
+		if(job_objective)
+			objectives += job_objective
+			job_objective = null // Only one job objective per traitor.
+			continue
 		objectives += forge_single_generic_objective()
 
 /**
@@ -190,6 +194,13 @@
 	steal_objective.owner = owner
 	steal_objective.find_target()
 	return steal_objective
+
+/datum/antagonist/traitor/proc/forge_job_objective()
+	var/datum/objective/job_objective = owner.assigned_role.generate_traitor_objective()
+	if(isnull(job_objective))
+		return null
+	job_objective.owner = owner
+	return job_objective
 
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)
 	. = ..()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -644,3 +644,7 @@
 /// Called when a mob that has this job is admin respawned
 /datum/job/proc/on_respawn(mob/new_character)
 	SSjob.equip_rank(new_character, new_character.mind.assigned_role, new_character.client)
+
+/// This proc may be called when someone of this job is made into a traitor to create custom objectives related to the job.
+/datum/job/proc/generate_traitor_objective()
+	return null

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -51,8 +51,6 @@
 	return "Due to staffing shortages, newly promoted Acting Captain [captain.real_name] on deck!"
 
 /datum/job/head_of_personnel/generate_traitor_objective()
-	if(prob(50))
-		return null
 	var/datum/objective/assassinate/captain_replacement/promotion = new()
 	promotion.target = promotion.find_target()
 	if(isnull(promotion.target))

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -69,7 +69,7 @@
 
 /datum/objective/assassinate/captain_replacement/update_explanation_text()
 	. = ..()
-	explanation_text = "Assassinate [target.name], the Captain, and steal [target.p_their()] ID card - becoming the new Captain in the process."
+	explanation_text = "Assassinate [target.name], the Captain, and steal [target.p_their()] ID card."
 
 /datum/objective/assassinate/captain_replacement/check_completion()
 	if(completed)

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -50,6 +50,47 @@
 /datum/job/head_of_personnel/get_captaincy_announcement(mob/living/captain)
 	return "Due to staffing shortages, newly promoted Acting Captain [captain.real_name] on deck!"
 
+/datum/job/head_of_personnel/generate_traitor_objective()
+	if(prob(50))
+		return null
+	var/datum/objective/assassinate/captain_replacement/promotion = new()
+	promotion.target = promotion.find_target()
+	if(isnull(promotion.target))
+		qdel(promotion)
+		return null
+
+	promotion.update_explanation_text()
+	return promotion
+
+/// Special assassination objective to kill the cap, take their id, and become the new captain
+/datum/objective/assassinate/captain_replacement
+	name = "replace the captain"
+	admin_grantable = FALSE
+
+/datum/objective/assassinate/captain_replacement/update_explanation_text()
+	. = ..()
+	explanation_text = "Assassinate [target.name], the Captain, and steal [target.p_their()] ID card - becoming the new Captain in the process."
+
+/datum/objective/assassinate/captain_replacement/check_completion()
+	if(completed)
+		return TRUE
+	if(!..())
+		return FALSE
+
+	for(var/datum/mind/hop as anything in get_owners())
+		if(!isliving(hop.current))
+			continue
+
+		if(locate(/obj/item/card/id/advanced/gold) in hop.current.get_all_contents())
+			return TRUE
+
+	return FALSE
+
+/datum/objective/assassinate/captain_replacement/find_target(dupe_search_range, list/blacklist)
+	for(var/datum/mind/fellow_head as anything in SSjob.get_all_heads() - blacklist)
+		if(is_captain_job(fellow_head.assigned_role))
+			return fellow_head
+	return null
 
 /datum/outfit/job/hop
 	name = "Head of Personnel"


### PR DESCRIPTION
## About The Pull Request

HoP traitors have a chance to get an objective to "replace the captain" requiring they assassinate the captain and steal their (or any) gold id. 

It can only be rolled if there's a captain (obviously) 

## Why It's Good For The Game

Figured we could give certain jobs fun unique objectives which lean into some common sci fi tropes, like "untrustworthy second in command". In this case, it'd be pretty fitting for a hop to have enough and try to take over the station themself.

However I kept the flavor pretty broad - for some they might take the objective as "I'm becoming the new captain", for others it might be "I'm jealous of their cool ID card". 

## Changelog

:cl: Melbert
add: HoP traitors can get an objective to "replace the captain" - requiring they assassinate the captain and steal their id.
/:cl:
