### PR TITLE
Moved the tramstation xeno egg into the middle of the chamber

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10512,7 +10512,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cAK" = (
-/obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/xenobio,
@@ -24574,6 +24573,11 @@
 /obj/machinery/transport/destination_sign/indicator/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
+"hLj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "hLr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -183119,7 +183123,7 @@ pHX
 qVr
 cAK
 ttj
-ttj
+hLj
 ttj
 ttj
 nzg


### PR DESCRIPTION

## About The Pull Request

See title

Fixes #92308 

## Why It's Good For The Game

Apparently people are failing to spot the egg hiding at the back of the chamber, moving it into the middle gives it a better chance of being seen. It also just looks neater in the middle.

## Changelog
:cl:
map: Tramstation's xenobiology now receives xeno eggs in the middle of the chamber instead of tucked away at the back.
/:cl:
