### PR TITLE
lets you put pills in slices of cheese and meats

### DIFF
--- a/code/game/objects/items/food/cheese.dm
+++ b/code/game/objects/items/food/cheese.dm
@@ -36,6 +36,10 @@
 	rat_heal = 10
 	crafting_complexity = FOOD_COMPLEXITY_1
 
+/obj/item/food/cheese/wedge/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/food_storage)
+
 /obj/item/food/cheese/wheel
 	name = "cheese wheel"
 	desc = "A big wheel of delicious Cheddar."
@@ -136,6 +140,10 @@
 	w_class = WEIGHT_CLASS_SMALL
 	rat_heal = 10
 	crafting_complexity = FOOD_COMPLEXITY_3
+
+/obj/item/food/cheese/firm_cheese_slice/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/food_storage)
 
 /obj/item/food/cheese/firm_cheese_slice/make_grillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/grilled_cheese, rand(25 SECONDS, 35 SECONDS), TRUE, TRUE)

--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -615,6 +615,10 @@
 	foodtypes = MEAT | RAW
 	var/meat_type = "meat"
 
+/obj/item/food/meat/rawcutlet/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/food_storage)
+
 /obj/item/food/meat/rawcutlet/make_grillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/cutlet/plain, rand(35 SECONDS, 50 SECONDS), TRUE, TRUE)
 
@@ -730,6 +734,10 @@
 /obj/item/food/meat/cutlet/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_MICROWAVE_COOKED, PROC_REF(on_microwave_cooked))
+
+/obj/item/food/meat/cutlet/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/food_storage)
 
 ///This proc handles setting up the correct meat name for the cutlet, this should definitely be changed with the food rework.
 /obj/item/food/meat/cutlet/proc/on_microwave_cooked(datum/source, atom/source_item, cooking_efficiency)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -155,7 +155,7 @@
 /obj/item/reagent_containers/applicator/pill/on_accidental_consumption(mob/living/carbon/victim, mob/living/carbon/user, obj/item/source_item, discover_after = FALSE)
 	var/datum/component/edible/edible_component = source_item.GetComponent(/datum/component/edible)
 	var/victim_perceived_quality = edible_component.get_perceived_food_quality(victim)
-	if(victim_perceived_quality < 1) // If you don't like the food then you notice the pill you just swallowed
+	if(victim_perceived_quality < FOOD_QUALITY_NORMAL) // If you don't like the food then you notice the pill you just swallowed
 		to_chat(victim, span_warning("You swallow something small. [source_item ? "Was that in [source_item]?" : ""]"))
 	on_consumption(victim, user)
 	return FALSE

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -153,9 +153,7 @@
  * On accidental consumption, consume the pill
  */
 /obj/item/reagent_containers/applicator/pill/on_accidental_consumption(mob/living/carbon/victim, mob/living/carbon/user, obj/item/source_item, discover_after = FALSE)
-	var/datum/component/edible/edible_component = source_item.GetComponent(/datum/component/edible)
-	var/victim_perceived_quality = edible_component.get_perceived_food_quality(victim)
-	if(victim_perceived_quality < FOOD_QUALITY_NORMAL) // If you don't like the food then you notice the pill you just swallowed
+	if(victim.get_food_taste_reaction(source_item) != FOOD_LIKED) // If you don't like the food then you notice the pill you just swallowed
 		to_chat(victim, span_warning("You swallow something small. [source_item ? "Was that in [source_item]?" : ""]"))
 	on_consumption(victim, user)
 	return FALSE

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -153,7 +153,10 @@
  * On accidental consumption, consume the pill
  */
 /obj/item/reagent_containers/applicator/pill/on_accidental_consumption(mob/living/carbon/victim, mob/living/carbon/user, obj/item/source_item, discover_after = FALSE)
-	to_chat(victim, span_warning("You swallow something small. [source_item ? "Was that in [source_item]?" : ""]"))
+	var/datum/component/edible/edible_component = source_item.GetComponent(/datum/component/edible)
+	var/victim_perceived_quality = edible_component.get_perceived_food_quality(victim)
+	if(victim_perceived_quality < 1) // If you don't like the food then you notice the pill you just swallowed
+		to_chat(victim, span_warning("You swallow something small. [source_item ? "Was that in [source_item]?" : ""]"))
 	on_consumption(victim, user)
 	return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Adds the food storage component to cutlets, cooked and raw, as well as slices of cheese. This means you can put pills in them.
Also changes pills on accidental consumption, if you like the food they are stuck into, then you don't even notice that you just ate a pill. Mmm cheese...
## Why It's Good For The Game

Food storage is a really funny component but only works on very few foods, like whole wheels of cheese or loaves of bread. Everyone knows the best way to sneak a pill is to put it in a slice of cheese.
## Changelog
:cl:
add: Lets small items be stuck into slices of cheese or lunch meat
balance: Pills in food no longer alert you that you've just swallowed one if you like the food they were stuck in (yum... cheese...)
/:cl:
