### PR TITLE
fixing the incorrect display of shotgun cartridge damage

### DIFF
--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -13,4 +13,4 @@
 #define MARTIALART_JUNGLEARTS "jungle arts"
 
 /// The number of hits required to crit a target
-#define HITS_TO_CRIT(damage) round(100 / damage, 0.1)
+#define HITS_TO_CRIT(damage) round(100 / (damage), 0.1)


### PR DESCRIPTION

## About The Pull Request
was
<img width="782" height="382" alt="rubber_became" src="https://github.com/user-attachments/assets/a19c951a-986d-4191-83bf-7194394cbef9" />


became
<img width="791" height="376" alt="rubber_was" src="https://github.com/user-attachments/assets/15534610-a478-4c51-b3bd-be89668f6b0e" />
## Why It's Good For The Game
now no one will shoot 200 times with a shotgun to kill someone anymore
## Changelog
:cl:
fix: the interns recalculated the damage of the shotguns catridges and made corrections
/:cl:
