### PR TITLE
Fixes `/datum/bodypart_overlay/mutant` misinterpreting `/datum/sprite_accessory`'s `gender_specific` var

### DIFF
--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -76,7 +76,7 @@
 	if(!sprite_datum)
 		CRASH("Trying to call get_image() on [type] while it didn't have a sprite_datum. This shouldn't happen, report it as soon as possible.")
 
-	var/gender = (limb?.limb_gender == FEMALE) ? "f" : "m"
+	var/gender = (limb?.limb_gender == "f") ? "f" : "m"
 	var/list/icon_state_builder = list()
 	icon_state_builder += sprite_datum.gender_specific ? gender : "m" //Male is default because sprite accessories are so ancient they predate the concept of not hardcoding gender
 	icon_state_builder += feature_key

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -76,7 +76,7 @@
 	if(!sprite_datum)
 		CRASH("Trying to call get_image() on [type] while it didn't have a sprite_datum. This shouldn't happen, report it as soon as possible.")
 
-	var/gender = (limb?.limb_gender == "f") ? "f" : "m"
+	var/gender = limb?.limb_gender || "m"
 	var/list/icon_state_builder = list()
 	icon_state_builder += sprite_datum.gender_specific ? gender : "m" //Male is default because sprite accessories are so ancient they predate the concept of not hardcoding gender
 	icon_state_builder += feature_key


### PR DESCRIPTION
## About The Pull Request
`get_image()` proc of `/datum/bodypart_overlay/mutant` assumed a `/obj/item/bodypart`'s `limb_gender` variable was a `FEMALE` or `MALE` define, when its actually a `"f"` `"m"` string.

## Why It's Good For The Game
Its nice that sprite accessories can be gender specific, even if we may not have any right now.

## Changelog

:cl:
fix: Mutant bodypart overlays (tails and et cetera) that are gender-specific now display correctly
/:cl:
