### PR TITLE
Biodegrade now dissolves all restraints simultaneously; including grabs

### DIFF
--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -44,6 +44,7 @@
 		for(var/beat in 1 to 3)
 			addtimer(CALLBACK(src, PROC_REF(make_puddle), restraint), beat SECONDS)
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), restraint, 'sound/items/tools/welder.ogg', 50, TRUE), beat SECONDS)
+		log_combat(user = user, target = restraint, what_done = "melted restraining container", addition = "(biodegrade)")
 		return
 	//otherwise it's some kind of worn restraint
 	user.visible_message(
@@ -53,6 +54,8 @@
 	addtimer(CALLBACK(restraint, TYPE_PROC_REF(/atom, atom_destruction), ACID), 1.5 SECONDS)
 	playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
 	make_puddle(restraint)
+	log_combat(user = user, target = restraint, what_done = "melted restraining equipped item", addition = "(biodegrade)")
+
 
 /datum/action/changeling/biodegrade/proc/make_puddle(obj/melted_restraint)
 	return new /obj/effect/decal/cleanable/greenglow(get_turf(melted_restraint))
@@ -68,6 +71,7 @@
 		hapless_manhandler.Stun(2 SECONDS)
 		hapless_manhandler.adjustFireLoss(40, updating_health = TRUE)
 		hapless_manhandler.stop_pulling()
+		log_combat(user = user, target = hapless_manhandler, what_done = "acid-spewed to escape a grab", addition = "(biodegrade)")
 		return
 	var/mob/living/carbon/hapless_carbon = hapless_manhandler
 	var/obj/item/bodypart/arm/doomed_limb = hapless_carbon.get_active_hand()
@@ -95,4 +99,5 @@
 	doomed_limb.dismember()
 	hapless_carbon.Stun(2 SECONDS)
 	hapless_carbon.stop_pulling()
+	log_combat(user = user, target = hapless_carbon, what_done = "delimbed to escape a grab", addition = "(biodegrade)")
 	return

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -9,18 +9,18 @@
 	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
-	..()
 	var/list/obj/restraints = list()
 	var/obj/item/clothing/suit/straitjacket = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	if(!straitjacket?.breakouttime)
 		straitjacket = null
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
 	var/obj/handcuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-	var/obj/some_manner_of_cage = user.loc
-	var/mob/living/space_invader = user.pulled_by
+	var/obj/some_manner_of_cage = astype(user.loc, /obj)
+	var/mob/living/space_invader = user.pulledby
 	if(!straitjacket && !legcuffs && !handcuffs && !some_manner_of_cage && !space_invader)
 		user.balloon_alert(user, "already free!")
 		return FALSE
+	..()
 	if(straitjacket)
 		restraints.Add(straitjacket)
 	if(legcuffs)
@@ -37,9 +37,62 @@
 
 /datum/action/changeling/biodegrade/proc/spew_acid(mob/living/carbon/human/user, obj/restraint)
 	if(restraint == user.loc)
-		restraint.visible_message("Bubbling acid start spewing out of [src]...")
-		addtimer(CALLBACK())
+		restraint.visible_message(span_userdanger("Bubbling acid start spewing out of [restraint]..."))
+		addtimer(CALLBACK(restraint, TYPE_PROC_REF(/atom, atom_destruction), ACID), 4 SECONDS)
+		// create multiple decals to signal to anyone pushing the locker to the crematorium
+		// that "oh lawd ling comin"
+		for(var/beat in 1 to 3)
+			addtimer(CALLBACK(src, PROC_REF(make_puddle), restraint), beat SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), restraint, 'sound/items/tools/welder.ogg', 50, TRUE), beat SECONDS)
+		return
+	//otherwise it's some kind of worn restraint
+	user.visible_message(
+		span_userdanger("[user] spews torrents of acid onto [restraint], melting it with horrifying ease."),
+		user.balloon_alert(user, "melting restraints..."),
+		span_danger("You hear retching, then the sizzling of powerful acid, closer to the sound of hissing steam."))
+	addtimer(CALLBACK(restraint, TYPE_PROC_REF(/atom, atom_destruction), ACID), 1.5 SECONDS)
+	playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
+	make_puddle(restraint)
 
+/datum/action/changeling/biodegrade/proc/make_puddle(obj/melted_restraint)
+	return new /obj/effect/decal/cleanable/greenglow(get_turf(melted_restraint))
 
-
- /proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hopeless_manhandler)
+/datum/action/changeling/biodegrade/proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hapless_manhandler)
+	if(!iscarbon(hapless_manhandler))
+		user.visible_message(
+			span_danger("[user] spews a torrent of sizzling acid onto [hapless_manhandler], using the opportunity to wrestle away."),
+			user.balloon_alert(user, "dissuading captor..."),
+			span_danger("You hear retching, then sizzling, quickly muffled by a loud keening of pain."))
+		playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
+		hapless_manhandler.emote("scream")
+		hapless_manhandler.Stun(2 SECONDS)
+		hapless_manhandler.adjustFireLoss(40, updating_health = TRUE)
+		hapless_manhandler.stop_pulling()
+		return
+	var/mob/living/carbon/hapless_carbon = hapless_manhandler
+	var/obj/item/bodypart/arm/doomed_limb = hapless_carbon.get_active_hand()
+	var/bio_state = doomed_limb.biological_state
+	var/danger_message
+	if(!(bio_state & BIO_FLESH) && !(bio_state & BIO_BONE))
+		if(bio_state & BIO_METAL)
+			danger_message = "metal and wire"
+		else
+			danger_message = "the limb"
+	else if (bio_state & BIO_FLESH)
+		if(bio_state & BIO_BONE)
+			danger_message = "blood and bone"
+	else if (bio_state & BIO_BONE)
+		danger_message = "the bony connections"
+	else//someone was being silly with bio_state in this case but let's avoid a runtime
+		danger_message = "the limb"
+	user.visible_message(
+		span_danger("[user] spews acid onto the arm [hapless_manhandler] grabs [user.p_them()] with, melting through [danger_message]!"),
+		user.balloon_alert(user, "removing captor's grab..."),
+		span_danger("You hear someone retching, followed quickly by a horrible sizzling, which is then muffled by a terrible wail of pain."))
+	to_chat(hapless_carbon, span_userdanger("YOUR ARM IS MELTING OFF!"))
+	playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
+	hapless_carbon.emote("scream")
+	doomed_limb.dismember()
+	hapless_carbon.Stun(2 SECONDS)
+	hapless_carbon.stop_pulling()
+	return

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -9,108 +9,37 @@
 	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
-	if(user.handcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-		if(!istype(O))
-			return FALSE
-		user.visible_message(span_warning("[user] vomits a glob of acid on [user.p_their()] [O]!"), \
-			span_warning("We vomit acidic ooze onto our restraints!"))
+	..()
+	var/list/obj/restraints = list()
+	var/obj/item/clothing/suit/straitjacket = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if(!straitjacket?.breakouttime)
+		straitjacket = null
+	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
+	var/obj/handcuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
+	var/obj/some_manner_of_cage = user.loc
+	var/mob/living/space_invader = user.pulled_by
+	if(!straitjacket && !legcuffs && !handcuffs && !some_manner_of_cage && !space_invader)
+		user.balloon_alert(user, "already free!")
+		return FALSE
+	if(straitjacket)
+		restraints.Add(straitjacket)
+	if(legcuffs)
+		restraints.Add(legcuffs)
+	if(handcuffs)
+		restraints.Add(handcuffs)
+	if(some_manner_of_cage)
+		restraints.Add(some_manner_of_cage)
+	for(var/obj/restraint as anything in restraints)
+		spew_acid(user, restraint)
+	if(space_invader)
+		punish_with_acid(user, space_invader)
+	return TRUE
 
-		addtimer(CALLBACK(src, PROC_REF(dissolve_handcuffs), user, O), 3 SECONDS)
-		log_combat(user, user.handcuffed, "melted handcuffs", addition = "(biodegrade)")
-		..()
-		return TRUE
+/datum/action/changeling/biodegrade/proc/spew_acid(mob/living/carbon/human/user, obj/restraint)
+	if(restraint == user.loc)
+		restraint.visible_message("Bubbling acid start spewing out of [src]...")
+		addtimer(CALLBACK())
 
-	if(user.legcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
-		if(!istype(O))
-			return FALSE
-		user.visible_message(span_warning("[user] vomits a glob of acid on [user.p_their()] [O]!"), \
-			span_warning("We vomit acidic ooze onto our restraints!"))
 
-		addtimer(CALLBACK(src, PROC_REF(dissolve_legcuffs), user, O), 3 SECONDS)
-		log_combat(user, user.legcuffed, "melted legcuffs", addition = "(biodegrade)")
-		..()
-		return TRUE
 
-	if(user.wear_suit?.breakouttime)
-		var/obj/item/clothing/suit/S = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(!istype(S))
-			return FALSE
-		user.visible_message(span_warning("[user] vomits a glob of acid across the front of [user.p_their()] [S]!"), \
-			span_warning("We vomit acidic ooze onto our [user.wear_suit.name]!"))
-		addtimer(CALLBACK(src, PROC_REF(dissolve_straightjacket), user, S), 3 SECONDS)
-		log_combat(user, user.wear_suit, "melted [user.wear_suit]", addition = "(biodegrade)")
-		..()
-		return TRUE
-
-	if(istype(user.loc, /obj/structure/closet))
-		var/obj/structure/closet/C = user.loc
-		if(!istype(C))
-			return FALSE
-		C.visible_message(span_warning("[C]'s hinges suddenly begin to melt and run!"))
-		to_chat(user, span_warning("We vomit acidic goop onto the interior of [C]!"))
-		addtimer(CALLBACK(src, PROC_REF(open_closet), user, C), 7 SECONDS)
-		log_combat(user, user.loc, "melted locker", addition = "(biodegrade)")
-		..()
-		return TRUE
-
-	if(istype(user.loc, /obj/structure/spider/cocoon))
-		var/obj/structure/spider/cocoon/C = user.loc
-		if(!istype(C))
-			return FALSE
-		C.visible_message(span_warning("[src] shifts and starts to fall apart!"))
-		to_chat(user, span_warning("We secrete acidic enzymes from our skin and begin melting our cocoon..."))
-		addtimer(CALLBACK(src, PROC_REF(dissolve_cocoon), user, C), 25) //Very short because it's just webs
-		log_combat(user, user.loc, "melted cocoon", addition = "(biodegrade)")
-		..()
-		return TRUE
-
-	var/obj/item/clothing/shoes/shoes = user.shoes
-	if(istype(shoes) && shoes.tied == SHOES_KNOTTED && !(shoes.resistance_flags & (INDESTRUCTIBLE|UNACIDABLE|ACID_PROOF)))
-		new /obj/effect/decal/cleanable/greenglow(shoes.drop_location())
-		user.visible_message(
-			span_warning("[user] vomits a glob of acid on [user.p_their()] tied up [shoes.name], melting [shoes.p_them()] into a pool of goo!"),
-			span_warning("We vomit acidic ooze onto our tied up [shoes.name], melting [shoes.p_them()] into a pool of goo!"),
-		)
-		log_combat(user, shoes, "melted own shoes", addition = "(biodegrade)")
-		qdel(shoes)
-		..()
-		return TRUE
-
-	user.balloon_alert(user, "already free!")
-	return FALSE
-
-/datum/action/changeling/biodegrade/proc/dissolve_handcuffs(mob/living/carbon/human/user, obj/O)
-	if(O && user.handcuffed == O)
-		user.visible_message(span_warning("[O] dissolve[O.gender == PLURAL?"":"s"] into a puddle of sizzling goop."))
-		new /obj/effect/decal/cleanable/greenglow(O.drop_location())
-		qdel(O)
-
-/datum/action/changeling/biodegrade/proc/dissolve_legcuffs(mob/living/carbon/human/user, obj/O)
-	if(O && user.legcuffed == O)
-		user.visible_message(span_warning("[O] dissolve[O.gender == PLURAL?"":"s"] into a puddle of sizzling goop."))
-		new /obj/effect/decal/cleanable/greenglow(O.drop_location())
-		qdel(O)
-
-/datum/action/changeling/biodegrade/proc/dissolve_straightjacket(mob/living/carbon/human/user, obj/S)
-	if(S && user.wear_suit == S)
-		user.visible_message(span_warning("[S] dissolves into a puddle of sizzling goop."))
-		new /obj/effect/decal/cleanable/greenglow(S.drop_location())
-		qdel(S)
-
-/datum/action/changeling/biodegrade/proc/open_closet(mob/living/carbon/human/user, obj/structure/closet/C)
-	if(C && user.loc == C)
-		C.visible_message(span_warning("[C]'s door breaks and opens!"))
-		new /obj/effect/decal/cleanable/greenglow(C.drop_location())
-		C.welded = FALSE
-		C.locked = FALSE
-		C.broken = TRUE
-		C.open()
-		to_chat(user, span_warning("We open the container restraining us!"))
-
-/datum/action/changeling/biodegrade/proc/dissolve_cocoon(mob/living/carbon/human/user, obj/structure/spider/cocoon/C)
-	if(C && user.loc == C)
-		new /obj/effect/decal/cleanable/greenglow(C.drop_location())
-		qdel(C) //The cocoon's destroy will move the changeling outside of it without interference
-		to_chat(user, span_warning("We dissolve the cocoon!"))
+ /proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hopeless_manhandler)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -424,7 +424,7 @@
 
 
 ///Get the item on the mob in the storage slot identified by the id passed in
-/mob/proc/get_item_by_slot(slot_id)
+/mob/proc/get_item_by_slot(slot_id) as /obj/item
 	return null
 
 /// Gets what slot the item on the mob is held in.


### PR DESCRIPTION

## About The Pull Request

Biodegrade in its current state is more of a knowledge check on what not to waste your evolution points on than it is a very useful ability. Any Security officer who knows you're a ling will cuff and weld your corpse into a locker as they make their leisurely stroll to the crematorium while your dribbling chemical regen has only let you remove one of up to four or five different types of restraint.

This pull request makes biodegrade remove all restraints at once. Additionally, it removes grabs as well, through a process which I find very themely for ling. Please observe our sweatsec officer preparing a neckgrab so they can harmbaton the ling into revival stasis again.

https://github.com/user-attachments/assets/d6505b1e-00af-48f5-8c00-22a16d0619e7

As well, biodegrade now removes all constraints simultaneously; so cuffing and welding a ling who has taken biodegrade is only a very temporary measure (4 seconds to melt a closet, 1.5 seconds to melt the cuffs, simultaneous)

https://github.com/user-attachments/assets/de17926c-cd6e-4dd2-abcb-072f8bb30f3a
## Why It's Good For The Game

This change is meant to bring changelings in line with their categorized "uncontainable" valid salad demarcation. Biodegrade kinda sucks, and this makes it not-suck.
## Changelog
:cl: Bisar
balance: The changeling's Biodegrade ability will now remove all restraints (cuffs, legcuffs, straitjackets, closets, and so on) simultaneously.
balance: An arm that has a changeling in a grab now counts as a restraint to be dissolved by biodegrade. Nanotrasen strongly discourages the favorite security past-time of changeling wrestling.
/:cl:
