### PR TITLE
Replaces the five tables in Wawa's garden

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -19576,8 +19576,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/flesh_shears{
-	pixel_y = 10;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
@@ -20469,7 +20469,7 @@
 	spawn_random_offset = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/table/wood/shuttle_bar,
+/obj/structure/table/wood,
 /turf/open/floor/iron/textured_large,
 /area/station/service/hydroponics/garden)
 "heP" = (
@@ -25628,7 +25628,7 @@
 	dir = 9
 	},
 /obj/item/storage/bag/plants,
-/obj/structure/table/wood/shuttle_bar,
+/obj/structure/table/wood,
 /turf/open/floor/iron/textured_large,
 /area/station/service/hydroponics/garden)
 "iVY" = (
@@ -32050,8 +32050,8 @@
 "kZS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/north{
-	req_access = list("hydroponics");
-	name = "Hydroponics Desk"
+	name = "Hydroponics Desk";
+	req_access = list("hydroponics")
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -32613,8 +32613,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/holosign_creator/robot_seat/bar{
-	pixel_y = 4;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /obj/item/clothing/head/hats/tophat,
 /turf/open/floor/iron/dark,
@@ -32825,8 +32825,8 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/item/toy/figure/ian{
-	pixel_y = 15;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 15
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
@@ -49957,8 +49957,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/greenscreen_camera{
 	dir = 8;
-	pixel_y = 6;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
@@ -50268,8 +50268,8 @@
 	pixel_y = 9
 	},
 /obj/item/stamp/head/hos{
-	pixel_y = 11;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 11
 	},
 /obj/machinery/computer/records/security/laptop{
 	dir = 1
@@ -52698,7 +52698,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/west,
-/obj/structure/table/wood/shuttle_bar,
+/obj/structure/table/wood,
 /turf/open/floor/iron/textured_large,
 /area/station/service/hydroponics/garden)
 "sdc" = (
@@ -54377,7 +54377,7 @@
 	dir = 6
 	},
 /obj/effect/spawner/random/food_or_drink/plant_produce,
-/obj/structure/table/wood/shuttle_bar,
+/obj/structure/table/wood,
 /turf/open/floor/iron/textured_large,
 /area/station/service/hydroponics/garden)
 "sFB" = (
@@ -55203,7 +55203,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
-/obj/structure/table/wood/shuttle_bar,
+/obj/structure/table/wood,
 /turf/open/floor/iron/textured_large,
 /area/station/service/hydroponics/garden)
 "sTS" = (
@@ -56091,8 +56091,8 @@
 "tkR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
-	req_access = list("hydroponics");
-	name = "Hydroponics Desk"
+	name = "Hydroponics Desk";
+	req_access = list("hydroponics")
 	},
 /obj/structure/desk_bell,
 /obj/machinery/door/firedoor,
@@ -64291,8 +64291,8 @@
 	pixel_y = 9
 	},
 /obj/item/holosign_creator/atmos{
-	pixel_y = 11;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 11
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/pipe_dispenser,


### PR DESCRIPTION

## About The Pull Request

<img width="876" height="397" alt="image" src="https://github.com/user-attachments/assets/fc8d9173-67cd-43fb-8715-1b5f8b282c72" />
These aren't the right tables for the occasion.

## Why It's Good For The Game

<img width="603" height="99" alt="image" src="https://github.com/user-attachments/assets/80e0b316-4d1e-44dc-98ce-d75156ed2bcc" />

wOOO!!!

## Changelog
:cl:
fix: Wawastation's garden tables won't fling you around anymore
/:cl:
