### PR TITLE
Fix xenobio console slime duplication

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -229,6 +229,10 @@
 ///Places every slime not controlled by a player into the internal storage, respecting its limits
 ///Returns TRUE to signal it hitting the limit, in case its being called from a loop and we want it to stop
 /obj/machinery/computer/camera_advanced/xenobio/proc/slime_pickup(mob/living/user, mob/living/basic/slime/target_slime)
+	if(target_slime in stored_slimes)
+		// It's possible for this proc to run multiple times on the same slime,
+		// so we need to check this to avoid duplicate entries.
+		return FALSE
 	if(stored_slimes.len >= max_slimes)
 		to_chat(user, span_warning("Slime storage is full."))
 		target_slime.balloon_alert(user, "storage full")

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -230,8 +230,8 @@
 ///Returns TRUE to signal it hitting the limit, in case its being called from a loop and we want it to stop
 /obj/machinery/computer/camera_advanced/xenobio/proc/slime_pickup(mob/living/user, mob/living/basic/slime/target_slime)
 	if(target_slime in stored_slimes)
-		// It's possible for this proc to run multiple times on the same slime,
-		// so we need to check this to avoid duplicate entries.
+		// It's possible for this proc to be called on a slime that's already being picked up,
+		// so we need to check whether we already have to avoid duplicate entries.
 		return FALSE
 	if(stored_slimes.len >= max_slimes)
 		to_chat(user, span_warning("Slime storage is full."))


### PR DESCRIPTION

## About The Pull Request

So it seems like it was possible for the `slime_pickup(...)` proc to be called on a slime we were already picking up when spam-clicking, especially on high time dilation, leading to the slime being added to the list of stored slimes twice.
This just adds an early return in case we have already added this slime to our list.
This fixes our issue.
## Why It's Good For The Game

Fixes #92270.
Fixes #91909.
Fixes #91686.
## Changelog
:cl:
fix: Xenobio console can no longer pick up the same slime multiple times.
/:cl:
