### PR TITLE
Tier 1 parts, Conveyors, Big manipulator & manumachine boards: available at all lathes, duct tape added to engineering lathe, hatchet recipe cost reduced ( 7.5 sheets -> 2.5 sheets )

### DIFF
--- a/code/modules/research/designs/autolathe/engineering_designs.dm
+++ b/code/modules/research/designs/autolathe/engineering_designs.dm
@@ -71,6 +71,17 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/duct_tape
+	name = "Duct Tape"
+	id = "duct_tape"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sticky_tape/duct
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_ENGINEERING,
+	)
+
 /datum/design/geiger
 	name = "Geiger Counter"
 	id = "geigercounter"

--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -303,7 +303,7 @@
 	name = "Hatchet"
 	id = "hatchet"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*7.5)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2.5)
 	build_path = /obj/item/hatchet
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -1281,80 +1281,79 @@
 	desc = "The circuit board for a big manipulator."
 	id = "big_manipulator"
 	build_path = /obj/item/circuitboard/machine/big_manipulator
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SERVICE
 
 /datum/design/board/manulathe
 	name = "Manufacturing Lathe Board"
 	desc = "The circuit board for this machine."
 	id = "manulathe"
 	build_path = /obj/item/circuitboard/machine/manulathe
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manucrafter
 	name = "Manufacturing Assembling Machine Board"
 	desc = "The circuit board for this machine."
 	id = "manucrafter"
 	build_path = /obj/item/circuitboard/machine/manucrafter
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
-
 /datum/design/board/manucrusher
 	name = "Manufacturing Crusher Board"
 	desc = "The circuit board for this machine."
 	id = "manucrusher"
 	build_path = /obj/item/circuitboard/machine/manucrusher
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manurouter
 	name = "Manufacturing Router Board"
 	desc = "The circuit board for this machine."
 	id = "manurouter"
 	build_path = /obj/item/circuitboard/machine/manurouter
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manusorter
 	name = "Conveyor Sort-Router Board"
 	desc = "The circuit board for this machine."
 	id = "manusorter"
 	build_path = /obj/item/circuitboard/machine/manusorter
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manuunloader
 	name = "Manufacturing Crate Unloader Board"
 	desc = "The circuit board for this machine."
 	id = "manuunloader"
 	build_path = /obj/item/circuitboard/machine/manuunloader
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/manusmelter
 	name = "Manufacturing Smelter Board"
 	desc = "The circuit board for this machine."
 	id = "manusmelter"
 	build_path = /obj/item/circuitboard/machine/manusmelter
+	build_type = AUTOLATHE | PROTOLATHE | IMPRINTER | AWAY_LATHE | AWAY_IMPRINTER
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_INITIAL + RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/mailsorter
 	name = "Mail Sorter Board"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -13,7 +13,7 @@
 	category = list(
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+	// No department_flag means this can be crafted at all lathes
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -38,7 +38,7 @@
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
 	)
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	// No department flag means this can be crafted at all lathes
 
 /datum/design/adv_capacitor
 	name = "Advanced Capacitor"
@@ -91,7 +91,7 @@
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
 	)
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	// No department flag means this can be crafted at all lathes
 
 /datum/design/adv_scanning
 	name = "Advanced Scanning Module"
@@ -144,7 +144,7 @@
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
 	)
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	// No department flag means this can be crafted at all lathes
 
 /datum/design/nano_servo
 	name = "Nano Servo"
@@ -197,7 +197,7 @@
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
 	)
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	// No department flag means this can be crafted at all lathes
 
 /datum/design/high_micro_laser
 	name = "High-Power Micro-Laser"
@@ -249,7 +249,7 @@
 		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
 	)
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	// No department flag means this can be crafted at all lathes
 
 /datum/design/adv_matter_bin
 	name = "Advanced Matter Bin"

--- a/code/modules/research/techweb/nodes/engi_nodes.dm
+++ b/code/modules/research/techweb/nodes/engi_nodes.dm
@@ -146,6 +146,7 @@
 		"wirecutters",
 		"light_bulb",
 		"light_tube",
+		"duct_tape",
 		"crossing_signal",
 		"guideway_sensor",
 		"manuunloader",


### PR DESCRIPTION

## About The Pull Request
Detailed in the title are the changes this PR encompasses.

Tier 1 parts are now available at all lathes. Tier 1 machines suck eggs, but what sucks even more eggs is all the engineers being dead/lazy/murderous and all you want for christmas is a servo for your silly little gimmick project.
Big manipulators were already available at all lathes but, funnily, not at an autolathe. This change just makes them available at autolathes too.
I see conveyors used more by chefs and bartenders than I do by engineering. As in, multiple times per week for the former, and... I cannot remember the last time I saw an engineer make a conveyor project? Anyway; conveyors were available everywhere but at the service lathe. This just makes them available at the service lathe.
Manumachines ( the rude goldberg crafting machines that are ~30% broken as of this PR ) are something I want to look at fixing in the near future and I see used by precisely no-one; this makes them available at all lathes, including the autolathe.

Duct tape was added for engineers to do tool-agnostic repairs to stuff, but was only available in vendors. This makes it available in the engineering lathe.

Finally, the odd bird out is hatchets for this; they're 7.5 sheets to craft for no reason I was able to ascertain considering the accessibility of things like bone daggers and plastitanium glass spears; as such, I lowered their price to 2.5 because if you're doing a hatchet man bit you may as well not encroach on the Roboticist tradition of using up everything in the ore silo.

## Why It's Good For The Game
Janky as they may be at current, big manipulators and manumachines are also the places where I've seen the funniest and/or most clever applications of automation lines. Though it's a WYCI moment, I also plan to overhaul big manipulators in the near future, and do what I can to fix a lot of the rough edges of manumachines. Having them more widely available at the lathes facilitates this.

Tier 1 parts being available at all the lathes facilitates people making personal changes or small repairs to their workspaces easier. I'll draw attention to RPEDs still being Science and Engineering exclusive; this is meant to smooth out a pain point for low pop players, or just those rounds when Engineering is a stooge circus and Science is a collection of anomaly hoarding sweats.

Quick post-note on Tier 1 parts; this _DOES NOT_ include high-capacity cells, as they're just plain so much better than the basic cells most things start with that I think it's a bit of soul to break into engineering or rifle through maintenance or cargo's lobby for one, instead.

Duct tape at Engineering lathes feels like an oversight fix though I could be wrong on that one. The adjustment to hatchet price feels like a mitigation of what could have either been a kneejerk jack-up of their cost in response to some hatchet flinging metagang of the past, or possibly a leftover from a migration of material cost. In any case, the new cost seems much more reasonable for what it is that hatchets offer.

## Changelog
:cl: Bisar
balance: Tier 1 parts (except for high-capacity power cells) are now available at all lathes.
balance: Big manipulator boards are now available at all lathes.
balance: Manumachine boards are now available at all lathes.
balance: Conveyor parts are now available at all lathes.
add: Duct tape is now available in the Engineering lathe.
balance: Hatchet material cost has been reduced, from 7.5 sheets of iron to 2.5 sheets of iron.
/:cl:
