### PR TITLE
Logging for morph snacks

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -189,6 +189,7 @@
 	if((delay > 0 SECONDS) && !do_after(src, delay, target = eatable))
 		return FALSE
 
+	log_combat(src, eatable, "ate", addition = "as morph")
 	visible_message(span_warning("[src] swallows [eatable] whole!"))
 	eatable.forceMove(src)
 	if(update_health != 0)


### PR DESCRIPTION
## About The Pull Request

This PR simply adds logging whenever a morph eats something (and where it was at the time)

## Why It's Good For The Game

These are barely available to players in-game but if admins spawn them or something it's quite hard to track what they were actually doing, considering how disruptive they can potentially be

## Changelog

:cl:
admins: Adds better logging for morphs eating things
/:cl:
