### PR TITLE
Prevents "Move To Top" verb from working on anchored objects

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -431,7 +431,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!isturf(loc) || usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
+	if(!isturf(loc) || usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED) || anchored)
 		return
 
 	if(isliving(usr))


### PR DESCRIPTION

## About The Pull Request

We use items as structures due to stupid code in a few places (intercoms, for once) and this verb can cause weird/broken behavior on them. Doesn't make sense from an IC perspective either.
Closes #92671

## Changelog
:cl:
fix: "Move To Top" verb no longer destroys wall-mounted intercoms
/:cl:
