### PR TITLE
Adds an argument to cargo logging to differentiate between Materials/Mining/Bitrunning/etc. and Regular Crates.

### DIFF
--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -227,8 +227,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			var/obj/structure/closet/crate = spawning_order.generate(pick_n_take(empty_turfs))
 			crate.name += " - #[spawning_order.id]"
 
-		SSblackbox.record_feedback("nested tally", "cargo_imports", 1, list("[spawning_order.pack.get_cost()]", "[spawning_order.pack.name]"))
-
+		SSblackbox.record_feedback("nested tally", "cargo_imports", 1, list("[spawning_order.pack.get_cost()]", "[spawning_order.pack.name]", "[spawning_order.orderer_rank]"))
 		var/from_whom = paying_for_this?.account_holder || "nobody (department order)"
 
 		investigate_log("Order #[spawning_order.id] ([spawning_order.pack.name], placed by [key_name(spawning_order.orderer_ckey)]), paid by [from_whom] has shipped.", INVESTIGATE_CARGO)


### PR DESCRIPTION
## About The Pull Request

This adds a `data` argument to the record_feedback used in the cargo shuttle's `buy()` proc, so that when we parse the data on superset, we have an additional field to filter by to better represent how some of these personal orders are being compared against each other.

## Why It's Good For The Game

Namely, I've been trying to get my data together again to start writing some design docs and get to fixing some issues again, and something's been bothering me about how the superset data was being collected on cargo crate purchases, so I've added an extra field to be able to better sort between the collected data and better represent the different methods of personal orders available via cargo, so we can make better decisions about the collected data.


## Changelog

No player facing changes.