### PR TITLE
Mobs with binary channel access now recieve a "New Host" message when a new AI is brought online.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -92,7 +92,7 @@
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))
 
 	//Heads up to other binary chat listeners that a new AI is online and listening to Binary.
-	if(announce_init_to_others && !(z == 1)) //Skip new syndicate AIs and also new AIs on centcom Z
+	if(announce_init_to_others && !is_centcom_level(z)) //Skip new syndicate AIs and also new AIs on centcom Z
 		for(var/mob/McMobby in GLOB.player_list)
 			if(McMobby == src)
 				continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -93,7 +93,7 @@
 
 	//Heads up to other binary chat listeners that a new AI is online and listening to Binary.
 	if(announce_init_to_others && !is_centcom_level(z)) //Skip new syndicate AIs and also new AIs on centcom Z
-		for(var/mob/McMobby in GLOB.player_list)
+		for(var/mob/McMobby as anything in GLOB.player_list)
 			if(McMobby == src)
 				continue
 			if(!McMobby.binarycheck())

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -93,11 +93,12 @@
 
 	//Heads up to other AIs that a new AI is online and listening to Binary.
 	if(announce_init_to_others)
-		for(var/mob/living/silicon/ai/remotehost in GLOB.ai_list)
-			if(remotehost == src)
+		for(var/mob/McMobby in GLOB.player_list)
+			if(McMobby == src)
 				continue
-			to_chat(remotehost, "<br><span class='notice'>NEW REMOTE HOST CONNECTED - ID: \"[src]\"</span><br>")
-			remotehost.playsound_local(remotehost, 'sound/machines/beep/twobeep.ogg', 50, pressure_affected = FALSE, use_reverb = FALSE)
+			if(!McMobby.binarycheck())
+				continue
+			to_chat(McMobby,span_binarysay("<span class=[SPAN_COMMAND]>\[ SYSTEM \] NEW REMOTE HOST HAS CONNECTED TO THIS CHANNEL -- ID: [src]</span>"), type = MESSAGE_TYPE_RADIO)
 
 /mob/living/silicon/ai/weak_syndie
 	radio = /obj/item/radio/headset/silicon/ai/evil

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -92,7 +92,7 @@
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))
 
 	//Heads up to other binary chat listeners that a new AI is online and listening to Binary.
-	if(announce_init_to_others && !(z == 1)) //Skip new syndicate AIs and also new AIs on centcomm Z
+	if(announce_init_to_others && !(z == 1)) //Skip new syndicate AIs and also new AIs on centcom Z
 		for(var/mob/McMobby in GLOB.player_list)
 			if(McMobby == src)
 				continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -91,11 +91,20 @@
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_TRIGGERED, PROC_REF(alarm_triggered))
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))
 
+	//Heads up to other AIs that a new AI is online and listening to Binary.
+	if(announce_init_to_others)
+		for(var/mob/living/silicon/ai/remotehost in GLOB.ai_list)
+			if(remotehost == src)
+				continue
+			to_chat(remotehost, "<br><span class='notice'>NEW REMOTE HOST CONNECTED - ID: \"[src]\"</span><br>")
+			remotehost.playsound_local(remotehost, 'sound/machines/beep/twobeep.ogg', 50, pressure_affected = FALSE, use_reverb = FALSE)
+
 /mob/living/silicon/ai/weak_syndie
 	radio = /obj/item/radio/headset/silicon/ai/evil
 	radio_enabled = TRUE
 	interaction_range = 1
 	sprint = 5
+	announce_init_to_others = FALSE
 
 /mob/living/silicon/ai/key_down(_key, client/user)
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -92,7 +92,7 @@
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))
 
 	//Heads up to other binary chat listeners that a new AI is online and listening to Binary.
-	if(announce_init_to_others)
+	if(announce_init_to_others && !(z == 1)) //Skip new syndicate AIs and also new AIs on centcomm Z
 		for(var/mob/McMobby in GLOB.player_list)
 			if(McMobby == src)
 				continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -91,7 +91,7 @@
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_TRIGGERED, PROC_REF(alarm_triggered))
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))
 
-	//Heads up to other AIs that a new AI is online and listening to Binary.
+	//Heads up to other binary chat listeners that a new AI is online and listening to Binary.
 	if(announce_init_to_others)
 		for(var/mob/McMobby in GLOB.player_list)
 			if(McMobby == src)

--- a/code/modules/mob/living/silicon/ai/ai_defines.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defines.dm
@@ -24,6 +24,8 @@
 	var/explodes_on_death = FALSE
 	/// Whether its MMI is a posibrain or regular MMI, used when being [obj/structure/ai_core][deconstructed]
 	var/posibrain_inside = TRUE
+	/// Whether other AIs get a "new host" announcement text. Syndicate AIs get to be sneaky and won't send the message.
+	var/announce_init_to_others = TRUE
 
 
 	/* STATE */


### PR DESCRIPTION
## About The Pull Request
Mobs with binary channel access will get a message (and sound alert) when a new AI is created. The message includes the new AI's name, but no location or any other information.

AIs spawned by the Syndicate Intellicard item will not send a message. This also only affects AIs, so Cyborgs and Binary Key users likewise do not create an alert.

New AIs spawning on Centcom for Admin nonsense also will not send an alert.
## Why It's Good For The Game
Binary is normally a reasonably safe place for AIs to discuss things with their borgs, and while it can be tapped into by various other users, sudden new AIs are the most likely to be detrimental if the older AI is on a harmful lawset. So now existing AIs get an alert that a new host is online and, more importantly, listening in.

Syndicate AIs, of course, need to be secret and get a pass on making alerts.
## Changelog
:cl:
add: AIs now get an alert when a new (non-syndicate) AI is brought online.
/:cl:
