### PR TITLE
Fixes emissive bloom being all white

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -38,8 +38,6 @@
 #define GHOST_PLANE 4
 #define POINT_PLANE 5
 
-#define RENDER_PLANE_UNLIT_GAME 9
-
 //---------- LIGHTING -------------
 /// Normal 1 per turf dynamic lighting underlays
 #define LIGHTING_PLANE 10
@@ -65,7 +63,12 @@
 #define EMISSIVE_BLOOM_MASK_TARGET "*RENDER_PLANE_EMISSIVE_BLOOM_MASK"
 #define RENDER_PLANE_EMISSIVE_BLOOM 16
 
+
 //-------------------- Lighting ---------------------
+
+/// Main game plane to which everything renders, which then is multiplied by light
+/// Should not be lit directly as it is sourced for emissive bloom
+#define RENDER_PLANE_UNLIT_GAME 19
 
 #define RENDER_PLANE_LIGHTING 20
 


### PR DESCRIPTION

## About The Pull Request

#92357 moved base unlit game below emissives which broke bloom. It should always be directly below RENDER_PLANE_LIGHTING

## Changelog
:cl:
fix: Fixed emissive bloom being all white
/:cl:
