### PR TITLE
Hovering over things on the same tile no longer closes the pet command menu, automatically closes it when you let go of the hotkey

### DIFF
--- a/code/datums/components/pet_commands/obeys_commands.dm
+++ b/code/datums/components/pet_commands/obeys_commands.dm
@@ -59,6 +59,7 @@
 /datum/component/obeys_commands/proc/on_key_unpressed(mob/living/source)
 	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_ATOM_MOUSE_ENTERED)
+	remove_from_viewers(source)
 
 /datum/component/obeys_commands/proc/remove_from_viewers(mob/living/source)
 	radial_viewers -= REF(source)
@@ -93,7 +94,8 @@
 	if(mouse_hovered == parent)
 		display_menu(friend)
 		return
-	if(isliving(mouse_hovered))
+
+	if(isliving(mouse_hovered) && mouse_hovered.loc != parent.loc)
 		remove_from_viewers(friend)
 
 /// Displays a radial menu of commands

--- a/code/datums/components/pet_commands/obeys_commands.dm
+++ b/code/datums/components/pet_commands/obeys_commands.dm
@@ -95,7 +95,8 @@
 		display_menu(friend)
 		return
 
-	if(isliving(mouse_hovered) && mouse_hovered.loc != parent.loc)
+	var/mob/living/owner = parent
+	if(isliving(mouse_hovered) && mouse_hovered.loc != owner.loc)
 		remove_from_viewers(friend)
 
 /// Displays a radial menu of commands


### PR DESCRIPTION

## About The Pull Request

Hovering over mobs on the same tile as the commanded mob will no longer close the command menu, and it will automatically get closed once the user lets go of the hotkey without having to forcefully time out.

## Why It's Good For The Game

The same tile requirement prevents the menu from fading out if you're trying to command the mob you're riding, and not closing the menu when unregistering the hover signal actually prevented you from getting rid of the menu without waiting for the automatic timeout, which is super weird and unintuitive.

## Changelog
:cl:
qol: Letting go of the pet command hotkey (Shift by default) will instantly close the menu
fix: Hovering over things on the same tile no longer closes the pet command menu
/:cl:
