### PR TITLE
Fix potential cleaner component runtimes

### DIFF
--- a/code/__DEFINES/cleaning.dm
+++ b/code/__DEFINES/cleaning.dm
@@ -14,7 +14,7 @@
 #define CLEAN_DONT_BLOCK_INTERACTION (1<<3)
 /// Return to do cleaning without actually cleaning anything
 /// Only does anything if [CLEAN_ALLOWED] is also returned
-#define CLEAN_NO_CLEANER_REAGENTS (1<<4)
+#define CLEAN_NO_WASH (1<<4)
 
 // Different kinds of things that can be cleaned.
 // Use these when overriding the wash proc or registering for the clean signals to check if your thing should be cleaned

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -65,16 +65,18 @@
 	if(isitem(source) && SHOULD_SKIP_INTERACTION(target, source, user))
 		return NONE
 
-	// By default, give XP
+	var/call_wash = TRUE
 	var/give_xp = TRUE
 	if(pre_clean_callback)
 		var/callback_return = pre_clean_callback.Invoke(source, target, user)
 		if(callback_return & CLEAN_BLOCKED)
 			return (callback_return & CLEAN_DONT_BLOCK_INTERACTION) ? NONE : ITEM_INTERACT_BLOCKING
+		if(callback_return & CLEAN_NO_CLEANER_REAGENTS)
+			call_wash = FALSE
 		if(callback_return & CLEAN_NO_XP)
 			give_xp = FALSE
 
-	INVOKE_ASYNC(src, PROC_REF(clean), source, target, user, give_xp)
+	INVOKE_ASYNC(src, PROC_REF(clean), source, target, user, call_wash, give_xp)
 	return ITEM_INTERACT_SUCCESS
 
 /**
@@ -86,13 +88,10 @@
  * * source the datum that sent the signal to start cleaning
  * * target the thing being cleaned
  * * user the person doing the cleaning
- * * clean_target set this to false if the target should not be washed and if experience should not be awarded to the user
+ * * clean_target set this to false if the target should not be washed
+ * * grant_xp set this to false if the user should not be granted cleaning experience
  */
-/datum/component/cleaner/proc/clean(datum/source, atom/target, mob/living/user, clean_target = TRUE)
-	//mops don't clean anything unless they're dipped in cleaning reagents
-	var/callback_return = pre_clean_callback.Invoke(source, target, user)
-	if(callback_return & CLEAN_NO_CLEANER_REAGENTS)
-		clean_target = FALSE
+/datum/component/cleaner/proc/clean(datum/source, atom/target, mob/living/user, call_wash = TRUE, grant_xp = TRUE)
 	//make sure we don't attempt to clean something while it's already being cleaned
 	if(HAS_TRAIT(target, TRAIT_CURRENTLY_CLEANING) || (SEND_SIGNAL(target, COMSIG_ATOM_PRE_CLEAN, user) & COMSIG_ATOM_CANCEL_CLEAN))
 		return
@@ -129,12 +128,12 @@
 	var/clean_succeeded = FALSE
 	if(do_after(user, cleaning_duration, target = target))
 		clean_succeeded = TRUE
-		if(clean_target)
-			for(var/obj/effect/decal/cleanable/cleanable_decal in target) //it's important to do this before you wash all of the cleanables off
+		for(var/obj/effect/decal/cleanable/cleanable_decal in target) //it's important to do this before you wash all of the cleanables off
+			if(call_wash && grant_xp)
 				user.mind?.adjust_experience(/datum/skill/cleaning, round(cleanable_decal.beauty / CLEAN_SKILL_BEAUTY_ADJUSTMENT))
-				all_cleaned[cleanable_decal] = GET_ATOM_BLOOD_DNA(cleanable_decal)
-			if(target.wash(cleaning_strength))
-				user.mind?.adjust_experience(/datum/skill/cleaning, round(CLEAN_SKILL_GENERIC_WASH_XP))
+			all_cleaned[cleanable_decal] = GET_ATOM_BLOOD_DNA(cleanable_decal)
+		if(call_wash && target.wash(cleaning_strength) && grant_xp)
+			user.mind?.adjust_experience(/datum/skill/cleaning, round(CLEAN_SKILL_GENERIC_WASH_XP))
 
 	on_cleaned_callback?.Invoke(source, target, user, clean_succeeded, all_cleaned)
 	//remove the cleaning overlay

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -88,7 +88,7 @@
  * * source the datum that sent the signal to start cleaning
  * * target the thing being cleaned
  * * user the person doing the cleaning
- * * clean_target set this to false if the target should not be washed
+ * * call_wash set this to false if the target should not be wash()ed
  * * grant_xp set this to false if the user should not be granted cleaning experience
  */
 /datum/component/cleaner/proc/clean(datum/source, atom/target, mob/living/user, call_wash = TRUE, grant_xp = TRUE)

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -71,7 +71,7 @@
 		var/callback_return = pre_clean_callback.Invoke(source, target, user)
 		if(callback_return & CLEAN_BLOCKED)
 			return (callback_return & CLEAN_DONT_BLOCK_INTERACTION) ? NONE : ITEM_INTERACT_BLOCKING
-		if(callback_return & CLEAN_NO_CLEANER_REAGENTS)
+		if(callback_return & CLEAN_NO_WASH)
 			call_wash = FALSE
 		if(callback_return & CLEAN_NO_XP)
 			give_xp = FALSE

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -125,7 +125,7 @@
 /obj/item/soap/proc/should_clean(datum/cleaning_source, atom/atom_to_clean, mob/living/cleaner)
 	. = CLEAN_ALLOWED
 	if(!check_allowed_items(atom_to_clean))
-		. |= CLEAN_NO_XP
+		. |= CLEAN_NO_XP|CLEAN_NO_WASH
 
 /**
  * Decrease the number of uses the bar of soap has.

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -52,7 +52,7 @@
 		return CLEAN_BLOCKED
 	if(reagents.has_reagent(amount = 1, chemical_flags = REAGENT_CLEANS))
 		return CLEAN_ALLOWED
-	return CLEAN_ALLOWED|CLEAN_NO_XP|CLEAN_NO_CLEANER_REAGENTS
+	return CLEAN_ALLOWED|CLEAN_NO_XP|CLEAN_NO_WASH
 
 /**
  * Applies reagents to the cleaned floor and removes them from the mop.


### PR DESCRIPTION
## About The Pull Request

`pre_clean_callback` is asserted to be nullable, so this would runtime if you have something with the default cleaner arguments

It probably shouldn't be invoked twice, anyways

## Changelog

Not player visible but could save a future coder or admin a minor headache 
