### PR TITLE
Fixes crusher trophies sometimes not dropping when they should/dropping duplicates

### DIFF
--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -36,14 +36,15 @@
 
 	var/datum/status_effect/crusher_damage/damage = target.has_status_effect(/datum/status_effect/crusher_damage)
 	if(damage && prob((damage.total_damage/target.maxHealth) * drop_mod)) //on average, you'll need to kill 4 creatures before getting the item. by default.
-		if(islist(trophy_type))
-			for(var/trophypath in trophy_type)
-				make_path(target, trophypath)
+		if(!islist(trophy_type))
+			make_path(target, trophy_type)
 			return
-		make_path(target, trophy_type)
+
+		for(var/trophypath in trophy_type)
+			make_path(target, trophypath)
 
 /datum/element/crusher_loot/proc/make_path(mob/living/target, path)
 	if(drop_immediately)
 		new path(get_turf(target))
 	else
-		target.butcher_results[path] = 1
+		target.guaranteed_butcher_results[path] = 1


### PR DESCRIPTION

## About The Pull Request

Changes crusher trophy drops from butchering to use guaranteed drops instead of RNG-dependant ones

## Why It's Good For The Game

Some mobs are limited in quantity (rare variants, such as ice/magmawings for example) and not getting a drop sucks, and getting duplicate drops is inconsistent with how del on death mob drops work.

## Changelog
:cl:
fix: Fixed crusher trophies sometimes not dropping when they should/dropping duplicates
/:cl:
