### PR TITLE
fix asset loading subsystem

### DIFF
--- a/code/controllers/subsystem/asset_loading.dm
+++ b/code/controllers/subsystem/asset_loading.dm
@@ -13,16 +13,19 @@ SUBSYSTEM_DEF(asset_loading)
 	while(length(generate_queue))
 		var/datum/asset/to_load = generate_queue[generate_queue.len]
 
+		last_queue_len = length(generate_queue)
+		generate_queue.len--
+
 		to_load.queued_generation()
 
 		if(MC_TICK_CHECK)
 			return
-		last_queue_len = length(generate_queue)
-		generate_queue.len--
+
 	// We just emptied the queue
 	if(last_queue_len && !length(generate_queue))
 		// Clean up cached icons, freeing memory.
 		rustg_iconforge_cleanup()
+		last_queue_len = 0
 
 /datum/controller/subsystem/asset_loading/proc/queue_asset(datum/asset/queue)
 #ifdef DO_NOT_DEFER_ASSETS

--- a/code/controllers/subsystem/asset_loading.dm
+++ b/code/controllers/subsystem/asset_loading.dm
@@ -25,7 +25,6 @@ SUBSYSTEM_DEF(asset_loading)
 	if(last_queue_len && !length(generate_queue))
 		// Clean up cached icons, freeing memory.
 		rustg_iconforge_cleanup()
-		last_queue_len = 0
 
 /datum/controller/subsystem/asset_loading/proc/queue_asset(datum/asset/queue)
 #ifdef DO_NOT_DEFER_ASSETS

--- a/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
+++ b/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
@@ -232,7 +232,7 @@
 		CRASH("Error during spritesheet generation for [name]: [data["error"]]")
 
 /datum/asset/spritesheet_batched/queued_generation()
-	realize_spritesheets(yield = TRUE)
+	INVOKE_ASYNC(src, PROC_REF(realize_spritesheets), TRUE) // The proc is called inside a subsystem and waits with an UNTIL
 
 /datum/asset/spritesheet_batched/ensure_ready()
 	if(!fully_generated)


### PR DESCRIPTION
## About The Pull Request
The entire asset loading had multiple issues.

Firstly, we could hit a tick check after an asset was generated and didn't remove the index, leading to the asset being generated twice.

Secondly, we had the issue that the icon forge batching uses UNTIL to wait until generation finishes. This led to the situation that the entire subsystem fire proc was paused outside of the internal tick check pause.
## Why It's Good For The Game
Especially on larger sprite sheets or when there're many to be generated this led to the situation that we looked up a rust job multiple times:
 
`[2025-08-08T18:42:11] Runtime in code/modules/asset_cache/iconforge/batched_spritesheet.dm,200: Spritesheet design UNKNOWN ERROR: NO SUCH JOB`

## Changelog
No player facing changes.
