### PR TITLE
Fixes air alarm scrubber buttons missing background

### DIFF
--- a/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.tsx
@@ -219,7 +219,7 @@ export const Scrubber = (props: ScrubberProps) => {
         <LabeledList.Item label="Mode">
           <Button
             icon={scrubbing ? 'filter' : 'sign-in-alt'}
-            color={scrubbing || 'danger'}
+            color={!scrubbing && 'danger'}
             content={scrubbing ? 'Scrubbing' : 'Siphoning'}
             onClick={() =>
               act('scrubbing', {


### PR DESCRIPTION
# About The Pull Request
- Fixes #92701

## Changelog
:cl:
fix: air alarm scrubber toggle mode button has its background colour again
/:cl:

