### PR TITLE
Nerfs the recharge rate in wiz modsuit

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -78,6 +78,8 @@
 	idle_power_cost = 0 //magic
 	use_energy_cost = 0 //magic too
 	max_charges = 5
+	recharge_start_delay = 20 SECONDS
+	charge_increment_delay = 3 SECONDS
 	shield_icon_file = 'icons/effects/magic.dmi'
 	shield_icon = "mageshield"
 	required_slots = list()


### PR DESCRIPTION

## About The Pull Request
Nerfs the wizard modsuit shield recharges, it takes 20 seconds (double the original time) for them to start recharging, and they recharge every 3 seconds (used to be 1 second). can tone it down a bit if its too much
## Why It's Good For The Game
I know wizard is meant to be super busted and all that, but a shield that blocks 5 attacks and it recharges every 10 seconds is extremely frustrating if not impossible to play against unless you bring a bomb, specially if they had any form of teleport (i dont think we should make all antags be only countered by bombs), wizard modsuit is already stacked with armour, no slips, anti flashbangs and space proofing, i think the shields are overkill 
## Changelog
:cl:
balance: wizard modsuit shield recharges slower
/:cl:
