### PR TITLE
Fixes dropdel embeds runtiming upon removal

### DIFF
--- a/code/datums/embedding.dm
+++ b/code/datums/embedding.dm
@@ -308,8 +308,8 @@
 /// Move self to owner's turf when our limb gets removed
 /datum/embedding/proc/on_removed(datum/source, mob/living/carbon/old_owner)
 	SIGNAL_HANDLER
-	stop_embedding()
-	parent.forceMove(old_owner.drop_location())
+	if (!stop_embedding()) // Dropdel?
+		parent.forceMove(old_owner.drop_location())
 
 /// Someone attempted to pull us out! Either the owner by inspecting themselves, or someone else by examining the owner and clicking the link.
 /datum/embedding/proc/rip_out(mob/living/jack_the_ripper)


### PR DESCRIPTION

## About The Pull Request

This code didn't take dropdel embeds into account

## Changelog
:cl:
fix: Fixed dropdel embeds runtiming upon removal
/:cl:
