### PR TITLE
Increase height of notice board UI so all papers actually fit on it.

### DIFF
--- a/tgui/packages/tgui/interfaces/NoticeBoard.tsx
+++ b/tgui/packages/tgui/interfaces/NoticeBoard.tsx
@@ -14,7 +14,7 @@ export const NoticeBoard = (props) => {
   const { allowed, items = [] } = data;
 
   return (
-    <Window width={425} height={176}>
+    <Window width={425} height={220}>
       <Window.Content backgroundColor="#704D25">
         {!items.length ? (
           <Section>


### PR DESCRIPTION

## About The Pull Request

While playing with the notice board I realized the UI would cut off beyond 6~ papers.
This ups the height of the UI to fit all 8 paper entries, with the same amount of buffer above and below.
## Why It's Good For The Game

It no longer cuts off several papers:
<img width="569" height="243" alt="image" src="https://github.com/user-attachments/assets/67dd432a-3574-45ce-8154-763c38a64937" />
## Changelog
:cl:
fix: The notice board UI actually fits the full 8 paper entries.
/:cl:
