### PR TITLE
Some metastation map tweaks and plumbing tweaks

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33857,7 +33857,7 @@
 	name = "Shower"
 	},
 /obj/machinery/shower/directional/south,
-/obj/structure/window/spawner/directional/east,
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "lHK" = (
@@ -58555,6 +58555,11 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"udB" = (
+/obj/structure/lattice,
+/obj/machinery/duct,
+/turf/open/space/basic,
+/area/space/nearstation)
 "udD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -120949,7 +120954,7 @@ aaa
 aaa
 aaa
 lMJ
-lMJ
+udB
 lMJ
 lMJ
 lMJ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1193,7 +1193,6 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "awy" = (
@@ -1693,7 +1692,7 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "aFz" = (
-/obj/machinery/vending/autodrobe,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "aFI" = (
@@ -2270,7 +2269,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "aOp" = (
@@ -11994,7 +11992,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "eiB" = (
@@ -15687,7 +15684,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fsh" = (
@@ -18162,7 +18158,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "gqV" = (
@@ -18374,6 +18369,15 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"guq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "guC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -22243,7 +22247,6 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "hMq" = (
@@ -24780,7 +24783,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "iBL" = (
@@ -28137,7 +28139,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jGr" = (
@@ -28181,7 +28182,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jGG" = (
@@ -30333,17 +30333,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"ksx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "ksM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31585,12 +31574,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"kOA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/wood,
-/area/station/commons/vacant_room/office)
 "kOB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32292,6 +32275,12 @@
 /obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"kZQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "laa" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/chapel{
@@ -33746,7 +33735,6 @@
 /area/station/science/cytology)
 "lFs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "lFF" = (
@@ -34740,7 +34728,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lXS" = (
-/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "lYc" = (
@@ -36057,6 +36044,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mvv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "mvN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -40190,7 +40182,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "nNJ" = (
@@ -42880,6 +42871,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"oMs" = (
+/obj/machinery/duct,
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "oMx" = (
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /obj/machinery/door/airlock/maintenance{
@@ -44966,7 +44962,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "pzz" = (
@@ -45861,6 +45856,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "pPh" = (
@@ -49059,7 +49055,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qSA" = (
@@ -51011,6 +51006,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "rAo" = (
@@ -51181,7 +51177,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "rEr" = (
@@ -52223,6 +52218,7 @@
 "rVY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "rVZ" = (
@@ -53189,8 +53185,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "soa" = (
-/obj/machinery/light/small/directional/south,
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "sof" = (
@@ -55336,6 +55333,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tar" = (
@@ -56332,7 +56330,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tsd" = (
@@ -57616,7 +57613,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/office)
 "tOP" = (
@@ -59322,7 +59318,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "uso" = (
@@ -63060,6 +63055,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/sign/poster/official/random/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "vCC" = (
@@ -66311,6 +66307,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"wGf" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "wGz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/light_construct/directional/east,
@@ -67369,6 +67370,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"xcp" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "xcv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86201,8 +86209,8 @@ htE
 scY
 iBK
 tON
-kOA
-kOA
+kEm
+kEm
 nNH
 pzu
 lXS
@@ -86466,7 +86474,7 @@ lFs
 lFs
 hMo
 gqP
-sTA
+eTg
 pOa
 pOa
 pOa
@@ -87237,7 +87245,7 @@ pOa
 pOa
 pOa
 pOa
-uOH
+kZQ
 jUb
 xIK
 bar
@@ -87481,7 +87489,7 @@ uxa
 bNQ
 aal
 sEk
-ksx
+aal
 jGD
 awg
 eiw
@@ -87494,7 +87502,7 @@ gXe
 vwi
 tql
 pOa
-aDl
+xcp
 jUb
 tWr
 qKs
@@ -88259,13 +88267,13 @@ fRG
 vsr
 wfZ
 soa
-pOa
+oMs
 aFz
-sXI
+mvv
 sNM
 tYi
 pOa
-uOH
+kZQ
 jUb
 ilQ
 oVn
@@ -88518,11 +88526,11 @@ fjD
 hsF
 pOa
 vJY
-sXI
-sXI
+mvv
+mvv
 rVY
 rAa
-kDS
+guq
 jUb
 sal
 gvg
@@ -88776,7 +88784,7 @@ oyx
 pOa
 xgG
 vJY
-gDZ
+wGf
 wev
 pOa
 uOH

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2323,15 +2323,6 @@
 /obj/structure/closet/crate/preopen,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"aPm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "aPq" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Auxilliary Surgery"
@@ -19789,7 +19780,6 @@
 "gTn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -21730,6 +21720,7 @@
 "hBC" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hBD" = (
@@ -25894,7 +25885,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iVi" = (
@@ -27964,15 +27954,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
-"jCn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/central)
 "jCr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -28208,6 +28189,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "jGN" = (
@@ -29106,6 +29088,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"jVx" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "jVy" = (
 /obj/machinery/portable_atmospherics/pump/lil_pump,
 /obj/effect/turf_decal/siding/purple{
@@ -52170,7 +52158,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "rUU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
@@ -53418,7 +53405,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
@@ -53611,7 +53597,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "sxg" = (
@@ -54474,6 +54459,7 @@
 	dir = 1
 	},
 /obj/structure/mirror/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sMB" = (
@@ -60322,12 +60308,6 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"uHt" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "uHA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -67091,15 +67071,6 @@
 /obj/item/storage/box/deputy,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"wVy" = (
-/obj/structure/sink/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "wVQ" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
@@ -67248,6 +67219,11 @@
 	},
 /turf/open/floor/grass,
 /area/station/science/research)
+"wZh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "wZk" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/showcase/cyborg/old{
@@ -67665,6 +67641,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"xgz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "xgB" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -91387,7 +91368,7 @@ ckE
 ckE
 oJD
 oPv
-nKE
+wZh
 xtu
 rvb
 ver
@@ -91643,7 +91624,7 @@ nKE
 vSu
 jtA
 nVJ
-wUQ
+bHE
 ktD
 bbd
 rZY
@@ -91900,7 +91881,7 @@ ekk
 mtj
 buN
 lTR
-wUQ
+bHE
 jGG
 agZ
 rvb
@@ -92157,7 +92138,7 @@ nKE
 tMK
 xgn
 xfx
-wUQ
+bHE
 kui
 fHC
 gNl
@@ -92414,7 +92395,7 @@ vWv
 hMq
 hMq
 sxf
-iMv
+jVx
 nKE
 xtu
 rvb
@@ -92670,7 +92651,7 @@ pSl
 eUN
 jpU
 jpU
-vJe
+xgz
 qXh
 ehg
 hgu
@@ -93438,10 +93419,10 @@ irL
 oNP
 rEt
 xST
-wVy
+pLz
 dpI
 ttE
-aPm
+ttE
 sZH
 wUG
 eGJ
@@ -93695,9 +93676,9 @@ mvY
 rne
 bXX
 iFi
-jCn
-uHt
-uHt
+eUW
+iFi
+iFi
 gTn
 fod
 uVx

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -206,6 +206,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "aeA" = (
@@ -517,6 +518,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/cryo)
 "aks" = (
@@ -10495,7 +10497,6 @@
 "dKO" = (
 /obj/structure/urinal/directional/north,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "dKY" = (
@@ -22798,7 +22799,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hVX" = (
@@ -26924,7 +26924,6 @@
 "jlY" = (
 /obj/structure/urinal/directional/north,
 /obj/effect/landmark/start/hangover,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "jmc" = (
@@ -30088,6 +30087,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "knt" = (
@@ -31503,7 +31503,6 @@
 /area/station/hallway/primary/central)
 "kMo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
@@ -33852,12 +33851,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lHH" = (
-/obj/structure/curtain,
-/obj/machinery/door/window/left/directional/south{
-	name = "Shower"
-	},
-/obj/machinery/shower/directional/south,
-/obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "lHK" = (
@@ -33987,7 +33980,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lLw" = (
-/obj/machinery/duct,
+/obj/machinery/shower/directional/south,
+/obj/structure/curtain,
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/machinery/door/window/left/directional/south{
+	name = "Shower"
+	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "lLB" = (
@@ -34123,6 +34121,7 @@
 "lNf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "lNh" = (
@@ -38182,6 +38181,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "nfy" = (
@@ -52175,6 +52175,7 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/directional/north,
+/obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rVb" = (
@@ -52244,7 +52245,6 @@
 "rWf" = (
 /obj/structure/urinal/directional/north,
 /obj/structure/cable,
-/obj/machinery/duct,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -60382,7 +60382,6 @@
 "uIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
@@ -61692,6 +61691,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "vgv" = (
@@ -65428,7 +65428,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wra" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9579,10 +9579,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/storage/gas)
-"dsB" = (
-/obj/machinery/duct,
-/turf/closed/wall,
-/area/station/service/library)
 "dsI" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -28741,11 +28737,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jPN" = (
-/obj/item/wrench,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jPU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=3-Central-Port";
@@ -58537,11 +58528,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"udB" = (
-/obj/structure/lattice,
-/obj/machinery/duct,
-/turf/open/space/basic,
-/area/space/nearstation)
 "udD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -91085,7 +91071,7 @@ bzH
 buH
 iVs
 pJi
-dsB
+sVY
 mjr
 mjr
 sVY
@@ -115774,7 +115760,7 @@ uQe
 pul
 nzo
 iGr
-jPN
+gSn
 fzM
 qOW
 nnD
@@ -120942,7 +120928,7 @@ aaa
 aaa
 aaa
 lMJ
-udB
+lMJ
 lMJ
 lMJ
 lMJ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18983,10 +18983,6 @@
 "gEF" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/structure/sink/kitchen/directional/south{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink"
-	},
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -20167,11 +20163,6 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"gZA" = (
-/obj/structure/lattice,
-/obj/structure/sink/directional/east,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gZM" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -27302,7 +27293,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "jsq" = (
-/obj/structure/sink/directional/west,
 /obj/structure/toilet{
 	pixel_y = 8
 	},
@@ -31744,6 +31734,13 @@
 /obj/machinery/announcement_system,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
+"kRy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "kRA" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -37493,7 +37490,6 @@
 /area/station/engineering/atmos)
 "mTB" = (
 /obj/effect/landmark/blobstart,
-/obj/structure/sink/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mTI" = (
@@ -43199,7 +43195,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oTD" = (
@@ -43917,7 +43912,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/sink/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
@@ -61664,10 +61658,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"vgK" = (
-/obj/structure/sink/kitchen/directional/east,
-/turf/closed/wall,
-/area/station/commons/fitness/recreation)
 "vgW" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "MiniSat Airlock Access"
@@ -107467,7 +107457,7 @@ rrt
 lMJ
 rrt
 aaa
-gZA
+lMJ
 aaa
 nvn
 mOl
@@ -107727,7 +107717,7 @@ aaa
 lMJ
 aaa
 szp
-vgK
+szp
 gEN
 sqH
 jAs
@@ -115278,7 +115268,7 @@ mMK
 jxH
 tMI
 pwZ
-fdZ
+kRy
 fdZ
 fdZ
 jvX

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -944,6 +944,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "art" = (
@@ -1190,6 +1191,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "awy" = (
@@ -1240,6 +1242,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "axO" = (
@@ -1428,6 +1431,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "aAS" = (
@@ -1933,8 +1937,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aJm" = (
-/obj/effect/spawner/random/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "aJn" = (
@@ -1942,6 +1947,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "aJv" = (
@@ -2262,6 +2268,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "aOp" = (
@@ -2725,6 +2732,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "aXF" = (
@@ -3011,6 +3019,7 @@
 "bbt" = (
 /obj/structure/girder,
 /obj/effect/spawner/random/structure/grille,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bbT" = (
@@ -3101,6 +3110,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "bdE" = (
@@ -3191,6 +3201,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery/aft)
 "bfj" = (
@@ -3664,6 +3675,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "bnx" = (
@@ -3898,6 +3910,7 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "bqX" = (
@@ -4023,6 +4036,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bsZ" = (
@@ -4033,16 +4047,12 @@
 /area/station/maintenance/aft/greater)
 "btn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/drinkingglasses,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/effect/spawner/random/food_or_drink/cups,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -4233,6 +4243,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"bwi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "bwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4290,6 +4305,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bxr" = (
@@ -4577,6 +4593,7 @@
 "bCE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "bCM" = (
@@ -5357,10 +5374,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bRG" = (
-/obj/machinery/shower/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "bRH" = (
@@ -5610,6 +5627,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bWe" = (
@@ -6047,6 +6065,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cfe" = (
@@ -6664,6 +6683,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/prison/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "crr" = (
@@ -6688,6 +6708,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "csn" = (
@@ -8199,6 +8220,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "cUk" = (
@@ -8379,6 +8401,11 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"cXs" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "cXw" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -8703,6 +8730,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ddO" = (
@@ -9560,6 +9588,10 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/storage/gas)
+"dsB" = (
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/station/service/library)
 "dsI" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -10243,6 +10275,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "dGD" = (
@@ -10640,6 +10673,7 @@
 	spawn_scatter_radius = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dMY" = (
@@ -10663,9 +10697,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dNC" = (
-/obj/structure/sink/directional/south,
 /obj/machinery/light/small/dim/directional/west,
-/mob/living/basic/mouse/brown/tom,
+/obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "dNX" = (
@@ -10769,6 +10802,7 @@
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dPL" = (
@@ -10977,6 +11011,7 @@
 /area/station/hallway/primary/central)
 "dSp" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "dSt" = (
@@ -11967,6 +12002,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "eiB" = (
@@ -12315,6 +12351,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "eni" = (
@@ -13885,8 +13922,6 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "ePA" = (
-/obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/button/door/directional/south{
 	id = "FitnessShower";
@@ -13894,6 +13929,7 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "ePN" = (
@@ -14083,6 +14119,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "eTg" = (
@@ -14224,6 +14261,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"eVU" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "eVX" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -14786,6 +14831,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ffU" = (
@@ -14904,6 +14950,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "fhB" = (
@@ -15106,6 +15153,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "fkl" = (
@@ -15599,6 +15647,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "frt" = (
@@ -15646,6 +15695,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fsh" = (
@@ -15821,6 +15871,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fxW" = (
@@ -15947,6 +15998,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "fAt" = (
@@ -16200,6 +16252,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "fFu" = (
@@ -16313,6 +16366,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "fGR" = (
@@ -16337,6 +16391,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "fHd" = (
@@ -16819,6 +16874,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "fRS" = (
@@ -17663,6 +17719,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/firealarm_sanity,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gjv" = (
@@ -18040,6 +18097,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /obj/effect/landmark/navigate_destination/janitor,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "gpB" = (
@@ -18112,6 +18170,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "gqV" = (
@@ -18258,6 +18317,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "gtm" = (
@@ -18280,6 +18340,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "gtR" = (
@@ -18314,6 +18375,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "guo" = (
@@ -18349,6 +18411,7 @@
 	pixel_x = -6;
 	pixel_y = 27
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "guL" = (
@@ -18716,6 +18779,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "gAI" = (
@@ -19630,6 +19694,7 @@
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "gQa" = (
@@ -19951,6 +20016,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "gXe" = (
@@ -20110,6 +20176,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"gZA" = (
+/obj/structure/lattice,
+/obj/structure/sink/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gZM" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -20159,6 +20230,7 @@
 "haE" = (
 /obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "haP" = (
@@ -20823,6 +20895,7 @@
 	name = "Permabrig Kitchen"
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "hnn" = (
@@ -21413,6 +21486,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "hxB" = (
@@ -21608,6 +21682,7 @@
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "hAW" = (
@@ -21973,6 +22048,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery/aft)
 "hIJ" = (
@@ -22115,11 +22191,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"hLs" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "hLv" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -22180,6 +22251,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "hMq" = (
@@ -22295,6 +22367,7 @@
 /obj/effect/spawner/random/trash/soap{
 	spawn_scatter_radius = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "hPk" = (
@@ -22578,6 +22651,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"hSP" = (
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "hSQ" = (
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
@@ -22721,6 +22798,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hVX" = (
@@ -24195,6 +24273,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "itY" = (
@@ -24225,6 +24304,7 @@
 /area/station/hallway/primary/central)
 "iuB" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iva" = (
@@ -24458,6 +24538,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "iyV" = (
@@ -24565,6 +24646,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
+"izJ" = (
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "izZ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -24704,6 +24789,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "iBL" = (
@@ -24753,6 +24839,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iDe" = (
@@ -25285,6 +25372,7 @@
 	dir = 1
 	},
 /mob/living/basic/lizard/wags_his_tail,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "iMR" = (
@@ -25593,6 +25681,7 @@
 /obj/structure/chair/stool/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iRh" = (
@@ -25733,6 +25822,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iTO" = (
@@ -26181,6 +26271,10 @@
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"jaM" = (
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "jaO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -26665,6 +26759,7 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "jjn" = (
@@ -27139,6 +27234,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jrI" = (
@@ -27564,6 +27660,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "jxM" = (
@@ -27696,6 +27793,7 @@
 "jzw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "jzD" = (
@@ -28059,6 +28157,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jGr" = (
@@ -28102,6 +28201,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jGG" = (
@@ -28251,11 +28351,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"jJk" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "jJl" = (
 /obj/structure/table/reinforced,
 /obj/structure/reagent_dispensers/servingdish,
@@ -28665,6 +28760,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
+"jPN" = (
+/obj/item/wrench,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jPU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=3-Central-Port";
@@ -30245,6 +30345,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"ksx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ksM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31487,6 +31598,12 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"kOA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/office)
 "kOB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31786,6 +31903,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "kUb" = (
@@ -32203,6 +32321,7 @@
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "lah" = (
@@ -32438,6 +32557,7 @@
 /area/station/medical/chem_storage)
 "lfm" = (
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "lfu" = (
@@ -32757,6 +32877,7 @@
 /area/station/medical/morgue)
 "lmn" = (
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "lmx" = (
@@ -32801,6 +32922,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "lnc" = (
@@ -32825,6 +32947,7 @@
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bottle/ammonia,
 /obj/structure/cable,
+/mob/living/basic/mouse/brown/tom,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "lnP" = (
@@ -32924,6 +33047,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
 "lpR" = (
@@ -33171,6 +33295,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "lug" = (
@@ -33634,6 +33759,7 @@
 /area/station/science/cytology)
 "lFs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "lFF" = (
@@ -33725,6 +33851,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"lHH" = (
+/obj/structure/curtain,
+/obj/machinery/door/window/left/directional/south{
+	name = "Shower"
+	},
+/obj/machinery/shower/directional/south,
+/obj/structure/window/spawner/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/commons/fitness/recreation)
 "lHK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -33852,11 +33987,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lLw" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Shower"
-	},
-/obj/machinery/shower/directional/south,
-/obj/structure/curtain,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "lLB" = (
@@ -34622,6 +34753,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lXS" = (
+/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "lYc" = (
@@ -34995,6 +35127,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
+"mfb" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/security/prison)
 "mfd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
@@ -35090,6 +35233,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"mhs" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "mhA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -35315,6 +35466,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "mml" = (
@@ -35810,6 +35962,7 @@
 /obj/structure/disposalpipe/sorting/mail,
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "mui" = (
@@ -35976,6 +36129,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "mwo" = (
@@ -36338,6 +36492,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "mCZ" = (
@@ -36436,7 +36591,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mEx" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/structure/reagent_dispensers/plumbed,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
@@ -36637,6 +36792,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "mHy" = (
@@ -37349,6 +37505,7 @@
 	name = "Observation Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "mTk" = (
@@ -37366,6 +37523,7 @@
 /area/station/engineering/atmos)
 "mTB" = (
 /obj/effect/landmark/blobstart,
+/obj/structure/sink/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mTI" = (
@@ -37488,6 +37646,7 @@
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mWU" = (
@@ -39400,6 +39559,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery/aft)
 "nCr" = (
@@ -39465,6 +39625,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nCQ" = (
@@ -40041,6 +40202,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "nNJ" = (
@@ -40525,6 +40687,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "nYU" = (
@@ -41015,6 +41178,14 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/starboard/lesser)
+"ohY" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/greater)
 "ohZ" = (
 /obj/machinery/suit_storage_unit/rd,
 /obj/effect/turf_decal/stripes/line{
@@ -41051,6 +41222,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"oiz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "oiI" = (
 /obj/machinery/air_sensor/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -42363,6 +42539,7 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
 "oGj" = (
@@ -43047,6 +43224,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oTD" = (
@@ -43108,6 +43286,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "oUK" = (
@@ -43164,6 +43343,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "oWc" = (
@@ -43366,6 +43546,7 @@
 /area/station/commons/fitness/recreation)
 "oZL" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "oZN" = (
@@ -43393,6 +43574,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "pab" = (
@@ -43594,7 +43776,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/cigbutt/roach,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "pdI" = (
@@ -43763,6 +43944,7 @@
 /obj/structure/cable,
 /obj/structure/sink/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pgU" = (
@@ -44144,6 +44326,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "pnD" = (
@@ -44319,6 +44502,7 @@
 	name = "Storage Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pqH" = (
@@ -44794,6 +44978,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "pzz" = (
@@ -45224,6 +45409,7 @@
 /obj/item/toy/plush/slimeplushie{
 	name = "Nanners"
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "pHv" = (
@@ -45361,6 +45547,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "pJv" = (
@@ -45555,6 +45742,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "pNk" = (
@@ -45753,6 +45941,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pQr" = (
@@ -45881,6 +46070,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "pSl" = (
@@ -46190,6 +46380,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pXh" = (
@@ -46298,6 +46489,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"pZr" = (
+/obj/machinery/duct,
+/turf/open/floor/carpet/green,
+/area/station/maintenance/port/aft)
 "pZG" = (
 /obj/machinery/power/solar_control{
 	id = "forestarboard";
@@ -46669,9 +46864,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/structure/chair_maintenance{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "qgt" = (
@@ -46835,6 +47027,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qiH" = (
@@ -46933,6 +47126,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "qkA" = (
@@ -47463,6 +47657,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qvJ" = (
@@ -47551,6 +47746,7 @@
 "qxr" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "qxt" = (
@@ -47647,6 +47843,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qzg" = (
@@ -47767,6 +47964,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "qBq" = (
@@ -48597,6 +48795,7 @@
 /obj/item/storage/bag/trash,
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "qOV" = (
@@ -48872,6 +49071,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qSA" = (
@@ -50993,6 +51193,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "rEr" = (
@@ -51057,7 +51258,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/sink/directional/east,
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "rFR" = (
@@ -51876,6 +52077,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "rTL" = (
@@ -52686,6 +52888,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "sik" = (
@@ -53390,6 +53593,7 @@
 	name = "Cleaning Closet"
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "swV" = (
@@ -53458,6 +53662,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"syg" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/food_or_drink/booze{
+	spawn_random_offset = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "syh" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "maintwarehouse"
@@ -54424,6 +54636,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sOP" = (
@@ -54473,6 +54686,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sPy" = (
@@ -54770,6 +54984,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"sTA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "sTK" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -55007,6 +55228,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "sXe" = (
@@ -55225,6 +55447,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"tbm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "tbp" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Access"
@@ -55525,6 +55754,7 @@
 	name = "Xenobiology Shutters";
 	req_access = list("xenobiology")
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "thY" = (
@@ -55795,6 +56025,7 @@
 	name = "Showers"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "tmK" = (
@@ -56115,6 +56346,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tsd" = (
@@ -56255,6 +56487,7 @@
 "tub" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "tug" = (
@@ -56346,6 +56579,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "twy" = (
@@ -56433,6 +56667,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tyj" = (
@@ -56771,6 +57006,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tEP" = (
@@ -57135,6 +57371,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "tLd" = (
@@ -57393,6 +57630,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/office)
 "tOP" = (
@@ -57870,6 +58108,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "tXq" = (
@@ -58313,6 +58552,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "udD" = (
@@ -58345,6 +58585,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"udO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "udU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -58595,6 +58842,14 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"ujP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ukc" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
@@ -58803,6 +59058,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"uom" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/security/prison)
 "uor" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -59068,6 +59331,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "uso" = (
@@ -59298,6 +59562,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uwa" = (
@@ -59385,6 +59650,10 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"uxA" = (
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "uxS" = (
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
@@ -59865,6 +60134,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "uFw" = (
@@ -59971,6 +60241,7 @@
 /area/station/engineering/storage/tech)
 "uGx" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "uGz" = (
@@ -60359,6 +60630,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "uNl" = (
@@ -60385,6 +60657,7 @@
 	id = "XenoPens";
 	name = "Xenobiology Lockdown"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "uND" = (
@@ -60406,6 +60679,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "uNS" = (
@@ -61342,6 +61616,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "vfa" = (
@@ -61423,6 +61698,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"vgK" = (
+/obj/structure/sink/kitchen/directional/east,
+/turf/closed/wall,
+/area/station/commons/fitness/recreation)
 "vgW" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "MiniSat Airlock Access"
@@ -62024,6 +62303,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"vpR" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/commons/fitness/recreation)
 "vqj" = (
 /obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
@@ -62126,6 +62410,7 @@
 "vsr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/auxiliary)
 "vsG" = (
@@ -63439,10 +63724,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"vOZ" = (
-/obj/machinery/duct,
-/turf/closed/wall,
-/area/station/commons/fitness/recreation)
 "vPf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -63640,6 +63921,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "vRr" = (
@@ -63886,6 +64168,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "vVE" = (
@@ -64018,6 +64301,7 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/firealarm_sanity,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vXj" = (
@@ -64571,6 +64855,7 @@
 "wfZ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "wgf" = (
@@ -65138,6 +65423,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wra" = (
@@ -65146,6 +65432,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wrc" = (
@@ -65726,6 +66013,7 @@
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wBe" = (
@@ -66965,6 +67253,7 @@
 /area/station/tcommsat/computer)
 "wZl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "wZo" = (
@@ -67165,6 +67454,7 @@
 /area/station/medical/surgery/aft)
 "xdQ" = (
 /obj/structure/sign/warning/hot_temp/directional/south,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "xdX" = (
@@ -67574,6 +67864,12 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"xjK" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/duct,
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "xkj" = (
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67622,6 +67918,10 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
+"xkB" = (
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "xkE" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/hangover,
@@ -68197,6 +68497,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft/lesser)
+"xuY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "xvd" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -68723,6 +69032,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"xDA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "xDD" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 9
@@ -69448,6 +69764,15 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"xSn" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/security/prison)
 "xSO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -70394,6 +70719,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "yia" = (
@@ -84109,7 +84435,7 @@ jUm
 cXW
 cXW
 bLm
-cXW
+pZr
 uxS
 uxS
 fgn
@@ -84366,7 +84692,7 @@ uke
 bLm
 cXW
 cXW
-cXW
+pZr
 oBA
 ruz
 ehn
@@ -84623,7 +84949,7 @@ esd
 htr
 htr
 dSQ
-dbm
+syg
 dbm
 ruz
 uxS
@@ -84880,7 +85206,7 @@ xqn
 uxS
 fQZ
 ehv
-sBL
+xjK
 iRg
 uxS
 ehn
@@ -85395,7 +85721,7 @@ ruz
 ehn
 uxS
 uxS
-shK
+bwi
 uxS
 uxS
 uxS
@@ -85890,8 +86216,8 @@ htE
 scY
 iBK
 tON
-kEm
-kEm
+kOA
+kOA
 nNH
 pzu
 lXS
@@ -86155,7 +86481,7 @@ lFs
 lFs
 hMo
 gqP
-eTg
+sTA
 pOa
 pOa
 pOa
@@ -86412,18 +86738,18 @@ njE
 fHV
 pOa
 flN
-eTg
-oEo
+sTA
+mhs
 fAo
 aAQ
-sNr
-ltp
+ujP
+tbm
 dMX
 qzf
 jrp
-ltp
+tbm
 wra
-ltp
+tbm
 jUb
 cBc
 aFf
@@ -86668,8 +86994,8 @@ sOF
 fkd
 eDC
 pOa
-ayH
-qgw
+jaM
+xDA
 jUb
 jUb
 jUb
@@ -86931,7 +87257,7 @@ jUb
 xIK
 bar
 nBp
-dqN
+hSP
 pqz
 iuB
 jUb
@@ -87170,7 +87496,7 @@ uxa
 bNQ
 aal
 sEk
-aal
+ksx
 jGD
 awg
 eiw
@@ -88491,7 +88817,7 @@ xNq
 xLB
 mbx
 wAX
-xNq
+eVU
 qvC
 nCL
 iCX
@@ -88758,7 +89084,7 @@ xxU
 bxq
 lpN
 sWZ
-qEf
+ohY
 rKf
 tSw
 laL
@@ -90766,7 +91092,7 @@ bzH
 buH
 iVs
 pJi
-sVY
+dsB
 mjr
 mjr
 sVY
@@ -91740,8 +92066,8 @@ crl
 pSa
 cUf
 csb
-vjF
-ejR
+uom
+xSn
 cji
 vjF
 ejR
@@ -91987,7 +92313,7 @@ hwZ
 rGe
 wtw
 tcW
-tcW
+mfb
 axO
 tcW
 tcW
@@ -91998,7 +92324,7 @@ tcW
 tcW
 odh
 tcW
-tcW
+mfb
 qAX
 bhN
 wBe
@@ -92255,7 +92581,7 @@ wZz
 wZz
 wZz
 oUU
-iFz
+xkB
 rDr
 wIM
 aCQ
@@ -92511,8 +92837,8 @@ wZz
 dNC
 qOT
 swR
-tGX
-iFz
+cXs
+xkB
 oDX
 dfB
 aCQ
@@ -104082,7 +104408,7 @@ aaa
 aaa
 mxn
 rrg
-gMZ
+mxn
 gMZ
 gMZ
 gMZ
@@ -104339,10 +104665,10 @@ aaa
 aaa
 lMJ
 aaa
+aaa
 ilh
-sab
+mQe
 wmf
-cur
 cur
 jFy
 cur
@@ -104594,11 +104920,11 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-aaa
+szp
+szp
+szp
 ilh
-mQe
-rXX
+oiz
 mVr
 jCj
 ihX
@@ -104852,12 +105178,12 @@ lMJ
 lMJ
 lMJ
 szp
-szp
-ilh
+lHH
+vpR
 ilh
 ipG
 gKc
-cur
+mQe
 vTf
 mVp
 ilh
@@ -105366,7 +105692,7 @@ iHc
 iHc
 aag
 aag
-vOZ
+szp
 vwp
 ilh
 ilh
@@ -107162,7 +107488,7 @@ rrt
 lMJ
 rrt
 aaa
-lMJ
+gZA
 aaa
 nvn
 mOl
@@ -107422,7 +107748,7 @@ aaa
 lMJ
 aaa
 szp
-szp
+vgK
 gEN
 sqH
 jAs
@@ -108003,7 +108329,7 @@ huG
 gPq
 wYB
 qlL
-siz
+udO
 hxz
 unL
 uNd
@@ -109290,7 +109616,7 @@ aXE
 tXk
 itW
 kGv
-izp
+xZb
 fWA
 fWA
 mhl
@@ -109544,7 +109870,7 @@ lFo
 dQy
 pDR
 unL
-hLs
+unL
 enf
 hCl
 aJm
@@ -109801,10 +110127,10 @@ unL
 unL
 unL
 unL
-xZb
+izJ
 fFq
 izp
-jJk
+goZ
 fWA
 kBQ
 lWq
@@ -115455,7 +115781,7 @@ uQe
 pul
 nzo
 iGr
-gSn
+jPN
 fzM
 qOW
 nnD
@@ -119345,7 +119671,7 @@ kcu
 jlU
 qgn
 mCV
-wyo
+xuY
 hbK
 aaa
 aaa
@@ -119600,9 +119926,9 @@ jQz
 nJr
 kcu
 jlU
-lUS
+uxA
 pHt
-rDf
+lUS
 hbK
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Dorms bathroom is expanded by two tiles, so that the plumbing isn't in a wall anymore
<img width="704" height="490" alt="image" src="https://github.com/user-attachments/assets/3805eb6b-50c8-4697-9840-0c0fe63e5949" />

Adds a small plumbing system to xenobiology.
<img width="1067" height="381" alt="image" src="https://github.com/user-attachments/assets/218fe783-026c-4afe-ba96-d043b084ecef" />

Fixes and expands service plumbing system
<img width="983" height="1046" alt="image" src="https://github.com/user-attachments/assets/20d5552d-669b-4368-a82a-99d7bb9e963f" />

Expands medbay plumbing system
<img width="1022" height="678" alt="image" src="https://github.com/user-attachments/assets/3f178b93-f4bb-43b4-ad30-4c3124ea824a" />

Adds a small plumbing  system to arrivals, and a secret wall to the abandoned theatre room
<img width="403" height="521" alt="image" src="https://github.com/user-attachments/assets/70f79912-f22a-4188-9db7-e92d95edbf9e" />

Adds a small plumbing system to permabrig
<img width="591" height="742" alt="image" src="https://github.com/user-attachments/assets/a2b7a858-8d26-446a-bd50-bcac254b398f" />


## Why It's Good For The Game

While sinks generate infinite water (slowy), we have a plumbing system in place so having more kitchen/shower appliances that use water connected to the system would not only fill them faster but would make more sense aswell

## Changelog

:cl: Ezel
fix: fixes kitchen plumbing not being connected to any water source
map: Adds and expands plumbing systems around metastation
map: Increased the dorms bathroom a little bit
/:cl:
