### PR TITLE
Remove a duplicate call to set_holo() in obj/machinery/holopad/activate_holo

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -566,7 +566,6 @@ Possible to do for anyone motivated enough:
 		hologram.name = "[user.name] (Hologram)"//If someone decides to right click.
 		set_holo(user, hologram)
 
-		set_holo(user, hologram)
 		visible_message(span_notice("A holographic image of [user] flickers to life before your eyes!"))
 
 		return hologram


### PR DESCRIPTION

## About The Pull Request
This is just a small fix removing a duplicated proc call in the guts of this proc to save my sanity as I work on a separate hologram-related thing.

## Why It's Good For The Game
If you make the code good other stuff in the game will be good too.

## Changelog
:cl: Bisar
fix: Removed a duplicated proc_call in the guts of the holopad functionality.
/:cl:
