### PR TITLE
lazily initialize `/datum/element/weapon_description` on examine

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -51,6 +51,8 @@
 #define NO_BLOOD_ON_ITEM (1 << 19)
 /// Whether this item should skip the /datum/component/fantasy applied on spawn on the RPG event. Used on things like stacks
 #define SKIP_FANTASY_ON_SPAWN (1<<20)
+/// If an item has had its /datum/element/weapon_description initialized or not.
+#define WEAPON_DESCRIPTION_INITIALIZED (1<<21)
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -280,8 +280,6 @@
 		if(damtype == BRUTE)
 			hitsound = SFX_SWING_HIT
 
-	add_weapon_description()
-
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_ITEM, src)
 
 	setup_reskinning()
@@ -474,6 +472,13 @@
 
 /obj/item/examine_descriptor(mob/user)
 	return "item"
+
+/obj/item/examine(mob/user)
+	// lazily initialize the weapon description element if it hasn't been already
+	if(!(item_flags & WEAPON_DESCRIPTION_INITIALIZED))
+		add_weapon_description()
+		item_flags |= WEAPON_DESCRIPTION_INITIALIZED
+	return ..()
 
 /obj/item/examine_more(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

currently, `/datum/element/weapon_description` is added during every single item init, even tho it only ever affects examines. i noticed while looking at tracy traces downstream that it spent a bit much time adding the weapon description, so why not just lazily initialize it during examine instead?

direct port of the same thing from https://github.com/Monkestation/Monkestation2.0/pull/7502

## Why It's Good For The Game

less wasted time during item init

## Changelog
:cl:
code: Item weapon description elements are now initialized when first examined, instead of immediately upon initialization.
/:cl:
