### PR TITLE
Changes organ manipulation surgery to use a radial menu instead of a tgui list

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -226,9 +226,17 @@
 			for(var/obj/item/organ/organ in organs)
 				organ.on_find(user)
 				organs -= organ
-				organs[organ.name] = organ
+				organs[organ] = organ
 
-			var/chosen_organ = tgui_input_list(user, "Remove which organ?", "Surgery", sort_list(organs))
+			var/obj/item/organ/chosen_organ = show_radial_menu(
+				user,
+				target,
+				organs,
+				radius = 15 + (length(organs) * 5),
+				require_near = TRUE,
+				tooltips = TRUE,
+				autopick_single_option = FALSE,
+			)
 			if(isnull(chosen_organ))
 				return SURGERY_STEP_FAIL
 			target_organ = chosen_organ


### PR DESCRIPTION
## About The Pull Request

What it says on the tin, changes the `tgui_input_list` in the organ manipulation surgery to instead use `show_radial_menu`

## Why It's Good For The Game

I think its nicer to be able to see the organs before pulling them out, alongside allowing you to easier locate whatever you want to pull out when there's a large amount of augments in someones chest

<details>
<summary>How the menu looks currently</summary>
  
<img width="1035" height="816" alt="image" src="https://github.com/user-attachments/assets/4ced17d2-9017-4d5b-b86e-50323eb9e3fd" />

</details>
<details>
<summary>How the menu looks after the PR</summary>
  
<img width="1035" height="816" alt="image" src="https://github.com/user-attachments/assets/2d317126-5298-487b-9a59-3bff7014a336" />
</details>
<details>
<summary>How the menu looks after the PR and after a roboticist got to them first</summary>
  
<img width="1035" height="818" alt="image" src="https://github.com/user-attachments/assets/21a6a503-ef6e-4e37-95e2-a1a15a8a0c58" />

</details>
</details>
<details>
<summary>Showing how the radial menu looks in darkness</summary>
  
<img width="1035" height="817" alt="image" src="https://github.com/user-attachments/assets/fadd5125-f22b-49fd-aa75-74b5aaa52d47" />

</details>

## Changelog

:cl:
qol: organ manipulation surgery now uses a radial menu instead of a tgui list
/:cl:
