### PR TITLE
Fixes winning ore vent wave defence by moving drone

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -263,24 +263,20 @@
  * If the node drone is dead, the ore vent is not tapped and the wave defense can be reattempted.
  *
  * Also gives xp and mining points to all nearby miners in equal measure.
- * Arguments:
- * - force: Set to true if you want to just skip all checks and make the vent start producing boulders.
  */
-/obj/structure/ore_vent/proc/handle_wave_conclusion(datum/source, force = FALSE)
+/obj/structure/ore_vent/proc/handle_wave_conclusion(datum/source)
 	SIGNAL_HANDLER
 
 	SEND_SIGNAL(src, COMSIG_VENT_WAVE_CONCLUDED)
 	COOLDOWN_RESET(src, wave_cooldown)
 	remove_shared_particles(/particles/smoke/ash)
 
-	if(force)
-		initiate_wave_win()
-		return
-
+	//happens in COMSIG_QDELETING
 	if(QDELETED(node))
 		initiate_wave_loss(loss_message = "\the [src] creaks and groans as the mining attempt fails, and the vent closes back up.")
 		return
 
+	//happens in COMSIG_MOVABLE_MOVED
 	if(get_turf(node) != get_turf(src))
 		initiate_wave_loss(loss_message = "The [node] detaches from the [src], and the vent closes back up!")
 		return //Start over!


### PR DESCRIPTION
## About The Pull Request
- Fixes #92079

The `force` parameter in `handle_wave_conclusion()` was being interpreted the wrong way in these 2 scenarios
- When `COMSIG_QDELETING` is sent `force` actually means are we deleting the object forcefully & not if we want to win the wave defence
- When `COMSIG_MOVABLE_MOVED` is sent `force` gets the old location of the drone(which gets misunderstood as TRUE because it's a non null value) & not if we want to win the wave defence

So let's just remove this parameter so that it doesn't get misinterpreted again. We don't lose any functionality with this because when analysing all the places `handle_wave_conclusion()` is called, no where is `force = TRUE` passed so the default is always assumed to be FALSE so we can just throw it away

## Changelog
:cl:
fix: You cannot win an ore vent wave defence by throwing a blue space crystal on the drone or by moving it in any other way
/:cl:

