### PR TITLE
Fixes surgical breath masks being adjustable

### DIFF
--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -13,6 +13,8 @@
 	visor_flags_cover = MASKCOVERSMOUTH
 	resistance_flags = NONE
 	interaction_flags_click = NEED_DEXTERITY|ALLOW_RESTING
+	/// Can this mask be adjusted?
+	var/adjustable = TRUE
 
 /datum/armor/mask_breath
 	bio = 50
@@ -22,15 +24,19 @@
 	return OXYLOSS
 
 /obj/item/clothing/mask/breath/attack_self(mob/user)
-	adjust_visor(user)
+	if(adjustable)
+		adjust_visor(user)
 
 /obj/item/clothing/mask/breath/click_alt(mob/user)
+	if(!adjustable)
+		return
 	adjust_visor(user)
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/clothing/mask/breath/examine(mob/user)
 	. = ..()
-	. += span_notice("Alt-click [src] to adjust it.")
+	if(adjustable)
+		. += span_notice("Alt-click [src] to adjust it.")
 
 /obj/item/clothing/mask/breath/medical
 	desc = "A close-fitting sterile mask that can be connected to an air supply."
@@ -52,8 +58,10 @@
 	righthand_file = 'icons/mob/inhands/clothing/masks_righthand.dmi'
 	body_parts_covered = NONE
 	flags_cover = NONE
+	actions_types = null
 	armor_type = /datum/armor/breath_muzzle
 	equip_delay_other = 2.5 SECONDS // my sprite has 4 straps, a-la a head harness. takes a while to equip, longer than a muzzle
+	adjustable = FALSE
 
 /obj/item/clothing/mask/breath/muzzle/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Closes #92616
Closes #92552

## Changelog
:cl:
fix: You can no longer adjust surgical breath masks to break their sprites.
/:cl:
