### PR TITLE
Fix for the issue of mulebots unable to buckle people to themselves.

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -45,6 +45,7 @@
 
 	// Snowflake for bots buckling people by dragging them onto them, unless in combat mode.
 	if(isbot(user))
+		var/mob/living/simple_animal/bot/bot_user = user
 		if (!bot_user.combat_mode)
 			return
 	// Snowflake for cyborgs buckling people by dragging them onto them, unless in combat mode.

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -43,15 +43,10 @@
 	if(!user.can_perform_action(source, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
 		return
 
-	// Snowflake for bots buckling people by dragging them onto them, unless in combat mode.
-	if(isbot(user))
-		var/mob/living/simple_animal/bot/bot_user = user
+	// Snowflake for cyborgs and bots buckling people by dragging them onto them, unless in combat mode.
+	if(iscyborg(user) || isbot(user))
+		var/mob/living/bot_user = user
 		if (!bot_user.combat_mode)
-			return
-	// Snowflake for cyborgs buckling people by dragging them onto them, unless in combat mode.
-	if (iscyborg(user))
-		var/mob/living/silicon/robot/cyborg_user = user
-		if (!cyborg_user.combat_mode)
 			return
 	// Snowflake for xeno consumption code
 	if (isalienadult(user))

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -43,6 +43,10 @@
 	if(!user.can_perform_action(source, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
 		return
 
+	// Snowflake for bots buckling people by dragging them onto them.
+	if(isbot(user))
+		if (!bot_user.combat_mode)
+			return
 	// Snowflake for cyborgs buckling people by dragging them onto them, unless in combat mode.
 	if (iscyborg(user))
 		var/mob/living/silicon/robot/cyborg_user = user

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -43,7 +43,7 @@
 	if(!user.can_perform_action(source, FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
 		return
 
-	// Snowflake for bots buckling people by dragging them onto them.
+	// Snowflake for bots buckling people by dragging them onto them, unless in combat mode.
 	if(isbot(user))
 		if (!bot_user.combat_mode)
 			return


### PR DESCRIPTION
## About The Pull Request
Crude but simple fix for mulebots trying to buckle people. Mouse dragging was opening stripping UI instead of buckling people.
Bots can't strip people anyway but I left a way to open strip UI. It is working just like for cyborgs, bot needs to be in combat mode to open it. Maybe someone will want to let Medbot strip people.

The issue happened when new strip UI was added 4 years ago: https://github.com/tgstation/tgstation/pull/57889

Before the new UI the problem was known and someone fixed it:
<img width="633" height="149" alt="obraz" src="https://github.com/user-attachments/assets/bfa3c323-60db-485c-a2d4-79c687839b74" />

But such simple solution isn't available anymore.
## Why It's Good For The Game
Fix good, we fix.
## Changelog
:cl:
fix: Fixed bots unable to buckle people to themselves.
/:cl:
