### PR TITLE
Removes the circular saw tool requirement to make a modular receiver

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -21,7 +21,7 @@
 
 /datum/crafting_recipe/receiver
 	name = "Modular Rifle Receiver"
-	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER, TOOL_SAW)
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
 	result = /obj/item/weaponcrafting/receiver
 	reqs = list(
 		/obj/item/stack/sheet/iron = 5,


### PR DESCRIPTION

## About The Pull Request

Literally what it says on the tin.

## Why It's Good For The Game

[ATHATH was right to raise concerns about this](https://github.com/tgstation/tgstation/pull/56322#discussion_r562851388) because it is a genuine bottleneck that shouldn't be a recipe requirement. It makes it still lathe reliant, so a pointless recipe for what is supposed to be a solution for when you don't have a lathe, just tools.

## Changelog
:cl:
remove: Removes the circular saw tool requirement for making modular receivers.
/:cl:
