### PR TITLE
Clientless mobs no longer log their emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -389,18 +389,21 @@
 *
 * Returns TRUE if it was able to run the emote, FALSE otherwise.
 */
-/atom/proc/manual_emote(text)
-	if(!text)
+/atom/proc/manual_emote(text, log_emote = TRUE)
+	if (!text)
 		CRASH("Someone passed nothing to manual_emote(), fix it")
 
-	log_message(text, LOG_EMOTE)
+	if (log_emote)
+		log_message(text, LOG_EMOTE)
 	visible_message(text, visible_message_flags = EMOTE_MESSAGE)
 	return TRUE
 
-/mob/manual_emote(text)
+/mob/manual_emote(text, log_emote = null)
 	if (stat != CONSCIOUS)
 		return FALSE
-	. = ..()
+	if (isnull(log_emote))
+		log_emote = !isnull(client)
+	. = ..(text, log_emote)
 	if (!.)
 		return FALSE
 	if (!client)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -101,7 +101,8 @@
 	if(!msg)
 		return
 
-	user.log_message(msg, LOG_EMOTE)
+	if(user.client)
+		user.log_message(msg, LOG_EMOTE)
 
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, "general_emote_audio_cooldown") && TIMER_COOLDOWN_FINISHED(user, type))


### PR DESCRIPTION

## About The Pull Request

Prevents mobs without a client from logging their (automated) emotes. Probably need feedback from @tgstation/head-admins on this one first.

## Why It's Good For The Game

This spams logs pretty badly, and is most likely undesired assuming from internal discussions. I don't think that we have player-controlled clientless emotes which cannot be tracked down via TGUI interactions.

## Changelog
:cl:
admin: Clientless mobs no longer log their emotes
/:cl:
