### PR TITLE
Releasing water vapor will now also clean radiation on items.

### DIFF
--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -413,7 +413,7 @@
 	for(var/mob/living/basic/slime/M in src)
 		M.apply_water()
 
-	wash(CLEAN_WASH, TRUE)
+	wash(CLEAN_WASH | CLEAN_RAD, TRUE)
 	return TRUE
 
 /turf/open/handle_slip(mob/living/slipper, knockdown_amount, obj/slippable, lube, paralyze_amount, daze_amount, force_drop)

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -121,7 +121,7 @@
 	rarity = 500
 	purchaseable = TRUE
 	base_value = 0.5
-	desc = "Water, in gas form. Makes things slippery."
+	desc = "Water, in gas form. Makes floors slippery and washes items on them."
 	primary_color = "#b0c4de"
 
 /datum/gas/hypernoblium

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -317,3 +317,4 @@ As the Captain, your sabre deals extra damage to Assistants (as long as they hav
 You can automatically extract and retract arm implants by 'activating' the empty hand they're on. This includes integrated toolsets, cursed katanas, and vorpal scythes.
 You can combine the Carpet reagent with various different reagents, such as Oil and Cyanide, to create unique carpet types.
 You can bake a birthday cake and then microwave it to create a legendary cake hat. You can then combine it with an energy sword to create an energy cake.
+You can quickly remove radiation from items in a room by releasing water vapor into the air around them (including worn items).


### PR DESCRIPTION

## About The Pull Request

Adds the `CLEAN_RAD` flag to those passed to the `turf/wash()` call in `turf/open/water_vapor_gas_act()`.
## Why It's Good For The Game

Washing items in a sink or shower is enough to clean the rads off of them and so it makes sense to me that releasing water vapor into a radiated room would have the same effect. Useful for radiation-related disasters that make a room really obnoxious to be in and gives the janitor a unique opportunity to fix something quickly given that they start with a water vapor canister.

![dreamseeker_DTIneot8tQ](https://github.com/user-attachments/assets/a8d54096-169d-474c-8b8a-2410de702ed3)
## Changelog
:cl: sushi
add: water vapor on a turf will now also wash radiation off of the items on it
/:cl:
