### PR TITLE
Fixes projectiles inheriting gun's pixel offsets when fired

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -90,7 +90,7 @@
 	var/direct_target
 	if(target && curloc.Adjacent(targloc, target=targloc, mover=src)) //if the target is right on our location or adjacent (including diagonally if reachable) we'll skip the travelling code in the proj's fire()
 		direct_target = target
-	loaded_projectile.aim_projectile(target, fired_from, params2list(params), spread)
+	loaded_projectile.aim_projectile(target, tk_firing(user, fired_from) ? fired_from : user, params2list(params), spread)
 	var/obj/projectile/loaded_projectile_cache = loaded_projectile
 	loaded_projectile = null
 	loaded_projectile_cache.fire(null, direct_target)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1271,6 +1271,11 @@
 			source_loc = new_loc
 		pixel_y = pixel_y % (ICON_SIZE_X / 2)
 
+	// We've got moved by turf offsets
+	if (starting != source_loc)
+		starting = source_loc
+		forceMove(source_loc)
+
 	if(length(modifiers))
 		var/list/calculated = calculate_projectile_angle_and_pixel_offsets(source, target_loc && target, modifiers)
 		p_x = calculated[2]


### PR DESCRIPTION

## About The Pull Request

Gun itself was passed as source when fired, which resulted in its pixel offsets being inherited. Also we didn't move projectiles over turfs, so any offsets larger than 32 pixels resulted in projectiles steering to the side.

## Changelog
:cl:
fix: Fixed projectiles inheriting gun's pixel offsets when fired
/:cl:
