### PR TITLE
Makes the arcade machine experiment succeed on game completion rather than item vending

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -29,8 +29,8 @@
 #define COMSIG_MACHINERY_SET_OCCUPANT "machinery_set_occupant"
 ///from /obj/machinery/destructive_scanner/proc/open(aggressive): Runs when the destructive scanner scans a group of objects. (list/scanned_atoms)
 #define COMSIG_MACHINERY_DESTRUCTIVE_SCAN "machinery_destructive_scan"
-///from /obj/machinery/computer/arcade/prizevend(mob/user, prizes = 1)
-#define COMSIG_ARCADE_PRIZEVEND "arcade_prizevend"
+///from /obj/machinery/computer/arcade/victory_tickets(tickets, sound = TRUE)
+#define COMSIG_ARCADE_VICTORY "arcade_victory"
 ///from /datum/controller/subsystem/air/proc/start_processing_machine: ()
 #define COMSIG_MACHINERY_START_PROCESSING_AIR "start_processing_air"
 ///from /datum/controller/subsystem/air/proc/stop_processing_machine: ()

--- a/code/game/machinery/computer/arcade/_arcade.dm
+++ b/code/game/machinery/computer/arcade/_arcade.dm
@@ -77,7 +77,6 @@
 
 ///Dispenses the proper prizes and gives them a positive mood event. If valid, has a small chance to give a pulse rifle.
 /obj/machinery/computer/arcade/proc/prizevend(mob/living/user, prizes = 1)
-	SEND_SIGNAL(src, COMSIG_ARCADE_PRIZEVEND, user, prizes)
 	if(user.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && HAS_TRAIT(user, TRAIT_GAMERGOD))
 		visible_message(span_notice("[user] inputs an intense cheat code!"),\
 		span_notice("You hear a flurry of buttons being pressed."))
@@ -99,3 +98,10 @@
 		var/atom/movable/the_prize = new prizeselect(get_turf(src))
 		playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
 		visible_message(span_notice("[src] dispenses [the_prize]!"), span_notice("You hear a chime and a clunk."))
+
+/obj/machinery/computer/arcade/proc/victory_tickets(tickets, sound = TRUE)
+	SEND_SIGNAL(src, COMSIG_ARCADE_VICTORY)
+	visible_message(span_notice("[src] dispenses [tickets] ticket\s!"))
+	new /obj/item/stack/arcadeticket((get_turf(src)), tickets)
+	if(sound)
+		playsound(loc, 'sound/machines/arcade/win.ogg', 40)

--- a/code/game/machinery/computer/arcade/amputation.dm
+++ b/code/game/machinery/computer/arcade/amputation.dm
@@ -23,9 +23,7 @@
 		qdel(chopchop)
 		user.mind?.adjust_experience(/datum/skill/gaming, 100)
 		user.won_game()
-		playsound(src, 'sound/machines/arcade/win.ogg', 50, TRUE)
-		new /obj/item/stack/arcadeticket((get_turf(src)), rand(6,10))
-		to_chat(user, span_notice("[src] dispenses a handful of tickets!"))
+		victory_tickets(rand(6,10))
 		return
 	if(!do_they_still_have_that_hand(user, chopchop))
 		to_chat(user, span_warning("The guillotine drops, but your hand seems to be gone already!"))

--- a/code/game/machinery/computer/arcade/battle.dm
+++ b/code/game/machinery/computer/arcade/battle.dm
@@ -232,8 +232,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] has outbombed Cuban Pete and been awarded a bomb.")
 		user.log_message("outbombed Cuban Pete and has been awarded a bomb.", LOG_GAME)
 	else
-		visible_message(span_notice("[src] dispenses 2 tickets!"))
-		new /obj/item/stack/arcadeticket((get_turf(src)), 2)
+		victory_tickets(2,FALSE)
 	player_gold += enemy_gold_reward
 	if(user)
 		var/exp_gained = DEFAULT_EXP_GAIN * all_worlds[player_current_world]

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -470,8 +470,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] made it to Orion on an emagged machine and got an explosive toy ship.")
 		user.log_message("made it to Orion on an emagged machine and got an explosive toy ship.", LOG_GAME)
 	else
-		new /obj/item/stack/arcadeticket((get_turf(src)), 2)
-		to_chat(user, span_notice("[src] dispenses 2 tickets!"))
+		victory_tickets(2)
 	obj_flags &= ~EMAGGED
 	name = initial(name)
 	desc = initial(desc)

--- a/code/modules/experisci/experiment/physical_experiments.dm
+++ b/code/modules/experisci/experiment/physical_experiments.dm
@@ -43,12 +43,12 @@
 		linked_experiment_handler.announce_message("Incorrect object for experiment.")
 		return FALSE
 
-	RegisterSignal(currently_scanned_atom, COMSIG_ARCADE_PRIZEVEND, PROC_REF(win_arcade))
+	RegisterSignal(currently_scanned_atom, COMSIG_ARCADE_VICTORY, PROC_REF(win_arcade))
 	linked_experiment_handler.announce_message("Experiment ready to start.")
 	return TRUE
 
 /datum/experiment/physical/arcade_winner/unregister_events()
-	UnregisterSignal(currently_scanned_atom, COMSIG_ARCADE_PRIZEVEND)
+	UnregisterSignal(currently_scanned_atom, COMSIG_ARCADE_VICTORY)
 
 /datum/experiment/physical/arcade_winner/check_progress()
 	. += EXPERIMENT_PROG_BOOL("Win an arcade game at a tracked arcade cabinet.", is_complete())


### PR DESCRIPTION

## About The Pull Request

Previously, the arcade game win experiment succeeded upon the machine calling `prizevend()`, meaning the experiment completed upon tickets being inserted into the machine, counter to the experiment's text. This pr changes the experiment to succeed upon the machine calling the new `victory_tickets()`, which has replaced each instance of a won game dispensing tickets.

## Why It's Good For The Game

fixes #80218
Standardized ticket dispensing

## Changelog
:cl:

fix: Arcade machine experiment now succeeds on output rather than input of tickets

/:cl:
