### PR TITLE
Allows hitting empty light fixures with things on combat mode

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -388,7 +388,7 @@
 		return
 
 	// attempt to stick weapon into light socket
-	if(status != LIGHT_EMPTY)
+	if(status != LIGHT_EMPTY || user.combat_mode)
 		return ..()
 	if(tool.tool_behaviour == TOOL_SCREWDRIVER) //If it's a screwdriver open it.
 		tool.play_tool_sound(src, 75)


### PR DESCRIPTION

## About The Pull Request

You previously couldn't actually hit an empty light fixture with anything, because you'd just stick it in the socket. This lets you hit it with things on combat mode

## Why It's Good For The Game

Things should be breakable, especially if they're made of juicy wires and metal

## Changelog
:cl:

qol: allows hitting empty light fixtures on combat mode

/:cl:
