### PR TITLE
[SPEC-OPS UPLINK] Add scream modsuit module (2 TC)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -177,3 +177,6 @@
 
 /// From /mob/living/carbon/proc/set_blood_type : (mob/living/carbon/user, datum/blood_type, update_cached_blood_dna_info)
 #define COMSIG_CARBON_CHANGED_BLOOD_TYPE "carbon_set_blood_type"
+
+///from mob/living/carbon/human/viewed_by_human(). Takes mob/living/carbon/human as argument
+#define COMSIG_HUMAN_VIEW_EQUIPMENT "human_view_equipment"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1076,6 +1076,57 @@
 		return FALSE
 	return head_covered || HAS_TRAIT(src, TRAIT_HEAD_ATMOS_SEALED)
 
+/mob/living/carbon/human/proc/view_humans_around()
+	for(var/mob/living/carbon/human/viewer as anything in GLOB.human_list)
+		if(src == viewer)
+			continue
+
+		// if src inside closet/box
+		var/turf/real_src_turf = get_turf(src.loc)
+
+		if(src.stat in list(CONSCIOUS, SOFT_CRIT)) // in conscious
+			if(!(src.is_blind())) // can see
+				if(!(viewer.invisibility || viewer.alpha <= 50)) //cloaked
+					if(isturf(viewer.loc)) // on a turf, because they could be in a closet, disposals, or a vehicle.
+						if(can_see(real_src_turf, viewer, 7))
+							viewer.viewed_by_human(src)
+
+		// if viewer inside closet/box
+		var/turf/real_viewer_turf = get_turf(viewer.loc)
+
+		if(viewer.stat in list(CONSCIOUS, SOFT_CRIT)) // in conscious
+			if(!(viewer.is_blind())) // can see
+				if(!(src.invisibility || src.alpha <= 50)) // cloaked
+					if(isturf(src.loc)) // on a turf, because they could be in a closet, disposals, or a vehicle.
+						if(can_see(real_viewer_turf, src, 7))
+							src.viewed_by_human(viewer)
+
+/mob/living/carbon/human/proc/viewed_by_human(mob/living/carbon/human/viewer)
+	if(head)
+		SEND_SIGNAL(head, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(wear_mask)
+		SEND_SIGNAL(wear_mask, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(glasses)
+		SEND_SIGNAL(glasses, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(ears)
+		SEND_SIGNAL(ears, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(wear_neck)
+		SEND_SIGNAL(wear_neck, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(wear_suit)
+		SEND_SIGNAL(wear_suit, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(w_uniform)
+		SEND_SIGNAL(w_uniform, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(back)
+		SEND_SIGNAL(back, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(gloves)
+		SEND_SIGNAL(gloves, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(belt)
+		SEND_SIGNAL(belt, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(wear_id)
+		SEND_SIGNAL(wear_id, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+	if(shoes)
+		SEND_SIGNAL(shoes, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)
+
 /mob/living/carbon/human/species/abductor
 	race = /datum/species/abductor
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -24,9 +24,17 @@
 /mob/living/carbon/human/mob_negates_gravity()
 	return dna.species.negates_gravity(src) || ..()
 
+
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
+
+	view_humans_around()
+
 	if(shoes && body_position == STANDING_UP && has_gravity(loc))
 		if((. && !moving_diagonally) || (!. && moving_diagonally == SECOND_DIAG_STEP))
 			SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
 
+/mob/living/carbon/human/forceMove(atom/destination)
+	. = ..()
+
+	view_humans_around()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2721,11 +2721,18 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		return
 	mob_mood.add_mood_event(arglist(args))
 
+/// Check a having mood category from the mob
+/mob/living/proc/has_mood_of_category(category)
+	if(QDELETED(mob_mood))
+		return
+	return mob_mood.has_mood_of_category(category)
+
 /// Clears a mood event from the mob
 /mob/living/proc/clear_mood_event(category)
 	if(QDELETED(mob_mood))
 		return
 	mob_mood.clear_mood_event(category)
+
 
 /// This should be called by games when the gamer reaches a winning state, just sends a signal
 /mob/living/proc/won_game()

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -102,6 +102,7 @@
 	update_speed()
 	RegisterSignal(src, COMSIG_ATOM_EXITED, PROC_REF(on_exit))
 	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, PROC_REF(on_potion))
+	RegisterSignal(src, COMSIG_HUMAN_VIEW_EQUIPMENT, PROC_REF(on_view_equipment))
 	for(var/obj/item/mod/module/module as anything in theme.inbuilt_modules)
 		module = new module(src)
 		install(module)
@@ -772,3 +773,9 @@
 	if (length(overrides))
 		return overrides[1]
 	return mutable_appearance(worn_icon, "[skin]-helmet-visor", layer = standing.layer + 0.1)
+
+/obj/item/mod/control/proc/on_view_equipment(datum/source, mob/living/carbon/human/viewer)
+	SIGNAL_HANDLER
+
+	for(var/obj/item/mod/module/module as anything in modules)
+		SEND_SIGNAL(module, COMSIG_HUMAN_VIEW_EQUIPMENT, viewer)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -551,3 +551,45 @@
 		Most point fingers at Cybersun Industries, but murmurs suggest it could even be even more clandestine organizations amongst the Syndicate branches. \
 		Whatever the case, if you are looking at one of these right now, don't show it to a space ninja." \
 	)
+
+
+/obj/item/mod/module/syndicate_screamer
+	name = "MOD Screamer Module"
+	desc = "An indescribable, terrifying module that strikes fear into those unprepared to view it. Only compatible with Syndicate modsuits."
+	icon_state = "brain_hurties"
+	complexity = 1
+	module_type = MODULE_TOGGLE
+	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.1
+	required_slots = list(ITEM_SLOT_HEAD)
+
+	var/list/allowed_mod_themes = list(
+		/datum/mod_theme/syndicate,
+		/datum/mod_theme/elite,
+		/datum/mod_theme/infiltrator
+	)
+
+/obj/item/mod/module/syndicate_screamer/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_MODULE_TRIGGERED, PROC_REF(on_module_triggered))
+	RegisterSignal(src, COMSIG_HUMAN_VIEW_EQUIPMENT, PROC_REF(on_view_equipment))
+
+/obj/item/mod/module/syndicate_screamer/proc/on_module_triggered(datum/source)
+	SIGNAL_HANDLER
+
+	if(!(is_type_in_list(mod.theme, allowed_mod_themes)))
+		balloon_alert(mod.wearer, "only compatible with Syndicate modsuits!")
+		return MOD_ABORT_USE
+
+/obj/item/mod/module/syndicate_screamer/proc/on_view_equipment(datum/source, mob/living/carbon/human/viewer)
+	// SIGNAL_HANDLER
+
+	var/mood_category = "scream module"
+
+	if(active && !viewer.has_mood_of_category(mood_category))
+		to_chat(viewer, span_notice("You see indescribable horror."))
+		viewer.add_mood_event(mood_category, /datum/mood_event/scream_module)
+		viewer.emote("scream")
+
+/datum/mood_event/scream_module
+	description = "I cannot forget the horror I experienced."
+	timeout = 1 MINUTES

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -757,6 +757,15 @@
 	cant_discount = TRUE
 	refundable = TRUE
 
+/datum/uplink_item/suits/screamer_module
+	name = "MODsuit Screamer Module"
+	desc = "An indescribably terrifying module recreated from Lovecraft's secret blueprints, causing involuntary screams within sight after activation. Only compatible with Syndicate modsuits."
+	item = /obj/item/mod/module/syndicate_screamer
+	cost = 2
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS
+	cant_discount = TRUE
+	refundable = TRUE
+
 // Devices
 
 /datum/uplink_item/device_tools/assault_pod


### PR DESCRIPTION
## About The Pull Request

Added spec-ops only (nukees, loner) modsuit module in uplink by 2 TC, сausing uncontrollable terror (auto *scream) when activated and observed within the FOV, except for the module carrier.

The price is justified not only by its guaranteed screams and loud noise, but also by its ability to detect enemies hiding in ambush (closets) with its unexpected and frightening appearance. 1 minute cooldown.

An invisible nukee (in a closet or stealth box) does not cause a screaming reaction and does not reveal itself.

The added code COMSIG_HUMAN_VIEW_EQUIPMENT can be used for the *salute module of HoS, or especially for the evil clown hat with *laugh, or for any other observation mechanics within the FOV.

WARNING: Allied nukees (like all antagonists) are also susceptible to intimidation, regardless of whether they have a module.

_The device recreates indescribable horror based on Lovecraft's secret drawings._

## Why It's Good For The Game

Some variety for TC nukee leftovers, allowing them to enjoy the endless *scream of station staff (And also spot ambushes in closets)

## Changelog

<img width="750" height="573" alt="image" src="https://github.com/user-attachments/assets/2887f806-c247-49e3-aadb-51e6770daec6" />
<img width="509" height="106" alt="image" src="https://github.com/user-attachments/assets/ee9cb72c-5268-4e90-8193-98bdd74ecef8" />


:cl:
add: Added screamer modsuit module to spec-ops uplink (2 TC)
code: Added "COMSIG_HUMAN_VIEW_EQUIPMENT" and "/view_humans_around" for handle viewing in-game human and their equipment
/:cl:
