### PR TITLE
Update SpacemanDMM suite to 1.11

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -17,7 +17,7 @@ export NODE_VERSION_LTS=22.11.0
 export BUN_VERSION=1.2.16
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.10
+export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.9.0


### PR DESCRIPTION
## About The Pull Request

Updates `SPACEMAN_DMM_VERSION` to `suite-1.11` in `dependencies.sh`, for the new https://github.com/SpaceManiac/SpacemanDMM/releases/tag/suite-1.11 release

## Why It's Good For The Game

finally... `load_ext`, `for(k,v)`, and `callee.proc.type` support

## Changelog

No user-facing changes.