### PR TITLE
Fugitive Hunters spawn again

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -830,7 +830,7 @@
 		HUNTER_PACK_MI13,
 	)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(check_spawn_hunters), hunter_backstory, 10 MINUTES), 1 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(check_spawn_hunters), 10 MINUTES), 1 MINUTES)
 
 /datum/dynamic_ruleset/midround/from_ghosts/fugitives/assign_role(datum/mind/candidate, datum/team/fugitive/team, turf/team_spawn)
 	candidate.current.forceMove(team_spawn)


### PR DESCRIPTION

## About The Pull Request

Fugitive hunters no longer runtime on their timer check. 

The `check_spawn_hunters` proc was getting passed the fugitive hunters' backstory (not needed in the proc) instead of the time until their expected spawn.
## Why It's Good For The Game

The fugitive hunters are a pretty important part of the fugitive antag. It's like playing hide and seek without any seekers. It sucks.

Closes the unresolved part of #92618.
## Changelog
:cl: Rhials
fix: Fugitive hunters spawn again.
/:cl:
