### PR TITLE
Fix firedoors spawning without area or ID in name

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -185,6 +185,8 @@
 
 /obj/machinery/door/firedoor/update_name(updates)
 	. = ..()
+	if(!my_area || !id_tag)
+		return
 	name = "[get_area_name(my_area)] [initial(name)] [id_tag]"
 
 /**


### PR DESCRIPTION

## About The Pull Request

Fire doors are supposed to have the name of their area and a unique ID tag in their name when they spawn, accomplished with `if(name == initial(name)) update_name()` in `/obj/machinery/door/firedoor/Initialize()`, the problem is `/obj/machinery/door/Initialize()` calls `update_appearance()` which triggers a name update before the fire door has an area or id set, which leads to its name being set to " firelock " instead of "firelock", which means it fails the `initial()` check and the name isn't updated with the now set area and ID. Fixes by adding a null check to `update_name()`

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed firelocks spawning with no area name or ID
/:cl:
