### PR TITLE
Machine Override mobs will no longer target/be targeted by AI turrets

### DIFF
--- a/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
+++ b/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
@@ -366,7 +366,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 
 /mob/living/basic/mimic/copy/machine
 	ai_controller = /datum/ai_controller/basic_controller/mimic_copy/machine
-	faction = list(FACTION_MIMIC, FACTION_SILICON)
+	faction = list(FACTION_MIMIC, FACTION_SILICON, FACTION_TURRET)
 
 /mob/living/basic/mimic/copy/ranged
 	icon = 'icons/turf/floors.dmi'


### PR DESCRIPTION

## About The Pull Request

They were missing FACTION_TURRET, which all sillycones bar cyborgs (drones, bots, etc) have. Hostile machines should probably also get it.
Closes #92603

## Changelog
:cl:
fix: Machine Override mobs will no longer target/be targeted by AI turrets
/:cl:
