### PR TITLE
Make ListInputModal not consume useBackend, allows use as component

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
@@ -9,7 +9,6 @@ import {
   KEY_Z,
 } from 'tgui-core/keycodes';
 
-import { useBackend } from '../../backend';
 import { InputButtons } from '../common/InputButtons';
 
 type ListInputModalProps = {
@@ -21,8 +20,6 @@ type ListInputModalProps = {
 };
 
 export const ListInputModal = (props: ListInputModalProps) => {
-  const { act } = useBackend();
-
   const { items = [], default_item, message, on_selected, on_cancel } = props;
 
   const [selected, setSelected] = useState(items.indexOf(default_item));
@@ -143,6 +140,7 @@ export const ListInputModal = (props: ListInputModalProps) => {
           <ListDisplay
             filteredItems={filteredItems}
             onClick={onClick}
+            onDoubleClick={on_selected}
             onFocusSearch={onFocusSearch}
             searchBarVisible={searchBarVisible}
             selected={selected}
@@ -153,9 +151,7 @@ export const ListInputModal = (props: ListInputModalProps) => {
             autoFocus
             autoSelect
             fluid
-            onEnter={() => {
-              act('submit', { entry: filteredItems[selected] });
-            }}
+            onEnter={() => on_selected(filteredItems[selected])}
             onChange={onSearch}
             placeholder="Search..."
             value={searchQuery}
@@ -173,14 +169,28 @@ export const ListInputModal = (props: ListInputModalProps) => {
   );
 };
 
+interface ListDisplayProps {
+  filteredItems: string[];
+  onClick: (itemIndex: number) => void;
+  onDoubleClick: (entry: string) => void;
+  onFocusSearch: () => void;
+  searchBarVisible: boolean;
+  selected: number;
+}
+
 /**
  * Displays the list of selectable items.
  * If a search query is provided, filters the items.
  */
-const ListDisplay = (props) => {
-  const { act } = useBackend();
-  const { filteredItems, onClick, onFocusSearch, searchBarVisible, selected } =
-    props;
+const ListDisplay = (props: ListDisplayProps) => {
+  const {
+    filteredItems,
+    onClick,
+    onDoubleClick,
+    onFocusSearch,
+    searchBarVisible,
+    selected,
+  } = props;
 
   return (
     <Section fill scrollable>
@@ -190,13 +200,10 @@ const ListDisplay = (props) => {
           className="candystripe"
           color="transparent"
           fluid
-          id={index}
+          id={`${index}`}
           key={index}
           onClick={() => onClick(index)}
-          onDoubleClick={(event) => {
-            event.preventDefault();
-            act('submit', { entry: filteredItems[selected] });
-          }}
+          onDoubleClick={() => onDoubleClick(item)}
           onKeyDown={(event) => {
             const keyCode = window.event ? event.which : event.keyCode;
             if (searchBarVisible && keyCode >= KEY_A && keyCode <= KEY_Z) {


### PR DESCRIPTION
## About The Pull Request

While not used elsewhere, the `ListInputModal` component makes internal use of `act` that isn't needed given the only (current) usage is in `ListInputWindow`, which handles all of the relevant logic. This PR removes that, relying instead on functionality passed in via its usage in `ListInputWindow`.

## Why It's Good For The Game

A downstream of some of these more core interfaces [is intending to](https://github.com/goonstation/goonstation/pull/24451) nest a `ListInputModal` in a different interface, and thus letting the implementation specific functionality be passed in facilitates this. Closer parity good.