### PR TITLE
[NO GBP] Silo logging hotfix 2 (includes hotfix 1): Multitool linking, decon/recon, funky define fix

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -181,7 +181,7 @@
 #define ACCESS_CENT_CAPTAIN "cent_captain"
 #define ACCESS_CENT_BAR "cent_bar"
 /// Special Ops. Captain's display case, Marauder and Seraph mechs.
-#define ACCESS_CENT_SPECOPS 188 ///Remind me to separate to captain, centcom, and syndicate mech access later -SonofSpace
+#define ACCESS_CENT_SPECOPS "cent_specops"
 
 /// - - - ANTAGONIST - - -
 /// SYNDICATE

--- a/code/controllers/subsystem/networks/id_access.dm
+++ b/code/controllers/subsystem/networks/id_access.dm
@@ -558,12 +558,12 @@ SUBSYSTEM_DEF(id_access)
 			. = __in_character_record_id_information(astype(target.get_idcard(), /obj/item/card/id/advanced))
 			return .
 		.["name"] = target.name
-		.["age"] = "INSPECT MANUFACTURER MANIFEST"
-		.["assignment"] = 0
-		.["account_id"] = "NO ACCOUNT."
-		.["account_holder"] = "NO ACCOUNT."
-		.["account_assignment"] = "N/A"
-		.["accesses"] = target.mind?.assigned_role?.title
+		.["age"] = 0
+		.["assignment"] = "Silicon"
+		.["account_id"] = null
+		.["account_holder"] = null
+		.["account_assignment"] = null
+		.["accesses"] = null
 		.[SILICON_OVERRIDE] = SILICON_OVERRIDE
 		return .
 	var/obj/item/card/id/advanced/id_card = astype(target_of_record, /obj/item/card/id/advanced)

--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -736,7 +736,7 @@
 /datum/component/material_container/proc/retrieve_all(target = null, atom/context = parent)
 	var/result = 0
 	for(var/MAT in materials)
-		result += retrieve_sheets(amount2sheet(materials[MAT]), MAT, target, context)
+		result += retrieve_sheets(amount2sheet(materials[MAT]), MAT, target, context, user_data = ID_DATA(null))
 	return result
 //============================================================================================
 

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -152,7 +152,7 @@ handles linking back and forth.
 					new_container.materials[mat] += mat_amount
 					mat_container.materials[mat] = 0
 			qdel(mat_container)
-		silo.connect_receptacle(src, parent)
+		new_silo.connect_receptacle(src, parent)
 		if(!(mat_container_flags & MATCONTAINER_NO_INSERT))
 			RegisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(on_item_insert))
 			RegisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION_SECONDARY, PROC_REF(on_secondary_insert))

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -113,8 +113,7 @@
 
 	ore_connected_machines = null
 	materials = null
-	qdel(radio)
-	radio = null
+	QDEL_NULL(radio)
 
 	return ..()
 

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -104,7 +104,6 @@
 	radio.keyslot.channels[RADIO_CHANNEL_SECURITY] = TRUE
 	radio.recalculateChannels()
 
-
 /obj/machinery/ore_silo/Destroy()
 	if (GLOB.ore_silo_default == src)
 		GLOB.ore_silo_default = null
@@ -114,6 +113,8 @@
 
 	ore_connected_machines = null
 	materials = null
+	qdel(radio)
+	radio = null
 
 	return ..()
 

--- a/tgui/packages/tgui/interfaces/OreSilo.tsx
+++ b/tgui/packages/tgui/interfaces/OreSilo.tsx
@@ -68,7 +68,7 @@ type Data = {
   id_required: BooleanLike;
 };
 
-export const OreSilo = (props: any) => {
+export const OreSilo = (props: Data) => {
   const { act, data } = useBackend<Data>();
   const { SHEET_MATERIAL_AMOUNT, machines, logs } = data;
 
@@ -107,7 +107,7 @@ export const OreSilo = (props: any) => {
             {currentTab === Tab.Logs && (
               <>
                 <RestrictButton />
-                <LogsList logs={logs!} />
+                <LogsList logs={logs} />
               </>
             )}
           </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Includes #92346

Additionally, fixes a non-pattern define that would fling the silo logging formatting off its spinwheel when it would recursively jsonify the logs.

Adds an id_read_failure for disassembling ore silos logging all their dropped materials.

## Why It's Good For The Game
Hotfixes for a PR

## Changelog
:cl: Bisar
fix: Ore silos should be able to be connected/disconnected/disassembled without any issues now.
fix: The define for CENTCOM_SPECOPS was incorrectly formatted; it has been fixed.
/:cl:
