### PR TITLE
[NO GBP] Fixes spraypainted items glowing in the dark

### DIFF
--- a/code/game/atom/atom_color.dm
+++ b/code/game/atom/atom_color.dm
@@ -132,8 +132,10 @@
 	if(!(overlay.appearance_flags & KEEP_TOGETHER))
 		// Recursively ensure any nested overlays/underlays also get the color filter
 		for(var/mutable_appearance/child_overlay as anything in overlay.overlays)
-			color_atom_overlay(child_overlay)
+			if(!(child_overlay.appearance_flags & KEEP_APART))
+				color_atom_overlay(child_overlay)
 		for(var/mutable_appearance/child_underlay as anything in overlay.underlays)
-			color_atom_overlay(child_underlay)
+			if(!(child_underlay.appearance_flags & KEEP_APART))
+				color_atom_overlay(child_underlay)
 
 	return overlay

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -466,7 +466,7 @@
 
 	. = list()
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
-		. += emissive_blocker(standing.icon, standing.icon_state, src, alpha = standing.alpha)
+		. += emissive_blocker(standing.icon, standing.icon_state, src)
 	SEND_SIGNAL(src, COMSIG_ITEM_GET_WORN_OVERLAYS, ., standing, isinhands, icon_file)
 
 /// worn_overlays to use when you'd want to use KEEP_APART. Don't use KEEP_APART neither there nor here, as it would break floating overlays


### PR DESCRIPTION

## About The Pull Request

We probably should be checking for KEEP_APART instructions while recursively coloring items. Yikes. Also fixes worn emissive blockers double dipping into owner's alpha, as emissives no longer have RESET_ALPHA on them.

Closes #92651

## Changelog
:cl:
fix: Fixed spraypainted items glowing in the dark
/:cl:
