### PR TITLE
Fixes facial hair gradient DNA runtiming

### DIFF
--- a/code/datums/dna/blocks/dna_identity_block.dm
+++ b/code/datums/dna/blocks/dna_identity_block.dm
@@ -116,7 +116,7 @@
 	return construct_block(SSaccessories.facial_hair_gradients_list.Find(target.grad_style[GRADIENT_FACIAL_HAIR_KEY]), length(SSaccessories.facial_hair_gradients_list))
 
 /datum/dna_block/identity/facial_gradient/apply_to_mob(mob/living/carbon/human/target, dna_hash)
-	var/gradient_style = SSaccessories.hair_gradients_list[deconstruct_block(get_block(dna_hash), length(SSaccessories.hair_gradients_list))]
+	var/gradient_style = SSaccessories.facial_hair_gradients_list[deconstruct_block(get_block(dna_hash), length(SSaccessories.facial_hair_gradients_list))]
 	target.set_facial_hair_gradient_style(gradient_style, update = FALSE)
 
 /datum/dna_block/identity/facial_gradient_color


### PR DESCRIPTION

## About The Pull Request

This broke some gradients as the order in which hair and facial hair gradients are positioned differs

## Changelog
:cl:
fix: Fixes facial hair gradient DNA runtiming and sometimes not adding proper gradients
/:cl:
