### PR TITLE
Engineering lathes are now inside Engineering proper, former lathe locations now have the monitoring consoles, atmos monitor consoles replaced with fire closets that include advanced extinguishers

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5490,10 +5490,13 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/rglass{
 	amount = 20;
-	pixel_x = 2;
-	pixel_y = -2
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = -9;
+	pixel_y = 9
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -6836,11 +6839,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "bHr" = (
-/obj/structure/table/reinforced,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/bot,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bHA" = (
@@ -10538,7 +10537,10 @@
 	dir = 4
 	},
 /obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap{
+	pixel_x = -1;
+	pixel_y = 8
+	},
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16133,8 +16135,14 @@
 /area/station/maintenance/department/science)
 "dYz" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = -1;
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -21316,7 +21324,10 @@
 "foL" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black{
+	pixel_x = 1;
+	pixel_y = 8
+	},
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/meson/engine/tray,
 /obj/effect/turf_decal/bot,
@@ -24927,9 +24938,9 @@
 "gho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/computer/atmos_control/nocontrol/master,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "ghq" = (
@@ -25277,8 +25288,14 @@
 /area/station/command/heads_quarters/cmo)
 "gme" = (
 /obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5;
+	pixel_y = 9
+	},
 /obj/item/stack/cable_coil,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
@@ -25805,14 +25822,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "grl" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "grm" = (
@@ -37437,10 +37447,22 @@
 "jkK" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/gloves/color/black{
+	pixel_x = 11;
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/color/black{
+	pixel_x = -9;
+	pixel_y = -8
+	},
+/obj/item/clothing/glasses/meson/engine{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/meson/engine{
+	pixel_x = -8;
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -43623,10 +43645,19 @@
 "kMI" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
-/obj/item/crowbar,
+/obj/item/wrench{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/obj/item/crowbar{
+	pixel_x = 5;
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/bot,
-/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_x = -2;
+	pixel_y = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kMN" = (
@@ -62064,8 +62095,14 @@
 "pwO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/mixed,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = -10;
+	pixel_y = 7
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -63152,6 +63189,34 @@
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"pIH" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 0;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "pIX" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/warning,
 /turf/open/floor/iron/dark,
@@ -69171,14 +69236,28 @@
 "rhf" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
-/obj/item/clothing/mask/gas,
-/obj/item/airlock_painter,
+/obj/item/clothing/mask/gas{
+	pixel_x = 15;
+	pixel_y = 13
+	},
+/obj/item/airlock_painter{
+	pixel_x = -2;
+	pixel_y = -7
+	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Center";
 	dir = 10;
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/item/airlock_painter/decal{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/toner{
+	pixel_x = 13;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rhi" = (
@@ -74414,9 +74493,9 @@
 "suH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/modular_computer/preset/civilian,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "suQ" = (
@@ -74433,12 +74512,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/atmospherics,
 /obj/item/book/manual/wiki/atmospherics{
-	pixel_x = 4;
-	pixel_y = -4
+	pixel_x = 8;
+	pixel_y = 5
 	},
-/obj/item/pipe_dispenser,
+/obj/item/book/manual/wiki/atmospherics{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = 0;
+	pixel_y = -6
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -78758,11 +78843,23 @@
 /area/station/maintenance/starboard/aft)
 "tyj" = (
 /obj/structure/table/reinforced,
-/obj/item/t_scanner,
-/obj/item/pipe_dispenser,
+/obj/item/t_scanner{
+	pixel_x = -11;
+	pixel_y = 0
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = 0;
+	pixel_y = -9
+	},
 /obj/effect/turf_decal/bot,
-/obj/item/pipe_dispenser,
-/obj/item/storage/belt/utility,
+/obj/item/pipe_dispenser{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/storage/belt/utility{
+	pixel_x = 10;
+	pixel_y = 0
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -82976,9 +83073,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/machinery/computer/security/telescreen/engine/directional/west,
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/atmos_control/nocontrol/master{
-	dir = 4
-	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/storage/gas)
 "uxG" = (
@@ -89411,9 +89507,8 @@
 /obj/item/radio/intercom/directional/west{
 	pixel_y = -8
 	},
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 4
-	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/storage/gas)
 "web" = (
@@ -91801,7 +91896,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "wGs" = (
@@ -94679,13 +94776,13 @@
 "xvf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Shared Storage";
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/computer/station_alert,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "xvo" = (
@@ -95939,13 +96036,12 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
 "xJn" = (
-/obj/structure/table/reinforced,
-/obj/item/airlock_painter/decal,
-/obj/effect/turf_decal/bot,
-/obj/item/toner,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 8;
+	pixel_y = 7
 	},
+/obj/machinery/cell_charger,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "xJo" = (
@@ -123171,7 +123267,7 @@ cui
 maI
 rvG
 vtQ
-vtQ
+pIH
 lIu
 rhf
 cRW

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2755,9 +2755,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "aMr" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -3231,17 +3228,10 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
 "aTj" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/utility/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aTp" = (
@@ -24021,7 +24011,6 @@
 /turf/open/floor/plating,
 /area/station/commons/dorms/laundry)
 "gJN" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/machinery/requests_console/directional/east{
 	department = "Engineering";
 	name = "Engineering Requests Console"
@@ -24029,6 +24018,9 @@
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/structure/window/spawner/directional/south,
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "gJT" = (
@@ -26153,14 +26145,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "hqA" = (
-/obj/structure/table,
-/obj/item/crowbar/large,
-/obj/item/storage/box/lights/mixed,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "hqE" = (
@@ -27005,9 +26990,8 @@
 	},
 /area/station/service/chapel)
 "hDh" = (
-/obj/machinery/computer/atmos_alert/station_only{
-	dir = 8
-	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "hDp" = (
@@ -30787,6 +30771,7 @@
 /area/station/service/kitchen/coldroom)
 "iKh" = (
 /obj/machinery/incident_display/delam/directional/north,
+/obj/machinery/computer/station_alert/station_only,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "iKj" = (
@@ -34335,9 +34320,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/computer/atmos_control/nocontrol/master{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -53883,9 +53865,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "phw" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 8
-	},
+/obj/machinery/computer/atmos_control/nocontrol/master,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "phz" = (
@@ -60448,9 +60428,13 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "qXt" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/nuka_cola{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -69348,14 +69332,30 @@
 /turf/open/floor/plating,
 /area/mine/eva)
 "tzH" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /obj/item/clothing/suit/hazardvest,
 /obj/structure/sign/warning/no_smoking/directional/north,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson/engine{
+	pixel_x = 12;
+	pixel_y = 4
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/item/storage/belt/utility{
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -73053,8 +73053,10 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "uCK" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "uCM" = (
@@ -75341,15 +75343,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "vnt" = (
-/obj/machinery/computer/station_alert/station_only{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/south{
 	id = "atmos"
 	},
 /obj/machinery/light_switch/directional/south{
 	pixel_x = -10
 	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "vnw" = (
@@ -83081,6 +83082,7 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/entry)
 "xAn" = (
+/obj/machinery/computer/atmos_alert/station_only,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "xAs" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -256,10 +256,7 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "afM" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "afN" = (
@@ -7816,6 +7813,12 @@
 /obj/item/hand_labeler,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"cKR" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "cKW" = (
 /obj/structure/secure_safe/directional/north,
 /obj/machinery/camera/directional/north{
@@ -9569,12 +9572,11 @@
 /area/station/science/ordnance/storage)
 "dss" = (
 /obj/machinery/status_display/evac/directional/west,
-/obj/machinery/computer/atmos_control/nocontrol/master{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -25027,12 +25029,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "iHy" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/computer/atmos_control/nocontrol/master{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/storage_shared)
 "iHD" = (
@@ -28659,9 +28663,7 @@
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
 "jPe" = (
-/obj/structure/table,
-/obj/item/airlock_painter,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jPf" = (
@@ -45652,9 +45654,6 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "pMH" = (
-/obj/machinery/computer/station_alert/station_only{
-	dir = 4
-	},
 /obj/structure/plaque/static_plaque/atmos{
 	pixel_x = -32
 	},
@@ -45665,6 +45664,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/storage/gas)
 "pMJ" = (
@@ -57343,9 +57344,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "tLd" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
@@ -62265,9 +62263,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "vqj" = (
-/obj/machinery/computer/atmos_alert/station_only{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -63976,13 +63971,15 @@
 	},
 /area/station/medical/treatment_center)
 "vSC" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/machinery/computer/station_alert/station_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/storage_shared)
 "vSI" = (
@@ -69020,6 +69017,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"xDI" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "xDM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/netpod,
@@ -112112,7 +112115,7 @@ bMA
 rao
 vaI
 yaF
-qaA
+cKR
 fTL
 qaA
 wgf
@@ -113151,7 +113154,7 @@ mdk
 kYG
 nJM
 lOg
-pom
+xDI
 pom
 uUL
 qsv

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -22463,10 +22463,22 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 8;
+	pixel_y = -5
+	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -32720,18 +32732,25 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "kwp" = (
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8
+/obj/structure/table{
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4
+	pixel_x = 7;
+	pixel_y = -6
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4
+	pixel_x = 9;
+	pixel_y = 6
 	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -38693,10 +38712,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
 "mvy" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
 	dir = 4
 	},
+/obj/machinery/computer/station_alert/station_only,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "mwd" = (
@@ -39571,8 +39590,23 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/item/stack/rods/fifty,
 /obj/item/radio/intercom/directional/east,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/obj/item/stack/rods/fifty{
+	pixel_x = 8;
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mLO" = (
@@ -45999,7 +46033,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pjQ" = (
-/obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
@@ -46009,6 +46042,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "pkk" = (
@@ -47470,18 +47506,23 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "pHb" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = 7
 	},
 /obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
+	pixel_x = -7;
+	pixel_y = 0
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 10;
+	pixel_x = -7
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pHl" = (
@@ -49755,14 +49796,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "qyP" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qyQ" = (
@@ -53042,13 +53079,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "rGU" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
-	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rHb" = (
@@ -53821,13 +53855,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "rSC" = (
-/obj/machinery/modular_computer/preset/civilian,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/atmos_control/nocontrol/master,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "rSH" = (
@@ -54534,9 +54568,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "shQ" = (
-/obj/machinery/modular_computer/preset/engineering{
-	dir = 8
-	},
+/obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "shV" = (
@@ -54908,17 +54940,29 @@
 	},
 /obj/structure/rack,
 /obj/item/clothing/glasses/meson/engine{
-	pixel_x = 2;
+	pixel_x = -9;
 	pixel_y = 3
 	},
-/obj/item/clothing/glasses/meson/engine,
 /obj/item/clothing/glasses/meson/engine{
-	pixel_x = 4;
-	pixel_y = 6
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
+/obj/item/clothing/glasses/meson/engine{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = 9;
+	pixel_y = 2
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = 4;
+	pixel_y = -9
+	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -57516,9 +57560,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "tiS" = (
 /obj/effect/landmark/navigate_destination/engineering,
-/obj/machinery/modular_computer/preset/cargochat/engineering{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58895,11 +58936,26 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/plasteel{
-	amount = 10
+	amount = 10;
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 9;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -68187,9 +68243,6 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/lobby)
 "wNY" = (
-/obj/machinery/computer/station_alert/station_only{
-	dir = 8
-	},
 /obj/machinery/requests_console/directional/east{
 	name = "Atmospherics Requests Console";
 	department = "Atmospherics"
@@ -68199,6 +68252,8 @@
 	network = list("ss13","engineering");
 	c_tag = "Engineering - Atmospherics Front Desk"
 	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wOb" = (
@@ -68645,10 +68700,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "wYO" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
 	dir = 8
 	},
+/obj/machinery/modular_computer/preset/cargochat/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "wYS" = (
@@ -68766,10 +68821,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "xaT" = (
-/obj/machinery/computer/atmos_control/nocontrol/master{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xbh" = (
@@ -68982,14 +69036,13 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "xfx" = (
-/obj/machinery/computer/atmos_alert/station_only{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/east{
 	name = "Atmospherics Lockdown";
 	id = "atmos";
 	req_access = list("atmospherics")
 	},
+/obj/structure/closet/firecloset,
+/obj/item/extinguisher/advanced,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xfH" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -4020,9 +4020,10 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/central)
 "btZ" = (
-/obj/machinery/computer/atmos_control/nocontrol/master,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/upper)
+/area/station/engineering/main)
 "bue" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -4832,11 +4833,9 @@
 	},
 /area/station/science/xenobiology)
 "bGU" = (
-/obj/machinery/computer/atmos_alert/station_only{
-	dir = 4
-	},
 /obj/machinery/camera/autoname/directional/south,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "bGW" = (
@@ -18869,6 +18868,10 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/item/mod/module/thermal_regulator{
+	pixel_x = 6;
+	pixel_y = 12
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "gCP" = (
@@ -35259,7 +35262,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "mio" = (
-/obj/machinery/computer/station_alert/station_only,
+/obj/item/extinguisher/advanced,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "mit" = (
@@ -45008,9 +45012,6 @@
 /area/station/engineering/main)
 "pCF" = (
 /obj/machinery/light/directional/south,
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
@@ -47116,6 +47117,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qmo" = (
@@ -47501,10 +47503,10 @@
 /area/station/maintenance/department/science)
 "qsu" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "qsx" = (
@@ -52194,11 +52196,11 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "rWM" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
+/obj/machinery/computer/station_alert,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "rWO" = (
@@ -54247,12 +54249,16 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "sDh" = (
-/obj/structure/rack,
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/plasma_stabilizer{
+	pixel_x = -115;
+	pixel_y = -36
+	},
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
+	},
+/obj/machinery/computer/atmos_control{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -111525,7 +111531,7 @@ rhS
 nHr
 gaN
 rhS
-sqw
+btZ
 ryC
 kqC
 qDR
@@ -178059,7 +178065,7 @@ pXL
 kOI
 eRl
 ovD
-btZ
+mio
 djW
 oas
 muw


### PR DESCRIPTION
## About The Pull Request
This pull request moves the engineering circuit printer and protolathe to be inside of engineering itself, rather than out or immediately adjacent to the lobby. In their place (except for Nebula which already had the consoles in shared storage), the alert and atmospheric monitor consoles have been placed instead, except for Nebula, where they had their positions swapped with vendors. Where the monitor consoles were in atmos, there are now 2-3 fire closets (depending on map) that have advanced extinguishers inside of them as well.

Less importantly though still worth mentioning, I pixel shifted some of the engineering supplies to make it more obvious how many of a given thing spawns on a given table or wherever, since a lot of engineering areas had 2-5 of something stacked in one spot invisibly.

### Icebox
<img width="352" height="896" alt="image" src="https://github.com/user-attachments/assets/c98bdbfa-cde0-4c5d-96e6-af9ec45658b3" /><img width="352" height="896" alt="image" src="https://github.com/user-attachments/assets/f2cab5af-9673-4617-b49c-0b7a7f29aa7f" />

### Delta
<img width="352" height="1408" alt="image" src="https://github.com/user-attachments/assets/0c892fe5-d7cd-4a45-8745-ddebddb61170" /><img width="352" height="1408" alt="image" src="https://github.com/user-attachments/assets/e5286d47-67b2-4c1b-9351-2f0d05331933" />

### Meta
<img width="352" height="1120" alt="image" src="https://github.com/user-attachments/assets/f6de44be-d583-44a5-a482-8594ce878a9e" /><img width="352" height="1120" alt="image" src="https://github.com/user-attachments/assets/1930e4a8-2694-48d7-a136-d1be14c58370" />

### Nebula
<img width="1184" height="352" alt="image" src="https://github.com/user-attachments/assets/3c5fe0cc-5f09-471a-bd28-0d7a55eef8c0" />
<img width="1184" height="352" alt="image" src="https://github.com/user-attachments/assets/954ad6a0-e679-45d0-acd9-79b17d3982a9" />

### Tram
<img width="352" height="896" alt="image" src="https://github.com/user-attachments/assets/5d1c482b-714e-4c55-adbe-cf3cd88641c4" /><img width="352" height="896" alt="image" src="https://github.com/user-attachments/assets/c2a659fd-544e-4ce7-9254-87c4a6137a25" />

### Wawa
**LOWER LEVEL**
<img width="352" height="896" alt="image" src="https://github.com/user-attachments/assets/f77ef678-4ee0-4440-aca0-9d4cc5ae1a29" /><img width="352" height="896" alt="image" src="https://github.com/user-attachments/assets/0e5efbd8-ba71-4279-b4a8-c3e31ee85e63" />
**UPPER LEVEL**
<img width="192" height="288" alt="image" src="https://github.com/user-attachments/assets/ae03521e-c4ee-448b-b889-ca540e429bb1" /><img width="192" height="288" alt="image" src="https://github.com/user-attachments/assets/45f01b31-96c7-4bcc-b268-b9b179343071" />


## Why It's Good For The Game
Engineering lathes offer access to equipment that has an outsized influence on the game compared to the other lathes; most operatively, jaws of life, but various other tools as well that you can wreak certain havoc with if you have basic competence in various engineering disciplines. The other departmental lathes usually require some sort of accompanying item to produce items that have a significant impact on gameplay (security lathes requiring guns for their various kits, science lathes requiring anomaly cores for most of their extremely powerful items).

As such, I thought it would be appropriate to slightly increase how "secure" they were by moving them into the you-should-not-be-here areas of engineering, rather than the lobbies.

In their place I chose to put the various monitoring consoles, because I trust that although they haven't learned it yet, one day the higher-order species of engineering players might discover you can look at these consoles to answer the million dollar screenshake question of "Toxins??" by just seeing if a bunch of fire and atmospheric alarms have popped up (you also have a PDA app that tells you all this information, but PDA apps are still a foreign language to 90% of the playerbase).

And because good things come in threes, I replaced where the consoles were in atmospherics with fire closets that also include an advanced extinguisher. Now that extinguishers are bulky rather than normal sized, they're much more difficult to carry around, and having two more advanced extinguishers available roundstart in a semi-accessible area where one might expect to find firefighting equipment seems a reasonable change to balance that out.

I did not make these changes to Catwalk, owing to the current overhaul or whatever is going on with it.

## Changelog
:cl: Bisar
map: Engineering lathes have been moved further into engineering.
map: Engineering lathes have been replaced in the various storages with monitoring consoles.
map: Atmospherics consoles have been replaced with fire closets that also include an additional advanced extinguisher.
map: The changes apply to: MetaStation, Delta Station, Wawa Station, Nebula Station, Icebox Station, Tram Station
/:cl:
