### PR TITLE
Laser Carbine and Disabler SMG as Goodies in Cargo and energy/laser cargo crates rebalance

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -94,14 +94,14 @@
 /datum/supply_pack/goody/energy_single
 	name = "Energy Gun Single-Pack"
 	desc = "Contains one energy gun, capable of firing both non-lethal and lethal blasts of light."
-	cost = PAYCHECK_COMMAND * 10
+	cost = PAYCHECK_COMMAND * 12
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/e_gun)
 
 /datum/supply_pack/goody/laser_single
 	name = "Laser Gun Single-Pack"
 	desc = "Contains one laser gun, the lethal workhorse of Nanotrasen security everywhere."
-	cost = PAYCHECK_COMMAND * 8
+	cost = PAYCHECK_COMMAND * 6
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/laser)
 

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -94,16 +94,30 @@
 /datum/supply_pack/goody/energy_single
 	name = "Energy Gun Single-Pack"
 	desc = "Contains one energy gun, capable of firing both non-lethal and lethal blasts of light."
-	cost = PAYCHECK_COMMAND * 12
+	cost = PAYCHECK_COMMAND * 10
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/e_gun)
 
 /datum/supply_pack/goody/laser_single
 	name = "Laser Gun Single-Pack"
 	desc = "Contains one laser gun, the lethal workhorse of Nanotrasen security everywhere."
-	cost = PAYCHECK_COMMAND * 6
+	cost = PAYCHECK_COMMAND * 8
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/laser)
+
+/datum/supply_pack/goody/carbine_single
+	name = "Laser Carbine Single_Pack"
+	desc = "Contains one laser carbines, capable of rapidly firing weak lasers."
+	cost = PAYCHECK_COMMAND * 8
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/gun/energy/laser/carbine)
+
+/datum/supply_pack/goody/smg_single
+	name = "Disabler SMG Single_Pack"
+	desc = "Contains one disabler SMGs, capable of rapidly firing weak disabler beams."
+	cost = PAYCHECK_COMMAND * 6
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/gun/energy/disabler/smg)
 
 /datum/supply_pack/goody/hell_single
 	name = "Hellgun Kit Single-Pack"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -268,11 +268,11 @@
 	name = "NT BR-38 Crate"
 	desc = "An experimental energy-based ballistic battle rifle. Only available to \
 		Nanotrasen stations for security purposes. DO NOT RESELL TO OUTSIDE COMPANIES. \
-		Contains three NT BR-38 rifles and six magazines containing .38 Standard."
+		Contains two NT BR-38 rifles and 4 magazines containing .38 Standard."
 	cost = CARGO_CRATE_VALUE * 100
 	contains = list(
-		/obj/item/gun/ballistic/automatic/battle_rifle = 3,
-		/obj/item/ammo_box/magazine/m38 = 6,
+		/obj/item/gun/ballistic/automatic/battle_rifle = 2,
+		/obj/item/ammo_box/magazine/m38 = 4,
 	)
 	crate_name = "battle rifle crate"
 

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -235,7 +235,7 @@
 	name = "Energy Guns Crate"
 	desc = "Contains three Energy Guns, capable of firing both nonlethal and lethal \
 		blasts of light."
-	cost = CARGO_CRATE_VALUE * 11
+	cost = CARGO_CRATE_VALUE * 18
 	contains = list(/obj/item/gun/energy/e_gun = 3)
 	crate_name = "energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
@@ -243,7 +243,7 @@
 /datum/supply_pack/security/armory/laser
 	name = "Lasers Crate"
 	desc = "Contains three lethal, high-energy laser guns."
-	cost = CARGO_CRATE_VALUE * 9
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/gun/energy/laser = 3)
 	crate_name = "laser crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
@@ -268,11 +268,11 @@
 	name = "NT BR-38 Crate"
 	desc = "An experimental energy-based ballistic battle rifle. Only available to \
 		Nanotrasen stations for security purposes. DO NOT RESELL TO OUTSIDE COMPANIES. \
-		Contains two NT BR-38 rifles and 4 magazines containing .38 Standard."
+		Contains three NT BR-38 rifles and 6 magazines containing .38 Standard."
 	cost = CARGO_CRATE_VALUE * 100
 	contains = list(
-		/obj/item/gun/ballistic/automatic/battle_rifle = 2,
-		/obj/item/ammo_box/magazine/m38 = 4,
+		/obj/item/gun/ballistic/automatic/battle_rifle = 3,
+		/obj/item/ammo_box/magazine/m38 = 6,
 	)
 	crate_name = "battle rifle crate"
 

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -65,14 +65,6 @@
 	contains = list(/obj/item/clothing/head/helmet/sec = 3)
 	crate_name = "helmet crate"
 
-/datum/supply_pack/security/laser
-	name = "Lasers Crate"
-	desc = "Contains three lethal, high-energy laser guns."
-	cost = CARGO_CRATE_VALUE * 4
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/gun/energy/laser = 3)
-	crate_name = "laser crate"
-
 /datum/supply_pack/security/securitybarriers
 	name = "Security Barrier Grenades"
 	desc = "Stem the tide with four Security Barrier grenades."
@@ -241,11 +233,19 @@
 
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
-	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal \
+	desc = "Contains three Energy Guns, capable of firing both nonlethal and lethal \
 		blasts of light."
-	cost = CARGO_CRATE_VALUE * 18
-	contains = list(/obj/item/gun/energy/e_gun = 2)
+	cost = CARGO_CRATE_VALUE * 11
+	contains = list(/obj/item/gun/energy/e_gun = 3)
 	crate_name = "energy gun crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+
+/datum/supply_pack/security/armory/laser
+	name = "Lasers Crate"
+	desc = "Contains three lethal, high-energy laser guns."
+	cost = CARGO_CRATE_VALUE * 9
+	contains = list(/obj/item/gun/energy/laser = 3)
+	crate_name = "laser crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/security/armory/laser_carbine
@@ -268,11 +268,11 @@
 	name = "NT BR-38 Crate"
 	desc = "An experimental energy-based ballistic battle rifle. Only available to \
 		Nanotrasen stations for security purposes. DO NOT RESELL TO OUTSIDE COMPANIES. \
-		Contains three NT BR-38 rifles and three magazines containing .38 Standard."
+		Contains three NT BR-38 rifles and six magazines containing .38 Standard."
 	cost = CARGO_CRATE_VALUE * 100
 	contains = list(
-		/obj/item/gun/ballistic/automatic/battle_rifle = 2,
-		/obj/item/ammo_box/magazine/m38 = 4,
+		/obj/item/gun/ballistic/automatic/battle_rifle = 3,
+		/obj/item/ammo_box/magazine/m38 = 6,
 	)
 	crate_name = "battle rifle crate"
 


### PR DESCRIPTION
## About The Pull Request
Adds Laser Carbine and Disabler SMG Single-Packs.
Laser Carbine Single-Pack costing 800 credits and Disabler SMG costing 600 credits.

Moved Laser Guns crate from security category to armory category. 
Added 3rd Energy Gun to Energy Guns crate. 

Added 3rd BR gun to BR crate and 2 more magazines making it 6 (2 for each gun).

This should bring gun crates to nice standardization of 3 guns in crate.
## Why It's Good For The Game
Standardization improves logistic and makes it easier for brain. (Standardization of guns inside of crates)
Laser guns being in armory category together with rest of the gun crates makes looking for guns to order less confusing.
More goodies to choose from, able to buy non lethal SMG I think is needed too. Especially with all lethal option in Goodies.
## Changelog
:cl:
add: Added Disabler SMG Single-Pack
add: Added Laser Carbine Sigle-Pack
balance: Moved Laser Guns crate from security to armory category in cargo
balance: Increased amount of Energy Guns to 3 in Energy Guns crate
balance: Increased amount of NT BR to 3 and magazines to 6 in NT BR crate
/:cl:
