### PR TITLE
Fixing bowls on specific food items 

### DIFF
--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -25,7 +25,6 @@
 		reagents.add_reagent(/datum/reagent/consumable/nutriment, 9)
 		reagents.add_reagent(/datum/reagent/consumable/nutriment/vitamin, 1)
 		
-
 /obj/item/food/bowled/mammi
 	name = "Mammi"
 	desc = "A bowl of mushy bread and milk. It reminds you, not too fondly, of a bowel movement."
@@ -48,7 +47,6 @@
 		/datum/reagent/consumable/nutriment/vitamin = 5,
 	)
 	trash_type = /obj/item/reagent_containers/cup/bowl
-
 
 	tastes = list("jelly" = 1, "mushroom" = 1)
 	foodtypes = VEGETABLES

--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -16,6 +16,7 @@
 	icon_state = "wishsoup"
 	food_reagents = list(/datum/reagent/water = 10)
 	tastes = list("wishes" = 1)
+	trash_type = /obj/item/reagent_containers/cup/bowl
 
 /obj/item/food/bowled/wish/Initialize(mapload)
 	. = ..()
@@ -23,7 +24,7 @@
 		desc = "A wish come true!"
 		reagents.add_reagent(/datum/reagent/consumable/nutriment, 9)
 		reagents.add_reagent(/datum/reagent/consumable/nutriment/vitamin, 1)
-		trash_type = /obj/item/reagent_containers/cup/bowl
+		
 
 /obj/item/food/bowled/mammi
 	name = "Mammi"
@@ -45,8 +46,10 @@
 		/datum/reagent/consumable/nutriment = 6,
 		/datum/reagent/drug/mushroomhallucinogen = 6,
 		/datum/reagent/consumable/nutriment/vitamin = 5,
-		trash_type = /obj/item/reagent_containers/cup/bowl
 	)
+	trash_type = /obj/item/reagent_containers/cup/bowl
+
+
 	tastes = list("jelly" = 1, "mushroom" = 1)
 	foodtypes = VEGETABLES
 	crafting_complexity = FOOD_COMPLEXITY_2
@@ -61,8 +64,10 @@
 		/datum/reagent/drug/mushroomhallucinogen = 3,
 		/datum/reagent/toxin/amatoxin = 6,
 		/datum/reagent/consumable/nutriment/vitamin = 5,
-		trash_type = /obj/item/reagent_containers/cup/bowl
 	)
+	trash_type = /obj/item/reagent_containers/cup/bowl
+
+
 	tastes = list("jelly" = 1, "mushroom" = 1)
 	foodtypes = VEGETABLES | TOXIC
 	crafting_complexity = FOOD_COMPLEXITY_2

--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -23,6 +23,7 @@
 		desc = "A wish come true!"
 		reagents.add_reagent(/datum/reagent/consumable/nutriment, 9)
 		reagents.add_reagent(/datum/reagent/consumable/nutriment/vitamin, 1)
+		trash_type = /obj/item/reagent_containers/cup/bowl
 
 /obj/item/food/bowled/mammi
 	name = "Mammi"
@@ -44,6 +45,7 @@
 		/datum/reagent/consumable/nutriment = 6,
 		/datum/reagent/drug/mushroomhallucinogen = 6,
 		/datum/reagent/consumable/nutriment/vitamin = 5,
+		trash_type = /obj/item/reagent_containers/cup/bowl
 	)
 	tastes = list("jelly" = 1, "mushroom" = 1)
 	foodtypes = VEGETABLES
@@ -59,6 +61,7 @@
 		/datum/reagent/drug/mushroomhallucinogen = 3,
 		/datum/reagent/toxin/amatoxin = 6,
 		/datum/reagent/consumable/nutriment/vitamin = 5,
+		trash_type = /obj/item/reagent_containers/cup/bowl
 	)
 	tastes = list("jelly" = 1, "mushroom" = 1)
 	foodtypes = VEGETABLES | TOXIC


### PR DESCRIPTION
## About The Pull Request

It changes the fact in wish soup, Spacylibertyduff, and amanita jelly that makes it so people eat the bowls, VIA a trash_type that spawns a bowl once the food is finished, Fixes https://github.com/tgstation/tgstation/issues/92155

## Why It's Good For The Game

People are using bowls which cant be returned to chef which directly (due to them being consumed) makes chefs job more difficult and annoying

## Changelog


:cl: Glu
fix: Certain food items that required bowl now drop a bowl post-consumption
/:cl:
