### PR TITLE
Disable GUEST_BAN by default

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -139,8 +139,9 @@ RESPAWN_DELAY 0
 ## set a hosted by name for unix platforms
 HOSTEDBY Yournamehere
 
-## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
-GUEST_BAN
+## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting).
+## You probably want this enabled for a production server.
+#GUEST_BAN
 
 ## IPINTEL:
 ## This allows you to detect likely proxies by checking ips against getipintel.net


### PR DESCRIPTION
Someone I'm helping got hit by this in local testing. These configs aren't really supposed to represent production recommendations so I think it's fine to just comment out