### PR TITLE
Changes human name updates to be request-based instead of being automatically done every single tick

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -236,6 +236,9 @@
 #define HUMAN_MAX_OXYLOSS 3
 #define HUMAN_CRIT_MAX_OXYLOSS (SSMOBS_DT/3)
 
+/// Combined brute and burn damage states on a human's head after which they become disfigured
+#define HUMAN_DISFIGURATION_HEAD_DAMAGE_STATES 3
+
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when your body temperature passes the 400K point
 #define HEAT_DAMAGE_LEVEL_3 4 //Amount of damage applied when your body temperature passes the 460K point and you are on fire

--- a/code/controllers/subsystem/networks/id_access.dm
+++ b/code/controllers/subsystem/networks/id_access.dm
@@ -457,7 +457,7 @@ SUBSYSTEM_DEF(id_access)
 
 	if (ishuman(id_card.loc))
 		var/mob/living/carbon/human/owner = id_card.loc
-		owner.sec_hud_set_ID()
+		owner.update_ID_card()
 
 /**
  * Removes a trim from a ID card.
@@ -478,7 +478,7 @@ SUBSYSTEM_DEF(id_access)
 
 	if (ishuman(id_card.loc))
 		var/mob/living/carbon/human/owner = id_card.loc
-		owner.sec_hud_set_ID()
+		owner.update_ID_card()
 
 /**
  * Adds the accesses associated with a trim to an ID card.

--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -44,6 +44,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	RegisterSignal(user, COMSIG_HUMAN_GET_VISIBLE_NAME, PROC_REF(on_name_inquiry))
 	RegisterSignal(user, COMSIG_HUMAN_GET_FORCED_NAME, PROC_REF(on_name_inquiry))
+	// This forces a name update on the user, so we don't need to call name update ourselves
 	ADD_TRAIT(user, TRAIT_UNKNOWN, REF(src))
 
 	current_slot = slot

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -311,9 +311,6 @@
 	user.log_message("has stripped [key_name(source)] of [item].", LOG_ATTACK, color="red")
 	source.log_message("has been stripped of [item] by [key_name(user)].", LOG_VICTIM, color="orange", log_globally=FALSE)
 
-	// Updates speed in case stripped speed affecting item
-	source.update_equipment_speed_mods()
-
 /// A representation of the stripping UI
 /datum/strip_menu
 	/// The owner who has the element /datum/element/strippable

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -213,7 +213,7 @@
 			if(id_trim)
 				if(!SSid_access.apply_trim_to_card(id_card, id_trim))
 					WARNING("Unable to apply trim [id_trim] to [id_card] in outfit [name].")
-				user.sec_hud_set_ID()
+				user.update_ID_card()
 
 	if(suit_store)
 		EQUIP_OUTFIT_ITEM(suit_store, ITEM_SLOT_SUITSTORE)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -262,12 +262,15 @@ Security HUDs! Basic mode shows only the job.
 
 //HOOKS
 
-/mob/living/carbon/human/proc/sec_hud_set_ID()
+/mob/living/carbon/human/proc/update_ID_card()
+	SIGNAL_HANDLER
+
 	var/sechud_icon_state = wear_id?.get_sechud_job_icon_state()
 	if(!sechud_icon_state || HAS_TRAIT(src, TRAIT_UNKNOWN))
 		sechud_icon_state = "hudno_id"
 	set_hud_image_state(ID_HUD, sechud_icon_state)
 	sec_hud_set_security_status()
+	update_visible_name()
 
 /mob/living/proc/sec_hud_set_implants()
 	for(var/hud_type in (list(IMPSEC_FIRST_HUD, IMPLOYAL_HUD, IMPSEC_SECOND_HUD) & hud_list))

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -150,18 +150,22 @@
 	RegisterSignal(user, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(holder_updated_overlays))
 	RegisterSignal(user, COMSIG_HUMAN_GET_VISIBLE_NAME, PROC_REF(holder_checked_name))
 	user.update_appearance(UPDATE_OVERLAYS)
-	user.name = user.get_visible_name()
 	if (!punctured)
 		user.add_fov_trait(REF(src), FOV_REVERSE_270_DEGRESS)
+	if (ishuman(user))
+		var/mob/living/carbon/human/as_human = user
+		as_human.update_visible_name()
 
 /// Called when you stop doing that
 /obj/item/newspaper/proc/on_unwielded(obj/item/source, mob/living/user)
 	REMOVE_TRAIT(user, TRAIT_FACE_COVERED, REF(src))
 	UnregisterSignal(user, list(COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_HUMAN_GET_VISIBLE_NAME))
 	user.update_appearance(UPDATE_OVERLAYS)
-	user.name = user.get_visible_name()
 	if (!punctured)
 		user.remove_fov_trait(REF(src), FOV_REVERSE_270_DEGRESS)
+	if (ishuman(user))
+		var/mob/living/carbon/human/as_human = user
+		as_human.update_visible_name()
 
 /// Called when we're being read and overlays are updated, we should show a big newspaper over the reader
 /obj/item/newspaper/proc/holder_updated_overlays(atom/reader, list/overlays)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -750,7 +750,7 @@
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	if(!silent)
 		play_drop_sound(DROP_SOUND_VOLUME)
-	user?.update_equipment_speed_mods()
+	user?.update_equipment(src)
 
 /// called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
@@ -813,7 +813,7 @@
 	item_flags |= IN_INVENTORY
 	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_NO_WORN_ICON), SIGNAL_REMOVETRAIT(TRAIT_NO_WORN_ICON)), PROC_REF(update_slot_icon), override = TRUE)
 
-	user.update_equipment_speed_mods()
+	user.update_equipment(src)
 
 	if(!initial && (slot_flags & slot) && (play_equip_sound()))
 		return

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1938,7 +1938,7 @@
 
 	var/mob/living/carbon/human/owner = user
 	if (!selected_trim_path) // Ensure that even without a trim update, we update user's sechud
-		owner.sec_hud_set_ID()
+		owner.update_ID_card()
 
 	if (registered_account)
 		return
@@ -2048,13 +2048,20 @@
 
 /obj/item/card/cardboard/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
-	if(slot == ITEM_SLOT_ID)
-		RegisterSignal(user, COMSIG_HUMAN_GET_VISIBLE_NAME, PROC_REF(return_visible_name))
-		RegisterSignal(user, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(return_message_name_part))
+	if(slot != ITEM_SLOT_ID)
+		return
+	RegisterSignal(user, COMSIG_HUMAN_GET_VISIBLE_NAME, PROC_REF(return_visible_name))
+	RegisterSignal(user, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(return_message_name_part))
+	if(ishuman(user))
+		var/mob/living/carbon/human/as_human = user
+		as_human.update_visible_name()
 
 /obj/item/card/cardboard/dropped(mob/user, silent = FALSE)
 	. = ..()
 	UnregisterSignal(user, list(COMSIG_HUMAN_GET_VISIBLE_NAME, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART))
+	if(ishuman(user))
+		var/mob/living/carbon/human/as_human = user
+		as_human.update_visible_name()
 
 /obj/item/card/cardboard/proc/return_visible_name(mob/living/carbon/human/source, list/identity)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/devices/mulligan_kit.dm
+++ b/code/game/objects/items/devices/mulligan_kit.dm
@@ -59,7 +59,7 @@
 	else
 		to_chat(user, span_notice("You quickly put your new ID card [placed_in]."))
 
-	user.sec_hud_set_ID()
+	user.update_ID_card()
 
 	var/mob/living/carbon/human/dummy/consistent/dummy = new() // For manifest rendering, unfortunately
 	dummy.physique = user.physique

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -51,7 +51,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/wearing_human = loc
 		if(wearing_human.wear_id == src)
-			wearing_human.sec_hud_set_ID()
+			wearing_human.update_ID_card()
 
 	update_label()
 	update_appearance(UPDATE_ICON)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_clothing.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_clothing.dm
@@ -87,15 +87,17 @@
 	if(disguise == null)
 		return
 	stealth_active = TRUE
-	if(ishuman(loc))
-		var/mob/living/carbon/human/wearer = loc
-		new /obj/effect/temp_visual/dir_setting/ninja/cloak(get_turf(wearer), wearer.dir)
-		RegisterSignal(wearer, COMSIG_HUMAN_GET_VISIBLE_NAME, PROC_REF(return_disguise_name))
-		wearer.icon = disguise.icon
-		wearer.icon_state = disguise.icon_state
-		wearer.cut_overlays()
-		wearer.add_overlay(disguise.overlays)
-		wearer.update_held_items()
+	if(!ishuman(loc))
+		return
+	var/mob/living/carbon/human/wearer = loc
+	new /obj/effect/temp_visual/dir_setting/ninja/cloak(get_turf(wearer), wearer.dir)
+	RegisterSignal(wearer, COMSIG_HUMAN_GET_VISIBLE_NAME, PROC_REF(return_disguise_name))
+	wearer.icon = disguise.icon
+	wearer.icon_state = disguise.icon_state
+	wearer.cut_overlays()
+	wearer.add_overlay(disguise.overlays)
+	wearer.update_held_items()
+	wearer.update_visible_name()
 
 /obj/item/clothing/suit/armor/abductor/vest/proc/return_disguise_name(mob/living/carbon/human/source, list/identity)
 	SIGNAL_HANDLER
@@ -108,12 +110,14 @@
 	if(!stealth_active)
 		return
 	stealth_active = FALSE
-	if(ishuman(loc))
-		var/mob/living/carbon/human/wearer = loc
-		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(wearer), wearer.dir)
-		UnregisterSignal(wearer, COMSIG_HUMAN_GET_VISIBLE_NAME)
-		wearer.cut_overlays()
-		wearer.regenerate_icons()
+	if(!ishuman(loc))
+		return
+	var/mob/living/carbon/human/wearer = loc
+	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(wearer), wearer.dir)
+	UnregisterSignal(wearer, COMSIG_HUMAN_GET_VISIBLE_NAME)
+	wearer.cut_overlays()
+	wearer.regenerate_icons()
+	wearer.update_visible_name()
 
 /obj/item/clothing/suit/armor/abductor/vest/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	DeactivateStealth()

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -139,7 +139,7 @@
 	trim = card.trim
 	if(ishuman(loc))
 		var/mob/living/carbon/human/wearing = loc
-		wearing.sec_hud_set_ID()
+		wearing.update_ID_card()
 	assignment = card.assignment
 	registered_age = card.registered_age
 	registered_name = card.registered_name

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -411,7 +411,7 @@
 			card.registered_account = account
 			account.bank_cards += card
 
-		equipped.sec_hud_set_ID()
+		equipped.update_ID_card()
 
 	var/obj/item/modular_computer/pda/pda = equipped.get_item_by_slot(pda_slot)
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	if(dep_trim)
 		var/obj/item/card/id/worn_id = spawning.get_idcard(hand_first = FALSE)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
-		spawning.sec_hud_set_ID()
+		spawning.update_ID_card()
 
 		// Update PDA to match new trim.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -247,7 +247,6 @@
 				W.layer = initial(W.layer)
 				SET_PLANE_EXPLICIT(W, initial(W.plane), src)
 		changeNext_move(0)
-	update_equipment_speed_mods() // In case cuffs ever change speed
 
 /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)
 	if(!I.loc || buckled)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -619,8 +619,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 /datum/species/proc/spec_life(mob/living/carbon/human/H, seconds_per_tick, times_fired)
 	SHOULD_CALL_PARENT(TRUE)
-	if(H.stat == DEAD)
-		return
 	if(HAS_TRAIT(H, TRAIT_NOBREATH) && (H.health < H.crit_threshold) && !HAS_TRAIT(H, TRAIT_NOCRITDAMAGE))
 		H.adjustBruteLoss(0.5 * seconds_per_tick)
 
@@ -1121,19 +1119,19 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * * humi (required)(type: /mob/living/carbon/human) The mob we will target
  */
 /datum/species/proc/handle_body_temperature(mob/living/carbon/human/humi, seconds_per_tick, times_fired)
-	//when in a cryo unit we suspend all natural body regulation
+	// When in a cryo unit we suspend all natural body regulation
 	if(istype(humi.loc, /obj/machinery/cryo_cell))
 		return
 
-	//Only stabilise core temp when alive and not in statis
+	// Only stabilise core temp when alive and not in statis
 	if(humi.stat < DEAD && !HAS_TRAIT(humi, TRAIT_STASIS))
 		body_temperature_core(humi, seconds_per_tick, times_fired)
 
-	//These do run in statis
+	// These do run in statis
 	body_temperature_skin(humi, seconds_per_tick, times_fired)
 	body_temperature_alerts(humi, seconds_per_tick, times_fired)
 
-	//Do not cause more damage in statis
+	// Do not cause more damage in statis
 	if(!HAS_TRAIT(humi, TRAIT_STASIS))
 		body_temperature_damage(humi, seconds_per_tick, times_fired)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -23,7 +23,6 @@
 
 	. = ..()
 
-	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_FACE_ACT, PROC_REF(clean_face))
 	AddComponent(/datum/component/personal_crafting, ui_human_crafting)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_HUMAN, 1, -6)
 	AddComponent(/datum/component/bloodysoles/feet)
@@ -75,7 +74,7 @@
 	//Update med hud images...
 	..()
 	//...sec hud images...
-	sec_hud_set_ID()
+	update_ID_card()
 	sec_hud_set_implants()
 	sec_hud_set_security_status()
 	//...fan gear

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -34,7 +34,12 @@
 		return pda.saved_identification
 	return if_no_id
 
-//repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere
+/// Used to update our name based on whether our face is obscured/disfigured
+/mob/living/carbon/human/proc/update_visible_name()
+	SIGNAL_HANDLER
+	name = get_visible_name()
+
+/// Combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere
 /mob/living/carbon/human/get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
 	var/list/identity = list(null, null, null)
 	SEND_SIGNAL(src, COMSIG_HUMAN_GET_VISIBLE_NAME, identity)

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/register_init_signals()
 	. = ..()
 
-	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_UNKNOWN), SIGNAL_REMOVETRAIT(TRAIT_UNKNOWN)), PROC_REF(on_unknown_trait))
+	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_UNKNOWN), SIGNAL_REMOVETRAIT(TRAIT_UNKNOWN)), PROC_REF(update_ID_card))
 	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_DWARF), SIGNAL_REMOVETRAIT(TRAIT_DWARF)), PROC_REF(on_dwarf_trait))
 	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_TOO_TALL), SIGNAL_REMOVETRAIT(TRAIT_TOO_TALL)), PROC_REF(on_tootall_trait))
 	RegisterSignal(src, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, PROC_REF(get_name_part))
@@ -11,12 +11,17 @@
 
 	RegisterSignal(src, COMSIG_ATOM_CONTENTS_WEIGHT_CLASS_CHANGED, PROC_REF(check_pocket_weght))
 
-/// Gaining or losing [TRAIT_UNKNOWN] updates our name and our sechud
-/mob/living/carbon/human/proc/on_unknown_trait(datum/source)
-	SIGNAL_HANDLER
+	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_FACE_ACT, PROC_REF(clean_face))
 
-	name = get_visible_name()
-	sec_hud_set_ID()
+	// List of signals which force a visible name update
+	// TRAIT_UNKNOWN is excluded as it calls update_ID_card which also calls update_visible_name
+	var/static/list/name_update_signals = list(
+		SIGNAL_ADDTRAIT(TRAIT_INVISIBLE_MAN),
+		SIGNAL_REMOVETRAIT(TRAIT_INVISIBLE_MAN),
+		SIGNAL_ADDTRAIT(TRAIT_DISFIGURED),
+		SIGNAL_REMOVETRAIT(TRAIT_DISFIGURED),
+	)
+	RegisterSignals(src, name_update_signals, PROC_REF(update_visible_name))
 
 /// Gaining or losing [TRAIT_DWARF] updates our height and grants passtable
 /mob/living/carbon/human/proc/on_dwarf_trait(datum/source)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -148,7 +148,7 @@
 			if(wear_id)
 				return
 			wear_id = equipping
-			sec_hud_set_ID()
+			update_ID_card()
 			update_worn_id()
 		if(ITEM_SLOT_EARS)
 			if(ears)
@@ -265,7 +265,7 @@
 			update_worn_belt()
 	else if(item_dropping == wear_id)
 		wear_id = null
-		sec_hud_set_ID()
+		update_ID_card()
 		if(!QDELETED(src))
 			update_worn_id()
 	else if(item_dropping == r_store)
@@ -420,3 +420,9 @@
 			new_bodypart.try_attach_limb(src, TRUE)
 			hand_bodyparts[i] = new_bodypart
 	..() //Don't redraw hands until we have organs for them
+
+/mob/living/carbon/human/update_equipment(obj/item/source)
+	. = ..()
+	// If the item we equipped/unequipped hides our face, we (potentially) need to update our name
+	if (source.flags_inv & HIDEFACE)
+		update_visible_name()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -47,7 +47,7 @@
 	handle_liver(seconds_per_tick, times_fired)
 	// For special species interactions
 	dna.species.spec_life(src, seconds_per_tick, times_fired)
-	return TRUE
+	return stat != DEAD
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	var/chest_covered = !get_bodypart(BODY_ZONE_CHEST)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -23,33 +23,31 @@
 		return
 
 	. = ..()
+
 	if(QDELETED(src))
 		return FALSE
 
-	//Body temperature stability and damage
+	// Body temperature stability and damage
 	dna.species.handle_body_temperature(src, seconds_per_tick, times_fired)
-	if(!HAS_TRAIT(src, TRAIT_STASIS))
-		if(stat != DEAD)
-			//handle active mutations
-			for(var/datum/mutation/mutation as anything in dna.mutations)
-				mutation.on_life(seconds_per_tick, times_fired)
-			//heart attack stuff
-			handle_heart(seconds_per_tick, times_fired)
-			//handles liver failure effects, if we lack a liver
-			handle_liver(seconds_per_tick, times_fired)
-
-		// for special species interactions
-		dna.species.spec_life(src, seconds_per_tick, times_fired)
-	else
+	if(HAS_TRAIT(src, TRAIT_STASIS))
 		for(var/datum/wound/iter_wound as anything in all_wounds)
 			iter_wound.on_stasis(seconds_per_tick, times_fired)
+		return stat != DEAD
 
-	//Update our name based on whether our face is obscured/disfigured
-	name = get_visible_name()
+	if(stat == DEAD)
+		return FALSE
 
-	if(stat != DEAD)
-		return TRUE
+	// Handle active mutations
+	for(var/datum/mutation/mutation as anything in dna.mutations)
+		mutation.on_life(seconds_per_tick, times_fired)
 
+	// Heart attack stuff
+	handle_heart(seconds_per_tick, times_fired)
+	// Handles liver failure effects, if we lack a liver
+	handle_liver(seconds_per_tick, times_fired)
+	// For special species interactions
+	dna.species.spec_life(src, seconds_per_tick, times_fired)
+	return TRUE
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	var/chest_covered = !get_bodypart(BODY_ZONE_CHEST)

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -135,6 +135,8 @@
 /datum/species/zombie/infectious/on_species_gain(mob/living/carbon/human/new_zombie, datum/species/old_species, pref_load, regenerate_icons)
 	. = ..()
 	new_zombie.set_combat_mode(TRUE)
+	// Needs to be added after combat mode is set
+	ADD_TRAIT(new_zombie, TRAIT_COMBAT_MODE_LOCK, SPECIES_TRAIT)
 
 	// Deal with the source of this zombie corruption
 	// Infection organ needs to be handled separately from mutant_organs
@@ -160,6 +162,7 @@
 
 /datum/species/zombie/infectious/on_species_loss(mob/living/carbon/human/was_zombie, datum/species/new_species, pref_load)
 	. = ..()
+	REMOVE_TRAIT(was_zombie, TRAIT_COMBAT_MODE_LOCK, SPECIES_TRAIT)
 	qdel(was_zombie.GetComponent(/datum/component/mutant_hands))
 	qdel(was_zombie.GetComponent(/datum/component/regenerator))
 
@@ -171,8 +174,6 @@
 
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/carbon_mob, seconds_per_tick, times_fired)
 	. = ..()
-	carbon_mob.set_combat_mode(TRUE) // THE SUFFERING MUST FLOW
-
 	if(!HAS_TRAIT(carbon_mob, TRAIT_CRITICAL_CONDITION) && SPT_PROB(2, seconds_per_tick))
 		playsound(carbon_mob, pick(spooks), 50, TRUE, 10)
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -42,19 +42,18 @@
 		return
 
 	if(!HAS_TRAIT(src, TRAIT_STASIS))
-
 		if(stat != DEAD)
 			//Mutations and radiation
 			handle_mutations(seconds_per_tick, times_fired)
 			//Breathing, if applicable
 			handle_breathing(seconds_per_tick, times_fired)
 
-		handle_diseases(seconds_per_tick, times_fired)// DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
+		handle_diseases(seconds_per_tick, times_fired) // DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
 
-		if (QDELETED(src)) // diseases can qdel the mob via transformations
+		if (QDELETED(src)) // Diseases can qdel the mob via transformations
 			return
 
-		//Handle temperature/pressure differences between body and environment
+		// Handle temperature/pressure differences between body and environment
 		var/datum/gas_mixture/environment = loc.return_air()
 		if(environment)
 			handle_environment(environment, seconds_per_tick, times_fired)
@@ -67,7 +66,7 @@
 		living_flags &= ~QUEUE_NUTRITION_UPDATE
 
 	if(stat != DEAD)
-		return 1
+		return TRUE
 
 /mob/living/proc/handle_breathing(seconds_per_tick, times_fired)
 	SEND_SIGNAL(src, COMSIG_LIVING_HANDLE_BREATHING, seconds_per_tick, times_fired)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1502,7 +1502,7 @@
 	else
 		living_flags |= QUEUE_NUTRITION_UPDATE
 
-/// Update equipment when something is equipped/dropped, to be overriden by children
+/// Update mob stats based on equipment we are wearing when an item is equipped/dropped, to be overriden by children
 /// source - Item that caused the update by being equipped/dropped
 /mob/proc/update_equipment(obj/item/source)
 	update_equipment_speed_mods()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1502,7 +1502,12 @@
 	else
 		living_flags |= QUEUE_NUTRITION_UPDATE
 
-///Apply a proper movespeed modifier based on items we have equipped
+/// Update equipment when something is equipped/dropped, to be overriden by children
+/// source - Item that caused the update by being equipped/dropped
+/mob/proc/update_equipment(obj/item/source)
+	update_equipment_speed_mods()
+
+/// Apply a proper movespeed modifier based on items we have equipped
 /mob/proc/update_equipment_speed_mods()
 	var/speedies = 0
 	var/immutable_speedies = 0

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -296,7 +296,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/human_wearer = loc
 		if(human_wearer.wear_id == src)
-			human_wearer.sec_hud_set_ID()
+			human_wearer.update_ID_card()
 
 	update_appearance()
 	update_slot_icon()
@@ -331,7 +331,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/human_wearer = loc
 		if(human_wearer.wear_id == src)
-			human_wearer.sec_hud_set_ID()
+			human_wearer.update_ID_card()
 
 	update_slot_icon()
 	update_appearance()
@@ -462,7 +462,7 @@
 		update_slot_icon()
 		if(ishuman(loc))
 			var/mob/living/carbon/human/human_wearer = loc
-			human_wearer.sec_hud_set_ID()
+			human_wearer.update_ID_card()
 	if(inserted_pai == gone)
 		update_appearance(UPDATE_ICON)
 	if(inserted_disk == gone)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -244,6 +244,12 @@
 			pill.forceMove(src)
 
 	name = "[owner.real_name]'s head"
+
+	/// If our owner loses their head, update their name as their face ~cannot be seen~ does not exist anymore
+	if (ishuman(owner))
+		var/mob/living/carbon/human/as_human = owner
+		as_human.update_visible_name()
+
 	return ..()
 
 ///Try to attach this bodypart to a mob, while replacing one if it exists, does nothing if it fails.
@@ -350,6 +356,11 @@
 	if(old_real_name)
 		new_head_owner.real_name = old_real_name
 	real_name = new_head_owner.real_name
+
+	/// Update our owner's name with ours
+	if (ishuman(owner))
+		var/mob/living/carbon/human/as_human = owner
+		as_human.update_visible_name()
 
 	//Handle dental implants
 	for(var/obj/item/reagent_containers/applicator/pill/pill in src)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -213,6 +213,16 @@
 /obj/item/bodypart/head/GetVoice()
 	return "The head of [real_name]"
 
+/obj/item/bodypart/head/update_bodypart_damage_state()
+	if (!ishuman(owner))
+		return ..()
+	var/old_states = brutestate + burnstate
+	. = ..()
+	var/new_states = brutestate + burnstate
+	var/mob/living/carbon/human/as_human = owner
+	if ((old_states >= HUMAN_DISFIGURATION_HEAD_DAMAGE_STATES && new_states < HUMAN_DISFIGURATION_HEAD_DAMAGE_STATES) || (old_states < HUMAN_DISFIGURATION_HEAD_DAMAGE_STATES && new_states >= HUMAN_DISFIGURATION_HEAD_DAMAGE_STATES))
+		as_human.update_visible_name()
+
 /obj/item/bodypart/head/monkey
 	icon = 'icons/mob/human/species/monkey/bodyparts.dmi'
 	icon_static = 'icons/mob/human/species/monkey/bodyparts.dmi'

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -116,7 +116,7 @@
 		display_pain(target, "The pain fades, your face feels new and unfamiliar!")
 	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
-		human_target.sec_hud_set_ID()
+		human_target.update_ID_card()
 	if(HAS_MIND_TRAIT(user, TRAIT_MORBID) && ishuman(user))
 		var/mob/living/carbon/human/morbid_weirdo = user
 		morbid_weirdo.add_mood_event("morbid_abominable_surgery_success", /datum/mood_event/morbid_abominable_surgery_success)


### PR DESCRIPTION

## About The Pull Request

Changes human name to update whenever anything that could result in their visible name changing occurs, such as changing IDs, equipping gasmasks, picking potted plants, etc. Currently name updates occur every ``Life()`` tick and in a few "special" cases, which causes a lot of name changes from sources such as equipment to not apply until the mob ticks, and makes us waste a tiiiny bit of CPU time on name updates. 
I've also slighly cleaned up human /Life() and made species' ``spec_life()`` not run when the mob is dead, as it was causing certain unintended interactions, such as slimepeople regenerating blood while dead.

## Why It's Good For The Game

Microoptimization, ensures that correct names are always used (in case something could update their name but the mob hasn't ticked yet), plus its just a cleaner implementation

## Changelog
:cl:
refactor: Refactored how human names are updated, yell at us on our github if you spot any bugs!
fix: Fixed slimepeople regenerating blood while dead
/:cl:
