### PR TITLE
don't send tgui windows to hell

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -209,16 +209,12 @@ export const backendMiddleware = (store) => {
       suspendRenderer();
       clearInterval(suspendInterval);
       suspendInterval = undefined;
-      // Tiny window in hell to not show previous content when resumed
-Byond.winset(Byond.windowId, {
+      // Tiny window to not show previous content when resumed
+      Byond.winset(Byond.windowId, {
         size: '1x1',
-        // Due to this, if you have a monitor /below/ the one you play SS13 on,
-        // that will become the 'closest' screen.
-        // If it's a different resolution, TGUI windows will spawn slightly off-center
-        // (positioned relatively to the lower monitor sizing)
-        pos: '1,1000000000',
-'is-visible': false,
-});
+        pos: '1,1',
+        'is-visible': false,
+      });
       setTimeout(() => focusMap());
     }
 


### PR DESCRIPTION
## About The Pull Request

1 pixel (less on most monitor resolutions, it'll render as subpixels only) flashing dark grey is not noticeable
this overcompensation is not needed
tested on goon and honestly i had to be looking really hard at the subpixels in the top left to actually even notice

## Why It's Good For The Game

less problems for people with weird setups
or buggy monitors

