### PR TITLE
Adds the reagent flag to Rootdough

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -196,6 +196,7 @@
 	result = /obj/item/food/rootdough
 	added_foodtypes = NUTS
 	category = CAT_LIZARD
+	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/rootdough/with_eggs
 	name = "Rootdough (With Eggs)"
@@ -207,6 +208,7 @@
 	)
 	result = /obj/item/food/rootdough/egg
 	removed_foodtypes = RAW
+	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/snail_nizaya
 	name = "Desert snail nizaya"
@@ -374,7 +376,6 @@
 	)
 	result = /obj/item/food/honey_roll
 	category = CAT_LIZARD
-	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/black_eggs
 	name = "Black scrambled eggs"


### PR DESCRIPTION

## About The Pull Request
Adds the CRAFT_CLEARS_REAGENTS flag to both rootdough recipes and removes my fix to the honey sweetroll.
## Why It's Good For The Game
Better to have the flag on the parent vs individual recipes

## Changelog
:cl:
fix: added the CRAFT_CLEARS_REAGENTS flag to the rootdough recipes, bananas + water will no longer doom lizard food ever again
/:cl:
