### PR TITLE
Fixes gas miners connecting to surrounding pipes.

### DIFF
--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -28,6 +28,7 @@
 	var/broken_message = "ERROR"
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 1.5
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
+	initialize_directions = NONE
 
 /obj/machinery/atmospherics/miner/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -34,9 +34,6 @@
 	. = ..()
 	set_active(active) //Force overlay update.
 
-/obj/machinery/atmospherics/miner/is_connectable(obj/machinery/atmospherics/target, given_layer)
-	return FALSE
-
 /obj/machinery/atmospherics/miner/examine(mob/user)
 	. = ..()
 	if(broken)

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -33,6 +33,9 @@
 	. = ..()
 	set_active(active) //Force overlay update.
 
+/obj/machinery/atmospherics/miner/is_connectable(obj/machinery/atmospherics/target, given_layer)
+	return FALSE
+
 /obj/machinery/atmospherics/miner/examine(mob/user)
 	. = ..()
 	if(broken)


### PR DESCRIPTION
## About The Pull Request
Closes #92578

awesome
<img width="181" height="180" alt="image" src="https://github.com/user-attachments/assets/63917bcc-71fe-42a5-b05e-ba50448e938b" />

## Why It's Good For The Game

They aren't supposed to do that and would just cause runtimes when you added them to pipelines didn't even provide any gas there's no intended interaction for that.

## Changelog
:cl:
fix: Fixes gas miners erroneously connecting to surrounding pipes, causing runtimes
/:cl:
