### PR TITLE
Coroner Office cabinets and more accesible organ storage

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -35901,6 +35901,7 @@
 	network = list("ss13","medbay");
 	c_tag = "Medbay - Upper Morgue"
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
 "kwQ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -49496,8 +49496,6 @@
 /area/station/hallway/primary/central/aft)
 "mmf" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 10
@@ -49507,6 +49505,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mmq" = (
@@ -65978,11 +65977,11 @@
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 4
 	},
-/obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qqe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20397,8 +20397,8 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "hif" = (
-/obj/structure/mannequin/skeleton,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hio" = (
@@ -28294,6 +28294,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "jLD" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3741,8 +3741,8 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "axE" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/trimline/neutral/warning,
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "axG" = (
@@ -48717,7 +48717,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/right)
 "qfS" = (
-/obj/machinery/smartfridge/organ,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -6028,8 +6028,8 @@
 /area/station/service/library)
 "ceF" = (
 /obj/structure/table,
-/obj/item/paper_bin/carbon,
 /obj/machinery/light_switch/directional/east,
+/obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ceN" = (
@@ -59600,8 +59600,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "uvn" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uvx" = (


### PR DESCRIPTION

## About The Pull Request
Placed cabinets in coroner's offices that did not have them, also moved some organ vendors so they can be accessed by people outside the office (nebula not included cause idk how i could do that without making it lose symmetry)
![delta](https://github.com/user-attachments/assets/01d25c2a-ac9d-4e20-b2a8-56b39599db8f)
## Why It's Good For The Game
autopsies leave documents, and its good to have somewhere to store them, not having a cabinet means you either need to just leave them on the floor/somewhere and that looks ugly, consistency too.

about the organ vendors, people rarely go to the coroner to get organs, i think this should encourage people to actually go to the organ harvester guy.
## Changelog
:cl:
qol: All coroner's offices that lacked a cabinet will now have one, coroner's organ fridge is now more accessible
/:cl:
