### PR TITLE
Prevents non-humantypes from whistling

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -796,7 +796,7 @@
 	message_mime = "makes a rude gesture!"
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/carbon/whistle
+/datum/emote/living/carbon/human/whistle
 	key = "whistle"
 	key_third_person = "whistles"
 	message = "whistles."
@@ -804,5 +804,5 @@
 	vary = TRUE
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 
-/datum/emote/living/carbon/whistle/get_sound(mob/living/user)
+/datum/emote/living/carbon/human/whistle/get_sound(mob/living/user)
 	return 'sound/mobs/humanoids/human/whistle/whistle1.ogg'


### PR DESCRIPTION
## About The Pull Request

Types the whistle emote to /human. 

## Why It's Good For The Game

fixes #83663 

## Changelog

:cl:

fix: Xenomorphs can no longer whistle

/:cl:
