### PR TITLE
Fixes unconfigured pill presses manufacturing pills that claim to be bottles

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -53,6 +53,7 @@
 			packaging_types += list(category_item)
 
 	packaging_type = GLOB.reagent_containers[CAT_PILLS][1]
+	packaging_category = CAT_PILLS
 	max_volume = initial(packaging_type.volume)
 	current_volume = clamp(current_volume, MIN_VOLUME, max_volume)
 
@@ -77,11 +78,11 @@
 		var/suffix
 		switch(packaging_category)
 			if(CAT_PILLS)
-				suffix = "Pill"
+				suffix = "pill"
 			if(CAT_PATCHES)
-				suffix = "Patch"
+				suffix = "patch"
 			else
-				suffix = "Bottle"
+				suffix = "bottle"
 		container.name = "[product_name] [suffix]"
 		reagents.trans_to(container, current_volume)
 		if (istype(container, /obj/item/reagent_containers/applicator/pill))


### PR DESCRIPTION

## About The Pull Request

Packaging category was unset until you swapped the product type in the UI, so it'd default to naming the pills bottles. Also decapitalized the suffixes for parity with the rest of pills/patches/bottles.

## Changelog
:cl:
fix: Fixed unconfigured pill presses manufacturing pills that claim to be bottles
spellcheck: Decapitalized pill press suffixes for parity with the rest of pills/patches/bottles
/:cl:
