### PR TITLE
Two new traitor objectives

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -336,6 +336,10 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define MAROON_PROB 30
 /// Probability that any job related objective is picked
 #define JOB_PROB 40
+/// Probability to having the credit heist objective roll
+#define HEIST_PROB 10
+/// If the heist objective did not roll, probability to have the archive destruction objective roll
+#define ALEXANDRIA_PROB 15
 
 /// How many telecrystals a normal traitor starts with
 #define TELECRYSTALS_DEFAULT 20

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -895,6 +895,129 @@ GLOBAL_LIST_EMPTY(possible_items)
 		to_chat(admin, span_boldwarning("No active AIs with minds."))
 	update_explanation_text()
 
+#define PAYDAY_EASY 15000
+#define PAYDAY_MEDIUM 27500
+#define PAYDAY_HARD 45000
+#define PAYDAY_DIFFICULTIES list(PAYDAY_EASY, PAYDAY_MEDIUM, PAYDAY_HARD)
+
+/datum/objective/heist
+	name = "heist a payday"
+	explanation_text = "Score yourself a payday."
+	admin_grantable = TRUE
+
+/datum/objective/heist/New(text)
+	. = ..()
+	target_amount = pick(PAYDAY_DIFFICULTIES)
+	update_explanation_text()
+
+/datum/objective/heist/update_explanation_text()
+	. = ..()
+	explanation_text = "Liberate [target_amount] Cr or more from the station's bank accounts or bank consoles, stored within a holochip or on an ID's bank account."
+
+/datum/objective/heist/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/mind in owners)
+		if(!isliving(mind.current))
+			continue
+
+		var/list/all_items = mind.current.get_all_contents()
+		for(var/obj/item in all_items)
+			if(HAS_TRAIT(item, TRAIT_ITEM_OBJECTIVE_BLOCKED))
+				continue
+
+			if(istype(item, /obj/item/holochip))
+				var/obj/item/holochip/loot
+				if(loot.credits >= target_amount)
+					return TRUE
+
+			if(istype(item, /obj/item/card/id))
+				var/obj/item/card/id/card
+				if(card.registered_account)
+					var/datum/bank_account/piggy_bank
+					if(piggy_bank.account_balance >= target_amount)
+						return TRUE
+	return FALSE
+
+#undef PAYDAY_EASY
+#undef PAYDAY_MEDIUM
+#undef PAYDAY_HARD
+#undef PAYDAY_DIFFICULTIES
+
+/datum/objective/alexandria
+	name = "destroy the station archives"
+	explanation_text = "Destroy Nanotrasen's archives."
+	admin_grantable = TRUE
+	var/list/cabinet_list = list()
+	var/purged_medical_archives = FALSE
+	var/purged_security_archives = FALSE
+
+/datum/objective/alexandria/New(text)
+	. = ..()
+	cabinet_list = build_cabinet_list()
+	for(var/obj/cabinet as anything in cabinet_list)
+		RegisterSignal(cabinet, COMSIG_QDELETING, PROC_REF(remove_cabinet_from_list))
+	update_explanation_text()
+
+/datum/objective/alexandria/proc/build_cabinet_list()
+	//employment cabinets
+	for(var/obj/cabinet as anything in GLOB.employmentCabinets)
+		cabinet_list += cabinet
+	//medical cabinets
+	for(var/area/station/medical/medbay/area in GLOB.areas)
+		for(var/area_turf in area.get_turfs_from_all_zlevels())
+			var/obj/structure/filingcabinet/medical/cabinet = locate() in area_turf
+			if(cabinet)
+				cabinet_list += cabinet
+	//security cabinets
+	for(var/area/station/security/area in GLOB.areas)
+		for(var/area_turf in area.get_turfs_from_all_zlevels())
+			var/obj/structure/filingcabinet/security/cabinet = locate() in area_turf
+			if(cabinet)
+				cabinet_list += cabinet
+	return cabinet_list
+
+/datum/objective/alexandria/proc/remove_cabinet_from_list(datum/cabinet, force)
+	SIGNAL_HANDLER
+	UnregisterSignal(cabinet, COMSIG_QDELETING)
+	LAZYREMOVE(cabinet_list, cabinet)
+	return NONE
+
+/datum/objective/alexandria/update_explanation_text()
+	. = ..()
+	var/cabinet_list_string
+	for(var/obj/cabinet as anything in cabinet_list)
+		cabinet_list_string += "• [get_area(cabinet)]\n"
+	if(cabinet_list_string)
+		explanation_text = "Purge the security and medical records console ONCE. \n\
+			Destroy the medical, security and employment archive cabinets in the following locations: \n\
+			[cabinet_list_string]"
+
+/datum/objective/alexandria/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/mind in owners)
+		if(!isliving(mind.current))
+			continue
+	if(!length(cabinet_list) && purged_medical_archives && purged_security_archives)
+		return TRUE
+	return FALSE
+
+// records console proc to add objective completion
+/obj/machinery/computer/records/proc/handle_traitor_objective(mob/living/carbon/human/user)
+	if(!user)
+		return
+	var/datum/mind/user_mind = user.mind ? user.mind : user.last_mind
+	if(!user_mind)
+		return
+	var/datum/antagonist/traitor/antag_datum = user_mind.has_antag_datum(/datum/antagonist/traitor)
+	if(!antag_datum)
+		return
+	var/datum/objective/alexandria/objective = locate() in antag_datum.objectives
+	if(objective)
+		if(istype(src, /obj/machinery/computer/records/medical))
+			objective.purged_medical_archives = TRUE
+		else if(istype(src, /obj/machinery/computer/records/security))
+			objective.purged_security_archives = TRUE
+
 /datum/objective/steal_n_of_type
 	name = "steal five of"
 	explanation_text = "Steal some items!"

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -91,6 +91,7 @@
 				balloon_alert(user, "records purged")
 				playsound(src, 'sound/machines/terminal/terminal_off.ogg', 70, TRUE)
 				investigate_log("[key_name(user)] purged all records.", INVESTIGATE_RECORDS)
+				handle_traitor_objective(user)
 			else
 				balloon_alert(user, "interrupted!")
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -192,6 +192,16 @@
 		kill_objective.find_target()
 		return kill_objective
 
+	if(prob(HEIST_PROB))
+		var/datum/objective/heist/heist_objective = new()
+		heist_objective.owner = owner
+		return heist_objective
+
+	else if(prob(ALEXANDRIA_PROB))
+		var/datum/objective/alexandria/alexandria_objective = new()
+		alexandria_objective.owner = owner
+		return alexandria_objective
+
 	var/datum/objective/steal/steal_objective = new()
 	steal_objective.owner = owner
 	steal_objective.find_target()


### PR DESCRIPTION
## About The Pull Request
Adds two new traitor objectives that can be rolled by all traitor types.
- A heisting objective, where a traitor has to steal credits from the station. There are 3 difficulty tiers.
- A sabotage objective, where all the archive cabinets have to be destroyed, and the medical and security records purged once.

## Why It's Good For The Game
Adds more variety to the objectives that can roll, as well as making archives and records more relevant. Both objectives fit well for saboteurs, the latter especially for traitors without Syndicate employer.

## Changelog

:cl:
add: Traitor objective to steal credits from crew or the station budget.
add: Traitor objective to destroy all archives and purge records on the station.
/:cl:
