### PR TITLE
Fixes borgs made with athlete brains runtiming when trying to examine an especially fit person

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2955,7 +2955,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	var/our_fitness_level = calculate_fitness()
 	var/their_fitness_level = scouter.calculate_fitness()
 
-	var/comparative_fitness = our_fitness_level / their_fitness_level
+	var/comparative_fitness = their_fitness_level ? our_fitness_level / their_fitness_level : 1
 
 	if (comparative_fitness > 2)
 		scouter.set_jitter_if_lower(comparative_fitness SECONDS)


### PR DESCRIPTION

## About The Pull Request

The trait is stuck on mind, so if an athlete gets borged they still have the fitness examiner trait, which results in division by zero as borgs have zero melee damage and thus, are the most unfit beings in the galaxy.

## Changelog
:cl:
fix: Fixed borgs made with athlete brains runtiming when trying to examine an especially fit person
/:cl:
