### PR TITLE
Fixes CRAB-17 sometimes not draining funds

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -245,11 +245,15 @@
  */
 /obj/structure/checkoutmachine/proc/expel_cash()
 	var/funds_remaining = internal_account.account_balance
+	var/safety = funds_remaining + 1 // In the absolute worst case scenario the loop will complete in funds_remaining steps, if this is counter reaches 0 something went terribly wrong and we need to leave
 	while(floor(funds_remaining))
 		var/amount_to_remove = min(funds_remaining, rand(1, round(internal_account.account_balance)/8))
 		var/obj/item/holochip/holochip = new (get_turf(src), amount_to_remove)
 		funds_remaining -= amount_to_remove
 		holochip.throw_at(pick(oview(7,get_turf(src))),10,1)
+		safety -= 1
+		if(safety <= 0)
+			CRASH("/obj/structure/checkoutmachine/proc/expel_cash() did not complete in the theoretical maximum number of steps. Starting value: [initial(funds_remaining)]. Value at crash: [funds_remaining].")
 
 
 /obj/effect/dumpeet_fall //Falling pod

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -253,7 +253,7 @@
 		holochip.throw_at(pick(oview(7,get_turf(src))),10,1)
 		safety -= 1
 		if(safety <= 0)
-			CRASH("/obj/structure/checkoutmachine/proc/expel_cash() did not complete in the theoretical maximum number of steps. Starting value: [initial(funds_remaining)]. Value at crash: [funds_remaining].")
+			CRASH("/obj/structure/checkoutmachine/proc/expel_cash() did not complete in the theoretical maximum number of steps. Starting value: [internal_account.account_balance]. Value at crash: [funds_remaining].")
 
 
 /obj/effect/dumpeet_fall //Falling pod

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -33,7 +33,6 @@
 		new /obj/effect/dumpeet_target(targetturf, L)
 
 		to_chat(user, span_notice("You have activated Protocol CRAB-17."))
-		message_admins("[ADMIN_LOOKUPFLW(user)] has activated Protocol CRAB-17.")
 		user.log_message("activated Protocol CRAB-17.", LOG_GAME)
 
 		dumped = TRUE
@@ -193,6 +192,7 @@
 	priority_announce("The credit deposit machine at [get_area(src)] has been destroyed. Station funds have stopped draining!", sender_override = "CRAB-17 Protocol")
 	if(internal_account.account_balance)
 		expel_cash()
+	QDEL_NULL(internal_account)
 	explosion(src, light_impact_range = 1, flame_range = 2)
 	REMOVE_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING, REF(src))
 	return ..()
@@ -221,11 +221,8 @@
 			accounts_to_rob -= B
 			continue
 		var/amount = round(B.account_balance * percentage_lost) // We don't want fractions of a credit stolen. That's just agony for everyone.
-		var/datum/bank_account/account = bogdanoff?.get_bank_account()
-		if (account) // get_bank_account() may return FALSE
-			account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")
-		else
-			internal_account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")
+		var/datum/bank_account/account = bogdanoff?.get_bank_account() || internal_account
+		account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")
 		B.bank_card_talk("You have lost [percentage_lost * 100]% of your funds! A spacecoin credit deposit machine is located at: [get_area(src)].")
 	addtimer(CALLBACK(src, PROC_REF(dump)), 15 SECONDS) //Drain every 15 seconds
 
@@ -247,10 +244,8 @@
  * Splits the balance of the internal_account into several smaller piles of cash and scatters them around the area.
  */
 /obj/structure/checkoutmachine/proc/expel_cash()
-	message_admins("Spitting out money")
 	var/funds_remaining = internal_account.account_balance
-	while(funds_remaining)
-		message_admins("[funds_remaining]")
+	while(floor(funds_remaining))
 		var/amount_to_remove = min(funds_remaining, rand(1, round(internal_account.account_balance)/8))
 		var/obj/item/holochip/holochip = new (get_turf(src), amount_to_remove)
 		funds_remaining -= amount_to_remove


### PR DESCRIPTION

## About The Pull Request

Fixes #92230

Fixes an issue where the CRAB-17 would sometimes fail to drain funds due to being unable to send money to an account.

In `dump()`:

```
var/datum/bank_account/account = bogdanoff?.get_bank_account()
if (account) // get_bank_account() may return FALSE
	account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")
	B.bank_card_talk("You have lost [percentage_lost * 100]% of your funds! A spacecoin credit deposit machine is located at: [get_area(src)].")
```

If during any call of `dump()` our Bogdanoff takes off their ID, never had one to begin with, or otherwise makes their bank account not visible to `get_bank_account()` the `if(account)` check fails and money is never drained.

Instead this PR adds an internal bank account to the CRAB-17, and any time `dump()` fails to find a destination account the money is stored in the CRAB-17's account. When destroyed any funds stored internally are scattered across the floor in a pile of smaller holochips.

Incidentally adds documentation to the relevant code.

## Why It's Good For The Game

Players expect the CRAB-17 to drain funds even if they don't have an account to send the money to. It's still preferable to have one so they get the money, but smearing it across the floor still forces the crew to fight over who gets it, and is more logical than sending it to the void.

## Changelog
:cl:
fix: CRAB-17 machines will now hold onto funds internally if they cannot find the original user's bank account to transfer them to.
/:cl:
