### PR TITLE
Gives constable helmet a hair mask and its armor back, fixes some hair masks not working

### DIFF
--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -64,7 +64,7 @@
 	var/strict_coverage_zones = NONE
 
 /datum/hair_mask/standard_hat_middle
-	icon_state = "hide_above_45deg_medium"
+	icon_state = "hide_above_45deg"
 	strict_coverage_zones = HAIR_APPENDAGE_TOP
 
 /datum/hair_mask/standard_hat_low

--- a/code/modules/clothing/head/hat.dm
+++ b/code/modules/clothing/head/hat.dm
@@ -27,6 +27,8 @@
 	inhand_icon_state = null
 	custom_price = PAYCHECK_COMMAND * 1.5
 	worn_y_offset = 4
+	armor_type = /datum/armor/head_helmet
+	hair_mask = /datum/hair_mask/standard_hat_middle
 
 /obj/item/clothing/head/costume/spacepolice
 	name = "space police cap"


### PR DESCRIPTION

## About The Pull Request

Also, all middle hair masks were broken because they had an incorrectly set icon_state
Closes #92450

## Why It's Good For The Game

Its supposed to be a replacement for the security helmet, and while it makes sense that it doesn't act as a full helmet (as it doesn't fully cover your head), it still probably should have armor as per original design (and also to not be useless for sec, who are the intended users of this item)

## Changelog
:cl:
fix: Fixed constable helmet not having any armor
fix: Fixed some hair masks not working
/:cl:
