### PR TITLE
Prevents you from attacking the fireplace if not enough fuel is present

### DIFF
--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -58,13 +58,14 @@
 		ignite()
 		return TRUE
 
-/obj/structure/fireplace/attackby(obj/item/T, mob/user)
-	if(istype(T, /obj/item/stack/sheet/mineral/wood))
-		var/obj/item/stack/sheet/mineral/wood/wood = T
+/obj/structure/fireplace/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(istype(tool, /obj/item/stack/sheet/mineral/wood))
+		var/obj/item/stack/sheet/mineral/wood/wood = tool
 		var/space_remaining = MAXIMUM_BURN_TIMER - burn_time_remaining()
 		var/space_for_logs = round(space_remaining / LOG_BURN_TIMER)
 		if(space_for_logs < 1)
-			to_chat(user, span_warning("You can't fit any more of [T] in [src]!"))
+			to_chat(user, span_warning("You can't fit any more of [tool] in [src]!"))
 			return COMPONENT_CANCEL_ATTACK_CHAIN
 
 		var/logs_used = min(space_for_logs, wood.amount)
@@ -73,21 +74,21 @@
 		user.visible_message(span_notice("[user] tosses some wood into [src]."), span_notice("You add some fuel to [src]."))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(istype(T, /obj/item/paper_bin))
-		var/obj/item/paper_bin/paper_bin = T
-		user.visible_message(span_notice("[user] throws [T] into [src]."), span_notice("You add [T] to [src]."))
+	if(istype(tool, /obj/item/paper_bin))
+		var/obj/item/paper_bin/paper_bin = tool
+		user.visible_message(span_notice("[user] throws [tool] into [src]."), span_notice("You add [tool] to [src]."))
 		adjust_fuel_timer(PAPER_BURN_TIMER * paper_bin.total_paper)
 		qdel(paper_bin)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(istype(T, /obj/item/paper))
-		user.visible_message(span_notice("[user] throws [T] into [src]."), span_notice("You throw [T] into [src]."))
+	if(istype(tool, /obj/item/paper))
+		user.visible_message(span_notice("[user] throws [tool] into [src]."), span_notice("You throw [tool] into [src]."))
 		adjust_fuel_timer(PAPER_BURN_TIMER)
-		qdel(T)
+		qdel(tool)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(T.ignition_effect(src, user))
-		try_light(T, user)
+	if(tool.ignition_effect(src, user))
+		try_light(tool, user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	return ..()

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -89,6 +89,7 @@
 	if(tool.ignition_effect(src, user))
 		try_light(tool, user)
 		return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /obj/structure/fireplace/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -65,28 +65,31 @@
 		var/space_for_logs = round(space_remaining / LOG_BURN_TIMER)
 		if(space_for_logs < 1)
 			to_chat(user, span_warning("You can't fit any more of [T] in [src]!"))
-			return
+			return COMPONENT_CANCEL_ATTACK_CHAIN
+
 		var/logs_used = min(space_for_logs, wood.amount)
 		wood.use(logs_used)
 		adjust_fuel_timer(LOG_BURN_TIMER * logs_used)
 		user.visible_message(span_notice("[user] tosses some wood into [src]."), span_notice("You add some fuel to [src]."))
-		return
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(istype(T, /obj/item/paper_bin))
 		var/obj/item/paper_bin/paper_bin = T
 		user.visible_message(span_notice("[user] throws [T] into [src]."), span_notice("You add [T] to [src]."))
 		adjust_fuel_timer(PAPER_BURN_TIMER * paper_bin.total_paper)
 		qdel(paper_bin)
-		return
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(istype(T, /obj/item/paper))
 		user.visible_message(span_notice("[user] throws [T] into [src]."), span_notice("You throw [T] into [src]."))
 		adjust_fuel_timer(PAPER_BURN_TIMER)
 		qdel(T)
-		return
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(try_light(T,user))
-		return
+	if(T.ignition_effect(src, user))
+		try_light(T, user)
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
 	return ..()
 
 /obj/structure/fireplace/update_overlays()

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -59,39 +59,36 @@
 		return TRUE
 
 /obj/structure/fireplace/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	. = ..()
 	if(istype(tool, /obj/item/stack/sheet/mineral/wood))
 		var/obj/item/stack/sheet/mineral/wood/wood = tool
 		var/space_remaining = MAXIMUM_BURN_TIMER - burn_time_remaining()
 		var/space_for_logs = round(space_remaining / LOG_BURN_TIMER)
 		if(space_for_logs < 1)
 			to_chat(user, span_warning("You can't fit any more of [tool] in [src]!"))
-			return COMPONENT_CANCEL_ATTACK_CHAIN
+			return ITEM_INTERACT_BLOCKING
 
 		var/logs_used = min(space_for_logs, wood.amount)
 		wood.use(logs_used)
 		adjust_fuel_timer(LOG_BURN_TIMER * logs_used)
 		user.visible_message(span_notice("[user] tosses some wood into [src]."), span_notice("You add some fuel to [src]."))
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/paper_bin))
 		var/obj/item/paper_bin/paper_bin = tool
 		user.visible_message(span_notice("[user] throws [tool] into [src]."), span_notice("You add [tool] to [src]."))
 		adjust_fuel_timer(PAPER_BURN_TIMER * paper_bin.total_paper)
 		qdel(paper_bin)
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/paper))
 		user.visible_message(span_notice("[user] throws [tool] into [src]."), span_notice("You throw [tool] into [src]."))
 		adjust_fuel_timer(PAPER_BURN_TIMER)
 		qdel(tool)
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return ITEM_INTERACT_SUCCESS
 
 	if(tool.ignition_effect(src, user))
 		try_light(tool, user)
-		return COMPONENT_CANCEL_ATTACK_CHAIN
-
-	return ..()
+		return ITEM_INTERACT_SUCCESS
 
 /obj/structure/fireplace/update_overlays()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Cancels the attack chain and prevents the player from hitting the fireplace with the tool if they interact with the fireplace by adding various fuel or attempting to light it

Before:
<img width="312" height="43" alt="image" src="https://github.com/user-attachments/assets/c052df8b-80c6-4cc9-984c-71e50293b929" />

After:
<img width="297" height="40" alt="image" src="https://github.com/user-attachments/assets/28e7bd1f-d5e1-44da-9836-82e46b195da5" />

## Why It's Good For The Game

Common sense? 

## Changelog

:cl:
fix: Now trying to light the fireplace will not make you attack it
/:cl: