### PR TITLE
Adds damage getter procs with a required_bodytype arg

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -229,7 +229,9 @@
  */
 /mob/living/carbon/get_organ_loss(slot, required_organ_flag = NONE)
 	var/obj/item/organ/affected_organ = get_organ_slot(slot)
-	if(affected_organ && required_organ_flag && (affected_organ.organ_flags & required_organ_flag))
+	if(affected_organ)
+		if(required_organ_flag && !(affected_organ.organ_flags & required_organ_flag))
+			return
 		return affected_organ.damage
 
 ////////////////////////////////////////////

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -102,7 +102,7 @@
  * Arguments:
  * *  required_bodytype - The bodytype(s) to match against.
  */
-/mob/living/carbon/getBruteLossForType(required_bodytype = ALL)
+/mob/living/carbon/proc/getBruteLossForType(required_bodytype = ALL)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
 		if(!(bodypart.bodytype & required_bodytype))

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -93,7 +93,7 @@
 /mob/living/carbon/getFireLoss(required_bodytype = NONE)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
-	if(!(bodypart.bodytype & required_bodytype))
+		if(!(bodypart.bodytype & required_bodytype))
 			continue
 		amount += bodypart.burn_dam
 	return round(amount, DAMAGE_PRECISION)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -82,7 +82,7 @@
 	return final_mod
 
 //These procs fetch a cumulative total damage from all bodyparts
-/mob/living/carbon/getBruteLoss(required_bodytype = NONE)
+/mob/living/carbon/getBruteLoss(required_bodytype = ALL)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
 		if(!(bodypart.bodytype & required_bodytype))
@@ -90,7 +90,7 @@
 		amount += bodypart.brute_dam
 	return round(amount, DAMAGE_PRECISION)
 
-/mob/living/carbon/getFireLoss(required_bodytype = NONE)
+/mob/living/carbon/getFireLoss(required_bodytype = ALL)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
 		if(!(bodypart.bodytype & required_bodytype))
@@ -202,7 +202,7 @@
  */
 /mob/living/carbon/get_organ_loss(slot, required_organ_flag = NONE)
 	var/obj/item/organ/affected_organ = get_organ_slot(slot)
-	if(affected_organ && (affected_organ.organ_flags & required_organ_flag))
+	if(affected_organ && required_organ_flag && (affected_organ.organ_flags & required_organ_flag))
 		return affected_organ.damage
 
 ////////////////////////////////////////////

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -82,7 +82,27 @@
 	return final_mod
 
 //These procs fetch a cumulative total damage from all bodyparts
-/mob/living/carbon/getBruteLoss(required_bodytype = ALL)
+/mob/living/carbon/getBruteLoss()
+	var/amount = 0
+	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
+		amount += bodypart.brute_dam
+	return round(amount, DAMAGE_PRECISION)
+
+/mob/living/carbon/getFireLoss()
+	var/amount = 0
+	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
+		amount += bodypart.burn_dam
+	return round(amount, DAMAGE_PRECISION)
+
+
+/**
+ * Returns the amount of bruteloss across all bodyparts meeting the matching bodytype.
+ * Useful for if you would like to check the bruteloss for only organic bodyparts, for example.
+ *
+ * Arguments:
+ * *  required_bodytype - The bodytype(s) to match against.
+ */
+/mob/living/carbon/getBruteLossForType(required_bodytype = ALL)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
 		if(!(bodypart.bodytype & required_bodytype))
@@ -90,7 +110,14 @@
 		amount += bodypart.brute_dam
 	return round(amount, DAMAGE_PRECISION)
 
-/mob/living/carbon/getFireLoss(required_bodytype = ALL)
+/**
+ * Returns the amount of fireloss across all bodyparts meeting the matching bodytype.
+ * Useful for if you would like to check the fireloss for only organic bodyparts, for example.
+ *
+ * Arguments:
+ * *  required_bodytype - The bodytype(s) to match against.
+ */
+/mob/living/carbon/proc/getFireLossForType(required_bodytype = ALL)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
 		if(!(bodypart.bodytype & required_bodytype))

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -82,15 +82,19 @@
 	return final_mod
 
 //These procs fetch a cumulative total damage from all bodyparts
-/mob/living/carbon/getBruteLoss()
+/mob/living/carbon/getBruteLoss(required_bodytype = NONE)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
+		if(!(bodypart.bodytype & required_bodytype))
+			continue
 		amount += bodypart.brute_dam
 	return round(amount, DAMAGE_PRECISION)
 
-/mob/living/carbon/getFireLoss()
+/mob/living/carbon/getFireLoss(required_bodytype = NONE)
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
+	if(!(bodypart.bodytype & required_bodytype))
+			continue
 		amount += bodypart.burn_dam
 	return round(amount, DAMAGE_PRECISION)
 
@@ -194,10 +198,11 @@
  *
  * Arguments:
  * * slot - organ slot, like [ORGAN_SLOT_HEART]
+ * * required_organ_flag - if you only want to check the damage of organs with the specified organ_flag(s) then you can use this.
  */
-/mob/living/carbon/get_organ_loss(slot)
+/mob/living/carbon/get_organ_loss(slot, required_organ_flag = NONE)
 	var/obj/item/organ/affected_organ = get_organ_slot(slot)
-	if(affected_organ)
+	if(affected_organ && (affected_organ.organ_flags & required_organ_flag))
 		return affected_organ.damage
 
 ////////////////////////////////////////////

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -266,7 +266,7 @@
 			return HAS_TRAIT(src, TRAIT_TOXIMMUNE) ? 0 : 1
 	return 1
 
-/mob/living/proc/getBruteLoss(required_bodytype)
+/mob/living/proc/getBruteLoss()
 	return bruteloss
 
 /mob/living/proc/can_adjust_brute_loss(amount, forced, required_bodytype)
@@ -401,7 +401,7 @@
 	if(updating_health)
 		updatehealth()
 
-/mob/living/proc/getFireLoss(required_bodytype)
+/mob/living/proc/getFireLoss()
 	return fireloss
 
 /mob/living/proc/can_adjust_fire_loss(amount, forced, required_bodytype)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -266,7 +266,7 @@
 			return HAS_TRAIT(src, TRAIT_TOXIMMUNE) ? 0 : 1
 	return 1
 
-/mob/living/proc/getBruteLoss()
+/mob/living/proc/getBruteLoss(required_bodytype)
 	return bruteloss
 
 /mob/living/proc/can_adjust_brute_loss(amount, forced, required_bodytype)
@@ -401,7 +401,7 @@
 	if(updating_health)
 		updatehealth()
 
-/mob/living/proc/getFireLoss()
+/mob/living/proc/getFireLoss(required_bodytype)
 	return fireloss
 
 /mob/living/proc/can_adjust_fire_loss(amount, forced, required_bodytype)
@@ -439,7 +439,7 @@
 /mob/living/proc/setOrganLoss(slot, amount, maximum, required_organ_flag)
 	return
 
-/mob/living/proc/get_organ_loss(slot)
+/mob/living/proc/get_organ_loss(slot, required_organ_flag)
 	return
 
 /mob/living/proc/getStaminaLoss()

--- a/code/modules/pai/defense.dm
+++ b/code/modules/pai/defense.dm
@@ -85,8 +85,8 @@
 	take_holo_damage(amount * ((forced) ? 1 : 0.25))
 	return COMPONENT_IGNORE_CHANGE
 
-/mob/living/silicon/pai/getBruteLoss(required_bodytype = NONE)
+/mob/living/silicon/pai/getBruteLoss(required_bodytype = ALL)
 	return HOLOCHASSIS_MAX_HEALTH - holochassis_health
 
-/mob/living/silicon/pai/getFireLoss(required_bodytype = NONE)
+/mob/living/silicon/pai/getFireLoss(required_bodytype = ALL)
 	return HOLOCHASSIS_MAX_HEALTH - holochassis_health

--- a/code/modules/pai/defense.dm
+++ b/code/modules/pai/defense.dm
@@ -85,8 +85,8 @@
 	take_holo_damage(amount * ((forced) ? 1 : 0.25))
 	return COMPONENT_IGNORE_CHANGE
 
-/mob/living/silicon/pai/getBruteLoss()
+/mob/living/silicon/pai/getBruteLoss(required_bodytype = NONE)
 	return HOLOCHASSIS_MAX_HEALTH - holochassis_health
 
-/mob/living/silicon/pai/getFireLoss()
+/mob/living/silicon/pai/getFireLoss(required_bodytype = NONE)
 	return HOLOCHASSIS_MAX_HEALTH - holochassis_health

--- a/code/modules/pai/defense.dm
+++ b/code/modules/pai/defense.dm
@@ -85,8 +85,8 @@
 	take_holo_damage(amount * ((forced) ? 1 : 0.25))
 	return COMPONENT_IGNORE_CHANGE
 
-/mob/living/silicon/pai/getBruteLoss(required_bodytype = ALL)
+/mob/living/silicon/pai/getBruteLoss()
 	return HOLOCHASSIS_MAX_HEALTH - holochassis_health
 
-/mob/living/silicon/pai/getFireLoss(required_bodytype = ALL)
+/mob/living/silicon/pai/getFireLoss()
 	return HOLOCHASSIS_MAX_HEALTH - holochassis_health

--- a/code/modules/unit_tests/mob_damage.dm
+++ b/code/modules/unit_tests/mob_damage.dm
@@ -100,13 +100,13 @@
 	if(included_types & BRUTELOSS)
 		TEST_ASSERT_EQUAL(round(testing_mob.getBruteLoss(), 1), amount, \
 			"(Testing getBruteLoss()) [testing_mob] should have [amount] brute damage, instead they have [testing_mob.getBruteLoss()]!")
-		TEST_ASSERT_EQUAL(round(testing_mob.getBruteLossForType(BODTYPE_ORGANIC), 1), amount, \
-			"(Testing getBruteLossForType(BODYTYPE_ORGANIC)) [testing_mob] should have [amount] brute damage, instead they have [testing_mob.getBruteLossForType(BODTYPE_ORGANIC)]!")
+		TEST_ASSERT_EQUAL(round(testing_mob.getBruteLossForType(BODYTYPE_ORGANIC), 1), amount, \
+			"(Testing getBruteLossForType(BODYTYPE_ORGANIC)) [testing_mob] should have [amount] brute damage, instead they have [testing_mob.getBruteLossForType(BODYTYPE_ORGANIC)]!")
 	if(included_types & FIRELOSS)
 		TEST_ASSERT_EQUAL(round(testing_mob.getFireLoss(), 1), amount, \
 			"(Testing getFireLoss()) [testing_mob] should have [amount] burn damage, instead they have [testing_mob.getFireLoss()]!")
-		TEST_ASSERT_EQUAL(round(testing_mob.getFireLossForType(BODTYPE_ORGANIC), 1), amount, \
-			"(Testing getFireLossForType(BODYTYPE_ORGANIC)) [testing_mob] should have [amount] burn damage, instead they have [testing_mob.getFireLossForType(BODTYPE_ORGANIC)]!")
+		TEST_ASSERT_EQUAL(round(testing_mob.getFireLossForType(BODYTYPE_ORGANIC), 1), amount, \
+			"(Testing getFireLossForType(BODYTYPE_ORGANIC)) [testing_mob] should have [amount] burn damage, instead they have [testing_mob.getFireLossForType(BODYTYPE_ORGANIC)]!")
 	if(included_types & OXYLOSS)
 		TEST_ASSERT_EQUAL(testing_mob.getOxyLoss(), amount, \
 			"[testing_mob] should have [amount] oxy damage, instead they have [testing_mob.getOxyLoss()]!")

--- a/code/modules/unit_tests/mob_damage.dm
+++ b/code/modules/unit_tests/mob_damage.dm
@@ -99,10 +99,14 @@
 			"[testing_mob] should have [amount] toxin damage, instead they have [testing_mob.getToxLoss()]!")
 	if(included_types & BRUTELOSS)
 		TEST_ASSERT_EQUAL(round(testing_mob.getBruteLoss(), 1), amount, \
-			"[testing_mob] should have [amount] brute damage, instead they have [testing_mob.getBruteLoss()]!")
+			"(Testing getBruteLoss()) [testing_mob] should have [amount] brute damage, instead they have [testing_mob.getBruteLoss()]!")
+		TEST_ASSERT_EQUAL(round(testing_mob.getBruteLossForType(BODTYPE_ORGANIC), 1), amount, \
+			"(Testing getBruteLossForType(BODYTYPE_ORGANIC)) [testing_mob] should have [amount] brute damage, instead they have [testing_mob.getBruteLossForType(BODTYPE_ORGANIC)]!")
 	if(included_types & FIRELOSS)
 		TEST_ASSERT_EQUAL(round(testing_mob.getFireLoss(), 1), amount, \
-			"[testing_mob] should have [amount] burn damage, instead they have [testing_mob.getFireLoss()]!")
+			"(Testing getFireLoss()) [testing_mob] should have [amount] burn damage, instead they have [testing_mob.getFireLoss()]!")
+		TEST_ASSERT_EQUAL(round(testing_mob.getFireLossForType(BODTYPE_ORGANIC), 1), amount, \
+			"(Testing getFireLossForType(BODYTYPE_ORGANIC)) [testing_mob] should have [amount] burn damage, instead they have [testing_mob.getFireLossForType(BODTYPE_ORGANIC)]!")
 	if(included_types & OXYLOSS)
 		TEST_ASSERT_EQUAL(testing_mob.getOxyLoss(), amount, \
 			"[testing_mob] should have [amount] oxy damage, instead they have [testing_mob.getOxyLoss()]!")

--- a/code/modules/unit_tests/mob_damage.dm
+++ b/code/modules/unit_tests/mob_damage.dm
@@ -93,7 +93,7 @@
  * * amount - the amount of damage to verify that the mob has
  * * included_types - Bitflag of damage types to check.
  */
-/datum/unit_test/mob_damage/proc/verify_damage(mob/living/testing_mob, amount, included_types = ALL)
+/datum/unit_test/mob_damage/proc/verify_damage(mob/living/carbon/testing_mob, amount, included_types = ALL)
 	if(included_types & TOXLOSS)
 		TEST_ASSERT_EQUAL(testing_mob.getToxLoss(), amount, \
 			"[testing_mob] should have [amount] toxin damage, instead they have [testing_mob.getToxLoss()]!")
@@ -128,7 +128,7 @@
  * * bodytypes - the bodytypes of damage to apply
  * * forced - whether or not this is forced damage
  */
-/datum/unit_test/mob_damage/proc/apply_damage(mob/living/testing_mob, amount, expected = -amount, included_types = ALL, biotypes = ALL, bodytypes = ALL, forced = FALSE)
+/datum/unit_test/mob_damage/proc/apply_damage(mob/living/carbon/testing_mob, amount, expected = -amount, included_types = ALL, biotypes = ALL, bodytypes = ALL, forced = FALSE)
 	var/damage_returned
 	if(included_types & TOXLOSS)
 		damage_returned = testing_mob.adjustToxLoss(amount, updating_health = FALSE, forced = forced, required_biotype = biotypes)
@@ -165,7 +165,7 @@
  * * bodytypes - the bodytypes of damage to apply
  * * forced - whether or not this is forced damage
  */
-/datum/unit_test/mob_damage/proc/set_damage(mob/living/testing_mob, amount, expected = -amount, included_types = ALL, biotypes = ALL, bodytypes = ALL, forced = FALSE)
+/datum/unit_test/mob_damage/proc/set_damage(mob/living/carbon/testing_mob, amount, expected = -amount, included_types = ALL, biotypes = ALL, bodytypes = ALL, forced = FALSE)
 	var/damage_returned
 	if(included_types & TOXLOSS)
 		damage_returned = testing_mob.setToxLoss(amount, updating_health = FALSE, forced = forced, required_biotype = biotypes)
@@ -473,7 +473,7 @@
  * * expected - the expected return value of the damage procs, if it differs from the default of (amount * 4)
  * * included_types - Bitflag of damage types to check.
  */
-/datum/unit_test/mob_damage/animal/verify_damage(mob/living/testing_mob, amount, expected, included_types = ALL)
+/datum/unit_test/mob_damage/animal/verify_damage(mob/living/carbon/testing_mob, amount, expected, included_types = ALL)
 	if(included_types & TOXLOSS)
 		TEST_ASSERT_EQUAL(testing_mob.getToxLoss(), 0, \
 			"[testing_mob] should have [0] toxin damage, instead they have [testing_mob.getToxLoss()]!")
@@ -491,7 +491,7 @@
 			"[testing_mob] should have [amount] stamina damage, instead they have [testing_mob.getStaminaLoss()]!")
 	return TRUE
 
-/datum/unit_test/mob_damage/animal/test_sanity_simple(mob/living/test_mob)
+/datum/unit_test/mob_damage/animal/test_sanity_simple(mob/living/carbon/test_mob)
 	// check to see if basic mob damage works
 
 	// Simple damage and healing
@@ -522,7 +522,7 @@
 	if(!test_apply_damage(test_mob, amount = -35, expected = 0))
 		TEST_FAIL("ABOVE FAILURE: failed test_sanity_simple! overhealing was not applied correctly")
 
-/datum/unit_test/mob_damage/animal/test_sanity_complex(mob/living/test_mob)
+/datum/unit_test/mob_damage/animal/test_sanity_complex(mob/living/carbon/test_mob)
 	// Heal up, so that errors from the previous tests we won't cause this one to fail
 	test_mob.fully_heal(HEAL_DAMAGE)
 	var/damage_returned

--- a/code/modules/unit_tests/organs.dm
+++ b/code/modules/unit_tests/organs.dm
@@ -83,6 +83,9 @@
 		"Mob level \"apply organ damage\" returned the wrong value for [slot_to_use] organ with default arguments.")
 	TEST_ASSERT_EQUAL(dummy.get_organ_loss(slot_to_use), test_organ.maxHealth, \
 		"Mob level \"apply organ damage\" can exceed the [slot_to_use] organ's damage cap with default arguments.")
+	TEST_ASSERT_EQUAL(dummy.get_organ_loss(slot_to_use, required_organ_flag = test_organ.organ_flags), test_organ.maxHealth, \
+		"(Testing get_organ_loss() with required_organ_flag = [test_organ.organ_flags]) \
+			Mob level \"apply organ damage\" can exceed the [slot_to_use] organ's damage cap with default arguments.")
 	dummy.fully_heal(HEAL_ORGANS)
 
 	// Tests [mob/living/proc/set_organ_damage]
@@ -97,6 +100,9 @@
 		"Mob level \"apply organ damage\" returned the wrong value for [slot_to_use] organ with a large maximum supplied.")
 	TEST_ASSERT_EQUAL(dummy.get_organ_loss(slot_to_use), test_organ.maxHealth, \
 		"Mob level \"apply organ damage\" can exceed the [slot_to_use] organ's damage cap with a large maximum supplied.")
+	TEST_ASSERT_EQUAL(dummy.get_organ_loss(slot_to_use, required_organ_flag = test_organ.organ_flags), test_organ.maxHealth, \
+		"(Testing get_organ_loss() with required_organ_flag = [test_organ.organ_flags]) \
+			Mob level \"apply organ damage\" can exceed the [slot_to_use] organ's damage cap with a large maximum supplied.")
 	dummy.fully_heal(HEAL_ORGANS)
 
 ///Allocate a human mob, give 'em a skillchip and a generic trauma, then see if it throws any error when the brain is removed.


### PR DESCRIPTION
## About The Pull Request

There is a way to specify bodytypes and organ flags when dealing damage, but no such thing exists when checking the damage for _some reason_.

This means you can't do easily something like check how much damage is done specifically to nonrobotic limbs.

No more! This PR just adds an arg that probably should have been there for a while now. Should not have any noticeable effects in-game.

## Why It's Good For The Game

Better procs for coders mean less of a need to do janky things.

## Changelog

:cl:
code: adds support to check for a required_bodytype or required_organ_flag for the damage getter procs
/:cl:
