### PR TITLE
Fixes newscaster channels having a random chance of breaking upon creation of a new channel, refactors how channels are tracked in the first place

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -158,8 +158,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	var/json_file = file("[GLOB.log_directory]/newscaster.json")
 	var/list/file_data = list()
 	var/pos = 1
-	for(var/V in GLOB.news_network.network_channels)
-		var/datum/feed_channel/channel = V
+	for(var/datum/feed_channel/channel as anything in GLOB.news_network.network_channels)
 		if(!istype(channel))
 			stack_trace("Non-channel in newscaster channel list")
 			continue

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -304,14 +304,8 @@
 	var/author_key = input["author_ckey"]
 	var/channel_name = input["message"]
 
-	var/found_channel = FALSE
-	for(var/datum/feed_channel/channel as anything in GLOB.news_network.network_channels)
-		if(channel.channel_name == channel_name)
-			found_channel = TRUE
-			break
-
-	// No channel with a matching name, abort
-	if (!found_channel)
+	var/datum/feed_channel/chosen_channel = GLOB.news_network.network_channels_by_name[channel_name]
+	if(isnull(chosen_channel)) // No channel with a matching name, abort
 		return
 
 	message_admins(span_adminnotice("Incoming cross-sector newscaster article by [author_key] in channel [channel_name]."))

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -196,11 +196,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	//Then, breaks down the messages that have been made on those channels.
 	if(current_channel)
 		for(var/datum/feed_message/feed_message as anything in current_channel.messages)
-			var/photo_ID = null
+			var/photo_id = null
 			var/list/comment_list
 			if(feed_message.img)
-				user << browse_rsc(feed_message.img, "tmp_photo[feed_message.message_ID].png")
-				photo_ID = "tmp_photo[feed_message.message_ID].png"
+				user << browse_rsc(feed_message.img, "tmp_photo[feed_message.message_id].png")
+				photo_id = "tmp_photo[feed_message.message_id].png"
 			for(var/datum/feed_comment/comment_message as anything in feed_message.comments)
 				comment_list += list(list(
 					"auth" = comment_message.author,
@@ -211,16 +211,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 				"auth" = feed_message.author,
 				"body" = feed_message.body,
 				"time" = feed_message.time_stamp,
-				"channel_num" = feed_message.parent_ID,
+				"channel_num" = feed_message.parent_id,
 				"censored_message" = feed_message.body_censor,
 				"censored_author" = feed_message.author_censor,
-				"ID" = feed_message.message_ID,
-				"photo" = photo_ID,
+				"ID" = feed_message.message_id,
+				"photo" = photo_id,
 				"comments" = comment_list
 			))
 
 
-	data["viewing_channel"] = current_channel?.channel_ID
+	data["viewing_channel"] = current_channel?.channel_id
 	data["paper"] = paper_remaining
 	//Here we display all the information about the current channel.
 	data["channelName"] = current_channel?.channel_name
@@ -264,7 +264,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			"author" = channel.author,
 			"censored" = channel.censored,
 			"locked" = channel.locked,
-			"ID" = channel.channel_ID,
+			"ID" = channel.channel_id,
 		))
 
 	data["channels"] = channel_list
@@ -293,19 +293,20 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 	switch(action)
 		if("setChannel")
-			var/prototype_channel = params["channel"]
-			if(isnull(prototype_channel))
+			var/selected_channel_id = params["channel"]
+			if(isnull(selected_channel_id))
 				return TRUE
-			for(var/datum/feed_channel/potential_channel as anything in GLOB.news_network.network_channels)
-				if(prototype_channel == potential_channel.channel_ID)
-					current_channel = potential_channel
+			var/datum/feed_channel/potential_channel = GLOB.news_network.network_channels_by_id["[selected_channel_id]"]
+			if(isnull(potential_channel))
+				return TRUE
+			current_channel = potential_channel
 
 		if("createStory")
 			if(!current_channel)
 				balloon_alert(user, "select a channel first!")
 				return TRUE
-			var/prototype_channel = params["current"]
-			create_story(user, channel_name = prototype_channel)
+			var/current_channel_id = params["current"]
+			create_story(user, channel_id = current_channel_id)
 
 		if("togglePhoto")
 			toggle_photo(user)
@@ -352,7 +353,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 				return TRUE
 			var/questionable_message = params["messageID"]
 			for(var/datum/feed_message/iterated_feed_message as anything in current_channel.messages)
-				if(iterated_feed_message.message_ID == questionable_message)
+				if(iterated_feed_message.message_id == questionable_message)
 					iterated_feed_message.toggle_censor_body()
 					break
 
@@ -366,7 +367,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 				return TRUE
 			var/questionable_message = params["messageID"]
 			for(var/datum/feed_message/iterated_feed_message in current_channel.messages)
-				if(iterated_feed_message.message_ID == questionable_message)
+				if(iterated_feed_message.message_id == questionable_message)
 					iterated_feed_message.toggle_censor_author()
 					break
 
@@ -378,11 +379,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
 				return TRUE
-			var/prototype_channel = (params["channel"])
-			for(var/datum/feed_channel/potential_channel in GLOB.news_network.network_channels)
-				if(prototype_channel == potential_channel.channel_ID)
-					current_channel = potential_channel
-					break
+			var/selected_channel_id = (params["channel"])
+			if(isnull(selected_channel_id))
+				return TRUE
+			var/datum/feed_channel/potential_channel = GLOB.news_network.network_channels_by_id["[selected_channel_id]"]
+			if(isnull(potential_channel))
+				return TRUE
+			current_channel = potential_channel
 			current_channel.toggle_censor_D_class()
 
 		if("startComment")
@@ -394,7 +397,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			if(!commentable_message)
 				return TRUE
 			for(var/datum/feed_message/iterated_feed_message as anything in current_channel.messages)
-				if(iterated_feed_message.message_ID == commentable_message)
+				if(iterated_feed_message.message_id == commentable_message)
 					current_message = iterated_feed_message
 			return TRUE
 
@@ -660,10 +663,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	if(isnull(channel_locked))
 		return TRUE
 
-	for(var/datum/feed_channel/iterated_feed_channel as anything in GLOB.news_network.network_channels)
-		if(iterated_feed_channel.channel_name == channel_name)
-			tgui_alert(user, "ERROR: Feed channel with that name already exists on the Network.", list("Okay"))
-			return TRUE
+	var/datum/feed_channel/potential_channel = GLOB.news_network.network_channels_by_name[channel_name]
+	if(potential_channel)
+		tgui_alert(user, "ERROR: Feed channel with that name already exists on the Network.", list("Okay"))
+		return TRUE
 
 	var/list/hard_filter_result = is_ic_filtered(channel_name)
 	if(hard_filter_result)
@@ -769,13 +772,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  * Verifies that the message is being written to a real feed_channel, then provides a text input for the feed story to be written into.
  * Finally, it submits the message to the network, is logged globally, and clears all message-specific variables from the machine.
  */
-/obj/machinery/newscaster/proc/create_story(mob/user, channel_name)
-	for(var/datum/feed_channel/potential_channel as anything in GLOB.news_network.network_channels)
-		if(channel_name == potential_channel.channel_ID)
-			current_channel = potential_channel
-			break
+/obj/machinery/newscaster/proc/create_story(mob/user, channel_id)
+	var/datum/feed_channel/potential_channel = GLOB.news_network.network_channels_by_id["[channel_id]"]
+	if(isnull(potential_channel))
+		return
+	current_channel = potential_channel
 
-	if (current_channel.receiving_cross_sector)
+	if(current_channel.receiving_cross_sector)
 		return
 
 	var/temp_message = tgui_input_text(user, "Write your Feed story", "Network Channel Handler", feed_channel_message, max_length = MAX_BROADCAST_LEN, multiline = TRUE)

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -264,10 +264,10 @@
 			var/has_image = FALSE
 			if(feed_messages.img)
 				has_image = TRUE
-				user << browse_rsc(feed_messages.img, "tmp_photo[feed_messages.message_ID].png")
+				user << browse_rsc(feed_messages.img, "tmp_photo[feed_messages.message_id].png")
 			channel_data["channel_messages"] += list(list(
 				"message" = "-[feed_messages.return_body(censored_check(feed_messages.body_censor_time))]",
-				"photo" = (has_image ? "tmp_photo[feed_messages.message_ID].png" : null),
+				"photo" = (has_image ? "tmp_photo[feed_messages.message_id].png" : null),
 				"author" = feed_messages.return_author(censored_check(feed_messages.author_censor_time)),
 			))
 	data["channel_data"] = list(channel_data)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -507,12 +507,8 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 				return
 			if(!GLOB.news_network)
 				say("No news network found on station. Aborting.")
-			var/channelexists = FALSE
-			for(var/datum/feed_channel/feed in GLOB.news_network.network_channels)
-				if(feed.channel_name == LIBRARY_NEWSFEED)
-					channelexists = TRUE
-					break
-			if(!channelexists)
+			var/datum/feed_channel/library_channel = GLOB.news_network.network_channels_by_name[LIBRARY_NEWSFEED]
+			if(isnull(library_channel))
 				GLOB.news_network.create_feed_channel(LIBRARY_NEWSFEED, "Library", "The official station book club!", null)
 
 			var/obj/machinery/libraryscanner/scan = get_scanner()


### PR DESCRIPTION
## About The Pull Request

So in a recent round I noticed the newscaster UI was acting kind of funky, where two channels seemed to overlap and weirdly pick between the two in unpredictable ways. Looking into it, it seemed that somehow the channels had managed to get their unique IDs to overlap-
Oh.
https://github.com/tgstation/tgstation/blob/5d3353e7af2b88ab9379d5fb567b24afd8776acd/code/game/machinery/newscaster/newscaster_data.dm#L109-L131
I see.

...I think that code speaks for itself, in how this could've gone wrong.

Anyhow, in this pr we entirely ditch this system, and instead make it use an incremental and thus guaranteed to be unique ID.
This fixes our issues.

While we're here, we also remove the unused `channel_IDs` list, and replace it with the associative lists `network_channels_by_id` and `network_channels_by_name`. This allows us to also stop iterating over every network channel until we find the one with the right name or ID.
We also rename some confusing, wrong, or non-standard vars while we're here.
## Why It's Good For The Game

Newscaster channels no longer have a random chance of breaking is good.
Not iterating over channels when we don't need to is good.
## Changelog
:cl:
refactor: Refactored how the newscaster network keeps track of channels. Please report any issues.
fix: Newscaster channels no longer have an increasing random chance of breaking whenever a new channel is made.
/:cl:
