### PR TITLE
Biodegrade rework PR, take 2

### DIFF
--- a/code/modules/antagonists/changeling/powers/_biodegrade_bioacid.dm
+++ b/code/modules/antagonists/changeling/powers/_biodegrade_bioacid.dm
@@ -1,0 +1,17 @@
+/datum/reagent/toxin/acid/bio_acid
+	name = "adaptive bio-acid"
+	description = "An immensely strong, acidic substance of seemingly biological origin. It is teeming with microscopic\
+	organisms that seem to alter its composition to most adaptively dissolve whatever it comes into contact with."
+	color = "#9455ff"
+	creation_purity = 100
+	toxpwr = 0
+	acidpwr = 100.0
+	ph = 0.0
+	chemical_flags = NONE // NONE to avoid this showing up in plants or mech syringes
+
+/datum/reagent/toxin/acid/bio_acid/expose_mob(mob/living/exposed_mob, methods = TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
+	if(IS_CHANGELING(exposed_mob))
+		to_chat(exposed_mob, span_changeling("We excrete a bio-agent to neutralize the bio-acid. It is routine and reflexive to do so."))
+		acidpwr = 0
+		volume = min(0.1, volume)
+	. = ..()

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -44,6 +44,7 @@
 		for(var/beat in 1 to 3)
 			addtimer(CALLBACK(src, PROC_REF(make_puddle), restraint), beat SECONDS)
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), restraint, 'sound/items/tools/welder.ogg', 50, TRUE), beat SECONDS)
+		log_combat(user = user, target = restraint, what_done = "melted restraining container", addition = "(biodegrade)")
 		return
 	//otherwise it's some kind of worn restraint
 	user.visible_message(
@@ -53,6 +54,8 @@
 	addtimer(CALLBACK(restraint, TYPE_PROC_REF(/atom, atom_destruction), ACID), 1.5 SECONDS)
 	playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
 	make_puddle(restraint)
+	log_combat(user = user, target = restraint, what_done = "melted restraining equipped item", addition = "(biodegrade)")
+
 
 /datum/action/changeling/biodegrade/proc/make_puddle(obj/melted_restraint)
 	return new /obj/effect/decal/cleanable/greenglow(get_turf(melted_restraint))
@@ -68,6 +71,7 @@
 		hapless_manhandler.Stun(2 SECONDS)
 		hapless_manhandler.adjustFireLoss(40, updating_health = TRUE)
 		hapless_manhandler.stop_pulling()
+		log_combat(user = user, target = hapless_manhandler, what_done = "acid-spewed to escape a grab", addition = "(biodegrade)")
 		return
 	var/mob/living/carbon/hapless_carbon = hapless_manhandler
 	var/obj/item/bodypart/arm/doomed_limb = hapless_carbon.get_active_hand()
@@ -95,4 +99,5 @@
 	doomed_limb.dismember()
 	hapless_carbon.Stun(2 SECONDS)
 	hapless_carbon.stop_pulling()
+	log_combat(user = user, target = hapless_carbon, what_done = "delimbed to escape a grab", addition = "(biodegrade)")
 	return

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -9,18 +9,18 @@
 	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
-	..()
 	var/list/obj/restraints = list()
 	var/obj/item/clothing/suit/straitjacket = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	if(!straitjacket?.breakouttime)
 		straitjacket = null
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
 	var/obj/handcuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-	var/obj/some_manner_of_cage = user.loc
-	var/mob/living/space_invader = user.pulled_by
+	var/obj/some_manner_of_cage = astype(user.loc, /obj)
+	var/mob/living/space_invader = user.pulledby
 	if(!straitjacket && !legcuffs && !handcuffs && !some_manner_of_cage && !space_invader)
 		user.balloon_alert(user, "already free!")
 		return FALSE
+	..()
 	if(straitjacket)
 		restraints.Add(straitjacket)
 	if(legcuffs)
@@ -37,9 +37,62 @@
 
 /datum/action/changeling/biodegrade/proc/spew_acid(mob/living/carbon/human/user, obj/restraint)
 	if(restraint == user.loc)
-		restraint.visible_message("Bubbling acid start spewing out of [src]...")
-		addtimer(CALLBACK())
+		restraint.visible_message(span_userdanger("Bubbling acid start spewing out of [restraint]..."))
+		addtimer(CALLBACK(restraint, TYPE_PROC_REF(/atom, atom_destruction), ACID), 4 SECONDS)
+		// create multiple decals to signal to anyone pushing the locker to the crematorium
+		// that "oh lawd ling comin"
+		for(var/beat in 1 to 3)
+			addtimer(CALLBACK(src, PROC_REF(make_puddle), restraint), beat SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), restraint, 'sound/items/tools/welder.ogg', 50, TRUE), beat SECONDS)
+		return
+	//otherwise it's some kind of worn restraint
+	user.visible_message(
+		span_userdanger("[user] spews torrents of acid onto [restraint], melting it with horrifying ease."),
+		user.balloon_alert(user, "melting restraints..."),
+		span_danger("You hear retching, then the sizzling of powerful acid, closer to the sound of hissing steam."))
+	addtimer(CALLBACK(restraint, TYPE_PROC_REF(/atom, atom_destruction), ACID), 1.5 SECONDS)
+	playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
+	make_puddle(restraint)
 
+/datum/action/changeling/biodegrade/proc/make_puddle(obj/melted_restraint)
+	return new /obj/effect/decal/cleanable/greenglow(get_turf(melted_restraint))
 
-
- /proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hopeless_manhandler)
+/datum/action/changeling/biodegrade/proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hapless_manhandler)
+	if(!iscarbon(hapless_manhandler))
+		user.visible_message(
+			span_danger("[user] spews a torrent of sizzling acid onto [hapless_manhandler], using the opportunity to wrestle away."),
+			user.balloon_alert(user, "dissuading captor..."),
+			span_danger("You hear retching, then sizzling, quickly muffled by a loud keening of pain."))
+		playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
+		hapless_manhandler.emote("scream")
+		hapless_manhandler.Stun(2 SECONDS)
+		hapless_manhandler.adjustFireLoss(40, updating_health = TRUE)
+		hapless_manhandler.stop_pulling()
+		return
+	var/mob/living/carbon/hapless_carbon = hapless_manhandler
+	var/obj/item/bodypart/arm/doomed_limb = hapless_carbon.get_active_hand()
+	var/bio_state = doomed_limb.biological_state
+	var/danger_message
+	if(!(bio_state & BIO_FLESH) && !(bio_state & BIO_BONE))
+		if(bio_state & BIO_METAL)
+			danger_message = "metal and wire"
+		else
+			danger_message = "the limb"
+	else if (bio_state & BIO_FLESH)
+		if(bio_state & BIO_BONE)
+			danger_message = "blood and bone"
+	else if (bio_state & BIO_BONE)
+		danger_message = "the bony connections"
+	else//someone was being silly with bio_state in this case but let's avoid a runtime
+		danger_message = "the limb"
+	user.visible_message(
+		span_danger("[user] spews acid onto the arm [hapless_manhandler] grabs [user.p_them()] with, melting through [danger_message]!"),
+		user.balloon_alert(user, "removing captor's grab..."),
+		span_danger("You hear someone retching, followed quickly by a horrible sizzling, which is then muffled by a terrible wail of pain."))
+	to_chat(hapless_carbon, span_userdanger("YOUR ARM IS MELTING OFF!"))
+	playsound(user, 'sound/items/tools/welder.ogg', 50, TRUE)
+	hapless_carbon.emote("scream")
+	doomed_limb.dismember()
+	hapless_carbon.Stun(2 SECONDS)
+	hapless_carbon.stop_pulling()
+	return

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -9,108 +9,37 @@
 	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
-	if(user.handcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-		if(!istype(O))
-			return FALSE
-		user.visible_message(span_warning("[user] vomits a glob of acid on [user.p_their()] [O]!"), \
-			span_warning("We vomit acidic ooze onto our restraints!"))
+	..()
+	var/list/obj/restraints = list()
+	var/obj/item/clothing/suit/straitjacket = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if(!straitjacket?.breakouttime)
+		straitjacket = null
+	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
+	var/obj/handcuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
+	var/obj/some_manner_of_cage = user.loc
+	var/mob/living/space_invader = user.pulled_by
+	if(!straitjacket && !legcuffs && !handcuffs && !some_manner_of_cage && !space_invader)
+		user.balloon_alert(user, "already free!")
+		return FALSE
+	if(straitjacket)
+		restraints.Add(straitjacket)
+	if(legcuffs)
+		restraints.Add(legcuffs)
+	if(handcuffs)
+		restraints.Add(handcuffs)
+	if(some_manner_of_cage)
+		restraints.Add(some_manner_of_cage)
+	for(var/obj/restraint as anything in restraints)
+		spew_acid(user, restraint)
+	if(space_invader)
+		punish_with_acid(user, space_invader)
+	return TRUE
 
-		addtimer(CALLBACK(src, PROC_REF(dissolve_handcuffs), user, O), 3 SECONDS)
-		log_combat(user, user.handcuffed, "melted handcuffs", addition = "(biodegrade)")
-		..()
-		return TRUE
+/datum/action/changeling/biodegrade/proc/spew_acid(mob/living/carbon/human/user, obj/restraint)
+	if(restraint == user.loc)
+		restraint.visible_message("Bubbling acid start spewing out of [src]...")
+		addtimer(CALLBACK())
 
-	if(user.legcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
-		if(!istype(O))
-			return FALSE
-		user.visible_message(span_warning("[user] vomits a glob of acid on [user.p_their()] [O]!"), \
-			span_warning("We vomit acidic ooze onto our restraints!"))
 
-		addtimer(CALLBACK(src, PROC_REF(dissolve_legcuffs), user, O), 3 SECONDS)
-		log_combat(user, user.legcuffed, "melted legcuffs", addition = "(biodegrade)")
-		..()
-		return TRUE
 
-	if(user.wear_suit?.breakouttime)
-		var/obj/item/clothing/suit/S = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(!istype(S))
-			return FALSE
-		user.visible_message(span_warning("[user] vomits a glob of acid across the front of [user.p_their()] [S]!"), \
-			span_warning("We vomit acidic ooze onto our [user.wear_suit.name]!"))
-		addtimer(CALLBACK(src, PROC_REF(dissolve_straightjacket), user, S), 3 SECONDS)
-		log_combat(user, user.wear_suit, "melted [user.wear_suit]", addition = "(biodegrade)")
-		..()
-		return TRUE
-
-	if(istype(user.loc, /obj/structure/closet))
-		var/obj/structure/closet/C = user.loc
-		if(!istype(C))
-			return FALSE
-		C.visible_message(span_warning("[C]'s hinges suddenly begin to melt and run!"))
-		to_chat(user, span_warning("We vomit acidic goop onto the interior of [C]!"))
-		addtimer(CALLBACK(src, PROC_REF(open_closet), user, C), 7 SECONDS)
-		log_combat(user, user.loc, "melted locker", addition = "(biodegrade)")
-		..()
-		return TRUE
-
-	if(istype(user.loc, /obj/structure/spider/cocoon))
-		var/obj/structure/spider/cocoon/C = user.loc
-		if(!istype(C))
-			return FALSE
-		C.visible_message(span_warning("[src] shifts and starts to fall apart!"))
-		to_chat(user, span_warning("We secrete acidic enzymes from our skin and begin melting our cocoon..."))
-		addtimer(CALLBACK(src, PROC_REF(dissolve_cocoon), user, C), 25) //Very short because it's just webs
-		log_combat(user, user.loc, "melted cocoon", addition = "(biodegrade)")
-		..()
-		return TRUE
-
-	var/obj/item/clothing/shoes/shoes = user.shoes
-	if(istype(shoes) && shoes.tied == SHOES_KNOTTED && !(shoes.resistance_flags & (INDESTRUCTIBLE|UNACIDABLE|ACID_PROOF)))
-		new /obj/effect/decal/cleanable/greenglow(shoes.drop_location())
-		user.visible_message(
-			span_warning("[user] vomits a glob of acid on [user.p_their()] tied up [shoes.name], melting [shoes.p_them()] into a pool of goo!"),
-			span_warning("We vomit acidic ooze onto our tied up [shoes.name], melting [shoes.p_them()] into a pool of goo!"),
-		)
-		log_combat(user, shoes, "melted own shoes", addition = "(biodegrade)")
-		qdel(shoes)
-		..()
-		return TRUE
-
-	user.balloon_alert(user, "already free!")
-	return FALSE
-
-/datum/action/changeling/biodegrade/proc/dissolve_handcuffs(mob/living/carbon/human/user, obj/O)
-	if(O && user.handcuffed == O)
-		user.visible_message(span_warning("[O] dissolve[O.gender == PLURAL?"":"s"] into a puddle of sizzling goop."))
-		new /obj/effect/decal/cleanable/greenglow(O.drop_location())
-		qdel(O)
-
-/datum/action/changeling/biodegrade/proc/dissolve_legcuffs(mob/living/carbon/human/user, obj/O)
-	if(O && user.legcuffed == O)
-		user.visible_message(span_warning("[O] dissolve[O.gender == PLURAL?"":"s"] into a puddle of sizzling goop."))
-		new /obj/effect/decal/cleanable/greenglow(O.drop_location())
-		qdel(O)
-
-/datum/action/changeling/biodegrade/proc/dissolve_straightjacket(mob/living/carbon/human/user, obj/S)
-	if(S && user.wear_suit == S)
-		user.visible_message(span_warning("[S] dissolves into a puddle of sizzling goop."))
-		new /obj/effect/decal/cleanable/greenglow(S.drop_location())
-		qdel(S)
-
-/datum/action/changeling/biodegrade/proc/open_closet(mob/living/carbon/human/user, obj/structure/closet/C)
-	if(C && user.loc == C)
-		C.visible_message(span_warning("[C]'s door breaks and opens!"))
-		new /obj/effect/decal/cleanable/greenglow(C.drop_location())
-		C.welded = FALSE
-		C.locked = FALSE
-		C.broken = TRUE
-		C.open()
-		to_chat(user, span_warning("We open the container restraining us!"))
-
-/datum/action/changeling/biodegrade/proc/dissolve_cocoon(mob/living/carbon/human/user, obj/structure/spider/cocoon/C)
-	if(C && user.loc == C)
-		new /obj/effect/decal/cleanable/greenglow(C.drop_location())
-		qdel(C) //The cocoon's destroy will move the changeling outside of it without interference
-		to_chat(user, span_warning("We dissolve the cocoon!"))
+ /proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hopeless_manhandler)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -424,7 +424,7 @@
 
 
 ///Get the item on the mob in the storage slot identified by the id passed in
-/mob/proc/get_item_by_slot(slot_id)
+/mob/proc/get_item_by_slot(slot_id) as /obj/item
 	return null
 
 /// Gets what slot the item on the mob is held in.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3231,6 +3231,7 @@
 #include "code\modules\antagonists\changeling\changeling_power.dm"
 #include "code\modules\antagonists\changeling\fallen_changeling.dm"
 #include "code\modules\antagonists\changeling\headslug_eggs.dm"
+#include "code\modules\antagonists\changeling\powers\_biodegrade_bioacid.dm"
 #include "code\modules\antagonists\changeling\powers\absorb.dm"
 #include "code\modules\antagonists\changeling\powers\adrenaline.dm"
 #include "code\modules\antagonists\changeling\powers\augmented_eyesight.dm"


### PR DESCRIPTION

## About The Pull Request
Please see https://github.com/tgstation/tgstation/pull/92442 for all the details of this PR's intent.

Changes from the auto-closed PR are; this will instead use splashing actual acid on whatever is grabbing the changeling to do the acid-sourced damage, and it addresses some reviews from the previous PR (including not being able to acid-melt things that can't be destroyed under any circumstance, or which have total acid protection)

At this time, it's a draft because in planning to use acid for the damage, I see that the way that I would handle acid armor for the reagents is kind of janky, so I'll be doing another PR to rework how reagents handle armor, in general.

## Why It's Good For The Game
Explained in the original PR, so the sparknotes are:

Makes biodegrade a more attractive ability for changeling by significantly increasing its use as a method to escape confinement of any sort. Hopefully it has the gumption to close up cheesy edge cases as well.

## Changelog
:cl: Bisar
changelog to be filled out after all review and draft changes are done
/:cl:
