### PR TITLE
Adds a 1/5 chance for Paradox Clone to spawn two for the price of one

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -699,8 +699,7 @@
 	candidate.transfer_to(bad_version, force_key_move = TRUE)
 
 	var/datum/antagonist/paradox_clone/antag = candidate.add_antag_datum(/datum/antagonist/paradox_clone)
-	antag.original_ref = WEAKREF(good_version.mind)
-	antag.setup_clone()
+	antag.setup_clone(good_version.mind)
 
 	playsound(bad_version, 'sound/items/weapons/zapbang.ogg', 30, TRUE)
 	bad_version.put_in_hands(new /obj/item/storage/toolbox/mechanical()) //so they dont get stuck in maints

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -678,10 +678,12 @@
 	min_pop = 10
 	max_antag_cap = 1
 	signup_atom_appearance = /obj/effect/bluespace_stream
+	/// Chance of getting another clone for the price of free
+	var/bonus_clone_chance = 20
 
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/New(list/dynamic_config)
 	. = ..()
-	max_antag_cap += prob(20) // 1/5 paradox clones will have (up to) two of the same guy
+	max_antag_cap += prob(bonus_clone_chance)
 
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/can_be_selected()
 	return ..() && !isnull(find_clone()) && !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = FALSE))

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -679,14 +679,20 @@
 	max_antag_cap = 1
 	signup_atom_appearance = /obj/effect/bluespace_stream
 
+/datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/New(list/dynamic_config)
+	. = ..()
+	max_antag_cap += prob(20) // 1/5 paradox clones will have (up to) two of the same guy
+
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/can_be_selected()
 	return ..() && !isnull(find_clone()) && !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = FALSE))
+
+/datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/create_execute_args()
+	return list(find_clone())
 
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/create_ruleset_body()
 	return // handled by assign_role() entirely
 
-/datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/assign_role(datum/mind/candidate)
-	var/mob/living/carbon/human/good_version = find_clone()
+/datum/dynamic_ruleset/midround/from_ghosts/paradox_clone/assign_role(datum/mind/candidate, mob/living/carbon/human/good_version)
 	var/mob/living/carbon/human/bad_version = good_version.make_full_human_copy(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = FALSE))
 	candidate.transfer_to(bad_version, force_key_move = TRUE)
 


### PR DESCRIPTION
## About The Pull Request

Paradox Clone ruleset has a 1/5 chance of spawning an additional clone of the same target. This chance is configurable (so server operators can disable it), but the amount of clones it adds is not.

The second clone is *not* on a team with the first. Paradox Clone's primary objective has been updated to `Be the only [x] alive`, rather than `Kill [x]`.

- [ ] I tested this pr

## Why It's Good For The Game

A while back someone suggested "What if Paradox Clone spawned a third clone with the objective to protect the guy instead of kill them" 

I thought this sounded pretty neat but the idea of spawning an antag that worked against antags seemed to be grounds for problems. So I stole half the idea. 

This adds a little more variety in Paradox Clone happenings:
- Clones have no idea or indication if there are other clones (unless you spawn together - which is not guaranteed), so each clone is less sure of things and has to improvise more
- Neither the clones nor the crew can be fully complacent after dealing with one "clone"
- More plausible deniability for Genetics or Changelings to mess with people
- And yes, even the clones aren't 100% sure if the *other* clone is real or fake, so now they're roped in on the fun

## Changelog

:cl: Melbert
add: There's a 1/5 chance that Paradox Clone spawns a second clone if there are enough candidates. Neither clone is aware of or on a team with the other - There can only be one.
add: Paradox Clones are now tasked to `Be the only [x] alive`, meaning means of identity cloning (such as Genetics or Changelings) may throw a wrench in your plan.
/:cl:
