### PR TITLE
Fixes `external_bodyshapes` not always applying its bodyshape to owner

### DIFF
--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -74,11 +74,6 @@
 		wash(CLEAN_TYPE_BLOOD)
 		organ_flags &= ~ORGAN_VIRGIN
 
-	if(external_bodytypes)
-		receiver.synchronize_bodytypes()
-	if(external_bodyshapes)
-		receiver.synchronize_bodyshapes()
-
 	receiver.organs |= src
 	receiver.organs_slot[slot] = src
 	owner = receiver
@@ -141,6 +136,11 @@
 	ADD_TRAIT(src, TRAIT_NODROP, ORGAN_INSIDE_BODY_TRAIT)
 	interaction_flags_item &= ~INTERACT_ITEM_ATTACK_HAND_PICKUP
 
+	if(external_bodytypes)
+		limb.owner?.synchronize_bodytypes()
+	if(external_bodyshapes)
+		limb.owner?.synchronize_bodyshapes()
+
 	if(bodypart_overlay)
 		limb.add_bodypart_overlay(bodypart_overlay)
 
@@ -186,8 +186,6 @@
 	SEND_SIGNAL(organ_owner, COMSIG_CARBON_LOSE_ORGAN, src, special)
 	ADD_TRAIT(src, TRAIT_USED_ORGAN, ORGAN_TRAIT)
 
-	organ_owner.synchronize_bodytypes()
-	organ_owner.synchronize_bodyshapes()
 	if(!special)
 		organ_owner.hud_used?.update_locked_slots()
 
@@ -247,6 +245,9 @@
 	item_flags &= ~ABSTRACT
 	REMOVE_TRAIT(src, TRAIT_NODROP, ORGAN_INSIDE_BODY_TRAIT)
 	interaction_flags_item |= INTERACT_ITEM_ATTACK_HAND_PICKUP
+
+	limb.owner?.synchronize_bodytypes()
+	limb.owner?.synchronize_bodyshapes()
 
 	if(!bodypart_overlay)
 		return


### PR DESCRIPTION
## About The Pull Request

The synchronize procs ran too early and would miss out on the last organ loaded, which is more likely to happen than you think.

## Why It's Good For The Game

In case TG ever wants to code mask sprites for snouted humanoids, you'll want this to work.

https://github.com/user-attachments/assets/a8a684be-87bc-4c68-886f-a7a6d5ba7051

## Changelog

:cl:
fix: Fixes the external_bodyshapes variable of organs, like the lizard snout which now actually flags lizards as having a snouted bodyshape
/:cl:
