### PR TITLE
Gives lizards lizard brains, and makes brain subtypes derive their traits from the base brain

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -450,6 +450,7 @@
 		TRAIT_EXPERT_FISHER, // live off land, fish from river
 		TRAIT_ROUGHRIDER, // ride beast, chase down prey, flee from danger
 		TRAIT_BEAST_EMPATHY, // know the way of beast, calm with food
+		TRAIT_TACKLING_TAILED_DEFENDER,
 	)
 
 /obj/item/organ/brain/golem

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -44,11 +44,17 @@
 	var/can_smoothen_out = TRUE
 	/// We got smooth from being washed
 	var/smooth_brain = FALSE
+	/// Variance in brain traits added by subtypes
+	var/variant_traits_added
+	/// Variance in brain traits removed by subtypes
+	var/variant_traits_removed
 
 /obj/item/organ/brain/Initialize(mapload)
 	. = ..()
 	// Brain size logic
 	transform = transform.Scale(brain_size)
+	organ_traits.Remove(variant_traits_removed)
+	organ_traits |= variant_traits_added
 
 /obj/item/organ/brain/on_mob_insert(mob/living/carbon/brain_owner, special = FALSE, movement_flags)
 	. = ..()
@@ -431,29 +437,20 @@
 	name = "zombie brain"
 	desc = "This glob of green mass can't have much intelligence inside it."
 	icon_state = "brain-x"
-
-/obj/item/organ/brain/zombie/Initialize(mapload)
-	. = ..()
-	organ_traits.Remove(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
-	organ_traits |= list(TRAIT_PRIMITIVE)
+	variant_traits_added = list(TRAIT_PRIMITIVE)
+	variant_traits_removed = list(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
 
 /obj/item/organ/brain/alien
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
-
-/obj/item/organ/brain/alien/Initialize(mapload)
-	. = ..()
-	organ_traits.Remove(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
+	variant_traits_removed = list(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
 
 /obj/item/organ/brain/primitive //No like books and stompy metal men
 	name = "primitive brain"
 	desc = "This juicy piece of meat has a clearly underdeveloped frontal lobe."
-
-/obj/item/organ/brain/primitive/Initialize(mapload)
-	. = ..()
-	organ_traits.Remove(TRAIT_LITERATE)
-	organ_traits |= list(
+	variant_traits_removed = list(TRAIT_LITERATE)
+	variant_traits_added = list(
 		TRAIT_PRIMITIVE, // No literacy
 		TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION,
 		TRAIT_EXPERT_FISHER, // live off land, fish from river
@@ -469,10 +466,7 @@
 	can_smoothen_out = FALSE
 	color = COLOR_GOLEM_GRAY
 	organ_flags = ORGAN_MINERAL
-
-/obj/item/organ/brain/golem/Initialize(mapload)
-	. = ..()
-	organ_traits |= TRAIT_ROCK_METAMORPHIC
+	variant_traits_added = list(TRAIT_ROCK_METAMORPHIC)
 
 /obj/item/organ/brain/lustrous
 	name = "lustrous brain"
@@ -512,10 +506,7 @@
 /obj/item/organ/brain/lizard
 	name = "lizard brain"
 	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."
-
-/obj/item/organ/brain/lizard/Initialize(mapload)
-	. = ..()
-	organ_traits |= TRAIT_TACKLING_TAILED_DEFENDER
+	variant_traits_added = list(TRAIT_TACKLING_TAILED_DEFENDER)
 
 /obj/item/organ/brain/ghost
 	name = "ghost brain"
@@ -529,10 +520,7 @@
 	desc = "A piece of juicy meat found in an ayy lmao's head."
 	icon_state = "brain-x"
 	brain_size = 1.3
-
-/obj/item/organ/brain/abductor/Initialize(mapload)
-	. = ..()
-	organ_traits |= TRAIT_REMOTE_TASTING
+	variant_traits_added = list(TRAIT_REMOTE_TASTING)
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -431,20 +431,29 @@
 	name = "zombie brain"
 	desc = "This glob of green mass can't have much intelligence inside it."
 	icon_state = "brain-x"
-	organ_traits = list(TRAIT_CAN_STRIP, TRAIT_PRIMITIVE)
+
+/obj/item/organ/brain/zombie/Initialize(mapload)
+	. = ..()
+	organ_traits.Remove(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
+	organ_traits |= list(TRAIT_PRIMITIVE)
 
 /obj/item/organ/brain/alien
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
-	organ_traits = list(TRAIT_CAN_STRIP)
+
+/obj/item/organ/brain/alien/Initialize(mapload)
+	. = ..()
+	organ_traits.Remove(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
 
 /obj/item/organ/brain/primitive //No like books and stompy metal men
 	name = "primitive brain"
 	desc = "This juicy piece of meat has a clearly underdeveloped frontal lobe."
-	organ_traits = list(
-		TRAIT_ADVANCEDTOOLUSER,
-		TRAIT_CAN_STRIP,
+
+/obj/item/organ/brain/primitive/Initialize(mapload)
+	. = ..()
+	organ_traits.Remove(TRAIT_LITERATE)
+	organ_traits |= list(
 		TRAIT_PRIMITIVE, // No literacy
 		TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION,
 		TRAIT_EXPERT_FISHER, // live off land, fish from river

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -500,7 +500,7 @@
 /obj/item/organ/brain/lizard
 	name = "lizard brain"
 	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."
-	organ_traits = list(TRAIT_TACKLING_TAILED_DEFENDER)
+	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP, TRAIT_LITERATE, TRAIT_TACKLING_TAILED_DEFENDER)
 
 /obj/item/organ/brain/ghost
 	name = "ghost brain"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -460,14 +460,16 @@
 	can_smoothen_out = FALSE
 	color = COLOR_GOLEM_GRAY
 	organ_flags = ORGAN_MINERAL
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP, TRAIT_ROCK_METAMORPHIC)
+
+/obj/item/organ/brain/golem/Initialize(mapload)
+	. = ..()
+	organ_traits |= TRAIT_ROCK_METAMORPHIC
 
 /obj/item/organ/brain/lustrous
 	name = "lustrous brain"
 	desc = "This is your brain on bluespace dust. Not even once."
 	icon_state = "random_fly_4"
 	can_smoothen_out = FALSE
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP)
 
 // This fixes an edge case from species/regenerate_organs that would transfer the brain trauma before organ/on_mob_remove can remove it
 // Prevents wizards from using the magic mirror to gain bluespace_prophet trauma and then switching to another race
@@ -501,7 +503,10 @@
 /obj/item/organ/brain/lizard
 	name = "lizard brain"
 	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP, TRAIT_LITERATE, TRAIT_TACKLING_TAILED_DEFENDER)
+
+/obj/item/organ/brain/lizard/Initialize(mapload)
+	. = ..()
+	organ_traits |= TRAIT_TACKLING_TAILED_DEFENDER
 
 /obj/item/organ/brain/ghost
 	name = "ghost brain"
@@ -515,7 +520,10 @@
 	desc = "A piece of juicy meat found in an ayy lmao's head."
 	icon_state = "brain-x"
 	brain_size = 1.3
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP, TRAIT_LITERATE, TRAIT_REMOTE_TASTING)
+
+/obj/item/organ/brain/abductor/Initialize(mapload)
+	. = ..()
+	organ_traits |= TRAIT_REMOTE_TASTING
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -19,6 +19,7 @@
 	)
 	mutanttongue = /obj/item/organ/tongue/lizard
 	mutanteyes = /obj/item/organ/eyes/lizard
+	mutantbrain = /obj/item/organ/brain/lizard
 	coldmod = 1.5
 	heatmod = 0.67
 	payday_modifier = 1.0

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -9,10 +9,7 @@
 	)
 	w_class = WEIGHT_CLASS_NORMAL
 	var/does_it_blind = FALSE
-
-/obj/item/organ/brain/psyker/Initialize(mapload)
-	. = ..()
-	organ_traits |= TRAIT_ANTIMAGIC_NO_SELFBLOCK
+	variant_traits_added = list(TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 
 /obj/item/organ/brain/psyker/on_mob_insert(mob/living/carbon/inserted_into)
 	. = ..()

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -7,9 +7,12 @@
 		/datum/action/cooldown/spell/charged/psychic_booster,
 		/datum/action/cooldown/spell/forcewall/psychic_wall,
 	)
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP, TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 	w_class = WEIGHT_CLASS_NORMAL
 	var/does_it_blind = FALSE
+
+/obj/item/organ/brain/psyker/Initialize(mapload)
+	. = ..()
+	organ_traits |= TRAIT_ANTIMAGIC_NO_SELFBLOCK
 
 /obj/item/organ/brain/psyker/on_mob_insert(mob/living/carbon/inserted_into)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Changes lizard's human brains to lizard brains, giving them the tackling trait they were supposed to have. Also gives standard brain traits to lizard brains, as well as giving the tackling trait to ashwalkers.
This ALSO makes it so that all brain subtypes derive their traits from the standard brain, which'll make them update traits with any additions to the standard brain.

## Why It's Good For The Game

fixes #92600

## Changelog
:cl:

fix: Lizard now have lizard brains

/:cl:
