### PR TITLE
Fixes raptor pixel offsets

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -652,16 +652,16 @@
 /datum/component/riding/creature/raptor/get_rider_offsets_and_layers(pass_index, mob/offsetter)
 	if(!SSmapping.is_planetary())
 		return list(
-			TEXT_NORTH = list( 7, 7),
-			TEXT_SOUTH = list( 2, 10),
-			TEXT_EAST =  list(12, 7),
-			TEXT_WEST =  list(10, 7),
+			TEXT_NORTH = list(-1, 7),
+			TEXT_SOUTH = list(2, 10),
+			TEXT_EAST =  list(0, 7),
+			TEXT_WEST =  list(0, 7),
 		)
 	return list(
-		TEXT_NORTH = list( 0, 7),
-		TEXT_SOUTH = list( 0, 10),
+		TEXT_NORTH = list(0, 7),
+		TEXT_SOUTH = list(0, 10),
 		TEXT_EAST =  list(-3, 9),
-		TEXT_WEST =  list( 3, 9),
+		TEXT_WEST =  list(3, 9),
 	)
 
 /datum/component/riding/creature/raptor/get_parent_offsets_and_layers()
@@ -671,6 +671,12 @@
 		TEXT_EAST =  list(0, 0, MOB_BELOW_PIGGYBACK_LAYER),
 		TEXT_WEST =  list(0, 0, MOB_BELOW_PIGGYBACK_LAYER),
 	)
+
+/datum/component/riding/creature/raptor/update_parent_layer_and_offsets(dir, animate)
+	. = ..()
+	var/mob/living/basic/raptor/raptor = parent
+	if (istype(raptor))
+		raptor.adjust_offsets(dir)
 
 /datum/component/riding/creature/raptor/fast
 	vehicle_move_delay = 1.5

--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -146,11 +146,22 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	adjust_offsets(new_dir)
 
 /mob/living/basic/raptor/proc/adjust_offsets(direction)
-	if(!change_offsets)
+	if (!change_offsets)
 		return
-	pixel_x = (direction & EAST) ? -20 : 0
-	pixel_y = (direction & NORTH) ? -5 : 0
 
+	switch (direction)
+		if (NORTH)
+			pixel_x = -8
+			pixel_y = -5
+		if (SOUTH)
+			pixel_x = 0
+			pixel_y = 0
+		if (EAST, SOUTHEAST, NORTHEAST)
+			pixel_x = -20
+			pixel_y = 0
+		if (WEST, SOUTHWEST, NORTHWEST)
+			pixel_x = -5
+			pixel_y = 0
 
 /mob/living/basic/raptor/early_melee_attack(atom/target, list/modifiers, ignore_cooldown)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

<img width="166" height="118" alt="dreamseeker_37t0MNU5jA" src="https://github.com/user-attachments/assets/24b1e04e-b14d-429a-b0c1-204146b07a8d" />
<img width="136" height="125" alt="dreamseeker_HoBk2zzy9b" src="https://github.com/user-attachments/assets/2e1139fe-7051-4085-8c76-859495bea134" />
<img width="145" height="134" alt="dreamseeker_KNIWzKUX1c" src="https://github.com/user-attachments/assets/aeeff869-4331-47d8-9199-a021858175fd" />

Currently raptor pixel offsets are completely broken and result in you sometimes being visually on the tile next to you, and are inconsistent between east and west rotation. This makes it nigh impossible to determine which tile you're on.

## Changelog
:cl:
fix: Fixed raptors and their riders having weird/confusing pixel offsets
/:cl:
