### PR TITLE
Declutters settlers a bit.

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -24,9 +24,9 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/mute, /datum/quirk/softspoken),
 	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
 	list(/datum/quirk/bilingual, /datum/quirk/foreigner, /datum/quirk/csl),
-	list(/datum/quirk/spacer_born, /datum/quirk/item_quirk/settler),
+	list(/datum/quirk/spacer_born, /datum/quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
-	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
+	list(/datum/quirk/settler, /datum/quirk/freerunning),
 	list(/datum/quirk/numb, /datum/quirk/selfaware),
 	list(/datum/quirk/empath, /datum/quirk/evil),
 ))

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -1,4 +1,4 @@
-/datum/quirk/item_quirk/settler
+/datum/quirk/settler
 	name = "Settler"
 	desc = "You are from a lineage of the earliest space settlers! While your family's generational exposure to varying gravity \
 		has resulted in a ... smaller height than is typical for your species, you make up for it by being much better at outdoorsmanship and \
@@ -6,7 +6,7 @@
 	gain_text = span_bold("You feel like the world is your oyster!")
 	lose_text = span_danger("You think you might stay home today.")
 	icon = FA_ICON_HOUSE
-	value = 4
+	value = 5
 	mob_trait = TRAIT_SETTLER
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 	medical_record_text = "Patient has been exposed to planetary conditions for extended periods, resulting in an excessively stout build."
@@ -23,22 +23,16 @@
 		TRAIT_STURDY_FRAME,
 	)
 
-/datum/quirk/item_quirk/settler/add(client/client_source)
+/datum/quirk/settler/add(client/client_source)
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
-	human_quirkholder.physiology.hunger_mod *= 0.75 //good for you, shortass, you don't get hungry nearly as often
 	human_quirkholder.add_traits(settler_traits, QUIRK_TRAIT)
 
-/datum/quirk/item_quirk/settler/add_unique(client/client_source)
-	give_item_to_holder(/obj/item/storage/box/papersack/wheat, list(LOCATION_BACKPACK, LOCATION_HANDS))
-	give_item_to_holder(/obj/item/storage/toolbox/fishing/small, list(LOCATION_BACKPACK, LOCATION_HANDS))
-
-/datum/quirk/item_quirk/settler/remove()
+/datum/quirk/settler/remove()
 	if(QDELING(quirk_holder))
 		return
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
 	human_quirkholder.remove_movespeed_modifier(/datum/movespeed_modifier/settler)
-	human_quirkholder.physiology.hunger_mod /= 0.75
 	human_quirkholder.remove_traits(settler_traits, QUIRK_TRAIT)

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -6,7 +6,7 @@
 	gain_text = span_bold("You feel like the world is your oyster!")
 	lose_text = span_danger("You think you might stay home today.")
 	icon = FA_ICON_HOUSE
-	value = 5
+	value = 4
 	mob_trait = TRAIT_SETTLER
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 	medical_record_text = "Patient has been exposed to planetary conditions for extended periods, resulting in an excessively stout build."

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -166,7 +166,7 @@
 	multiplicative_slowdown = -26
 
 /datum/movespeed_modifier/settler
-	multiplicative_slowdown = 0.25
+	multiplicative_slowdown = 0.2
 	blacklisted_movetypes = FLOATING|FLYING
 
 /datum/movespeed_modifier/basilisk_overheat

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -166,7 +166,7 @@
 	multiplicative_slowdown = -26
 
 /datum/movespeed_modifier/settler
-	multiplicative_slowdown = 0.3
+	multiplicative_slowdown = 0.25
 	blacklisted_movetypes = FLOATING|FLYING
 
 /datum/movespeed_modifier/basilisk_overheat

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -166,7 +166,7 @@
 	multiplicative_slowdown = -26
 
 /datum/movespeed_modifier/settler
-	multiplicative_slowdown = 0.2
+	multiplicative_slowdown = 0.3
 	blacklisted_movetypes = FLOATING|FLYING
 
 /datum/movespeed_modifier/basilisk_overheat


### PR DESCRIPTION
## About The Pull Request

Removes the hunger protection settlers get.
Removes the items that settlers spawn with.

## Why It's Good For The Game

>Hunger

This bloats the quirk in a really noninteractive way, and most people wouldn't even notice it as a meaningful upside. I don't even know what I was thinking adding this.

> Items

They're clutter, and mostly existed to get you to interact with the new mechanics that this quirk was incentivizing you to go interact with. Now that those mechanics have expanded a bit, this is no longer necessary.

## Changelog
:cl:
balance: Removes the hunger protection settlers get.
balance: Removes the items that settlers spawn with.
/:cl:
