### PR TITLE
Splattercasting Infinite Blood Fix

### DIFF
--- a/code/datums/components/splattercasting.dm
+++ b/code/datums/components/splattercasting.dm
@@ -75,7 +75,7 @@
 		return
 
 	//normal cooldown spell has
-	var/cooldown_remaining = spell.next_use_time - world.time
+	var/cooldown_remaining = max(spell.next_use_time - world.time,0)
 	//how much we discount, we make the spell cost 1/10th of its actual cooldown
 	var/new_cooldown = cooldown_remaining / 10
 	//convert how much cooldown that spell saved into blood cost


### PR DESCRIPTION
## About The Pull Request

One line change, max(variable,0) means if the variable is negative then it is 0 instead

cooldown_remaining can be negative, whether its due to how spell.next_use_time and world.time is measured, or due to something else. This makes sure no blood spell will ever give you free blood back, touch spells are still broken, this PR doesn't change that, they simply do not interact with splattercasting period as of now, which is not intended. Sanguine spells not interacting IS intended.

## Why It's Good For The Game

No infinite time stop (via this method, anyway)

## Changelog

:cl:
fix: Splattercasting touch spells no longer give infinite blood
/:cl:
