### PR TITLE
Cleanbots can now clean Cigbutts

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -106,6 +106,7 @@
 		/obj/item/trash,
 		/obj/item/food/deadmouse,
 		/obj/effect/decal/remains,
+		/obj/item/cigbutt,
 	))
 	///drawings we hunt
 	var/static/list/cleanable_drawings = typecacheof(list(/obj/effect/decal/cleanable/crayon))


### PR DESCRIPTION
No more roaches and rollies everywhere. Baby's first PR.
## About The Pull Request

Adds cigbutts to the list of trash on cleanbots. Cleanbots will now melt and sweep cigarette butts, cigar butts, roaches, etc.

## Why It's Good For The Game

Cigarette trash is still trash, and deserves to be melted like the rest of the trash.

## Changelog
:cl:
add: Cleanbots now clean up used cigarettes.
/:cl:
