### PR TITLE
glass ore (aka sand) is now actually made of sand

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -521,9 +521,6 @@
 /// from /obj/item/detective_scanner/scan(): (mob/user, list/extra_data)
 #define COMSIG_DETECTIVE_SCANNED "det_scanned"
 
-/// from /obj/machinery/mineral/ore_redemption/pickup_item when it successfully picks something up
-#define COMSIG_ORM_COLLECTED_ORE "orm_collected_ore"
-
 /// from /obj/plunger_act when an object is being plungered
 #define COMSIG_PLUNGER_ACT "plunger_act"
 

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -741,7 +741,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		MAT_CATEGORY_ITEM_MATERIAL = TRUE,
 		MAT_CATEGORY_ITEM_MATERIAL_COMPLEMENTARY = TRUE,
 		)
-	sheet_type = /obj/item/stack/sheet/sandblock
+	ore_type = /obj/item/stack/ore/glass
 	value_per_unit = 2 / SHEET_MATERIAL_AMOUNT
 	strength_modifier = 0.5
 	integrity_modifier = 0.1

--- a/code/game/objects/effects/spawners/random/decoration.dm
+++ b/code/game/objects/effects/spawners/random/decoration.dm
@@ -7,7 +7,7 @@
 	name = "decoration material spawner"
 	icon_state = "tile"
 	loot = list(
-		/obj/item/stack/sheet/sandblock{amount = 30} = 25,
+		/obj/item/stack/ore/glass/thirty = 25,
 		/obj/item/stack/sheet/mineral/wood{amount = 30} = 25,
 		/obj/item/stack/sheet/bronze/thirty = 20,
 		/obj/item/stack/tile/noslip{amount = 20} = 10,

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -993,26 +993,6 @@ GLOBAL_LIST_INIT(pizza_sheet_recipes, list(
 /obj/item/stack/sheet/pizza/five
 	amount = 5
 
-/obj/item/stack/sheet/sandblock
-	name = "blocks of sand"
-	desc = "You're too old to be playing with sandcastles. Now you build... sandstations."
-	singular_name = "sand block"
-	icon_state = "sheet-sandstone"
-	mats_per_unit = list(/datum/material/sand = SHEET_MATERIAL_AMOUNT)
-	merge_type = /obj/item/stack/sheet/sandblock
-	material_type = /datum/material/sand
-	material_modifier = 1
-	drop_sound = SFX_STONE_DROP
-	pickup_sound = SFX_STONE_PICKUP
-
-/obj/item/stack/sheet/sandblock/fifty
-	amount = 50
-/obj/item/stack/sheet/sandblock/twenty
-	amount = 20
-/obj/item/stack/sheet/sandblock/five
-	amount = 5
-
-
 /obj/item/stack/sheet/hauntium
 	name = "haunted sheets"
 	desc = "These sheets seem cursed."

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -162,12 +162,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		to_chat(user, span_notice("You remove the water reclaimer from [src]"))
 		return
 
-	if(istype(O, /obj/item/stack/ore/glass))
-		new /obj/item/stack/sheet/sandblock(loc)
-		to_chat(user, span_notice("You wet the sand in the sink and form it into a block."))
-		O.use(1)
-		return
-
 	if(istype(O, /obj/item/stock_parts/water_recycler))
 		if(has_water_reclaimer)
 			to_chat(user, span_warning("There is already has a water recycler installed."))

--- a/code/game/objects/structures/water_structures/water_source.dm
+++ b/code/game/objects/structures/water_structures/water_source.dm
@@ -94,12 +94,6 @@
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 		return
 
-	if(istype(attacking_item, /obj/item/stack/ore/glass))
-		new /obj/item/stack/sheet/sandblock(loc)
-		to_chat(user, span_notice("You wet the sand and form it into a block."))
-		attacking_item.use(1)
-		return
-
 	if(!user.combat_mode || (attacking_item.item_flags & NOBLUDGEON))
 		to_chat(user, span_notice("You start washing [attacking_item]..."))
 		busy = TRUE

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -170,13 +170,13 @@
 
 	//smelting the ore
 	for(var/obj/item/stack/ore/gathered_ore as anything in ore_list)
-		if(isnull(gathered_ore.refined_type))
+		var/obj/item/smelted_ore = gathered_ore.on_orm_collection(src)
+		if(isnull(smelted_ore))
 			continue
 
-		if(materials.insert_item(gathered_ore, ore_multiplier) <= 0)
-			unload_mineral(gathered_ore) //if rejected unload
+		if(materials.insert_item(smelted_ore, ore_multiplier) <= 0)
+			unload_mineral(smelted_ore) //if rejected unload
 
-		SEND_SIGNAL(src, COMSIG_ORM_COLLECTED_ORE)
 
 	if(!console_notify_timer)
 		// gives 5 seconds for a load of ores to be sucked up by the ORM before it sends out request console notifications. This should be enough time for most deposits that people make

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -43,6 +43,16 @@
 	if(stack_overlays)
 		. += stack_overlays
 
+/**
+ * Called when the ore is collected by an ore redemption machine. returns the ore itself.
+ * Normally, ores without a refined type aren't collected by the orm.
+ * It can also be overriden for more specific behavior (for example, sand is smelted into glass beforehand because of different mats).
+ */
+/obj/item/stack/ore/proc/on_orm_collection()
+	if(isnull(refined_type))
+		return null
+	return src
+
 /obj/item/stack/ore/welder_act(mob/living/user, obj/item/I)
 	..()
 	if(!refined_type)
@@ -98,7 +108,7 @@
 	icon_state = "glass"
 	singular_name = "sand pile"
 	points = 1
-	mats_per_unit = list(/datum/material/glass=SHEET_MATERIAL_AMOUNT)
+	mats_per_unit = list(/datum/material/sand = SHEET_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/glass
 	w_class = WEIGHT_CLASS_TINY
 	mine_experience = 0 //its sand
@@ -113,6 +123,11 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 /obj/item/stack/ore/glass/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()
 	AddComponent(/datum/component/storm_hating)
+
+/obj/item/stack/ore/glass/on_orm_collection() //we need to smelt the glass beforehand because the silo and orm don't accept sand mats
+	var/obj/item/stack/sheet/glass = new refined_type(drop_location(), amount)
+	qdel(src)
+	return glass
 
 /obj/item/stack/ore/glass/get_main_recipes()
 	. = ..()
@@ -137,6 +152,9 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		return TRUE
 
 	return FALSE
+
+/obj/item/stack/ore/glass/thirty
+	amount = 30
 
 /obj/item/stack/ore/glass/basalt
 	name = "volcanic ash"


### PR DESCRIPTION
## About The Pull Request
sand blocks existed for the only purpose of making sand available as a material. However, the only method to get them was pretty whimsical and the existence of the feature wasn't really conveyed to the player, which involves rinsing regular sand in a sink... and before you ask, we also have sandstone, which can be crafted just by using the sand in hands, no water involved. In fact, the sand blocks use the same sprites for regular sandstone, except they have no recipes associated to them, nothing! Nada!

Let's address the elephant in the room: We already have sand, however said sand already has the glass material attached to it even before being smelted, so if you put sand into the Autolathe, you get glass, yay. Sand blocks really only existed to make up for the shortcoming of whoever coded the sand material at the time.

But enough ranting. As the title says, sand is now made of sand, sand blocks are kill. I've been careful enough to give the ORM the ability to smelt gathered sand into glass beforehand, so miners won't curse me for making them _actually_ use the smelter for once, "I will rather die to a goliath than have anything to do with that". However, this still means you cannot shove sand directly into lathes and expect glass out of it. Get a welder.

## Why It's Good For The Game


## Changelog

:cl:
balance: sand is now made of sand and not glass. Get a welder if you plan to shove it into a protolathe.
del: Removed now useless sand blocks.
/:cl:
