### PR TITLE
[NO GBP] Vendor load limit Qol & custom vendor deconstruction fix

### DIFF
--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -34,10 +34,7 @@
 		return
 
 	//copy product hash keys
-	if(installed_refill.products)
-		installed_refill.products.Cut()
-	else
-		installed_refill.products = list()
+	installed_refill.products.Cut()
 	installed_refill.products += products
 
 	//move products to canister
@@ -131,6 +128,8 @@
 /obj/machinery/vending/custom/restock(obj/item/vending_refill/canister)
 	. = 0
 	if(!canister.products?.len)
+		if(!canister.products)
+			canister.products = list()
 		return
 
 	var/update_static_data = FALSE

--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -34,7 +34,10 @@
 		return
 
 	//copy product hash keys
-	installed_refill.products.Cut()
+	if(installed_refill.products)
+		installed_refill.products.Cut()
+	else
+		installed_refill.products = list()
 	installed_refill.products += products
 
 	//move products to canister

--- a/code/modules/vending/vendor/interaction.dm
+++ b/code/modules/vending/vendor/interaction.dm
@@ -1,6 +1,3 @@
-/// Maximum amount of items in a storage bag that we're transferring items to the vendor from.
-#define MAX_VENDING_INPUT_AMOUNT 30
-
 //================================TOOL ACTS==============================================
 /obj/machinery/vending/crowbar_act(mob/living/user, obj/item/attack_item)
 	if(!component_parts)
@@ -115,9 +112,6 @@
 			var/loaded = 0
 			var/denied_items = 0
 			for(var/obj/item/the_item in storage_item.contents)
-				if(contents.len >= MAX_VENDING_INPUT_AMOUNT) // no more than 30 item can fit inside, legacy from snack vending although not sure why it exists
-					to_chat(user, span_warning("[src]'s compartment is full."))
-					break
 				if(loadingAttempt(the_item, user))
 					loaded++
 				else
@@ -231,5 +225,3 @@
 	. = ..()
 	if (!Adjacent(user, src))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-#undef MAX_VENDING_INPUT_AMOUNT


### PR DESCRIPTION
## About The Pull Request
- Fixes runtime when deconstructing custom vending machine
- Removes arbitrary limit on loading items from a bag into the vending machine.

## Changelog
:cl:
qol: you can stock more than 30 items from a bag into an vending machine
fix: fixes runtime when deconstructing custom vending machines
/:cl:

