### PR TITLE
Guards against runtiming in the middle of the client Destroy() proc

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -596,7 +596,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	GLOB.clients -= src
 	GLOB.directory -= ckey
-	persistent_client.set_client(null)
+	if(persistent_client)
+		persistent_client.set_client(null)
 
 	log_access("Logout: [key_name(src)]")
 	GLOB.ahelp_tickets.ClientLogout(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -598,6 +598,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	GLOB.directory -= ckey
 	if(persistent_client)
 		persistent_client.set_client(null)
+	else
+		stack_trace("A client was Del()'d without a persistent_client! This should not be happening.)"
 
 	log_access("Logout: [key_name(src)]")
 	GLOB.ahelp_tickets.ClientLogout(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -599,7 +599,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(persistent_client)
 		persistent_client.set_client(null)
 	else
-		stack_trace("A client was Del()'d without a persistent_client! This should not be happening.)"
+		stack_trace("A client was Del()'d without a persistent_client! This should not be happening.")
 
 	log_access("Logout: [key_name(src)]")
 	GLOB.ahelp_tickets.ClientLogout(src)


### PR DESCRIPTION
## About The Pull Request

Tin.

Runtiming in this spot is really not good and may have potentially caused a crash for one of our rounds.

Not sure how it happened exactly, but it costs nothing to be safe here.

<img width="696" height="38" alt="image" src="https://github.com/user-attachments/assets/c56c5c18-8ae0-428f-a407-b2e3de79d87a" />

## Why It's Good For The Game

Let clients finish their destruction

## Changelog

Not player-facing