### PR TITLE
Lets jackets as a whole clothing category carry handguns and holsters, improvised weapons on a few more 'assistant' clothing options, and minor changes

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -316,6 +316,7 @@ GLOBAL_LIST_INIT(personal_carry_allowed, list(
 	/obj/item/storage/belt/holster,
 	/obj/item/gun/ballistic/automatic/pistol,
 	/obj/item/gun/ballistic/revolver,
+	/obj/item/gun/energy/disabler/smoothbore,
 ))
 
 /// Allowed list for improvised firearms

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -310,6 +310,22 @@ GLOBAL_LIST_INIT(mining_suit_allowed, list(
 	/obj/item/spear,
 ))
 
+// Allowed list for personal carry firearms and holsters
+
+GLOBAL_LIST_INIT(personal_carry_allowed, list(
+	/obj/item/storage/belt/holster,
+	/obj/item/gun/ballistic/automatic/pistol,
+	/obj/item/gun/ballistic/revolver,
+))
+
+/// Allowed list for improvised firearms
+
+GLOBAL_LIST_INIT(improvised_firearm_allowed, list(
+	/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+	/obj/item/gun/energy/laser/musket,
+	/obj/item/gun/energy/disabler/smoothbore,
+))
+
 /// List of all "tools" that can fit into belts or work from toolboxes
 
 GLOBAL_LIST_INIT(tool_items, list(

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -77,6 +77,10 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor_type = /datum/armor/costume_justice
 
+/obj/item/clothing/suit/costume/justice/Initialize(mapload)
+	. = ..()
+	allowed = GLOB.security_vest_allowed
+
 /datum/armor/costume_justice
 	melee = 35
 	bullet = 30
@@ -122,7 +126,10 @@
 	inhand_icon_state = "imperium_monk"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDESHOES|HIDEJUMPSUIT|HIDEBELT
-	allowed = list(/obj/item/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/flashlight/flare/candle, /obj/item/tank/internals/emergency_oxygen)
+
+/obj/item/clothing/suit/costume/imperium_monk/Initialize(mapload)
+	. = ..()
+	allowed = GLOB.chaplain_suit_allowed
 
 /obj/item/clothing/suit/costume/chickensuit
 	name = "chicken suit"
@@ -354,8 +361,6 @@
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
 	inhand_icon_state = "labcoat"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|FEET
-	//cold_protection = CHEST|GROIN|ARMS
-	//min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	allowed = list()
 	hoodtype = /obj/item/clothing/head/hooded/ian_hood
 	dog_fashion = /datum/dog_fashion/back
@@ -367,8 +372,6 @@
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "ian"
 	body_parts_covered = HEAD
-	//cold_protection = HEAD
-	//min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	flags_inv = HIDEHAIR|HIDEEARS
 
 /obj/item/clothing/suit/hooded/bee_costume // It's Hip!
@@ -619,6 +622,7 @@
 /obj/item/clothing/suit/costume/hawaiian/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/adjust_fishing_difficulty, -5)
+	allowed += GLOB.personal_carry_allowed
 
 /obj/item/clothing/suit/costume/football_armor
 	name = "football protective gear"
@@ -636,6 +640,10 @@
 	name = "comedian coat"
 	desc = "I mean, don’t you have to be funny to be a comedian?"
 	icon_state = "joker_coat"
+
+/obj/item/clothing/suit/costume/joker/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.personal_carry_allowed
 
 /obj/item/clothing/suit/costume/deckers
 	name = "decker hoodie"

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -5,16 +5,21 @@
 		/obj/item/flashlight,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
+		/obj/item/tank/jetpack/oxygen/captain,
 		/obj/item/toy,
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/lighter,
 		/obj/item/radio,
-		/obj/item/storage/belt/holster,
 		)
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	species_exception = list(/datum/species/golem)
+
+/obj/item/clothing/suit/jacket/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.personal_carry_allowed
+	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/toggle/jacket
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
@@ -23,16 +28,21 @@
 		/obj/item/flashlight,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
+		/obj/item/tank/jetpack/oxygen/captain,
 		/obj/item/toy,
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/lighter,
 		/obj/item/radio,
-		/obj/item/storage/belt/holster,
 		)
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	species_exception = list(/datum/species/golem)
+
+/obj/item/clothing/suit/jacket/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.personal_carry_allowed
+	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/toggle/jacket/sweater
 	name = "sweater jacket"
@@ -100,17 +110,6 @@
 	desc = "Aviators not included."
 	icon_state = "bomberjacket"
 	inhand_icon_state = "brownjsuit"
-	allowed = list(
-		/obj/item/flashlight,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/lighter,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-		/obj/item/gun/energy/laser/musket,
-		/obj/item/radio,
-	)
 
 /obj/item/clothing/suit/jacket/leather
 	name = "leather jacket"
@@ -119,20 +118,6 @@
 	inhand_icon_state = "hostrench"
 	resistance_flags = NONE
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
-	allowed = list(
-		/obj/item/flashlight,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/lighter,
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/ballistic/revolver/c38/detective,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-		/obj/item/gun/energy/laser/musket,
-		/obj/item/radio,
-	)
 
 /obj/item/clothing/suit/jacket/leather/biker
 	name = "biker jacket"
@@ -166,20 +151,6 @@
 	desc = "A canvas jacket styled after classical American military garb. Feels sturdy, yet comfortable."
 	icon_state = "militaryjacket"
 	inhand_icon_state = null
-	allowed = list(
-		/obj/item/flashlight,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/lighter,
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/ballistic/revolver/c38/detective,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-		/obj/item/gun/energy/laser/musket,
-		/obj/item/radio,
-	)
 
 /obj/item/clothing/suit/jacket/letterman
 	name = "letterman jacket"
@@ -201,20 +172,6 @@
 	icon_state = "letterman_s"
 	inhand_icon_state = null
 	species_exception = list(/datum/species/golem)
-	allowed = list(
-		/obj/item/flashlight,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/lighter,
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/ballistic/revolver/c38/detective,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-		/obj/item/gun/energy/laser/musket,
-		/obj/item/radio,
-	)
 
 /obj/item/clothing/suit/jacket/letterman_nanotrasen
 	name = "blue letterman jacket"

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -37,7 +37,7 @@
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	species_exception = list(/datum/species/golem)
 
-/obj/item/clothing/suit/jacket/Initialize(mapload)
+/obj/item/clothing/suit/toggle/jacket/Initialize(mapload)
 	. = ..()
 	allowed += GLOB.personal_carry_allowed
 

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -5,7 +5,6 @@
 		/obj/item/flashlight,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
-		/obj/item/tank/jetpack/oxygen/captain,
 		/obj/item/toy,
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/lighter,

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -19,7 +19,6 @@
 /obj/item/clothing/suit/jacket/Initialize(mapload)
 	. = ..()
 	allowed += GLOB.personal_carry_allowed
-	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/toggle/jacket
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
@@ -42,7 +41,6 @@
 /obj/item/clothing/suit/jacket/Initialize(mapload)
 	. = ..()
 	allowed += GLOB.personal_carry_allowed
-	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/toggle/jacket/sweater
 	name = "sweater jacket"
@@ -67,6 +65,10 @@
 	flags_1 = IS_PLAYER_COLORABLE_1
 	blood_overlay_type = "coat"
 	flags_inv = HIDEBELT
+
+/obj/item/clothing/suit/toggle/jacket/trenchcoat/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/jacket/blazer
 	name = "blazer jacket"
@@ -111,6 +113,10 @@
 	icon_state = "bomberjacket"
 	inhand_icon_state = "brownjsuit"
 
+/obj/item/clothing/suit/jacket/bomber/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
+
 /obj/item/clothing/suit/jacket/leather
 	name = "leather jacket"
 	desc = "Pompadour not included."
@@ -118,6 +124,10 @@
 	inhand_icon_state = "hostrench"
 	resistance_flags = NONE
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
+
+/obj/item/clothing/suit/jacket/leather/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/jacket/leather/biker
 	name = "biker jacket"
@@ -152,12 +162,20 @@
 	icon_state = "militaryjacket"
 	inhand_icon_state = null
 
+/obj/item/clothing/suit/jacket/miljacket/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
+
 /obj/item/clothing/suit/jacket/letterman
 	name = "letterman jacket"
 	desc = "A classic brown letterman jacket. Looks pretty hot and heavy."
 	icon_state = "letterman"
 	inhand_icon_state = null
 	species_exception = list(/datum/species/golem)
+
+/obj/item/clothing/suit/jacket/letterman/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
 
 /obj/item/clothing/suit/jacket/letterman_red
 	name = "red letterman jacket"
@@ -166,6 +184,10 @@
 	inhand_icon_state = null
 	species_exception = list(/datum/species/golem)
 
+/obj/item/clothing/suit/jacket/letterman_red/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
+
 /obj/item/clothing/suit/jacket/letterman_syndie
 	name = "blood-red letterman jacket"
 	desc = "Oddly, this jacket seems to have a large S on the back..."
@@ -173,9 +195,17 @@
 	inhand_icon_state = null
 	species_exception = list(/datum/species/golem)
 
+/obj/item/clothing/suit/jacket/letterman_syndie/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed
+
 /obj/item/clothing/suit/jacket/letterman_nanotrasen
 	name = "blue letterman jacket"
 	desc = "A blue letterman jacket with a proud Nanotrasen N on the back. The tag says that it was made in Space China."
 	icon_state = "letterman_n"
 	inhand_icon_state = null
 	species_exception = list(/datum/species/golem)
+
+/obj/item/clothing/suit/jacket/letterman_nanotrasen/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.improvised_firearm_allowed


### PR DESCRIPTION

## About The Pull Request

Jackets as a category now can carry handguns like pistols and revolvers and can hold holsters in their suit storage. This also includes hawaiian shirts and comedian coats.

More 'assistant' jackets can carry improvised firearms.

Justice suits (which are actually security vests in disguise if you can believe it) hold security gear.

Imperium monk outfits now hold the true list of chaplain suit storage items, and not just a limited list.

## Why It's Good For The Game

These lists were kind of a mess so using some more consistent holder lists should make things easier going forward for making sure suits across a category are at least consistent with one another. Redefining the allowed list usually means a lot of items get lost from parent to child.

The additions were either potentially oversights, or are because of either for reference or trope reasons.

I actually think I overlooked the imperium suit last time I touched chaplain clothing suit storage.

## Changelog
:cl:
balance: Jackets can carry personal firearms and holsters in their suit storage. So can hawaiian shirts and comedian suits.
balance: More 'assistant' attire can fit improvised weapons.
balance: Justice suits can fit security items in their suit storage.
fix: Imperium monk outfits now hold the true list of chaplain suit storage items, and not just a limited list.
/:cl:
