### PR TITLE
[NO GBP] Fixes mobs without guaranteed butcher drops not dropping any crusher trophies

### DIFF
--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -46,5 +46,8 @@
 /datum/element/crusher_loot/proc/make_path(mob/living/target, path)
 	if(drop_immediately)
 		new path(get_turf(target))
-	else
-		target.guaranteed_butcher_results[path] = 1
+		return
+
+	if (!target.guaranteed_butcher_results)
+		target.guaranteed_butcher_results = list()
+	target.guaranteed_butcher_results[path] = 1


### PR DESCRIPTION

## About The Pull Request

I've tested this on goliaths, but mobs like watchers and brimdemons don't have guaranteed drops so this will error out.

## Changelog
:cl:
fix: Fixed mobs without guaranteed butcher drops not dropping any crusher trophies
/:cl:
