### PR TITLE
Fixes a few biome warnings

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -432,13 +432,14 @@ class ChatRenderer {
 
           const reactRoot = createRoot(childNode);
 
-          /* eslint-disable react/no-danger */
+          // biome-ignore-start lint/security/noDangerouslySetInnerHtml: ignore
           reactRoot.render(
             <Element {...outputProps}>
               <span dangerouslySetInnerHTML={oldHtml} />
             </Element>,
             childNode,
           );
+          // biome-ignore-end lint/security/noDangerouslySetInnerHtml: ignore
         }
 
         // Highlight text

--- a/tgui/packages/tgui-setup/helpers.js
+++ b/tgui/packages/tgui-setup/helpers.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 (function () {
   // Utility functions
   var hasOwn = Object.prototype.hasOwnProperty;

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -89,9 +89,7 @@ class PaintCanvas extends Component<PaintCanvasProps> {
     if (this.zoom !== this.props.zoom) {
       this.prepareCanvas();
       this.syncCanvas();
-    }
-    // eslint-disable-next-line max-len
-    else if (
+    } else if (
       (this.props.value !== undefined &&
         JSON.stringify(this.baseImageData) !==
           JSON.stringify(fromDM(this.props.value))) ||

--- a/tgui/packages/tgui/interfaces/DetectiveBoard/Evidence.tsx
+++ b/tgui/packages/tgui/interfaces/DetectiveBoard/Evidence.tsx
@@ -170,7 +170,7 @@ export function Evidence(props: Props) {
               {evidence.type === 'photo' ? (
                 <img className="Evidence__Icon" src={evidence.photo_url} />
               ) : (
-                // eslint-disable-next-line react/no-danger
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: ignore
                 <div dangerouslySetInnerHTML={{ __html: evidence.text }} />
               )}
             </Box>

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -34,7 +34,7 @@ export const MarkdownRenderer = (props: MarkdownRendererProps) => {
     content = sanitizeText(content, /* advHtml = */ false);
   }
 
-  // eslint-disable-next-line react/no-danger
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: ignore
   return <div dangerouslySetInnerHTML={{ __html: content }} />;
 };
 

--- a/tgui/packages/tgui/interfaces/NtosCivCargoHoldTerminal.jsx
+++ b/tgui/packages/tgui/interfaces/NtosCivCargoHoldTerminal.jsx
@@ -26,15 +26,13 @@ export const NtosCivCargoHoldTerminal = (props) => {
             <Section
               title="Bounty Choice"
               buttons={
-                <>
-                  <Button
-                    icon={id_bounty_info ? 'recycle' : 'pen'}
-                    color={id_bounty_info ? 'green' : 'default'}
-                    tooltip={id_bounty_info ? 'Replace Bounty' : 'New Bounty'}
-                    disabled={!id_inserted}
-                    onClick={() => act('bounty')}
-                  />
-                </>
+                <Button
+                  icon={id_bounty_info ? 'recycle' : 'pen'}
+                  color={id_bounty_info ? 'green' : 'default'}
+                  tooltip={id_bounty_info ? 'Replace Bounty' : 'New Bounty'}
+                  disabled={!id_inserted}
+                  onClick={() => act('bounty')}
+                />
               }
             >
               <LabeledList>

--- a/tgui/packages/tgui/interfaces/OreSilo.tsx
+++ b/tgui/packages/tgui/interfaces/OreSilo.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
   VirtualList,
 } from 'tgui-core/components';
-import { BooleanLike, classes } from 'tgui-core/react';
+import { type BooleanLike, classes } from 'tgui-core/react';
 import { capitalize } from 'tgui-core/string';
 
 import { useBackend } from '../backend';

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-undef */
 import { useContext } from 'react';
 import {
   Button,

--- a/tgui/packages/tgui/interfaces/ParticleEdit/index.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-undef */
 import {
   createContext,
   type Dispatch,

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -50,7 +50,6 @@ type QuirkListProps = {
 };
 
 type QuirkProps = {
-  // eslint-disable-next-line react/no-unused-prop-types
   onClick: (quirkName: string, quirk: Quirk) => void;
   randomBodyEnabled: boolean;
   selected: boolean;
@@ -87,7 +86,6 @@ function QuirkList(props: QuirkProps & QuirkListProps) {
 type QuirkDisplayProps = {
   quirk: Quirk & { failTooltip?: string };
   // bugged
-  // eslint-disable-next-line react/no-unused-prop-types
   quirkKey: string;
 } & QuirkProps;
 

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -391,11 +391,11 @@ const ProductPrice = (props: ProductPriceProps) => {
   const { data } = useBackend<VendingData>();
   const { displayed_currency_name } = data;
   const { discount, free, product, redPrice } = props;
-  let standardPrice = product.price + '';
+  let standardPrice = `${product.price}`;
   if (free) {
     standardPrice = 'FREE';
   } else if (discount) {
-    standardPrice = redPrice + '';
+    standardPrice = `${redPrice}`;
   }
   return (
     <Stack.Item fontSize={0.85} color={'gold'}>


### PR DESCRIPTION
## About The Pull Request

- Fixes an unnecessary fragment in bounty terminal PDA app
- Change import to type import in ore silo
- Change two instances of string concatenation to templates in vending machines
- Removes some now-obsolete suppression comments for eslint, replaces the rest with biome equivalents

## Why It's Good For The Game

Less linter warnings, with these fixes the only ones left are warnings about using dangerouslySetInnerHTML

## Changelog

N/A
