### PR TITLE
Prevents bone from being grilled into steak

### DIFF
--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -153,6 +153,9 @@
 /obj/item/food/meat/slab/human/mutant/skeleton/make_processable()
 	return //skeletons don't have cutlets
 
+/obj/item/food/meat/slab/human/mutant/skeleton/make_grillable()
+	return
+
 /obj/item/food/meat/slab/human/mutant/zombie
 	name = "meat (rotten)"
 	icon_state = "rottenmeat"


### PR DESCRIPTION

## About The Pull Request

Removes the ability to grill the mutant/skeleton subtype of meat slabs, because there's no meat on that bone.

## Why It's Good For The Game

closes #88767
there ain't no meat on that bone

## Changelog
:cl:

del: you can't grill a bone into a steak anymore

/:cl:
