### PR TITLE
Stores photo album persistence by ckey instead of by key, fixing inconsistencies

### DIFF
--- a/code/datums/quirks/neutral_quirks/photographer.dm
+++ b/code/datums/quirks/neutral_quirks/photographer.dm
@@ -12,7 +12,7 @@
 /datum/quirk/item_quirk/photographer/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/storage/photo_album/personal/photo_album = new(get_turf(human_holder))
-	photo_album.persistence_id = "personal_[human_holder.last_mind?.key]" // this is a persistent album, the ID is tied to the account's key to avoid tampering
+	photo_album.persistence_id = "personal_[human_holder.last_mind?.ckey]" // this is a persistent album, the ID is tied to the account's key to avoid tampering
 	photo_album.persistence_load()
 	photo_album.name = "[human_holder.real_name]'s photo album"
 

--- a/code/datums/quirks/neutral_quirks/photographer.dm
+++ b/code/datums/quirks/neutral_quirks/photographer.dm
@@ -12,7 +12,7 @@
 /datum/quirk/item_quirk/photographer/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/storage/photo_album/personal/photo_album = new(get_turf(human_holder))
-	photo_album.persistence_id = "personal_[human_holder.last_mind?.ckey]" // this is a persistent album, the ID is tied to the account's key to avoid tampering
+	photo_album.persistence_id = "personal_[ckey(human_holder.last_mind?.key)]" // this is a persistent album, the ID is tied to the account's key to avoid tampering
 	photo_album.persistence_load()
 	photo_album.name = "[human_holder.real_name]'s photo album"
 

--- a/tools/photo_json_to_ckeys.py
+++ b/tools/photo_json_to_ckeys.py
@@ -1,0 +1,78 @@
+'''
+Usage:
+    $ python photo_json_to_ckeys.py path/to/photo_albums.json -o path/to/photo_albums.json
+
+This script will convert all personal entries to ckey() format.
+It will also merge any entries that are from the same ckey into a single record.
+
+'''
+
+#!/usr/bin/env python3
+#!/usr/bin/env python3
+import argparse, json
+import re
+from collections import defaultdict
+
+def detect_eol(text: str) -> str:
+    if '\r\n' in text:
+        return '\r\n'
+    elif '\r' in text:
+        return '\r'
+    else:
+        return '\n'
+
+def ckey(text: str) -> str:
+    t = text.lower()
+    return ''.join(ch for ch in t if ch.isalnum() or ch == '@')
+
+def merge_ckey_entries(data: dict) -> dict:
+    merged = defaultdict(lambda: {"ids": [], "has_null": False})
+    for orig, reps in data.items():
+        norm = ("personal_" + ckey(orig[len("personal_"):])) if orig.startswith("personal_") else orig
+        entry = merged[norm]
+        if reps is None:
+            entry["has_null"] = True
+        else:
+            for rep in reps:
+                if rep is None:
+                    entry["has_null"] = True
+                else:
+                    entry["ids"].append(rep)
+
+    output = {}
+    for k, info in merged.items():
+        seen, unique = set(), []
+        for i in info["ids"]:
+            if i not in seen:
+                seen.add(i)
+                unique.append(i)
+        if unique:
+            output[k] = unique
+        elif info["has_null"]:
+            output[k] = None
+        else:
+            output[k] = []
+    return output
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('infile', help='Input JSON file path')
+    p.add_argument('-o', '--output', help='Output JSON file path (optional)')
+    args = p.parse_args()
+
+    txt = open(args.infile, 'r', encoding='utf-8', newline='').read()
+    eol = detect_eol(txt)
+    data = json.loads(txt)
+    merged = merge_ckey_entries(data)
+
+    out_text = json.dumps(merged, indent='\t', separators=(', ', ': '))
+
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8', newline='') as out:
+            out.write(out_text)
+    else:
+        print(out_text, end='')
+
+if __name__ == '__main__':
+    main()
+

--- a/tools/photo_json_to_ckeys.py
+++ b/tools/photo_json_to_ckeys.py
@@ -2,12 +2,12 @@
 Usage:
     $ python photo_json_to_ckeys.py path/to/photo_albums.json -o path/to/photo_albums.json
 
-This script will convert all personal entries to ckey() format.
+This script is designed to convert all personal entries in photo_albums.json to ckey() format.
 It will also merge any entries that are from the same ckey into a single record.
+The intent here is to provide hosts with a quick and easy way to fix their persistence json files.
 
 '''
 
-#!/usr/bin/env python3
 #!/usr/bin/env python3
 import argparse, json
 import re


### PR DESCRIPTION
## About The Pull Request

So this is a bit of a weird one.

Photo album persistence is being stored by `key` currently, instead of by `ckey`. 

This is an issue due to a byond (bug? intended behavior?) whereby if anything reassigns a mob's `key` it will behind-the-scenes get `ckey()`'d if that player is currently online. This can easily be tested via VV.

What this means is that if a player logs in/out, ghosts, etc, their `key` can become lowercased with formatting removed.

`key/ckey` are magic variables in byond so I we can't really be sure of the exact mechanism for how this happens, but it's likely due to the way that it tries to connect an online player to the key entered.

<details><summary>Proof that this happens independently of any codebase</summary>

<img width="613" height="308" alt="image" src="https://github.com/user-attachments/assets/d0fe3670-982c-488e-a33c-2128a1f8eddd" />

</details>

In short we shouldn't really be using `key` for anything raw, and if we do use it then it needs to be `ckey()`'d to be consistent.

## For server hosts:

I've included a script that server hosts may run to merge any duplicated keys/ckeys in their persistence files and convert it to the ckey() format, in `tools/photo_json_to_ckeys.py`.

## Why It's Good For The Game

Fixes peoples photo albums potentially being fragmented across multiple entries, essentially losing access.

## Changelog

:cl:
fix: fixes a bug that could cause people to lose their photo albums sometimes
/:cl:
