### PR TITLE
Brings back the Tweak PR tag! #mytweak! #tweakit! 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,7 @@ sound: added/modified/removed audio or sound effects
 image: added/modified/removed some icons or images
 map: added/modified/removed map content
 spellcheck: fixed a few typos
+tweak: tweaked a few things
 code: changed some code
 refactor: refactored some code
 config: changed some config setting

--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -22,5 +22,6 @@ reset_label = "GBP: Reset"
 "Refactor" = 10
 "Sound" = 3
 "Sprites" = 3
+"Tweak" = -2
 "Unit Tests" = 6
 "Wallening Revert Recovery" = 10


### PR DESCRIPTION
## About The Pull Request

This is a GitHub change so it does not need a CL. Potato originally said I needed a maintainer to approve of this idea to PR it so here's that just in case...

<img width="653" height="69" alt="image" src="https://github.com/user-attachments/assets/68d37a4b-03c5-4dc8-8b66-8f144a4a52ad" />


What is the tweak tag you may ask? It's a little old tag/label we used to have that was removed in https://github.com/tgstation/tgstation/pull/56890. So what is it for? Tweak is for small changes that aren't really QOL. The key is that they are small improvements or adjustments. People will surely perhaps try to say their balance PR is really just a tweak, but people already do that with QOL, or they fix a typo or something and call that a Fix and if the PR it's part of is good it's just ignored. 

## Why It's Good For The Game

Small changes are what a lot of people start out contributing with and I happen to have a fondness for them. People who notice/care about GBP are less likely to make small changes if it's going to cost the same amount of GBP as making a huge rebalance. I think these kind of improvements are focused and easy to review and I don't think we should disincentivize people from making them. ~~A key part of the PR that removed tweak, the atomic tag, is also gone now.~~ Not sure how I misread that. While this does not give you free GBP for making smaller PRs like that did it does give you more options. 

