### PR TITLE
Adds working? infinite recursion logging

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -11,14 +11,37 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		log_world("uncaught runtime error: [E]")
 		return ..()
 
-	//this is snowflake because of a byond bug (ID:2306577), do not attempt to call non-builtin procs in this if
+	//this is snowflake because of a byond bug (ID:2306577), do not attempt to call non-builtin procs in this block OR BEFORE IT
 	if(copytext(E.name, 1, 32) == "Maximum recursion level reached")//32 == length() of that string + 1
-		//log to world while intentionally triggering the byond bug.
+		var/list/proc_path_to_count = list()
+		var/crashed = FALSE
+		try
+			var/callee/stack_entry = caller
+			while(!isnull(stack_entry))
+				proc_path_to_count[stack_entry.proc] += 1
+				stack_entry = stack_entry.caller
+		catch
+			//union job. avoids crashing the stack again
+			//I just do not trust this construct to work reliably
+			crashed = TRUE
+
+		var/list/split = splittext(E.desc, "\n")
+		for (var/i in 1 to split.len)
+			if (split[i] != "" || copytext(split[1], 1, 2) != "  ")
+				split[i] = "  [split[i]]"
+		split += "--Stack Info [crashed ? "(Crashed, may be missing info)" : ""]:"
+		for(var/path in proc_path_to_count)
+			split += "  [path] = [proc_path_to_count[path]]"
+		E.desc = jointext(split, "\n")
+		SEND_TEXT(world.log, "\[[time2text(world.timeofday,"hh:mm:ss")]\] Runtime Error: [E.name]\n[E.desc]")
+		//log to world while intentionally triggering the byond bug. this does not DO anything, it just errors
+		//(seemingly because of the extra proc call to logger inside log_world interestingly enough)
 		log_world("runtime error: [E.name]\n[E.desc]")
 		//if we got to here without silently ending, the byond bug has been fixed.
-		log_world("The bug with recursion runtimes has been fixed. Please remove the snowflake check from world/Error in [__FILE__]:[__LINE__]")
+		log_world("The \"bug\" with recursion runtimes has been fixed. Please remove the snowflake check from world/Error in [__FILE__]:[__LINE__]")
 		return //this will never happen.
 
+	// Proc calls are allowed past this point
 	else if(copytext(E.name, 1, 18) == "Out of resources!")//18 == length() of that string + 1
 		log_world("BYOND out of memory. Restarting ([E?.file]:[E?.line])")
 		TgsEndProcess()
@@ -154,3 +177,9 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 #endif
 
 #undef ERROR_USEFUL_LEN
+
+/// Exists to trigger infinite recursion runtimes in testing
+/proc/recurse(times)
+	if(times <= 0)
+		return
+	recurse(times - 1)


### PR DESCRIPTION
## About The Pull Request

This appears to have broken. So far as I can tell the old idea was that triggering another failure (byond kicking your head in for going deep again) should emit an error to world.log, or be logged BY log_world.

I believe this either broke due to a byond update, or because of the change from macro to proc introduced in #73604

Anyway regardless this is megabad because it masks errors that can just fuck things right up. So I'm going back to the old method of literally just send it to world.log manually. I'm also cleaning up the error a bit and adding some context that would have been useful to me historically, see image.

Oh also I added recurse(), a proc which calls itself X amount of times, for testing recursion logging.

## Why It's Good For The Game
Smartkar and I ran into some mc crashes today which we could not debug, I am 99% sure this was because we simply did not have the relevant errors to read.

<img width="811" height="605" alt="image" src="https://github.com/user-attachments/assets/91902afb-0590-42ab-9c0f-7ef2cce63dcf" />

## Changelog
:cl:
server: Infinite recursion errors should log properly now
/:cl:
