### PR TITLE
Improves stacking statuses code by only creating overlays for the effects that need them

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -397,9 +397,7 @@
 	stack_threshold = 10
 	max_stacks = 10
 	overlay_file = 'icons/effects/bleed.dmi'
-	underlay_file = 'icons/effects/bleed.dmi'
 	overlay_state = "bleed"
-	underlay_state = "bleed"
 	var/bleed_damage = 200
 
 /datum/status_effect/stacking/saw_bleed/fadeout_effect()


### PR DESCRIPTION

## About The Pull Request

We probably shouldn't be doing all of this work for all the stacking status effects without visuals considering only a single status effect uses the overlay system as of now.

## Changelog
:cl:
code: Stacking status effects without visual overlays will no longer try to create them and fail to do so.
/:cl:
