### PR TITLE
Makes fishing gloves MODule lower difficulty rather than increasing

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -997,7 +997,7 @@
 	var/obj/item/gloves = mod.get_part_from_slot(ITEM_SLOT_GLOVES)
 	if(!gloves)
 		return
-	gloves.AddComponent(/datum/component/adjust_fishing_difficulty, 5)
+	gloves.AddComponent(/datum/component/adjust_fishing_difficulty, -5)
 	if(equipped)
 		gloves.AddComponent(/datum/component/profound_fisher, equipped, delete_rod_when_deleted = FALSE)
 


### PR DESCRIPTION

## About The Pull Request

It was increasing the difficulty of fishing, when it shouldn't've.

## Why It's Good For The Game

closes #92674

## Changelog
:cl:

fix: Fishing gloves MODule now actually lowers the difficulty of fishing like it says

/:cl:
