### PR TITLE
Fixes how temperatures work with clothing and metabolism stabilizing core temp nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1143,7 +1143,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * * humi (required) The mob we will stabilize
  */
 /datum/species/proc/body_temperature_core(mob/living/carbon/human/humi, seconds_per_tick, times_fired)
-	var/natural_change = get_temp_change_amount(humi.get_body_temp_normal() - humi.coretemperature, 0.06 * seconds_per_tick)
+	var/natural_change = get_temp_change_amount(humi.get_body_temp_normal() - humi.coretemperature, 0.04 * seconds_per_tick)
 	humi.adjust_coretemperature(humi.metabolism_efficiency * natural_change)
 
 /**
@@ -1199,7 +1199,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		// Get the changes to the skin from the core temp
 		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
 		// change rate of 0.045 to reflect temp back to the skin at the slight higher rate then core to skin
-		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, 0.045 * seconds_per_tick)
+		var/core_skin_change = get_temp_change_amount(core_skin_diff, 0.045 * seconds_per_tick)
 
 		// We do not want to over shoot after using protection
 		if(core_skin_diff > 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -5,9 +5,9 @@
 // bitflags for the percentual amount of protection a piece of clothing which covers the body part offers.
 // Used with human/proc/get_heat_protection() and human/proc/get_cold_protection()
 // The values here should add up to 1.
-// Hands and feet have 2.5%, arms and legs 7.5%, each of the torso parts has 15% and the head has 30%
-#define THERMAL_PROTECTION_HEAD 0.3
-#define THERMAL_PROTECTION_CHEST 0.15
+// Hands and feet have 2.5%, arms and legs 7.5%,the torso has 22.5% and the head has 22.5%
+#define THERMAL_PROTECTION_HEAD 0.225
+#define THERMAL_PROTECTION_CHEST 0.225
 #define THERMAL_PROTECTION_GROIN 0.15
 #define THERMAL_PROTECTION_LEG_LEFT 0.075
 #define THERMAL_PROTECTION_LEG_RIGHT 0.075


### PR DESCRIPTION
## About The Pull Request
This is a fix that "should" make so wearing only a helmet or a suit isn't enough to withstand cold space.
The % protection of head and chest have been equalized. Head lowered from 30% to 22.5% and chest raised from 15% to 22.5%.

Another big change is removal of thermal protection taking part in calculation about heat transfer from core to skin.
It already takes part when transferring heat/cold from area to skin. We don't need double protection and it doesn't make sense either.

Smaller change: Lowered tick rate per second for stabilizing core temperature from 0.06 to 0.04.
From my testing the 0.06 was enough to keep the core temperature high enough to never go below COLD_DAMAGE_LEVEL_1 when wearing a Space helmet.
If you ever played Lizard you know how quickly they go cold. That is because of this. They don't have it at all. That is how powerful it is.
At the same time adjusting any other tick rates per second would effect Lizard which don't have this problem.

Fixes: https://github.com/tgstation/tgstation/issues/92575
## Why It's Good For The Game
Being "Let me solo her" but with Space helmet shouldn't be available solution for living in space.
In other words: no butt nuked with just Space helmet and never taking cold damage.
## Changelog
:cl:
balance: Nerf to metabolism stabilizing core temperature
fix: It takes more than just a helmet to protect yourself from space and heat
/:cl:
