### PR TITLE
Plastic surgery message no longer broadcasts to viewers

### DIFF
--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -93,7 +93,7 @@
 				for(var/namelist as anything in disguises.picture?.names_seen)
 					names += namelist
 			else
-				user.visible_message(span_warning("You have no picture to base the appearance on, reverting to random appearances."))
+				to_chat(user, span_warning("You have no picture to base the appearance on, reverting to random appearances."))
 				for(var/i in 1 to 10)
 					names += target.generate_random_mob_name(TRUE)
 		else


### PR DESCRIPTION

## About The Pull Request

The message for generating random appearances during plastic surgery is a to_chat instead of a visible_message now.
## Why It's Good For The Game

The message is directed at, and only relevant for, the guy doing surgery. This doesn't need to be broadcast.
## Changelog
:cl: Rhials
fix: When lacking a reference picture for plastic surgery, the alert message will be sent to the surgery performer instead of everyone nearby.
/:cl:
