### PR TITLE
correctly subtypes rogue items

### DIFF
--- a/code/modules/bitrunning/objects/gimmick_disks/dungeon_disk.dm
+++ b/code/modules/bitrunning/objects/gimmick_disks/dungeon_disk.dm
@@ -111,7 +111,7 @@
 		/obj/item/clothing/under/color/black,
 		/obj/item/clothing/shoes/sneakers/black,
 		/obj/item/clothing/mask/facescarf/rogue,
-		/obj/item/clothing/glasses/eyepatch,
+		/obj/item/clothing/glasses/eyepatch/rogue,
 		/obj/item/bedsheet/black/rogue_cape,
 		/obj/item/storage/belt/fannypack/black/rogue,
 		/obj/item/knife/combat/survival,
@@ -125,7 +125,7 @@
 	icon_state = "/obj/item/clothing/mask/facescarf/rogue"
 	greyscale_colors = "#292929"
 
-/obj/item/clothing/glasses/eyepatch
+/obj/item/clothing/glasses/eyepatch/rogue
 	name = "eyepatch of SEALING"
 
 /obj/item/bedsheet/black/rogue_cape

--- a/code/modules/bitrunning/objects/gimmick_disks/dungeon_disk.dm
+++ b/code/modules/bitrunning/objects/gimmick_disks/dungeon_disk.dm
@@ -109,7 +109,7 @@
 
 	granted_items = list(
 		/obj/item/clothing/under/color/black,
-		/obj/item/clothing/shoes/sneakers/black,
+		/obj/item/clothing/shoes/sneakers/black/rogue,
 		/obj/item/clothing/mask/facescarf/rogue,
 		/obj/item/clothing/glasses/eyepatch/rogue,
 		/obj/item/bedsheet/black/rogue_cape,
@@ -117,7 +117,7 @@
 		/obj/item/knife/combat/survival,
 	)
 
-/obj/item/clothing/shoes/sneakers/black
+/obj/item/clothing/shoes/sneakers/black/rogue
 	name = "sneaker of SNEAKING"
 
 /obj/item/clothing/mask/facescarf/rogue


### PR DESCRIPTION
## About The Pull Request
someone forgot to actually subtype these items
## Why It's Good For The Game
i tried to go to the definition of eyepatches and got brought here. it hasnt been an issue because of this being earlier in the load order.
## Changelog
:cl:
fix: some rogue bitrunning gimmick items have there silly names now.
/:cl:
