### PR TITLE
Hide ammo/magazines from spy bounties if you haven't claimed the relative guns yet

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -453,6 +453,12 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 /// Very difficult to accomplish, almost guaranteed to require crew conflict
 #define SPY_DIFFICULTY_HARD "Hard"
 
+/// special class for spy bounties locked behind other rewards
+#define SPY_BOUNTIES_RESTRICTED "Restricted"
+
+/// Chance that an item is removed from the pool after being put as reward for a spy bounty
+#define SPY_REWARD_REMOVAL_CHANCE 80
+
 /// Camera net used by battle royale objective
 #define BATTLE_ROYALE_CAMERA_NET "battle_royale_camera_net"
 

--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -186,10 +186,10 @@
 				failed_attempts -= 1
 				qdel(bounty)
 
-	//Hand out restricted bounties if we have any, which are locked behind other rewards.
-	var/amount_to_give = bounties_to_give[SPY_BOUNTIES_RESTRICTED]
-	var/list/restricted_items = possible_uplink_items[SPY_BOUNTIES_RESTRICTED]
+	//Hand out restricted bounties if we have any (but not always), which are locked behind other rewards.
+	var/amount_to_give = rand(0, bounties_to_give[SPY_BOUNTIES_RESTRICTED])
 	if(amount_to_give > 0 && length(restricted_items))
+		var/list/restricted_items = rand(0, possible_uplink_items[SPY_BOUNTIES_RESTRICTED])
 		var/attempts_left = num_attempts_override || amount_to_give * 3 //less wiggle room as these aren't fundamental
 		while(attempts_left > 0)
 			attempts_left--

--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -45,6 +45,13 @@
 	min_val = 0
 	integer = TRUE
 
+/// Spy config: Changes the amount of bounties that are locked behind required previous rewards (typically ammo), otherwise hidden.
+/datum/config_entry/number/spy_bounty_max_restricted
+	default = 4
+	min_val = 0
+	max_val = 5
+	integer = TRUE
+
 /**
  * ## Spy bounty handler
  *
@@ -73,6 +80,7 @@
 		SPY_DIFFICULTY_EASY = 4,
 		SPY_DIFFICULTY_MEDIUM = 2,
 		SPY_DIFFICULTY_HARD = 2,
+		SPY_BOUNTIES_RESTRICTED = 4,
 	)
 
 	/// Assoc list of all active bounties.
@@ -96,6 +104,7 @@
 		SPY_DIFFICULTY_EASY = list(),
 		SPY_DIFFICULTY_MEDIUM = list(),
 		SPY_DIFFICULTY_HARD = list(),
+		SPY_BOUNTIES_RESTRICTED = list(),
 	)
 
 /datum/spy_bounty_handler/New()
@@ -104,6 +113,7 @@
 		SPY_DIFFICULTY_EASY = CONFIG_GET(number/spy_bounty_max_easy),
 		SPY_DIFFICULTY_MEDIUM = CONFIG_GET(number/spy_bounty_max_medium),
 		SPY_DIFFICULTY_HARD = CONFIG_GET(number/spy_bounty_max_hard),
+		SPY_BOUNTIES_RESTRICTED = CONFIG_GET(number/spy_bounty_max_restricted),
 	)
 
 	for(var/datum/spy_bounty/bounty as anything in subtypesof(/datum/spy_bounty))
@@ -126,6 +136,9 @@
 			possible_uplink_items[SPY_DIFFICULTY_MEDIUM] += item
 		if(item.cost >= CONFIG_GET(number/spy_hard_reward_tc_threshold))
 			possible_uplink_items[SPY_DIFFICULTY_HARD] += item
+
+		if(item.spy_bounty_requirements)
+			possible_uplink_items[SPY_BOUNTIES_RESTRICTED] += item
 
 	refresh_bounty_list()
 
@@ -167,6 +180,30 @@
 			else
 				failed_attempts -= 1
 				qdel(bounty)
+
+	//Hand out restricted bounties if we have any, which are locked behind other rewards.
+	var/amount_to_give = bounties_to_give[SPY_BOUNTIES_RESTRICTED]
+	var/list/restricted_items = possible_uplink_items[SPY_BOUNTIES_RESTRICTED]
+	if(amount_to_give > 0 && length(restricted_items))
+		var/attempts_left = num_attempts_override || amount_to_give * 3 //less wiggle room as these aren't fundamental
+		while(attempts_left > 0)
+			attempts_left--
+			var/datum/uplink_item/picked_item = pick(restricted_items)
+			//find which difficulty category the item belongs to, and initialize the relative bounty
+			for(var/difficulty in bounties)
+				if(!(picked_item in possible_uplink_items[difficulty]))
+					continue
+				var/picked_bounty = pick_weight(bounty_types[difficulty])
+				var/datum/spy_bounty/bounty = new picked_bounty(src, picked_item)
+				if(bounty.initalized)
+					amount_to_give--
+					bounty.clear_post_claim = TRUE
+					bounties[difficulty] += bounty
+					break
+				qdel(bounty)
+
+			if(amount_to_give <= 0 || !length(restricted_items))
+				break
 
 	claimed_bounties_from_last_pool.Cut()
 	num_refreshes += 1

--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -188,8 +188,8 @@
 
 	//Hand out restricted bounties if we have any (but not always), which are locked behind other rewards.
 	var/amount_to_give = rand(0, bounties_to_give[SPY_BOUNTIES_RESTRICTED])
+	var/list/restricted_items = rand(0, possible_uplink_items[SPY_BOUNTIES_RESTRICTED])
 	if(amount_to_give > 0 && length(restricted_items))
-		var/list/restricted_items = rand(0, possible_uplink_items[SPY_BOUNTIES_RESTRICTED])
 		var/attempts_left = num_attempts_override || amount_to_give * 3 //less wiggle room as these aren't fundamental
 		while(attempts_left > 0)
 			attempts_left--

--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -74,6 +74,9 @@
 	/// This number will override that calculation with a set value - used for testing and debugging.
 	var/num_attempts_override = 0
 
+	/// List of typepaths of the rewards from all claimed bounties (the items, rather than their uplink representations), used for restricted bounties.
+	var/list/claimed_bounty_rewards = list()
+
 	/// Assoc list that dictates how much of each bounty difficulty to give out at once.
 	/// Modified by the number of times we have refreshed bounties.
 	VAR_PRIVATE/list/base_bounties_to_give = list(
@@ -146,7 +149,9 @@
 /datum/spy_bounty_handler/proc/get_all_bounties() as /list
 	var/list/all_bounties = list()
 	for(var/difficulty in bounties)
-		all_bounties += bounties[difficulty]
+		for(var/datum/spy_bounty/bounty as anything in bounties[difficulty])
+			if(!bounty.reward_item.spy_bounty_requirements || (claimed_bounty_rewards & bounty.reward_item.spy_bounty_requirements))
+				all_bounties += bounty
 
 	return all_bounties
 

--- a/code/modules/antagonists/spy/spy_uplink.dm
+++ b/code/modules/antagonists/spy/spy_uplink.dm
@@ -10,8 +10,6 @@
 	var/datum/weakref/spy_ref
 	/// The handler which manages all bounties across all spies.
 	var/static/datum/spy_bounty_handler/handler
-	/// To be filled with the typepaths of the various rewards (the items, rather than their uplink representation)
-	var/list/rewards_received = list()
 
 /datum/component/spy_uplink/Initialize(datum/antagonist/spy/spy)
 	if(!isitem(parent))
@@ -157,7 +155,7 @@
 	bounty.claimed = TRUE
 
 	var/atom/movable/reward = bounty.reward_item.spawn_item_for_generic_use(spy)
-	rewards_received += reward.type
+	handler.claimed_bounty_rewards |= reward.type
 	if(bounty.clear_post_claim && prob(SPY_REWARD_REMOVAL_CHANCE))
 		handler.possible_uplink_items[SPY_BOUNTIES_RESTRICTED] -= reward
 	if(isitem(reward))
@@ -192,8 +190,6 @@
 
 	data["bounties"] = list()
 	for(var/datum/spy_bounty/bounty as anything in handler.get_all_bounties())
-		if(bounty.reward_item.spy_bounty_requirements && !(rewards_received & bounty.reward_item.spy_bounty_requirements))
-			continue //hide them from the uplink. It's still possible to claim it, however you'd need someone else to reveal you what the bounty even is.
 		UNTYPED_LIST_ADD(data["bounties"], bounty.to_ui_data())
 	data["time_left"] = timeleft(handler.refresh_timer)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -109,9 +109,16 @@
 	/// Uses the purchase log, so items purchased that are not visible in the purchase log will not count towards this.
 	/// However, they won't be purchasable afterwards.
 	var/lock_other_purchases = FALSE
+	/**
+	 * If not null, spy bounties with this reward will only be shown (in a separate category) to spies
+	 * that have been previously reward with ONE of the items in the list. Can also be a simple path, to be wrapped in a list on init.
+	 */
+	var/list/spy_bounty_requirements
 
 /datum/uplink_item/New()
 	. = ..()
+	if(spy_bounty_requirements)
+		spy_bounty_requirements = typecacheof(LIST_VALUE_WRAP_LISTS(spy_bounty_requirements))
 	if(stock_key != UPLINK_SHARED_STOCK_UNIQUE)
 		return
 	stock_key = type

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -13,6 +13,7 @@
 	cost = 2
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 	purchasable_from = ~UPLINK_SERIOUS_OPS
+	spy_bounty_requirements = /obj/item/storage/toolbox/guncase/traitor/donksoft
 
 /datum/uplink_item/ammo/pistol
 	name = "9mm Magazine Case"
@@ -22,30 +23,32 @@
 	cost = 2
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
+	spy_bounty_requirements = /obj/item/storage/toolbox/guncase/traitor
 
-/datum/uplink_item/ammo/pistolap
+/datum/uplink_item/ammo/pistol/New()
+	..()
+	spy_bounty_requirements -= subtypesof(/obj/item/storage/toolbox/guncase/traitor) //Only makarov guncase accepted
+
+/datum/uplink_item/ammo/pistol/ap
 	name = "9mm Armour Piercing Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
 			These rounds are less effective at injuring the target but penetrate protective gear."
 	item = /obj/item/ammo_box/magazine/m9mm/ap
 	cost = 2
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
-/datum/uplink_item/ammo/pistolhp
+/datum/uplink_item/ammo/pistol/hp
 	name = "9mm Hollow Point Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
 			These rounds are more damaging but ineffective against armour."
 	item = /obj/item/ammo_box/magazine/m9mm/hp
 	cost = 3
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
-/datum/uplink_item/ammo/pistolfire
+/datum/uplink_item/ammo/pistol/fire
 	name = "9mm Incendiary Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
 			Loaded with incendiary rounds which inflict little damage, but ignite the target."
 	item = /obj/item/ammo_box/magazine/m9mm/fire
 	cost = 2
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
@@ -53,5 +56,6 @@
 			For when you really need a lot of things dead."
 	item = /obj/item/ammo_box/a357
 	cost = 4
-	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY) //nukies get their own version
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS //nukies get their own version
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
+	spy_bounty_requirements = /obj/item/gun/ballistic/revolver

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -78,6 +78,7 @@
 	desc = "An additional 8-round buckshot magazine for use with the Bulldog shotgun. Front towards enemy."
 	item = /obj/item/ammo_box/magazine/m12g
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 /datum/uplink_item/ammo_nuclear/basic/slug
 	name = "12g Slug Drum (Bulldog)"
@@ -85,6 +86,7 @@
 		Now 8 times less likely to shoot your pals."
 	item = /obj/item/ammo_box/magazine/m12g/slug
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 /datum/uplink_item/ammo_nuclear/basic/flechette
 	name = "12g Flechette Shells (Bulldog)"
@@ -92,6 +94,7 @@
 		Getting stopped by armor? Why not flechette? Turn meat and kevlar to tatters!"
 	item = /obj/item/ammo_box/magazine/m12g/flechette
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 /datum/uplink_item/ammo_nuclear/basic/donk
 	name = "12g Donk Co. 'Donk Spike' Flechette Magazine Box (Bulldog)"
@@ -100,6 +103,7 @@
 		the price of one purchase! WARNING: DO NOT SNIFF THE MAGAZINES!"
 	item = /obj/item/storage/box/syndie_kit/shotgun_surplus
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 /datum/uplink_item/ammo_nuclear/incendiary/dragon
 	name = "12g Dragon's Breath Drum (Bulldog)"
@@ -107,6 +111,7 @@
 		'I'm a fire starter, twisted fire starter!'"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 /datum/uplink_item/ammo_nuclear/special/meteor
 	name = "12g Meteorslug Shells (Bulldog)"
@@ -114,6 +119,7 @@
 		Great for blasting holes into the hull and knocking down enemies."
 	item = /obj/item/ammo_box/magazine/m12g/meteor
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 // ~~ Ansem Pistol ~~
 
@@ -128,6 +134,7 @@
 	desc = "An additional 8-round 10mm magazine, compatible with the Ansem pistol."
 	item = /obj/item/ammo_box/magazine/m10mm
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/automatic/pistol/clandestine
 
 /datum/uplink_item/ammo_nuclear/ap/m10mm
 	name = "10mm Armour Piercing Magazine (Ansem)"
@@ -135,6 +142,7 @@
 		These rounds are less effective at injuring the target but penetrate protective gear."
 	item = /obj/item/ammo_box/magazine/m10mm/ap
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/automatic/pistol/clandestine
 
 /datum/uplink_item/ammo_nuclear/hp/m10mm
 	name = "10mm Hollow Point Magazine (Ansem)"
@@ -142,6 +150,7 @@
 		These rounds are more damaging but ineffective against armour."
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/automatic/pistol/clandestine
 
 /datum/uplink_item/ammo_nuclear/incendiary/m10mm
 	name = "10mm Incendiary Magazine (Ansem)"
@@ -149,6 +158,7 @@
 		Loaded with incendiary rounds which inflict less damage, but ignite the target."
 	item = /obj/item/ammo_box/magazine/m10mm/fire
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/automatic/pistol/clandestine
 
 //Medium-cost: 14 TC each. Meant for more expensive purchases with a goal in mind.
 
@@ -219,7 +229,7 @@
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \
 		For when you really need a lot of things dead. Unlike field agents, operatives get a premium price for their speedloaders!"
 	item = /obj/item/ammo_box/a357
-	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	purchasable_from = parent_type::purchasable_from
 
 /datum/uplink_item/ammo_nuclear/special/revolver/phasic
 	name = ".357 Phasic Speed Loader (Revolver)"
@@ -228,6 +238,7 @@
 		The name is a misnomer. It doesn't contain any lead whatsoever!"
 	item = /obj/item/ammo_box/a357/phasic
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/revolver
 
 /datum/uplink_item/ammo_nuclear/special/revolver/heartseeker
 	name = ".357 Heartseeker Speed Loader (Revolver)"
@@ -237,6 +248,7 @@
 	item = /obj/item/ammo_box/a357/heartseeker
 	cost = 3
 	purchasable_from = parent_type::purchasable_from | UPLINK_SPY
+	spy_bounty_requirements = /obj/item/gun/ballistic/revolver
 
 // ~~ Grenade Launcher ~~
 // 'If god had wanted you to live, he would not have created ME!'

--- a/code/modules/uplink/uplink_items/spy_unique.dm
+++ b/code/modules/uplink/uplink_items/spy_unique.dm
@@ -103,6 +103,7 @@
 	desc = "A box of buckshot rounds for a shotgun. For when you don't want to miss."
 	item = /obj/item/storage/box/lethalshot
 	cost = 1
+	spy_bounty_requirements = /obj/item/gun/ballistic/shotgun
 
 /datum/uplink_item/spy_unique/shotgun_ammo/breacher_slug
 	name = "Box of Breacher Slugs"


### PR DESCRIPTION
## About The Pull Request
Spy bounties with ammo boxes and magazines as rewards often clutter the uplink. Chit-chatted about it with Melbert today, and he said it would be better if those were only shown to players that had previously claimed bounties for the relative guns.

It's a bit trickier than that though, since **simply** hiding them would solve the problem only at a surface-level, because we'd end up offering players fewer options than we ought to, so I had to make a separate category of bounties with the appropriate code so they would be shown in addition to those that have claimed the requirements, without hindering the rest.
Also they are not really a true category in the uplink, it's just a pool of items (mainly ammo) that are picked after the standard bounty generation.


## Why It's Good For The Game

This will probably make the loot a tiny bit less shit sometimes.

## Changelog

:cl:
balance: spy bounties that reward ammo boxes and magazines no longer clutter the spy uplinks and are only shown when at least one spy has claimed a bounty with the required firearm as reward, on top of whatever is normally offered.
/:cl:
