### PR TITLE
Fix spraycan-painted clothing not showing on short-height characters (Settler)

### DIFF
--- a/code/game/atom/atom_color.dm
+++ b/code/game/atom/atom_color.dm
@@ -120,20 +120,20 @@
 
 /// Same as update_atom_color, but simplifies overlay coloring
 /atom/proc/color_atom_overlay(mutable_appearance/overlay)
-    overlay.color = color
-    if (!cached_color_filter)
-        return overlay
-    // Apply the atom's color filter to the overlay using named filters so that
-    // later calls to add_filter/update_filters (e.g., height displacement filters)
-    // do not wipe out our coloration. Mirror prior behavior by propagating to
-    // child overlays unless KEEP_TOGETHER is present.
-    overlay.add_filter(ATOM_PRIORITY_COLOR_FILTER, ATOM_PRIORITY_COLOR_FILTER_PRIORITY, cached_color_filter)
+	overlay.color = color
+	if (!cached_color_filter)
+		return overlay
+	// Apply the atom's color filter to the overlay using named filters so that
+	// later calls to add_filter/update_filters (e.g., height displacement filters)
+	// do not wipe out our coloration. Mirror prior behavior by propagating to
+	// child overlays unless KEEP_TOGETHER is present.
+	overlay.add_filter(ATOM_PRIORITY_COLOR_FILTER, ATOM_PRIORITY_COLOR_FILTER_PRIORITY, cached_color_filter)
 
-    if(!(overlay.appearance_flags & KEEP_TOGETHER))
-        // Recursively ensure any nested overlays/underlays also get the color filter
-        for(var/mutable_appearance/child_overlay as anything in overlay.overlays)
-            color_atom_overlay(child_overlay)
-        for(var/mutable_appearance/child_underlay as anything in overlay.underlays)
-            color_atom_overlay(child_underlay)
+	if(!(overlay.appearance_flags & KEEP_TOGETHER))
+		// Recursively ensure any nested overlays/underlays also get the color filter
+		for(var/mutable_appearance/child_overlay as anything in overlay.overlays)
+			color_atom_overlay(child_overlay)
+		for(var/mutable_appearance/child_underlay as anything in overlay.underlays)
+			color_atom_overlay(child_underlay)
 
-    return overlay
+	return overlay

--- a/code/game/atom/atom_color.dm
+++ b/code/game/atom/atom_color.dm
@@ -120,7 +120,20 @@
 
 /// Same as update_atom_color, but simplifies overlay coloring
 /atom/proc/color_atom_overlay(mutable_appearance/overlay)
-	overlay.color = color
-	if (!cached_color_filter)
-		return overlay
-	return filter_appearance_recursive(overlay, cached_color_filter)
+    overlay.color = color
+    if (!cached_color_filter)
+        return overlay
+    // Apply the atom's color filter to the overlay using named filters so that
+    // later calls to add_filter/update_filters (e.g., height displacement filters)
+    // do not wipe out our coloration. Mirror prior behavior by propagating to
+    // child overlays unless KEEP_TOGETHER is present.
+    overlay.add_filter(ATOM_PRIORITY_COLOR_FILTER, ATOM_PRIORITY_COLOR_FILTER_PRIORITY, cached_color_filter)
+
+    if(!(overlay.appearance_flags & KEEP_TOGETHER))
+        // Recursively ensure any nested overlays/underlays also get the color filter
+        for(var/mutable_appearance/child_overlay as anything in overlay.overlays)
+            color_atom_overlay(child_overlay)
+        for(var/mutable_appearance/child_underlay as anything in overlay.underlays)
+            color_atom_overlay(child_underlay)
+
+    return overlay


### PR DESCRIPTION
## About The Pull Request

https://github.com/user-attachments/assets/858081ed-114a-4f34-a925-e6b0250c29e2


Fixes spraycan-painted clothing not appearing painted when worn by short-height characters (e.g., with the Settler quirk). The item color filter was being effectively dropped when height displacement filters were applied to worn overlays.

Implementation: update color_atom_overlay() to apply the atom’s color as a named filter on the overlay (and recursively on child overlays/underlays), preserving coloration even when additional filters (like height) are later added.
## Why It's Good For The Game
Fixes #92536
Fixes a visible inconsistency: painted clothes now look painted on-mob for short-height characters.
Improves clarity and player feedback; reduces confusion when using spray cans.
The approach is robust and benefits other cases where overlays receive filters after coloration.
## Changelog
:cl:
fix: Spraycan-painted clothing now displays correctly when worn by short-height characters (e.g., Settler); paint no longer disappears on the mob sprite.
code: Worn overlay coloration now uses named filters and recurses to child overlays, making it resilient to later filter changes (like height displacement).
/:cl:
