### PR TITLE
Allow localhosts to set "dev override preferences" to load a specific preference savefile for guests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Local overrides--you can use this to change the config for your dev environment (like setting up SQL) without worrying about committing it
 /config/dev_overrides.txt
+/config/dev_preferences.json
 
 #Ignore everything in datafolder and subdirectories
 /data/**/*

--- a/code/__DEFINES/admin_verb.dm
+++ b/code/__DEFINES/admin_verb.dm
@@ -92,3 +92,4 @@ _ADMIN_VERB(verb_path_name, verb_permissions, verb_name, verb_desc, verb_categor
 
 // Visibility flags
 #define ADMIN_VERB_VISIBLITY_FLAG_MAPPING_DEBUG "Map-Debug"
+#define ADMIN_VERB_VISIBLITY_FLAG_LOCALHOST "Localhost"

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -38,6 +38,9 @@
 
 #define TOGGLES_DEFAULT_CHAT (CHAT_OOC|CHAT_DEAD|CHAT_PRAYER|CHAT_PULLR|CHAT_GHOSTPDA|CHAT_GHOSTRADIO|CHAT_BANKCARD|CHAT_GHOSTLAWS|CHAT_LOGIN_LOGOUT)
 
+/// File path to the dev preference json file, which is loaded by guests while localhosting.
+#define DEV_PREFS_PATH "config/dev_preferences.json"
+
 #define PARALLAX_INSANE "Insane"
 #define PARALLAX_HIGH "High"
 #define PARALLAX_MED "Medium"

--- a/code/controllers/subsystem/admin_verbs.dm
+++ b/code/controllers/subsystem/admin_verbs.dm
@@ -132,6 +132,8 @@ SUBSYSTEM_DEF(admin_verbs)
 
 	// refresh their verbs
 	admin_visibility_flags[admin.ckey] ||= list()
+	if(admin.is_localhost())
+		admin_visibility_flags[admin.ckey] |= list(ADMIN_VERB_VISIBLITY_FLAG_LOCALHOST)
 	for(var/datum/admin_verb/verb_singleton as anything in get_valid_verbs_for_admin(admin))
 		verb_singleton.assign_to_client(admin)
 	admin.init_verbs()

--- a/code/datums/json_savefile.dm
+++ b/code/datums/json_savefile.dm
@@ -118,3 +118,7 @@ GENERAL_PROTECT_DATUM(/datum/json_savefile)
 		return TRUE
 
 	return FALSE
+
+/// Copies the entire tree to another json savefile datum, overwriting whatever was in the other datum before.
+/datum/json_savefile/proc/copy_to_savefile(datum/json_savefile/other_savefile)
+	other_savefile.tree = tree.Copy()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1037,6 +1037,9 @@ ADMIN_VERB(export_save_to_dev_preference, R_DEBUG, "Export Save as Dev Preferenc
 	if(!usr.client.is_localhost())
 		tgui_alert(usr, "You shouldn't be using this right now!", "Export Failed", list("OK"))
 		return
+	if(is_guest_key(usr.ckey))
+		tgui_alert(usr, "Guests don't have preferences to export.", "Export Failed", list("OK"))
+		return
 	var/datum/preferences/usr_prefs = usr.client.prefs
 	var/datum/json_savefile/dev_save = new("config/dev_preferences.json")
 	usr_prefs.save_preferences()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1034,16 +1034,18 @@ ADMIN_VERB(count_instances, R_DEBUG, "Count Atoms/Datums", "Count how many atom 
 
 ADMIN_VERB_VISIBILITY(export_save_to_dev_preference, ADMIN_VERB_VISIBLITY_FLAG_LOCALHOST)
 ADMIN_VERB(export_save_to_dev_preference, R_DEBUG, "Export Save as Dev Preferences", "Exports your savefile to be used by any guests that connect to your localost.", ADMIN_CATEGORY_SERVER)
-	if(!usr.client.is_localhost())
-		tgui_alert(usr, "You shouldn't be using this right now!", "Export Failed", list("OK"))
+	if(!user.is_localhost())
+		tgui_alert(user, "You shouldn't be using this right now!", "Export Failed", list("OK"))
+		log_admin("[key_name(user)] attempted to export preferences to [DEV_PREFS_PATH] - this is normally locked to localhost only!")
+		stack_trace("Export Save as Dev Preferences was called by a non-localhost user!")
 		return
-	if(is_guest_key(usr.key))
-		tgui_alert(usr, "Guests don't have preferences to export.", "Export Failed", list("OK"))
+	if(is_guest_key(user.key))
+		tgui_alert(user, "Guests don't have preferences to export.", "Export Failed", list("OK"))
 		return
-	var/datum/preferences/usr_prefs = usr.client.prefs
+	var/datum/preferences/user_prefs = user.prefs
 	var/datum/json_savefile/dev_save = new(DEV_PREFS_PATH)
-	usr_prefs.save_preferences()
-	usr_prefs.savefile.copy_to_savefile(dev_save)
+	user_prefs.save_preferences()
+	user_prefs.savefile.copy_to_savefile(dev_save)
 	dev_save.save()
-	tgui_alert(usr, "Exported preferences to [DEV_PREFS_PATH]. \
+	tgui_alert(user, "Exported preferences to [DEV_PREFS_PATH]. \
 		Next time you localhost as a guest it will use this savefile as-is.", "Export Complete", list("OK thanks"))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1037,7 +1037,7 @@ ADMIN_VERB(export_save_to_dev_preference, R_DEBUG, "Export Save as Dev Preferenc
 	if(!usr.client.is_localhost())
 		tgui_alert(usr, "You shouldn't be using this right now!", "Export Failed", list("OK"))
 		return
-	if(is_guest_key(usr.ckey))
+	if(is_guest_key(usr.key))
 		tgui_alert(usr, "Guests don't have preferences to export.", "Export Failed", list("OK"))
 		return
 	var/datum/preferences/usr_prefs = usr.client.prefs

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1041,9 +1041,9 @@ ADMIN_VERB(export_save_to_dev_preference, R_DEBUG, "Export Save as Dev Preferenc
 		tgui_alert(usr, "Guests don't have preferences to export.", "Export Failed", list("OK"))
 		return
 	var/datum/preferences/usr_prefs = usr.client.prefs
-	var/datum/json_savefile/dev_save = new("config/dev_preferences.json")
+	var/datum/json_savefile/dev_save = new(DEV_PREFS_PATH)
 	usr_prefs.save_preferences()
 	usr_prefs.savefile.copy_to_savefile(dev_save)
 	dev_save.save()
-	tgui_alert(usr, "Exported preferences to /config/dev_preferences.json. \
+	tgui_alert(usr, "Exported preferences to [DEV_PREFS_PATH]. \
 		Next time you localhost as a guest it will use this savefile as-is.", "Export Complete", list("OK thanks"))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1031,3 +1031,16 @@ ADMIN_VERB(count_instances, R_DEBUG, "Count Atoms/Datums", "Count how many atom 
 	. = list()
 	CRASH("count_datums not supported on OpenDream")
 #endif
+
+ADMIN_VERB_VISIBILITY(export_save_to_dev_preference, ADMIN_VERB_VISIBLITY_FLAG_LOCALHOST)
+ADMIN_VERB(export_save_to_dev_preference, R_DEBUG, "Export Save as Dev Preferences", "Exports your savefile to be used by any guests that connect to your localost.", ADMIN_CATEGORY_SERVER)
+	if(!usr.client.is_localhost())
+		tgui_alert(usr, "You shouldn't be using this right now!", "Export Failed", list("OK"))
+		return
+	var/datum/preferences/usr_prefs = usr.client.prefs
+	var/datum/json_savefile/dev_save = new("config/dev_preferences.json")
+	usr_prefs.save_preferences()
+	usr_prefs.savefile.copy_to_savefile(dev_save)
+	dev_save.save()
+	tgui_alert(usr, "Exported preferences to /config/dev_preferences.json. \
+		Next time you localhost as a guest it will use this savefile as-is.", "Export Complete", list("OK thanks"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(IS_CLIENT_OR_MOCK(parent))
 		if(is_guest_key(parent.key))
 			if(parent.is_localhost())
-				path = "config/dev_preferences.json" // guest + locallost = dev instance, load dev preferences if possible
+				path = DEV_PREFS_PATH // guest + locallost = dev instance, load dev preferences if possible
 			else
 				load_and_save = FALSE // guest + not localhost = guest on live, don't save anything
 		else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -101,8 +101,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		middleware += new middleware_type(src)
 
 	if(IS_CLIENT_OR_MOCK(parent))
-		load_and_save = !is_guest_key(parent.key)
-		load_path(parent.ckey)
+		var/is_guest = is_guest_key(parent.key)
+		var/is_localhost = parent.is_localhost(parent)
+		load_and_save = !is_guest
+		if(is_localhost && is_guest)
+			path = "config/dev_preferences.json"
+		else
+			load_path(parent.ckey)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -101,13 +101,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		middleware += new middleware_type(src)
 
 	if(IS_CLIENT_OR_MOCK(parent))
-		var/is_guest = is_guest_key(parent.key)
-		var/is_localhost = parent.is_localhost(parent)
-		load_and_save = !is_guest
-		if(is_localhost && is_guest)
-			path = "config/dev_preferences.json"
+		if(is_guest_key(parent.key))
+			if(parent.is_localhost())
+				path = "config/dev_preferences.json" // guest + locallost = dev instance, load dev preferences if possible
+			else
+				load_and_save = FALSE // guest + not localhost = guest on live, don't save anything
 		else
-			load_path(parent.ckey)
+			load_path(parent.ckey) // not guest = load their actual savefile
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -275,6 +275,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/save_preferences()
 	if(!savefile)
 		CRASH("Attempted to save the preferences of [parent] without a savefile. This should have been handled by load_preferences()")
+	if(path == DEV_PREFS_PATH)
+		// Don't save over dev preferences
+		return TRUE
+
 	savefile.set_entry("version", SAVEFILE_VERSION_MAX) //updates (or failing that the sanity checks) will ensure data is not invalid at load. Assume up-to-date
 
 	for (var/preference_type in GLOB.preference_entries)


### PR DESCRIPTION
## About The Pull Request

A verb is now available on localhost called `"Export Save as Dev Preferences"`

This exports your current savefile to `/config/dev_preferences.json`

If you then connect to your localhost as a guest, it will load `dev_preferences.json` as your preference datum 

This allows for devs testing the game locally to load preferences for guests.
(Guests connecting to live servers are completely unaffected.)

## Why It's Good For The Game

Initially I only did this because the recent keybinding changes have destroyed my muscle memory when testing w/o logging in.

But as I worked on it I thought of a few other usecases, like when implementing preference version migration - the dev preference is never saved which means you can re-compile as much as you want without needing to revert your save manually.
