### PR TITLE
[NO GBP] Fixes the discord PR announcement workflow

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action != "labeled" || github.event.label.name == "Stale" }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Stale' }}
     steps:
       - name: "Check for DISCORD_WEBHOOK"
         id: secrets_set
@@ -26,7 +26,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: ${{ github.event.action != "labeled" && "GET_ACTION" || "**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**" }}
+          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || '**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**' }}
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || '**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**' }}
+          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || format('**Pull Request {0} automatically marked as stale.**', github.event.pull_request.number) }}
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4


### PR DESCRIPTION
## About The Pull Request

I forgot that strings in expressions **MUST** be enclosed in single-quotes and not double-quotes.

## Why It's Good For The Game

The PR announcement workflow needs to not be completely borked.

## Changelog

No player-facing changes.
