### PR TITLE
Fixes an issue where called shuttles would say "1 minutes" instead of "1 minute"

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -378,7 +378,8 @@
 					requisition_paper.update_appearance()
 
 				ui.user.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)
-				say("The supply shuttle has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minutes.")
+				var/arrives_in_minutes = SSshuttle.supply.timeLeft(600)
+				say("The supply shuttle has been called and will arrive in [arrives_in_minutes] minute[arrives_in_minutes == 1 ? "" : "s"].")
 				SSshuttle.moveShuttle(cargo_shuttle, docking_home, TRUE)
 
 			. = TRUE

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -378,8 +378,7 @@
 					requisition_paper.update_appearance()
 
 				ui.user.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)
-				var/minutes_to_arrival = SSshuttle.supply.timeLeft(600)
-				say("The supply shuttle has been called and will arrive in [minutes_to_arrival] minute[minutes_to_arrival == 1 ? "" : "s"].")
+				say("The supply shuttle has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minute\s.")
 				SSshuttle.moveShuttle(cargo_shuttle, docking_home, TRUE)
 
 			. = TRUE

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -378,8 +378,8 @@
 					requisition_paper.update_appearance()
 
 				ui.user.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)
-				var/arrives_in_minutes = SSshuttle.supply.timeLeft(600)
-				say("The supply shuttle has been called and will arrive in [arrives_in_minutes] minute[arrives_in_minutes == 1 ? "" : "s"].")
+				var/minutes_to_arrival = SSshuttle.supply.timeLeft(600)
+				say("The supply shuttle has been called and will arrive in [minutes_to_arrival] minute[minutes_to_arrival == 1 ? "" : "s"].")
 				SSshuttle.moveShuttle(cargo_shuttle, docking_home, TRUE)
 
 			. = TRUE

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -187,7 +187,8 @@
 				usr.investigate_log("sent the supply shuttle away.", INVESTIGATE_CARGO)
 			else
 				usr.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)
-				computer.say("The supply shuttle has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minutes.")
+				var/arrives_in_minutes = SSshuttle.supply.timeLeft(600)
+				computer.say("The supply shuttle has been called and will arrive in [arrives_in_minutes] minute[arrives_in_minutes == 1 ? "" : "s"].")
 				SSshuttle.moveShuttle(cargo_shuttle, docking_home, TRUE)
 			. = TRUE
 		if("loan")

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -187,8 +187,7 @@
 				usr.investigate_log("sent the supply shuttle away.", INVESTIGATE_CARGO)
 			else
 				usr.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)
-				var/minutes_to_arrival = SSshuttle.supply.timeLeft(600)
-				computer.say("The supply shuttle has been called and will arrive in [minutes_to_arrival] minute[minutes_to_arrival == 1 ? "" : "s"].")
+				computer.say("The supply shuttle has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minute\s.")
 				SSshuttle.moveShuttle(cargo_shuttle, docking_home, TRUE)
 			. = TRUE
 		if("loan")

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -187,8 +187,8 @@
 				usr.investigate_log("sent the supply shuttle away.", INVESTIGATE_CARGO)
 			else
 				usr.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)
-				var/arrives_in_minutes = SSshuttle.supply.timeLeft(600)
-				computer.say("The supply shuttle has been called and will arrive in [arrives_in_minutes] minute[arrives_in_minutes == 1 ? "" : "s"].")
+				var/minutes_to_arrival = SSshuttle.supply.timeLeft(600)
+				computer.say("The supply shuttle has been called and will arrive in [minutes_to_arrival] minute[minutes_to_arrival == 1 ? "" : "s"].")
 				SSshuttle.moveShuttle(cargo_shuttle, docking_home, TRUE)
 			. = TRUE
 		if("loan")

--- a/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
@@ -47,9 +47,9 @@
 		SSshuttle.emergency_last_call_loc = signal_origin
 	else
 		SSshuttle.emergency_last_call_loc = null
-
+	var/arrives_in_minutes = timeLeft(60 SECONDS)
 	priority_announce(
-		text = "The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [(timeLeft(60 SECONDS))] minutes.[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]",
+		text = "The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [arrives_in_minutes] minute[arrives_in_minutes == 1 ? "" : "s"].[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]",
 		title = "Emergency Shuttle Dispatched",
 		sound = ANNOUNCER_SHUTTLECALLED,
 		sender_override = "Emergency Shuttle Uplink Alert",

--- a/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
@@ -47,9 +47,9 @@
 		SSshuttle.emergency_last_call_loc = signal_origin
 	else
 		SSshuttle.emergency_last_call_loc = null
-	var/arrives_in_minutes = timeLeft(60 SECONDS)
+	var/minutes_to_arrival = timeLeft(60 SECONDS)
 	priority_announce(
-		text = "The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [arrives_in_minutes] minute[arrives_in_minutes == 1 ? "" : "s"].[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]",
+		text = "The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [minutes_to_arrival] minute[minutes_to_arrival == 1 ? "" : "s"].[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]",
 		title = "Emergency Shuttle Dispatched",
 		sound = ANNOUNCER_SHUTTLECALLED,
 		sender_override = "Emergency Shuttle Uplink Alert",

--- a/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
@@ -47,9 +47,8 @@
 		SSshuttle.emergency_last_call_loc = signal_origin
 	else
 		SSshuttle.emergency_last_call_loc = null
-	var/minutes_to_arrival = timeLeft(60 SECONDS)
 	priority_announce(
-		text = "The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [minutes_to_arrival] minute[minutes_to_arrival == 1 ? "" : "s"].[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]",
+		text = "The emergency shuttle has been called. [red_alert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(60 SECONDS)] minute\s.[reason][SSshuttle.emergency_last_call_loc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ][SSshuttle.admin_emergency_no_recall ? "\n\nWarning: Shuttle recall subroutines disabled; Recall not possible." : ""]",
 		title = "Emergency Shuttle Dispatched",
 		sound = ANNOUNCER_SHUTTLECALLED,
 		sender_override = "Emergency Shuttle Uplink Alert",


### PR DESCRIPTION
## About The Pull Request
<img width="397" height="190" alt="image" src="https://github.com/user-attachments/assets/41e915bc-6d8c-4180-83f1-12380c76554c" />

<img width="220" height="112" alt="image" src="https://github.com/user-attachments/assets/ef3aa542-e6e3-4983-8917-66009d4f843e" />

## Why It's Good For The Game
It. is good 👍 

## Changelog

:cl:
spellcheck: shuttles will now say "arriving in 1 minute" instead of "1 minutes"
/:cl:

