### PR TITLE
Fixes runtime when leaving your brains out to dry

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -338,7 +338,7 @@
 /obj/item/organ/brain/check_damage_thresholds(mob/M)
 	. = ..()
 	// If we crossed blinking brain damage thresholds either way, update our blinking
-	if ((prev_damage > BRAIN_DAMAGE_ASYNC_BLINKING && damage < BRAIN_DAMAGE_ASYNC_BLINKING) || (prev_damage < BRAIN_DAMAGE_ASYNC_BLINKING && damage > BRAIN_DAMAGE_ASYNC_BLINKING))
+	if (owner && ((prev_damage > BRAIN_DAMAGE_ASYNC_BLINKING && damage < BRAIN_DAMAGE_ASYNC_BLINKING) || (prev_damage < BRAIN_DAMAGE_ASYNC_BLINKING && damage > BRAIN_DAMAGE_ASYNC_BLINKING)))
 		var/obj/item/organ/eyes/eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
 		eyes?.animate_eyelids(owner)
 


### PR DESCRIPTION
## About The Pull Request
Fixes a runtime where owner-less brains would runtime upon swapping from <60 damage to >60 damage.

This makes it so that brains no longer attempt to update their owner's eyeballs when they have no owner.

before fix:
<img width="1280" height="690" alt="dreamseeker_2025-08-17_10-43-43" src="https://github.com/user-attachments/assets/d04e794b-2b5e-40e8-b9ce-f9a0be81ae94" />

After fix (ignore the fact there was another runtime for something unrelated, I can't be bothered to dig into signal code):
<img width="1280" height="690" alt="dreamseeker_2025-08-17_11-12-23" src="https://github.com/user-attachments/assets/bd7b7226-7fd8-48ac-99f4-b6d3849ad95d" />
## Why It's Good For The Game
Less runtimes = good

Also keeps the chat from being spammed with BIG BOLD RED TEXT that there's a runtime
## Changelog
:cl:
fix: Brains will no longer runtime when owner-less
/:cl:
