### PR TITLE
Tac Workboots in Loadout

### DIFF
--- a/code/modules/loadout/categories/shoes.dm
+++ b/code/modules/loadout/categories/shoes.dm
@@ -42,3 +42,7 @@
 /datum/loadout_item/shoes/glow_shoes
 	name = "Shoes (Glowing, Colourable)"
 	item_path = /obj/item/clothing/shoes/glow
+
+/datum/loadout_item/shoes/jackboots
+	name = "Workboots (Black)"
+	item_path = /obj/item/clothing/shoes/workboots/black


### PR DESCRIPTION
## About The Pull Request

Puts le new "tactical workboots" in le loadout

## Why It's Good For The Game

I think there's a fair argument that there are many jobs on the station would REASONABLY wear boots over flimsy sneakers:

- Assistants
- Botanists (Well, preferably would use tan, but that's engi's thing)
- Atmospheric Technicians (Now that I think about it, why don't these guys spawn with tan engi workboots?)
- Cargo Technicians
- Janitor (Seriously this is the grimiest guy ever) 
- Scientists (Some) 

So let them wear boots. Jumpsuited and booted goon is sci-fi kino.

## Changelog

:cl: Melbert
add: Adds Black Workboots to Loadout
/:cl:

