### PR TITLE
Remove double (Computer Board) on custom shuttle boards

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -676,9 +676,9 @@
 		machine.connect_to_shuttle(TRUE, shuttle)
 
 /obj/item/circuitboard/computer/shuttle/flight_control
-	name = "Shuttle Flight Control (Computer Board)"
+	name = "Shuttle Flight Control"
 	build_path = /obj/machinery/computer/shuttle/custom_shuttle
 
 /obj/item/circuitboard/computer/shuttle/docker
-	name = "Shuttle Navigation Computer (Computer Board)"
+	name = "Shuttle Navigation Computer"
 	build_path = /obj/machinery/computer/camera_advanced/shuttle_docker/custom


### PR DESCRIPTION

## About The Pull Request

computer boards saying (Computer Board) is done by name_extension on the base board, and the shuttle boards had a second one in their base name.

## Why It's Good For The Game

Only need one (Computer Board)

## Changelog
:cl:
spellcheck: Made shuttle computer boards only say (Computer Board) once
/:cl:
