### PR TITLE
Changes the tooltip for holders of the lockable_storage component to be accurate

### DIFF
--- a/code/datums/components/lockable_storage.dm
+++ b/code/datums/components/lockable_storage.dm
@@ -91,9 +91,8 @@
 		if(source in user.held_items)
 			context[SCREENTIP_CONTEXT_LMB] = "Open storage"
 			return CONTEXTUAL_SCREENTIP_SET
-		else
-			context[SCREENTIP_CONTEXT_RMB] = "Open storage"
-			return CONTEXTUAL_SCREENTIP_SET
+		context[SCREENTIP_CONTEXT_RMB] = "Open storage"
+		return CONTEXTUAL_SCREENTIP_SET
 
 	if(can_hack_open)
 		switch(held_item.tool_behaviour)

--- a/code/datums/components/lockable_storage.dm
+++ b/code/datums/components/lockable_storage.dm
@@ -88,6 +88,15 @@
 /datum/component/lockable_storage/proc/on_requesting_context_from_item(datum/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER
 	if(isnull(held_item))
+		if(user.get_slot_by_item(source))
+			context[SCREENTIP_CONTEXT_LMB] = "Open storage"
+			return CONTEXTUAL_SCREENTIP_SET
+		else
+			context[SCREENTIP_CONTEXT_RMB] = "Open storage"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	if(held_item == source)
+		if(source.loc == user)
 		context[SCREENTIP_CONTEXT_LMB] = "Open storage"
 		return CONTEXTUAL_SCREENTIP_SET
 

--- a/code/datums/components/lockable_storage.dm
+++ b/code/datums/components/lockable_storage.dm
@@ -88,17 +88,12 @@
 /datum/component/lockable_storage/proc/on_requesting_context_from_item(datum/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER
 	if(isnull(held_item))
-		if(user.get_slot_by_item(source))
+		if(source in user.held_items)
 			context[SCREENTIP_CONTEXT_LMB] = "Open storage"
 			return CONTEXTUAL_SCREENTIP_SET
 		else
 			context[SCREENTIP_CONTEXT_RMB] = "Open storage"
 			return CONTEXTUAL_SCREENTIP_SET
-
-	if(held_item == source)
-		if(source.loc == user)
-		context[SCREENTIP_CONTEXT_LMB] = "Open storage"
-		return CONTEXTUAL_SCREENTIP_SET
 
 	if(can_hack_open)
 		switch(held_item.tool_behaviour)


### PR DESCRIPTION
## About The Pull Request

Previously, it would always say [left-click icon] open storage if you had an empty hand. This makes it so that if the item is on the ground, it'll say [right-click icon] open storage. if it's in your other hand, it'll still say [left-click icon]. 

## Why It's Good For The Game

fixes #87340

## Changelog
:cl:

fix: tooltip for secure briefcases now shows correct button.

/:cl:
