### PR TITLE
Adds plumbing to toilets

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_1.dmm
@@ -31,9 +31,8 @@
 /area/ruin/space/djstation)
 "v" = (
 /obj/structure/toilet{
-	pixel_y = 8
+	dir = 1
 	},
-/obj/machinery/duct,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/djstation)

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_2.dmm
@@ -4,9 +4,6 @@
 /area/template_noop)
 "d" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/ruin/space/djstation)
-"f" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/ruin/space/djstation)
@@ -95,7 +92,7 @@ Y
 a
 i
 M
-f
+Z
 d
 V
 i

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_3.dmm
@@ -15,7 +15,6 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/djstation)
 "d" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -60227,6 +60227,7 @@
 	id_tag = "restroom_3";
 	name = "Toilet Unit"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "rJo" = (
@@ -64219,6 +64220,7 @@
 	id_tag = "restroom_2";
 	name = "Toilet Unit"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "sVA" = (
@@ -77306,6 +77308,7 @@
 	id_tag = "restroom_1";
 	name = "Toilet Unit"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "wOr" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1631,6 +1631,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "asv" = (
@@ -5730,7 +5731,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
 /obj/structure/toilet{
-	dir = 8
+	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/landmark/start/hangover,
@@ -7388,6 +7389,10 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"bNS" = (
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/station/medical/break_room)
 "bNT" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
@@ -27188,7 +27193,7 @@
 "gGT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/button/door/directional/south{
@@ -50505,6 +50510,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room/council)
+"mxX" = (
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/station/science/breakroom)
 "mxY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
@@ -66301,6 +66310,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "qvi" = (
@@ -67603,7 +67613,7 @@
 "qKz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
-	dir = 8
+	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
@@ -132205,7 +132215,7 @@ fDF
 fDF
 peU
 cHO
-aAj
+mxX
 qQM
 jYk
 vsV
@@ -140442,7 +140452,7 @@ cky
 dki
 lvZ
 jQB
-lvZ
+bNS
 lvZ
 pkg
 lvZ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -42228,6 +42228,11 @@
 	dir = 10
 	},
 /area/station/science/research)
+"lUp" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "lUw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43662,6 +43667,7 @@
 	id_tag = "Toilet2";
 	name = "Unit 2"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/textured,
 /area/station/commons/toilet)
 "msN" = (
@@ -44244,6 +44250,7 @@
 	id_tag = "Toilet1";
 	name = "Unit 1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/textured,
 /area/station/commons/toilet)
 "mBr" = (
@@ -82279,6 +82286,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"xpD" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "xpE" = (
 /obj/structure/table,
 /obj/item/knife/kitchen,
@@ -84614,6 +84625,7 @@
 /area/station/security/prison/mess)
 "xWG" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "xWM" = (
@@ -248838,7 +248850,7 @@ pBs
 eYF
 sNj
 fKR
-hsB
+xpD
 uja
 ise
 iuv
@@ -249095,7 +249107,7 @@ pBs
 uja
 uja
 uja
-hsB
+xpD
 uja
 wJk
 iuv
@@ -249352,7 +249364,7 @@ pBs
 uja
 kDz
 mBm
-twU
+lUp
 uja
 uPT
 poL
@@ -249609,7 +249621,7 @@ kqP
 uja
 uja
 uja
-hsB
+xpD
 uja
 ehq
 kOq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -22725,7 +22725,8 @@
 /area/station/medical/virology)
 "hVX" = (
 /obj/structure/toilet{
-	pixel_y = 8
+	pixel_y = 8;
+	dir = 4
 	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/newscaster/directional/south,
@@ -33259,6 +33260,7 @@
 	id_tag = "Toilet4";
 	name = "Unit 4"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "lvZ" = (
@@ -33769,7 +33771,8 @@
 /area/station/tcommsat/computer)
 "lJm" = (
 /obj/structure/toilet{
-	pixel_y = 8
+	pixel_y = 8;
+	dir = 4
 	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/newscaster/directional/south,
@@ -39933,7 +39936,7 @@
 /area/station/maintenance/port)
 "nKO" = (
 /obj/structure/toilet{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/newscaster/directional/east,
@@ -41333,6 +41336,7 @@
 	id_tag = "Toilet1";
 	name = "Unit 1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "ooz" = (
@@ -49516,7 +49520,8 @@
 /area/station/engineering/atmos)
 "rdT" = (
 /obj/structure/toilet{
-	pixel_y = 8
+	pixel_y = 8;
+	dir = 4
 	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/newscaster/directional/south,
@@ -56487,6 +56492,7 @@
 	id_tag = "Toilet3";
 	name = "Unit 3"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "tzE" = (
@@ -61412,6 +61418,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "vgv" = (
@@ -63755,6 +63762,7 @@
 	id_tag = "Toilet2";
 	name = "Unit 2"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "vTf" = (
@@ -104618,7 +104626,7 @@ xnU
 dIO
 jlY
 vgu
-fLz
+kAF
 lvU
 nKO
 dIO

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10680,6 +10680,7 @@
 /area/station/cargo/warehouse)
 "cDZ" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "cEb" = (
@@ -17681,6 +17682,7 @@
 	name = "Unit 1";
 	id_tag = "Toilet1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "ffL" = (
@@ -26822,6 +26824,7 @@
 	name = "Unit 2";
 	id_tag = "Toilet2"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "iCh" = (
@@ -36737,6 +36740,7 @@
 	name = "Unit 3";
 	id_tag = "Toilet3"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "lMJ" = (
@@ -51172,6 +51176,7 @@
 	name = "Unit 5";
 	id_tag = "Toilet5"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "qYJ" = (
@@ -51961,6 +51966,7 @@
 	name = "Unit 4";
 	id_tag = "Toilet4"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "rlZ" = (
@@ -62536,6 +62542,7 @@
 /area/station/service/hydroponics/garden)
 "uOY" = (
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "uOZ" = (
@@ -85480,7 +85487,7 @@ apC
 apC
 veV
 veV
-hAD
+alT
 hAD
 veV
 pdr
@@ -85737,12 +85744,12 @@ abM
 apC
 nmk
 ffE
-hAD
+alT
 hAD
 veV
 veV
 kMD
-hAD
+alT
 rlX
 oEl
 apC
@@ -86251,12 +86258,12 @@ abM
 apC
 paH
 iCe
-hAD
+alT
 hAD
 veV
 veV
 kMD
-hAD
+alT
 qYx
 rgT
 apC
@@ -86508,7 +86515,7 @@ abM
 apC
 veV
 veV
-hAD
+alT
 hAD
 ubY
 ubY
@@ -86765,7 +86772,7 @@ abM
 apC
 lYZ
 lMw
-hAD
+alT
 hAD
 hAD
 hAD

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -588,6 +588,7 @@
 	id_tag = "u5";
 	name = "Unit 5"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "ajQ" = (
@@ -30257,6 +30258,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "kub" = (
@@ -39392,6 +39394,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "nDC" = (
@@ -43826,6 +43829,7 @@
 /area/station/solars/starboard/fore)
 "pik" = (
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "piE" = (
@@ -47519,6 +47523,7 @@
 	id_tag = "u2";
 	name = "Unit 2"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "qsI" = (
@@ -52021,6 +52026,7 @@
 	id_tag = "u4";
 	name = "Unit 4"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "rUu" = (
@@ -52492,6 +52498,7 @@
 	id_tag = "u1";
 	name = "Unit 1"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "saa" = (
@@ -53865,6 +53872,7 @@
 "swe" = (
 /obj/structure/urinal/directional/north,
 /obj/machinery/light/small/dim/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "swi" = (
@@ -54467,6 +54475,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sGV" = (
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "sHa" = (
@@ -63417,6 +63426,7 @@
 /obj/structure/urinal/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "vPP" = (
@@ -68337,6 +68347,7 @@
 	id_tag = "u3";
 	name = "Unit 3"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "xzP" = (

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -46,9 +46,7 @@
 	set_recipient_reagents_holder(custom_receiver ? custom_receiver : parent_movable.reagents)
 
 	if(start)
-		//We're registering here because I need to check whether we start active or not, and this is just easier
-		//Should be called after we finished. Done this way because other networks need to finish setting up aswell
-		RegisterSignal(parent, COMSIG_COMPONENT_ADDED, PROC_REF(enable))
+		enable()
 
 /datum/component/plumbing/RegisterWithParent()
 	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING), PROC_REF(disable))
@@ -60,7 +58,7 @@
 
 /datum/component/plumbing/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING, COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH, COMSIG_OBJ_HIDE, \
-	COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_ATOM_DIR_CHANGE, COMSIG_MOVABLE_CHANGE_DUCT_LAYER, COMSIG_COMPONENT_ADDED))
+	COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_ATOM_DIR_CHANGE, COMSIG_MOVABLE_CHANGE_DUCT_LAYER))
 	REMOVE_TRAIT(parent, TRAIT_UNDERFLOOR, REF(src))
 
 /datum/component/plumbing/Destroy()
@@ -233,10 +231,8 @@
 			duct.update_appearance()
 
 ///settle wherever we are, and start behaving like a piece of plumbing
-/datum/component/plumbing/proc/enable(obj/object, datum/component/component)
-	SIGNAL_HANDLER
-	if(active || (component && component != src))
-		UnregisterSignal(parent, list(COMSIG_COMPONENT_ADDED))
+/datum/component/plumbing/proc/enable()
+	if(active)
 		return
 
 	update_dir()

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -110,10 +110,12 @@
 
 /obj/machinery/medipen_refiller/plunger_act(obj/item/plunger/attacking_plunger, mob/living/user, reinforced)
 	user.balloon_alert_to_viewers("furiously plunging...", "plunging medipen refiller...")
-	if(do_after(user, 3 SECONDS, target = src))
-		user.balloon_alert_to_viewers("finished plunging")
-		reagents.expose(get_turf(src), TOUCH)
-		reagents.clear_reagents()
+	if(!do_after(user, 3 SECONDS, target = src))
+		return TRUE
+	user.balloon_alert_to_viewers("finished plunging")
+	reagents.expose(get_turf(src), TOUCH)
+	reagents.clear_reagents()
+	return TRUE
 
 /obj/machinery/medipen_refiller/wrench_act(mob/living/user, obj/item/tool)
 	default_unfasten_wrench(user, tool)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -130,10 +130,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 
 /obj/machinery/shower/plunger_act(obj/item/plunger/attacking_plunger, mob/living/user, reinforced)
 	user.balloon_alert_to_viewers("furiously plunging...", "plunging shower...")
-	if(do_after(user, 3 SECONDS, target = src))
-		user.balloon_alert_to_viewers("finished plunging")
-		reagents.expose(get_turf(src), TOUCH) //splash on the floor
-		reagents.clear_reagents()
+	if(!do_after(user, 3 SECONDS, target = src))
+		return TRUE
+	user.balloon_alert_to_viewers("finished plunging")
+	reagents.expose(get_turf(src), TOUCH) //splash on the floor
+	reagents.clear_reagents()
+	begin_processing()
+	return TRUE
 
 /obj/machinery/shower/attackby(obj/item/tool, mob/user, list/modifiers, list/attack_modifiers)
 	if(istype(tool, /obj/item/stock_parts/water_recycler))

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -159,7 +159,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		O.play_tool_sound(src)
 		has_water_reclaimer = FALSE
 		new/obj/item/stock_parts/water_recycler(get_turf(loc))
-		to_chat(user, span_notice("You remove the water reclaimer from [src]"))
+		to_chat(user, span_notice("You remove the water reclaimer from [src]."))
 		return
 
 	if(istype(O, /obj/item/stack/ore/glass))

--- a/code/game/objects/structures/water_structures/toilet.dm
+++ b/code/game/objects/structures/water_structures/toilet.dm
@@ -7,45 +7,71 @@
 	density = FALSE
 	anchored = TRUE
 
-	///Boolean if whether the toilet is currently flushing.
+	/// Boolean if whether the toilet is currently flushing.
 	var/flushing = FALSE
-	///Boolean if the toilet seat is up.
+	/// Boolean if the toilet seat is up.
 	var/cover_open = FALSE
-	///Boolean if the cistern is up, allowing items to be put in/out.
+	/// Boolean if the cistern is up, allowing items to be put in/out.
 	var/cistern_open = FALSE
-	///The combined weight of all items in the cistern put together.
+	/// The combined weight of all items in the cistern put together.
 	var/w_items = 0
-	///Reference to the mob being given a swirlie.
+	/// Reference to the mob being given a swirlie.
 	var/mob/living/swirlie
-	///The type of material used to build the toilet.
+	/// The type of material used to build the toilet.
 	var/buildstacktype = /obj/item/stack/sheet/iron
-	///How much of the buildstacktype is needed to construct the toilet.
+	/// How much of the buildstacktype is needed to construct the toilet.
 	var/buildstackamount = 1
-	///Lazylist of items in the cistern.
+	/// Lazylist of items in the cistern.
 	var/list/cistern_items
-	///Lazylist of fish in the toilet, not to be mixed with the items in the cistern. Max of 3
+	/// Lazylist of fish in the toilet, not to be mixed with the items in the cistern. Max of 3
 	var/list/fishes
+	/// Does the toilet have a water recycler to recollect its water supply?
+	var/has_water_reclaimer = TRUE
+	/// Units of water to reclaim per second
+	var/reclaim_rate = 0.5
+	/// What reagent does the toilet flush with
+	var/reagent_id = /datum/reagent/water
+	/// How much reagent can the cistern contain
+	var/reagent_capacity = 200
+	/// Item stuck in the basin of the toilet
+	var/obj/item/stuck_item = null
 
-/obj/structure/toilet/Initialize(mapload)
+/obj/structure/toilet/Initialize(mapload, has_water_reclaimer = null)
 	. = ..()
 	cover_open = round(rand(0, 1))
+	if(!isnull(has_water_reclaimer))
+		src.has_water_reclaimer = has_water_reclaimer
 	update_appearance(UPDATE_ICON)
 	if(mapload && SSmapping.level_trait(z, ZTRAIT_STATION))
 		AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/toilet])
 	AddElement(/datum/element/fish_safe_storage)
 	register_context()
+	create_reagents(reagent_capacity)
+	if(src.has_water_reclaimer)
+		reagents.add_reagent(reagent_id, reagent_capacity)
+	AddComponent(/datum/component/plumbing/simple_demand, extend_pipe_to_edge = TRUE)
 
 /obj/structure/toilet/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(user.pulling && isliving(user.pulling))
 		context[SCREENTIP_CONTEXT_LMB] = "Give Swirlie"
-	else if(cover_open && istype(held_item, /obj/item/fish))
-		context[SCREENTIP_CONTEXT_LMB] = "Insert Fish"
-	else if(cover_open && LAZYLEN(fishes))
-		context[SCREENTIP_CONTEXT_LMB] = "Grab Fish"
+	if(cover_open)
+		if(isnull(held_item))
+			if(LAZYLEN(fishes))
+				context[SCREENTIP_CONTEXT_LMB] = "Grab Fish"
+		else if(istype(held_item, /obj/item/fish))
+			context[SCREENTIP_CONTEXT_LMB] = "Insert Fish"
+		else if(istype(held_item, /obj/item/plunger))
+			context[SCREENTIP_CONTEXT_LMB] = "Unclog"
+		else if(held_item.w_class <= WEIGHT_CLASS_SMALL)
+			context[SCREENTIP_CONTEXT_LMB] = "Insert Item"
 	else if(cistern_open)
 		if(isnull(held_item))
 			context[SCREENTIP_CONTEXT_LMB] = "Check Cistern"
+		else if(held_item.tool_behaviour == TOOL_SCREWDRIVER && has_water_reclaimer)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove Reclaimer"
+		else if(istype(held_item, /obj/item/stock_parts/water_recycler) && !has_water_reclaimer)
+			context[SCREENTIP_CONTEXT_LMB] = "Install Reclaimer"
 		else
 			context[SCREENTIP_CONTEXT_LMB] = "Insert Item"
 	context[SCREENTIP_CONTEXT_RMB] = "Flush"
@@ -54,8 +80,14 @@
 
 /obj/structure/toilet/examine(mob/user)
 	. = ..()
-	if(cover_open && LAZYLEN(fishes))
-		. += span_notice("You can see fish in the toilet, you can probably take one out.")
+	if(cover_open)
+		if(LAZYLEN(fishes))
+			. += span_notice("You can see fish in the toilet, you can probably take one out.")
+		if(stuck_item)
+			. += span_notice("There seems to be something small in [src]'s bowl...")
+	if(cistern_open && has_water_reclaimer)
+		. += span_notice("A water recycler is installed. Its attached by a pair of screws.")
+		. += span_notice("Its display states: [reagents.total_volume]/[reagents.maximum_volume] liquids remaining.")
 
 /obj/structure/toilet/examine_more(mob/user)
 	. = ..()
@@ -66,6 +98,7 @@
 	. = ..()
 	QDEL_LAZYLIST(fishes)
 	QDEL_LAZYLIST(cistern_items)
+	QDEL_NULL(stuck_item)
 
 /obj/structure/toilet/Exited(atom/movable/gone, direction)
 	. = ..()
@@ -101,11 +134,17 @@
 		if(swirlie)
 			return
 		if(cover_open)
+			if(!reagents.total_volume)
+				to_chat(user, span_notice("\The [src] is dry!"))
+				return
 			grabbed_mob.visible_message(span_danger("[user] starts to give [grabbed_mob] a swirlie!"), span_userdanger("[user] starts to give you a swirlie..."))
 			swirlie = grabbed_mob
 			var/was_alive = (swirlie.stat != DEAD)
 			if(!do_after(user, 3 SECONDS, target = src, timed_action_flags = IGNORE_HELD_ITEM))
 				swirlie = null
+				return
+			if(!reagents.total_volume)
+				to_chat(user, span_notice("\The [src] is dry!"))
 				return
 			grabbed_mob.visible_message(span_danger("[user] gives [grabbed_mob] a swirlie!"), span_userdanger("[user] gives you a swirlie!"), span_hear("You hear a toilet flushing."))
 			if(iscarbon(grabbed_mob))
@@ -158,7 +197,25 @@
 	. = ..()
 	if(flushing)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(reagents.total_volume <= 50)
+		to_chat(user, span_notice("You press the flush lever, but nothing happens."))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 	flushing = TRUE
+	var/something_stuck = !isnull(stuck_item)
+	if(!something_stuck && LAZYLEN(fishes))
+		for(var/obj/item/fish/fish as anything in fishes)
+			if(fish.w_class >= WEIGHT_CLASS_NORMAL)
+				something_stuck = TRUE
+				break
+
+	if(something_stuck)
+		reagents.create_foam(/datum/effect_system/fluid_spread/foam, 10, notification = span_danger("[src] overflows, spilling its cistern's contents everywhere!"), log = TRUE)
+	else
+		reagents.remove_all(50)
+
+	begin_reclamation()
 	playsound(src, 'sound/machines/toilet_flush.ogg', cover_open ? 40 : 20, TRUE)
 	if(cover_open && (dir & SOUTH))
 		update_appearance(UPDATE_OVERLAYS)
@@ -183,50 +240,97 @@
 	else
 		for(var/datum/material/M as anything in custom_materials)
 			new M.sheet_type(loc, FLOOR(custom_materials[M] / SHEET_MATERIAL_AMOUNT, 1))
+	if(has_water_reclaimer)
+		new /obj/item/stock_parts/water_recycler(drop_location())
+	if(stuck_item)
+		stuck_item.forceMove(drop_location())
 
-/obj/structure/toilet/attackby(obj/item/attacking_item, mob/living/user, list/modifiers, list/attack_modifiers)
+/obj/structure/toilet/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
+		return NONE
+
 	add_fingerprint(user)
-	if(cover_open && istype(attacking_item, /obj/item/fish))
+	if(cover_open && istype(tool, /obj/item/fish))
 		if(fishes >= 3)
 			to_chat(user, span_warning("There's too many fishes, flush them down first."))
-			return
-		if(!user.transferItemToLoc(attacking_item, src))
-			to_chat(user, span_warning("\The [attacking_item] is stuck to your hand!"))
-			return
-		var/obj/item/fish/the_fish = attacking_item
+			return ITEM_INTERACT_BLOCKING
+		if(!user.transferItemToLoc(tool, src))
+			to_chat(user, span_warning("\The [tool] is stuck to your hand!"))
+			return ITEM_INTERACT_BLOCKING
+		var/obj/item/fish/the_fish = tool
 		if(the_fish.status == FISH_DEAD)
-			to_chat(user, span_warning("You place [attacking_item] into [src], may it rest in peace."))
+			to_chat(user, span_warning("You place [tool] into [src], may it rest in peace."))
 		else
-			to_chat(user, span_notice("You place [attacking_item] into [src], hopefully no one will miss it!"))
-		LAZYADD(fishes, attacking_item)
-		return
+			to_chat(user, span_notice("You place [tool] into [src], hopefully no one will miss it!"))
+		LAZYADD(fishes, tool)
+		return ITEM_INTERACT_SUCCESS
 
-	if(cistern_open && !user.combat_mode)
-		if(attacking_item.w_class > WEIGHT_CLASS_NORMAL)
-			to_chat(user, span_warning("[attacking_item] does not fit!"))
-			return
-		if(w_items + attacking_item.w_class > WEIGHT_CLASS_HUGE)
+	if(cistern_open)
+		if(istype(tool, /obj/item/stock_parts/water_recycler))
+			if(has_water_reclaimer)
+				to_chat(user, span_warning("[src] already has a water recycler installed."))
+				return ITEM_INTERACT_BLOCKING
+
+			playsound(src, 'sound/machines/click.ogg', 20, TRUE)
+			qdel(tool)
+			has_water_reclaimer = TRUE
+			begin_reclamation()
+			return ITEM_INTERACT_SUCCESS
+
+		if(tool.w_class > WEIGHT_CLASS_NORMAL)
+			to_chat(user, span_warning("[tool] does not fit!"))
+			return ITEM_INTERACT_BLOCKING
+		if(w_items + tool.w_class > WEIGHT_CLASS_HUGE)
 			to_chat(user, span_warning("The cistern is full!"))
-			return
-		if(!user.transferItemToLoc(attacking_item, src))
-			to_chat(user, span_warning("\The [attacking_item] is stuck to your hand, you cannot put it in the cistern!"))
-			return
-		LAZYADD(cistern_items, attacking_item)
-		w_items += attacking_item.w_class
-		to_chat(user, span_notice("You carefully place [attacking_item] into the cistern."))
-		return
+			return ITEM_INTERACT_BLOCKING
+		if(!user.transferItemToLoc(tool, src))
+			to_chat(user, span_warning("\The [tool] is stuck to your hand, you cannot put it in the cistern!"))
+			return ITEM_INTERACT_BLOCKING
+		LAZYADD(cistern_items, tool)
+		w_items += tool.w_class
+		to_chat(user, span_notice("You carefully place [tool] into the cistern."))
+		return ITEM_INTERACT_SUCCESS
 
-	if(is_reagent_container(attacking_item) && !user.combat_mode)
-		if (!cover_open)
-			return
-		if(istype(attacking_item, /obj/item/food/monkeycube))
-			var/obj/item/food/monkeycube/cube = attacking_item
-			cube.Expand()
-			return
-		var/obj/item/reagent_containers/RG = attacking_item
-		RG.reagents.add_reagent(/datum/reagent/water, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
-		to_chat(user, span_notice("You fill [RG] from [src]. Gross."))
-	return ..()
+	if(!cover_open)
+		return NONE
+
+	if(!is_reagent_container(tool))
+		if(tool.w_class > WEIGHT_CLASS_SMALL)
+			return NONE
+
+		if(stuck_item)
+			to_chat(user, span_warning("There's already something blocking [src]'s drain pipe!"))
+			return ITEM_INTERACT_BLOCKING
+
+		if(!user.transferItemToLoc(tool, src))
+			to_chat(user, span_warning("\The [tool] is stuck to your hand!"))
+			return ITEM_INTERACT_BLOCKING
+
+		stuck_item = tool
+		to_chat(user, span_notice("You drop [tool] into [src]'s bowl."))
+		return ITEM_INTERACT_SUCCESS
+
+	if(reagents.total_volume <= 0)
+		to_chat(user, span_notice("\The [src] is dry."))
+		return ITEM_INTERACT_BLOCKING
+
+	if(istype(tool, /obj/item/food/monkeycube))
+		var/obj/item/food/monkeycube/cube = tool
+		cube.Expand()
+		return ITEM_INTERACT_SUCCESS
+
+	var/obj/item/reagent_containers/container = tool
+	if(!container.is_refillable())
+		return NONE
+
+	if(container.reagents.holder_full())
+		to_chat(user, span_notice("\The [container] is full."))
+		return ITEM_INTERACT_BLOCKING
+
+	reagents.trans_to(container, container.amount_per_transfer_from_this, transferred_by = user)
+	begin_reclamation()
+	to_chat(user, span_notice("You fill [container] from [src]. Gross."))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/toilet/crowbar_act(mob/living/user, obj/item/tool)
 	to_chat(user, span_notice("You start to [cistern_open ? "replace the lid on" : "lift the lid off"] the cistern..."))
@@ -240,10 +344,38 @@
 		update_appearance(UPDATE_ICON_STATE)
 	return ITEM_INTERACT_SUCCESS
 
+/obj/structure/toilet/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!cistern_open)
+		to_chat(user, span_warning("You need to open [src]'s cistern first!"))
+		return ITEM_INTERACT_BLOCKING
+
+	if(!has_water_reclaimer)
+		to_chat(user, span_warning("\the [src] doesn't have a water reclaimer installed."))
+		return ITEM_INTERACT_BLOCKING
+
+	tool.play_tool_sound(src)
+	has_water_reclaimer = FALSE
+	new /obj/item/stock_parts/water_recycler(drop_location())
+	to_chat(user, span_notice("You remove the water reclaimer from \the [src]."))
+	return ITEM_INTERACT_SUCCESS
+
 /obj/structure/toilet/wrench_act(mob/living/user, obj/item/tool)
 	tool.play_tool_sound(src)
 	deconstruct()
 	return ITEM_INTERACT_SUCCESS
+
+/obj/structure/toilet/plunger_act(obj/item/plunger/attacking_plunger, mob/living/user, reinforced)
+	user.balloon_alert_to_viewers("furiously plunging...")
+	if(!do_after(user, 3 SECONDS, target = src))
+		return TRUE
+	user.balloon_alert_to_viewers("finished plunging")
+	reagents.expose(get_turf(src), TOUCH) //splash on the floor
+	reagents.clear_reagents()
+	begin_reclamation()
+	if(stuck_item)
+		stuck_item.forceMove(drop_location())
+		stuck_item = null
+	return TRUE
 
 ///Ends the flushing animation and updates overlays if necessary
 /obj/structure/toilet/proc/end_flushing()
@@ -252,9 +384,19 @@
 		update_appearance(UPDATE_OVERLAYS)
 	QDEL_LAZYLIST(fishes)
 
+/obj/structure/toilet/proc/begin_reclamation()
+	START_PROCESSING(SSplumbing, src)
+
+/obj/structure/toilet/process(seconds_per_tick)
+	// Water reclamation complete?
+	if(!has_water_reclaimer || reagents.total_volume >= reagents.maximum_volume)
+		return PROCESS_KILL
+	reagents.add_reagent(reagent_id, reclaim_rate * seconds_per_tick)
+
 /obj/structure/toilet/greyscale
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstacktype = null
+	has_water_reclaimer = FALSE
 
 /obj/structure/toilet/secret
 	var/secret_type = null

--- a/code/game/objects/structures/water_structures/toilet.dm
+++ b/code/game/objects/structures/water_structures/toilet.dm
@@ -49,7 +49,7 @@
 	create_reagents(reagent_capacity)
 	if(src.has_water_reclaimer)
 		reagents.add_reagent(reagent_id, reagent_capacity)
-	//AddComponent(/datum/component/plumbing/simple_demand, extend_pipe_to_edge = TRUE)
+	AddComponent(/datum/component/plumbing/simple_demand, extend_pipe_to_edge = TRUE)
 
 /obj/structure/toilet/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()

--- a/code/game/objects/structures/water_structures/toilet.dm
+++ b/code/game/objects/structures/water_structures/toilet.dm
@@ -49,7 +49,7 @@
 	create_reagents(reagent_capacity)
 	if(src.has_water_reclaimer)
 		reagents.add_reagent(reagent_id, reagent_capacity)
-	AddComponent(/datum/component/plumbing/simple_demand, extend_pipe_to_edge = TRUE)
+	//AddComponent(/datum/component/plumbing/simple_demand, extend_pipe_to_edge = TRUE)
 
 /obj/structure/toilet/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -161,7 +161,6 @@ All the important duct code:
 		duct_stack.add_atom_colour(duct_color, FIXED_COLOUR_PRIORITY)
 		drop_on_wrench = null
 	if(!QDELING(src))
-		stack_trace("pipe got deleted at [AREACOORD(src)]")
 		qdel(src)
 
 ///Special proc to draw a new connect frame based on neighbours. not the norm so we can support multiple duct kinds

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -56,7 +56,8 @@ All the important duct code:
 		active = FALSE
 		set_anchored(FALSE)
 	else if(!can_anchor())
-		stack_trace("Overlapping ducts detected at [AREACOORD(src)], unanchoring one.")
+		if(mapload)
+			log_mapping("Overlapping ducts detected at [AREACOORD(src)], unanchoring one.")
 		// Note that qdeling automatically drops a duct stack
 		return INITIALIZE_HINT_QDEL
 
@@ -160,7 +161,6 @@ All the important duct code:
 		duct_stack.add_atom_colour(duct_color, FIXED_COLOUR_PRIORITY)
 		drop_on_wrench = null
 	if(!QDELING(src))
-		stack_trace("1")
 		qdel(src)
 
 ///Special proc to draw a new connect frame based on neighbours. not the norm so we can support multiple duct kinds
@@ -363,7 +363,6 @@ All the important duct code:
 
 		// Turn into a duct stack and then merge to the in-hand stack.
 		var/obj/item/stack/ducts/stack = new(duct.loc, 1, FALSE)
-		stack_trace("2")
 		qdel(duct)
 		if(stack.can_merge(src))
 			stack.merge(src)

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -56,8 +56,7 @@ All the important duct code:
 		active = FALSE
 		set_anchored(FALSE)
 	else if(!can_anchor())
-		if(mapload)
-			log_mapping("Overlapping ducts detected at [AREACOORD(src)], unanchoring one.")
+		stack_trace("Overlapping ducts detected at [AREACOORD(src)], unanchoring one.")
 		// Note that qdeling automatically drops a duct stack
 		return INITIALIZE_HINT_QDEL
 
@@ -161,6 +160,7 @@ All the important duct code:
 		duct_stack.add_atom_colour(duct_color, FIXED_COLOUR_PRIORITY)
 		drop_on_wrench = null
 	if(!QDELING(src))
+		stack_trace("1")
 		qdel(src)
 
 ///Special proc to draw a new connect frame based on neighbours. not the norm so we can support multiple duct kinds
@@ -363,6 +363,7 @@ All the important duct code:
 
 		// Turn into a duct stack and then merge to the in-hand stack.
 		var/obj/item/stack/ducts/stack = new(duct.loc, 1, FALSE)
+		stack_trace("2")
 		qdel(duct)
 		if(stack.can_merge(src))
 			stack.merge(src)

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -161,6 +161,7 @@ All the important duct code:
 		duct_stack.add_atom_colour(duct_color, FIXED_COLOUR_PRIORITY)
 		drop_on_wrench = null
 	if(!QDELING(src))
+		stack_trace("pipe got deleted at [AREACOORD(src)]")
 		qdel(src)
 
 ///Special proc to draw a new connect frame based on neighbours. not the norm so we can support multiple duct kinds

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -98,7 +98,9 @@
 
 /obj/machinery/plumbing/plunger_act(obj/item/plunger/attacking_plunger, mob/living/user, reinforced)
 	user.balloon_alert_to_viewers("furiously plunging...")
-	if(do_after(user, 3 SECONDS, target = src))
-		user.balloon_alert_to_viewers("finished plunging")
-		reagents.expose(get_turf(src), TOUCH) //splash on the floor
-		reagents.clear_reagents()
+	if(!do_after(user, 3 SECONDS, target = src))
+		return TRUE
+	user.balloon_alert_to_viewers("finished plunging")
+	reagents.expose(get_turf(src), TOUCH) //splash on the floor
+	reagents.clear_reagents()
+	return TRUE

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -22,10 +22,12 @@
 
 /obj/machinery/iv_drip/plumbing/plunger_act(obj/item/plunger/attacking_plunger, mob/living/user, reinforced)
 	user.balloon_alert_to_viewers("furiously plunging...", "plunging iv drip...")
-	if(do_after(user, 3 SECONDS, target = src))
-		user.balloon_alert_to_viewers("finished plunging")
-		reagents.expose(get_turf(src), TOUCH) //splash on the floor
-		reagents.clear_reagents()
+	if(!do_after(user, 3 SECONDS, target = src))
+		return TRUE
+	user.balloon_alert_to_viewers("finished plunging")
+	reagents.expose(get_turf(src), TOUCH) //splash on the floor
+	reagents.clear_reagents()
+	return TRUE
 
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/tool)
 	if(default_unfasten_wrench(user, tool) != SUCCESSFUL_UNFASTEN)


### PR DESCRIPTION

## About The Pull Request

Toilets no longer act as infinite instant water sources, instead working like showers and sinks - requiring either plumbing, or water reclaimers to restore their cistern's supply. If a toilet has a large enough fish inside, or if someone accidentally drops a small item into it, when flushing it'll spew out all of its cistern's contents around itself (Dropped items can be removed using a plunger after a small delay). 
Also fixed plunger act code on some plumbing objects, and converted toilets to use item interactions.

### This is a commission for ImprovedName/Ezel

## Why It's Good For The Game

Makes toilets more intresting with plumbing, and brings them more inline with other plumbing appliances so that way you can't just make a toilet with 1 material sheet and conjure a infinite water resouce anywhere you please without a water recycler.
Also you can get up to some silly stuff with foam production.

## Changelog
:cl:
add: Toilets now require plumbing or water reclaimers to function, and can get clogged by small items.
fix: Trying to use plungers on plumbing objects will no longer hit them after finishing the interaction.
code: Updated toilet item interaction code
/:cl:
