### PR TITLE
Removes the magical healing anti-stun inspiration banners from Catwalk and replace them with their mundane variants

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -8559,8 +8559,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "cAs" = (
-/obj/item/banner,
 /obj/structure/disposalpipe/segment,
+/obj/item/banner/command/mundane,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "cAv" = (
@@ -41184,7 +41184,9 @@
 /area/station/cargo/warehouse)
 "mdn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/banner/red,
+/obj/item/banner/red{
+	inspiration_available = 0
+	},
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "mdp" = (
@@ -64057,7 +64059,9 @@
 /area/station/security/courtroom)
 "sTK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/banner/blue,
+/obj/item/banner/blue{
+	inspiration_available = 0
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/eighties,


### PR DESCRIPTION

## About The Pull Request
These inspiration banners are removed on all the other maps a long long time ago but they were put on Catwalk. They let you use them in hand to heal brute, burn, and stuns. As I understand it they aren't meant to be available to crewmembers outside of admin events and gimmicks.

## Why It's Good For The Game
Fixes an oversight

## Changelog
:cl: Bisar
fix: Correct a few banners on Catwalk Station to be mundane banners, and not the magic barriers that heal you and remove your stuns.
/:cl:
