### PR TITLE
Fixes #92714 - Admin Cure Diseases now adds immunity to disease

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -99,7 +99,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				message_admins("[key_name_admin(holder)] has cured all diseases.")
 				for(var/thing in SSdisease.active_diseases)
 					var/datum/disease/D = thing
-					D.cure(0)
+					D.cure()
 
 		if("list_bombers")
 			holder.holder.list_bombers()

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -94,7 +94,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 
 		//Buttons for helpful stuff. This is where people land in the tgui
 		if("clear_virus")
-			var/choice = tgui_alert(usr, "Are you sure you want to cure all disease?",, list("Yes", "Cancel"))
+			var/choice = tgui_alert(usr, "Are you sure you want to cure all disease? This will also grant immunity for that disease",, list("Yes", "Cancel"))
 			if(choice == "Yes")
 				message_admins("[key_name_admin(holder)] has cured all diseases.")
 				for(var/thing in SSdisease.active_diseases)


### PR DESCRIPTION

## About The Pull Request

Fixes #92714

Admin Cure all in secrets.dm explicitly did not add immunity from curing all diseases, which meant re-infection happened, it passed a value of 0 which prevented immunity.

It is permanent immunity to that disease with no time limit so added a prompt to clarify the button.
## Why It's Good For The Game

- Makes the anti disease button for admins better
## Changelog
:cl:
fix: Admin Secrets - "Cure all diseases" now adds immunity to that disease
/:cl:
