### PR TITLE
[No GBP] Makes sure the labeler can't readd labels that were explicitly removed by maintainers

### DIFF
--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -200,8 +200,8 @@ export async function get_updated_label_set({ github, context }) {
   if (body)
     check_body_for_labels(body).forEach((label) => updated_labels.add(label));
 
-  // Keep track of labels that were manually added by maintainers in the events.
-  // And make sure they -stay- added.
+  // Keep track of labels that were manually added/removed by maintainers in the events.
+  // And make sure they -stay- added/removed.
   try {
     await github.paginate(
       github.rest.issues.listEventsForTimeline,
@@ -218,6 +218,11 @@ export async function get_updated_label_set({ github, context }) {
             eventData.actor?.login !== "github-actions"
           ) {
             updated_labels.add(eventData.label.name);
+          } else if (
+            eventData.event === "unlabeled" &&
+            eventData.actor?.login !== "github-actions"
+          ) {
+            updated_labels.delete(eventData.label.name);
           }
         }
       }

--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -218,16 +218,16 @@ export async function get_updated_label_set({ github, context }) {
     // That way, if a maintainer removes and then re-adds the same label it
     // remains true to their final intent.
     for (const eventData of events.reverse()) {
+      // Skip all bot actions
+      if (eventData.actor?.login === "github-actions") {
+        continue;
+      }
       if (
-        eventData.event === "labeled" &&
-        eventData.actor?.login !== "github-actions"
-      ) {
-        updated_labels.add(eventData.label.name);
+        eventData.event === "labeled") {
+          updated_labels.add(eventData.label.name);
       } else if (
-        eventData.event === "unlabeled" &&
-        eventData.actor?.login !== "github-actions"
-      ) {
-        updated_labels.delete(eventData.label.name);
+        eventData.event === "unlabeled") {
+          updated_labels.delete(eventData.label.name);
       }
     }
 } catch (error) {

--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -222,12 +222,10 @@ export async function get_updated_label_set({ github, context }) {
       if (eventData.actor?.login === "github-actions") {
         continue;
       }
-      if (
-        eventData.event === "labeled") {
-          updated_labels.add(eventData.label.name);
-      } else if (
-        eventData.event === "unlabeled") {
-          updated_labels.delete(eventData.label.name);
+      if (eventData.event === "labeled") {
+        updated_labels.add(eventData.label.name);
+      } else if (eventData.event === "unlabeled") {
+        updated_labels.delete(eventData.label.name);
       }
     }
 } catch (error) {

--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -214,10 +214,9 @@ export async function get_updated_label_set({ github, context }) {
     );
 
     // The REST api returns timeline events in reverse chronological order
-    // So let's reverse them to have oldest->newest.
-    // In the end we only want the last state of a given label
+    // So let's reverse them to have it go from oldest -> newest.
     // That way, if a maintainer removes and then re-adds the same label it
-    // remain as they put it.
+    // remains true to their final intent.
     for (const eventData of events.reverse()) {
       if (
         eventData.event === "labeled" &&


### PR DESCRIPTION
## About The Pull Request

Tin, I just realized 2 things: 

1) that the script is only checking the 'labeled' event but it should also be checking the 'unlabeled' one, in case the workflows have added a label that the maintainers do not wish to be added.

and 

2) that the events are returned from the API in reverse chronological order. So say if a maintainer adds a label then removes it later, it should not attempt to add the same label again.

This resolves both issues by putting the API's response into an array, reversing it, and adding or removing the label from the final set, which after going through all the events in chronological order will accurately reflect the final state of labels.

## Why It's Good For The Game

More maintainer QoL, and tightens up some edge cases.

## Changelog

Not player-facing