### PR TITLE
fixes "whispering" misspelling for the hallucination anomaly

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomalies_hallucination.dm
@@ -11,7 +11,7 @@
 	var/static/list/messages = list(
 		span_warning("You feel your conscious mind fall apart!"),
 		span_warning("Reality warps around you!"),
-		span_warning("Something's wispering around you!"),
+		span_warning("Something's whispering around you!"),
 		span_warning("You are going insane!"),
 	)
 	///Do we spawn misleading decoys?


### PR DESCRIPTION

## About The Pull Request

#92525

## Why It's Good For The Game

fixes #92525

## Changelog
:cl:

spellcheck: whispering now spelled correctly

/:cl:
