### PR TITLE
Fixes constant and realtime station time being calculated incorrectly

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -8,7 +8,7 @@
 	return time2text(wtime, format, NO_TIMEZONE)
 
 ///returns the current IC station time in a world.time format
-/proc/station_time(display_only = FALSE, wtime=world.time)
+/proc/station_time(wtime = world.time)
 	return (((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % (24 HOURS)
 
 ///returns the current IC station time in a human readable format

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -129,7 +129,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
  * the timezone is the time value offset from the local time. It's to be applied outside time2text() to get the AM/PM right.
  */
 /proc/time_to_twelve_hour(time, format = "hh:mm:ss", timezone = TIMEZONE_UTC)
-	time = MODULUS(time + (timezone HOURS), 24 HOURS)
+	time = MODULUS(time + (timezone * (1 HOURS)), 24 HOURS)
 	var/am_pm = "AM"
 	if(time > 12 HOURS)
 		am_pm = "PM"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -129,7 +129,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
  * the timezone is the time value offset from the local time. It's to be applied outside time2text() to get the AM/PM right.
  */
 /proc/time_to_twelve_hour(time, format = "hh:mm:ss", timezone = TIMEZONE_UTC)
-	time = MODULUS(time + (timezone - GLOB.timezoneOffset) HOURS, 24 HOURS)
+	time = MODULUS(time + (timezone HOURS), 24 HOURS)
 	var/am_pm = "AM"
 	if(time > 12 HOURS)
 		am_pm = "PM"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -9,7 +9,7 @@
 
 ///returns the current IC station time in a world.time format
 /proc/station_time(display_only = FALSE, wtime=world.time)
-	return ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+	return (((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % (24 HOURS)
 
 ///returns the current IC station time in a human readable format
 /proc/station_time_timestamp(format = "hh:mm:ss", wtime)
@@ -19,11 +19,11 @@
 	if(isnum(force_set))
 		SSticker.gametime_offset = force_set
 		return
-	SSticker.gametime_offset = rand(0, 864000) //hours in day * minutes in hour * seconds in minute * deciseconds in second
+	SSticker.gametime_offset = rand(0, 24 HOURS) //hours in day * minutes in hour * seconds in minute * deciseconds in second
 	if(prob(50))
-		SSticker.gametime_offset = FLOOR(SSticker.gametime_offset, 3600)
+		SSticker.gametime_offset = FLOOR(SSticker.gametime_offset, 1 HOURS)
 	else
-		SSticker.gametime_offset = CEILING(SSticker.gametime_offset, 3600)
+		SSticker.gametime_offset = CEILING(SSticker.gametime_offset, 1 HOURS)
 
 ///returns timestamp in a sql and a not-quite-compliant ISO 8601 friendly format. Do not use for SQL, use NOW() instead
 /proc/ISOtime(timevar)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -142,11 +142,13 @@ SUBSYSTEM_DEF(ticker)
 
 		GLOB.syndicate_code_response_regex = codeword_match
 
-	start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)
+	start_at = world.time + (CONFIG_GET(number/lobby_countdown) SECONDS)
+	round_start_time = start_at // May be changed later, but prevents the time from jumping back when the round actually starts
 	if(CONFIG_GET(flag/randomize_shift_time))
 		gametime_offset = rand(0, 23) HOURS
 	else if(CONFIG_GET(flag/shift_time_realtime))
-		gametime_offset = world.timeofday
+		gametime_offset = world.timeofday + GLOB.timezoneOffset
+		station_time_rate_multiplier = 1
 	else
 		gametime_offset = (CONFIG_GET(number/shift_time_start_hour) HOURS)
 	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -142,15 +142,15 @@ SUBSYSTEM_DEF(ticker)
 
 		GLOB.syndicate_code_response_regex = codeword_match
 
-	start_at = world.time + (CONFIG_GET(number/lobby_countdown) SECONDS)
+	start_at = world.time + (CONFIG_GET(number/lobby_countdown) * (1 SECONDS))
 	round_start_time = start_at // May be changed later, but prevents the time from jumping back when the round actually starts
 	if(CONFIG_GET(flag/randomize_shift_time))
-		gametime_offset = rand(0, 23) HOURS
+		gametime_offset = rand(0, 23) * (1 HOURS)
 	else if(CONFIG_GET(flag/shift_time_realtime))
 		gametime_offset = world.timeofday + GLOB.timezoneOffset
 		station_time_rate_multiplier = 1
 	else
-		gametime_offset = (CONFIG_GET(number/shift_time_start_hour) HOURS)
+		gametime_offset = (CONFIG_GET(number/shift_time_start_hour) * (1 HOURS))
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/ticker/fire()


### PR DESCRIPTION

## About The Pull Request

Sorta-config related, replaced magic numbers in station time code with defines and fixed station time calculations.
Constant time was (incorrectly) adjusted by your timezone in actual station time calculations despite us changing all time ops to UTC+0, and realtime was adjusted by your timezone in the wrong direction (realtime returns GMT, and station time itself deducted your timezone again). Also fixed station_time_debug debug proc using seconds instead of deciseconds (by converting it to defines)

I've also made realtime config change time dilation factor from 12 to 1, as its intended to make station time reflect real time *in the server's own timezone*, and 12x time dilation made it deviate from that extremely quickly (this does not affect gameplay in any meaningful manner, station time dilation only affects displayed clock time and not any in-game events except nightshifts)

- Closes #92380

## Changelog
:cl:
fix: Fixed constant and realtime station time being calculated incorrectly
/:cl:
