### PR TITLE
Fixes tutorial UI not working at all

### DIFF
--- a/code/modules/tutorials/tutorial_instruction.dm
+++ b/code/modules/tutorials/tutorial_instruction.dm
@@ -32,6 +32,7 @@
 	maptext_y = -2
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = TUTORIAL_INSTRUCTIONS_LAYER
+	appearance_flags = parent_type::appearance_flags | KEEP_APART
 
 /atom/movable/screen/tutorial_instruction_text/Initialize(mapload, datum/hud/hud_owner, message, client/client)
 	. = ..()

--- a/code/modules/tutorials/tutorial_skip.dm
+++ b/code/modules/tutorials/tutorial_skip.dm
@@ -24,6 +24,7 @@
 /atom/movable/screen/tutorial_skip_text
 	alpha = 0
 	layer = TUTORIAL_INSTRUCTIONS_LAYER
+	appearance_flags = parent_type::appearance_flags | KEEP_APART
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	maptext_height = 32
 	maptext_width = 200


### PR DESCRIPTION
## About The Pull Request

The tutorial UIs setting their color forces them to have KEEP_TOGETHER which breaks tutorial rendering, this fixes that
fixes #89866

## Changelog

:cl:
fix: New player tutorials will no longer look extremely broken
/:cl:
