### PR TITLE
Add bind (shift-alt-primary) specifically for opening the TGUI loot panel

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -86,6 +86,9 @@
 		if(LAZYACCESS(modifiers, CTRL_CLICK))
 			CtrlShiftClickOn(A)
 			return
+		if (LAZYACCESS(modifiers, ALT_CLICK))
+			alt_shift_click_on(A)
+			return
 		ShiftClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))

--- a/code/_onclick/click_alt.dm
+++ b/code/_onclick/click_alt.dm
@@ -105,7 +105,7 @@
  **/
 /mob/proc/alt_shift_click_on(atom/target)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	return NONE
+	return FALSE
 
 /**
  * ## Bind for unambiguously opening the loot panel as a living mob.
@@ -115,20 +115,21 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 	return try_open_loot_panel_on(target)
 
-//Helper for determining if a living mob may open the loot panel for some target, since it is shared between
-//alt and alt-shift click.
+///Helper for determining if a living mob may open the loot panel for some target, since it is shared between
+///alt and alt-shift click.
+///Returns FALSE if the mob is unable to open the loot panel at the target and TRUE if the loot panel was opened.
 /mob/living/proc/try_open_loot_panel_on(atom/target)
 	if(!CAN_I_SEE(target) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
-		return
+		return FALSE
 
 	// No alt clicking to view turf from beneath
 	if(HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING))
-		return
+		return FALSE
 
 	/// No loot panel if it's on our person
 	if(isobj(target) && (target in get_all_gear()))
 		to_chat(src, span_warning("You can't search for this item, it's already in your inventory! Take it off first."))
-		return
+		return FALSE
 
 	client.loot_panel.open(get_turf(target))
 	return TRUE

--- a/code/_onclick/click_alt.dm
+++ b/code/_onclick/click_alt.dm
@@ -28,20 +28,10 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	. = ..()
-	if(. || !CAN_I_SEE(target) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
+	if(.)
 		return
 
-	// No alt clicking to view turf from beneath
-	if(HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING))
-		return
-
-	/// No loot panel if it's on our person
-	if(isobj(target) && (target in get_all_gear()))
-		to_chat(src, span_warning("You can't search for this item, it's already in your inventory! Take it off first."))
-		return
-
-	client.loot_panel.open(get_turf(target))
-	return TRUE
+	return try_open_loot_panel_on(target)
 
 /**
  * ## Custom alt click interaction
@@ -109,3 +99,36 @@
 /atom/proc/click_alt_secondary(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
 	return NONE
+
+/**
+ * ## No-op for unambiguous loot panel bind as a non-living mob.
+ **/
+/mob/proc/alt_shift_click_on(atom/target)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return NONE
+
+/**
+ * ## Bind for unambiguously opening the loot panel as a living mob.
+ * This raises no signals and is not meant to have its behavior overridden.
+ **/
+/mob/living/alt_shift_click_on(atom/target)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return try_open_loot_panel_on(target)
+
+//Helper for determining if a living mob may open the loot panel for some target, since it is shared between
+//alt and alt-shift click.
+/mob/living/proc/try_open_loot_panel_on(atom/target)
+	if(!CAN_I_SEE(target) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
+		return
+
+	// No alt clicking to view turf from beneath
+	if(HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING))
+		return
+
+	/// No loot panel if it's on our person
+	if(isobj(target) && (target in get_all_gear()))
+		to_chat(src, span_warning("You can't search for this item, it's already in your inventory! Take it off first."))
+		return
+
+	client.loot_panel.open(get_turf(target))
+	return TRUE


### PR DESCRIPTION

## About The Pull Request

Adds a new bind `AltShiftClickOn` for explicitly opening the TGUI loot panel at some tile without raising any signals or calling into an override-able proc. This bind is in addition to the already existing alt-click and it is not intended to replace it.

This is similar to [this pr](https://github.com/tgstation/tgstation/pull/92307) but does not replace the old bind nor add any features beyond the bind opening the loot panel.

## Why It's Good For The Game

Originally I started looking into this because it was very obnoxious that I was able to interact with pipes placed in walls, but not pipes placed underneath windows. I had thought the issue was because the window overlapped the pipe and was unable to open the loot panel to get at it because the window handles alt-clicks through the `simple_rotation` component's signal handler. Unfortunately the pipe is still obscured by the window, so this does not fix that.

However I still see this as useful as it allows opening the very nice and wonderful loot panel on a pile of items which may or may not handle the alt click signal without needing to hunt for a pixel of the tile (or of an item you _think_ may not handle it) to do so. 

## Changelog

:cl:
qol: shift+alt will open the tgui loot panel on any tile without being intercepted by items that may be on the tile
code: adds a shift+alt click on proc for living mobs to explicitly open the tgui loot panel in addition to the already existing alt bind
/:cl:

