### PR TITLE
Fixing Catwalk's HyperTorus Equipment

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -29621,11 +29621,11 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/obj/item/hfr_box/body/waste_output{
+/obj/structure/table,
+/obj/item/hfr_box/body/fuel_input{
 	pixel_x = 10;
 	pixel_y = 9
 	},
-/obj/structure/table,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "iIS" = (


### PR DESCRIPTION
## About The Pull Request

Replaces one of the two HyperTorus Waste Output construction cubes at (186, 159, 2) with a HyperTorus Fuel Input construction cube

## Why It's Good For The Game

Lacking the appropriate shift-start equipment to perform stable and safe fusion is Quite Bad(TM) for Catwalk-Class stations. Replacing it with the correct variant of HyperTorus Construction Cube  is Quite Good(TM) and will allow atmospherics to once again operate nominally without requiring external assistance.

## Changelog

:cl:
fix: NanoTrasen's atmospherics division has replaced an incorrectly supplied HyperTorus Construction Cube(TM) with the correct variant on Catwalk-Class stations
/:cl: