### PR TITLE
Fixes map export breaking semi colon dependent strings

### DIFF
--- a/code/modules/admin/verbs/map_export.dm
+++ b/code/modules/admin/verbs/map_export.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(save_file_chars, list(
 	if(istext(value))
 		//Prevent symbols from being because otherwise you can name something
 		// [";},/obj/item/gun/energy/laser/instakill{name="da epic gun] and spawn yourself an instakill gun.
-		return "\"[hashtag_newlines_and_tabs("[value]", list("{"="", "}"="", "\""="", ";"="", ","=""))]\""
+		return "\"[hashtag_newlines_and_tabs("[value]", list("{"="", "}"="", "\""="", ","=""))]\""
 	if(isnum(value) || ispath(value))
 		return "[value]"
 	if(islist(value))


### PR DESCRIPTION
## About The Pull Request
Take the atmos gas mixture string for example. All parts of the gas mixture is appended together with semicolon `;`
https://github.com/tgstation/tgstation/blob/d2ec1056ab5aaf494cba4877fe8d65a6cbf39cf9/code/modules/atmospherics/gasmixtures/gas_mixture.dm#L768

However the map export replaces semicolon `;` with an empty string ` `
https://github.com/tgstation/tgstation/blob/d2ec1056ab5aaf494cba4877fe8d65a6cbf39cf9/code/modules/admin/verbs/map_export.dm#L180

We don't want that cause you get broken gas strings. There is no problem in writing special strings that would spawn items because we are already replacing `{` & `}` with empty strings so the string becomes non parseable anyway

## Changelog
:cl:
fix: map export won't break exported gas strings & other that depend on semicolon
/:cl:

