### PR TITLE
gives the skeleton species the skeleton faction

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -16,7 +16,6 @@
 		TRAIT_UNHUSKABLE,
 	)
 
-	inherent_factions = list(FACTION_SKELETON) // close enough
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	inherent_respiration_type = RESPIRATION_PLASMA
 	mutantlungs = /obj/item/organ/lungs/plasmaman

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -16,6 +16,7 @@
 		TRAIT_UNHUSKABLE,
 	)
 
+	inherent_factions = list(FACTION_SKELETON) // close enough
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	inherent_respiration_type = RESPIRATION_PLASMA
 	mutantlungs = /obj/item/organ/lungs/plasmaman

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -23,6 +23,7 @@
 		TRAIT_UNHUSKABLE,
 		TRAIT_XENO_IMMUNE,
 	)
+	inherent_factions = list(FACTION_SKELETON)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
 	mutanttongue = /obj/item/organ/tongue/bone
 	mutantstomach = /obj/item/organ/stomach/bone


### PR DESCRIPTION
## About The Pull Request

NPC skeleton mobs are no longer hostile to players of the skeleton species ~~or to players of the plasmaman species~~. It's similar to how bees won't attack podpeople.

## Why It's Good For The Game

skeletons should be allowed to chill with their homies

This also makes fishing with a bone fishing rod much less dangerous if you're a skeleton ~~(or a plasmaman)~~, as the skeleton mobs that pop out won't attack you.

## Changelog

:cl:
balance: NPC skeleton mobs are no longer hostile to players of the skeleton species.
/:cl: