### PR TITLE
TGUI Loot Panel (popup box with all the things on a turf) moved from Alt+Click -> Shift+Alt+Click, TGUI Loot Panel now supports scroll-wheel-click interactions (pointing, ..., other stuff, probably? but pointing for sure)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -86,6 +86,9 @@
 		if(LAZYACCESS(modifiers, CTRL_CLICK))
 			CtrlShiftClickOn(A)
 			return
+		if(LAZYACCESS(modifiers, ALT_CLICK))
+			AltShiftClickOn(A)
+			return
 		ShiftClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))

--- a/code/_onclick/click_alt.dm
+++ b/code/_onclick/click_alt.dm
@@ -31,16 +31,6 @@
 	if(. || !CAN_I_SEE(target) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
 		return
 
-	// No alt clicking to view turf from beneath
-	if(HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING))
-		return
-
-	/// No loot panel if it's on our person
-	if(isobj(target) && (target in get_all_gear()))
-		to_chat(src, span_warning("You can't search for this item, it's already in your inventory! Take it off first."))
-		return
-
-	client.loot_panel.open(get_turf(target))
 	return TRUE
 
 /**
@@ -109,3 +99,55 @@
 /atom/proc/click_alt_secondary(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
 	return NONE
+
+/**
+ * ## Snowflake click interaction for TGUI loot_panel
+ * Due to the immense utility of the tgui loot panel when it comes to interacting with
+ * items on turfs that are cluttered or suffering from some chicanery with plane layers
+ * or other such nonsense, this is defined and expressly intended to be the way to open
+ * a tgui loot_panel for an item's given turf. It is, unlike the other ctrl/alt/shift click
+ * interactions, meant to NOT BE OVERRIDDEN in any circumstance. For modifying the behavior of
+ * objects/datums/etc in regards to the tgui loot_panel, it's recommended to instead make those
+ * changes in the loot_panel's DM or TS code, instead.
+ *
+ * It is attached to Shift+Alt due to Shift being the longtime default bind for examination, and
+ * adding the 'Alt' modifier as the way to then examine the contents of a turf in a TGUI window
+ * seems like a reasonable extension.
+ * * target - whatever we just shift+alt clicked on.
+ */
+/mob/proc/AltShiftClickOn(atom/target)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return NONE
+
+/**
+ * Here we steal most of the old code for determining whether a living mob with all the restrictions
+ * on their sight should not be able to open a loot_panel for a given atom's turf.
+ */
+/mob/living/AltShiftClickOn(atom/target)
+	SHOULD_NOT_OVERRIDE(TRUE)
+
+	if(!CAN_I_SEE(target) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
+		return
+
+	// No alt clicking to view turf from beneath
+	if(HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING))
+		return
+
+	/// No loot panel if it's on our person
+	if(isobj(target) && (target in get_all_gear()))
+		to_chat(src, span_warning("You can't search for this item, it's already in your inventory! Take it off first."))
+		return
+
+	client.loot_panel.open(get_turf(target))
+	return TRUE
+
+/**
+ * There really shouldn't be any fathomable circumstance where observers aren't able to examine
+ * the contents of a turf at their leisure, so we let dead mobs open up a lootpanel for anything they
+ * can click on.
+ */
+/mob/dead/AltShiftClickOn(atom/target)
+	SHOULD_NOT_OVERRIDE(TRUE)
+
+	client.loot_panel.open(get_turf(target))
+	return TRUE

--- a/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
@@ -38,6 +38,16 @@ export function LootBox(props: Props) {
       p={0}
       fluid
       color="transparent"
+      onMouseDown={(event) =>
+        event.button === 1 &&
+        act('grab', {
+          middle: true,
+          alt: event.altKey,
+          ctrl: event.ctrlKey,
+          ref: item.ref,
+          shift: event.shiftKey,
+        })
+      }
       onClick={(event) =>
         act('grab', {
           alt: event.altKey,
@@ -50,7 +60,10 @@ export function LootBox(props: Props) {
         event.preventDefault();
         act('grab', {
           right: true,
+          alt: event.altKey,
+          ctrl: event.ctrlKey,
           ref: item.ref,
+          shift: event.shiftKey,
         });
       }}
     >


### PR DESCRIPTION
## About The Pull Request
As God's Strongest Chief Engineer, alt-clicking on stuff in an attempt to open a TGUI loot panel on a given turf is a maddening exercise in the alt-click override chain and tribal knowledge on what stuff you're allow to alt-click to open the lootpanel vs what stuff you'll alt-click with no feedback whatsoever and you standing there with an RPD in-hand and a flouride stare as the Supermatter is delaminating and you just want to decon the floor under a decal that is catching all your clicks.

So, I've added an Shift+Alt click interaction for mobs that is intended to unilaterally serve as the interface to open a TGUI loot panel for a given turf. As well, my javascript powers have doubled since last I met with LootBox.tsx, so there is now support for the vast array of middle-click interactions that are available such as pointing and uh, tons of other stuff, probably.

## Why It's Good For The Game
Alt-click interactions overriding your attempts to decon the floor or pick one single item in a pile of items with their own alt-click functionality makes me want to become the Joker. I'm certain I'm not the only person that this drives absolutely fucking crazy. As well, more integration of TGUI to game interface functionality always seems good, to me.

## Changelog
:cl: Bisar
qol: You're now able to middle-click interact with things in the TGUI loot panel (that box that pops up with all the stuff on a turf)
code: The binding to open up a TGUI lootpanel is now, exclusively, Shift+Alt+Click, changed from Alt+Click.
qol: Shift+Alt clicking anything at all will now always open up a TGUI loot panel for the turf that atom resides on (assuming you're able to see it)
code: Added a Shift+Alt click interaction for mobs; documentation outlines that this is meant to not be overridden and to instead serve as the undisputed method with which to open a TGUI loot panel for a given atom's turf.
/:cl:
