### PR TITLE
Makes both chefs spawn roundstart instead of just 1(correct branch edition)

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -4,7 +4,7 @@
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 2
-	spawn_positions = 1
+	spawn_positions = 2
 	supervisors = SUPERVISOR_HOP
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "COOK"


### PR DESCRIPTION
## About The Pull Request
This PR allows both chefs spawn roundstart

## Why It's Good For The Game
Only 1 chef can spawn roundstart where the other can only latejoin i think its dumb to be restrictive like that, theres alot of arguements that two chefs is fucking ass to play in a kitchen, but that shouldn't mean it should be restrictive like this either pick a poison let both chefs spawn roundstart or just dont have two chefs at all

## Changelog

:cl: Ezel
qol: Both chefs can now spawn roundstart
/:cl:
