### PR TITLE
Armsky starts with weapons check again

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -93,7 +93,7 @@
 	desc = "It's Sergeant-At-Armsky! He's a disgruntled assistant to the warden that would probably shoot you if he had hands."
 	health = 45
 	bot_mode_flags = ~(BOT_MODE_CAN_BE_SAPIENT|BOT_MODE_AUTOPATROL)
-	security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_IDS | SECBOT_CHECK_RECORDS
+	security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_IDS | SECBOT_CHECK_RECORDS | SECBOT_CHECK_WEAPONS
 
 /mob/living/simple_animal/bot/secbot/beepsky/jr
 	name = "Officer Pipsqueak"


### PR DESCRIPTION
## About The Pull Request

Armsky stuns people holding weapons without a permit again

## Why It's Good For The Game

Seems to have been an entirely undocumented change made from #62510

It's kinda Armsky's whole point - you pick up a laser gun and he stuns your ass for the next century

Given it's been FOUR YEARS(!!), I'm tagging this as a balance I guess...

## Changelog

:cl: Melbert
balance: Armsky will detain people who yoink weapons out of the armory without a permit again.
/:cl:
