### PR TITLE
don't use `get_all_contents` every process for family heirlooms

### DIFF
--- a/code/datums/quirks/negative_quirks/family_heirloom.dm
+++ b/code/datums/quirks/negative_quirks/family_heirloom.dm
@@ -58,7 +58,7 @@
 /datum/quirk/item_quirk/family_heirloom/process()
 	var/obj/family_heirloom = heirloom?.resolve()
 
-	if(family_heirloom && (family_heirloom in quirk_holder.get_all_contents()))
+	if(family_heirloom && quirk_holder.contains(family_heirloom))
 		quirk_holder.clear_mood_event("family_heirloom_missing")
 		quirk_holder.add_mood_event("family_heirloom", /datum/mood_event/family_heirloom)
 	else


### PR DESCRIPTION

## About The Pull Request

the family heirloom quirk runs `get_all_contents` on the quirk holder every process. which is kinda dumb and wasteful when we are looking to see if the quirk holder has an item _that we already have a reference to_... `/atom/proc/contains` exists and works just fine for this.

## Why It's Good For The Game

`get_all_contents` is very wasteful and unneeded for this use-case

## Changelog

no user-facing changes