### PR TITLE
Fixes multitool/wirecutters interaction with mechs (and wires)

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -257,12 +257,13 @@
 
 /datum/wires/proc/interact(mob/user)
 	if(!interactable(user))
-		return
+		return FALSE
 	ui_interact(user)
 	for(var/A in assemblies)
 		var/obj/item/I = assemblies[A]
 		if(istype(I) && I.on_found(user))
-			return
+			break
+	return TRUE
 
 /**
  * Checks whether wire assignments should be revealed.

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -269,6 +269,8 @@
 		return part.try_attach_part(user, src, FALSE)
 
 	if(is_wire_tool(tool) && (mecha_flags & PANEL_OPEN))
+		if(user.combat_mode)
+			return
 		if(wires.interact(user))
 			return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request

hi

## Changelog

:cl:
fix: Fixed wires interaction and fixed mech multitool/wirecutters interaction.
/:cl:
