### PR TITLE
Fix delayed camera playsound

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -331,11 +331,12 @@
 	return
 
 /obj/item/camera/proc/after_picture(mob/user, datum/picture/picture)
+	if(!silent)
+		playsound(loc, SFX_POLAROID, 75, TRUE, -3)
+
 	if(print_picture_on_snap)
 		printpicture(user, picture)
 
-	if(!silent)
-		playsound(loc, SFX_POLAROID, 75, TRUE, -3)
 
 /obj/item/camera/proc/printpicture(mob/user, datum/picture/picture) //Normal camera proc for creating photos
 	pictures_left--


### PR DESCRIPTION

## About The Pull Request
The sound effect was delayed until the "printpicture" proc was completed. Customizing the photo paused this proc until the player either confirmed or rejected the customization, which caused the sound effect to be delayed - though flash still played.

## Why It's Good For The Game
Camera working as intended

## Changelog
:cl:
fix: Camera flash sound now plays before customization, fixing the delayed sound issue caused by it.
/:cl:
