### PR TITLE
Tomatoes now ferment into vinegar

### DIFF
--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -25,7 +25,7 @@
 	foodtypes = VEGETABLES
 	grind_results = list(/datum/reagent/consumable/ketchup = 0)
 	juice_typepath = /datum/reagent/consumable/tomatojuice
-	distill_reagent = /datum/reagent/consumable/enzyme
+	distill_reagent = /datum/reagent/consumable/vinegar
 
 // Blood Tomato
 /obj/item/seeds/tomato/blood


### PR DESCRIPTION
## About The Pull Request

Tomatoes now ferment into vinegar instead of universal enzyme

## Why It's Good For The Game

Currently there is no way to actually make vinegar outside of synthesizing it as a cyborg or ordering from cargo/buying from the produce orders console. Bungo fruits contain universal enzyme as a reagent, so swapping tomatoes to fermenting into vinegar seemed reasonable, but I am open for other suggestions (I was considering just making it a juicing option for red-beets as well)


https://github.com/user-attachments/assets/f13c63c5-99fc-4552-981d-18bcbccc84fe


## Changelog
:cl:
qol: tomatoes now ferment into vinegar
/:cl:
