### PR TITLE
The art gallery app can now be downloaded on PDAs and laptops (no printing)

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -394,6 +394,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/emojipedia,
 		/datum/computer_file/program/newscaster,
+		/datum/computer_file/program/portrait_printer,
 	)
 
 /obj/item/modular_computer/pda/curator/Initialize(mapload)

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -7,7 +7,7 @@
  * ## the art gallery viewer/printer!
  *
  * Program that lets the curator (or anyone really) browse all of the portraits in the database
- * They are also to print them out as they please if installed on a console with paper in it (no PDAs and laptops).
+ * Stationary consoles can also print them out as they please as long as they've enough paper
  */
 /datum/computer_file/program/portrait_printer
 	filename = "PortraitPrinter"
@@ -31,7 +31,7 @@
 
 /datum/computer_file/program/portrait_printer/ui_static_data(mob/user)
 	. = ..()
-	.["is_console"] = (computer.hardware_flag & PROGRAM_CONSOLE)
+	.["is_console"] = computer.hardware_flag & PROGRAM_CONSOLE
 
 /datum/computer_file/program/portrait_printer/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -4,19 +4,17 @@
 
 
 /**
- * ## portrait printer!
+ * ## the art gallery viewer/printer!
  *
- * Program that lets the curator browse all of the portraits in the database
- * They are free to print them out as they please.
+ * Program that lets the curator (or anyone really) browse all of the portraits in the database
+ * They are also to print them out as they please if installed on a console with paper in it (no PDAs and laptops).
  */
 /datum/computer_file/program/portrait_printer
 	filename = "PortraitPrinter"
 	filedesc = "Marlowe Treeby's Art Galaxy"
 	downloader_category = PROGRAM_CATEGORY_EQUIPMENT
 	program_open_overlay = "dummy"
-	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art."
-	download_access = list(ACCESS_LIBRARY)
-	can_run_on_flags = PROGRAM_CONSOLE
+	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art, the latter only available on stationary consoles."
 	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 9
 	tgui_id = "NtosPortraitPrinter"
@@ -30,6 +28,10 @@
 	var/search_mode = PAINTINGS_FILTER_SEARCH_TITLE
 	/// Stores the result of the search, for later access.
 	var/list/matching_paintings
+
+/datum/computer_file/program/portrait_printer/ui_static_data(mob/user)
+	. = ..()
+	.["is_console"] = (computer.hardware_flag & PROGRAM_CONSOLE)
 
 /datum/computer_file/program/portrait_printer/ui_data(mob/user)
 	var/list/data = list()
@@ -65,6 +67,8 @@
 	matching_paintings = SSpersistent_paintings.painting_ui_data(filter = search_mode, search_text = search_string)
 
 /datum/computer_file/program/portrait_printer/proc/print_painting(selected_painting)
+	if(!(computer.hardware_flag & PROGRAM_CONSOLE))
+		return
 	if(computer.stored_paper < CANVAS_PAPER_COST)
 		to_chat(usr, span_notice("Printing error: Your printer needs at least [CANVAS_PAPER_COST] paper to print a canvas."))
 		return

--- a/tgui/packages/tgui/interfaces/NtosPortraitPrinter.jsx
+++ b/tgui/packages/tgui/interfaces/NtosPortraitPrinter.jsx
@@ -113,7 +113,7 @@ export const NtosPortraitPrinter = (props) => {
                     <Stack.Item grow={3}>
                       <Button
                         icon="check"
-                        content={is_console ? "View Only" : "Print Portrait"}
+                        content={!is_console ? "View Only" : "Print Portrait"}
                         disabled={!got_paintings || !is_console}
                         onClick={() =>
                           act('select', {

--- a/tgui/packages/tgui/interfaces/NtosPortraitPrinter.jsx
+++ b/tgui/packages/tgui/interfaces/NtosPortraitPrinter.jsx
@@ -15,7 +15,7 @@ import { NtosWindow } from '../layouts';
 export const NtosPortraitPrinter = (props) => {
   const { act, data } = useBackend();
   const [listIndex, setListIndex] = useState(0);
-  const { paintings, search_string, search_mode } = data;
+  const { paintings, search_string, search_mode, is_console } = data;
   const got_paintings = !!paintings.length;
   const current_portrait_title = got_paintings && paintings[listIndex].title;
   const current_portrait_author =
@@ -113,8 +113,8 @@ export const NtosPortraitPrinter = (props) => {
                     <Stack.Item grow={3}>
                       <Button
                         icon="check"
-                        content="Print Portrait"
-                        disabled={!got_paintings}
+                        content={is_console ? "View Only" : "Print Portrait"}
+                        disabled={!got_paintings || !is_console}
                         onClick={() =>
                           act('select', {
                             selected: paintings[listIndex].ref,


### PR DESCRIPTION
## About The Pull Request
"Marlowe Treeby's Art Galaxy" can now be installed on all modular computers and the library restriction has been removed, however the print function is still only available to stationary consoles.

## Why It's Good For The Game
Being able to view the complete gallery of pixelated drawings from your PDA without having to barge in on the other side of the library counter doesn't seem like a bad thing to me.

## Changelog

:cl:
balance: As a continued effort to promote art and culture among the crew, the "Marlowe Treeby's Art Galaxy" application has been made available for download on all computer devices, with no access restrictions. Printing can still only be done on a stationary console. The curator's PDA has it preinstalled now.
/:cl:
