### PR TITLE
[NO GBP] Restores jumping emote sound

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -147,6 +147,7 @@
 /datum/emote/jump
 	key = "jump"
 	key_third_person = "jumps"
+	message = "jumps!"
 	// Allows ghosts to jump
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
 	affected_by_pitch = FALSE


### PR DESCRIPTION
## About The Pull Request

<img width="384" height="223" alt="image" src="https://github.com/user-attachments/assets/797ec17f-fdec-418e-a6ba-c2e8a637ba7d" />

Fixes #92709

#88464 - Accidentally broke jumping sound on the emote - There was a later commit to that same PR to undo it but not sure if been merged.

Just making this PR so that it can be fully fixed.

Can close this if we wanna re-merge 88464.
## Why It's Good For The Game

- Jump jump jump jumping noises yay
## Changelog
:cl:
fix: Restores jumping emote sound
/:cl:
