### PR TITLE
Blocks mobs with players controlling them from breeding (ie. sentience potion'd raptors)

### DIFF
--- a/code/datums/components/breeding.dm
+++ b/code/datums/components/breeding.dm
@@ -51,6 +51,9 @@
 	if(source.combat_mode)
 		return
 
+	if(source.client || target.client)
+		return
+
 	if(!is_type_in_typecache(target, can_breed_with))
 		return
 


### PR DESCRIPTION
## About The Pull Request

Blocks mobs with players controlling them from breeding (ie. sentience potion'd raptors)

Fixes #92914

## Why It's Good For The Game

![qccy1xz6klt51 (2)](https://github.com/user-attachments/assets/d8456903-cbe6-477f-aa88-6a76179a594c)

## Changelog

:cl:
fix: Blocks mobs with players controlling them from breeding (ie. sentience potion'd raptors)
/:cl: