### PR TITLE
Updates the AFK logout report to utilize configs for it's timers

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -124,9 +124,6 @@
 #define RANK_SOURCE_BACKUP "rank_backup"
 #define RANK_SOURCE_TEMPORARY "rank_temp"
 
-/// Amount of time after the round starts that the player disconnect report is issued.
-#define ROUNDSTART_LOGOUT_REPORT_TIME (10 MINUTES)
-
 /// Threshold in minutes for counting a player as AFK on the roundstart report.
 #define ROUNDSTART_LOGOUT_AFK_THRESHOLD (ROUNDSTART_LOGOUT_REPORT_TIME * 0.7)
 

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -124,9 +124,6 @@
 #define RANK_SOURCE_BACKUP "rank_backup"
 #define RANK_SOURCE_TEMPORARY "rank_temp"
 
-/// Threshold in minutes for counting a player as AFK on the roundstart report.
-#define ROUNDSTART_LOGOUT_AFK_THRESHOLD (ROUNDSTART_LOGOUT_REPORT_TIME * 0.7)
-
 /// Number of identical messages required before the spam-prevention will warn you to stfu
 #define SPAM_TRIGGER_WARNING 5
 /// Number of identical messages required before the spam-prevention will automute you

--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -16,6 +16,9 @@ GLOBAL_VAR_INIT(admin_notice, "") // Admin notice that all clients see when join
 // A list of all the special byond lists that need to be handled different by vv
 GLOBAL_LIST_INIT(vv_special_lists, init_special_list_names())
 
+// Stores the value set for the AFK timer callback
+GLOBAL_VAR(logout_timer_set)
+
 /proc/init_special_list_names()
 	var/list/output = list()
 	var/obj/sacrifice = new

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -640,12 +640,10 @@
 
 /datum/config_entry/number/roundstart_logout_report_time_average
 	default = 10 MINUTES
-	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/roundstart_logout_report_time_variance
 	default = 3 MINUTES
-	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/reopen_roundstart_suicide_roles

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -638,6 +638,15 @@
 
 /datum/config_entry/flag/picture_logging_camera
 
+/datum/config_entry/number/roundstart_logout_report_time_average
+	default = 10 MINUTES
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/roundstart_logout_report_time_variance
+	default = 3 MINUTES
+	integer = FALSE
+	min_val = 0
 
 /datum/config_entry/flag/reopen_roundstart_suicide_roles
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -313,7 +313,11 @@ SUBSYSTEM_DEF(ticker)
 	if(!CONFIG_GET(flag/no_intercept_report))
 		GLOB.communications_controller.queue_roundstart_report()
 	// Queue admin logout report
-	addtimer(CALLBACK(src, PROC_REF(display_roundstart_logout_report)), ROUNDSTART_LOGOUT_REPORT_TIME)
+	var/roundstart_logout_timer = CONFIG_GET(number/roundstart_logout_report_time_average)
+	var/roundstart_report_variance = CONFIG_GET(number/roundstart_logout_report_time_variance)
+	var/randomized_callback_timer = rand((roundstart_logout_timer - roundstart_report_variance), (roundstart_logout_timer + roundstart_report_variance))
+	addtimer(CALLBACK(src, PROC_REF(display_roundstart_logout_report)), randomized_callback_timer)
+	GLOB.logout_timer_set = randomized_callback_timer
 	// Queue suicide slot handling
 	if(CONFIG_GET(flag/reopen_roundstart_suicide_roles))
 		var/delay = (CONFIG_GET(number/reopen_roundstart_suicide_roles_delay) * 1 SECONDS) || 4 MINUTES
@@ -367,6 +371,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/display_roundstart_logout_report()
 	var/list/msg = list("[span_boldnotice("Roundstart logout report")]\n\n")
+
 	for(var/i in GLOB.mob_living_list)
 		var/mob/living/L = i
 		var/mob/living/carbon/C = L
@@ -379,7 +384,7 @@ SUBSYSTEM_DEF(ticker)
 
 		if(L.ckey && L.client)
 			var/failed = FALSE
-			if(L.client.inactivity >= ROUNDSTART_LOGOUT_AFK_THRESHOLD) //Connected, but inactive (alt+tabbed or something)
+			if(L.client.inactivity >= GLOB.logout_timer_set) //Connected, but inactive (alt+tabbed or something)
 				msg += "<b>[L.name]</b> ([L.key]), the [L.job] (<font color='#ffcc00'><b>Connected, Inactive</b></font>)\n"
 				failed = TRUE //AFK client
 			if(!failed && L.stat)
@@ -409,6 +414,8 @@ SUBSYSTEM_DEF(ticker)
 					else
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] ([span_bolddanger("Ghosted")])\n"
 						continue //Ghosted while alive
+
+	msg += "[span_boldnotice("Roundstart logout reported at: [DisplayTimeText(GLOB.logout_timer_set)]")]\n"
 
 	var/concatenated_message = msg.Join()
 	log_admin(concatenated_message)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -55,6 +55,11 @@ HUMANS_NEED_SURNAMES
 ## If uncommented, this forces all players to use random names !and appearances!.
 #FORCE_RANDOM_NAMES
 
+## Amount of time after the round starts that the player disconnect report is issued, randomized by ROUNDSTART_LOGOUT_REPORT_TIME_VARIANCE as a lower and upper possible timer
+## Setting ROUNDSTART_LOGOUT_REPORT_TIME_VARIANCE to 0 will result in no variance, and only display the time in ROUNDSTART_LOGOUT_REPORT_TIME_AVERAGE
+ROUNDSTART_LOGOUT_REPORT_TIME_VARIANCE 1800
+ROUNDSTART_LOGOUT_REPORT_TIME_AVERAGE 6000
+
 ## Unhash this to turn on automatic reopening of a player's job if they suicide at roundstart
 #REOPEN_ROUNDSTART_SUICIDE_ROLES
 


### PR DESCRIPTION

## About The Pull Request

Rather than use hardcoded timers for the logout report, the report instead utilizes a timer based on config values. The default value is the current live value.

This timer can also be configurated to utilize randomization. Currently, it defaults to randomizing between -3 minutes to +3 minutes for when the report is sent.

The logout report timer is also added to the admin log.

## Why It's Good For The Game

This shouldn't be dictated by the codebase, as it is an admin tool.

## Changelog
:cl:
admin: AFK logout report timers are now determined by a config rather than a hardcoded value.
/:cl:
