### PR TITLE
Sets the X-01 Multiphase to 12 lethal shots to match the energy gun

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -36,7 +36,7 @@
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
-	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE * 1.2)
+	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE * 1.2)
 
 /obj/item/ammo_casing/energy/laser/musket
 	projectile_type = /obj/projectile/beam/laser/musket


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. If you saw a PR similar to this one. You didn't.

## Why It's Good For The Game

It's really weird that the X-01 is, for whatever reason, inferior to the energy gun in terms of lethal capacity but not in terms of nonlethal capacity. I don't really get it, so let's put in two shots.

## Changelog
:cl:
balance: The Multiphase X-01 has 12 lethal shots to match the capacity of the standard energy gun.
/:cl:
