### PR TITLE
Fixes signal conflict hell on attachable seclights

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -334,6 +334,8 @@
 ///Called when the current_holder is qdeleted, to remove the light effect.
 /datum/component/overlay_lighting/proc/on_parent_attached_to_qdel(atom/movable/source, force)
 	SIGNAL_HANDLER
+	if(isnull(parent_attached_to))
+		return
 	UnregisterSignal(parent_attached_to, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
 	if(directional)
 		UnregisterSignal(parent_attached_to, COMSIG_ATOM_DIR_CHANGE)


### PR DESCRIPTION

## About The Pull Request

This could get called **after** the component parent got deleted because signals are saved before being called, so the overlay lighting component unregging didn't prevent the call from going through. Pretty sure this is the cleanest way to do this.

## Changelog
:cl:
fix: Fixes seclights attached to objects runtiming when their parent object gets deleted
/:cl:
