### PR TITLE
Power cells no longer have an increased time to print( 10 seconds per cell -> 3.2 seconds per cell), megacell print time lowered from 10 seconds to 5 seconds

### DIFF
--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -8,7 +8,6 @@
 	id = "basic_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE |MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/glass =SMALL_MATERIAL_AMOUNT * 0.5)
-	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/power_store/cell/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
@@ -21,7 +20,6 @@
 	id = "high_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.6)
-	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/power_store/cell/high/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
@@ -34,7 +32,6 @@
 	id = "super_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.7)
-	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/power_store/cell/super/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_2
@@ -47,7 +44,6 @@
 	id = "hyper_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 7, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.8)
-	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/power_store/cell/hyper/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_3
@@ -60,7 +56,6 @@
 	id = "bluespace_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 8, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 1.2, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 1.6, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 1.6, /datum/material/titanium =SMALL_MATERIAL_AMOUNT * 3, /datum/material/bluespace =SMALL_MATERIAL_AMOUNT)
-	construction_time = 10 SECONDS
 	build_path = /obj/item/stock_parts/power_store/cell/bluespace/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_4
@@ -73,7 +68,7 @@
 	id = "basic_battery"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE |MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 12, /datum/material/glass =SMALL_MATERIAL_AMOUNT * 2)
-	construction_time = 10 SECONDS
+	construction_time = 5 SECONDS
 	build_path = /obj/item/stock_parts/power_store/battery/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
@@ -86,7 +81,7 @@
 	id = "high_battery"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 12, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3)
-	construction_time = 10 SECONDS
+	construction_time = 5 SECONDS
 	build_path = /obj/item/stock_parts/power_store/battery/high/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_2
@@ -99,7 +94,7 @@
 	id = "super_battery"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 12, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 4)
-	construction_time = 10 SECONDS
+	construction_time = 5 SECONDS
 	build_path = /obj/item/stock_parts/power_store/battery/super/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_3
@@ -112,7 +107,7 @@
 	id = "hyper_battery"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 12, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 5)
-	construction_time = 10 SECONDS
+	construction_time = 5 SECONDS
 	build_path = /obj/item/stock_parts/power_store/battery/hyper/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_3
@@ -125,7 +120,7 @@
 	id = "bluespace_battery"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 12, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 1.2, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 6, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 1.6, /datum/material/titanium =SMALL_MATERIAL_AMOUNT * 3, /datum/material/bluespace =SMALL_MATERIAL_AMOUNT)
-	construction_time = 10 SECONDS
+	construction_time = 5 SECONDS
 	build_path = /obj/item/stock_parts/power_store/battery/bluespace/empty
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_4


### PR DESCRIPTION

## About The Pull Request
This PR makes simple adjustments of the construction_time for the designs of these items; power cells no longer have an increased time to print per-item, taking the standard item print time (though, relevantly, they do not get the *0.2 modifier for stock parts that other stock parts get). As well, megacells have had their print time slashed in half, from 10 seconds to 5 seconds. These are all with respect for the default print time that most items have, which is 3.2 seconds.

## Why It's Good For The Game
Cells having such a massive print time is a painful experience for everyone involved either directly or indirectly. Any construction project that may fathomably involve cells such as machines, mechs, cyborgs, new rooms, or upgrading things like SMES or APCs is rendered into a session of meditative patience. Not to mention that, with current fabricator design, you can casually sabotage  science or engineering by queuing up 50 cells to print.

On top of the time to print, there is still the time to charge the cell, as cells start empty. For megacells this causes little issue, typically, but for standard power cells, the eternity you waited to print 5 cells is now compounded with standing there spending the round time and your free time waiting for the number to go up, assuming there is any power in the network to spare, and assuming the charger is upgraded enough for the cell tier you printed to charge within your children's lifetime.

This changes that. Megacells, due to their higher potential for influencing the round ( rigging them then sticking them in a shorted APC for instance, mech construction) still have a slightly increased time to print over a standard item, and the power cells are treated as standard items for printing, due their own broad utility. With this change I'm hoping to encourage building and upgrading things that involve power cells, rather than punishing players with oppressive queues at the lathe. Maybe someday, people will join as engineers to participate as engineers, instead of for the soft all-access, but that is outside the scope of this PR.

## Changelog
:cl: Bisar
qol: Power cells and megacells now take much less time to print.
balance: Power cells now take the base-item time-to-print ( 10 seconds -> 3.2 seconds ), WITHOUT the stock-item print speed increase.
balance: Megacells now take 5 seconds to print ( 10 seconds -> 5 seconds), WITHOUT the stock-item print speed increase.
/:cl:
