### PR TITLE
Misspeled Kotra Wellington to correct Korta Wellington 

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -1041,7 +1041,7 @@
 	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * (4/3))
 
 /obj/item/food/korta_wellington
-	name = "Kotra wellington"
+	name = "Korta wellington"
 	desc = "A luxurious log of beef, covered in a fine mushroom duxelle and pancetta ham, then bound in korta pastry."
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "korta_wellington"


### PR DESCRIPTION

## About The Pull Request
Fixing a mistake in the name of the dish korta wellington
## Why It's Good For The Game
Local lizards was in agony because of this dish misspeled name
## Changelog
:cl:
fix: after lizard raid on the popular chef show "Kotra Wellington" was renamed to "Korta Wellington"
/:cl:
