### PR TITLE
Fixes random runtime for round start silo connections

### DIFF
--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -85,6 +85,10 @@ handles linking back and forth.
 
 	silo = null
 
+	//mapload only if the parent gets deleted by some random event before the round begins
+	if(QDELETED(parent))
+		return
+
 	mat_container = parent.AddComponent( \
 		/datum/component/material_container, \
 		SSmaterials.materials_by_category[MAT_CATEGORY_SILO], \

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -23,6 +23,8 @@ handles linking back and forth.
 	var/mat_container_flags = NONE
 	///List of signals to hook onto the local container
 	var/list/mat_container_signals
+	///Callback for round start silo connections. Have to cancel this if the parent gets destroyed before round start
+	VAR_PRIVATE/datum/callback/connection
 
 /datum/component/remote_materials/Initialize(
 	mapload,
@@ -46,7 +48,8 @@ handles linking back and forth.
 		connect_to_silo = TRUE
 
 	if(mapload) // wait for silo to initialize during mapload
-		SSticker.OnRoundstart(CALLBACK(src, PROC_REF(_PrepareStorage), connect_to_silo))
+		connection = CALLBACK(src, PROC_REF(_PrepareStorage))
+		SSticker.OnRoundstart(connection, connect_to_silo)
 	else //directly register in round
 		_PrepareStorage(connect_to_silo)
 
@@ -60,6 +63,7 @@ handles linking back and forth.
 /datum/component/remote_materials/proc/_PrepareStorage(connect_to_silo)
 	PRIVATE_PROC(TRUE)
 
+	connection = null
 	if (connect_to_silo)
 		silo = GLOB.ore_silo_default
 		if (silo)
@@ -72,6 +76,9 @@ handles linking back and forth.
 		_MakeLocal()
 
 /datum/component/remote_materials/Destroy()
+	if(connection)
+		SSticker.round_start_events -= connection
+		connection = null
 	if(silo)
 		allow_standalone = FALSE
 		disconnect()
@@ -84,10 +91,6 @@ handles linking back and forth.
 	PRIVATE_PROC(TRUE)
 
 	silo = null
-
-	//mapload only if the parent gets deleted by some random event before the round begins
-	if(QDELETED(parent))
-		return
 
 	mat_container = parent.AddComponent( \
 		/datum/component/material_container, \

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -48,8 +48,8 @@ handles linking back and forth.
 		connect_to_silo = TRUE
 
 	if(mapload) // wait for silo to initialize during mapload
-		connection = CALLBACK(src, PROC_REF(_PrepareStorage))
-		SSticker.OnRoundstart(connection, connect_to_silo)
+		connection = CALLBACK(src, PROC_REF(_PrepareStorage), connect_to_silo)
+		SSticker.OnRoundstart(connection)
 	else //directly register in round
 		_PrepareStorage(connect_to_silo)
 

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -77,7 +77,7 @@ handles linking back and forth.
 
 /datum/component/remote_materials/Destroy()
 	if(connection)
-		SSticker.round_start_events -= connection
+		LAZYREMOVE(SSticker.round_start_events, connection)
 		connection = null
 	if(silo)
 		allow_standalone = FALSE


### PR DESCRIPTION
## About The Pull Request
Happens randomly only at round start. Between the time the silo connection gets initialized (i.e. when the atom subsystem is initialized) & the round start literarily anything can happen like the atom getting destroyed by some random event resulting in the parent becoming null.

So we check for that & abort accordingly

## Changelog
:cl:
fix: Fixes random runtime for round start silo connections
/:cl:
