### PR TITLE
Shiv shouldn't be crafted through crafting recipe datums. Removes redundant cable cuffs recipe

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
@@ -9,12 +9,8 @@
 	)
 	result = /obj/item/knife/shiv
 	category = CAT_WEAPON_MELEE
+	non_craftable = TRUE
 	steps = list("Use cloth on a glass shard of any type")
-
-/datum/crafting_recipe/restraints
-	reqs = list(/obj/item/stack/cable_coil = 15)
-	result = /obj/item/restraints/handcuffs/cable
-	category = CAT_TOOLS
 
 /datum/crafting_recipe/runed_metal
 	reqs = list(/obj/item/stack/sheet/plasteel = 1)


### PR DESCRIPTION
## About The Pull Request
the datum is found in the recipes guide file, yet it's completely craftable. The problem here is that you can use any kind of glass shard this way, and the result will always be a generic glass shiv, unlike the manual way, in which the type of shiv you get depends on the type of glass shard you use (standard, plasma, titanium, plastitanium).

I've also removed the crafting recipe for cable restraints. This was also in recipes guide file, however it provided no steps to it, while also being craftable despite the file it's in. I've thought about providing steps to it instead, but I figured out making cable restraints in the game is the kind of baby step that players can intuitively figure out on their own once they know that clicking Z while the item is in your active hand slot is how you generally interact with held items. They won't look for a tiny 16x16 button.
Also, this causes the color of the resulting cuffs to not align with that of the cables used to make it.

## Why It's Good For The Game
See above.

## Changelog

:cl:
fix: Shivs cannot be erroneously crafted via crafting menu anymore. That'd cause you to get a generic glass shiv if you were to use sturdier shards like plasma or titanium.
del: Removed the recipe for cable handcuffs from the crafting menu.
/:cl:
