### PR TITLE
Fixes tables allowing people standing on them to climb over things freely when deconstructed

### DIFF
--- a/code/datums/components/climb_walkable.dm
+++ b/code/datums/components/climb_walkable.dm
@@ -13,7 +13,7 @@
 /datum/component/climb_walkable/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ATOM_TRIED_PASS)
 	for (var/atom/movable/climber in get_turf(parent))
-		REMOVE_TRAIT(parent, TRAIT_ON_CLIMBABLE, REF(src))
+		REMOVE_TRAIT(climber, TRAIT_ON_CLIMBABLE, REF(src))
 
 /datum/component/climb_walkable/proc/on_enter(datum/source, atom/movable/arrived)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Closes #92269

## Changelog
:cl:
fix: Fixed tables allowing people standing on them to climb over things freely when deconstructed
/:cl:
