### PR TITLE
Fixes infinite loop in closet resist code

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1038,15 +1038,13 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	return TRUE
 
 /obj/structure/closet/container_resist_act(mob/living/user, loc_required = TRUE)
-	if(isstructure(loc))
-		relay_container_resist_act(user, loc)
 	if(opened)
 		return
 	if(ismovable(loc))
 		user.changeNext_move(CLICK_CD_BREAKOUT)
 		user.last_special = world.time + CLICK_CD_BREAKOUT
-		var/atom/movable/AM = loc
-		AM.relay_container_resist_act(user, src)
+		var/atom/movable/movable_parent = loc
+		movable_parent.relay_container_resist_act(user, src)
 		return
 	if(!welded && !locked)
 		open()
@@ -1075,7 +1073,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			to_chat(user, span_warning("You fail to break out of [src]!"))
 
 /obj/structure/closet/relay_container_resist_act(mob/living/user, obj/container)
-	container.container_resist_act(user)
+	container_resist_act(user)
 
 /// Check if someone is still resisting inside, and choose to either keep shaking or stop shaking the closet
 /obj/structure/closet/proc/check_if_shake()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -73,22 +73,22 @@
 	if(!hasmob)
 		disposal_holder.destinationTag = sort_tag
 
-/obj/item/delivery/relay_container_resist_act(mob/living/user, obj/object)
+/obj/item/delivery/relay_container_resist_act(mob/living/user, obj/container)
 	if(ismovable(loc))
 		var/atom/movable/movable_loc = loc //can't unwrap the wrapped container if it's inside something.
-		movable_loc.relay_container_resist_act(user, object)
+		movable_loc.relay_container_resist_act(user, container)
 		return
-	to_chat(user, span_notice("You lean on the back of [object] and start pushing to rip the wrapping around it."))
-	if(do_after(user, 5 SECONDS, target = object))
-		if(!user || user.stat != CONSCIOUS || user.loc != object || object.loc != src)
+	to_chat(user, span_notice("You lean on the back of [container] and start pushing to rip the wrapping around it."))
+	if(do_after(user, 5 SECONDS, target = container))
+		if(!user || user.stat != CONSCIOUS || user.loc != container || container.loc != src)
 			return
-		to_chat(user, span_notice("You successfully removed [object]'s wrapping!"))
-		object.forceMove(loc)
+		to_chat(user, span_notice("You successfully removed [container]'s wrapping!"))
+		container.forceMove(loc)
 		unwrap_contents()
 		post_unwrap_contents(user)
 	else
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
-			to_chat(user, span_warning("You fail to remove [object]'s wrapping!"))
+			to_chat(user, span_warning("You fail to remove [container]'s wrapping!"))
 
 /obj/item/delivery/update_icon_state()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

If two closets are nested in each other they'll call this shit in a loop forever, because closets treat relay_container_resist_act differently then everything else in the game for seemingly no reason. It's stupid, so let's just not do that.

## Why It's Good For The Game

Crab rocket should not kill the master controller
