### PR TITLE
[NO GBP] Fix to burned mess

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -72,6 +72,9 @@
 ///Sent to the newly spawned object when it's baked in an oven.
 #define COMSIG_ITEM_BAKED_RESULT "item_baked_result"
 
+///Called on the result spawned during decomposition: (obj/decomposed)
+#define COMSIG_OBJ_DECOMPOSITION_RESULT "obj_decomposition_result"
+
 //Drink
 
 ///from base of obj/item/reagent_containers/cup/attack(): (mob/M, mob/user)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -86,15 +86,16 @@
 	var/atom/original_object = parent
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
 	var/atom/baked_result = new bake_result(used_tray)
-	if(baked_result.reagents && positive_result) //make space and tranfer reagents if it has any & the resulting item isn't bad food or other bad baking result
+	if(positive_result && istype(original_object, /obj/item/food) && istype(baked_result, /obj/item/food))
+		var/obj/item/food/original_food = original_object
+		var/obj/item/food/baked_food = baked_result
+		LAZYADD(baked_food.intrinsic_food_materials, original_food.intrinsic_food_materials)
+	//make space and tranfer reagents if it has any, also let any bad result handle removing or converting the transferred reagents on its own terms
+	if(baked_result.reagents)
 		baked_result.reagents.clear_reagents()
 		original_object.reagents.trans_to(baked_result, original_object.reagents.total_volume)
 		if(added_reagents) // Add any new reagents that should be added
 			baked_result.reagents.add_reagent_list(added_reagents)
-		if(istype(original_object, /obj/item/food) && istype(baked_result, /obj/item/food))
-			var/obj/item/food/original_food = original_object
-			var/obj/item/food/baked_food = baked_result
-			LAZYADD(baked_food.intrinsic_food_materials, original_food.intrinsic_food_materials)
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -91,7 +91,7 @@
 		var/obj/item/food/baked_food = baked_result
 		LAZYADD(baked_food.intrinsic_food_materials, original_food.intrinsic_food_materials)
 	//make space and tranfer reagents if it has any, also let any bad result handle removing or converting the transferred reagents on its own terms
-	if(baked_result.reagents)
+	if(baked_result.reagents && original_object.reagents)
 		baked_result.reagents.clear_reagents()
 		original_object.reagents.trans_to(baked_result, original_object.reagents.total_volume)
 		if(added_reagents) // Add any new reagents that should be added

--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -117,7 +117,12 @@
 	if(produce_ants)
 		new /obj/effect/decal/cleanable/ants(decomp.loc)
 	if(decomp_result)
-		new decomp_result(decomp.loc)
+		var/atom/movable/result = new decomp_result(decomp.loc)
+		//make space and tranfer reagents if it has any, also let any bad result handle removing or converting the transferred reagents on its own terms
+		if(result.reagents && decomp.reagents)
+			result.reagents.clear_reagents()
+			decomp.reagents.trans_to(result, decomp.reagents.total_volume)
+		SEND_SIGNAL(result, COMSIG_OBJ_DECOMPOSITION_RESULT, decomp)
 	decomp.visible_message(span_warning("[decomp] gets overtaken by mold[produce_ants ? " and ants":""]! Gross!"))
 	qdel(decomp)
 	return

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -159,9 +159,10 @@
 	if(IsEdible(grilled_result) && positive_result)
 		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
 		grilled_result.reagents.clear_reagents()
-		original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
-		if(added_reagents) // Add any new reagents that should be added
-			grilled_result.reagents.add_reagent_list(added_reagents)
+	//Let any bad result handle removing or converting the transferred reagents on its own terms
+	original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
+	if(added_reagents) // Add any new reagents that should be added
+		grilled_result.reagents.add_reagent_list(added_reagents)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	SEND_SIGNAL(grilled_result, COMSIG_ITEM_GRILLED_RESULT, parent)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -147,7 +147,6 @@
 	if(isstack(parent)) //Check if its a sheet, for grilling multiple things in a stack
 		var/obj/item/stack/stack_parent = original_object
 		grilled_result = new cook_result(original_object.loc, stack_parent.amount)
-
 	else
 		grilled_result = new cook_result(original_object.loc)
 		if(istype(original_object, /obj/item/food) && istype(grilled_result, /obj/item/food))
@@ -158,11 +157,12 @@
 
 	if(IsEdible(grilled_result) && positive_result)
 		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
-		grilled_result.reagents.clear_reagents()
-	//Let any bad result handle removing or converting the transferred reagents on its own terms
-	original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
-	if(added_reagents) // Add any new reagents that should be added
-		grilled_result.reagents.add_reagent_list(added_reagents)
+	//make space and tranfer reagents if it has any, also let any bad result handle removing or converting the transferred reagents on its own terms
+	if(grilled_result.reagents && original_object.reagents)
+		grilled_result.reagents?.clear_reagents()
+		original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
+		if(added_reagents) // Add any new reagents that should be added
+			grilled_result.reagents.add_reagent_list(added_reagents)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	SEND_SIGNAL(grilled_result, COMSIG_ITEM_GRILLED_RESULT, parent)

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -6,6 +6,8 @@
 	var/atom/result_typepath
 	/// Reagents that should be added to the result
 	var/list/added_reagents
+	/// Whether this is a bad recipe or not. It affects some checks.
+	var/bad_recipe
 
 /datum/element/microwavable/Attach(obj/item/target, microwave_type, list/reagents, bad_recipe = FALSE)
 	. = ..()
@@ -15,15 +17,15 @@
 		CRASH("microwavable element attached without a microwave_type arg")
 
 	result_typepath = microwave_type
-
 	added_reagents = reagents
+	src.bad_recipe = bad_recipe
 
 	RegisterSignal(target, COMSIG_ITEM_MICROWAVE_ACT, PROC_REF(on_microwaved))
 
 	if(!bad_recipe)
 		RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
-	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || skip_matcheck || !target.custom_materials || isstack(target))
+	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || bad_recipe || !target.custom_materials || isstack(target))
 		return
 
 	var/atom/result = new result_typepath
@@ -57,10 +59,6 @@
 
 	if(IS_EDIBLE(result) && !bad_recipe)
 		BLACKBOX_LOG_FOOD_MADE(result.type)
-		result.reagents.clear_reagents()
-		source.reagents?.trans_to(result, source.reagents.total_volume)
-		if(added_reagents) // Add any new reagents that should be added
-			result.reagents.add_reagent_list(added_reagents)
 
 		if(istype(source, /obj/item/food) && istype(result, /obj/item/food))
 			var/obj/item/food/original_food = source
@@ -70,6 +68,12 @@
 		if(microwaver && microwaver.mind)
 			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))
 
+	//make space and tranfer reagents if it has any, also let any bad result handle removing or converting the transferred reagents on its own terms
+	if(result.reagents && source.reagents)
+		result.reagents.clear_reagents()
+		source.reagents.trans_to(result, source.reagents.total_volume)
+		if(added_reagents) // Add any new reagents that should be added
+			result.reagents.add_reagent_list(added_reagents)
 
 	SEND_SIGNAL(result, COMSIG_ITEM_MICROWAVE_COOKED, source, efficiency)
 	SEND_SIGNAL(source, COMSIG_ITEM_MICROWAVE_COOKED_FROM, result, efficiency)

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -152,7 +152,7 @@
 /// This proc handles the microwave component. Overwrite if you want special microwave results.
 /// By default, all food is microwavable. However, they will be microwaved into a bad recipe (burnt mess).
 /obj/item/food/proc/make_microwaveable()
-	AddElement(/datum/element/microwavable, /obj/item/food/badrecipe, skip_matcheck = TRUE)
+	AddElement(/datum/element/microwavable, /obj/item/food/badrecipe, bad_recipe = TRUE)
 
 ///This proc handles trash components, overwrite this if you want the object to spawn trash
 /obj/item/food/proc/make_leave_trash()

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -29,7 +29,7 @@
 	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), positive_result, TRUE, list(/datum/reagent/medicine/omnizine = omnizine_to_add))
 
 /obj/item/food/donkpocket/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, string_assoc_list(list(/datum/reagent/medicine/omnizine = omnizine_to_add)), !positive_result)
+	AddElement(/datum/element/microwavable, warm_type, string_assoc_list(list(/datum/reagent/medicine/omnizine = omnizine_to_add)), bad_recipe = !positive_result)
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -194,7 +194,7 @@
 /obj/item/food/badrecipe/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_GRILL_PROCESS, PROC_REF(OnGrill))
-	RegisterSignals(src, list(COMSIG_ITEM_GRILLED_RESULT, COMSIG_ITEM_BAKED_RESULT, COMSIG_ITEM_MICROWAVE_COOKED), PROC_REF(convert_to_bad_food))
+	RegisterSignals(src, list(COMSIG_ITEM_GRILLED_RESULT, COMSIG_ITEM_BAKED_RESULT, COMSIG_ITEM_MICROWAVE_COOKED, COMSIG_OBJ_DECOMPOSITION_RESULT), PROC_REF(convert_to_bad_food))
 	if(stink_particles)
 		add_shared_particles(stink_particles)
 

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -194,7 +194,7 @@
 /obj/item/food/badrecipe/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_GRILL_PROCESS, PROC_REF(OnGrill))
-	RegisterSignals(src, list(COMSIG_ITEM_GRILLED_RESULT, COMSIG_ITEM_BAKED_RESULT, COMSIG_ITEM_MICROWAVE_COOKED_FROM), PROC_REF(convert_to_bad_food))
+	RegisterSignals(src, list(COMSIG_ITEM_GRILLED_RESULT, COMSIG_ITEM_BAKED_RESULT, COMSIG_ITEM_MICROWAVE_COOKED), PROC_REF(convert_to_bad_food))
 	if(stink_particles)
 		add_shared_particles(stink_particles)
 


### PR DESCRIPTION
## About The Pull Request
#92394 did more harm than good.

First, only the microwavable element transferred reagents even if the result was a burned mess (in general, a non-positive one), while grillable and bakeable comps didn't... but that's because I've overlooked a few checks that skipped the "transfer reagents to the result" step, which the microwavable element also has, though it stopped working as intended after I messed with it.
However, I think it's stupid for bad recipes to have a static amount of "bad food" reagent in them, and overcooking a whole cake shouldn't yield the same reagents as a bag of chips burned to a crisp, so I scrapped those damn bad_result checks, and finally let the burned mess item itself handle converting the consumable reagents into "bad food".

Second, examining most food items no longer tells you that you can make a burned mess if you microwave it.

## Why It's Good For The Game
This fixes the above issues.

## Changelog

:cl:
fix: Examining most food items no longer tells you that you can make burned mess by microwaving them.
fix: Burned mess now has "bad food" in it more or less proportional to the nutrients of the item you just overcooked. This also applies to decomposition now.
/:cl:
