### PR TITLE
Minor fixes of R&D department on tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -37564,7 +37564,9 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "lZJ" = (
-/obj/machinery/elevator_control_panel/directional/south,
+/obj/machinery/elevator_control_panel/directional/south{
+	linked_elevator_id = "tram_xeno_lift"
+	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "lZW" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10551,7 +10551,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cAK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
@@ -10930,8 +10929,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/off/dark{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "cHZ" = (
@@ -17942,14 +17943,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/tram/left)
 "fjA" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
+	},
+/obj/machinery/door/window/elevator/right/directional/west{
+	transport_linked_id = "tram_xeno_lift"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -22213,9 +22211,17 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/lesser)
 "gNr" = (
-/obj/machinery/processor/slime,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -23629,10 +23635,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "hox" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "hoA" = (
@@ -24514,6 +24520,19 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/mmi{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 8;
+	pixel_y = -2
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
@@ -27546,9 +27565,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iQG" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/button/elevator/directional/north{
 	id = "tram_xeno_lift"
 	},
@@ -27559,6 +27575,9 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/door/window/elevator/left/directional/east{
+	transport_linked_id = "tram_xeno_lift"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "iQH" = (
@@ -30075,11 +30094,8 @@
 /turf/open/space/openspace,
 /area/station/solars/starboard/fore)
 "jGx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/machinery/computer/atmos_control/ordnancemix{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -32845,6 +32861,12 @@
 	},
 /turf/open/space/openspace,
 /area/space)
+"kza" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "kzg" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -34463,6 +34485,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"kZa" = (
+/obj/machinery/camera/directional/south{
+	pixel_x = 21;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "kZh" = (
 /turf/open/floor/eighties/red,
 /area/station/commons/fitness/recreation/entertainment)
@@ -35793,7 +35822,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/aiupload,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lxi" = (
@@ -35954,6 +35982,7 @@
 /area/station/engineering/atmos)
 "lyQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lyR" = (
@@ -37142,6 +37171,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"lTo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply,
+/turf/closed/wall,
+/area/station/science/ordnance)
 "lTs" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/fore)
@@ -37531,12 +37564,9 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "lZJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/obj/machinery/elevator_control_panel/directional/south,
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "lZW" = (
 /turf/closed/wall,
 /area/station/maintenance/department/cargo)
@@ -39881,6 +39911,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"mVN" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "mVS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/left/directional/west{
@@ -41295,7 +41331,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nuu" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "nuw" = (
@@ -47963,19 +47999,16 @@
 "pQy" = (
 /obj/structure/table,
 /obj/item/multitool/circuit{
-	pixel_x = -8
+	pixel_x = -7;
+	pixel_y = 0
 	},
 /obj/item/multitool/circuit{
-	pixel_x = -4
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/obj/item/multitool/circuit,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 8;
-	pixel_y = -2
+/obj/item/multitool/circuit{
+	pixel_x = 7;
+	pixel_y = 0
 	},
 /obj/machinery/camera/directional/south{
 	network = list("ss13","rd");
@@ -48099,14 +48132,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "pUi" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
+	},
+/obj/machinery/door/window/elevator/left/directional/east{
+	transport_linked_id = "tram_xeno_lift"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -50177,8 +50207,8 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal)
 "qHa" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "qHe" = (
@@ -51023,6 +51053,10 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/box/red,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "qWy" = (
@@ -51588,6 +51622,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"rfi" = (
+/obj/machinery/camera/directional/north,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rfQ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -52205,6 +52243,14 @@
 	network = list("ss13","rd");
 	c_tag = "Science - Xenobiology South"
 	},
+/obj/structure/closet{
+	anchored = 1;
+	name = "Cold protection gear"
+	},
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "roR" = (
@@ -53241,7 +53287,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -53250,6 +53295,9 @@
 	areastring = "/area/station/science/ordnance/burnchamber"
 	},
 /obj/structure/sign/warning/hot_temp/directional/south,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "rLP" = (
@@ -53521,6 +53569,7 @@
 /area/station/construction/mining/aux_base)
 "rPv" = (
 /obj/machinery/light/small/dim/directional/south,
+/obj/machinery/camera/directional/south,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rPH" = (
@@ -55427,6 +55476,10 @@
 	req_access = list("science")
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/door/window/left/directional/west{
+	name = "Robotics Desk";
+	req_access = list("robotics")
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -58202,7 +58255,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "twv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/machinery/atmospherics/pipe/smart/simple/supply{
+	dir = 9
+	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
 "twz" = (
@@ -58709,9 +58764,6 @@
 /obj/machinery/camera/directional/north{
 	network = list("ss13","rd","xeno");
 	c_tag = "Science - Xenobiology Lower Containment Chamber"
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
 	},
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
@@ -60034,6 +60086,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"udg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/explab)
 "udk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -60828,6 +60889,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"upf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "upj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/item/radio/intercom/directional/south,
@@ -62873,9 +62941,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
 "uXn" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -62889,6 +62954,9 @@
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /obj/effect/mapping_helpers/airalarm/link{
 	chamber_id = "ordnanceburn"
+	},
+/obj/machinery/computer/atmos_control/ordnancemix{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -64650,20 +64718,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/tram/mid)
 "vBl" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -5;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
+/obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "vBn" = (
@@ -65446,6 +65506,16 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"vOW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/directional/north{
+	pixel_x = 21;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "vPg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -66758,6 +66828,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"wpr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/storage)
 "wpH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -66860,10 +66937,6 @@
 /obj/structure/rack,
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/test_chamber/directional/north,
-/obj/item/storage/box/beakers{
-	pixel_x = 5;
-	pixel_y = 3
-	},
 /obj/item/grenade/chem_grenade{
 	pixel_x = -7;
 	pixel_y = 7
@@ -66871,6 +66944,10 @@
 /obj/item/grenade/chem_grenade{
 	pixel_x = -7;
 	pixel_y = 1
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
@@ -69991,13 +70068,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xAM" = (
-/obj/machinery/elevator_control_panel{
-	pixel_y = 2;
-	linked_elevator_id = "tram_xeno_lift";
-	preset_destination_names = list("2"="Lower                                                                Deck", "3"="Upper                                                                Deck")
+/obj/machinery/atmospherics/pipe/smart/simple/supply{
+	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
+/area/station/science/ordnance/burnchamber)
 "xAR" = (
 /obj/machinery/door/airlock/security{
 	name = "Prison Workshop"
@@ -70110,14 +70185,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "xCr" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/machinery/smartfridge/extract/preloaded,
 /obj/machinery/light/directional/north,
+/obj/machinery/door/window/elevator/right/directional/west{
+	transport_linked_id = "tram_xeno_lift"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "xCs" = (
@@ -115316,7 +115390,7 @@ rwb
 qVr
 bfH
 bfH
-jTC
+upf
 qVr
 aaa
 aaa
@@ -116079,7 +116153,7 @@ oNT
 dUT
 gdC
 qVr
-bfH
+rfi
 oxe
 ahk
 hdA
@@ -116093,7 +116167,7 @@ sml
 bfH
 bfH
 oxe
-jTC
+upf
 qVr
 aaa
 aaa
@@ -119163,7 +119237,7 @@ ebs
 hFH
 tYB
 qVr
-jTC
+vOW
 oxe
 bfH
 bfH
@@ -119177,7 +119251,7 @@ uAF
 ahk
 hdA
 oxe
-bfH
+kZa
 qVr
 aaa
 aaa
@@ -119657,7 +119731,7 @@ owO
 owO
 cJS
 rKD
-cVU
+udg
 cFW
 cFW
 nEB
@@ -119940,7 +120014,7 @@ bOi
 dUT
 aaa
 qVr
-jTC
+vOW
 bfH
 bfH
 qVr
@@ -122760,7 +122834,7 @@ dfz
 xVv
 qOo
 qOo
-lZJ
+xZs
 yei
 gBr
 hee
@@ -123011,7 +123085,7 @@ dhM
 pUC
 fXK
 lyC
-hox
+wpr
 hox
 dfz
 vqO
@@ -123787,7 +123861,7 @@ lkK
 aeg
 gPB
 qOo
-qOo
+kza
 jGx
 aej
 oAn
@@ -124046,7 +124120,7 @@ xwi
 vJC
 qWf
 rLG
-eOZ
+xAM
 eOZ
 gkD
 gkD
@@ -124302,7 +124376,7 @@ frV
 frT
 ryK
 jLH
-jLH
+lTo
 twv
 aaa
 aaa
@@ -182126,7 +182200,7 @@ tYp
 pbH
 pbH
 pbH
-pbH
+qVr
 qVr
 qVr
 qVr
@@ -182384,7 +182458,7 @@ pbH
 uvU
 umu
 qVr
-qVr
+tBo
 mFh
 tBo
 tBo
@@ -182642,7 +182716,7 @@ mAL
 nKU
 qVr
 tEx
-tBo
+mVN
 tBo
 tBo
 qVr
@@ -182898,8 +182972,8 @@ pbH
 bmz
 pIx
 qVr
-ttj
 tBo
+ttj
 tBo
 tBo
 tBo
@@ -182910,8 +182984,8 @@ xVF
 eJQ
 bNx
 aSt
-aSt
-xAM
+lZJ
+qVr
 aaa
 aaa
 aaa
@@ -183926,7 +184000,7 @@ pbH
 vSa
 cJR
 qVr
-qVr
+tBo
 tBo
 tBo
 tBo
@@ -184182,7 +184256,7 @@ tYp
 pbH
 pbH
 pbH
-pbH
+qVr
 qVr
 qVr
 qVr

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -37563,12 +37563,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
-"lZJ" = (
-/obj/machinery/elevator_control_panel/directional/south{
-	linked_elevator_id = "tram_xeno_lift"
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "lZW" = (
 /turf/closed/wall,
 /area/station/maintenance/department/cargo)
@@ -65904,6 +65898,11 @@
 	dir = 6
 	},
 /obj/structure/ladder,
+/obj/machinery/elevator_control_panel/directional/south{
+	linked_elevator_id = "tram_xeno_lift";
+	pixel_x = 31;
+	pixel_y = -31
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "vXL" = (
@@ -182983,7 +182982,7 @@ xVF
 eJQ
 bNx
 aSt
-lZJ
+aSt
 qVr
 aaa
 aaa

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -53284,9 +53284,6 @@
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
 "rLG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request
Make rnd easy to play on it.

- adds to toxin burn chamber output freezer instead of lonely connector with freezer. canisters position now are more better to take nitrogen.

- slime proccesor now are more close to consoles, fridge are moved to past place of slime proccesor. Add mising cameras in containment pens. Added locker with cold protection in xenobio. Removed flying AI upload monitor from xenobio (no clue how its turned out to be there). Lift from xeno to cyto are now 4w sided and elevator panel now directional. Xenobio chamber extended to remove 2x2 walls opposite rnd server

- added robo access desk to RnD  

- add MMI to exp-lab

You also can check difs or type what i should also fix

<details> <summary>Images</summary>
TOXINS

<img width="576" height="608" alt="StrongDMM-2025-08-25 13 46 19" src="https://github.com/user-attachments/assets/ea9558ad-862c-4366-80fe-e259c6381f78" /> before
<img width="576" height="608" alt="StrongDMM-2025-08-25 13 45 56" src="https://github.com/user-attachments/assets/a24cf896-4a13-4f60-a279-702456903fec" /> pr changes

XENOBIO

<img width="736" height="640" alt="StrongDMM-2025-08-25 13 46 45" src="https://github.com/user-attachments/assets/a918f491-3baf-4078-a91d-5f9159e87082" /> before
<img width="736" height="640" alt="StrongDMM-2025-08-25 14 06 35" src="https://github.com/user-attachments/assets/02516bee-dbfb-4bf3-8617-6cb9f1a1e280" /> pr changes

XENOBIO CHAMBER

<img width="544" height="576" alt="StrongDMM-2025-08-25 14 07 12" src="https://github.com/user-attachments/assets/47a8fcd7-4144-4348-bfb7-dd0c94a58640" /> before
<img width="544" height="576" alt="StrongDMM-2025-08-25 14 06 56" src="https://github.com/user-attachments/assets/f1ed4bb3-5813-48e1-83b3-3eba9c77c5b5" /> pr changes

CIRCUITS ROOM

<img width="256" height="384" alt="StrongDMM-2025-08-25 14 07 56" src="https://github.com/user-attachments/assets/0f2cc32c-271b-4292-a840-1cdeee8f37c9" /> before
<img width="256" height="384" alt="StrongDMM-2025-08-25 14 08 08" src="https://github.com/user-attachments/assets/a0e093d9-ffd8-498f-866c-40bb2e081efb" /> pr changes
</details>

## Why It's Good For The Game
its makes research department easier to play on it when map rotation rolls tramstation, now you can make trit without transposition of freezer. now ppl can play in xenobio cuz pens has cameras now. Someone who mains circuits will get MMI roundstart. 

## Changelog
:cl: Glamyr
fix: Xenobio pens on tramstation now has cameras
qol: Lone freezer on tramstation ordnance connected to burn chamber
qol: Circuit lab on tramstation now have MMI roundstart
map: Moved ordnance canisters on tramstation
map: Placed robo access desk opp of rnd
map: Removed AI Monitor Upload from xenobio
/:cl:
