### PR TITLE
Remove pepperproof and mouth coverage from Swat helmet

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -365,7 +365,7 @@
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	flags_cover = HEADCOVERSEYES
 
 
 /obj/item/clothing/head/helmet/thunderdome


### PR DESCRIPTION
## About The Pull Request
Simple change so Swat helmets don't protect from pepper spray. As it is they come with Swat masks - one of the best pepper spray protection, it doesn't get dirty so you don't need to wash it.
Swat helmets are looking too similar to sec helmets and those don't give pepperproof protection.

Don't worry, swat helmets will get attachable seclights *soon*!
<img width="62" height="63" alt="obraz" src="https://github.com/user-attachments/assets/cff68841-c9cd-4aa7-8490-8e393ec9ba51" /> 
<img width="64" height="66" alt="obraz" src="https://github.com/user-attachments/assets/b1df8149-be07-40f1-9a5b-f644e3df5985" />


Same thing with mouth coverage - mouth is fully exposed (huge reason why pepper spray would work)
## Why It's Good For The Game
Visual should tell players what to expect!
## Changelog
:cl:
balance: Swat helmets lost their mouth coverage
balance: Swat helmets lost their pepperproof
/:cl:
