### PR TITLE
Unnerfs the attack speed of sentience first basic mobs

### DIFF
--- a/code/modules/mob/living/basic/cytology/vatbeast.dm
+++ b/code/modules/mob/living/basic/cytology/vatbeast.dm
@@ -15,6 +15,7 @@
 	damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 1, STAMINA = 1, OXY = 1)
 	melee_damage_lower = 25
 	melee_damage_upper = 25
+	melee_attack_cooldown = CLICK_CD_MELEE
 	obj_damage = 40
 	unsuitable_atmos_damage = 0
 	attack_sound = 'sound/items/weapons/punch3.ogg'

--- a/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid.dm
+++ b/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid.dm
@@ -10,6 +10,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BUG
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	melee_attack_cooldown = CLICK_CD_MELEE
 	maxHealth = 300
 	health = 300
 

--- a/code/modules/mob/living/basic/space_fauna/bear/_bear.dm
+++ b/code/modules/mob/living/basic/space_fauna/bear/_bear.dm
@@ -127,6 +127,7 @@
 	obj_damage = 11
 	melee_damage_lower = 0
 	melee_damage_upper = 0
+	melee_attack_cooldown = CLICK_CD_MELEE
 	sharpness = NONE //it's made of butter
 	armour_penetration = 0
 	response_harm_continuous = "takes a bite out of"


### PR DESCRIPTION

## About The Pull Request

This PR gives vat beast, mega arachnid and butterbear 0.8 seconds attack cd, instead of the default basic mob 2 second attack CD. 

## Why It's Good For The Game

All mobs used to have a human like 0.8 second attack delay when sentient, this was changed for basic mobs a while ago to normalize the attack rate between AI controlled and sentient mobs. 

This mostly makes sense, but the faster attack rate also helped make up for the fact that human controlled mobs don't have aimbot unlike AI mobs.

And some of the basic mobs slowed down were designed to be player controlled and balanced around the 0.8 second click cd. 

This brings them back where they were intended to be when played

As a side effect it makes the AI controlled vatbeasts and mega arachnids more deadly. 

I think that isn't a bad thing as one of the design goals for cytology to set it apart from gold slimes was that breeding giant space monsters should be dangerous.

## Changelog

:cl:
balance: vatbeasts, mega arachnids and butterbears now attack much quicker, in line with their old player controlled attack speed.
/:cl:

