### PR TITLE
Fix digital clocks still processing on SSmachines

### DIFF
--- a/code/game/machinery/digital_clock.dm
+++ b/code/game/machinery/digital_clock.dm
@@ -9,6 +9,7 @@
 	density = FALSE
 	layer = ABOVE_WINDOW_LAYER
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 7, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 4)
+	subsystem_type = /datum/controller/subsystem/processing/digital_clock
 
 /obj/item/wallframe/digital_clock
 	name = "digital clock frame"
@@ -79,12 +80,7 @@
 
 /obj/machinery/digital_clock/Initialize(mapload)
 	. = ..()
-	START_PROCESSING(SSdigital_clock, src)
 	find_and_hang_on_wall()
-
-/obj/machinery/digital_clock/Destroy()
-	STOP_PROCESSING(SSdigital_clock, src)
-	return ..()
 
 /obj/machinery/digital_clock/process(seconds_per_tick)
 	if(machine_stat & NOPOWER)


### PR DESCRIPTION
## About The Pull Request

due to how machines work, all machines will be added to `SSmachines` processing by default. you are supposed to set `subsystem_type` if you want them to process on a different subsystem... so the digital clocks subsystem literally never worked bc it would start processing on SSmachines _first_ when `/obj/machinery/Initialize()` called `begin_processing()`, and thus `START_PROCESSING(SSdigital_clock, src)` wouldn't do anything at all.

port of my fix from [Monkestation/Monkestation2.0@`0527747` (#7524)](https://github.com/Monkestation/Monkestation2.0/pull/7524/commits/05277475235a0d8c11b4eea605b051ded79bcedb)

## Why It's Good For The Game

things working as intended is good

## Changelog

:cl:
fix: Digital clocks now process on the correct subsystem.
/:cl: