### PR TITLE
Makes the dynamic tester tiers / population caps start at 1

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_testing.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_testing.dm
@@ -70,14 +70,14 @@ ADMIN_VERB(dynamic_tester, R_DEBUG, "Dynamic Tester", "See dynamic probabilities
 	switch(action)
 		if("set_num_players")
 			var/old_num = num_players
-			num_players = min(text2num(params["num_players"]), 1)
+			num_players = max(text2num(params["num_players"]), 1)
 			if(old_num != num_players)
 				update_reports()
 			return TRUE
 
 		if("set_tier")
 			var/old_tier = tier
-			tier = min(text2num(params["tier"]), 1)
+			tier = max(text2num(params["tier"]), 1)
 			if(old_tier != tier)
 				update_reports()
 			return TRUE

--- a/code/controllers/subsystem/dynamic/dynamic_testing.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_testing.dm
@@ -70,14 +70,14 @@ ADMIN_VERB(dynamic_tester, R_DEBUG, "Dynamic Tester", "See dynamic probabilities
 	switch(action)
 		if("set_num_players")
 			var/old_num = num_players
-			num_players = text2num(params["num_players"])
+			num_players = min(text2num(params["num_players"]), 1)
 			if(old_num != num_players)
 				update_reports()
 			return TRUE
 
 		if("set_tier")
 			var/old_tier = tier
-			tier = text2num(params["tier"])
+			tier = min(text2num(params["tier"]), 1)
 			if(old_tier != tier)
 				update_reports()
 			return TRUE

--- a/tgui/packages/tgui/interfaces/DynamicTester.tsx
+++ b/tgui/packages/tgui/interfaces/DynamicTester.tsx
@@ -70,7 +70,7 @@ export const DynamicTester = () => {
               <NumberInput
                 ml={0.5}
                 value={tier}
-                minValue={0}
+                minValue={1}
                 maxValue={4}
                 step={1}
                 onChange={(e) => act('set_tier', { tier: e })}
@@ -81,7 +81,7 @@ export const DynamicTester = () => {
               <NumberInput
                 ml={0.5}
                 value={num_players}
-                minValue={0}
+                minValue={1}
                 maxValue={200}
                 step={1}
                 onChange={(e) => act('set_num_players', { num_players: e })}


### PR DESCRIPTION
## About The Pull Request

No antags are spawned at 0 anyway, and it causes some runtimes. 

## Why It's Good For The Game

## Changelog

Not player-facing