### PR TITLE
Fixes light flickering potentially causing lag

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -502,22 +502,24 @@
 
 /obj/machinery/light/proc/flicker(amount = rand(10, 20))
 	set waitfor = FALSE
-	if(flickering)
+	if(flickering || !on || status != LIGHT_OK)
 		return
+
+	. = TRUE // did we actually flicker? Send this now because we expect immediate response, before sleeping.
 	flickering = TRUE
-	if(on && status == LIGHT_OK)
-		. = TRUE //did we actually flicker? Send this now because we expect immediate response, before sleeping.
-		for(var/i in 1 to amount)
-			if(status != LIGHT_OK || !has_power())
-				break
-			on = !on
-			update(FALSE)
-			sleep(rand(5, 15))
-		if(has_power())
-			on = (status == LIGHT_OK)
-		else
-			on = FALSE
+	for(var/i in 1 to amount)
+		if(status != LIGHT_OK || !has_power())
+			break
+		on = !on
 		update(FALSE)
+		stoplag(rand(0.5 SECONDS, 1.5 SECONDS))
+
+	if(has_power())
+		on = (status == LIGHT_OK)
+	else
+		on = FALSE
+
+	update(FALSE)
 	flickering = FALSE
 
 // ai attack - make lights flicker, because why not

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -106,7 +106,7 @@
  * * flicker_source - The center of the flicker. If null the whole powernet will flicker
  * * falloff_distance - Only relevant if you passed a source. Areas beyond this distance will be less and less likely to flicker.
  */
-/datum/powernet/proc/propagate_light_flicker(atom/flicker_source, falloff_distance = 64)
+/datum/powernet/proc/propagate_light_flicker(atom/flicker_source, falloff_distance = 32)
 	if(flickering || !length(nodes))
 		return
 
@@ -116,20 +116,19 @@
 		if(!istype(terminal.master, /obj/machinery/power/apc))
 			continue
 
-		if(isnull(flicker_source))
-			if(!prob(95))
-				continue
-		else
-			var/flicker_prob = 95 + (3 * (falloff_distance - get_dist(flicker_source, terminal)))
-			if(!prob(min(95, flicker_prob)))
-				continue
+		var/flicker_prob = 85
+		if(!isnull(flicker_source))
+			flicker_prob = 85 + min(3 * (falloff_distance - get_dist(flicker_source, terminal)), 0)
+
+		if(!prob(flicker_prob))
+			continue
 
 		var/flicker_count = rand(1, 3)
 		most_flickers = max(most_flickers, flicker_count)
 		var/obj/machinery/power/apc/apc = terminal.master
 		for(var/obj/machinery/light/light as anything in apc.get_lights())
 			light.flicker(flicker_count)
-		CHECK_TICK
+			CHECK_TICK
 
 	// don't let another flicker propagation until our slowest area is done (with some added leeway)
 	addtimer(VARSET_CALLBACK(src, flickering, FALSE), most_flickers * 2 SECONDS)


### PR DESCRIPTION

## About The Pull Request

Light flickering was forcing itself into async via waitfor but used sleeps and thus had zero respect for MC consumption. We fix the lag by 
- A) making it use stoplag instead of sleep and moving CHECK_TICK to be per-light instead of per-APC
- B) reducing chance of lights to flicker in a particular room (reducing the amount of flickers looks weird) 
- C) reducing falloff distance to 32 from 64, as latter is half to third the station on most maps.

## Changelog
:cl:
fix: Fixed light flickering potentially causing lag
/:cl:
