### PR TITLE
Fix discord PR announce workflow

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action != "labeled" || github.event.label.name == "Stale" }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Stale' }}
     steps:
       - name: "Check for DISCORD_WEBHOOK"
         id: secrets_set
@@ -26,7 +26,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: ${{ github.event.action != "labeled" && "GET_ACTION" || "**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**" }}
+          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || '**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**' }}
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || '**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**' }}
+          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || format('**Pull Request {0} automatically marked as stale.**', github.event.pull_request.number) }}
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4


### PR DESCRIPTION

## About The Pull Request

The things in " needed to be in ' and there needed to be a format() call so the literal string ${{ github.event.pull_request.number }} isn't used instead of the number

## Why It's Good For The Game

It's broken, tested this fix on my own repo and it works
<img width="417" height="339" alt="image" src="https://github.com/user-attachments/assets/80057e2e-9c82-499b-ae81-3ea4dca5be38" />

