### PR TITLE
Solo fugitives spawn with a toolbox, like group fugitives do

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -835,8 +835,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/assign_role(datum/mind/candidate, datum/team/fugitive/team, turf/team_spawn)
 	candidate.current.forceMove(team_spawn)
 	equip_fugitive(candidate.current, team)
-	if(length(selected_minds) > 1 && candidate == selected_minds[1])
-		equip_fugitive_leader(candidate.current)
+	equip_fugitive_leader(candidate.current)
 	playsound(candidate.current, 'sound/items/weapons/emitter.ogg', 50, TRUE)
 
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/proc/equip_fugitive(mob/living/carbon/human/fugitive, datum/team/fugitive/team)
@@ -861,8 +860,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/proc/equip_fugitive_leader(mob/living/carbon/human/fugitive)
 	var/turf/leader_turf = get_turf(fugitive)
-	var/obj/item/storage/toolbox/mechanical/toolbox = new(leader_turf)
-	fugitive.put_in_hands(toolbox)
+	fugitive.put_in_hands(new /obj/item/storage/toolbox/mechanical())
 
 	switch(fugitive_backstory)
 		if(FUGITIVE_BACKSTORY_SYNTH)

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -835,7 +835,8 @@
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/assign_role(datum/mind/candidate, datum/team/fugitive/team, turf/team_spawn)
 	candidate.current.forceMove(team_spawn)
 	equip_fugitive(candidate.current, team)
-	equip_fugitive_leader(candidate.current)
+	if(candidate == selected_minds[1])
+		equip_fugitive_leader(candidate.current)
 	playsound(candidate.current, 'sound/items/weapons/emitter.ogg', 50, TRUE)
 
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/proc/equip_fugitive(mob/living/carbon/human/fugitive, datum/team/fugitive/team)

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -860,7 +860,8 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/proc/equip_fugitive_leader(mob/living/carbon/human/fugitive)
 	var/turf/leader_turf = get_turf(fugitive)
-	fugitive.put_in_hands(new /obj/item/storage/toolbox/mechanical())
+	var/obj/item/storage/toolbox/mechanical/toolbox = new(leader_turf)
+	fugitive.put_in_hands(toolbox)
 
 	switch(fugitive_backstory)
 		if(FUGITIVE_BACKSTORY_SYNTH)


### PR DESCRIPTION

## About The Pull Request

Solo fugitives weren't getting their toolbox because `equip_fugitive_leader()` doesn't get called. While this makes sense, seeing as there isn't a "leader" to equip, there isn't actually a reason not to call this for single fugitives.

So, `equip_fugitive_leader()` now runs for all fugitive quantities. If someone wants to add more essential equipment for newly spawned fugitives, it should go there alongside the toolbox.
## Why It's Good For The Game

Partially handles #92618.
## Changelog
:cl: Rhials
fix: Solo fugitives now spawn with a mechanical toolbox, as intended.
/:cl:
