### PR TITLE
You Done Fluxd Up Now; Flux anomalies become more dangerous correlated to the excess power in the powernet

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_flux.dm
+++ b/code/game/objects/effects/anomalies/anomalies_flux.dm
@@ -3,9 +3,14 @@
 	icon_state = "flux"
 	density = TRUE
 	anomaly_core = /obj/item/assembly/signaler/anomaly/flux
-	var/canshock = FALSE
-	var/shockdamage = 20
 	var/explosive = FLUX_EXPLOSIVE
+	///range in whuich we zap
+	var/zap_range = 1
+	///strength of the zappy
+	var/zap_power = 2500
+	///the zappy flags
+	var/zap_flags = ZAP_GENERATES_POWER | ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE
+	var/shock_damage = 1
 
 /obj/effect/anomaly/flux/Initialize(mapload, new_lifespan, explosive = FLUX_EXPLOSIVE)
 	. = ..()
@@ -16,11 +21,30 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	apply_wibbly_filters(src)
 
+
 /obj/effect/anomaly/flux/anomalyEffect()
 	..()
-	canshock = TRUE
-	for(var/mob/living/M in range(0, src))
+	for(var/mob/living/M in range(max(zap_range/3, 1), src))
 		mobShock(M)
+	var/area/area = get_area(src)
+	if(area.apc)
+		zap_power = area.apc.terminal?.surplus() > zap_power ? area.apc.terminal?.surplus() : zap_power
+	else
+		var/obj/structure/cable/found_node = locate(/obj/structure/cable) in range(zap_range, src)
+		if(found_node?.powernet?.netexcess > zap_power)
+			zap_power = found_node.powernet.netexcess
+	zap_range = max(zap_power / (50 KILO WATTS), 1)
+	var/machine_explode_chance = zap_range// 1 MW excess power = 20% chance to explode machines in range
+	if(prob(machine_explode_chance))
+		zap_flags |= ZAP_MACHINE_EXPLOSIVE | ZAP_MOB_STUN
+	tesla_zap(source = src, zap_range = zap_range, power = zap_power, cutoff = 1e3, zap_flags = zap_flags)
+	//If we popped our machine_explode_chance, reset everything to the initial value
+	//Highly likely to destroy the area's APC in short order if there's a ton of excess power
+	//so subsequent checks to area.apc will just keep everything as it was
+	if(zap_flags & ZAP_MACHINE_EXPLOSIVE && !(initial(zap_flags) & ZAP_MACHINE_EXPLOSIVE))
+		zap_power = initial(zap_power)
+		zap_range = initial(zap_range)
+		zap_flags = initial(zap_flags)
 
 /obj/effect/anomaly/flux/update_overlays()
 	. = ..()
@@ -37,9 +61,9 @@
 	mobShock(AM)
 
 /obj/effect/anomaly/flux/proc/mobShock(mob/living/M)
-	if(canshock && istype(M))
-		canshock = FALSE
-		M.electrocute_act(shockdamage, name, flags = SHOCK_NOGLOVES)
+	if(istype(M))
+		// 10% as powerful as the damage from its tesla zap
+		M.electrocute_act(min(zap_power / 6000, 50), name, flags = SHOCK_NOGLOVES)
 
 /obj/effect/anomaly/flux/detonate()
 	switch(explosive)
@@ -62,14 +86,6 @@
 /obj/effect/anomaly/flux/big
 	immortal = TRUE
 	anomaly_core = null
-	shockdamage = 30
-
-	///range in whuich we zap
-	var/zap_range = 1
-	///strength of the zappy
-	var/zap_power = 2500
-	///the zappy flags
-	var/zap_flags = ZAP_GENERATES_POWER | ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE
 
 /obj/effect/anomaly/flux/big/Initialize(mapload, new_lifespan)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
This pull request modifies flux anomalies to exhibit the following behavior:

Going off of, in priority
A) The area's APC, if it exists and has a terminal
B) If the APC is broken, any random wire within its zap_range (initial range is 1)
Once it has acquired one of these targets, it compares its current zap_power ( initial is 2500 ) against the excess WATTS availble to that resource. Notably, this makes APC function as ghetto tesla coils; if you separate an area APC from the powernet quickly, it will still use the APC's excess power as its basis of reference.

If the excess power available to its acquired target is higher than its zap power, its zap_power is set to that number. Zap_range is recalculated to be the higher of either:

1
or
zap_power / 50,000

As well, the flux anomaly now has a machine_explosion_chance, equal to zap_range.

Flux anomalies will now give off tesla zaps with respect to their zap_range and zap_power (tesla_zap damage is built-in, calculated to be 90 at the highest with factorial dropoff per-zap in the chain). With every tesla_zap, it will roll its current machine_explosion_chance. If the roll is successful, its next tesla zap will add two flags to it: ZAP_MOB_STUN (stuns you if it zaps you) and ZAP_EXPLOSIION_MACHINE (explosively destroy machines that it zaps).
It will then reset to the base of 2500 zap_power, 1 zap_range, and removal of these two flags.

At round start, before power is set up, this will be what you expect: zap_range of 1 at the standard zap_power of 2500 ( tesla_zap damage is (zap_power/600) ).
With 1 MW of excess power in the network ( science or engineering failing to upgrade APCs or failing to upgrade machines (which increases power draw ) results in a 20% chance of the machine_explosion rolling, with pointblank zap damage of the cap at 90, divided by 1.5 per zap target hop, as per tesla_zap's internals.

Roundstart standard bar of SSD people:

https://github.com/user-attachments/assets/6c2decd9-d69b-4fb6-8d65-7aae6800056f

Bar full of SSD people after an engineer jacked all the SMES to have 1 MW of excess power in the powernet:


https://github.com/user-attachments/assets/047cef69-2c92-4a98-bc3e-6e77b5478503



## Why It's Good For The Game
This serves a dual purpose: making flux anomalies dangerous to account for how useful they are ( Voltaic combat hearts, tesla armor, tesla cannons ) and to give powergaming and/or negligent engineering players pause in how power is managed; the current attitude around power in-game is to hotwire the supermatter or max the SMES to fuck over anyone who tries to hack a door, or just because they're a silly little guy in yellow gloves.

Flux anomalies in their current state are something of a joke, and the only risk they pose is if they go ignored or unnoticed; their benefits massively dwarf any of the risks of briefly dipping in and out to neutralize them. This change seeks to balance their risk and their danger with the reward, while also factoring in player agency in just how much risk they would actually pose.

## Changelog
:cl: Bisar
add: Flux anomalies now become more dangerous with the amount of excess power in the powernet.
/:cl:
