### PR TITLE
Buffs godslayer armor values

### DIFF
--- a/code/modules/mining/lavaland/mining_loot/godslayer.dm
+++ b/code/modules/mining/lavaland/mining_loot/godslayer.dm
@@ -21,10 +21,10 @@
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
 /datum/armor/cloak_godslayer
-	melee = 50
-	bullet = 25
-	laser = 25
-	energy = 25
+	melee = 70
+	bullet = 50
+	laser = 30
+	energy = 40
 	bomb = 50
 	bio = 50
 	fire = 100


### PR DESCRIPTION



## About The Pull Request

Buffs the godslayer armor values to be on par with ash drake, and a little better

<img width="232" height="205" alt="image" src="https://github.com/user-attachments/assets/79692721-99fd-4dba-82c4-b1e02fb814c2" />

## Why It's Good For The Game

Why the fuck is an armor that you have to fight 2 megafauna (one being the hardest in the game imo) worse than an armor that you have to butcher 3 ice drakes to make. it was straight up just not worth the effort you had to put in to make it, AND it was a downgrade from the standard armor you should have (considering everyone gets drake armor on icebox as a miner)

## Changelog
 

:cl:
balance: Buffs godslayer armor values to be worth the effort you have to put in to getting it.
/:cl:


