### PR TITLE
Adds toggleable suit sensor boosting to the MOD status display

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -243,9 +243,9 @@
 	incompatible_modules = list(/obj/item/mod/module/status_readout)
 	tgui_id = "status_readout"
 	required_slots = list(ITEM_SLOT_BACK)
-	/// Does this show damage types, body temp, satiety
+	/// Does this show damage types, body temp, satiety?
 	var/display_detailed_vitals = TRUE
-	/// Does this show DNA data
+	/// Does this show DNA data?
 	var/display_dna = FALSE
 	/// Does this show the round ID and shift time?
 	var/display_time = FALSE
@@ -253,6 +253,8 @@
 	var/death_sound = 'sound/effects/flatline3.ogg'
 	/// Death sound volume. Please be responsible with this.
 	var/death_sound_volume = 50
+	/// Does this boost suit sensor status across Z-levels?
+	var/sensor_boost = TRUE
 
 /obj/item/mod/module/status_readout/add_ui_data()
 	. = ..()
@@ -291,6 +293,7 @@
 	. = ..()
 	.["display_detailed_vitals"] = add_ui_configuration("Detailed Vitals", "bool", display_detailed_vitals)
 	.["display_dna"] = add_ui_configuration("DNA Information", "bool", display_dna)
+	.["sensor_boost"] = add_ui_configuration("Suit Sensor Booster", "bool", sensor_boost)
 
 /obj/item/mod/module/status_readout/configure_edit(key, value)
 	switch(key)
@@ -298,12 +301,23 @@
 			display_detailed_vitals = text2num(value)
 		if("display_dna")
 			display_dna = text2num(value)
+		if("sensor_boost")
+			sensor_boost = text2num(value)
+			update_sensor_booster()
 
 /obj/item/mod/module/status_readout/on_part_activation()
 	RegisterSignal(mod.wearer, COMSIG_LIVING_DEATH, PROC_REF(death_sound))
+	update_sensor_booster()
 
 /obj/item/mod/module/status_readout/on_part_deactivation(deleting)
 	UnregisterSignal(mod.wearer, COMSIG_LIVING_DEATH)
+	REMOVE_TRAIT(mod.wearer, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
+
+/obj/item/mod/module/status_readout/proc/update_sensor_booster()
+	if(sensor_boost)
+		ADD_TRAIT(mod.wearer, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
+	else
+		REMOVE_TRAIT(mod.wearer, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 
 /obj/item/mod/module/status_readout/proc/death_sound(mob/living/carbon/human/wearer)
 	SIGNAL_HANDLER

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -302,6 +302,7 @@
 		and even useful information such as their overall health and wellness. This one comes with a clock that calibrates to the \
 		local system time, and an operational ID number display. The vital monitor's speaker has been removed."
 	display_time = TRUE
+	sensor_boost = FALSE
 	death_sound = null
 	death_sound_volume = null
 


### PR DESCRIPTION
## About The Pull Request

Adds a Suit Sensor Booster toggle to MOD status display modules, which, when activated, provides the multi-Z suit sensors trait to the wearer, allowing their suit sensors to relay to any crew monitoring console; perfect for the miner paranoid about being left for dead on Lavaland while wearing a MODsuit. (Note: they're still going to have to bother Research for the module. It's not included with the mining MOD.)

<img width="644" height="237" alt="image" src="https://github.com/user-attachments/assets/1c41b1b4-2fdb-48c0-b222-dddd903d77ab"/>

<img width="233" height="212" alt="image" src="https://github.com/user-attachments/assets/8d1d8623-6ac2-4669-811e-435bffb87870" />


<img width="336" height="114" alt="image" src="https://github.com/user-attachments/assets/8fdbde93-6d4e-46cf-b55e-6faa55337772" />


## Why It's Good For The Game
You can't use kheiral cuffs in a MODsuit but the functionality of "HELLO MEDBAY I AM VERY DEAD" is pretty good and should probably be made more available.

## Changelog

:cl:
add: MOD status display modules (from Field Surgery Modules) now default to boosting suit sensors to be multi-Z capable. This can be turned off, and defaults to off for space ninjas' MODs.
/:cl:
