### PR TITLE
Ensures that mi-gos cannot crash servers

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -33,6 +33,8 @@
 	var/static/list/migo_sounds
 	/// Odds migo will dodge
 	var/dodge_prob = 10
+	/// Are we dodging an attack during this move?
+	var/dodging = FALSE
 
 /mob/living/basic/migo/Initialize(mapload)
 	. = ..()
@@ -68,7 +70,7 @@
 		make_migo_sound()
 
 /mob/living/basic/migo/Move(atom/newloc, dir, step_x, step_y)
-	if(!ckey && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
+	if(!dodging && !ckey && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
 		return dodge(newloc, dir)
 	else
 		return ..()
@@ -77,9 +79,11 @@
 	//Assuming we move towards the target we want to swerve toward them to get closer
 	var/cdir = turn(move_direction, 45)
 	var/ccdir = turn(move_direction, -45)
+	dodging = TRUE
 	. = Move(get_step(loc,pick(cdir, ccdir)))
 	if(!.)//Can't dodge there so we just carry on
 		. = Move(moving_to, move_direction)
+	dodging = FALSE
 
 /// The special hatsune miku themed mi-go.
 /mob/living/basic/migo/hatsune


### PR DESCRIPTION

## About The Pull Request

If a migo somehow (adminbus, ahem ahem) gets 100% dodge chance, it will create an infinite move recursion and crash the server. Or if we just get incredibly unlucky with a low health migo, as each failed dodge has a 75% chance to result in another dodge (due to calling move twice), even more so with diagonal movement.

Happened twice already, if you're wondering.

## Changelog
:cl:
fix: Fixed a potential server crash caused by Mi-Gos
/:cl:
