### PR TITLE
Crystal blinking leaves a worn item behind half the time

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -52,13 +52,12 @@
 	if(!carbon_user.get_equipped_items())
 		return
 	var/obj/item/lost_in_translation = pick(carbon_user.get_equipped_items())
-
-	carbon_user.dropItemToGround(lost_in_translation,TRUE,TRUE,TRUE,get_turf(L))
+	carbon_user.dropItemToGround(lost_in_translation,FALSE,TRUE,TRUE,get_turf(L))
 	if(lost_in_translation.slot_flags & ITEM_SLOT_ICLOTHING || lost_in_translation.slot_flags & ITEM_SLOT_OCLOTHING)
 		to_chat(carbon_user,span_boldwarning("\The [lost_in_translation] and everything it held is torn off of you as you teleport!"))
 	else
 		to_chat(carbon_user,span_warning("\The [lost_in_translation] is thrown off your person as you teleport!"))
-	balloon_alert(carbon_user,"Something's missing!")
+	balloon_alert(carbon_user,"something's missing!")
 
 
 /obj/item/stack/ore/bluespace_crystal/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -40,7 +40,26 @@
 	use(1)
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/L)
+	if(prob(50))
+		baggage_mishap(L)
 	do_teleport(L, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+
+///drops a worn item at the location of teleportation and notifies teleportee
+/obj/item/stack/ore/bluespace_crystal/proc/baggage_mishap(mob/living/L)
+	if(!iscarbon(L))
+		return
+	var/mob/living/carbon/carbon_user = L
+	if(!carbon_user.get_equipped_items())
+		return
+	var/obj/item/lost_in_translation = pick(carbon_user.get_equipped_items())
+
+	carbon_user.dropItemToGround(lost_in_translation,TRUE,TRUE,TRUE,get_turf(L))
+	if(lost_in_translation.slot_flags & ITEM_SLOT_ICLOTHING || lost_in_translation.slot_flags & ITEM_SLOT_OCLOTHING)
+		to_chat(carbon_user,span_boldwarning("\The [lost_in_translation] and everything it held is torn off of you as you teleport!"))
+	else
+		to_chat(carbon_user,span_warning("\The [lost_in_translation] is thrown off your person as you teleport!"))
+	balloon_alert(carbon_user,"Something's missing!")
+
 
 /obj/item/stack/ore/bluespace_crystal/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!..()) // not caught in mid-air


### PR DESCRIPTION
## About The Pull Request

alternate to #92142 

Half a chance to drop a worn item on blink. Does not include pockets(lost if uniform taken) or held items.
Includes thrown crystals.
Routes to counter this:
Wear a bunch of extraneous crap to lower the chance of losing something important.
Strip nude and teleport while clutching your bag in hand
Put your valuable stuff somewhere safe while warping about(lame)

## Why It's Good For The Game

le logistical consideration to spamming bluespace crystals.
Losing your jumpsuit and being totally fucked over is a 1 in 14 chance if your wearing what most jobs spawn in with.
Losing your ID is 1 in 7 since jumpsuits take those with them.

RNG in combat is good actually. BScrystals will probably start getting confiscated.
## Changelog

:cl:
balance: Blinking with bluespace crystals has half a chance to pluck something you're wearing off.
/:cl:
