### PR TITLE
Fix held item slowdowns

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -180,7 +180,7 @@
 	SET_PLANE_EXPLICIT(I, ABOVE_HUD_PLANE, src)
 	if(I.pulledby)
 		I.pulledby.stop_pulling()
-	if(!I.on_equipped(src, ITEM_SLOT_HANDS, initial = visuals_only))
+	if(!has_equipped(I, ITEM_SLOT_HANDS, initial = visuals_only))
 		return FALSE
 	update_held_items()
 	I.pixel_x = I.base_pixel_x

--- a/code/modules/mob/living/basic/drone/inventory.dm
+++ b/code/modules/mob/living/basic/drone/inventory.dm
@@ -74,7 +74,7 @@
 			return
 
 	//Call back for item being equipped to drone
-	equipping.on_equipped(src, slot)
+	has_equipped(equipping, slot)
 
 /mob/living/basic/drone/getBackSlot()
 	return ITEM_SLOT_DEX_STORAGE

--- a/code/modules/mob/living/basic/guardian/guardian_types/dextrous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/dextrous.dm
@@ -81,7 +81,7 @@
 	internal_storage = equipping
 	update_inv_internal_storage()
 
-	equipping.on_equipped(src, slot)
+	has_equipped(equipping, slot)
 	return TRUE
 
 /mob/living/basic/guardian/dextrous/getBackSlot()

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -160,7 +160,7 @@
 	//Item has been handled at this point and equipped callback can be safely called
 	//We cannot call it for items that have not been handled as they are not yet correctly
 	//in a slot (handled further down inheritance chain, probably living/carbon/human/equip_to_slot
-	if(!not_handled)
+	if(!not_handled && slot != ITEM_SLOT_HANDS) // put in hands calls equipped on its own, annoyingly
 		has_equipped(equipping, slot, initial)
 
 	return not_handled

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -175,6 +175,8 @@
 
 	update_equipment_speed_mods()
 	hud_used?.update_locked_slots()
+	if(!(slot & item.slot_flags))
+		return
 	add_item_coverage(item)
 
 /mob/living/carbon/has_unequipped(obj/item/item)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -175,8 +175,10 @@
 
 	update_equipment_speed_mods()
 	hud_used?.update_locked_slots()
-	if(!(slot & item.slot_flags))
+	if(!(slot & item.slot_flags)) // Things below only update if slotted in (ie: not held)
 		return
+	if(item.hair_mask)
+		update_body()
 	add_item_coverage(item)
 
 /mob/living/carbon/has_unequipped(obj/item/item)
@@ -186,6 +188,8 @@
 
 	update_equipment_speed_mods()
 	hud_used?.update_locked_slots()
+	if(item.hair_mask)
+		update_body()
 	remove_item_coverage(item)
 
 /mob/living/carbon/doUnEquip(obj/item/item_dropping, force, newloc, no_move, invdrop = TRUE, silent = FALSE)


### PR DESCRIPTION
## About The Pull Request

Fixes #92907 

Missed a place where it's called manually

Fixes #92915
Fixes #92928

Hair masks relied on `update_obscured` calling `update_body`

## Changelog

:cl: Melbert
fix: Fix held items with slowdown not working
fix: Fix hair mask updating oddly
/:cl: