### PR TITLE
[NO GBP] Fixes runtime for vendors using department cards

### DIFF
--- a/code/modules/vending/vendor/inventory.dm
+++ b/code/modules/vending/vendor/inventory.dm
@@ -273,7 +273,7 @@
 	var/datum/bank_account/account = paying_id_card.registered_account
 
 	//deduct money from person
-	if(!discountless && account.account_job.paycheck_department == payment_department)
+	if(!discountless && account.account_job?.paycheck_department == payment_department)
 		price_to_use = max(round(price_to_use * DEPARTMENT_DISCOUNT), 1) //No longer free, but signifigantly cheaper.
 	if(attempt_charge(src, mob_paying, price_to_use) & COMPONENT_OBJ_CANCEL_CHARGE)
 		speak("You do not possess the funds to purchase [product_to_vend.name].")


### PR DESCRIPTION
## About The Pull Request
Cause the `account_job` is null so it run-timed

## Changelog
:cl:
fix: no runtime for vendors using department cards
/:cl:

