### PR TITLE
Fixes an oversight with suit accessory overlays

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -33,7 +33,7 @@
 		return
 
 	var/obj/item/clothing/accessory/displayed = undershirt.attached_accessories[1]
-	if(displayed.above_suit)
+	if(displayed.above_suit && undershirt.accessory_overlay)
 		. += undershirt.accessory_overlay
 
 /obj/item/clothing/suit/separate_worn_overlays(mutable_appearance/standing, mutable_appearance/draw_target, isinhands = FALSE, icon_file)

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -289,14 +289,15 @@
 
 	LAZYADD(attached_accessories, accessory)
 	accessory.forceMove(src)
+
+	if(isnull(accessory_overlay))
+		create_accessory_overlay()
+
 	// Allow for accessories to react to the acccessory list now
 	accessory.successful_attach(src)
 
 	if(user && attach_message)
 		balloon_alert(user, "accessory attached")
-
-	if(isnull(accessory_overlay))
-		create_accessory_overlay()
 
 	update_appearance()
 	return TRUE
@@ -320,10 +321,11 @@
 
 	// Remove it from the list before detaching
 	LAZYREMOVE(attached_accessories, removed)
-	removed.detach(src)
 
 	if(isnull(accessory_overlay) && LAZYLEN(attached_accessories))
 		create_accessory_overlay()
+
+	removed.detach(src)
 
 	update_appearance()
 


### PR DESCRIPTION
## About The Pull Request

Just because an accessory has `above_suit` set to `TRUE` does not mean the suit has an `accessory_overlay`.

You wouldn't wanna add a null to the overlays list to return here so make sure we actually have one first.

(It turns out, it is actually silently doing this every time you first attach or remove an accessory-when an accessory is added, it calls `successful_attach()` which ends up calling `update_clothing()` which calls `worn_overlays()`--all _before_ creating the `accessory_overlay` -- which results in a `null` in the returned list of `worn_overlays()`)

Shifts the ordering around so that this race condition no longer occurs.

<details> 

<summary> yep, still works exactly like before </summary>

![dreamseeker_GFSoX2rPW8](https://github.com/user-attachments/assets/f48b423f-f9b9-4d20-893b-2d139b3e100f)

</details>

<details>

<summary> stack trace so you can see the problematic order of operations </summary>

<img width="1332" height="152" alt="image" src="https://github.com/user-attachments/assets/ce4eadbd-53e4-42f3-9665-60cb001c9ac2" />

</details>

## Why It's Good For The Game

Bugfix

## Changelog

Not player facing