### PR TITLE
Ammo-related pellet clouds (buckshot, rubbershot, etc.) respect speed and stamina multipliers

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -108,6 +108,8 @@
 
 	// things like mouth executions and gunpoints can multiply the damage and wounds of projectiles, so this makes sure those effects are applied to each pellet instead of just one
 	var/original_damage = shell.loaded_projectile.damage
+	var/original_stamina = shell.loaded_projectile.stamina
+	var/original_speed = shell.loaded_projectile.speed
 	var/original_wounds_bonus = shell.loaded_projectile.wound_bonus
 	var/original_bare_wounds_bonus = shell.loaded_projectile.exposed_wound_bonus
 	var/original_ignored_faction = shell.loaded_projectile.ignored_factions
@@ -123,6 +125,8 @@
 		RegisterSignal(shell.loaded_projectile, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(pellet_hit))
 		RegisterSignals(shell.loaded_projectile, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_QDELETING), PROC_REF(pellet_range))
 		shell.loaded_projectile.damage = original_damage
+		shell.loaded_projectile.stamina = original_stamina
+		shell.loaded_projectile.speed = original_speed
 		shell.loaded_projectile.wound_bonus = original_wounds_bonus
 		shell.loaded_projectile.exposed_wound_bonus = original_bare_wounds_bonus
 		shell.loaded_projectile.ignored_factions = original_ignored_faction


### PR DESCRIPTION
## About The Pull Request
Title. Adds missing stamina and projectile speed variable copies to copied pellets.

## Why It's Good For The Game
Consistency.

## Changelog

:cl:
fix: Stamina and projectile speed multipliers on pellet-cloud projectiles (e.g. buckshot, rubber shot, flechettes) now respect appropriate multipliers when fired from appropriate guns.
/:cl: