### PR TITLE
Fixes constant runtimes and broken APC processing behavior on emagged APCs

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -594,11 +594,10 @@
 		hacked_flicker_counter = hacked_flicker_counter - 1
 		if(hacked_flicker_counter <= 0)
 			flicker_hacked_icon()
-		if(COOLDOWN_FINISHED(src, malf_ai_pt_generation) && cell.use(60 KILO JOULES)>0 && malfai.malf_picker.processing_time<MALF_MAX_PP) // Over time generation of malf points for the ai controlling it, costs a bit of power
-			COOLDOWN_START(src, malf_ai_pt_generation, 30 SECONDS)
-			malfai.malf_picker.processing_time += 1
 
-
+	if(malfai && COOLDOWN_FINISHED(src, malf_ai_pt_generation) && cell.use(60 KILO JOULES) > 0 && malfai.malf_picker.processing_time < MALF_MAX_PP) // Over time generation of malf points for the ai controlling it, costs a bit of power
+		COOLDOWN_START(src, malf_ai_pt_generation, 30 SECONDS)
+		malfai.malf_picker.processing_time += 1
 
 	//dont use any power from that channel if we shut that power channel off
 	if(operating)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -590,7 +590,7 @@
 		force_update = TRUE
 		return
 
-	if(obj_flags & EMAGGED || malfai)
+	if((obj_flags & EMAGGED) || malfai)
 		hacked_flicker_counter = hacked_flicker_counter - 1
 		if(hacked_flicker_counter <= 0)
 			flicker_hacked_icon()


### PR DESCRIPTION

## About The Pull Request

If an APC was emagged it would permanently half-break as it would assume that it had a malf AI that it needed to add points to, and would not update its charge states

## Changelog
:cl:
fix: Fixed constant runtimes and broken APC processing behavior on emagged APCs
/:cl:
