### PR TITLE
Holy melon sidegrade

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -80,7 +80,7 @@
 	species = "holymelon"
 	plantname = "Holy Melon Vines"
 	product = /obj/item/food/grown/holymelon
-	genes = list(/datum/plant_gene/trait/glow/yellow, /datum/plant_gene/trait/anti_magic)
+	genes = list(/datum/plant_gene/trait/glow/yellow)
 	mutatelist = null
 	reagents_add = list(/datum/reagent/water/holywater = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = PLANT_MODERATELY_RARE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -294,7 +294,7 @@
 	ph = 7.5 //God is alkaline
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_UNAFFECTED_BY_METABOLISM // Operates at fixed metabolism for balancing memes.
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/holywater
-	metabolized_traits = list(TRAIT_HOLY)
+	//metabolized_traits = list(TRAIT_HOLY)
 
 /datum/glass_style/drinking_glass/holywater
 	required_drink_type = /datum/reagent/water/holywater

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -294,7 +294,7 @@
 	ph = 7.5 //God is alkaline
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_UNAFFECTED_BY_METABOLISM // Operates at fixed metabolism for balancing memes.
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/holywater
-	//metabolized_traits = list(TRAIT_HOLY)
+	metabolized_traits = list(TRAIT_HOLY, TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 
 /datum/glass_style/drinking_glass/holywater
 	required_drink_type = /datum/reagent/water/holywater


### PR DESCRIPTION
## About The Pull Request

Holy melons held in your hand will no longer block magic. Holy water now provides magic immunity.

Removes the only way for 'anti magic' to be expressed in plant genes.

## Why It's Good For The Game

If you hold a holy melon in an offhand, you can become nearly completely immune to most of the highest threat antagonists (wizard, heretic, cult) forever. I believe this ability would be better off instead as the effect of ingesting it, so it's not a total immunity. (also powercreep?)

Questionably makes magic immunity more obtainable (by the chaplain) but the chaplain should be the one producing holy water and weapons against magic users when the station really needs it.

Additionally, magic immunity no longer takes up a hand. 

## Changelog
:cl:
change: Holy melons held in your hand will no longer provide magic immunity
change: Holy water provides magic immunity
/:cl:
