### PR TITLE
[NO GBP] Fixes oil ignition, sanity checks blood DNA and adds some logging to it

### DIFF
--- a/code/datums/elements/easy_ignite.dm
+++ b/code/datums/elements/easy_ignite.dm
@@ -88,8 +88,6 @@
 
 	if (!item_ignition(source, tool, user))
 		return ITEM_INTERACT_BLOCKING
-
-	ignite(source, user)
 	return ITEM_INTERACT_SUCCESS
 
 /datum/element/easy_ignite/proc/item_ignition(obj/item/source, obj/item/tool, mob/user)

--- a/code/modules/forensics/forensics_helpers.dm
+++ b/code/modules/forensics/forensics_helpers.dm
@@ -114,6 +114,11 @@
 	. = ..()
 	if (isnull(blood_DNA_to_add))
 		return .
+	if (!islist(blood_DNA_to_add))
+		CRASH("add_blood_DNA on [src] ([type]) has been passed a non-list blood_DNA_to_add ([blood_DNA_to_add])!")
+	for (var/blood_key in blood_DNA_to_add)
+		if (isnull(blood_DNA_to_add[blood_key]))
+			CRASH("add_blood_DNA on [src] ([type]) has been passed bad blood_DNA_to_add ([blood_key] - [blood_DNA_to_add[blood_key]] key-value pair)!")
 	cached_blood_color = null
 	cached_blood_emissive = null
 	if (forensics)


### PR DESCRIPTION

## About The Pull Request

Oil blood will no longer try to ignite twice when hit with a welder, runtiming on the second try.
Also added crashes when ``add_blood_DNA`` is passed non-list or lists with null assoc values, as both are invalid and cause crashes, because I need to hunt down a stupid bug.

## Changelog
:cl:
fix: Trying to ignite oil with a welding tool no longer runtimes due to it trying to get ignited twice
/:cl:
