### PR TITLE
Adds a Pulse Rifle to the Cargo Goodies for 75,000 credits.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -12,6 +12,13 @@
 	cost = 100000
 	contains = list(/obj/item/modular_computer/pda/clear)
 
+/datum/supply_pack/goody/pulse_rifle
+	name = "Pulse Rifle"
+	desc = "A Nanotrasen-issue Pulse Rifle. Valued at 75 thousand credits. Requires a weapons permit to order."
+	cost = 75000
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/gun/energy/pulse
+
 /datum/supply_pack/goody/dumdum38
 	name = ".38 DumDum Speedloader Single-Pack"
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."


### PR DESCRIPTION
## About The Pull Request

Adds a Pulse Rifle to the Cargo Goodies for 75,000 credits.

## Why It's Good For The Game

Provides an aspirational goal to reach for within a round for your personal economic position. Adds more utility to the CRAB-17 theft of money. Expands energy weapon coverage on the station.

## Changelog

:cl:
refactor: Adds a Pulse Rifle to the Cargo Goodies for 75,000 credits.
/:cl: