### PR TITLE
[NO GBP]Fixes bz formation nitrous oxide decomposition not actually creating the decomposed gas.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -555,8 +555,8 @@
 		ASSERT_GAS(/datum/gas/nitrogen, air)
 		ASSERT_GAS(/datum/gas/oxygen, air)
 		var/amount_decomposed = 0.4 * bz_formed * nitrous_oxide_decomposed_factor
-		cached_gases[/datum/gas/nitrogen] += amount_decomposed
-		cached_gases[/datum/gas/oxygen] += 0.5 * amount_decomposed
+		cached_gases[/datum/gas/nitrogen][MOLES] += amount_decomposed
+		cached_gases[/datum/gas/oxygen][MOLES] += 0.5 * amount_decomposed
 
 	ASSERT_GAS(/datum/gas/bz, air)
 	cached_gases[/datum/gas/bz][MOLES] += bz_formed * (1-nitrous_oxide_decomposed_factor)


### PR DESCRIPTION
Fixes bz formation nitrous oxide decomposition trying to modify the gas IDs instead of their [MOLES] value.
## About The Pull Request
Fixes BZ formation not properly creating nitrogen and oxygen due to trying to add to the gas lists themselves instead of their mole value. This is something I missed in #67602 and only found because I randomly decided to ask copilot to fix reactions.dm out of curiosity.
## Why It's Good For The Game
So BZ formation nitrous oxide decomposition works properly.
## Changelog
:cl:
fix: Fixes BZ formation not actually creating the nitrogen and oxygen when it decomposes nitrous oxide.
/:cl:
