### PR TITLE
remove shitty tgui UI flashing 2: size positioning boogaloo

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -209,12 +209,16 @@ export const backendMiddleware = (store) => {
       suspendRenderer();
       clearInterval(suspendInterval);
       suspendInterval = undefined;
-      // Tiny window in outer space to not show previous content when resumed
-      Byond.winset(Byond.windowId, {
+      // Tiny window in hell to not show previous content when resumed
+Byond.winset(Byond.windowId, {
         size: '1x1',
-        pos: '1000000000,1000000000',
-        'is-visible': false,
-      });
+        // Due to this, if you have a monitor /below/ the one you play SS13 on,
+        // that will become the 'closest' screen.
+        // If it's a different resolution, TGUI windows will spawn slightly off-center
+        // (positioned relatively to the lower monitor sizing)
+        pos: '1,1000000000',
+'is-visible': false,
+});
       setTimeout(() => focusMap());
     }
 

--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -209,7 +209,10 @@ export const backendMiddleware = (store) => {
       suspendRenderer();
       clearInterval(suspendInterval);
       suspendInterval = undefined;
+      // Tiny window in outer space to not show previous content when resumed
       Byond.winset(Byond.windowId, {
+        size: '1x1',
+        pos: '1000000000,1000000000',
         'is-visible': false,
       });
       setTimeout(() => focusMap());


### PR DESCRIPTION
## About The Pull Request

i hate this shitty flashing bullshit, i develop a real game that should be taken seriously:

https://github.com/user-attachments/assets/eee05688-14d9-486d-8c89-deeb3ab4d45e

what if we could live in a world without it

oh yeah i did that (again)


https://github.com/user-attachments/assets/351a3243-7835-488a-8d5e-405f640660b8


## Why It's Good For The Game

 i'm just upstreaming this so it's less work for me to port changes in 2 years

if you don't think this shit is good you should look at this spoiler:

<details>
<summary>bad opinion zone</summary>

![bad](https://github.com/user-attachments/assets/f207e5d4-7a24-481d-9446-aa0a0edf8528)

</details>

direct all people who have billion pixel tall screens who are scared of a single pixel flashing for a frame towards the goonstation ideas and suggestions subforum

oh i also wrote this section of the code originally a year ago in #86868 lol, but that only fixed it in IE not wv2

## Changelog
:cl:
fix: tgui windows should now stop flashing for a single frame elsewhere when opening
/:cl:

