### PR TITLE
Changes "Couldn't" to "Can't" on Z-Level move failures

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -456,7 +456,7 @@
 		return FALSE
 	if((!(z_move_flags & ZMOVE_IGNORE_OBSTACLES) && !(start.zPassOut(direction) && destination.zPassIn(direction))) || (!(z_move_flags & ZMOVE_ALLOW_ANCHORED) && anchored))
 		if(z_move_flags & ZMOVE_FEEDBACK)
-			to_chat(rider || src, span_warning("You couldn't move there!"))
+			to_chat(rider || src, span_warning("You can't move there!"))
 		return FALSE
 	return destination //used by some child types checks and zMove()
 

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -260,7 +260,7 @@
 	if(remote_eye.zMove(UP))
 		to_chat(owner, span_notice("You move upwards."))
 	else
-		to_chat(owner, span_notice("You couldn't move upwards!"))
+		to_chat(owner, span_notice("You can't move upwards!"))
 
 /datum/action/innate/camera_multiz_down
 	name = "Move down a floor"
@@ -274,7 +274,7 @@
 	if(remote_eye.zMove(DOWN))
 		to_chat(owner, span_notice("You move downwards."))
 	else
-		to_chat(owner, span_notice("You couldn't move downwards!"))
+		to_chat(owner, span_notice("You can't move downwards!"))
 
 /obj/machinery/computer/camera_advanced/human_ai/screwdriver_act(mob/living/user, obj/item/tool)
 	balloon_alert(user, "repackaging...")


### PR DESCRIPTION

## About The Pull Request

Changes "Couldn't" to "Can't" on Z-level move failures

## Why It's Good For The Game

Why is it in past tense? Every time I see this message I ask myself that question and each time I search my soul but I find no answer to satisfy me. I stare at the word and feel hatred burning within me. One of us must go.

## Changelog
:cl:

spellcheck: When failing to move up or down a Z-Level, you are now tied to the present

/:cl:
