### PR TITLE
Fixes cyborgs taking burn damage from lasers, and brute from EMP

### DIFF
--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -121,12 +121,14 @@
 	flash_act(affect_silicon = 1)
 
 /mob/living/silicon/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE)
+	if(hitting_projectile.damage_type == BURN)
+		hitting_projectile.damage_type = BRUTE //Burn is for wire damage. Brute is the outer chassis.
 	. = ..()
 	if(. != BULLET_ACT_HIT)
 		return .
 
 	var/prob_of_knocking_dudes_off = 0
-	if(hitting_projectile.damage_type == BRUTE || hitting_projectile.damage_type == BURN)
+	if(hitting_projectile.damage_type == BRUTE)
 		prob_of_knocking_dudes_off = hitting_projectile.damage * 1.5
 	if(hitting_projectile.stun || hitting_projectile.knockdown || hitting_projectile.paralyze)
 		prob_of_knocking_dudes_off = 100

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -109,9 +109,9 @@
 		return
 	switch(severity)
 		if(1)
-			src.take_bodypart_damage(20)
+			src.take_bodypart_damage(burn = 20)
 		if(2)
-			src.take_bodypart_damage(10)
+			src.take_bodypart_damage(burn = 10)
 	to_chat(src, span_userdanger("*BZZZT*"))
 	for(var/mob/living/M in buckled_mobs)
 		if(prob(severity*50))


### PR DESCRIPTION

## About The Pull Request
Used to be,  cyborgs would take brute damage from ranged burn attacks, like lasers and emitters and whatnot. The intention was that these dealt `chassis` damage, and burn was being reused as `wire` damage. So EMPs damaged internal wiring, lasers hit the outer shell.

This was changed in #79024, due to a refractoring of the proc, but it's not listed in the changelog, so I believe it was an oversight.

On an unrelated note, while testing this and the fix I made, I found that EMP damage was incorrectly being dealt to silicons as brute/`chassis` damage, due to how the damage was called. So that's also been fixed.
## Why It's Good For The Game
Bugfix.
## Changelog
:cl:
fix: Cyborgs correctly take brute damage from lasers again.
fix: Cyborgs correctly take burn damage from EMP again.
/:cl:
