### PR TITLE
Stops eyelidless corpses from trying (and failing) to blink

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -453,6 +453,8 @@
 /// Animates one eyelid at a time, thanks BYOND and thanks animation chains
 /obj/item/organ/eyes/proc/animate_eyelid(obj/effect/abstract/eyelid_effect/eyelid, mob/living/carbon/human/parent, sync_blinking = TRUE, list/anim_times = null)
 	. = list()
+	if(isnull(eyelid)) // Can't blink if we don't have eyelids
+		return
 	var/prevent_loops = HAS_TRAIT(parent, TRAIT_PREVENT_BLINK_LOOPS)
 	animate(eyelid, alpha = 0, time = 0, loop = (prevent_loops ? 0 : -1))
 

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -453,7 +453,7 @@
 /// Animates one eyelid at a time, thanks BYOND and thanks animation chains
 /obj/item/organ/eyes/proc/animate_eyelid(obj/effect/abstract/eyelid_effect/eyelid, mob/living/carbon/human/parent, sync_blinking = TRUE, list/anim_times = null)
 	. = list()
-	if(isnull(eyelid)) // Can't blink if we don't have eyelids
+	if(isnull(eyelid)) // Can't blink if we don't have an eyelid
 		return
 	var/prevent_loops = HAS_TRAIT(parent, TRAIT_PREVENT_BLINK_LOOPS)
 	animate(eyelid, alpha = 0, time = 0, loop = (prevent_loops ? 0 : -1))


### PR DESCRIPTION
## About The Pull Request

<img width="1348" height="569" alt="91YPV6s2tG" src="https://github.com/user-attachments/assets/4c86243e-ac0d-4d39-8646-f55c314bb9d3" />

Saw this amusing runtime-dead bodies spawned in the morgue with randomized injuries have a chance to spawn with eyes that were damaged so much as to be qdeleted.

The `check_damage_threshold()` proc occurs before the actual damage gets dealt, so it is possible to enter the blinking procs with eyelids that have become null. This just adds a safety check for that.

## Why It's Good For The Game

silly bugfix

## Changelog

:cl:
fix: dead bodies in the morgue will no longer try to blink
/:cl:
