### PR TITLE
Makes shuttle docks keep track of their position to ensure that shuttle catastrophe does not cause a random crashlanding

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -54,6 +54,13 @@
 		return
 	SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED
 	SSshuttle.unload_preview()
+	// We need to move our docking port back in case a crashlanding shuttle has been purchased previously
+	for(var/obj/docking_port/stationary/port as anything in SSshuttle.stationary_docking_ports)
+		if(port.shuttle_id != "emergency_home")
+			continue
+		var/turf/initial_loc = locate(port.initial_x, port.initial_y, port.initial_z)
+		port.forceMove(initial_loc)
+		break
 	SSshuttle.existing_shuttle = SSshuttle.emergency
 	SSshuttle.action_load(new_shuttle, replace = TRUE)
 	log_shuttle("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")

--- a/code/modules/shuttle/stationary_port/stationary_port.dm
+++ b/code/modules/shuttle/stationary_port/stationary_port.dm
@@ -10,8 +10,12 @@
 	var/shuttle_template_id
 	/// Used to check if the shuttle template is enabled in the config file
 	var/json_key
-	///If true, the shuttle can always dock at this docking port, despite its area checks, or if something is already docked
+	/// If true, the shuttle can always dock at this docking port, despite its area checks, or if something is already docked
 	var/override_can_dock_checks = FALSE
+	// Our initial roundstart coordinates
+	var/initial_x = -1
+	var/initial_y = -1
+	var/initial_z = -1
 
 /obj/docking_port/stationary/get_save_vars()
 	return ..() + NAMEOF(src, roundstart_template)
@@ -26,6 +30,10 @@
 	if(mapload)
 		for(var/turf/T in return_turfs())
 			T.turf_flags |= NO_RUINS
+
+	initial_x = x
+	initial_y = y
+	initial_z = z
 
 	if(SSshuttle.initialized)
 		return INITIALIZE_HINT_LATELOAD


### PR DESCRIPTION

## About The Pull Request

- Closes #92444

## Changelog
:cl:
fix: Shuttle catastrophe should no longer cause random unintended crashlandings
/:cl:
