### PR TITLE
restores the X-01 Multiphase to 12 lethal shots after it was mistakenly set to 10 (2 years ago)

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -36,7 +36,7 @@
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
-	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE * 1.2)
+	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE * 1.2)
 
 /obj/item/ammo_casing/energy/laser/musket
 	projectile_type = /obj/projectile/beam/laser/musket


### PR DESCRIPTION

## About The Pull Request

[This PR](https://github.com/tgstation/tgstation/pull/78677) accidentally took off two shots from the total number of lethal shots that the X-01 Multiphase had available during a refactor. This is not a listed change. Before this change (and a bunch of power changes that slightly muddied this), the laser casing would use 120 charge from a cell capacity of 1200. So, 12 total possible shots.

## Why It's Good For The Game

I'm really surprised this went entirely unnoticed for so long.

## Changelog
:cl:
fix: The X-01 Multiphase Energy Gun once again has 12 lethal shots rather than 10.
/:cl:
