### PR TITLE
Fixes augmentation with organed bodyparts

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -929,7 +929,7 @@
 	hand_bodyparts[lost_hand.held_index] = null
 
 ///Proc to hook behavior on bodypart additions. Do not directly call. You're looking for [/obj/item/bodypart/proc/try_attach_limb()].
-/mob/living/carbon/proc/add_bodypart(obj/item/bodypart/new_bodypart)
+/mob/living/carbon/proc/add_bodypart(obj/item/bodypart/new_bodypart, special = FALSE)
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	new_bodypart.on_adding(src)
@@ -942,6 +942,10 @@
 
 	// Tell the organs in the bodyparts that we are in a mob again
 	for(var/obj/item/organ/organ in new_bodypart)
+		if(special && get_organ_slot(organ.slot))
+			organ.bodypart_remove(new_bodypart)
+			organ.forceMove(drop_location())
+			continue
 		organ.mob_insert(src)
 
 	switch(new_bodypart.body_part)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -942,6 +942,8 @@
 
 	// Tell the organs in the bodyparts that we are in a mob again
 	for(var/obj/item/organ/organ in new_bodypart)
+		// Conflict detected!! This is handled by bodypart_insert too, but when special = TRUE we don't want them moving around all willy-nilly
+		// So just drop it
 		if(special && get_organ_slot(organ.slot))
 			organ.bodypart_remove(new_bodypart)
 			organ.forceMove(drop_location())

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -251,10 +251,12 @@
 	if(!istype(limb_owner))
 		return
 	var/obj/item/bodypart/old_limb = limb_owner.get_bodypart(body_zone)
+
 	if(old_limb)
 		old_limb.drop_limb(TRUE)
 
-	. = try_attach_limb(limb_owner, special)
+	. = try_attach_limb(limb_owner, TRUE)
+
 	if(!.) //If it failed to replace, re-attach their old limb as if nothing happened.
 		old_limb.try_attach_limb(limb_owner, TRUE)
 
@@ -289,7 +291,7 @@
 
 	SEND_SIGNAL(new_limb_owner, COMSIG_CARBON_ATTACH_LIMB, src, special, lazy)
 	SEND_SIGNAL(src, COMSIG_BODYPART_ATTACHED, new_limb_owner, special, lazy)
-	new_limb_owner.add_bodypart(src)
+	new_limb_owner.add_bodypart(src, special)
 
 	if(!lazy)
 		LAZYREMOVE(new_limb_owner.body_zone_dismembered_by, body_zone)


### PR DESCRIPTION
Augmenting someone with a bodypart already containing organs would runtime in bodypart_insert, but not mob_insert, so you could have multiple implants (that were very buggy and EMP proof)

This was mostly buggines caused by special flags not being observed everywhere. We expect to reject the incoming organ, but while rejecting it we insert it (ow)

Fixed it by having the bodypart_insert reject new incoming conflicting organs when using the special flags, and that just kinda fixes everything

closes #86813 

:cl:
fix: Fixes augmenting with organ-containing limbs being buggy as hell due to organ slots conflicting
/:cl:

The organ inside the old bodypart takes priority if there is a conflict. The incoming and denied organ is then simply dropped on the floor 