### PR TITLE
Replaces flamethrower unique hit_reaction handling with the bullet_intercepting component

### DIFF
--- a/code/datums/components/bullet_intercepting.dm
+++ b/code/datums/components/bullet_intercepting.dm
@@ -15,7 +15,7 @@
 	/// Number of things we can block before we delete ourself (stop being able to block)
 	var/block_charges = INFINITY
 
-/datum/component/bullet_intercepting/Initialize(block_chance = 2, block_type = BULLET, active_slots, datum/callback/on_intercepted, block_charges = INFINITY)
+/datum/component/bullet_intercepting/Initialize(block_chance = 2, block_type = list(BULLET), active_slots, datum/callback/on_intercepted, block_charges = INFINITY)
 	. = ..()
 	if (!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -58,15 +58,16 @@
 /// Called when wearer is shot, check if we're going to block the hit
 /datum/component/bullet_intercepting/proc/on_wearer_shot(mob/living/victim, obj/projectile/bullet)
 	SIGNAL_HANDLER
-	if (victim != wearer || victim.stat == DEAD || bullet.armor_flag != block_type)
+	if (victim != wearer || victim.stat == DEAD || !prob(block_chance))
 		return NONE
-	if (!prob(block_chance))
-		return NONE
-	on_intercepted?.Invoke(victim, bullet)
-	block_charges--
-	if (block_charges <= 0)
-		qdel(src)
-	return PROJECTILE_INTERRUPT_HIT
+	for (var/blocktype in block_type)
+		if (bullet.armor_flag == blocktype)
+			on_intercepted?.Invoke(victim, bullet)
+			block_charges--
+			if (block_charges <= 0)
+				qdel(src)
+			return PROJECTILE_INTERRUPT_HIT
+	return NONE
 
 /// Called when wearer is deleted, stop tracking them
 /datum/component/bullet_intercepting/proc/on_wearer_deleted()

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -133,14 +133,6 @@
 		return
 
 	else if(istype(W, /obj/item/tank/internals/plasma))
-		AddComponent(\
-			/datum/component/bullet_intercepting,\
-			block_chance = 15,\
-			on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
-			active_slots = ITEM_SLOT_HANDS,\
-			block_charges = 1,\
-			block_type = list(BULLET,LASER),\
-		)
 		if(ptank)
 			if(user.transferItemToLoc(W,src))
 				ptank.forceMove(get_turf(src))
@@ -172,7 +164,6 @@
 	user.put_in_hands(ptank)
 	ptank = null
 	to_chat(user, span_notice("You remove the plasma tank from [src]!"))
-	qdel(src.GetComponent(/datum/component/bullet_intercepting))
 	update_appearance()
 	return CLICK_ACTION_SUCCESS
 
@@ -246,6 +237,14 @@
 
 /obj/item/flamethrower/Initialize(mapload)
 	. = ..()
+	AddComponent(\
+	/datum/component/bullet_intercepting,\
+		block_chance = 15,\
+		on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
+		active_slots = ITEM_SLOT_HANDS,\
+		block_type = list(BULLET,LASER),\
+		is_blocking_check = CALLBACK(src, PROC_REF(check_tank)),\
+	)
 	if(create_full)
 		if(!weldtool)
 			weldtool = new /obj/item/weldingtool(src)
@@ -256,14 +255,6 @@
 		status = TRUE
 		if(create_with_tank)
 			ptank = new /obj/item/tank/internals/plasma/full(src)
-			AddComponent(\
-				/datum/component/bullet_intercepting,\
-				block_chance = 15,\
-				on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
-				active_slots = ITEM_SLOT_HANDS,\
-				block_charges = 1,\
-				block_type = list(BULLET,LASER),\
-			)
 		update_appearance()
 	RegisterSignal(src, COMSIG_ITEM_RECHARGED, PROC_REF(instant_refill))
 
@@ -279,6 +270,9 @@
 	holder.log_message("held a flamethrower tank detonated by a projectile ([bullet])", LOG_GAME)
 	igniter.ignite_turf(src,target_turf, release_amount = 100)
 	qdel(ptank)
+
+/obj/item/flamethrower/proc/check_tank()
+	return ptank
 
 /obj/item/assembly/igniter/proc/flamethrower_process(turf/open/location)
 	location.hotspot_expose(heat,2)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -138,6 +138,14 @@
 				ptank.forceMove(get_turf(src))
 				ptank = W
 				to_chat(user, span_notice("You swap the plasma tank in [src]!"))
+			AddComponent(\
+				/datum/component/bullet_intercepting,\
+				block_chance = 15,\
+				on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
+				active_slots = ITEM_SLOT_HANDS,\
+				block_charges = 1,\
+				block_type = list(BULLET,LASER),\
+			)
 			return
 		if(!user.transferItemToLoc(W, src))
 			return
@@ -247,6 +255,14 @@
 		status = TRUE
 		if(create_with_tank)
 			ptank = new /obj/item/tank/internals/plasma/full(src)
+			AddComponent(\
+				/datum/component/bullet_intercepting,\
+				block_chance = 100,\
+				on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
+				active_slots = ITEM_SLOT_HANDS,\
+				block_charges = 1,\
+				block_type = list(BULLET,LASER),\
+			)
 		update_appearance()
 	RegisterSignal(src, COMSIG_ITEM_RECHARGED, PROC_REF(instant_refill))
 
@@ -256,15 +272,12 @@
 /obj/item/flamethrower/full/tank
 	create_with_tank = TRUE
 
-/obj/item/flamethrower/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
-	if(damage && attack_type == PROJECTILE_ATTACK && damage_type != STAMINA && prob(15))
-		owner.visible_message(span_danger("\The [attack_text] hits the fuel tank on [owner]'s [name], rupturing it! What a shot!"))
-		var/turf/target_turf = get_turf(owner)
-		owner.log_message("held a flamethrower tank detonated by a projectile ([hitby])", LOG_GAME)
-		igniter.ignite_turf(src,target_turf, release_amount = 100)
-		qdel(ptank)
-		return 1 //It hit the flamethrower, not them
-
+/obj/item/flamethrower/proc/intercepted_bullet_reaction(mob/living/holder, obj/projectile/bullet)
+	holder.visible_message(span_danger("\The [bullet] hits the fuel tank on [holder]'s [name], rupturing it! What a shot!"))
+	var/turf/target_turf = get_turf(holder)
+	holder.log_message("held a flamethrower tank detonated by a projectile ([bullet])", LOG_GAME)
+	igniter.ignite_turf(src,target_turf, release_amount = 100)
+	qdel(ptank)
 
 /obj/item/assembly/igniter/proc/flamethrower_process(turf/open/location)
 	location.hotspot_expose(heat,2)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -133,19 +133,19 @@
 		return
 
 	else if(istype(W, /obj/item/tank/internals/plasma))
+		AddComponent(\
+			/datum/component/bullet_intercepting,\
+			block_chance = 15,\
+			on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
+			active_slots = ITEM_SLOT_HANDS,\
+			block_charges = 1,\
+			block_type = list(BULLET,LASER),\
+		)
 		if(ptank)
 			if(user.transferItemToLoc(W,src))
 				ptank.forceMove(get_turf(src))
 				ptank = W
 				to_chat(user, span_notice("You swap the plasma tank in [src]!"))
-			AddComponent(\
-				/datum/component/bullet_intercepting,\
-				block_chance = 15,\
-				on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
-				active_slots = ITEM_SLOT_HANDS,\
-				block_charges = 1,\
-				block_type = list(BULLET,LASER),\
-			)
 			return
 		if(!user.transferItemToLoc(W, src))
 			return
@@ -172,6 +172,7 @@
 	user.put_in_hands(ptank)
 	ptank = null
 	to_chat(user, span_notice("You remove the plasma tank from [src]!"))
+	qdel(src.GetComponent(/datum/component/bullet_intercepting))
 	update_appearance()
 	return CLICK_ACTION_SUCCESS
 
@@ -257,7 +258,7 @@
 			ptank = new /obj/item/tank/internals/plasma/full(src)
 			AddComponent(\
 				/datum/component/bullet_intercepting,\
-				block_chance = 100,\
+				block_chance = 15,\
 				on_intercepted = CALLBACK(src, PROC_REF(intercepted_bullet_reaction)),\
 				active_slots = ITEM_SLOT_HANDS,\
 				block_charges = 1,\


### PR DESCRIPTION
## About The Pull Request

Flamethrower exploding when shot was handled by hit_reaction previously, and will now use the generic bullet_intercepting component. Also adds handling for multiple projectile types in the bullet_intercepting component, as well as a check for whether the object currently can block bullets. Should have no gameplay changes.

## Why It's Good For The Game

closes #81863 , they said it'd be better consistency

## Changelog
:cl:

no player-facing changes(hopefully)

/:cl:
