### PR TITLE
Fixes 2 platform problems

### DIFF
--- a/code/game/objects/structures/platform.dm
+++ b/code/game/objects/structures/platform.dm
@@ -1,4 +1,4 @@
-#define PLATFORM_BASE_MATERIAL_AMOUNT 2000
+#define PLATFORM_BASE_MATERIAL_AMOUNT (2 * SHEET_MATERIAL_AMOUNT)
 
 /// A raised platform you can stand on top of
 /obj/structure/platform
@@ -21,7 +21,7 @@
 	/// Icon used for the frame
 	var/frame_icon = 'icons/obj/smooth_structures/platform/frame_faces/window_frame_normal.dmi'
 	/// Material used in our construction
-	var/sheet_type = /obj/item/stack/sheet/iron
+	var/sheet_type = null
 	/// Count of sheets used in our construction
 	var/sheet_amount = 2
 	/// What footstep do we use?


### PR DESCRIPTION
## About The Pull Request
- Fixes #92453. It now gives more preference to custom materials by having tis default `sheet_type` set to `null`
- Fixes some platforms having 10x times the custom materials than the sheets that were used to construct them. It now scales with the material economy

## Changelog
:cl:
fix: deconstructing material platforms drops the correct sheet types
fix: certain material platforms now have the correct amount of custom materials in them
/:cl:

