### PR TITLE
Refactor brains to inherit traits from parent

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -504,6 +504,10 @@
 	name = "lizard brain"
 	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."
 
+/obj/item/organ/brain/lizard/Initialize(mapload)
+	. = ..()
+	organ_traits |= list(TRAIT_TACKLING_TAILED_DEFENDER)
+
 /obj/item/organ/brain/ghost
 	name = "ghost brain"
 	desc = "How are you even able to hold this?"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -423,21 +423,30 @@
 	name = "zombie brain"
 	desc = "This glob of green mass can't have much intelligence inside it."
 	icon_state = "brain-x"
-	organ_traits = list(TRAIT_CAN_STRIP, TRAIT_PRIMITIVE)
+
+/obj/item/organ/brain/zombie/Initialize(mapload)
+	. = ..()
+	organ_traits.Remove(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
+	organ_traits |= list(TRAIT_PRIMITIVE)
 
 /obj/item/organ/brain/alien
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
-	organ_traits = list(TRAIT_CAN_STRIP)
+
+/obj/item/organ/brain/alien/Initialize(mapload)
+	. = ..()
+	organ_traits.Remove(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
 
 /obj/item/organ/brain/primitive //No like books and stompy metal men
 	name = "primitive brain"
 	desc = "This juicy piece of meat has a clearly underdeveloped frontal lobe."
-	organ_traits = list(
-		TRAIT_ADVANCEDTOOLUSER,
-		TRAIT_CAN_STRIP,
-		TRAIT_PRIMITIVE, // No literacy
+
+/obj/item/organ/brain/primitive/Initialize(mapload)
+	. = ..()
+	organ_traits.Remove(TRAIT_LITERATE)
+	organ_traits |= list(
+		TRAIT_PRIMITIVE,
 		TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION,
 		TRAIT_EXPERT_FISHER, // live off land, fish from river
 		TRAIT_ROUGHRIDER, // ride beast, chase down prey, flee from danger
@@ -451,14 +460,16 @@
 	can_smoothen_out = FALSE
 	color = COLOR_GOLEM_GRAY
 	organ_flags = ORGAN_MINERAL
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP, TRAIT_ROCK_METAMORPHIC)
+
+/obj/item/organ/brain/golem/Initialize(mapload)
+	. = ..()
+	organ_traits |= list(TRAIT_ROCK_METAMORPHIC)
 
 /obj/item/organ/brain/lustrous
 	name = "lustrous brain"
 	desc = "This is your brain on bluespace dust. Not even once."
 	icon_state = "random_fly_4"
 	can_smoothen_out = FALSE
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP)
 
 // This fixes an edge case from species/regenerate_organs that would transfer the brain trauma before organ/on_mob_remove can remove it
 // Prevents wizards from using the magic mirror to gain bluespace_prophet trauma and then switching to another race
@@ -492,7 +503,6 @@
 /obj/item/organ/brain/lizard
 	name = "lizard brain"
 	desc = "This juicy piece of meat has a oversized brain stem and cerebellum, with not much of a limbic system to speak of at all. You would expect its owner to be pretty cold blooded."
-	organ_traits = list(TRAIT_TACKLING_TAILED_DEFENDER)
 
 /obj/item/organ/brain/ghost
 	name = "ghost brain"
@@ -506,7 +516,10 @@
 	desc = "A piece of juicy meat found in an ayy lmao's head."
 	icon_state = "brain-x"
 	brain_size = 1.3
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_CAN_STRIP, TRAIT_LITERATE, TRAIT_REMOTE_TASTING)
+
+/obj/item/organ/brain/abductor/Initialize(mapload)
+	. = ..()
+	organ_traits |= list(TRAIT_REMOTE_TASTING)
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -7,9 +7,12 @@
 		/datum/action/cooldown/spell/charged/psychic_booster,
 		/datum/action/cooldown/spell/forcewall/psychic_wall,
 	)
-	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP, TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 	w_class = WEIGHT_CLASS_NORMAL
 	var/does_it_blind = FALSE
+
+/obj/item/organ/brain/psyker/Initialize(mapload)
+	. = ..()
+	organ_traits |= list(TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 
 /obj/item/organ/brain/psyker/on_mob_insert(mob/living/carbon/inserted_into)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Instead of manually hardcoding every trait by c/p'ing a list, this changes brain subtypes to naturally inherit the `organ_traits` of the parent and then perform modifications in `Initialize()`. The main benefit is that if traits are ever added or removed from the parent `/obj/item/organ/brain` it will automatically update all the children subtypes.

## Why It's Good For The Game
Small refactor to make the code less brittle.

## Changelog
:cl:
code: Refactor brains to inherit traits from parent type
/:cl:
