### PR TITLE
Fix force say and close the say popup instead of just clearing it

### DIFF
--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -138,15 +138,16 @@ export function TguiSay() {
 
   function handleForceSay(): void {
     const iterator = channelIterator.current;
+    const currentValue = innerRef.current?.value;
 
     // Only force say if we're on a visible channel and have typed something
-    if (!value || iterator.isVisible()) return;
+    if (!currentValue || !iterator.isVisible()) return;
 
     const prefix = currentPrefix ?? '';
-    const grunt = iterator.isSay() ? prefix + value : value;
+    const grunt = iterator.isSay() ? prefix + currentValue : currentValue;
 
     messages.current.forceSayMsg(grunt, iterator.current());
-    unloadChat();
+    handleClose();
   }
 
   function handleIncrementChannel(): void {

--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -82,11 +82,7 @@ export function TguiSay() {
       setButtonContent(currentPrefix.current ?? iterator.current());
 
       // Empty input, resets the channel
-    } else if (
-      currentPrefix.current &&
-      iterator.isSay() &&
-      value?.length === 0
-    ) {
+    } else if (currentPrefix.current && iterator.isSay() && value?.length === 0) {
       setCurrentPrefix(null);
       setButtonContent(iterator.current());
     }

--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -27,13 +27,11 @@ export function TguiSay() {
   const chatHistory = useRef(new ChatHistory());
   const messages = useRef(byondMessages);
   const scale = useRef(true);
+  const currentPrefix = useRef<keyof typeof RADIO_PREFIXES | null>(null);
 
   // I initially wanted to make these an object or a reducer, but it's not really worth it.
   // You lose the granulatity and add a lot of boilerplate.
   const [buttonContent, setButtonContent] = useState('');
-  const [currentPrefix, setCurrentPrefix] = useState<
-    keyof typeof RADIO_PREFIXES | null
-  >(null);
   const [lightMode, setLightMode] = useState(false);
   const [maxLength, setMaxLength] = useState(1024);
   const [size, setSize] = useState(WindowSize.Small);
@@ -41,6 +39,10 @@ export function TguiSay() {
 
   const position = useRef([window.screenX, window.screenY]);
   const isDragging = useRef(false);
+
+  function setCurrentPrefix(prefix: keyof typeof RADIO_PREFIXES | null): void {
+    currentPrefix.current = prefix;
+  }
 
   function handleArrowKeys(direction: KEY.Up | KEY.Down): void {
     const chat = chatHistory.current;
@@ -77,10 +79,14 @@ export function TguiSay() {
     // User is on a chat history message
     if (!chat.isAtLatest()) {
       chat.reset();
-      setButtonContent(currentPrefix ?? iterator.current());
+      setButtonContent(currentPrefix.current ?? iterator.current());
 
       // Empty input, resets the channel
-    } else if (currentPrefix && iterator.isSay() && value?.length === 0) {
+    } else if (
+      currentPrefix.current &&
+      iterator.isSay() &&
+      value?.length === 0
+    ) {
       setCurrentPrefix(null);
       setButtonContent(iterator.current());
     }
@@ -123,7 +129,7 @@ export function TguiSay() {
 
   function handleEnter(): void {
     const iterator = channelIterator.current;
-    const prefix = currentPrefix ?? '';
+    const prefix = currentPrefix.current ?? '';
 
     if (value?.length && value.length < maxLength) {
       chatHistory.current.add(value);
@@ -143,7 +149,7 @@ export function TguiSay() {
     // Only force say if we're on a visible channel and have typed something
     if (!currentValue || !iterator.isVisible()) return;
 
-    const prefix = currentPrefix ?? '';
+    const prefix = currentPrefix.current ?? '';
     const grunt = iterator.isSay() ? prefix + currentValue : currentValue;
 
     messages.current.forceSayMsg(grunt, iterator.current());
@@ -163,9 +169,9 @@ export function TguiSay() {
     const iterator = channelIterator.current;
     let newValue = event.currentTarget.value;
 
-    const newPrefix = getPrefix(newValue) || currentPrefix;
+    const newPrefix = getPrefix(newValue) || currentPrefix.current;
     // Handles switching prefixes
-    if (newPrefix && newPrefix !== currentPrefix) {
+    if (newPrefix && newPrefix !== currentPrefix.current) {
       setButtonContent(RADIO_PREFIXES[newPrefix]);
       setCurrentPrefix(newPrefix);
       newValue = newValue.slice(3);
@@ -269,7 +275,7 @@ export function TguiSay() {
 
   const theme =
     (lightMode && 'lightMode') ||
-    (currentPrefix && RADIO_PREFIXES[currentPrefix]) ||
+    (currentPrefix.current && RADIO_PREFIXES[currentPrefix.current]) ||
     channelIterator.current.current();
 
   return (


### PR DESCRIPTION

## About The Pull Request

Changes `handleForceSay` to access the popups value via the `innerRef` instead of the `value` variable and changes `currentPrefix` into a Ref for similar reasons. 

I can't explain very well WHY this fixes it, as I'm no typescript developer, but I assume it has to do with how `handleForceSay` is being used as a subscription callback. So, the other functions being used that way may have similar issues but I'd rather not touch anymore than this. 

The condition within was also incorrect but just never got anywhere because `value` would always be empty.

This also changes it to close the say popup rather than just clearing it. IMO it makes more sense to do this as currently this really only happens when you are taking damage or getting stunned, so it only going half way even though it ejected your text feels awkward. 
## Why It's Good For The Game

Fixes a feature that has been seemingly broken and forgotten about for over half a year. Maybe there's some context for why it was never fixed idk. But, yknow, its cool and I'd like to see it in game.

![dreamseeker_fPcVtN8LkH](https://github.com/user-attachments/assets/f66461f1-ae48-4edd-b5f6-6a81de227647)
## Changelog
:cl: sushi
fix: force say works again
/:cl:
