### PR TITLE
Voltaic Combat Cyberheart balance changes: EMP immunity changes, no longer able to self-implant without surgery, now restores blood consistently vs. only with the core, no longer deletes itself upon removal,

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -199,6 +199,7 @@
 	// Just in case the heart has migrated from its owner in the meantime of this status effect
 	if(associated_heart.owner == owner)
 		associated_heart.start_recharge()
+	associated_heart = null
 
 /atom/movable/screen/alert/status_effect/anomalock_active
 	name = "voltaic overdrive"


### PR DESCRIPTION

## About The Pull Request
The Voltaic cyberheart is an absolute powerhouse anomaly core item with no downsides and, seemingly, no weaknesses. Alongside that, it would confer total EMP immunity to whoever had it implanted, completely removing an entire avenue of counterplay toward people who got the heart implanted alongside their massive suite of gamer cybernetics. This has been persistently oppressive to fight against, and even though I've engaged in the power fantasy myself more than once as Luchadore Spinal Implant EMP Immune Security Officer, it has become keenly apparent to me that this thing is just plain overpowered.

As such, I instituted the following changes:
- When you are EMP'd with the core-activated heart, it kicks in the survival mechanism in response. The duration of the survival mechanism is unchanged. Your EMP immunity (complete and total) is unchanged until the survival mechanism wears off.
- The survival mechanism is now tied in with the EMP immunity. If you've popped up from crit with the survival mechanism OR the survival mechanism has fired off in response to an EMP, during the cooldown for the mechanism to recharge, the EMP immunity of the heart applies only to itself. The heart is totally immune to EMPs with or without the anomaly core. The heart confers EMP immunity to its wearer WITH the anomaly core but NOT during the survival cooldown.
- The heart no longer deletes itself whenever it's removed from its holder. I don't know the actual reason behind this having been part of its mechanics but as far as I can tell, it really just amounted to a "nuh uh!" if you wasted a gamer with this heart to steal it.
- The heart can no longer be inserted without surgery. Completely removing any need to interact with other players to get an anomaly core ORGAN seems far too Lone Wolf Killing Machine for our multiplayer social engineering storytelling game. This is with the deliberate consideration that if you get a chest augment you can perform self-surgery.
- The heart now has its core-inserted additional blood replenishment as its base replenishment rate, with or without the core. It's still a combat cyberheart even if your ADHD is too severe for you to learn Ordnance or read the bomb recipe Meta Spreadsheets.

## Why It's Good For The Game
Users of the Voltaic are oppressive to fight against; crit immunity on a 5 minute cooldown and total EMP immunity, alongside shock immunity and recharging any electronics (including guns) on your person blows every single other application of anomaly cores out of the water, not to mention the heart being implantable by anyone simply by clicking yourself with it. Its current design hacks away many of the logical counterplay options to a cybernetic heart (and to cybernetic powergamers) without any assistance from other players really being necessary.

With the changes I've made in this pull request, reasonable avenues of counterplay are opened without removing many of the trademarks of the heart such as its EMP immunity; instead, it's a strategic resource that someone else can strategically disable, with the understanding that if they do trip its EMP immunity, you're still crit-immune for thirty seconds, and they need to make use of your EMP vulnerability in the 4 minutes and 30 seconds after the survival mechanism has fired off.

And making the core-inserted blood volume replenishment its base rate lets you freely say that you "ain't got time to bleed" and seems like a fair thing for the heart to have at base.

## Changelog
:cl: Bisar
balance: The Voltaic combat cyberheart no longer gives full, permanent EMP immunity to its owner when implanted with a core. The EMP immunity now shares a cooldown with the crit survival mechanic.
balance: The Voltaic combat cyberheart can no longer be inserted without surgery.
balance: The Voltaic combat cyberheart's enhanced blood restoration with a core is now a base feature, with or without a core.
balance: The Voltaic combat cyberheart no longer deletes itself whenever it is removed from an owner.
/:cl:
