### PR TITLE
[TEST MERGE PLEASE] Clean out carbon & human Life() and their call trees just a bit; wounds and bodyparts (though not yet organs) now process based on signal registration

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_life.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_life.dm
@@ -1,0 +1,9 @@
+///From living/Life(). (deltatime, times_fired)
+#define COMSIG_LIVING_LIFE "living_life"
+	/// Block the Life() proc from proceeding... this should really only be done in some really wacky situations.
+	#define COMPONENT_LIVING_CANCEL_LIFE_PROCESSING (1<<0)
+
+/// from /mob/living/carbon/Life(): (seconds_per_tick = SSMOBS_DT, times_fired)
+#define COMSIG_LIFE_WOUND_PROCESS "life_wound_process"
+#define COMSIG_LIFE_WOUND_STASIS_PROCESS "life_wound_stasis_process"
+#define COMSIG_LIFE_HANDLE_BODYPARTS "life_handle_bodyparts"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -51,10 +51,6 @@
 #define COMSIG_LIVING_TRY_SYRINGE_WITHDRAW "living_try_syringe_withdraw"
 ///from base of mob/living/set_usable_legs()
 #define COMSIG_LIVING_LIMBLESS_SLOWDOWN  "living_limbless_slowdown"
-///From living/Life(). (deltatime, times_fired)
-#define COMSIG_LIVING_LIFE "living_life"
-	/// Block the Life() proc from proceeding... this should really only be done in some really wacky situations.
-	#define COMPONENT_LIVING_CANCEL_LIFE_PROCESSING (1<<0)
 ///From living/set_resting(): (new_resting, silent, instant)
 #define COMSIG_LIVING_RESTING "living_resting"
 

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -295,13 +295,15 @@
 			start_limping_if_we_should() // the status effect already handles removing itself
 			add_or_remove_actionspeed_mod()
 
+/// If someone wants their wound to do something special in stasis, they need to manually
+/// implement a registration for processing while on stasis.
 /datum/wound/proc/wound_enter_stasis(datum/victim, trait)
 	SIGNAL_HANDLER
 	UnregisterSignal(src, COMSIG_LIFE_WOUND_PROCESS)
 
 /datum/wound/proc/wound_exit_stasis(datum/victim, trait)
 	SIGNAL_HANDLER
-	RegisterSignal(src, COMSIG_LIFE_WOUND_PROCESS)
+	RegisterSignal(src, COMSIG_LIFE_WOUND_PROCESS, PROC_REF(handle_process))
 
 /// Proc called to change the variable `limb` and react to the event.
 /datum/wound/proc/set_limb(obj/item/bodypart/new_value, replaced = FALSE)

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -299,11 +299,11 @@
 /// implement a registration for processing while on stasis.
 /datum/wound/proc/wound_enter_stasis(datum/victim, trait)
 	SIGNAL_HANDLER
-	UnregisterSignal(src, COMSIG_LIFE_WOUND_PROCESS)
+	UnregisterSignal(victim, COMSIG_LIFE_WOUND_PROCESS)
 
 /datum/wound/proc/wound_exit_stasis(datum/victim, trait)
 	SIGNAL_HANDLER
-	RegisterSignal(src, COMSIG_LIFE_WOUND_PROCESS, PROC_REF(handle_process))
+	RegisterSignal(victim, COMSIG_LIFE_WOUND_PROCESS, PROC_REF(handle_process))
 
 /// Proc called to change the variable `limb` and react to the event.
 /datum/wound/proc/set_limb(obj/item/bodypart/new_value, replaced = FALSE)

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -75,10 +75,10 @@
 	QDEL_NULL(active_trauma)
 	return ..()
 
-/datum/wound/blunt/bone/handle_process(seconds_per_tick, times_fired)
+/datum/wound/blunt/bone/handle_process(datum/sig_source, seconds_per_tick, times_fired)
 	. = ..()
 
-	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS))
+	if (!victim)
 		return
 
 	if(limb.body_zone == BODY_ZONE_HEAD && brain_trauma_group && world.time > next_trauma_cycle)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -37,9 +37,8 @@
 	/// Once we reach infestation beyond WOUND_INFESTATION_SEPSIS, we get this many warnings before the limb is completely paralyzed (you'd have to ignore a really bad burn for a really long time for this to happen)
 	var/strikes_to_lose_limb = 3
 
-/datum/wound/burn/flesh/handle_process(seconds_per_tick, times_fired)
-
-	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS))
+/datum/wound/burn/flesh/handle_process(datum/sig_source, seconds_per_tick, times_fired)
+	if (!victim)
 		return
 
 	. = ..()

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -96,8 +96,8 @@
 		return BLOOD_FLOW_INCREASING
 	return BLOOD_FLOW_STEADY
 
-/datum/wound/pierce/bleed/handle_process(seconds_per_tick, times_fired)
-	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS))
+/datum/wound/pierce/bleed/handle_process(datum/sig_source, seconds_per_tick, times_fired)
+	if (!victim)
 		return
 
 

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -145,8 +145,8 @@
 	if(clot_rate < 0)
 		return BLOOD_FLOW_INCREASING
 
-/datum/wound/slash/flesh/handle_process(seconds_per_tick, times_fired)
-	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS))
+/datum/wound/slash/flesh/handle_process(datum/sig_source, seconds_per_tick, times_fired)
+	if (!victim)
 		return
 
 	// in case the victim has the NOBLOOD trait, the wound will simply not clot on its own

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -28,6 +28,7 @@
 
 	//Body temperature stability and damage
 	dna.species.handle_body_temperature(src, seconds_per_tick, times_fired)
+
 	if(!HAS_TRAIT(src, TRAIT_STASIS))
 		if(stat != DEAD)
 			//handle active mutations
@@ -40,9 +41,6 @@
 
 		// for special species interactions
 		dna.species.spec_life(src, seconds_per_tick, times_fired)
-	else
-		for(var/datum/wound/iter_wound as anything in all_wounds)
-			iter_wound.on_stasis(seconds_per_tick, times_fired)
 
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -480,8 +480,10 @@
 	update_icon_dropped()
 
 //Return TRUE to get whatever mob this is in to update health.
-/obj/item/bodypart/proc/on_life(seconds_per_tick, times_fired)
+/obj/item/bodypart/proc/on_life(datum/sig_source, seconds_per_tick, times_fired)
 	SHOULD_CALL_PARENT(TRUE)
+	SIGNAL_HANDLER
+	return
 
 /**
  * #receive_damage

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -393,6 +393,7 @@
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_movable.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_movement.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_x_act.dm"
+#include "code\__DEFINES\dcs\signals\signals_mob\signals_life.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_ai.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_arcade.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_basic.dm"


### PR DESCRIPTION

## About The Pull Request
This reworks some of the guts of wounds and bodyparts to instead use signal (de)registration to determiine whether they should process on a given tick, rather than returning a null if they shouldn't process for that tick. I also cleaned up a couple of places I thought could benefit from a dustoff but I haven't made any massive changes otherwise. 

## Why It's Good For The Game
If a proc was going to return null we may as well not call it at all; as it is all our wounds just return null if you're on stasis, and all our bodyparts get on_life() called even though not a single one has an override. Systems like this that are decoupled to such a degree that they only loop to return nulls can be elegantly moved to work off signal registration instead.

## Changelog
:cl: Bisar
code: Wounds and bodyparts (not organs) now process based on signal registration.
/:cl:
