### PR TITLE
Removes Blood Beam's ability to turn iron sheets into cult metal

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -193,10 +193,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	. += span_notice("- Unanchored wall girder")
 	. += span_notice("- Computer or Machine frame (with circuitboard)")
 
-/obj/item/stack/sheet/iron/narsie_act()
-	new /obj/item/stack/sheet/runed_metal(loc, amount)
-	qdel(src)
-
 /obj/item/stack/sheet/iron/fifty
 	amount = 50
 


### PR DESCRIPTION
## About The Pull Request

Blood beam, while supposed to be quite costly can be used after slicing the throat of a single monkey.
You could then, put as many iron sheets on the floor as you wanted, aim your blood beam at it (aiming away from the center of the station recommended) and convert potentially multiple full stacks of it 1:1 into cult metal.

## Why It's Good For The Game

Cultists already have a dedicated spell for creating cult metal requiring plasteel instead, which is usually harder to gather in bulk especially early on. That interaction completely overshadows it. As a fun fact, it's also older than the change that moved the construct spell from iron to plasteel so it's likely somebody just forgot.

## Changelog
:cl:
balance: Blood beams no longer converts iron sheets into cult metal.
/:cl:
