### PR TITLE
Adds support for alternate mining visual icons

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -32,11 +32,11 @@
 	var/obj/item/boulder/spawned_boulder = null
 	/// How much ore we spawn when we're mining a mineralType.
 	var/mineralAmt = 3
-	///Holder for the icon of the image we display when we're pinged by a mining scanner
+	/// The icon of the image we display when we're pinged by a mining scanner. If unset this will just be the default 'icons/effects/ore_visuals.dmi'
 	var/scan_icon
-	///Holder for the image we display when we're pinged by a mining scanner
+	/// Placeholder for the icon_state of the image we display when we're pinged by a mining scanner
 	var/scan_state = ""
-	///If true, this turf will not call AfterChange during change_turf calls.
+	/// If true, this turf will not call AfterChange during change_turf calls.
 	var/defer_change = FALSE
 	/// If true you can mine the mineral turf without tools.
 	var/weak_turf = FALSE

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -32,6 +32,8 @@
 	var/obj/item/boulder/spawned_boulder = null
 	/// How much ore we spawn when we're mining a mineralType.
 	var/mineralAmt = 3
+	///Holder for the icon of the image we display when we're pinged by a mining scanner
+	var/scan_icon
 	///Holder for the image we display when we're pinged by a mining scanner
 	var/scan_state = ""
 	///If true, this turf will not call AfterChange during change_turf calls.

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -32,8 +32,8 @@
 	var/obj/item/boulder/spawned_boulder = null
 	/// How much ore we spawn when we're mining a mineralType.
 	var/mineralAmt = 3
-	/// The icon of the image we display when we're pinged by a mining scanner. If unset this will just be the default 'icons/effects/ore_visuals.dmi'
-	var/scan_icon
+	/// The icon of the image we display when we're pinged by a mining scanner, to be overridden if you want to use an alternate file for a subtype.
+	var/scan_icon = 'icons/effects/ore_visuals.dmi'
 	/// Placeholder for the icon_state of the image we display when we're pinged by a mining scanner
 	var/scan_state = ""
 	/// If true, this turf will not call AfterChange during change_turf calls.

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -28,8 +28,8 @@
 
 /obj/item/mining_scanner/admin/attack_self(mob/user)
 	for(var/turf/closed/mineral/mineral_turf in world)
-		mineral_turf.icon = mineral_turf.scan_icon
 		if(mineral_turf.scan_state)
+			mineral_turf.icon = mineral_turf.scan_icon
 			mineral_turf.icon_state = mineral_turf.scan_state
 	qdel(src)
 

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -27,9 +27,11 @@
 /obj/item/mining_scanner/admin
 
 /obj/item/mining_scanner/admin/attack_self(mob/user)
-	for(var/turf/closed/mineral/M in world)
-		if(M.scan_state)
-			M.icon_state = M.scan_state
+	for(var/turf/closed/mineral/mineral_turf in world)
+		if(mineral_turf.scan_icon)
+			mineral_turf.icon = mineral_turf.scan_icon
+		if(mineral_turf.scan_state)
+			mineral_turf.icon_state = mineral_turf.scan_state
 	qdel(src)
 
 /obj/item/t_scanner/adv_mining_scanner
@@ -91,6 +93,8 @@
 		var/obj/effect/temp_visual/mining_overlay/scan_overlay = locate(/obj/effect/temp_visual/mining_overlay) in mineral
 		if(!scan_overlay)
 			scan_overlay = new(mineral)
+			if(mineral.scan_icon)
+				scan_overlay.icon = mineral.scan_icon
 			scan_overlay.icon_state = mineral.scan_state
 			continue
 

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -28,8 +28,7 @@
 
 /obj/item/mining_scanner/admin/attack_self(mob/user)
 	for(var/turf/closed/mineral/mineral_turf in world)
-		if(mineral_turf.scan_icon)
-			mineral_turf.icon = mineral_turf.scan_icon
+		mineral_turf.icon = mineral_turf.scan_icon
 		if(mineral_turf.scan_state)
 			mineral_turf.icon_state = mineral_turf.scan_state
 	qdel(src)
@@ -93,8 +92,7 @@
 		var/obj/effect/temp_visual/mining_overlay/scan_overlay = locate(/obj/effect/temp_visual/mining_overlay) in mineral
 		if(!scan_overlay)
 			scan_overlay = new(mineral)
-			if(mineral.scan_icon)
-				scan_overlay.icon = mineral.scan_icon
+			scan_overlay.icon = mineral.scan_icon
 			scan_overlay.icon_state = mineral.scan_state
 			continue
 


### PR DESCRIPTION
## About The Pull Request

Currently the way it's set up, the only way to add new ores to the current icons that flash + show up on scanners is to override the entire .dmi. This is not a small .dmi file, so I thought it would be a good idea to let people make their own icons containing any addons.

## Why It's Good For The Game

Better support for modular content.

## Changelog

Not player-facing