### PR TITLE
Removes a remaining mention of the cytology plumbing RCD

### DIFF
--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -169,7 +169,7 @@
 	name = "Cytology supplies crate"
 	desc = "Did out-of-control specimens pulverize xenobiology? Here's some more \
 		supplies for further testing. Contains a microscope, biopsy tool, two petri dishes, \
-		a box of swabs, and a plumbing tool."
+		and a box of swabs."
 	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_XENOBIOLOGY
 	contains = list(/obj/structure/microscope,


### PR DESCRIPTION

## About The Pull Request

As stated in the title. In #84235 cytology plumbers got removed, but they still remained in the crate description.

## Why It's Good For The Game

Misleading people into thinking someting exists isn't that good actually.

## Changelog

:cl:
spellcheck: The cytology crate no longer references the non-existent research plumbing constructor.
/:cl:

