### PR TITLE
Moves bots elsewhere on wawa AI Sat to stop girder blockage at round start.

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -1038,8 +1038,7 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "aqT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
+/mob/living/basic/bot/cleanbot,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "arl" = (
@@ -11307,10 +11306,6 @@
 /area/station/service/janitor)
 "dWb" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/mob/living/basic/bot/repairbot,
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -16826,6 +16821,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"fSI" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "fSK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -24204,12 +24206,11 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "iuU" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/mob/living/basic/bot/cleanbot,
-/obj/effect/turf_decal/stripes{
-	dir = 5
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "iuV" = (
@@ -28150,8 +28151,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "jNg" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
+/mob/living/basic/bot/repairbot,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jNh" = (
@@ -58674,6 +58674,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/service/theater)
+"udu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "udG" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
@@ -102189,7 +102198,7 @@ qYV
 sQd
 rgp
 mIe
-qBt
+udu
 vBs
 hfm
 eVE
@@ -169011,7 +169020,7 @@ faK
 lXe
 aOQ
 iXx
-dVu
+fSI
 jMy
 srs
 mxt

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -16821,13 +16821,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
-"fSI" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "fSK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -169020,7 +169013,7 @@ faK
 lXe
 aOQ
 iXx
-fSI
+dVu
 jMy
 srs
 mxt


### PR DESCRIPTION
## About The Pull Request
| Round start pest |
|--------|
| <img width="603" height="791" alt="image" src="https://github.com/user-attachments/assets/196a40ec-b272-41af-a070-e6c50f8eeb85" /> | 


Currently the fixit bot blocks off wawa AI sat space entrance with girders every round start, due to its close proximity to the open space, the little guy believes it is a space breach and wants to fix it.

So I have exiled him up the stairs where he cannot build girders anymore.

The cleaner bot used to live downstairs too and up he goes as well.

|   After |
|--------|
| <img width="857" height="1149" alt="image" src="https://github.com/user-attachments/assets/a58ca7bb-30fb-4759-b829-e518f726edec" />|
| <img width="782" height="1148" alt="image" src="https://github.com/user-attachments/assets/919ed107-0f76-438c-a9be-eb214808c063" /> |
## Why It's Good For The Game

- Unintentional round start blockage
- Ghost spawn bots a little safer meaning more players can use them
- I fixed this during Wallening, that got unmerged, forgot about it, saw it again and went to fix it again.
## Changelog
:cl:
fix: Moves bots elsewhere on wawa AI Sat to stop girder blockage at round start.
/:cl:
