### PR TITLE
Makes angel wings more maneuverable

### DIFF
--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -1,5 +1,5 @@
 #define FUNCTIONAL_WING_FORCE 2.25 NEWTONS
-#define FUNCTIONAL_WING_STABILIZATION 1.2 NEWTONS
+#define FUNCTIONAL_WING_STABILIZATION 4.5 NEWTONS
 
 ///hud action for starting and stopping flight
 /datum/action/innate/flight


### PR DESCRIPTION

## About The Pull Request

Increases wing stabilization force for the wings from the flight potion, allowing much quicker halting.
As a comparison, a single key press used to displace you roughly 5 tiles, after these changes, it will only displace you two.

## Why It's Good For The Game

Newtonian movement made wings hard to maneuver and annoying to use, this aims to make them more usable.
I'm not sure about how well they'll do in combat, since after this change you still keep a substantial speed bonus, but to my knowledge it was like that before and not many people complained. If it becomes a problem, the speed can be adjusted as well.

## Changelog

:cl:
qol: Made angel wings more maneuverable
/:cl:

