### PR TITLE
Makes slime reproduction not delete the original slime

### DIFF
--- a/code/modules/mob/living/basic/slime/actions.dm
+++ b/code/modules/mob/living/basic/slime/actions.dm
@@ -106,11 +106,11 @@
 		balloon_alert(src, "overcrowded!")
 		return
 
-	var/list/babies = list()
-	var/new_nutrition = round(nutrition * 0.9)
-	var/new_powerlevel = round(powerlevel / 4)
+	var/new_nutrition = floor(nutrition * 0.9)
+	var/new_powerlevel = floor(powerlevel * 0.25)
 	var/turf/drop_loc = drop_location()
 
+	var/list/created_slimes = list(src)
 	var/list/slime_friends = list()
 	for(var/faction_member in faction)
 		var/mob/living/possible_friend = locate(faction_member) in GLOB.mob_living_list
@@ -118,42 +118,34 @@
 			continue
 		slime_friends += possible_friend
 
-	for(var/i in 1 to 4)
-		var/child_colour
-
-		if(mutation_chance >= 100)
-			child_colour = /datum/slime_type/rainbow
-		else if(prob(mutation_chance))
-			child_colour = pick_weight(slime_type.mutations)
-		else
-			child_colour = slime_type.type
-
-		var/mob/living/basic/slime/baby
-		baby = new(drop_loc, child_colour)
-
-		if(ckey)
-			baby.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
-
-		baby.powerlevel = new_powerlevel
-		if(i != 1)
-			step_away(baby, src)
-
+	for(var/i in 1 to 3)
+		var/mob/living/basic/slime/baby = new(drop_loc, get_random_mutation())
+		created_slimes += baby
 		for(var/slime_friend in slime_friends)
 			baby.befriend(slime_friend)
 
-		babies += baby
-		if(mutation_chance == 0)
-			baby.mutation_chance = 0
-		else
-			baby.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
 		SSblackbox.record_feedback("tally", "slime_babies_born", 1, baby.slime_type.colour)
+		step_away(baby, src)
 
-	var/mob/living/basic/slime/new_slime = pick(babies) // slime that the OG slime will move into.
-	new_slime.set_combat_mode(TRUE)
+	set_nutrition(SLIME_STARTING_NUTRITION)
+	for(var/mob/living/basic/slime/baby as anything in created_slimes)
+		if(ckey) // Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
+			baby.set_nutrition(new_nutrition)
+		baby.powerlevel = new_powerlevel
+		if(mutation_chance)
+			baby.mutation_chance = clamp(mutation_chance + rand(-5, 5), 0, 100)
+		else
+			baby.mutation_chance = 0
 
-	if(isnull(mind))
-		new_slime.PossessByPlayer(key)
+	set_life_stage(SLIME_LIFE_STAGE_BABY)
+	set_slime_type(get_random_mutation())
+	amount_grown = 0
+	mutator_used = FALSE
+
+/mob/living/basic/slime/proc/get_random_mutation()
+	if(mutation_chance >= 100)
+		return /datum/slime_type/rainbow
+	else if(prob(mutation_chance))
+		return pick_weight(slime_type.mutations)
 	else
-		mind.transfer_to(new_slime)
-
-	qdel(src)
+		return slime_type.type

--- a/code/modules/mob/living/basic/slime/life.dm
+++ b/code/modules/mob/living/basic/slime/life.dm
@@ -7,7 +7,7 @@
 	if(!HAS_TRAIT(src, TRAIT_STASIS)) //No hunger in stasis
 		handle_nutrition(seconds_per_tick)
 
-	handle_slime_stasis(seconds_per_tick)
+	handle_slime_stasis()
 
 /mob/living/basic/slime/handle_environment(datum/gas_mixture/environment, seconds_per_tick, times_fired)
 	..()
@@ -17,7 +17,7 @@
 		remove_status_effect(/datum/status_effect/freon, SLIME_COLD)
 
 ///Handles if a slime's environment would cause it to enter stasis. Ignores TRAIT_STASIS
-/mob/living/basic/slime/proc/handle_slime_stasis(seconds_per_tick)
+/mob/living/basic/slime/proc/handle_slime_stasis()
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/bz_percentage = 0

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -21,8 +21,8 @@
 	maxHealth = 150
 	health = 150
 	mob_biotypes = MOB_SLIME
-	melee_damage_lower = 5
-	melee_damage_upper = 25
+	melee_damage_lower = 7
+	melee_damage_upper = 17
 	wound_bonus = -45
 	can_buckle_to = FALSE
 
@@ -125,8 +125,8 @@
 		for(var/datum/slime_type/slime_type as anything in subtypesof(/datum/slime_type))
 			possible_slime_types[slime_type] = new slime_type
 
+	set_life_stage(new_life_stage, TRUE)
 	set_slime_type(new_type)
-	set_life_stage(new_life_stage)
 	set_nutrition(SLIME_STARTING_NUTRITION)
 
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = 2)
@@ -250,29 +250,23 @@
 		. += span_warning("It seems too overcroweded to properly reproduce!")
 
 ///Changes the slime's current life state
-/mob/living/basic/slime/proc/set_life_stage(new_life_stage = SLIME_LIFE_STAGE_BABY)
+/mob/living/basic/slime/proc/set_life_stage(new_life_stage = SLIME_LIFE_STAGE_BABY, initial = FALSE)
 	life_stage = new_life_stage
+	if(life_stage == SLIME_LIFE_STAGE_ADULT)
+		health /= 0.75
+		maxHealth /= 0.75
+		melee_damage_lower *= 2
+		melee_damage_upper *= 2
+		obj_damage = 15
+		wound_bonus = -90
 
-	switch(life_stage)
-		if(SLIME_LIFE_STAGE_BABY)
-
-			health = initial(health)
-			maxHealth = initial(maxHealth)
-
-			obj_damage = initial(obj_damage)
-			melee_damage_lower = initial(melee_damage_lower)
-			melee_damage_upper = initial(melee_damage_upper)
-			wound_bonus = initial(wound_bonus)
-
-		if(SLIME_LIFE_STAGE_ADULT)
-
-			health = 200
-			maxHealth = 200
-
-			obj_damage = 15
-			melee_damage_lower += 10
-			melee_damage_upper += 10
-			wound_bonus = -90
+	else if(!initial)
+		health *= 0.75
+		maxHealth *= 0.75
+		melee_damage_lower *= 0.5
+		melee_damage_upper *= 0.5
+		obj_damage = initial(obj_damage)
+		wound_bonus = initial(wound_bonus)
 
 	ai_controller.set_blackboard_key(BB_SLIME_LIFE_STAGE, life_stage)
 	update_mob_action_buttons()

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -223,7 +223,7 @@
 	for(var/mob/living/basic/slime/stored_slime in stored_slimes)
 		stored_slime.forceMove(target_turf)
 		REMOVE_TRAIT(stored_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
-		stored_slime.handle_slime_stasis(0)
+		stored_slime.handle_slime_stasis()
 	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
 
 ///Places every slime not controlled by a player into the internal storage, respecting its limits


### PR DESCRIPTION
## About The Pull Request

- Makes slime reproduction not delete the original slime, instead now 3 more slimes are produced and the original slime is set to the *original amounts of nutrition, power and growth
- Slimes no longer lose their damage/health bonuses from the fugu gland when becoming children AND its no longer better to fugu gland an adult slime than a baby one, its the same.
- Fixes an oversight in my previous PR that made adult-spawned slimes still have a baby name
- Handle_slime_stasis() no longer accepts delta_time as a variable

## Why It's Good For The Game

> Makes slime reproduction not delete the original slime, instead now 3 more slimes are produced and the original slime is set to the *original amounts of nutrition, power and growth
- This makes slimes behave more like you'd expect, names/status effects (like fugu gland, radio potion or love potion), admin-made objectives to kill them are kept. Your slime losing the fugu gland and its bluespace radio because it decided to reproduce is strange.
> Slimes no longer lose their damage/health bonuses from the fugu gland when becoming children.
- The fact that giving a fugu gland to an adult slime would result in higher damage than giving it to a child and then growing it up is a bit jank.
- Also if that adult fugu'd slime became a child again (via death) it would lose its health bonus and melee bonus whilst keeping its big sprite, giving it a massive disadvantage, safe to say not very intended. (This did have a ripple effect of child slimes having a bit lower DPS, but overall not much changed, values before and after below)

<details>
<summary>melee_lower and upper damage changes</summary>

melee_lower / melee_upper
\> Before
child: 5/25
adult: 15/35

child + fugu: 10/50
child + fugu > adult: 20/60
adult + fugu: 30/70
\> After

child: 7/17
adult: 14/34

child + fugu: 14/34
adult + fugu: 28/68

</details>

> Fixes an oversight in my previous PR that made adult-spawned slimes still have a baby name
- I forgor
> Handle_slime_stasis() no longer accepts delta_time as a variable
- Never uses it, no reason to keep it

## Changelog

:cl:
balance: baby slimes have slightly weaker melee damage
fix: fugu gland's melee and HP buffs no longer wear off on slimes if they become babies after dying as an adult
/:cl:
