### PR TITLE
Fix some potential sources of flaky ci runtimes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -483,7 +483,7 @@
 	name = "landing marker"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ml" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3107,7 +3107,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ig" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/grimy,


### PR DESCRIPTION
<## About The Pull Request

<img width="1943" height="110" alt="image" src="https://github.com/user-attachments/assets/a7035301-37a6-4c2f-b0a1-e72b9537fef7" />

Was looking into this, and noticed a couple of older maps that did not have things mapped to nearstation areas.

## Why It's Good For The Game

Less CI failures

## Changelog

Nothing player-facing