### PR TITLE
Fixes recovered crew blood-related runtimes

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -476,6 +476,9 @@
 	if (!splatter_turf)
 		splatter_turf = get_turf(src)
 
+	if (!splatter_turf)
+		return
+
 	// Check for husking and TRAIT_NOBLOOD
 	switch (can_bleed(BLOOD_COVER_TURFS))
 		if (BLEED_NONE)


### PR DESCRIPTION

## About The Pull Request

This was runtiming as recovered crew attempted to attack corpses with weapons in nullspace, thus trying to add blood to null turfs. This case should just early return null as nothing got created.

## Changelog
:cl:
fix: Fixed recovered crew blood-related runtimes
/:cl:
