### PR TITLE
[no gbp] small oversight with crafting and tools

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -244,7 +244,7 @@
 
 			var/found_behaviors = contents[CONTENTS_TOOL_BEHAVIOUR]
 			for(var/behavior in recipe.tool_behaviors)
-				recipe_time += found_behaviors[behavior]
+				recipe_time += dynamic_recipe_time * found_behaviors[behavior]
 
 		if(!do_after(crafter, round(recipe_time, 0.1 SECONDS), target = crafter))
 			return "."


### PR DESCRIPTION
## About The Pull Request
While looking for possible reported issues and reviewing my own code post-merge, I've found out that I've made an error in the logic for crafting and tool speed. It's basically just one line in which the value wasn't multiplied by `dynamic_recipe_time` anyway, meaning some recipes were faster than they ought to.

## Why It's Good For The Game
Fixing an issue.

## Changelog

:cl:
fix: Crafting recipes with tools such as wirecutters, wrenches, screwdrivers etc. should take the right amount of time to complete.
/:cl:
