### PR TITLE
Implements [OPTIONAL] Swap Left/Right hand, changes [OPTIONAL] default keybinds to accomodate

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -68,6 +68,8 @@
 #define COMSIG_KB_MOB_CYCLEINTENTRIGHT_DOWN "keybinding_mob_cycleintentright_down"
 #define COMSIG_KB_MOB_CYCLEINTENTLEFT_DOWN "keybinding_mob_cycleintentleft_down"
 #define COMSIG_KB_MOB_SWAPHANDS_DOWN "keybinding_mob_swaphands_down"
+#define COMSIG_KB_MOB_SELECTRIGHTHAND_DOWN "keybinding_mob_selectrighthand_down"
+#define COMSIG_KB_MOB_SELECTLEFTHAND_DOWN "keybinding_mob_selectlefthand_down"
 #define COMSIG_KB_MOB_ACTIVATEINHAND_DOWN "keybinding_mob_activateinhand_down"
 #define COMSIG_KB_MOB_DROPITEM_DOWN "keybinding_mob_dropitem_down"
 #define COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN "keybinding_mob_targetcyclehead_down"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -6,7 +6,7 @@
 	return ishuman(user.mob)
 
 /datum/keybinding/human/quick_equip
-	hotkey_keys = list("E")
+	hotkey_keys = list("Z")
 	name = "quick_equip"
 	full_name = "Quick equip"
 	description = "Quickly puts an item in the best slot available"
@@ -21,7 +21,7 @@
 	return TRUE
 
 /datum/keybinding/human/quick_equip_belt
-	hotkey_keys = list("ShiftE")
+	hotkey_keys = list("ShiftZ")
 	name = "quick_equip_belt"
 	full_name = "Quick equip belt"
 	description = "Put held thing in belt or take out most recent thing from belt"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -6,7 +6,7 @@
 	return ishuman(user.mob)
 
 /datum/keybinding/human/quick_equip
-	hotkey_keys = list("Z")
+	hotkey_keys = list("R")
 	name = "quick_equip"
 	full_name = "Quick equip"
 	description = "Quickly puts an item in the best slot available"
@@ -21,7 +21,7 @@
 	return TRUE
 
 /datum/keybinding/human/quick_equip_belt
-	hotkey_keys = list("ShiftZ")
+	hotkey_keys = list("ShiftR")
 	name = "quick_equip_belt"
 	full_name = "Quick equip belt"
 	description = "Put held thing in belt or take out most recent thing from belt"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -167,7 +167,7 @@
 	return TRUE
 
 /datum/keybinding/living/toggle_throw_mode
-	hotkey_keys = list("R", "Southwest") // END
+	hotkey_keys = list("Southwest") // END
 	name = "toggle_throw_mode"
 	full_name = "Toggle throw mode"
 	description = "Toggle throwing the current item or not."

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -21,7 +21,7 @@
 	return TRUE
 
 /datum/keybinding/mob/swap_hands
-	hotkey_keys = list("X")
+	hotkey_keys = list("Unbound")
 	name = "swap_hands"
 	full_name = "Swap hands"
 	description = ""
@@ -39,14 +39,14 @@
 	var/hand_index = NONE
 
 /datum/keybinding/mob/select_hand/right
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list("Q")
 	name = "select_right_hand"
 	full_name = "Swap to Right Hand"
 	keybind_signal = COMSIG_KB_MOB_SELECTRIGHTHAND_DOWN
 	hand_index = RIGHT_HANDS
 
 /datum/keybinding/mob/select_hand/left
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list("E")
 	name = "select_left_hand"
 	full_name = "Swap to Left Hand"
 	keybind_signal = COMSIG_KB_MOB_SELECTLEFTHAND_DOWN
@@ -66,7 +66,7 @@
 	return TRUE
 
 /datum/keybinding/mob/activate_inhand
-	hotkey_keys = list("Z")
+	hotkey_keys = list("R")
 	name = "activate_inhand"
 	full_name = "Activate in-hand"
 	description = "Uses whatever item you have inhand"
@@ -81,7 +81,7 @@
 	return TRUE
 
 /datum/keybinding/mob/drop_item
-	hotkey_keys = list("Q")
+	hotkey_keys = list("X")
 	name = "drop_item"
 	full_name = "Drop Item"
 	description = ""

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -66,7 +66,7 @@
 	return TRUE
 
 /datum/keybinding/mob/activate_inhand
-	hotkey_keys = list("R")
+	hotkey_keys = list("Z")
 	name = "activate_inhand"
 	full_name = "Activate in-hand"
 	description = "Uses whatever item you have inhand"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -35,6 +35,36 @@
 	M.swap_hand()
 	return TRUE
 
+/datum/keybinding/mob/select_hand
+	var/hand_index = NONE
+
+/datum/keybinding/mob/select_hand/right
+	hotkey_keys = list("Unbound")
+	name = "select_right_hand"
+	full_name = "Swap to Right Hand"
+	keybind_signal = COMSIG_KB_MOB_SELECTRIGHTHAND_DOWN
+	hand_index = RIGHT_HANDS
+
+/datum/keybinding/mob/select_hand/left
+	hotkey_keys = list("Unbound")
+	name = "select_left_hand"
+	full_name = "Swap to Left Hand"
+	keybind_signal = COMSIG_KB_MOB_SELECTLEFTHAND_DOWN
+	hand_index = LEFT_HANDS
+
+/datum/keybinding/mob/select_hand/down(client/user, turf/target)
+	. = ..()
+	if(.)
+		return
+
+	var/mob/user_mob = user.mob
+	var/active_hand_set = ceil(user_mob.active_hand_index / 2) - 1 //offset
+	var/desired_hand_index = hand_index + (2 * active_hand_set)
+
+	user_mob.swap_hand(desired_hand_index)
+
+	return TRUE
+
 /datum/keybinding/mob/activate_inhand
 	hotkey_keys = list("Z")
 	name = "activate_inhand"

--- a/code/modules/tutorials/tutorials/switch_hands.dm
+++ b/code/modules/tutorials/tutorials/switch_hands.dm
@@ -50,18 +50,28 @@
 
 	switch (stage)
 		if (STAGE_SHOULD_SWAP_HAND)
-			var/hand_name = IS_RIGHT_INDEX(hand_to_watch) ? "right" : "left"
+			var/datum/keybinding/mob/select_hand/hand_keybinding
+			var/hand_name
+			if (IS_RIGHT_INDEX(hand_to_watch))
+				hand_keybinding = /datum/keybinding/mob/select_hand/right
+				hand_name = "right"
+			else
+				hand_keybinding = /datum/keybinding/mob/select_hand/left
+				hand_name = "left"
+
 			show_instruction(keybinding_message(
-				/datum/keybinding/mob/swap_hands,
+				hand_keybinding,
 				"Press '%KEY%' to use your [hand_name] hand",
 				"Click '<b>SWAP</b>' to use your [hand_name] hand",
 			))
+
 		if (STAGE_PICK_UP_ITEM)
 			show_instruction("Pick something up!")
 
 /datum/tutorial/switch_hands/proc/on_swap_hands()
 	SIGNAL_HANDLER
 
+	//FIXME: this checking breaks easily
 	if (isnull(user.get_active_held_item()))
 		stage = STAGE_PICK_UP_ITEM
 		show_instructions()


### PR DESCRIPTION
## About The Pull Request

- Adds **OPTIONAL** keybinds that lets you select a specific hand
- Alters **OPTIONAL** default keybinds as such:
  - Q: Swap to Right Hand (replacing Drop item)
  - E: Swap to Left Hand (replacing Quick equip)
  - R: Quick equip (replacing Toggle Throw Mode)
  - ShiftR: Quick equip belt
  - X: Drop item (replacing Swap hands)
  - Swap hands is Unbound

## Why It's Good For The Game

Swapping hands has always been somewhat awkward. Since it depends on the currently selected hand, swapping your hands requires you to look away from what you're doing and mentally process what you're holding and what you have selected. In the heat of the moment (like a fight) it's really easy to forget which hand you have selected and do something you did not want to do (like accidentally hug your target instead of attack them). This makes it so that, at the very least, you only need to check what you're holding.

The **OPTIONAL** default keybinds **THAT ARE OPTIONAL YOU DON'T HAVE TO USE THEM** were altered so that new players use this new feature, hopefully alleviating some of the hiccups from learning hand swapping.
## Changelog

:cl:
qol: Added [OPTIONAL] keybinds to for Swap Left/Right hands. Check your keybinds. [NOT OPTIONAL]
/:cl:
