### PR TITLE
Makes monster cores display above lying mobs

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -228,6 +228,7 @@
 #define BELOW_MOB_LAYER 3.7
 #define LOW_MOB_LAYER 3.75
 #define LYING_MOB_LAYER 3.8
+#define ABOVE_LYING_MOB_LAYER 3.85
 #define VEHICLE_LAYER 3.9
 #define MOB_BELOW_PIGGYBACK_LAYER 3.94
 //#define MOB_LAYER 4 //For easy recordkeeping; this is a byond define

--- a/code/datums/elements/above_mob_drop.dm
+++ b/code/datums/elements/above_mob_drop.dm
@@ -1,0 +1,21 @@
+/// Element that makes mob drops appear above their corpses until moved or picked up
+/datum/element/above_mob_drop
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// Layer to which items are initially changed
+	var/target_layer = ABOVE_LYING_MOB_LAYER
+
+/datum/element/above_mob_drop/Attach(datum/target, target_layer = ABOVE_LYING_MOB_LAYER)
+	. = ..()
+	if (!ismovable(target))
+		return ELEMENT_INCOMPATIBLE
+	src.target_layer = target_layer
+	var/atom/movable/owner = target
+	owner.layer = target_layer
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
+/datum/element/above_mob_drop/proc/on_moved(atom/movable/source)
+	SIGNAL_HANDLER
+	if (source.layer == target_layer)
+		source.layer = initial(source.layer)
+	Detach(source)

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -35,6 +35,7 @@
 		It will rapidly decay into uselessness. but don't worry because it's already useless."
 	icon = 'icons/obj/medical/organs/mining_organs.dmi'
 	icon_state = "hivelord_core"
+	layer = ABOVE_LYING_MOB_LAYER
 	actions_types = list(/datum/action/cooldown/monster_core_action)
 
 	item_flags = NOBLUDGEON
@@ -57,6 +58,8 @@
 	var/desc_inert
 	/// Status effect applied by this organ
 	var/datum/status_effect/user_status
+	/// Have we changed our layer to a normal item's layer?
+	var/layer_swapped = FALSE
 
 /obj/item/organ/monster_core/Initialize(mapload)
 	. = ..()
@@ -82,6 +85,15 @@
 /obj/item/organ/monster_core/Destroy(force)
 	deltimer(decay_timer)
 	return ..()
+
+/obj/item/organ/monster_core/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
+	. = ..()
+	if (layer_swapped)
+		return
+	// After being picked up, etc, reset our layer to that of a normal item
+	layer_swapped = TRUE
+	if (layer == initial(layer))
+		layer = /obj/item/organ::layer
 
 /obj/item/organ/monster_core/on_mob_insert(mob/living/carbon/target_carbon, special = FALSE, movement_flags)
 	. = ..()

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -35,7 +35,6 @@
 		It will rapidly decay into uselessness. but don't worry because it's already useless."
 	icon = 'icons/obj/medical/organs/mining_organs.dmi'
 	icon_state = "hivelord_core"
-	layer = ABOVE_LYING_MOB_LAYER
 	actions_types = list(/datum/action/cooldown/monster_core_action)
 
 	item_flags = NOBLUDGEON
@@ -58,12 +57,11 @@
 	var/desc_inert
 	/// Status effect applied by this organ
 	var/datum/status_effect/user_status
-	/// Have we changed our layer to a normal item's layer?
-	var/layer_swapped = FALSE
 
 /obj/item/organ/monster_core/Initialize(mapload)
 	. = ..()
 	decay_timer = addtimer(CALLBACK(src, PROC_REF(go_inert)), time_to_decay, TIMER_STOPPABLE)
+	AddElement(/datum/element/above_mob_drop)
 
 /obj/item/organ/monster_core/examine(mob/user)
 	. = ..()
@@ -85,15 +83,6 @@
 /obj/item/organ/monster_core/Destroy(force)
 	deltimer(decay_timer)
 	return ..()
-
-/obj/item/organ/monster_core/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
-	. = ..()
-	if (layer_swapped)
-		return
-	// After being picked up, etc, reset our layer to that of a normal item
-	layer_swapped = TRUE
-	if (layer == initial(layer))
-		layer = /obj/item/organ::layer
 
 /obj/item/organ/monster_core/on_mob_insert(mob/living/carbon/target_carbon, special = FALSE, movement_flags)
 	. = ..()

--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -11,6 +11,7 @@
 	actions_types = list(/datum/action/cooldown/monster_core_action/regenerative_core)
 	icon_state = "hivelord_core"
 	icon_state_inert = "hivelord_core_decayed"
+	layer = ABOVE_LYING_MOB_LAYER
 
 /obj/item/organ/monster_core/regenerative_core/preserve(implanted = FALSE)
 	if (implanted)

--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -11,7 +11,6 @@
 	actions_types = list(/datum/action/cooldown/monster_core_action/regenerative_core)
 	icon_state = "hivelord_core"
 	icon_state_inert = "hivelord_core_decayed"
-	layer = ABOVE_LYING_MOB_LAYER
 
 /obj/item/organ/monster_core/regenerative_core/preserve(implanted = FALSE)
 	if (implanted)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1456,6 +1456,7 @@
 #include "code\datums\dna\blocks\dna_features_block.dm"
 #include "code\datums\dna\blocks\dna_identity_block.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\above_mob_drop.dm"
 #include "code\datums\elements\ai_control_examine.dm"
 #include "code\datums\elements\ai_flee_while_injured.dm"
 #include "code\datums\elements\ai_held_item.dm"


### PR DESCRIPTION

## About The Pull Request

Monster cores now render above lying mobs and corpses, making them easier to grab during fights. They reset to object layer once moved or picked up to avoid visual issues.

## Why It's Good For The Game

During vent defenses when you encounter legions while low on heals you may be tempted to grab a core to buff and regen, but as they're rendered below mobs you either have to pixel hunt through a skeleton's ribs, or use right click to pick it up via the context menu. Both of these options make for a rather unpleasant experience, this should make it less painful to do.
Technically applies to other mobs as well, but I doubt that anyone is butchering monsters mid-fight for lobstrocity or brimdemon cores.

## Changelog
:cl:
qol: Monster cores now display above corpses when dropped
/:cl:
