### PR TITLE
Water evaporation no longer cools below 0C.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -142,6 +142,7 @@
 		if(exposed_turf.air)
 			var/datum/gas_mixture/air = exposed_turf.air
 			air.temperature = clamp(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp), T0C, air.temperature) // the max temperature check is for weird phenomena like freon combustion
+			exposed_turf.temperature = clamp(min(exposed_turf.temperature-(cool_temp*1000), exposed_turf.temperature/cool_temp), T20C, exposed_turf.temperature) // turfs normally don't go below T20C so I'll just clamp it to that in case of weird phenomena.
 			air.react(src)
 			qdel(hotspot)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -141,7 +141,7 @@
 	if(hotspot && !isspaceturf(exposed_turf)) // the water evaporates in an endothermic reaction
 		if(exposed_turf.air)
 			var/datum/gas_mixture/air = exposed_turf.air
-			air.temperature = min(max(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp), T0C), air.temperature) // the max temperature check is for weird phenomena like freon combustion
+			air.temperature = min(max(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp), T0C), air.temperature) // the outer min temperature check is for weird phenomena like freon combustion
 			exposed_turf.temperature = clamp(min(exposed_turf.temperature-(cool_temp*1000), exposed_turf.temperature/cool_temp), T20C, exposed_turf.temperature) // turfs normally don't go below T20C so I'll just clamp it to that in case of weird phenomena.
 			air.react(src)
 			qdel(hotspot)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -138,10 +138,10 @@
 	var/cool_temp = cooling_temperature
 
 	var/obj/effect/hotspot/hotspot = (locate(/obj/effect/hotspot) in exposed_turf)
-	if(hotspot && !isspaceturf(exposed_turf))
+	if(hotspot && !isspaceturf(exposed_turf)) // the water evaporates in an endothermic reaction
 		if(exposed_turf.air)
 			var/datum/gas_mixture/air = exposed_turf.air
-			air.temperature = max(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp),TCMB)
+			air.temperature = clamp(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp), T0C, air.temperature) // the max temperature check is for weird phenomena like freon combustion
 			air.react(src)
 			qdel(hotspot)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -141,7 +141,7 @@
 	if(hotspot && !isspaceturf(exposed_turf)) // the water evaporates in an endothermic reaction
 		if(exposed_turf.air)
 			var/datum/gas_mixture/air = exposed_turf.air
-			air.temperature = clamp(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp), T0C, air.temperature) // the max temperature check is for weird phenomena like freon combustion
+			air.temperature = min(max(min(air.temperature-(cool_temp*1000), air.temperature/cool_temp), T0C), air.temperature) // the max temperature check is for weird phenomena like freon combustion
 			exposed_turf.temperature = clamp(min(exposed_turf.temperature-(cool_temp*1000), exposed_turf.temperature/cool_temp), T20C, exposed_turf.temperature) // turfs normally don't go below T20C so I'll just clamp it to that in case of weird phenomena.
 			air.react(src)
 			qdel(hotspot)


### PR DESCRIPTION
## About The Pull Request
Water evaporation no longer cools the air below 0C. It will also cool the floor now.
## Why It's Good For The Game
The maximum humidity in the air rapidly drops when it gets below 0C, and there is no more heat to boil the water since it already got cooled. For compensation, water evaporation now cools the floor too. Extinguishing fires caused a problem where the room went way too cold and slippery, which was just ridiculous and annoying. It was also too powerful and made a lot of fires an insignificant problem. It was also used to cheese hypernoblium formation, which wasn't the intended method, skips intended progression and felt extremely gamey.
## Changelog
:cl:
fix: Fixes water evaporation cooling the air to 2.7 Kelvin.
balance: Water evaporation can cool the floor.
/:cl:
