### PR TITLE
Removes space plane optimization

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -62,12 +62,7 @@
 	var/turf/screen_location = get_turf(screenmob)
 
 	if(SSmapping.level_trait(screen_location?.z, ZTRAIT_NOPARALLAX))
-		for(var/atom/movable/screen/plane_master/white_space as anything in get_true_plane_masters(PLANE_SPACE))
-			white_space.hide_plane(screenmob)
 		return FALSE
-
-	for(var/atom/movable/screen/plane_master/white_space as anything in get_true_plane_masters(PLANE_SPACE))
-		white_space.unhide_plane(screenmob)
 
 	if (SSlag_switch.measures[DISABLE_PARALLAX] && !HAS_TRAIT(viewmob, TRAIT_BYPASS_MEASURES))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

The lightmask plate takes all turfs as input lines, using them to decide where is and is not allowed to render ANYTHING on the below lighting section of the game plate. So we are NOT actually allowed to toggle off the space plate if there's no parallax, because there can be no parallax and still be turfs on the space plane (carpeting and such)

## Why It's Good For The Game

Fixes #92497 

## Changelog
:cl:
fix: Using fake space tiles on icebox will no longer summon the endless void
/:cl:
