### PR TITLE
Gives blood to heretic victims upon arriving in mansus

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -22,6 +22,8 @@
 
 /datum/status_effect/unholy_determination/on_apply()
 	owner.add_traits(list(TRAIT_COAGULATING, TRAIT_NOCRITDAMAGE, TRAIT_NOSOFTCRIT), TRAIT_STATUS_EFFECT(id))
+	if(owner.blood_volume < BLOOD_VOLUME_OKAY)
+		owner.blood_volume = BLOOD_VOLUME_OKAY
 	return TRUE
 
 /datum/status_effect/unholy_determination/on_remove()


### PR DESCRIPTION

## About The Pull Request

Restores victims of a heretic sacrifice's blood to blood_volume_okay if they need it upon arriving in the mansus.
Does not conflict with #92119.

## Why It's Good For The Game

closes #88557
As was said in the issue, dying because you were too asleep to do anything about it is lame. The determination buff already gives you quite strong blood regen, but it's the initial value that counts.

## Changelog

:cl:

qol: You will no longer fall asleep from bloodloss upon arriving in the Mansus.

/:cl:
