### PR TITLE
Prevent escape pods from being considered "planetary" by the Spacer perk

### DIFF
--- a/code/__HELPERS/levels.dm
+++ b/code/__HELPERS/levels.dm
@@ -52,9 +52,13 @@
 		// Central Command is definitely in space
 		return FALSE
 
-	if(what.onSyndieBase())
+	if(what.onSyndieBase() && !what.on_escaped_shuttle())
 		// Syndicate recon outpost is on some moon or something
 		return TRUE
+
+	if(is_reserved_level(what_turf.z))
+		// Reserved levels are primarily shuttles aside from syndie base
+		return FALSE
 
 	// Finally, more specific checks are ran for edge cases, such as lazily loaded map templates or away missions. Not perfect.
 	return istype(what_turf) && what_turf.planetary_atmos && what_turf.has_gravity()


### PR DESCRIPTION

## About The Pull Request

The Spacer perk checked is_on_a_planet(), which checked a few other things including onSyndieBase(), but onSyndieBase() was made for scoring purposes(I think) so onSyndieBase() end returns on_escaped_shuttle(), which is true for escape pods so onSyndieBase() was returning true for escape pods, so escape pods got syndicate gravity.

This pr only lets the syndicate base give gravity if it's not on a shuttle, and makes reserved areas by default space(except syndie base). 

## Why It's Good For The Game

fixes #81750
fixes #89960

## Changelog
:cl:

fix: Escape pods no longer have planetary gravity

/:cl:
