### PR TITLE
Makes synthflesh patches not spam visible messages every tick

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -495,10 +495,9 @@
 	if(!iscarbon(exposed_mob))
 		return
 	var/mob/living/carbon/carbies = exposed_mob
-	if(carbies.stat == DEAD)
-		show_message = 0
 	if(!(methods & (PATCH|TOUCH|VAPOR)))
 		return
+
 	var/current_bruteloss = carbies.getBruteLoss() // because this will be changed after calling adjustBruteLoss()
 	var/current_fireloss = carbies.getFireLoss() // because this will be changed after calling adjustFireLoss()
 	var/touch_protection_interference = (1 - touch_protection)
@@ -514,7 +513,8 @@
 
 	if(need_mob_update)
 		carbies.updatehealth()
-	if(show_message)
+
+	if(show_message && carbies.stat != DEAD)
 		to_chat(carbies, span_danger("You feel your burns and bruises healing! It stings like hell!"))
 
 	carbies.add_mood_event("painful_medicine", /datum/mood_event/painful_medicine)
@@ -525,10 +525,12 @@
 
 	//don't try to unhusk mobs above burn damage threshold
 	if (carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD * 2.5)
-		carbies.visible_message(span_minoralert("The liquid fails to properly stick on [carbies]. [carbies]'s burns need to be repaired first!"))
+		if (show_message)
+			carbies.visible_message(span_minoralert("The liquid fails to properly stick on [carbies]. [carbies]'s burns need to be repaired first!"))
 		return
 	else if (carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD)
-		carbies.visible_message(span_boldnotice("A rubbery liquid partially coats [carbies]'s burns... It seems more is required to fully unhusk!"))
+		if (show_message)
+			carbies.visible_message(span_boldnotice("A rubbery liquid partially coats [carbies]'s burns... It seems more is required to fully unhusk!"))
 		return
 
 	var/datum/reagent/synthflesh = carbies.reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh)
@@ -545,7 +547,7 @@
 		carbies.reagents.remove_reagent(/datum/reagent/medicine/c2/synthflesh, current_volume) // consume the synthflesh, it won't do anything in their blood
 		//we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!"))
-	else
+	else if (show_message)
 		carbies.visible_message(span_boldnotice("A rubbery liquid partially coats [carbies]'s burns... It seems more is required to fully unhusk!"))
 
 /******ORGAN HEALING******/


### PR DESCRIPTION

## About The Pull Request

Patches rely on show_message to prevent spam due to microdozing, which synthflesh proudly ignored. Fixed this by making unhusk failure messages respect show_message, and moving stat check to only affect the dead person's personal to_chat

## Why It's Good For The Game

The spam is absurd and clogs up chats of everyone in medbay

## Changelog
:cl:
fix: Made synthflesh patches not spam chat messages every tick
/:cl:
