### PR TITLE
[NO GBP] hotfix for malformed cyborg logs in ore silo logs

### DIFF
--- a/code/controllers/subsystem/networks/id_access.dm
+++ b/code/controllers/subsystem/networks/id_access.dm
@@ -558,12 +558,12 @@ SUBSYSTEM_DEF(id_access)
 			. = __in_character_record_id_information(astype(target.get_idcard(), /obj/item/card/id/advanced))
 			return .
 		.["name"] = target.name
-		.["age"] = "INSPECT MANUFACTURER MANIFEST"
-		.["assignment"] = 0
-		.["account_id"] = "NO ACCOUNT."
-		.["account_holder"] = "NO ACCOUNT."
-		.["account_assignment"] = "N/A"
-		.["accesses"] = target.mind?.assigned_role?.title
+		.["age"] = 0
+		.["assignment"] = "Silicon"
+		.["account_id"] = null
+		.["account_holder"] = null
+		.["account_assignment"] = null
+		.["accesses"] = null
 		.[SILICON_OVERRIDE] = SILICON_OVERRIDE
 		return .
 	var/obj/item/card/id/advanced/id_card = astype(target_of_record, /obj/item/card/id/advanced)

--- a/tgui/packages/tgui/interfaces/OreSilo.tsx
+++ b/tgui/packages/tgui/interfaces/OreSilo.tsx
@@ -68,7 +68,7 @@ type Data = {
   id_required: BooleanLike;
 };
 
-export const OreSilo = (props: any) => {
+export const OreSilo = (props: Data) => {
   const { act, data } = useBackend<Data>();
   const { SHEET_MATERIAL_AMOUNT, machines, logs } = data;
 
@@ -107,7 +107,7 @@ export const OreSilo = (props: any) => {
             {currentTab === Tab.Logs && (
               <>
                 <RestrictButton />
-                <LogsList logs={logs!} />
+                <LogsList logs={logs} />
               </>
             )}
           </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Fixes up ID_DATA for reporting logs for silicons, which I really should have tested. Also sands down a couple of funky places in the .tsx file.

## Why It's Good For The Game
Hotfix

## Changelog
:cl: Bisar
fix: Merged a fix for ID_DATA(silicon) reporting
/:cl:
