### PR TITLE
MAP - Catwalk - Lower Science changes

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -7,7 +7,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/catwalk_floor,
 /area/station/science/server)
 "aat" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -588,6 +588,7 @@
 	dir = 9
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/science/server)
 "akt" = (
@@ -1076,6 +1077,7 @@
 /obj/item/storage/belt/utility/full{
 	pixel_y = 1
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white/textured_corner{
 	dir = 8
 	},
@@ -2635,7 +2637,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/catwalk_floor,
 /area/station/science/server)
 "aRg" = (
 /obj/machinery/door/airlock/maintenance,
@@ -5052,6 +5054,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"bCx" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/construction)
 "bCC" = (
 /obj/machinery/suit_storage_unit/captain,
 /obj/machinery/status_display/evac/directional/north,
@@ -13510,14 +13520,6 @@
 /obj/machinery/computer/mechpad,
 /turf/open/floor/iron/smooth,
 /area/station/science/robotics)
-"dYN" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/station/science/lab)
 "dYY" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -13840,6 +13842,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/effect/spawner/random/trash/graffiti,
+/obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "ecC" = (
@@ -15162,6 +15165,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "exM" = (
@@ -17070,14 +17076,6 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
-"fdi" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/structure/sign/directions/science/directional/south,
-/turf/open/floor/iron,
-/area/station/science/lab)
 "fdl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18652,7 +18650,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/corner{
+/obj/effect/turf_decal/trimline/purple/arrow_ccw{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -27571,6 +27569,9 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "idq" = (
@@ -27666,6 +27667,10 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/light/directional/south,
+/obj/structure/sign/directions/science/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "igc" = (
@@ -28952,10 +28957,7 @@
 /area/station/engineering/atmos/upper)
 "izU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/arrow_ccw,
 /turf/open/floor/iron/sepia,
 /area/station/hallway/secondary/construction)
 "izW" = (
@@ -32692,7 +32694,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/catwalk_floor,
 /area/station/science/server)
 "jBt" = (
 /obj/effect/landmark/event_spawn,
@@ -34544,15 +34546,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
-"kdV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/arrow_ccw{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/construction)
 "keh" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured_large,
@@ -41201,6 +41194,18 @@
 /obj/item/mop,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
+"mdw" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/arrow_ccw{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/construction)
 "mdx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -44404,6 +44409,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "nec" = (
@@ -45644,7 +45650,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/catwalk_floor,
 /area/station/science/server)
 "nvB" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -46141,6 +46147,7 @@
 /obj/machinery/firealarm/directional/west{
 	pixel_y = -3
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "nCg" = (
@@ -46586,7 +46593,6 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
 "nIA" = (
@@ -48555,9 +48561,6 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "omO" = (
@@ -52405,6 +52408,7 @@
 	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "puR" = (
@@ -54247,13 +54251,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
-"pTp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/arrow_ccw,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/construction)
 "pTu" = (
 /obj/machinery/door/airlock/wood{
 	name = "Service Hall"
@@ -55485,6 +55482,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"qoN" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "qoX" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 2;
@@ -59584,6 +59591,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
+"rAs" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/lab)
 "rAD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -60550,9 +60561,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "rPn" = (
@@ -60755,14 +60763,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"rRQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/station/science/lab)
 "rRW" = (
 /obj/item/ammo_casing/spent{
 	pixel_x = 7;
@@ -63701,19 +63701,6 @@
 	},
 /turf/open/floor/engine/hull/air,
 /area/station/medical/medbay/central)
-"sOb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/arrow_ccw{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/construction)
 "sOl" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/item/stack/rods/two,
@@ -64876,14 +64863,6 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"tgL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/arrow_ccw,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/construction)
 "tgT" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -68267,6 +68246,9 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "uiH" = (
@@ -75655,13 +75637,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/construction/mining/aux_base)
-"wnJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/construction)
 "wnO" = (
 /turf/open/openspace,
 /area/station/medical/psychology)
@@ -77338,6 +77313,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
+"wOO" = (
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/airlock/research{
+	name = "R&D's Backdoor"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "wOR" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/status_display/evac/directional/north,
@@ -77356,18 +77343,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
-"wPb" = (
-/obj/machinery/door/airlock/research{
-	name = "R&D's Backdoor"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/turf/open/floor/iron,
-/area/station/science/lab)
 "wPf" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/landmark/event_spawn,
@@ -80173,13 +80148,24 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"xIl" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "xIp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
-/obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "xIJ" = (
@@ -81305,7 +81291,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/half,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/textured_half,
 /area/station/science/robotics)
 "xZn" = (
@@ -116434,8 +116419,8 @@ xgC
 ihW
 pRG
 qnW
-jkr
-rRQ
+tNP
+yfK
 noJ
 pgp
 ntN
@@ -116691,13 +116676,13 @@ neB
 nwd
 hsx
 xYS
-jkr
-qgj
+tNP
+yfK
 nIu
 gal
 fwp
 lei
-fdi
+lmc
 fAl
 lGy
 ajB
@@ -116955,9 +116940,9 @@ miO
 rPd
 rPd
 omG
-wPb
-sOb
-kdV
+fAl
+pcR
+uxt
 jbW
 qnM
 wKb
@@ -117206,15 +117191,15 @@ gXG
 gXG
 gXG
 jkr
-dYN
-ntN
+qgj
+rAs
 grd
 ntN
 rkW
 lmc
 fAl
-pcR
-pTp
+bCx
+uxt
 sQJ
 wKb
 wKb
@@ -117471,7 +117456,7 @@ gPd
 qyA
 fAl
 pcR
-tgL
+ajB
 nLp
 wKb
 mWI
@@ -117726,9 +117711,9 @@ gal
 vWv
 vWv
 lmc
-fAl
+tNP
 mgh
-pTp
+uxt
 cOe
 wKb
 cpD
@@ -117980,11 +117965,11 @@ uGP
 kxo
 iCa
 lbe
-idj
+xIl
 idj
 uix
-fAl
-wnJ
+tNP
+pcR
 izU
 dxN
 cWU
@@ -118240,9 +118225,9 @@ uZS
 vMR
 oof
 exo
-fAl
+tNP
 pcR
-pTp
+uxt
 xaz
 bQe
 qYi
@@ -118499,7 +118484,7 @@ nCI
 ifV
 fAl
 lGy
-tgL
+ajB
 xaz
 bQe
 iLy
@@ -118753,9 +118738,9 @@ ntN
 bEw
 rOk
 uPL
-exo
-fAl
-pcR
+qoN
+wOO
+mdw
 fAI
 jpp
 vQH


### PR DESCRIPTION
## About The Pull Request

| Before | After | Why this Change |
| -------- | -------- | -------- |
| ![image](https://hackmd.io/_uploads/Bk4m08x5lg.png) | ![image](https://hackmd.io/_uploads/SyvmRPg9lx.png)     | Several sci players could not find ordanance round to round, just make it a bit more obvious as they are seperate, plus windows for more interaction     |
| ![image](https://hackmd.io/_uploads/Sk7n_vx5lx.png) | ![image](https://hackmd.io/_uploads/H12r0Pgqxe.png)     | Adds windows to Robotics so they are less isolated from general Science, bit more visual activity going on as robotics can already see from above   |
| ![image](https://hackmd.io/_uploads/S1S8KDl9xe.png) | ![image](https://hackmd.io/_uploads/HJMtRvxcle.png)     | Adds one extra light as this area is darkness personified, leaves some shadow on the stairs, adds a tiny light to just in server room door as well   |
| ![image](https://hackmd.io/_uploads/SkYvcPg9lg.png) | ![image](https://hackmd.io/_uploads/rkHo0vxcxl.png)  | Why does catwalk not use catwalks in the server room, purely aesthetic choice   |
## Why It's Good For The Game

- Part of a wider project to make the Catwalk map better
- Changes are going to be broken up per PR and branch for easier review and approval
## Changelog
:cl:
map: Catwalk lower Science changes [C.A.T]
/:cl:
