### PR TITLE
Fixes newspapers not lighting on fire from lighters

### DIFF
--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -44,6 +44,8 @@
 		wield_callback = CALLBACK(src, PROC_REF(on_wielded)),\
 		unwield_callback = CALLBACK(src, PROC_REF(on_unwielded)),\
 	)
+	AddElement(/datum/element/burn_on_item_ignition)
+	RegisterSignal(src, COMSIG_ATOM_IGNITED_BY_ITEM, PROC_REF(close_paper_ui))
 	creation_time = GLOB.news_network.last_action
 	for(var/datum/feed_channel/iterated_feed_channel in GLOB.news_network.network_channels)
 		news_content += iterated_feed_channel
@@ -54,8 +56,6 @@
 	saved_wanted_body = GLOB.news_network.wanted_issue.body
 	if(GLOB.news_network.wanted_issue.img)
 		saved_wanted_icon = GLOB.news_network.wanted_issue.img
-	AddElement(/datum/element/burn_on_item_ignition)
-	RegisterSignal(src, COMSIG_ATOM_IGNITED_BY_ITEM, PROC_REF(close_paper_ui))
 
 /obj/item/newspaper/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(held_item)
@@ -106,7 +106,7 @@
 			owner.update_appearance(UPDATE_OVERLAYS)
 		return ITEM_INTERACT_SUCCESS
 
-	if (!user.can_write(tool))
+	if (!user.can_write(tool, TRUE))
 		return NONE
 
 	if (scribble_page == current_page)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -138,7 +138,7 @@
 /// Checks for whether we can vandalize this book, to ensure we still can after each input.
 /// Uses to_chat over balloon alerts to give more detailed information as to why.
 /obj/item/book/proc/can_vandalize(mob/living/user, obj/item/tool)
-	if(!user.can_perform_action(src) || !user.can_write(tool))
+	if(!user.can_perform_action(src) || !user.can_write(tool, TRUE))
 		return FALSE
 	if(user.is_blind())
 		to_chat(user, span_warning("As you are trying to write on the book, you suddenly feel very stupid!"))


### PR DESCRIPTION

## About The Pull Request

Closes #92636
Actually two bugs in one, also fixes books printing the same message thinking that you're trying to vandalize them.

## Changelog
:cl:
fix: Fixed newspapers not lighting on fire from lighters
/:cl:
