### PR TITLE
Fixes hotspring related hard del

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -202,7 +202,7 @@
 
 ///Registers the signals from the immerse element and calls dip_in if the movable has the required trait.
 /turf/open/water/hot_spring/proc/enter_hot_spring(atom/movable/movable)
-	if(is_type_in_typecache(triggering_atom, GLOB.immerse_ignored_movable)) // So we don't immerse weird things like turf decals/effects, projectiles, etc
+	if(is_type_in_typecache(movable, GLOB.immerse_ignored_movable)) // So we don't immerse weird things like turf decals/effects, projectiles, etc
 		return FALSE
 	RegisterSignal(movable, SIGNAL_ADDTRAIT(TRAIT_IMMERSED), PROC_REF(dip_in))
 	if(isliving(movable)) //so far, exiting a hot spring only has effects on living mobs.

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -202,6 +202,8 @@
 
 ///Registers the signals from the immerse element and calls dip_in if the movable has the required trait.
 /turf/open/water/hot_spring/proc/enter_hot_spring(atom/movable/movable)
+	if(is_type_in_typecache(triggering_atom, GLOB.immerse_ignored_movable)) // So we don't immerse weird things like turfs, projectiles, etc
+		return FALSE
 	RegisterSignal(movable, SIGNAL_ADDTRAIT(TRAIT_IMMERSED), PROC_REF(dip_in))
 	if(isliving(movable)) //so far, exiting a hot spring only has effects on living mobs.
 		RegisterSignal(movable, SIGNAL_REMOVETRAIT(TRAIT_IMMERSED), PROC_REF(dip_out))

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -202,7 +202,7 @@
 
 ///Registers the signals from the immerse element and calls dip_in if the movable has the required trait.
 /turf/open/water/hot_spring/proc/enter_hot_spring(atom/movable/movable)
-	if(is_type_in_typecache(triggering_atom, GLOB.immerse_ignored_movable)) // So we don't immerse weird things like turfs, projectiles, etc
+	if(is_type_in_typecache(triggering_atom, GLOB.immerse_ignored_movable)) // So we don't immerse weird things like turf decals/effects, projectiles, etc
 		return FALSE
 	RegisterSignal(movable, SIGNAL_ADDTRAIT(TRAIT_IMMERSED), PROC_REF(dip_in))
 	if(isliving(movable)) //so far, exiting a hot spring only has effects on living mobs.


### PR DESCRIPTION
## About The Pull Request

Likely caused specifically by the fishing portal.

<details> <summary> aka this </summary>

<img width="1139" height="1061" alt="StrongDMM_AOL3MQJqRI" src="https://github.com/user-attachments/assets/57f59a74-6c9d-471e-9e76-f60013b7f965" />

</details>

The `/obj/effect/turf_decal/weather/dirt` was being immersed wrongfully I believe leading to this.

```
[2025-08-09 19:13:12.462] ## REF SEARCH Finished searching globals
[2025-08-09 19:13:14.110] ## REF SEARCH Finished searching native globals
[2025-08-09 19:17:43.734] ## REF SEARCH Found /obj/effect/turf_decal/weather/dirt [0x203cd58] in list World -> /turf/open/water/hot_spring [0x10174d3] -> _signal_procs (list).
[2025-08-09 19:17:43.734] ## REF SEARCH All references to /obj/effect/turf_decal/weather/dirt [0x203cd58] found, exiting.
[2025-08-09 19:17:43.734] ## REF SEARCH Finished searching atoms
[2025-08-09 19:17:46.762] ## REF SEARCH Beginning search for references to a /obj/effect/turf_decal/weather/dirt, looking for 1 refs.
```

## Why It's Good For The Game

Less hard dels

## Changelog

Nothing player-facing