### PR TITLE
Things that are edible now count as golem food if their materials allow it.

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -539,7 +539,7 @@ Behavior that's still missing from this component that original food items had t
 			if(effect?.can_consume(eater))
 				effect.on_consumption(eater, owner, effect_stack_amount)
 
-	if(fraction > 1) //don't bother if the item is about to be deleted anyway...
+	if(fraction >= 1) //don't bother if the item is about to be deleted anyway...
 		return
 
 	if(is_stack) //stacks use up sheets, which recalulates the materials already.

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -531,15 +531,15 @@ Behavior that's still missing from this component that original food items had t
 	var/is_stack = isstack(owner)
 
 	if(owner.custom_materials) //food may also apply golem buffs if it contains certain materials and the mob has the required trait
-		var/effect_stack_amount = (owner.custom_materials[owner.custom_materials[1]] * fraction) / SHEET_MATERIAL_AMOUNT
-		var/datum/material/main_mat = owner.get_master_material()
-		var/datum/golem_food_buff/effect
-		if(main_mat.sheet_type)
-			effect = GLOB.golem_stack_food_directory[main_mat.sheet_type]
-		if(!effect && main_mat.ore_type)
-			effect = GLOB.golem_stack_food_directory[main_mat.ore_type]
-		if(effect?.can_consume(eater))
-			effect.on_consumption(eater, owner, effect_stack_amount)
+		for(var/datum/material/material as anything in owner.custom_materials)
+			var/effect_stack_amount = (owner.custom_materials[material] * fraction) / SHEET_MATERIAL_AMOUNT
+			var/datum/golem_food_buff/effect
+			if(material.sheet_type)
+				effect = GLOB.golem_stack_food_directory[material.sheet_type]
+			if(!effect && material.ore_type)
+				effect = GLOB.golem_stack_food_directory[material.ore_type]
+			if(effect?.can_consume(eater))
+				effect.on_consumption(eater, owner, effect_stack_amount)
 
 	if(fraction > 1) //don't bother if the item is about to be deleted anyway...
 		return

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -530,14 +530,12 @@ Behavior that's still missing from this component that original food items had t
 	var/atom/owner = parent
 	var/is_stack = isstack(owner)
 
-	if(owner.custom_materials) //food may also apply golem buffs if it contains certain materials and the mob has the required trait
+	//food may also apply golem buffs if it contains certain materials and the mob has the required trait
+	if(owner.custom_materials && HAS_TRAIT(eater, TRAIT_ROCK_EATER))
 		for(var/datum/material/material as anything in owner.custom_materials)
 			var/effect_stack_amount = (owner.custom_materials[material] * fraction) / SHEET_MATERIAL_AMOUNT
 			var/datum/golem_food_buff/effect
-			if(material.sheet_type)
-				effect = GLOB.golem_stack_food_directory[material.sheet_type]
-			if(!effect && material.ore_type)
-				effect = GLOB.golem_stack_food_directory[material.ore_type]
+			effect = GLOB.golem_stack_food_directory[material.sheet_type || material.ore_type]
 			if(effect?.can_consume(eater))
 				effect.on_consumption(eater, owner, effect_stack_amount)
 

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -23,8 +23,9 @@
 	fishing_gravity_mult = 1.1
 
 /datum/material/iron/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
+		return TRUE
 
 ///Breaks extremely easily but is transparent.
 /datum/material/glass
@@ -62,8 +63,9 @@
 	fishing_gravity_mult = 0.9
 
 /datum/material/glass/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5, sharpness = TRUE) //cronch
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5, sharpness = TRUE) //cronch
+		return TRUE
 
 /datum/material/glass/on_main_applied(atom/source, mat_amount, multiplier)
 	. = ..()
@@ -110,8 +112,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_gravity_mult = 1.1
 
 /datum/material/silver/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
+		return TRUE
 
 ///Slight force increase
 /datum/material/gold
@@ -186,8 +189,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_gravity_mult = 1.1
 
 /datum/material/diamond/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
+		return TRUE
 
 ///Is slightly radioactive
 /datum/material/uranium
@@ -444,8 +448,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_gravity_mult = 1.1
 
 /datum/material/titanium/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
+		return TRUE
 
 /datum/material/runite
 	name = "runite"
@@ -484,8 +489,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		REMOVE_TRAIT(source, TRAIT_ROD_REMOVE_FISHING_DUD, REF(src)) //light-absorbing, environment-cancelling fishing rod.
 
 /datum/material/runite/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
+		return TRUE
 
 ///Force decrease
 /datum/material/plastic
@@ -568,7 +574,8 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		wooden.resistance_flags &= ~FLAMMABLE
 
 /datum/material/wood/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(5, BRUTE, BODY_ZONE_HEAD)
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(5, BRUTE, BODY_ZONE_HEAD)
 	victim.reagents.add_reagent(/datum/reagent/cellulose, rand(8, 12))
 	source_item?.reagents?.add_reagent(/datum/reagent/cellulose, source_item.reagents.total_volume*(2/5))
 
@@ -613,8 +620,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		REMOVE_TRAIT(source, TRAIT_ROD_REMOVE_FISHING_DUD, REF(src)) //light-absorbing, environment-cancelling fishing rod.
 
 /datum/material/adamantine/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
+		return TRUE
 
 ///RPG Magic.
 /datum/material/mythril
@@ -657,8 +665,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		qdel(source.GetComponent(/datum/component/fantasy))
 
 /datum/material/mythril/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
+		return TRUE
 
 //formed when freon react with o2, emits a lot of plasma when heated
 /datum/material/hot_ice
@@ -728,8 +737,9 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	fishing_gravity_mult = 0.7
 
 /datum/material/metalhydrogen/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
-	return TRUE
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
+		return TRUE
 
 //I don't like sand. It's coarse, and rough, and irritating, and it gets everywhere.
 /datum/material/sand
@@ -847,7 +857,8 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/runedmetal/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.reagents.add_reagent(/datum/reagent/fuel/unholywater, rand(8, 12))
-	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
 	return TRUE
 
 /datum/material/bronze
@@ -1079,6 +1090,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		REMOVE_TRAIT(source, TRAIT_ROD_IGNORE_ENVIRONMENT, REF(src)) //light-absorbing, environment-cancelling fishing rod.
 
 /datum/material/zaukerite/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
-	victim.apply_damage(30, BURN, BODY_ZONE_HEAD, wound_bonus = 5)
+	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
+		victim.apply_damage(30, BURN, BODY_ZONE_HEAD, wound_bonus = 5)
 	source_item?.reagents?.add_reagent(/datum/reagent/toxin/plasma, source_item.reagents.total_volume*5)
 	return TRUE

--- a/code/game/atom/atom_materials.dm
+++ b/code/game/atom/atom_materials.dm
@@ -378,16 +378,7 @@
 	var/list/cached_materials = custom_materials
 	if(!length(cached_materials))
 		return null
-
-	var/most_common_material = null
-	var/max_amount = 0
-	for(var/material in cached_materials)
-		if(cached_materials[material] > max_amount)
-			most_common_material = material
-			max_amount = cached_materials[material]
-
-	if(most_common_material)
-		return GET_MATERIAL_REF(most_common_material)
+	return GET_MATERIAL_REF(cached_materials[1]) //materials are sorted by amount, the first is always the main one
 
 /**
  * Gets the total amount of materials in this atom.

--- a/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
@@ -42,10 +42,10 @@
 	/// Order in which to heal damage types
 	var/list/damage_heal_order = list(BRUTE, BURN, TOX, OXY)
 
-/datum/golem_food_buff/iron/apply_effects(mob/living/carbon/consumer, atom/movable/consumed)
+/datum/golem_food_buff/iron/apply_effects(mob/living/carbon/consumer, atom/movable/consumed, multiplier = 1)
 	if (consumer.health == consumer.maxHealth)
 		return
-	consumer.heal_ordered_damage(healed_amount, damage_heal_order)
+	consumer.heal_ordered_damage(healed_amount * multiplier, damage_heal_order)
 	new /obj/effect/temp_visual/heal(get_turf(consumer), COLOR_HEALING_CYAN)
 
 /datum/golem_food_buff/uranium
@@ -90,7 +90,7 @@
 	exclusive = FALSE
 	added_info = "After consumption, you can launch this mineral like a rocket. It's a little hard to keep down."
 
-/datum/golem_food_buff/gibtonite/apply_effects(mob/living/carbon/human/consumer, atom/movable/consumed)
+/datum/golem_food_buff/gibtonite/apply_effects(mob/living/carbon/human/consumer, atom/movable/consumed, multiplier = 1)
 	var/obj/item/gibtonite_hand/new_hand = new(null, /* held_gibtonite = */ consumed)
 
 	if(consumer.put_in_hands(new_hand))
@@ -108,10 +108,14 @@
 	exclusive = FALSE
 	added_info = "After consumption, you can use the stored power to teleport yourself."
 
-/datum/golem_food_buff/bluespace/apply_effects(mob/living/carbon/human/consumer, obj/item/stack/consumed)
+/datum/golem_food_buff/bluespace/apply_effects(mob/living/carbon/human/consumer, atom/movable/consumed, multiplier = 1)
+	if(multiplier <= 0.2)
+		return
 	var/obj/item/bluespace_finger/new_hand = new
-	if (consumed.amount == 1)
-		consumer.dropItemToGround(consumed)
+	if (isstack(consumed))
+		var/obj/item/stack/stack = consumed
+		if(stack.amount == 1)
+			consumer.dropItemToGround(stack)
 	if (consumer.put_in_hands(new_hand, del_on_fail = TRUE))
 		return
 	consumer.balloon_alert(consumer, "no free hands!")

--- a/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
@@ -17,15 +17,15 @@
 	return !existing || istype(existing, status_effect)
 
 /// Called when someone actually eats this
-/datum/golem_food_buff/proc/on_consumption(mob/living/carbon/consumer, atom/movable/consumed)
+/datum/golem_food_buff/proc/on_consumption(mob/living/carbon/consumer, atom/movable/consumed, multiplier = 1)
 	if (!HAS_TRAIT(consumer, TRAIT_ROCK_METAMORPHIC))
 		return
-	apply_effects(consumer, consumed)
+	apply_effects(consumer, consumed, multiplier)
 
 /// Apply our desired effects to the eater
-/datum/golem_food_buff/proc/apply_effects(mob/living/carbon/consumer, atom/movable/consumed)
+/datum/golem_food_buff/proc/apply_effects(mob/living/carbon/consumer, atom/movable/consumed, multiplier = 1)
 	if (status_effect)
-		consumer.apply_status_effect(status_effect)
+		consumer.apply_status_effect(status_effect, multiplier)
 
 /// Can eat at any time, but isn't very nutritious
 /datum/golem_food_buff/glass

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -94,9 +94,16 @@
 		animate(alpha = 50, time = 7.5 SECONDS, loop = -1, easing = SINE_EASING)
 	return TRUE
 
-/datum/status_effect/golem/on_creation(mob/living/new_owner)
+/datum/status_effect/golem/on_creation(mob/living/new_owner, multiplier = 1)
+	///instead of straight out multiplying the duration, we use exponents to flatten the duration so it doesn't become exceedingly long for golems
+	var/exponent = 0.2
 	if(!isgolem(new_owner))
 		duration *= 0.1
+		exponent = 0.5 //non-golem benefit more from higher multipliers since it normally only lasts for 30 seconds for them.
+	if(multiplier > 1)
+		duration *= multiplier ** exponent
+	else // if the multiplier is lower than 1, don't bother using powers.
+		duration *= multiplier
 	var/buff_duration = duration
 	. = ..()
 	if (!.)


### PR DESCRIPTION
## About The Pull Request
This PR allows golems or anyone with the genetic mutation to benefit from the effects of golem food if what they're eating is made of a material tied to ore or sheets with golem food effects.

In layman terms, this means you can deepfry a chair and get golem buffs that way. The duration also scales with the amount of material consumed, which also depends on the bite size of the food. Smaller doses translate to a shorter duration of the effect, while the viceversa is also true (however with diminishing returns).

Also, you won't take immediate damage from biting, food with items made of metals and glass stuffed into it if you've the rock eater trait (come on dude, you eat literal raw diamonds). This has nothing to do with golem food, but it's one less peeve off the list as I slowly and occasionally work on material datums and their presence in the game.

## Why It's Good For The Game
Adding some depth to materials and food, albeit not much.

## Changelog

:cl:
add: Things that are edible may also count as golem food if the materials they're made of allow it.
/:cl:
