### PR TITLE
More enhancements for vending

### DIFF
--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -289,7 +289,7 @@
 		return
 
 	var/obj/item/card/id/id_card = user.get_idcard(TRUE)
-	if(!id_card || !id_card.registered_account || !id_card.registered_account.account_job)
+	if(QDELETED(id_card))
 		balloon_alert(user, "no card found!")
 		flick(icon_deny, src)
 		return

--- a/code/modules/vending/vendor/inventory.dm
+++ b/code/modules/vending/vendor/inventory.dm
@@ -265,26 +265,23 @@
 /obj/machinery/vending/proc/proceed_payment(obj/item/card/id/paying_id_card, mob/living/mob_paying, datum/data/vending_product/product_to_vend, price_to_use, discountless)
 	PROTECTED_PROC(TRUE)
 
-	//do we have an account with job to purchase
+	//returned items are free
+	if(LAZYLEN(product_to_vend.returned_products))
+		return TRUE
+
+	//account to use. optional cause we handle cash on hand transfers as well
 	var/datum/bank_account/account = paying_id_card.registered_account
-	if(!account || !account.account_job) //unregistered account & jobless
-		speak("Your do not have a valid account with an registered job.")
-		return FALSE
 
 	//deduct money from person
-	if(account.account_job && account.account_job.paycheck_department == payment_department && !discountless)
+	if(!discountless && account.account_job.paycheck_department == payment_department)
 		price_to_use = max(round(price_to_use * DEPARTMENT_DISCOUNT), 1) //No longer free, but signifigantly cheaper.
-	if(LAZYLEN(product_to_vend.returned_products))
-		price_to_use = 0 //returned items are free
-	if(price_to_use && (attempt_charge(src, mob_paying, price_to_use) & COMPONENT_OBJ_CANCEL_CHARGE))
+	if(attempt_charge(src, mob_paying, price_to_use) & COMPONENT_OBJ_CANCEL_CHARGE)
 		speak("You do not possess the funds to purchase [product_to_vend.name].")
 		flick(icon_deny,src)
 		return FALSE
 
 	//transfer money to machine
-	var/datum/bank_account/paying_id_account = SSeconomy.get_dep_account(payment_department)
-	if(paying_id_account)
-		SSblackbox.record_feedback("amount", "vending_spent", price_to_use)
-		log_econ("[price_to_use] credits were inserted into [src] by [account.account_holder] to buy [product_to_vend].")
+	SSblackbox.record_feedback("amount", "vending_spent", price_to_use)
+	log_econ("[price_to_use] credits were inserted into [src] by [account.account_holder] to buy [product_to_vend].")
 	credits_contained += round(price_to_use * VENDING_CREDITS_COLLECTION_AMOUNT)
 	return TRUE

--- a/code/modules/vending/vendor/ui_data.dm
+++ b/code/modules/vending/vendor/ui_data.dm
@@ -63,7 +63,6 @@
 
 /obj/machinery/vending/ui_static_data(mob/user)
 	var/list/data = list()
-	data["onstation"] = onstation
 	if(ad_list.len)
 		data["ad"] = ad_list[rand(1, ad_list.len)]
 	data["all_products_free"] = all_products_free

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -45,7 +45,6 @@ type Category = {
 
 type VendingData = {
   all_products_free: boolean;
-  onstation: boolean;
   ad: string;
   department: string;
   jobDiscount: number;
@@ -66,7 +65,6 @@ export const Vending = () => {
 
   const {
     all_products_free,
-    onstation,
     ad,
     product_records = [],
     coin_records = [],
@@ -112,7 +110,7 @@ export const Vending = () => {
     <Window width={431} height={635}>
       <Window.Content>
         <Stack fill vertical>
-          {!!onstation && !all_products_free && (
+          {!all_products_free && (
             <Stack.Item>
               <UserDetails />
             </Stack.Item>


### PR DESCRIPTION
## About The Pull Request
- Var `on_station` is no longer sent to the UI as it is redundant with `all_products_free`. Saved bandwidth
- Dispensing free returned products no longer produces logs of 0 credits into the economy
- Removed excess null checks for account stuff

## Changelog
:cl:
code: improved code for vending machine payment process
fix: stop logging 0 credit purchases when vending machines are dispensing returned products
/:cl:

