### PR TITLE
Fixes chasm jaunters not working while you're buckled to a mob or an object

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -138,3 +138,8 @@
 #define COMSIG_MOVABLE_BUMP_PUSHED "movable_bump_pushed"
 	/// Stop it from moving
 	#define COMPONENT_NO_PUSH (1<<0)
+
+/// Called when the atom is dropped into a chasm: (turf/chasm)
+#define COMSIG_MOVABLE_CHASM_DROPPED "movable_charm_dropped"
+	/// Stop it from actually dropping into the chasm
+	#define COMPONENT_NO_CHASM_DROP (1<<0)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -114,22 +114,13 @@
 		if(HAS_TRAIT(thing_to_check, TRAIT_CHASM_STOPPER))
 			return CHASM_NOT_DROPPING
 
+	if(!ismob(dropped_thing))
+		return CHASM_DROPPING
+
 	//Flies right over the chasm
-	if(ismob(dropped_thing))
-		var/mob/M = dropped_thing
-		if(M.buckled) //middle statement to prevent infinite loops just in case!
-			var/mob/buckled_to = M.buckled
-			if((!ismob(M.buckled) || (buckled_to.buckled != M)) && !droppable(M.buckled))
-				return CHASM_REGISTER_SIGNALS
-		if(ishuman(dropped_thing))
-			var/mob/living/carbon/human/victim = dropped_thing
-			if(istype(victim.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/jaunter = victim.belt
-				var/turf/chasm = get_turf(victim)
-				var/fall_into_chasm = jaunter.chasm_react(victim)
-				if(!fall_into_chasm)
-					chasm.visible_message(span_boldwarning("[victim] falls into the [chasm]!")) //To freak out any bystanders
-				return fall_into_chasm ? CHASM_DROPPING : CHASM_NOT_DROPPING
+	var/mob/victim = dropped_thing
+	if(victim.buckled && droppable(victim.buckled) != CHASM_DROPPING)
+		return CHASM_REGISTER_SIGNALS
 	return CHASM_DROPPING
 
 #undef CHASM_NOT_DROPPING
@@ -142,12 +133,21 @@
 	if(!dropped_thing || !falling_ref?.resolve())
 		falling_atoms -= falling_ref
 		return
+
 	falling_atoms[falling_ref] = (falling_atoms[falling_ref] || 0) + 1
 	var/turf/below_turf = target_turf
 	var/atom/parent = src.parent
 
 	if(falling_atoms[falling_ref] > 1)
 		return // We're already handling this
+
+	if(SEND_SIGNAL(dropped_thing, COMSIG_MOVABLE_CHASM_DROPPED, parent) & COMPONENT_NO_CHASM_DROP)
+		return
+
+	// Free (if possible) and drop all buckled mobs separately, so drivers can escape their doomed vehicle if they're not glued to it
+	for(var/mob/living/buckled as anything in dropped_thing.buckled_mobs)
+		dropped_thing.unbuckle_mob(buckled)
+		drop_stuff(buckled)
 
 	if(below_turf)
 		if(HAS_TRAIT(dropped_thing, TRAIT_CHASM_DESTROYED))

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -50,7 +50,7 @@
 			to_chat(user, span_notice("\The [src] found no beacons in the world to anchor a wormhole to."))
 		else
 			visible_message(span_notice("\The [src] found no beacons in the world to anchor a wormhole to!"))
-		return TRUE // used for chasm code
+		return FALSE
 
 	var/list/destinations = get_destinations()
 	var/chosen_beacon = pick(destinations)
@@ -62,7 +62,7 @@
 		try_move_adjacent(tunnel)
 
 	qdel(src)
-	return FALSE // used for chasm code
+	return TRUE
 
 /obj/item/wormhole_jaunter/emp_act(power)
 	. = ..()
@@ -77,20 +77,43 @@
 
 	var/mob/M = loc
 	if(istype(M) && triggered)
-		M.visible_message(span_warning("Your [src.name] overloads and activates!"))
+		M.visible_message(span_userdanger("Your [src.name] overloads and activates!"))
 		SSblackbox.record_feedback("tally", "jaunter", 1, "EMP") // EMP accidental activation
 		activate(M, FALSE, TRUE)
 	else if(triggered)
 		visible_message(span_warning("\The [src] overloads and activates!"))
 		activate()
 
-/obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	var/fall_into_chasm = activate(user, FALSE, TRUE)
+/obj/item/wormhole_jaunter/equipped(mob/user, slot, initial)
+	. = ..()
+	if (slot & ITEM_SLOT_BELT)
+		RegisterSignal(user, COMSIG_MOVABLE_CHASM_DROPPED, PROC_REF(chasm_react))
 
-	if(!fall_into_chasm)
-		to_chat(user, span_notice("Your [src.name] activates, saving you from the chasm!"))
-		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-	return fall_into_chasm
+/obj/item/wormhole_jaunter/dropped(mob/user, silent)
+	. = ..()
+	UnregisterSignal(user, COMSIG_MOVABLE_CHASM_DROPPED)
+
+		/*
+		if(ishuman(dropped_thing))
+			var/mob/living/carbon/human/victim = dropped_thing
+			if(istype(victim.belt, /obj/item/wormhole_jaunter))
+				var/obj/item/wormhole_jaunter/jaunter = victim.belt
+				var/turf/chasm = get_turf(victim)
+				var/fall_into_chasm = jaunter.chasm_react(victim)
+				if(!fall_into_chasm)
+				return fall_into_chasm ? CHASM_DROPPING : CHASM_NOT_DROPPING
+		*/
+
+/obj/item/wormhole_jaunter/proc/chasm_react(mob/living/user, turf/chasm)
+	SIGNAL_HANDLER
+
+	if(!activate(user, FALSE, TRUE))
+		return
+
+	to_chat(user, span_userdanger("Your [src] activates, saving you from \the [chasm]!"))
+	chasm.visible_message(span_boldwarning("[user] falls into \the [chasm]!")) // To freak out any bystanders
+	SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // Chasm automatic activation
+	return COMPONENT_NO_CHASM_DROP
 
 //jaunter tunnel
 /obj/effect/portal/jaunt_tunnel

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -93,17 +93,6 @@
 	. = ..()
 	UnregisterSignal(user, COMSIG_MOVABLE_CHASM_DROPPED)
 
-		/*
-		if(ishuman(dropped_thing))
-			var/mob/living/carbon/human/victim = dropped_thing
-			if(istype(victim.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/jaunter = victim.belt
-				var/turf/chasm = get_turf(victim)
-				var/fall_into_chasm = jaunter.chasm_react(victim)
-				if(!fall_into_chasm)
-				return fall_into_chasm ? CHASM_DROPPING : CHASM_NOT_DROPPING
-		*/
-
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/living/user, turf/chasm)
 	SIGNAL_HANDLER
 


### PR DESCRIPTION

## About The Pull Request

Now all mobs are unbuckled from falling objects and dropped individually, similarly to how lava functions. Also updated jaunters to be comsig-based rather than chasms snowflake checking for jaunters in belt slots.
Closes #92663

## Changelog
:cl:
fix: Fixed chasm jaunters not working while you're buckled to a mob or an object
code: Updated chasm jaunters to use signals instead of being hardcoded in chasm code.
/:cl:
