### PR TITLE
Pre-sort PDA messengers by name/job instead of sorting every time we list them

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -153,12 +153,6 @@
 /proc/cmp_typepaths_asc(A, B)
 	return sorttext("[B]","[A]")
 
-/proc/cmp_pdaname_asc(datum/computer_file/program/messenger/A, datum/computer_file/program/messenger/B)
-	return sorttext(B?.computer?.saved_identification, A?.computer?.saved_identification)
-
-/proc/cmp_pdajob_asc(datum/computer_file/program/messenger/A, datum/computer_file/program/messenger/B)
-	return sorttext(B?.computer?.saved_job, A?.computer?.saved_job)
-
 /proc/cmp_num_string_asc(A, B)
 	return text2num(A) - text2num(B)
 

--- a/code/modules/admin/admin_pda_message.dm
+++ b/code/modules/admin/admin_pda_message.dm
@@ -29,8 +29,7 @@ ADMIN_VERB(message_pda, R_ADMIN, "PDA Message", "Send a message to a user's PDA.
 /datum/admin_pda_panel/ui_static_data(mob/user)
 	var/list/data = list()
 	var/list/available_messengers = list()
-	for(var/messenger_ref in get_messengers_sorted_by_name())
-		var/datum/computer_file/program/messenger/messenger = GLOB.pda_messengers[messenger_ref]
+	for(var/datum/computer_file/program/messenger/messenger as anything in GLOB.pda_messengers_by_name)
 		available_messengers[REF(messenger)] = list(
 			ref = REF(messenger),
 			username = get_messenger_name(messenger),
@@ -55,8 +54,7 @@ ADMIN_VERB(message_pda, R_ADMIN, "PDA Message", "Send a message to a user's PDA.
 			if(!spam && (ref in GLOB.pda_messengers))
 				targets += GLOB.pda_messengers[ref]
 			else
-				for(var/messenger_ref in get_messengers_sorted_by_name())
-					var/datum/computer_file/program/messenger/messenger = GLOB.pda_messengers[messenger_ref]
+				for(var/datum/computer_file/program/messenger/messenger as anything in GLOB.pda_messengers_by_name)
 					if(messenger.invisible && !params["include_invisible"])
 						continue
 					targets += messenger

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_data.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_data.dm
@@ -1,5 +1,9 @@
 /// A list of all active and visible messengers
 GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
+/// A list of all active and visible messengers
+GLOBAL_LIST_EMPTY_TYPED(pda_messengers_by_job, /datum/computer_file/program/messenger)
+/// A list of all active and visible messengers
+GLOBAL_LIST_EMPTY_TYPED(pda_messengers_by_name, /datum/computer_file/program/messenger)
 
 /// Registers an NTMessenger instance to the list of pda_messengers.
 /proc/add_messenger(datum/computer_file/program/messenger/messenger)
@@ -16,6 +20,9 @@ GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
 		return
 
 	GLOB.pda_messengers[messenger_ref] = messenger
+	BINARY_INSERT_PROC_COMPARE(messenger, GLOB.pda_messengers_by_job, /datum/computer_file/program/messenger, messenger, compare_job, COMPARE_KEY)
+	BINARY_INSERT_PROC_COMPARE(messenger, GLOB.pda_messengers_by_name, /datum/computer_file/program/messenger, messenger, compare_name, COMPARE_KEY)
+
 
 /// Unregisters an NTMessenger instance from the pda_messengers table.
 /proc/remove_messenger(datum/computer_file/program/messenger/messenger)
@@ -26,15 +33,10 @@ GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
 	if(!(messenger_ref in GLOB.pda_messengers))
 		return
 
-	GLOB.pda_messengers.Remove(messenger_ref)
+	GLOB.pda_messengers -= messenger_ref
+	GLOB.pda_messengers_by_job -= messenger
+	GLOB.pda_messengers_by_name -= messenger
 
-/// Gets all messengers, sorted by their name
-/proc/get_messengers_sorted_by_name()
-	return sortTim(GLOB.pda_messengers.Copy(), GLOBAL_PROC_REF(cmp_pdaname_asc), associative = TRUE)
-
-/// Gets all messengers, sorted by their job
-/proc/get_messengers_sorted_by_job()
-	return sortTim(GLOB.pda_messengers.Copy(), GLOBAL_PROC_REF(cmp_pdajob_asc), associative = TRUE)
 
 /// Get the display name of a messenger instance
 /proc/get_messenger_name(datum/computer_file/program/messenger/messenger)

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -759,10 +759,10 @@
 			comp.explode(usr, from_message_menu = TRUE)
 
 /datum/computer_file/program/messenger/proc/compare_name(datum/computer_file/program/messenger/rhs)
-	return sorttext(rhs?.computer?.saved_identification, computer?.saved_identification)
+	return sorttext(rhs.computer?.saved_identification, computer?.saved_identification)
 
 /datum/computer_file/program/messenger/proc/compare_job(datum/computer_file/program/messenger/rhs)
-	return sorttext(rhs?.computer?.saved_job, computer?.saved_job)
+	return sorttext(rhs.computer?.saved_job, computer?.saved_job)
 
 #undef PDA_MESSAGE_TIMESTAMP_FORMAT
 #undef MAX_PDA_MESSAGE_LEN

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -88,10 +88,9 @@
 /datum/computer_file/program/messenger/proc/get_messengers()
 	var/list/dictionary = list()
 
-	var/list/messengers_sorted = sort_by_job ? get_messengers_sorted_by_job() : get_messengers_sorted_by_name()
+	var/list/messengers_sorted = sort_by_job ? GLOB.pda_messengers_by_job : GLOB.pda_messengers_by_name
 
-	for(var/messenger_ref in messengers_sorted)
-		var/datum/computer_file/program/messenger/messenger = messengers_sorted[messenger_ref]
+	for(var/datum/computer_file/program/messenger/messenger as anything in messengers_sorted)
 		if(!istype(messenger) || !istype(messenger.computer))
 			continue
 		if(messenger == src || messenger.invisible)
@@ -758,6 +757,12 @@
 
 			var/obj/item/modular_computer/pda/comp = computer
 			comp.explode(usr, from_message_menu = TRUE)
+
+/datum/computer_file/program/messenger/proc/compare_name(datum/computer_file/program/messenger/rhs)
+	return sorttext(rhs?.computer?.saved_identification, computer?.saved_identification)
+
+/datum/computer_file/program/messenger/proc/compare_job(datum/computer_file/program/messenger/rhs)
+	return sorttext(rhs?.computer?.saved_job, computer?.saved_job)
 
 #undef PDA_MESSAGE_TIMESTAMP_FORMAT
 #undef MAX_PDA_MESSAGE_LEN

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -56,8 +56,7 @@
 		data["ntnetlogs"] += list(list("entry" = i))
 
 	data["tablets"] = list()
-	for(var/messenger_ref in get_messengers_sorted_by_name())
-		var/datum/computer_file/program/messenger/app = GLOB.pda_messengers[messenger_ref]
+	for(var/datum/computer_file/program/messenger/app as anything in GLOB.pda_messengers_by_name)
 		var/obj/item/modular_computer/pda = app.computer
 
 		var/list/tablet_data = list()


### PR DESCRIPTION
## About The Pull Request

this gets rid of the `get_messengers_sorted_by_name` and `get_messengers_sorted_by_job` procs, instead replacing them with two new global lists: `GLOB.pda_messengers_by_name` and `GLOB.pda_messengers_by_job`

those two lists are updated in the `add_messenger` proc, which uses the binary insert macros to insert it into the properly sorted place.

why? bc sorts suck for performance and all inserts/removals to this list go thru a single proc anyways, so we can just ensure it's sorted like this once, instead of re-sorting each time.

thanks to @LemonInTheDark for helping me with this

<details>
<summary><h3>Testing Proof</h3></summary>

<img width="1708" height="1349" alt="2025-08-16 (1755391989) ~ dreamseeker" src="https://github.com/user-attachments/assets/1e2dc99a-1863-4a35-8032-8ae64706fdaa" />

<img width="1708" height="1349" alt="2025-08-16 (1755392002) ~ dreamseeker" src="https://github.com/user-attachments/assets/4d9b3bd0-7f3a-410b-a073-1bf2bd69690b" />

</details>

## Why It's Good For The Game

because doing a sort repeatedly whenever someone has their PDA messenger open is stupid and sucks

## Changelog

no player-facing changes
