### PR TITLE
Bitrunner virtual area shuttle exploit

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -142,6 +142,20 @@
 	if(!istype(board, board_type) || !board.build_path)
 		balloon_alert(user, "invalid board!")
 		return FALSE
+
+	// Check if we're in a virtual domain and trying to install shuttle circuit boards to stop loot gremlins escaping back to station
+	var/area/current_area = get_area(src)
+	if(istype(current_area, /area/virtual_domain))
+		if(istype(board, /obj/item/circuitboard/computer/shuttle) || \
+		   ispath(board.build_path, /obj/machinery/computer/shuttle) || \
+		   ispath(board.build_path, /obj/machinery/computer/camera_advanced/shuttle_docker))
+			board.visible_message(span_danger("[board] sparks and burns out! Nanotrasen thanks you for your creativity. Your innovation has been denied and deleted."))
+			do_sparks(5, FALSE, src)
+			playsound(src, 'sound/effects/clockcult_gateway_disrupted.ogg', 50, TRUE)
+			qdel(board)
+			balloon_alert(user, "circuit board destroyed!")
+			return FALSE
+
 	if(by_hand && !user.transferItemToLoc(board, src))
 		return FALSE
 	else if(!board.forceMove(src))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -142,7 +142,6 @@
 	if(!istype(board, board_type) || !board.build_path)
 		balloon_alert(user, "invalid board!")
 		return FALSE
-
 	if(by_hand && !user.transferItemToLoc(board, src))
 		return FALSE
 	else if(!board.forceMove(src))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -143,19 +143,6 @@
 		balloon_alert(user, "invalid board!")
 		return FALSE
 
-	// Check if we're in a virtual domain and trying to install shuttle circuit boards to stop loot gremlins escaping back to station
-	var/area/current_area = get_area(src)
-	if(istype(current_area, /area/virtual_domain))
-		if(istype(board, /obj/item/circuitboard/computer/shuttle) || \
-		   ispath(board.build_path, /obj/machinery/computer/shuttle) || \
-		   ispath(board.build_path, /obj/machinery/computer/camera_advanced/shuttle_docker))
-			board.visible_message(span_danger("[board] sparks and burns out! Nanotrasen thanks you for your creativity. Your innovation has been denied and deleted."))
-			do_sparks(5, FALSE, src)
-			playsound(src, 'sound/effects/clockcult_gateway_disrupted.ogg', 50, TRUE)
-			qdel(board)
-			balloon_alert(user, "circuit board destroyed!")
-			return FALSE
-
 	if(by_hand && !user.transferItemToLoc(board, src))
 		return FALSE
 	else if(!board.forceMove(src))

--- a/code/modules/bitrunning/netpod/utils.dm
+++ b/code/modules/bitrunning/netpod/utils.dm
@@ -77,7 +77,16 @@
 		return
 
 	balloon_alert(neo, "establishing connection...")
-	if(!do_after(neo, 2 SECONDS, src))
+
+	// Prevent hand interactions during loading to stop smuggling exploits into virtual domain
+	ADD_TRAIT(neo, TRAIT_HANDS_BLOCKED, TRAIT_GENERIC)
+
+	var/connection_successful = do_after(neo, 2 SECONDS, src)
+
+	// Re-enable hand interactions after loading attempt
+	REMOVE_TRAIT(neo, TRAIT_HANDS_BLOCKED, TRAIT_GENERIC)
+
+	if(!connection_successful)
 		open_machine()
 		return
 


### PR DESCRIPTION
## About The Pull Request

Fixes #92463


https://github.com/user-attachments/assets/df5016ed-3198-4ec5-a704-6ea8e3899552



### Backpack full of goodies to smuggle in
<img width="250" alt="image" src="https://github.com/user-attachments/assets/3f1e35c7-3258-416e-be24-989644c13fe5" />

### Temporary "Neo" trait added to disable hands during the 2 second load
<img width="250" alt="image" src="https://github.com/user-attachments/assets/bfea17ea-ca67-4602-a0aa-658ecaaa7502" />

### Hands work fine in and out of domain after the 2 seconds, no smuggled items
<img width="250" alt="image" src="https://github.com/user-attachments/assets/0470fa85-82e0-438f-9f7f-151b19f0e675" />



## Why It's Good For The Game

- Fixes an exploit to take loot out of the Virtual Domain via build a shuttle.
- Explicitly prevents people taking items into the Virtual Domain.

## Changelog
:cl:
fix: Bitrunner virtual area smuggling exploit
/:cl:

> [!NOTE]
> Previous attempt at fixing this was changed.