### PR TITLE
Refactors some of the card code to use new attack chain, adds a limit to card decks

### DIFF
--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -78,31 +78,33 @@
 /obj/item/toy/cards/cardhand/proc/check_menu(mob/living/user)
 	return isliving(user) && !user.incapacitated
 
-/obj/item/toy/cards/cardhand/attackby(obj/item/weapon, mob/living/user, list/params, list/attack_modifier, flip_card = FALSE)
+/obj/item/toy/cards/cardhand/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	var/obj/item/toy/singlecard/card
+	if(istype(tool, /obj/item/toy/singlecard))
+		card = tool
 
-	if(istype(weapon, /obj/item/toy/singlecard))
-		card = weapon
-
-	if(istype(weapon, /obj/item/toy/cards/deck))
-		var/obj/item/toy/cards/deck/dealer_deck = weapon
+	if(istype(tool, /obj/item/toy/cards/deck))
+		var/obj/item/toy/cards/deck/dealer_deck = tool
 		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED)) // recycle cardhand into deck (if unwielded)
-			dealer_deck.insert(src)
-			user.balloon_alert_to_viewers("puts card in deck")
-			return
+			if(dealer_deck.insert(src))
+				user.balloon_alert_to_viewers("puts card in deck")
+				return ITEM_INTERACT_SUCCESS
+
+			to_chat(user, span_warning("\The [dealer_deck] is stacked too high!"))
+			return ITEM_INTERACT_BLOCKING
+
 		card = dealer_deck.draw(user)
 
-	if(card)
-		if(flip_card)
+	if(!card)
+		return NONE
+
+	if(insert(card))
+		if(LAZYACCESS(modifiers, RIGHT_CLICK))
 			card.Flip()
-		insert(card)
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	return ..()
-
-/obj/item/toy/cards/cardhand/attackby_secondary(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
-	attackby(weapon, user, modifiers, flip_card = TRUE)
-	return SECONDARY_ATTACK_CONTINUE_CHAIN
+	to_chat(user, span_warning("You can't hold any more cards in your hand!"))
+	return ITEM_INTERACT_BLOCKING
 
 #define CARDS_MAX_DISPLAY_LIMIT 5 // the amount of cards that are displayed in a hand
 #define CARDS_PIXEL_X_OFFSET -5 // start out displaying the 1st card -5 pixels left

--- a/code/modules/cards/cards.dm
+++ b/code/modules/cards/cards.dm
@@ -6,6 +6,8 @@
 	max_integrity = 50
 	/// Do all the cards drop to the floor when thrown at a person
 	var/can_play_52_card_pickup = TRUE
+	/// How many cards can we hold at the same time
+	var/card_limit = 21
 
 	/// List of card atoms for a hand or deck
 	var/list/obj/item/toy/singlecard/card_atoms
@@ -64,29 +66,29 @@
  * All cards that are inserted have their angle and pixel offsets reset to zero however their
  * flip state does not change unless it's being inserted into a deck which is always facedown
  * (see the deck/insert proc)
+ * Returns the list of inserted cards
  *
  * Arguments:
  * * card_item - Either a singlecard or cardhand that gets inserted into the src
  */
 /obj/item/toy/cards/proc/insert(obj/item/toy/card_item)
 	fetch_card_atoms()
+	// Can't add any cards, don't do anything
+	if (count_cards() >= card_limit)
+		return null
 
-	var/cards_to_add = list()
-	var/obj/item/toy/cards/cardhand/recycled_cardhand
+	var/list/cards_to_add = list()
 
 	if(istype(card_item, /obj/item/toy/singlecard))
 		cards_to_add += card_item
 
 	if(istype(card_item, /obj/item/toy/cards/cardhand))
-		recycled_cardhand = card_item
+		var/obj/item/toy/cards/cardhand/recycled_cardhand = card_item
+		cards_to_add += recycled_cardhand.fetch_card_atoms()
 
-		var/list/recycled_cards = recycled_cardhand.fetch_card_atoms()
-
-		for(var/obj/item/toy/singlecard/card in recycled_cards)
-			cards_to_add += card
-			recycled_cards -= card
-			card.moveToNullspace()
-		qdel(recycled_cardhand)
+	if(length(cards_to_add) + count_cards() > card_limit)
+		// Remove all cards past however many we can fit
+		cards_to_add.Cut(card_limit - count_cards() + 1, length(cards_to_add) + 1)
 
 	for(var/obj/item/toy/singlecard/card in cards_to_add)
 		card.forceMove(src)
@@ -98,8 +100,12 @@
 		card.transform = M
 		card.update_appearance()
 		card_atoms += card
-		cards_to_add -= card
+
+	if(istype(card_item, /obj/item/toy/cards/cardhand))
+		qdel(card_item)
+
 	update_appearance()
+	return cards_to_add
 
 /**
  * Draws a card from the deck or hand of cards.

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -147,25 +147,29 @@
 	name = flipped ? cardname : "card"
 	return ..()
 
-/obj/item/toy/singlecard/attackby(obj/item/item, mob/living/user, list/params, list/attack_modifier, flip_card=FALSE)
-	var/obj/item/toy/singlecard/card
+/obj/item/toy/singlecard/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	var/obj/item/toy/singlecard/card = null
 
-	if(istype(item, /obj/item/toy/cards/deck))
-		var/obj/item/toy/cards/deck/dealer_deck = item
+	if(istype(tool, /obj/item/toy/cards/deck))
+		var/obj/item/toy/cards/deck/dealer_deck = tool
 		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED)) // recycle card into deck (if unwielded)
-			dealer_deck.insert(src)
-			user.balloon_alert_to_viewers("puts card in deck")
-			return
+			if(dealer_deck.insert(src))
+				user.balloon_alert_to_viewers("puts card in deck")
+				return ITEM_INTERACT_SUCCESS
+
+			to_chat(user, span_warning("\The [dealer_deck] is stacked too high!"))
+			return ITEM_INTERACT_BLOCKING
+
 		card = dealer_deck.draw(user)
 
-	if(istype(item, /obj/item/toy/singlecard))
-		card = item
+	if(istype(tool, /obj/item/toy/singlecard))
+		card = tool
 
 	if(card) // card + card = combine into cardhand
-		if(flip_card)
+		if(LAZYACCESS(modifiers, RIGHT_CLICK))
 			card.Flip()
 
-		if(istype(item, /obj/item/toy/cards/deck))
+		if(istype(tool, /obj/item/toy/cards/deck))
 			// only decks cause a balloon alert
 			user.balloon_alert_to_viewers("deals a card")
 
@@ -179,63 +183,48 @@
 			user.temporarilyRemoveItemFromInventory(src, TRUE)
 			new_cardhand.pickup(user)
 			user.put_in_active_hand(new_cardhand)
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(istype(item, /obj/item/toy/cards/cardhand)) // insert into cardhand
-		var/obj/item/toy/cards/cardhand/target_cardhand = item
-		target_cardhand.insert(src)
-		return
+	if(istype(tool, /obj/item/toy/cards/cardhand)) // insert into cardhand
+		return tool.item_interaction(user, src, modifiers)
 
-	var/can_item_write
 	var/marked_cheating_color
 
-	if(istype(item, /obj/item/pen))
-		var/obj/item/pen/pen = item
-		can_item_write = TRUE
+	if(istype(tool, /obj/item/pen))
+		var/obj/item/pen/pen = tool
 		marked_cheating_color = (pen.colour == "white" && "invisible") || pen.colour
 
-	if(istype(item, /obj/item/toy/crayon))
-		var/obj/item/toy/crayon/crayon = item
-		can_item_write = TRUE
+	if(istype(tool, /obj/item/toy/crayon))
+		var/obj/item/toy/crayon/crayon = tool
 		marked_cheating_color = (crayon.crayon_color == "mime" && "invisible") || crayon.crayon_color
 
-	if(can_item_write && !blank) // You cheated not only the game, but yourself
+	if(marked_cheating_color && !blank && IS_WRITING_UTENSIL(tool)) // You cheated not only the game, but yourself
 		marked_color = marked_cheating_color
-		to_chat(user, span_notice("You put a [marked_color] mark in the corner of [src] with the [item]. Cheat to win!"))
-		return
+		to_chat(user, span_notice("You put a [marked_color] mark in the corner of [src] with the [tool]. Cheat to win!"))
+		return ITEM_INTERACT_SUCCESS
 
-	if(can_item_write)
-		if(!user.is_literate())
-			to_chat(user, span_notice("You scribble illegibly on [src]!"))
-			return
+	if(!user.can_write(tool))
+		return NONE
 
-		var/cardtext = stripped_input(user, "What do you wish to write on the card?", "Card Writing", "", 50)
-		if(!cardtext || !user.can_perform_action(src))
-			return
+	var/cardtext = stripped_input(user, "What do you wish to write on the card?", "Card Writing", "", 50)
+	if(!cardtext || !user.can_perform_action(src))
+		return ITEM_INTERACT_BLOCKING
 
-		cardname = cardtext
-		blank = FALSE
-		update_appearance()
-		return
-	return ..()
-
-/obj/item/toy/singlecard/attackby_secondary(obj/item/item, mob/living/user, list/modifiers, list/attack_modifiers)
-	attackby(item, user, modifiers, flip_card=TRUE)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	cardname = cardtext
+	blank = FALSE
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/toy/singlecard/attack_hand_secondary(mob/living/carbon/human/user, modifiers)
 	attack_self(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-/obj/item/toy/singlecard/attack_self_secondary(mob/living/carbon/human/user, modifiers)
-	attack_self(user)
 
 /obj/item/toy/singlecard/attack_self(mob/living/carbon/human/user)
 	if(!ishuman(user) || !user.can_perform_action(src, NEED_DEXTERITY|FORBID_TELEKINESIS_REACH))
 		return
 
 	Flip()
-	if(isturf(src.loc)) // only display tihs message when flipping in a visible spot like on a table
+	if(isturf(src.loc)) // only display this message when flipping in a visible spot like on a table
 		user.balloon_alert_to_viewers("flips a card")
 
 /obj/item/toy/singlecard/click_alt(mob/living/carbon/human/user)


### PR DESCRIPTION

## About The Pull Request

Updates card items to use ``item_interaction``, cleans up some of the code, adds a 54 card limit to normal decks (special decks retain their custom limits) and prevents adding cards past said limit. Card hands now have a limit of 21 cards.
- Closes #92551

## Changelog
:cl:
fix: You cannot stack infinite amount of cards in decks to explode clients of whoever they get thrown at.
refactor: Rewrote card items to use new interaction code.
/:cl:
