### PR TITLE
Spellchecks the double The on acid on floors

### DIFF
--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -269,5 +269,5 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(!crosser.acid_act(acid_power, acid_used, FEET))
 		return
 	playsound(crosser, SFX_SEAR, 50, TRUE)
-	to_chat(crosser, span_userdanger("The acid on the [parent] burns you!"))
+	to_chat(crosser, span_userdanger("The acid on \the [parent] burns you!"))
 	set_volume(max(acid_volume - acid_used, 10))


### PR DESCRIPTION

## About The Pull Request

makes the "the" a "\the"

## Why It's Good For The Game

fixes #92822

## Changelog
:cl:

spellcheck: fixes double the on acid on floors

/:cl:
