### PR TITLE
Fix hard delete related to martial arts combo HUDs

### DIFF
--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -352,6 +352,9 @@
 		remove_verb(remove_from, help_verb)
 	UnregisterSignal(remove_from, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_LIVING_GRAB, COMSIG_LIVING_TABLE_SLAMMING, COMSIG_LIVING_TABLE_LIMB_SLAMMING))
 	if(!isnull(combo_display))
+		var/datum/hud/hud_used = remove_from.hud_used
+		hud_used.infodisplay -= combo_display
+		hud_used.show_hud(hud_used.hud_version)
 		QDEL_NULL(combo_display)
 
 ///Gives the owner of the martial art the combo HUD.


### PR DESCRIPTION

## About The Pull Request

Martial arts styles that feature a combo UI add themselves to `hud_used.infodisplay` when they're activated, but they do not remove themselves from there before qdeling, leading to a hard delete and the user's viewport becoming unusable. (See downstream report [here](https://github.com/Bubberstation/Bubberstation/issues/4091) for screenshots). Adds code to clean up properly in `deactivate_style()`

## Why It's Good For The Game

Fix hard delete and HUD bug

## Changelog

:cl:
fix: fixed scarp breaking your HUD sometimes
/:cl:
