### PR TITLE
[NO GBP] Removes a redundant crafting recipe

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -8,15 +8,6 @@
 	)
 	category = CAT_TOOLS
 
-/datum/crafting_recipe/bonfire
-	name = "Bonfire"
-	time = 6 SECONDS
-	reqs = list(/obj/item/grown/log = 5)
-	parts = list(/obj/item/grown/log = 5) //Will be returned if the bonfire is dismantled
-	blacklist = list(/obj/item/grown/log/steel)
-	result = /obj/structure/bonfire
-	category = CAT_TOOLS
-
 /datum/crafting_recipe/boneshovel
 	name = "Serrated Bone Shovel"
 	reqs = list(


### PR DESCRIPTION
## About The Pull Request
Bonfires can already be made by using planks (wood sheets). Keeping the other method of making a bonfire is mainly irrelevant and redundant since you can use any sharp tool to cut the logs into planks in this game anyway, so nobody's gonna miss this crafting recipe dearly.

## Why It's Good For The Game
Redundant crafting recipe.

## Changelog

:cl:
del: Removed a mainly redundant recipe for bonfires.
/:cl:

