### PR TITLE
Fixes Peanut Butter and Banana Rootbread Sandwich from being uneatable

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -487,6 +487,8 @@
 	result = /obj/item/food/rootbread_peanut_butter_banana
 	added_foodtypes = FRUIT
 	category = CAT_LIZARD
+	crafting_flags = CRAFT_CLEARS_REAGENTS
+
 // Soups
 
 /datum/crafting_recipe/food/reaction/soup/atrakor_dumplings


### PR DESCRIPTION

## About The Pull Request
Fixes the issue with water + banana killing all the nutriment, i should have checked this recipe the same time i fixed the honey sweetroll but i forgot it existed

## Why It's Good For The Game
fix bug

## Changelog
:cl:
fix: you can eat peanut butter and banana rootbread sandwiches now, hooray
/:cl:
