### PR TITLE
fixes a typo in an admin message about achievements cleanup

### DIFF
--- a/code/controllers/subsystem/achievements.dm
+++ b/code/controllers/subsystem/achievements.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(achievements)
 
 	var/list/orphaned_keys = get_orphaned_keys(FALSE)
 	if(orphaned_keys.len)
-		message_admins("Achievement metadata found without matching achievement, use Achievement-Admin-Panel verb to cleanup if necessary")
+		message_admins("Achievement metadata found without matching achievement, use Achievements-Admin-Panel verb to cleanup if necessary")
 
 /// returns list of metadata keys and versions in db with no matching achievement datum, either deleted achievements, or from server with code ahead of us.
 /datum/controller/subsystem/achievements/proc/get_orphaned_keys(include_archived = TRUE)


### PR DESCRIPTION

## About The Pull Request

the verb is achievements-admin-panel

## Why It's Good For The Game

tells the admin what to actually type

## Changelog

:cl:
spellcheck: fixed a typo in the admin message about achievements cleanup
/:cl:
