### PR TITLE
Crew Monitoring Consoles now display DNR status

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -45,6 +45,7 @@
 		"name",
 		"job",
 		"life_status",
+		"dnr_status",
 		"suffocation",
 		"toxin",
 		"burn",
@@ -65,6 +66,7 @@
 		entry["name"] = player_record["name"]
 		entry["job"] = player_record["assignment"]
 		entry["life_status"] = player_record["life_status"]
+		entry["dnr_status"] = player_record["dnr_status"]
 		entry["suffocation"] = player_record["oxydam"]
 		entry["toxin"] = player_record["toxdam"]
 		entry["burn"] = player_record["burndam"]
@@ -248,6 +250,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Broken sensors show garbage data
 		if (uniform.has_sensor == BROKEN_SENSORS)
 			entry["life_status"] = rand(0,1)
+			entry["dnr_status"] = rand(0,1)
 			entry["area"] = pick_list (ION_FILE, "ionarea")
 			entry["oxydam"] = rand(0,175)
 			entry["toxdam"] = rand(0,175)
@@ -262,6 +265,15 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (sensor_mode >= SENSOR_LIVING)
 			entry["life_status"] = tracked_living_mob.stat
 
+		var/mob/dead/observer/ghost = tracked_living_mob.get_ghost(TRUE, TRUE)
+		var/obj/item/organ/brain = tracked_living_mob.get_organ_by_type(/obj/item/organ/brain)
+		var/client_like = tracked_living_mob.client || HAS_TRAIT(tracked_living_mob, TRAIT_MIND_TEMPORARILY_GONE)
+		var/valid_ghost = ghost?.can_reenter_corpse && ghost?.client
+		var/valid_soul = brain || HAS_TRAIT(tracked_living_mob, TRAIT_FAKE_SOULLESS)
+		if((brain && client_like) || (valid_ghost && valid_soul))
+			entry["dnr_status"] = 0
+		else
+			entry["dnr_status"] = 1
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)
 			entry += list(

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -25,6 +25,7 @@ const SORT_NAMES = {
 
 const STAT_LIVING = 0;
 const STAT_DEAD = 4;
+const STAT_DNR = 1
 
 const SORT_OPTIONS = ['health', 'ijob', 'name', 'area'];
 
@@ -127,6 +128,7 @@ type CrewSensor = {
   assignment: string | undefined;
   ijob: number;
   life_status: number;
+  dnr_status: number;
   oxydam: number;
   toxdam: number;
   burndam: number;
@@ -229,6 +231,7 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
     assignment,
     ijob,
     life_status,
+    dnr_status,
     oxydam,
     toxdam,
     burndam,
@@ -261,6 +264,7 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
         ) : (
           <Icon name="skull" color="#801308" size={1} />
         )}
+        {dnr_status !== STAT_DNR ? '' : ' (DNR)'}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (


### PR DESCRIPTION
## About The Pull Request

Crew monitoring consoles now display DNR status. Because DNR status and SSD is effectively the same in the eyes of the code, it also marks mobs as DNR if they are SSD. Requires sensors to be at least binary alive or dead, or above
<img width="539" height="83" alt="image" src="https://github.com/user-attachments/assets/6811a4b1-1c87-4ba2-bb07-794252981501" />

## Why It's Good For The Game

I dunno I've never played on TG i was asked / commissioned to make this
(Reasoning pending from the person who asked me to do this)

## Changelog


:cl: Cheese
add: Crew Monitoring consoles now display DNR status
/:cl: