### PR TITLE
Fix for the labeler's management of maintainer added labels

### DIFF
--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -194,9 +194,7 @@ export async function get_updated_label_set({ github, context }) {
 
   // Always check body/title (otherwise we can lose the changelog labels)
   if (title)
-    check_title_for_labels(title).forEach((label) =>
-      updated_labels.add(label)
-    );
+    check_title_for_labels(title).forEach((label) => updated_labels.add(label));
   if (body)
     check_body_for_labels(body).forEach((label) => updated_labels.add(label));
 
@@ -213,13 +211,9 @@ export async function get_updated_label_set({ github, context }) {
       }
     );
 
-    // The REST api returns timeline events in reverse chronological order
-    // So let's reverse them to have it go from oldest -> newest.
-    // That way, if a maintainer removes and then re-adds the same label it
-    // remains true to their final intent.
-    for (const eventData of events.reverse()) {
+    for (const eventData of events) {
       // Skip all bot actions
-      if (eventData.actor?.login === "github-actions") {
+      if (eventData.actor?.login === "github-actions[bot]") {
         continue;
       }
       if (eventData.event === "labeled") {
@@ -228,9 +222,9 @@ export async function get_updated_label_set({ github, context }) {
         updated_labels.delete(eventData.label.name);
       }
     }
-} catch (error) {
-  console.error("Error fetching paginated events:", error);
-}
+  } catch (error) {
+    console.error("Error fetching paginated events:", error);
+  }
 
   // Always remove Test Merge Candidate
   updated_labels.delete("Test Merge Candidate");


### PR DESCRIPTION
## About The Pull Request

This will (hopefully) be the very last labeler related PR I make for a while.

Turns out the code I wrote for the event list had some minor flaws. Namely, "github-actions" is actually "github-actions[bot]"

<img width="573" height="125" alt="image" src="https://github.com/user-attachments/assets/4184a871-aaf8-4975-b83a-5bbf75f46b8f" />

Additionally the need to reverse() the events list is removed when you paginate, seemingly. So stops doing that; they're already in chronological order with the pagination so reversing on top of that actually makes them go back in reverse chronological order.

That is on me for not testing that, I had assumed it was good. Tested and seems to be obeying the rules now.

## Why It's Good For The Game

Fix

## Changelog

Not player-facing