### PR TITLE
[NO GBP] Fixes empty vending canisters in some cases

### DIFF
--- a/code/game/objects/items/vending_items.dm
+++ b/code/game/objects/items/vending_items.dm
@@ -35,26 +35,23 @@
 	. = ..()
 	name = "\improper [machine_name] restocking unit"
 
-	if(istype(loc, /obj/machinery/vending))
-		var/obj/machinery/vending/vendor = loc
-		products = vendor.products.Copy()
-		contraband = vendor.contraband.Copy()
-		premium = vendor.premium.Copy()
-	else
-		products = list()
-		contraband = list()
-		premium = list()
-
 /obj/item/vending_refill/examine(mob/user)
 	. = ..()
+
 	var/num = get_part_rating()
 	if (!num)
-		. += "It's empty!"
+		. += span_notice("It's empty!")
+	else if(num == INFINITY)
+		. += span_notice("It's full of supplies!")
 	else
-		. += "It can restock [num] item\s."
+		. += span_notice("It can restock [num] item\s.")
 
 /obj/item/vending_refill/get_part_rating()
 	. = 0
+	//first time needs to be filled by the vending machine
+	if(!products)
+		return INFINITY
+
 	for(var/key in products)
 		. += products[key]
 	for(var/key in contraband)

--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -324,6 +324,11 @@
 	icon_state = "refill_custom"
 	custom_premium_price = PAYCHECK_CREW
 
+/obj/item/vending_refill/custom/get_part_rating()
+	. = 0
+	for(var/key in products)
+		. += products[key]
+
 /obj/machinery/vending/custom/unbreakable
 	name = "Indestructible Vendor"
 	resistance_flags = INDESTRUCTIBLE

--- a/code/modules/vending/vendor/inventory.dm
+++ b/code/modules/vending/vendor/inventory.dm
@@ -93,6 +93,13 @@
  */
 /obj/machinery/vending/proc/restock(obj/item/vending_refill/canister)
 	. = 0
+
+	//to initialize product category & cargo ordered canisters for the 1st time
+	if(!canister.products)
+		canister.products = products.Copy()
+		canister.contraband = contraband.Copy()
+		canister.premium = premium.Copy()
+
 	var/list/datum/data/vending_product/record_list
 	var/list/canister_list
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #92527
- Closes #92537

## Changelog
:cl:
fix: product category vendors start out correctly filled & can be refilled with cargo ordered vending canisters again
/:cl:

