### PR TITLE
Fixes ordering hat stabilizer module actually buying a tanning module

### DIFF
--- a/code/modules/cargo/markets/market_items/misc.dm
+++ b/code/modules/cargo/markets/market_items/misc.dm
@@ -72,7 +72,7 @@
 /datum/market_item/misc/hat_stabilizer
 	name = "MOD Hat Stabilizer Module"
 	desc = "Don't sacrifice style for substance with this module! Hats not included."
-	item = /obj/item/mod/module/tanner
+	item = /obj/item/mod/module/hat_stabilizer
 	price_min = CARGO_CRATE_VALUE * 2
 	price_max = CARGO_CRATE_VALUE * 3
 	stock_max = 2


### PR DESCRIPTION

## About The Pull Request
When you ordered a MOD hat stabilizer module on the black market you would get ripped off and get a tanning module instead, but not even as a feature where the black market gives you the wrong item as a joke or anything. This was just someone forgetting to update the line after copy pasting.
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: you can actually get the hat stabilizer modsuit module on the black market
/:cl:
