### PR TITLE
Has knife-cleanbots steal identificiation from ids rather than mind

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -305,9 +305,14 @@
 		return
 
 	var/mob/living/carbon/stabbed_carbon = shanked_victim
-	var/assigned_role = stabbed_carbon.mind?.assigned_role.title
-	if(!isnull(assigned_role))
-		update_title(assigned_role)
+
+	if(ishuman(shanked_victim))
+		var/mob/living/carbon/human/stabbed_human = shanked_victim
+		var/obj/item/card/id/id = stabbed_human.wear_id?.GetID()
+		if(!isnull(id))
+			var/assigned_role = id.assignment
+			if(!isnull(assigned_role))
+				update_title(assigned_role)
 
 	zone_selected = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	INVOKE_ASYNC(weapon, TYPE_PROC_REF(/obj/item, attack), stabbed_carbon, src)


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/92533 by having knife cleanbots read your worn id rather than reading your mind.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3a40c315-de4c-4e86-9b76-d4401eb06998" />

edit: Incidentally makes a harder achievement much easier because its based on id rather than magic mind reading
## Why It's Good For The Game

exploit to find out someone's identity bad
## Changelog
:cl:

fix: knifed up cleanbots will now read your id card rather than your mind when stealing valor

/:cl:
