### PR TITLE
MOD ash accretion fully cancels base mining MOD slowdown

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -369,7 +369,7 @@
 	/// Armor values per tile.
 	var/datum/armor/armor_mod = /datum/armor/mod_ash_accretion
 	/// Speed added when you're fully covered in ash.
-	var/speed_added = -0.5
+	var/speed_added = -0.75
 	/// Turfs that let us accrete ash.
 	var/static/list/accretion_turfs
 	/// Turfs that let us keep ash.


### PR DESCRIPTION
## About The Pull Request
Title. Sets ash accretion's speed boost from -0.5 to -0.75 to cancel the default deployed slowdown of 0.75 on the mining MODsuit.

## Why It's Good For The Game
Makes the mining MODsuit a little nicer to use, giving it mobility on-par with every other on-foot option instead of having 0.25 slowdown even while fully active. It's still got less melee armor than the megafauna armors (drake, HECK) and it's still limited by having to maintain charge, and the armor falls off painfully quick if you step on a stray non-ashen tile, though, which should keep it in check.

## Changelog

:cl:
balance: The mining MODsuit's ash accretion module now fully cancels the base slowdown from activating the MOD.
/:cl: