### PR TITLE
Ensured that biogens cannot brick themselves via various means

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -195,9 +195,12 @@
 	. += emissive_appearance(icon, "[icon_state]_o_screen", src)
 
 /obj/machinery/biogenerator/wrench_act(mob/living/user, obj/item/tool)
-	if(default_unfasten_wrench(user, tool))
-		return ITEM_INTERACT_SUCCESS
-	return ITEM_INTERACT_BLOCKING
+	switch(default_unfasten_wrench(user, tool))
+		if(SUCCESSFUL_UNFASTEN)
+			return ITEM_INTERACT_SUCCESS
+		if(FAILED_UNFASTEN)
+			return ITEM_INTERACT_BLOCKING
+	return NONE
 
 /obj/machinery/biogenerator/screwdriver_act(mob/living/user, obj/item/tool)
 	if(!default_deconstruction_screwdriver(user, icon_state, icon_state, tool))

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -274,18 +274,12 @@
 /obj/machinery/biogenerator/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(istype(arrived, /obj/item/food))
-		current_item_count += 1
-		RegisterSignal(arrived, COMSIG_QDELETING, PROC_REF(on_item_qdel))
+		current_item_count += 1 // No need to track qdels because they call Exited()
 
 /obj/machinery/biogenerator/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(istype(gone, /obj/item/food))
 		current_item_count -= 1
-		UnregisterSignal(gone, COMSIG_QDELETING)
-
-/obj/machinery/biogenerator/proc/on_item_qdel(datum/source)
-	SIGNAL_HANDLER
-	current_item_count -= 1
 
 /// Activates biomass processing and converts all inserted food products into biomass
 /obj/machinery/biogenerator/proc/start_process()

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -155,7 +155,7 @@
 		. += span_notice(" - Productivity at <b>[productivity * 100]%</b>.")
 		. += span_notice(" - Converting <b>[processed_items_per_cycle]</b> pieces of food per cycle.")
 		. += span_notice(" - Matter consumption at <b>[1 / efficiency * 100]</b>%.")
-		. += span_notice(" - Internal biomass converter capacity at <b>[max_items]</b> pieces of food, and currently holding <b>[current_item_count] piece[current_item_count == 1 ? "" : "s"]</b>.")
+		. += span_notice(" - Internal biomass converter capacity at <b>[max_items]</b> pieces of food, and currently holding <b>[current_item_count] piece\s</b>.")
 
 	if(welded_down)
 		. += span_info("It's moored firmly to the floor. You can unsecure its moorings with a <b>welder</b>.")


### PR DESCRIPTION

## About The Pull Request

Closes #92638
Tracking item count via a var is a pretty bad idea as there's a ton of ways this could backfire, so I changed it to track entries/exits/qdels instead
Also updated them to use item_interaction and tool acts

## Changelog
:cl:
fix: Ensured that biogens cannot brick themselves via various means
code: Updated biogen code
/:cl:
