### PR TITLE
Adds admin verb to disable cameranet updates (because Catwalk keeps exploding)

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -70,6 +70,9 @@
 /// The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
 /// Accepts an optional partial_update argument, that blocks any calls out to chunks that could affect us, like above or below
 /datum/camerachunk/proc/update(partial_update = FALSE)
+	if(GLOB.block_camera_updates)
+		return
+
 	var/list/updated_visible_turfs = list()
 
 	for(var/z_level in lower_z to upper_z)
@@ -179,3 +182,8 @@
 		obscuredTurfs[obscured_turf] = new_static
 
 #undef UPDATE_BUFFER_TIME
+
+GLOBAL_VAR_INIT(block_camera_updates, FALSE)
+
+ADMIN_VERB(pause_camera_updates, R_ADMIN, "Toggle Camera Updates", "Stop security cameras from updating, meaning what they see now is what they will see forever.", ADMIN_CATEGORY_DEBUG)
+	GLOB.block_camera_updates = !GLOB.block_camera_updates


### PR DESCRIPTION
## About The Pull Request

This keeps happening on Multi-z but especially Catwalk

<img width="554" height="58" alt="image" src="https://github.com/user-attachments/assets/eff3f0e5-49d6-4997-b4d7-05eff6432155" />

It needs to be fixed but in the meanwhile I think admins should just have a way to block updates and assuage the lag (that isn't "remove the AI from the game")
