### PR TITLE
[NO GBP] Ore silo logging fix 3: Error-catching for bad logs, adding logging to another couple calls

### DIFF
--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -207,6 +207,7 @@
 	if(!islist(user_data))
 		// Just allow to salvage the situation
 		. = COMPONENT_ORE_SILO_ALLOW
+		user_data = ID_DATA(null)
 		CRASH("Invalid data passed to check_permitted")
 	if(user_data[SILICON_OVERRIDE] || user_data[CHAMELEON_OVERRIDE] || astype(user_data["accesses"], /list)?.Find(ACCESS_QM))
 		return COMPONENT_ORE_SILO_ALLOW

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -139,6 +139,7 @@
 	. = ..()
 	if (.)
 		return
+	var/alist/user_data = ID_DATA(usr)
 
 	switch (action)
 		if ("print")
@@ -150,7 +151,7 @@
 			if (!(design.build_type & COMPONENT_PRINTER))
 				return TRUE
 
-			if (!materials.can_use_resource(user_data = ID_DATA(usr)))
+			if (!materials.can_use_resource(user_data = user_data))
 				return TRUE
 
 			if (!materials.mat_container.has_materials(design.materials, efficiency_coeff))
@@ -159,7 +160,7 @@
 
 			balloon_alert_to_viewers("printed [design.name]")
 
-			materials.use_materials(design.materials, efficiency_coeff, 1, "printed", "[design.name]")
+			materials.use_materials(design.materials, efficiency_coeff, 1, "printed", "[design.name]", user_data)
 			var/atom/printed_design = new design.build_path(drop_location())
 			printed_design.pixel_x = printed_design.base_pixel_x + rand(-5, 5)
 			printed_design.pixel_y = printed_design.base_pixel_y + rand(-5, 5)
@@ -167,7 +168,7 @@
 			var/datum/material/material = locate(params["ref"])
 			var/amount = text2num(params["amount"])
 			// SAFETY: eject_sheets checks for valid mats
-			materials.eject_sheets(material, amount)
+			materials.eject_sheets(material_ref = material, eject_amount = amount, user_data = user_data)
 
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Creates a null entry ID_DATA read is user_data was invalid for whatever reason, adds user_data to another couple cases of the data being read.

## Why It's Good For The Game
More fixes

## Changelog
:cl: Bisar
fix: Fixed a couple of missing entries for user_data
code: Ore silo logs will now generate an entry for a failed ID_DATA entry instead of not generating anything if the initial provided user_data wasn't valid.
/:cl:
