### PR TITLE
Makes slimes all share the same slime_type

### DIFF
--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -83,8 +83,10 @@
 	///Has a mutator been used on the slime? Only one is allowed
 	var/mutator_used = FALSE
 
-	//The datum that handles the slime colour's core and possible mutations
-	var/datum/slime_type/slime_type
+	// The datum that handles the slime colour's core and possible mutations
+	var/datum/slime_type/slime_type = null
+	// After a slime is initialized, a list of all possible initialized datums of slime_types
+	var/static/list/possible_slime_types = null
 
 	//CORE-CROSSING CODE
 
@@ -108,7 +110,7 @@
 	/// Our reproduction action
 	var/datum/action/innate/slime/reproduce/reproduce_action
 
-/mob/living/basic/slime/Initialize(mapload, new_type=/datum/slime_type/grey, new_life_stage=SLIME_LIFE_STAGE_BABY)
+/mob/living/basic/slime/Initialize(mapload, new_type = /datum/slime_type/grey, new_life_stage = SLIME_LIFE_STAGE_BABY)
 
 	. = ..()
 
@@ -118,11 +120,13 @@
 	reproduce_action = new (src)
 	reproduce_action.Grant(src)
 
+	if(isnull(possible_slime_types))
+		possible_slime_types = list()
+		for(var/datum/slime_type/slime_type as anything in subtypesof(/datum/slime_type))
+			possible_slime_types[slime_type] = new slime_type
+
 	set_slime_type(new_type)
 	set_life_stage(new_life_stage)
-	update_name()
-	regenerate_icons()
-
 	set_nutrition(SLIME_STARTING_NUTRITION)
 
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = 2)
@@ -143,9 +147,9 @@
 	ai_controller.set_blackboard_key(BB_SLIME_REPRODUCE, reproduce_action)
 
 /mob/living/basic/slime/Destroy()
-
 	QDEL_NULL(evolve_action)
 	QDEL_NULL(reproduce_action)
+	slime_type = null
 
 	return ..()
 
@@ -153,7 +157,7 @@
 /mob/living/basic/slime/random
 
 /mob/living/basic/slime/random/Initialize(mapload, new_colour, new_life_stage)
-	return ..(mapload, pick(subtypesof(/datum/slime_type)), prob(50) ? SLIME_LIFE_STAGE_ADULT : SLIME_LIFE_STAGE_BABY)
+	return ..(mapload, null, prob(50) ? SLIME_LIFE_STAGE_ADULT : SLIME_LIFE_STAGE_BABY)
 
 ///Friendly docile subtype
 /mob/living/basic/slime/pet
@@ -273,13 +277,13 @@
 	ai_controller.set_blackboard_key(BB_SLIME_LIFE_STAGE, life_stage)
 	update_mob_action_buttons()
 
-///Sets the slime's type, name and its icons
-/mob/living/basic/slime/proc/set_slime_type(new_type)
-	slime_type = new new_type
+/// Sets the slime's type, name and its icons.
+/// If not provided with a type it will instead be random
+/mob/living/basic/slime/proc/set_slime_type(new_type = null)
+	if(isnull(new_type))
+		new_type = subtypesof(/datum/slime_type)
 
-///randomizes the colour of a slime
-/mob/living/basic/slime/proc/random_colour()
-	set_slime_type(pick(subtypesof(/datum/slime_type)))
+	slime_type = possible_slime_types[new_type]
 	update_name()
 	regenerate_icons()
 

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -281,7 +281,7 @@
 /// If not provided with a type it will instead be random
 /mob/living/basic/slime/proc/set_slime_type(new_type = null)
 	if(isnull(new_type))
-		new_type = subtypesof(/datum/slime_type)
+		new_type = pick(subtypesof(/datum/slime_type))
 
 	slime_type = possible_slime_types[new_type]
 	update_name()

--- a/code/modules/mob/living/basic/slime/slime_type.dm
+++ b/code/modules/mob/living/basic/slime/slime_type.dm
@@ -10,6 +10,12 @@
 	///The hexcode used by the slime to colour their victims
 	var/rgb_code
 
+/datum/slime_type/Destroy(force)
+	if(!force)
+		stack_trace("Something tried to delete a \"/datum/slime_type\", this should never happen as could lead to slime colors being broken!")
+		return QDEL_HINT_LETMELIVE
+	return ..()
+
 //TIER 0
 
 /datum/slime_type/grey

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -278,6 +278,5 @@ Charged extracts:
 /obj/item/slimecross/charged/rainbow/do_effect(mob/user)
 	user.visible_message(span_warning("[src] swells and splits into three new slimes!"))
 	for(var/i in 1 to 3)
-		var/mob/living/basic/slime/new_slime = new (get_turf(user))
-		new_slime.random_colour()
+		new /mob/living/basic/slime/random(get_turf(user))
 	return ..()

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -206,10 +206,9 @@ Regenerative extracts:
 	if(isslime(target))
 		target.visible_message(span_warning("The [target] suddenly changes color!"))
 		var/mob/living/basic/slime/target_slime = target
-		target_slime.random_colour()
+		target_slime.set_slime_type()
 	if(isjellyperson(target))
 		target.reagents.add_reagent(/datum/reagent/mutationtoxin/jelly,5)
-
 
 /obj/item/slimecross/regenerative/pink
 	colour = SLIME_TYPE_PINK

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -200,7 +200,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/green
 	colour = SLIME_TYPE_GREEN
-	effect_desc = "Fully heals the target and changes the spieces or color of a slime or jellyperson."
+	effect_desc = "Fully heals the target and changes the species or color of a slime or jellyperson."
 
 /obj/item/slimecross/regenerative/green/core_effect(mob/living/target, mob/user)
 	if(isslime(target))


### PR DESCRIPTION
## About The Pull Request

- All slimes of the same color share the same `slime_type`, saving a tiny amount of memory whenever a xenobiologist exists
> Also slime_types were never manually deleted by the code, only possibly being deleted by the GC later on. This makes the whole thing a bit a bit more sane.

<details>
<summary>Minor changes</summary>

- Charged rainbow now properly uses `/mob/living/basic/slime/random` instead of `/mob/living/basic/slime` and then randomizing its color
- `set_slime_type` now actually updates its name and icons like it says in the comment description instead of them being set at initialize()
- `random_colour` was deleted, being replaced by calling `set_slime_type` with no argument or with null as its argument
- the random color slime subtype now calls the `set_slime_type` proc and lets it randomize the color instead of doing it itself

</details>

## Why It's Good For The Game

> All slimes of the same color share the same `slime_type`, saving a tiny amount of memory whenever a xenobiologist exists
- Its a slight improvement but its still good since most shifts will have a xenobiologist making a good chunk of slimes

<details>
<summary>Minor change explanations</summary>

> Charged rainbow now properly uses `/mob/living/basic/slime/random` instead of `/mob/living/basic/slime` and then randomizing its color
- Very minor nitpick, still should be just spawning that subtype
> `set_slime_type` now actually updates its name and icons like it says in the comment description instead of them being set at initialize()
- if any admin or a future coder wants to change a slime's color now it should properly work with just that proc
> `random_colour` was deleted, being replaced by calling `set_slime_type` with no argument or with null as its argument
- there are 2 places calling it, 1 of them that shouldn't be calling it in the first place, i think its fine to squish it under that proc
> the random color slime subtype now calls the `set_slime_type` proc and lets it randomize the color instead of doing it itself
- Its a bit cleaner

</details>

## Changelog
Edited this out since these aren't player-facing changes. - Ghommie