### PR TITLE
Allows wizard grand ritual to choose cargo warehouse as rune location

### DIFF
--- a/code/modules/antagonists/wizard/grand_ritual/grand_ritual.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_ritual.dm
@@ -73,7 +73,6 @@
 	))
 	/// Areas where you can't be tasked to draw a rune, usually because they're too mean
 	var/static/list/area_blacklist = typecacheof(list(
-		/area/station/cargo/warehouse, // This SHOULD be fine except SOMEBODY gave this area to a kilo structure which is IN SPACE
 		/area/station/engineering/supermatter,
 		/area/station/engineering/transit_tube,
 		/area/station/science/ordnance/bomb,


### PR DESCRIPTION

## About The Pull Request

Removes cargo/warehouse area from the wizard Grand Ritual blacklist

## Why It's Good For The Game

The written reason was that Kilostation has an area mapped as cargo/warehouse in space offstation, and Kilostation is long gone. No reason for it to be on the blacklist anymore. The comment even says "this should be fine".

## Changelog
:cl:

fix: Cargo's warehouse is now magically charged enough to cast the Grand Ritual

/:cl:
