### PR TITLE
Buffs the amount EMPs drain cells to be worthwhile

### DIFF
--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -39,6 +39,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	maxcharge = STANDARD_CELL_CHARGE * 60 // initial charge reduced on init
 	chargerate = STANDARD_CELL_RATE * 0.3 //charging is about 70% less efficient than lithium batteries.
+	emp_damage_modifier = 4 // 15 shots.
 	charge_light_type = null
 	connector_type = "leadacid"
 	grind_results = list(/datum/reagent/lead = 15, /datum/reagent/toxin/acid = 15, /datum/reagent/water = 20)

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -784,7 +784,8 @@
 	if (!cell)
 		return
 	if (!(. & EMP_PROTECT_SELF))
-		deductcharge(STANDARD_CELL_CHARGE / severity)
+		cell.emp_act(severity)
+
 	if (cell.charge >= cell_hit_cost)
 		var/scramble_time
 		scramble_mode()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -100,7 +100,7 @@
 /obj/item/stock_parts/power_store/cell/ninja
 	name = "black power cell"
 	icon_state = "bscell"
-	emp_damage_modifier = 3
+	emp_damage_modifier = 2 //Better because ninja
 	maxcharge = STANDARD_CELL_CHARGE * 10
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.6)
 	chargerate = STANDARD_CELL_RATE
@@ -108,7 +108,7 @@
 /obj/item/stock_parts/power_store/cell/high
 	name = "high-capacity power cell"
 	icon_state = "hcell"
-	emp_damage_modifier = 3 // Four hits
+	emp_damage_modifier = 4 // Three hits
 	maxcharge = STANDARD_CELL_CHARGE * 10
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.6)
 	chargerate = STANDARD_CELL_RATE * 0.75
@@ -120,7 +120,7 @@
 /obj/item/stock_parts/power_store/cell/super
 	name = "super-capacity power cell"
 	icon_state = "scell"
-	emp_damage_modifier = 4 // Five hits
+	emp_damage_modifier = 5 // Four hits
 	maxcharge = STANDARD_CELL_CHARGE * 20
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT * 3)
 	chargerate = STANDARD_CELL_RATE
@@ -131,7 +131,7 @@
 /obj/item/stock_parts/power_store/cell/hyper
 	name = "hyper-capacity power cell"
 	icon_state = "hpcell"
-	emp_damage_modifier = 5 // Six Hits
+	emp_damage_modifier = 6 // Five Hits
 	maxcharge = STANDARD_CELL_CHARGE * 30
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT * 4)
 	chargerate = STANDARD_CELL_RATE * 1.5
@@ -143,7 +143,7 @@
 	name = "bluespace power cell"
 	desc = "A rechargeable transdimensional power cell."
 	icon_state = "bscell"
-	emp_damage_modifier = 5 //Eight Hits
+	emp_damage_modifier = 5 // Six hits.
 	maxcharge = STANDARD_CELL_CHARGE * 40
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*6)
 	chargerate = STANDARD_CELL_RATE * 2

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -16,6 +16,7 @@
 	throwforce = 5
 	throw_speed = 2
 	throw_range = 5
+	emp_damage_modifier = 1
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*7, /datum/material/glass=SMALL_MATERIAL_AMOUNT*0.5)
 	grind_results = list(/datum/reagent/lithium = 15, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
@@ -53,6 +54,7 @@
 	desc = "A power cell with a slightly higher capacity than normal!"
 	icon_state = "9v_cell"
 	maxcharge = STANDARD_CELL_CHARGE * 2.5
+
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.5)
 	chargerate = STANDARD_CELL_RATE * 0.5
 
@@ -83,6 +85,7 @@
 
 /obj/item/stock_parts/power_store/cell/pulse //200 pulse shots
 	name = "pulse rifle power cell"
+	emp_damage_modifier = 0.5
 	maxcharge = STANDARD_CELL_CHARGE * 40
 	chargerate = STANDARD_CELL_RATE * 0.75
 
@@ -97,6 +100,7 @@
 /obj/item/stock_parts/power_store/cell/ninja
 	name = "black power cell"
 	icon_state = "bscell"
+	emp_damage_modifier = 3
 	maxcharge = STANDARD_CELL_CHARGE * 10
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.6)
 	chargerate = STANDARD_CELL_RATE
@@ -104,10 +108,11 @@
 /obj/item/stock_parts/power_store/cell/high
 	name = "high-capacity power cell"
 	icon_state = "hcell"
+	emp_damage_modifier = 3 // Four hits
 	maxcharge = STANDARD_CELL_CHARGE * 10
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.6)
 	chargerate = STANDARD_CELL_RATE * 0.75
-	
+
 
 /obj/item/stock_parts/power_store/cell/high/empty
 	empty = TRUE
@@ -115,6 +120,7 @@
 /obj/item/stock_parts/power_store/cell/super
 	name = "super-capacity power cell"
 	icon_state = "scell"
+	emp_damage_modifier = 4 // Five hits
 	maxcharge = STANDARD_CELL_CHARGE * 20
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT * 3)
 	chargerate = STANDARD_CELL_RATE
@@ -125,6 +131,7 @@
 /obj/item/stock_parts/power_store/cell/hyper
 	name = "hyper-capacity power cell"
 	icon_state = "hpcell"
+	emp_damage_modifier = 5 // Six Hits
 	maxcharge = STANDARD_CELL_CHARGE * 30
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT * 4)
 	chargerate = STANDARD_CELL_RATE * 1.5
@@ -136,6 +143,7 @@
 	name = "bluespace power cell"
 	desc = "A rechargeable transdimensional power cell."
 	icon_state = "bscell"
+	emp_damage_modifier = 5 //Eight Hits
 	maxcharge = STANDARD_CELL_CHARGE * 40
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*6)
 	chargerate = STANDARD_CELL_RATE * 2
@@ -146,6 +154,7 @@
 /obj/item/stock_parts/power_store/cell/infinite
 	name = "infinite-capacity power cell"
 	icon_state = "icell"
+	emp_damage_modifier = 0
 	maxcharge = INFINITY //little disappointing if you examine it and it's not huge
 	custom_materials = list(/datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT)
 	chargerate = INFINITY
@@ -172,6 +181,7 @@
 	icon = 'icons/obj/service/hydroponics/harvest.dmi'
 	icon_state = "potato"
 	maxcharge = STANDARD_CELL_CHARGE * 0.3
+	emp_damage_modifier = 0.5 //It's biological, so no silicon to fry.
 	charge_light_type = null
 	connector_type = null
 	custom_materials = null
@@ -185,6 +195,7 @@
 /obj/item/stock_parts/power_store/cell/emproof
 	name = "\improper EMP-proof cell"
 	desc = "An EMP-proof cell."
+	emp_damage_modifier = 0
 	maxcharge = STANDARD_CELL_CHARGE * 0.5
 
 /obj/item/stock_parts/power_store/cell/emproof/Initialize(mapload)
@@ -242,6 +253,7 @@
 	connector_type = null
 	custom_materials = null
 	grind_results = null
+	emp_damage_modifier = 0
 
 /obj/item/stock_parts/power_store/cell/ethereal/examine(mob/user)
 	. = ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -100,7 +100,7 @@
 /obj/item/stock_parts/power_store/cell/ninja
 	name = "black power cell"
 	icon_state = "bscell"
-	emp_damage_modifier = 2 //Better because ninja
+	emp_damage_modifier = 3
 	maxcharge = STANDARD_CELL_CHARGE * 10
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.6)
 	chargerate = STANDARD_CELL_RATE
@@ -108,7 +108,7 @@
 /obj/item/stock_parts/power_store/cell/high
 	name = "high-capacity power cell"
 	icon_state = "hcell"
-	emp_damage_modifier = 4 // Three hits
+	emp_damage_modifier = 3
 	maxcharge = STANDARD_CELL_CHARGE * 10
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.6)
 	chargerate = STANDARD_CELL_RATE * 0.75
@@ -120,7 +120,7 @@
 /obj/item/stock_parts/power_store/cell/super
 	name = "super-capacity power cell"
 	icon_state = "scell"
-	emp_damage_modifier = 5 // Four hits
+	emp_damage_modifier = 5
 	maxcharge = STANDARD_CELL_CHARGE * 20
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT * 3)
 	chargerate = STANDARD_CELL_RATE
@@ -131,7 +131,7 @@
 /obj/item/stock_parts/power_store/cell/hyper
 	name = "hyper-capacity power cell"
 	icon_state = "hpcell"
-	emp_damage_modifier = 6 // Five Hits
+	emp_damage_modifier = 5
 	maxcharge = STANDARD_CELL_CHARGE * 30
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT * 4)
 	chargerate = STANDARD_CELL_RATE * 1.5
@@ -143,7 +143,7 @@
 	name = "bluespace power cell"
 	desc = "A rechargeable transdimensional power cell."
 	icon_state = "bscell"
-	emp_damage_modifier = 5 // Six hits.
+	emp_damage_modifier = 5
 	maxcharge = STANDARD_CELL_CHARGE * 40
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*6)
 	chargerate = STANDARD_CELL_RATE * 2
@@ -181,7 +181,7 @@
 	icon = 'icons/obj/service/hydroponics/harvest.dmi'
 	icon_state = "potato"
 	maxcharge = STANDARD_CELL_CHARGE * 0.3
-	emp_damage_modifier = 0.5 //It's biological, so no silicon to fry.
+	emp_damage_modifier = 0.5 //It's biological, so
 	charge_light_type = null
 	connector_type = null
 	custom_materials = null

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -241,7 +241,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	use((STANDARD_CELL_CHARGE /severity) * emp_damage_modifier, force = TRUE)
+	use((STANDARD_CELL_CHARGE /severity) * emp_damage_modifier , force = TRUE)
 
 /obj/item/stock_parts/power_store/ex_act(severity, target)
 	. = ..()

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -35,7 +35,7 @@
 	///Does the cell start without any charge?
 	var/empty = FALSE
 	// Damage multiplier the cells take from emps to prevent stuff like bluespace cells taking 40 shots to drain.
-	var/emp_damage_modifier
+	var/emp_damage_modifier = 1
 
 /obj/item/stock_parts/power_store/get_cell()
 	return src

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -34,6 +34,8 @@
 	var/connector_type = "standard"
 	///Does the cell start without any charge?
 	var/empty = FALSE
+	// How much extra damage the cells take from emps to prevent stuff like bluespace cells taking 40 shots to drain.
+	var/emp_damage_modifier
 
 /obj/item/stock_parts/power_store/get_cell()
 	return src
@@ -239,7 +241,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	use(STANDARD_CELL_CHARGE / severity, force = TRUE)
+	use((STANDARD_CELL_CHARGE /severity) * emp_damage_modifier, force = TRUE)
 
 /obj/item/stock_parts/power_store/ex_act(severity, target)
 	. = ..()

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -34,7 +34,7 @@
 	var/connector_type = "standard"
 	///Does the cell start without any charge?
 	var/empty = FALSE
-	// How much extra damage the cells take from emps to prevent stuff like bluespace cells taking 40 shots to drain.
+	// Damage multiplier the cells take from emps to prevent stuff like bluespace cells taking 40 shots to drain.
 	var/emp_damage_modifier
 
 /obj/item/stock_parts/power_store/get_cell()


### PR DESCRIPTION
Simply put, EMPs now drain cells at hopefully decent rates. Starting at basic high capacity, a heavy emp (aka a direct ion rifle hit) drains 1/3 of the battery, with each successive tier of cell taking an extra heavy emp to drain it. At the end, the data looks like this:

- Basic Cell: Instantly drained. Unchanged.
- High Capacity: 3 hits
- Super Capacity: 4 Hits
- Hyper Capacity: 6 Hits
- Bluespace: 8 hits.

Also potatoes take halfed emp damage, because theres not really much silicon to emp, given its a potato.
## Why It's Good For The Game

As of now, this is the stats to drain a cell with EMPs. (Do note some stuff just doesnt drain at all and this is for those that do just run the proc to the cell itself)

- Basic Cell: Instantly drained.
- High Capacity: 10 hits
- Super Capacity: 20 Hits
- Hyper Capacity: 30 Hits
- Bluespace: 40 hits.

The EMP gun on the station can shoot 10 bolts before needing a recharge. It is *physically impossible* to use the ion to depower something with an upgraded cell without needing to reload, and even landing 10 direct hits with the ion to bring down a stock cell is frankly a big ask. Additionally, using emps as crew or sec runs the risk of you getting caught in the splash damage and now your modsuit/pda/whatever doesnt work. Hopefully, this will make the EMP gun actually useful for its intended purpose of countering silicons/mechs.

## Changelog
:cl: WebcomicArtist
balance: EMPs now drain cells better, starting at 3 emps to drain a basic cell, up to 8 for bluespace.
/:cl:
