### PR TITLE
Fixes two inverted hallucination conditions

### DIFF
--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -93,7 +93,7 @@
 
 	var/lower_cd = lower_tick_interval
 	var/upper_cd = upper_tick_interval
-	if(!variable_tier)
+	if(variable_tier)
 		var/seconds_left = (duration - world.time) / 10
 		switch(seconds_left)
 			if(0 to 20)

--- a/code/modules/hallucination/eyes_in_dark.dm
+++ b/code/modules/hallucination/eyes_in_dark.dm
@@ -82,7 +82,7 @@
 /obj/effect/abstract/floating_eyes/process(seconds_per_tick)
 	var/turf/below_us = get_turf(src)
 	var/mob/seer = seer_ref?.resolve()
-	if(below_us.get_lumcount() < LIGHTING_TILE_IS_DARK || seer?.lighting_cutoff >= 2.5 || get_dist(seer, src) <= 1)
+	if(below_us.get_lumcount() > LIGHTING_TILE_IS_DARK || seer?.lighting_cutoff >= 2.5 || get_dist(seer, src) <= 1)
 		graceful_delete()
 
 /obj/effect/abstract/floating_eyes/proc/graceful_delete()


### PR DESCRIPTION
## About The Pull Request

Fixes #92639

The eyes-in-dark hallucination worked, but dispelled instantly due to checking "is light" instead of "is dark"

Hallucination tier logic was inverted so it only re-calculated max tiers for hallucination effects which didn't want them recalculated

## Changelog

:cl: Melbert
fix: Wackier hallucinations should rear their head again
fix: Ghost eyes hallucination works properly
/:cl:

