### PR TITLE
Prevents remote signaler suicide from transferring between bodies

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -37,14 +37,13 @@
 	suicide_mob = REF(user)
 	return MANUAL_SUICIDE_NONLETHAL
 
-/obj/item/assembly/signaler/proc/manual_suicide(datum/mind/suicidee)
-	var/mob/living/user = suicidee.current
+/obj/item/assembly/signaler/proc/manual_suicide()
+	var/mob/living/user = suicider.current
 	if(!istype(user))
 		return
-	if(suicide_mob == REF(user))
-		user.visible_message(span_suicide("[user]'s [src] receives a signal, killing [user.p_them()] instantly!"))
-	else
-		user.visible_message(span_suicide("[user]'s [src] receives a signal and [user.p_they()] die[user.p_s()] like a gamer!"))
+	if(suicide_mob != REF(user))
+		return
+	user.visible_message(span_suicide("[user]'s [src] receives a signal, killing [user.p_them()] instantly!"))
 	user.set_suicide(TRUE)
 	user.adjustOxyLoss(200)//it sends an electrical pulse to their heart, killing them. or something.
 	user.death(FALSE)
@@ -164,7 +163,7 @@
 	if(signal.data["code"] != code)
 		return
 	if(suicider)
-		manual_suicide(suicider)
+		manual_suicide()
 		return
 
 	// If the holder is a TTV, we want to store the last received signal to incorporate it into TTV logging, else wipe it.


### PR DESCRIPTION

## About The Pull Request

Makes it so that if you leave the body you ate the signaler with, you won't be killed in your new body. The old body will also not be killed. 

## Why It's Good For The Game

fixes #86732

Originally, there was [an issue with mindswap wizards being able to just kill people with this](#45855), but this was fixed with #45865. This "Fix" just made it so that it follows you between bodies, presumably as cathartic revenge against attempted exploiters. But nowadays, it's just an odd thing that looks like a bug.

## Changelog
:cl:

fix: prevents eaten remote signalers from following you between bodies

/:cl:
