### PR TITLE
Fixes tank holder description

### DIFF
--- a/code/game/objects/structures/tank_holder.dm
+++ b/code/game/objects/structures/tank_holder.dm
@@ -35,11 +35,14 @@
 
 /obj/structure/tank_holder/examine(mob/user)
 	. = ..()
-	. += "It is [anchored ? "wrenched to the floor." : "The <i>bolts</i> on the bottom are unsecured."]<br/>"
-	if(tank)
-		. += "It is holding one [tank]."
+	if(anchored)
+		. += span_notice("It is <b>bolted</b> to the floor.")
 	else
-		. += "It is empty."
+		. += span_notice("The <i>bolts</i> on the bottom are unsecured.")
+	if(tank)
+		. += span_notice("It is holding \a [tank].")
+	else
+		. += span_notice("It is empty.")
 	. += span_notice("It is held together by some <b>screws</b>.")
 
 /obj/structure/tank_holder/attackby(obj/item/W, mob/living/user, list/modifiers, list/attack_modifiers)

--- a/code/game/objects/structures/tank_holder.dm
+++ b/code/game/objects/structures/tank_holder.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/canisters.dmi'
 	icon_state = "holder"
 
-	custom_materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT)
+	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
 
 	density = FALSE
 	anchored = FALSE

--- a/code/game/objects/structures/tank_holder.dm
+++ b/code/game/objects/structures/tank_holder.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/canisters.dmi'
 	icon_state = "holder"
 
-	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)
 
 	density = FALSE
 	anchored = FALSE


### PR DESCRIPTION

## About The Pull Request
Fixes "It is The bolts[...]" in tank holder desc, changes tanks from "one" to "a"/"an" (i.e. "an oxygen tank" instead of "one oxygen tank") and adds span_notice to the other parts of the description to fit with the screws message.
## Why It's Good For The Game
Fixes a grammar mistake in the description.
The "one [...]" doesn't make sense for something that only holds a single tank at a time.
Using span_notice for the description makes it more uniform and consistent.
## Changelog
:cl:
spellcheck: Fixes "It is The bolts on the bottom are..." in tank holder descriptions, and improves grammar for inserted objects.
/:cl:
