### PR TITLE
Lowers the TC price of the Suppressor

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -48,7 +48,7 @@
 	name = "Suppressor"
 	desc = "This suppressor will silence the shots of the weapon it is attached to for increased stealth and superior ambushing capability. It is compatible with many small ballistic guns including the Makarov, Stechkin APS and C-20r, but not revolvers or energy guns."
 	item = /obj/item/suppressor
-	cost = 3
+	cost = 1
 	surplus = 10
 	purchasable_from = ~UPLINK_CLOWN_OPS
 


### PR DESCRIPTION
## About The Pull Request

TC price on the suppressor has been lowered from 3 to 1 TC.

## Why It's Good For The Game

The suppressor is an incredibly niche utility item that's dependant on another purchase to see any use, the Makarov.

While the Makarov is a pretty solid choice for a sidearm,  I don't think its only attachment should cost more than some of our grenade bundles.

## Changelog

:cl:
balance: Uplink price on the suppressor has been lowered from 3 to 1 TC.
/:cl:

