### PR TITLE
Burned mess from culinary disasters is once again toxic.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -50,7 +50,7 @@
 	#define COMPONENT_HANDLED_GRILLING (1<<0)
 ///Called when an object is turned into another item through grilling ontop of a griddle
 #define COMSIG_ITEM_GRILLED "item_grill_completed"
-///Sent to the newly spawned object when it's grilled on a grilled.
+///Sent to the newly spawned object when it's grilled on a griddle.
 #define COMSIG_ITEM_GRILLED_RESULT "item_grilled_result"
 
 ///Called when the object is grilled by the grill (not to be confused by the griddle, but oh gee the two should be merged in one)

--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -50,6 +50,8 @@
 	#define COMPONENT_HANDLED_GRILLING (1<<0)
 ///Called when an object is turned into another item through grilling ontop of a griddle
 #define COMSIG_ITEM_GRILLED "item_grill_completed"
+///Sent to the newly spawned object when it's grilled on a grilled.
+#define COMSIG_ITEM_GRILLED_RESULT "item_grilled_result"
 
 ///Called when the object is grilled by the grill (not to be confused by the griddle, but oh gee the two should be merged in one)
 #define COMSIG_ITEM_BARBEQUE_GRILLED "item_barbeque_grilled"
@@ -67,6 +69,8 @@
 	#define COMPONENT_BAKING_BAD_RESULT (1<<2)
 ///Called when an object is turned into another item through baking in an oven
 #define COMSIG_ITEM_BAKED "item_bake_completed"
+///Sent to the newly spawned object when it's baked in an oven.
+#define COMSIG_ITEM_BAKED_RESULT "item_baked_result"
 
 //Drink
 

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -125,6 +125,7 @@
 			ignored_mobs = asomnia_hadders,
 		)
 	SEND_SIGNAL(parent, COMSIG_ITEM_BAKED, baked_result)
+	SEND_SIGNAL(baked_result, COMSIG_ITEM_BAKED_RESULT, parent)
 	qdel(parent)
 
 ///Gives info about the items baking status so you can see if its almost done

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -164,6 +164,7 @@
 			grilled_result.reagents.add_reagent_list(added_reagents)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
+	SEND_SIGNAL(grilled_result, COMSIG_ITEM_GRILLED_RESULT, parent)
 	if(who_placed_us)
 		ADD_TRAIT(grilled_result, TRAIT_FOOD_CHEF_MADE, who_placed_us)
 

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -54,8 +54,6 @@
 		result.set_custom_materials(source.custom_materials)
 
 	var/efficiency = istype(used_microwave) ? used_microwave.efficiency : 1
-	SEND_SIGNAL(result, COMSIG_ITEM_MICROWAVE_COOKED, source, efficiency)
-	SEND_SIGNAL(source, COMSIG_ITEM_MICROWAVE_COOKED_FROM, result, efficiency)
 
 	if(IS_EDIBLE(result) && (result_typepath != default_typepath))
 		BLACKBOX_LOG_FOOD_MADE(result.type)
@@ -71,6 +69,10 @@
 
 		if(microwaver && microwaver.mind)
 			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))
+
+
+	SEND_SIGNAL(result, COMSIG_ITEM_MICROWAVE_COOKED, source, efficiency)
+	SEND_SIGNAL(source, COMSIG_ITEM_MICROWAVE_COOKED_FROM, result, efficiency)
 
 	qdel(source)
 

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -194,8 +194,27 @@
 /obj/item/food/badrecipe/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_GRILL_PROCESS, PROC_REF(OnGrill))
+	RegisterSignals(src, list(COMSIG_ITEM_GRILLED_RESULT, COMSIG_ITEM_BAKED_RESULT, COMSIG_ITEM_MICROWAVE_COOKED_FROM), PROC_REF(convert_to_bad_food))
 	if(stink_particles)
 		add_shared_particles(stink_particles)
+
+///Prevents grilling burnt shit from well, burning.
+/obj/item/food/badrecipe/proc/OnGrill()
+	SIGNAL_HANDLER
+	return COMPONENT_HANDLED_GRILLING
+
+/**
+ * The bad food reagent is cleared when cooked rather than just spawned and the reagents of the item this is from are transferred to this instead,
+ * So we want to convert most of the consumable reagents into bad food, which is what makes the burned mess a bad thing to eat, taste aside.
+ */
+/obj/item/food/badrecipe/proc/convert_to_bad_food(atom/source)
+	SIGNAL_HANDLER
+	var/bad_food_amount = 0
+	for(var/datum/reagent/consumable/food_reagent in reagents.reagent_list)
+		var/amount_to_remove = food_reagent.volume * rand(6, 8) * 0.1 //around 60% to 80% of the volume is to be converted.
+		reagents.remove_reagent(food_reagent.type, amount_to_remove, safety = FALSE)
+		bad_food_amount += amount_to_remove
+	reagents.add_reagent(/datum/reagent/toxin/bad_food, bad_food_amount, reagtemp = reagents.chem_temp)
 
 /obj/item/food/badrecipe/Destroy(force)
 	if (stink_particles)
@@ -226,11 +245,6 @@
 /obj/item/food/badrecipe/moldy/bacteria/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2, 4), 25)
-
-///Prevents grilling burnt shit from well, burning.
-/obj/item/food/badrecipe/proc/OnGrill()
-	SIGNAL_HANDLER
-	return COMPONENT_HANDLED_GRILLING
 
 /obj/item/food/spidereggs
 	name = "spider eggs"


### PR DESCRIPTION
## About The Pull Request
When an item is cooked, reagents are generally cleared from the resulting object and the reagents of the source object are transferred to it instead. This means burned mess won't have its toxins when cooked, locking you out of one or two chemistry recipes that require it while also making the item generally not toxic at all.
So to fix it, we simply have to replace all or most of the consumable reagents inside the burned mess with bad food, via component signals.

## Why It's Good For The Game
Fixing an issue with food and chemistry.

## Changelog

:cl:
fix: burned mess made with a microwave, oven or griddle once again toxins.
/:cl:
