### PR TITLE
Let heretics see their UI while dead

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -236,7 +236,7 @@
 
 /datum/antagonist/heretic/ui_status(mob/user, datum/ui_state/state)
 	if(isnull(owner.current) || owner.current.stat == DEAD) // If the owner is dead, we can't show the UI.
-		return UI_INTERACTIVE
+		return UI_UPDATE
 	return ..()
 
 /datum/antagonist/heretic/get_preview_icon()

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -235,8 +235,8 @@
 	return ..()
 
 /datum/antagonist/heretic/ui_status(mob/user, datum/ui_state/state)
-	if(user.stat == DEAD)
-		return UI_CLOSE
+	if(isnull(owner.current) || owner.current.stat == DEAD) // If the owner is dead, we can't show the UI.
+		return UI_INTERACTIVE
 	return ..()
 
 /datum/antagonist/heretic/get_preview_icon()


### PR DESCRIPTION

## About The Pull Request
Let heretics see their UI while dead, currently we just force close it.

## Why It's Good For The Game
There's no valid reason besides fear of being able to buy abilities while dead to dissalow the heretic to look at the UI while dead. Right?
With UI_UPDATE you can't click on anything anyway and ui_act already early returns if you only have UI_UPDATE, only possible issue is if ui_act doesn't early return on the parent return value, but heretic's does.

## Changelog

:cl:
add: Heretics can now look at their UI while dead, though you can't buy stuff
/:cl:

