### PR TITLE
follow up fix for #92508

### DIFF
--- a/code/controllers/subsystem/asset_loading.dm
+++ b/code/controllers/subsystem/asset_loading.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(asset_loading)
 	flags = SS_NO_INIT
 	runlevels = RUNLEVEL_LOBBY|RUNLEVELS_DEFAULT
 	var/list/datum/asset/generate_queue = list()
+	var/assets_generating = 0
 	var/last_queue_len = 0
 
 /datum/controller/subsystem/asset_loading/fire(resumed)
@@ -22,7 +23,7 @@ SUBSYSTEM_DEF(asset_loading)
 			return
 
 	// We just emptied the queue
-	if(last_queue_len && !length(generate_queue))
+	if(last_queue_len && !length(generate_queue) && !assets_generating)
 		// Clean up cached icons, freeing memory.
 		rustg_iconforge_cleanup()
 

--- a/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
+++ b/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
@@ -189,8 +189,10 @@
 	var/data_out
 	if(yield || !isnull(job_id))
 		if(isnull(job_id))
+			SSasset_loading.assets_generating++
 			job_id = rustg_iconforge_generate_async("data/spritesheets/", name, entries_json, do_cache, FALSE, TRUE)
 		UNTIL((data_out = rustg_iconforge_check(job_id)) != RUSTG_JOB_NO_RESULTS_YET)
+		SSasset_loading.assets_generating--
 	else
 		data_out = rustg_iconforge_generate("data/spritesheets/", name, entries_json, do_cache, FALSE, TRUE)
 	if (data_out == RUSTG_JOB_ERROR)


### PR DESCRIPTION

## About The Pull Request
This is a follow up patch for #92508, otherwise than said in coderbus, calling the cleanup too early can lead to bad assets. We'll now keep track of the count of assets in generation and only clean up after they all have passed the generation.
<img width="3067" height="455" alt="grafik" src="https://github.com/user-attachments/assets/0b65acf3-464f-436c-8a60-84c9472be6cd" />
## Why It's Good For The Game
## Changelog
There should be nothing player facing here as the asset job fails straight up if the cache was cleared too early.
