### PR TITLE
[NO GBP] Support non ascii char list read in `/datum/parsed_map/readlist()`

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -1040,14 +1040,14 @@ GLOBAL_LIST_EMPTY(map_model_default)
 					begin = TRUE
 				else if(char == ")")
 					closing_count += 1
-				index += 1
+				index += length(char)
 			trim_right = trim(copytext(text, start_index, index))
 			if(is_simple)
 				trim_left = trim_right
-			if(index == length(text)) //stops a wasteful iteration when we reach the end
+			if(index >= length(text)) //stops a wasteful iteration when we reach the end
 				position = 0
 			else
-				old_position = index + 1 //this moves our pointer past , to the next element
+				old_position = index + length(text[index]) //this moves our pointer past , to the next element
 		else if(position)
 			old_position = position + length(text[position])
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -1034,7 +1034,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			var/index = start_index
 			var/begin = FALSE
 			while(!begin || (opening_count != closing_count))
-				var/char = copytext(text, index, index + 1)
+				var/char = text[index]
 				if(char == "(")
 					opening_count += 1
 					begin = TRUE

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -1034,7 +1034,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			var/index = start_index
 			var/begin = FALSE
 			while(!begin || (opening_count != closing_count))
-				var/char = text[index]
+				var/char = copytext(text, index, index + 1)
 				if(char == "(")
 					opening_count += 1
 					begin = TRUE


### PR DESCRIPTION
## About The Pull Request
I haven't seen an use case for this but upon reviewing my code i saw it didn't match up with how the char pointer is incremented everywhere else. It should increment fully over to the next char instead of the default increment of 1 which might not always be the case based on the char type in the list

## Changelog
:cl:
code: non ascii chars inside lists in map files can be read without error
/:cl:


