### PR TITLE
the junkening

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/junk.dm
+++ b/code/modules/projectiles/ammunition/ballistic/junk.dm
@@ -1,10 +1,10 @@
 // Junk
 
-/obj/item/ammo_casing/junk
+/obj/item/ammo_casing/shotgun/junk
 	name = "improvised junk round"
 	desc = "What is in the shell? Shoot it to find out."
 	icon_state = "improvshell"
-	caliber = CALIBER_JUNK
+	caliber = CALIBER_SHOTGUN
 	projectile_type = /obj/projectile/bullet/junk
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*2, /datum/material/glass=SMALL_MATERIAL_AMOUNT*1)
 
@@ -15,29 +15,29 @@
 	desc = "Bullet. Bullet Bullet."
 	icon_state = "junkround"
 	loot = list(
-		/obj/item/ammo_casing/junk = 50,
-		/obj/item/ammo_casing/junk/incendiary = 20,
-		/obj/item/ammo_casing/junk/shock = 20,
-		/obj/item/ammo_casing/junk/hunter = 20,
-		/obj/item/ammo_casing/junk/phasic = 5,
-		/obj/item/ammo_casing/junk/ripper = 5,
-		/obj/item/ammo_casing/junk/reaper = 1,
+		/obj/item/ammo_casing/shotgun/junk = 50,
+		/obj/item/ammo_casing/shotgun/junk/incendiary = 20,
+		/obj/item/ammo_casing/shotgun/junk/shock = 20,
+		/obj/item/ammo_casing/shotgun/junk/hunter = 20,
+		/obj/item/ammo_casing/shotgun/junk/phasic = 5,
+		/obj/item/ammo_casing/shotgun/junk/ripper = 5,
+		/obj/item/ammo_casing/shotgun/junk/reaper = 1,
 	)
 
-/obj/item/ammo_casing/junk/incendiary
+/obj/item/ammo_casing/shotgun/junk/incendiary
 	projectile_type = /obj/projectile/bullet/incendiary/fire/junk
 
-/obj/item/ammo_casing/junk/phasic
+/obj/item/ammo_casing/shotgun/junk/phasic
 	projectile_type = /obj/projectile/bullet/junk/phasic
 
-/obj/item/ammo_casing/junk/shock
+/obj/item/ammo_casing/shotgun/junk/shock
 	projectile_type = /obj/projectile/bullet/junk/shock
 
-/obj/item/ammo_casing/junk/hunter
+/obj/item/ammo_casing/shotgun/junk/hunter
 	projectile_type = /obj/projectile/bullet/junk/hunter
 
-/obj/item/ammo_casing/junk/ripper
+/obj/item/ammo_casing/shotgun/junk/ripper
 	projectile_type = /obj/projectile/bullet/junk/ripper
 
-/obj/item/ammo_casing/junk/reaper
+/obj/item/ammo_casing/shotgun/junk/reaper
 	projectile_type = /obj/projectile/bullet/junk/reaper

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -13,8 +13,8 @@
 
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun
 	name = "pipegun internal magazine"
-	caliber = CALIBER_JUNK
-	ammo_type = /obj/item/ammo_casing/junk
+	caliber = CALIBER_SHOTGUN
+	ammo_type = /obj/item/ammo_casing/shotgun/junk
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol
@@ -24,12 +24,12 @@
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
 	name = "regal pipegun internal magazine"
 	max_ammo = 4
-	ammo_type = /obj/item/ammo_casing/junk/reaper
+	ammo_type = /obj/item/ammo_casing/shotgun/junk/reaper
 
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol/prime
 	name = "regal pipe pistol internal magazine"
 	max_ammo = 6
-	ammo_type = /obj/item/ammo_casing/junk/reaper
+	ammo_type = /obj/item/ammo_casing/shotgun/junk/reaper
 
 /obj/item/ammo_box/magazine/internal/enchanted
 	max_ammo = 1

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -296,8 +296,8 @@
 	worn_icon_state = "pipegun"
 	fire_sound = 'sound/items/weapons/gun/sniper/shot.ogg'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun
-
-	projectile_damage_multiplier = 1.35
+	spread = 15
+	projectile_damage_multiplier = 1
 	obj_flags = UNIQUE_RENAME
 	can_be_sawn_off = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL


### PR DESCRIPTION
## About The Pull Request

Junk rounds are now shotgun rounds. Pipeguns can now take normal shotgun rounds.

Slight pipegun adjustment that I think is good (more spread, less damage)

## Why It's Good For The Game

Pipeguns are useless in their current state. You make them a handful of times when you're starting to learn the game, and then you realize how shit and useless they are. You're better off just getting a real gun, that shoots real bullets. 

You really only need a nail and a hammer to shoot a bullet in real life. Someone with some know-how should be able to slap together a pipe with a firing mechanism. 

5 minutes of google searching found a handful of people making pipeguns shooting 12 gauge bullets without an issue in real life.

Also junk rounds are even more useful, because they are mass-producible (while still weak) shotgun rounds.

## Changelog
:cl:
change; Junk rounds can go in shotguns
change; Pipeguns can take normal shotgun ammo
/:cl:
