### PR TITLE
Adds bottles back to chemmasters, and also gives tubes to condimasters too, I guess

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -2,7 +2,6 @@
 /// List of containers the Chem Master machine can print
 GLOBAL_LIST_INIT(reagent_containers, list(
 	CAT_CONDIMENTS = list(
-		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/condiment/flour,
 		/obj/item/reagent_containers/condiment/sugar,
 		/obj/item/reagent_containers/condiment/rice,
@@ -27,7 +26,8 @@ GLOBAL_LIST_INIT(reagent_containers, list(
 		/obj/item/reagent_containers/condiment/pack,
 	),
 	CAT_TUBES = list(
-		/obj/item/reagent_containers/cup/tube
+		/obj/item/reagent_containers/cup/tube,
+		/obj/item/reagent_containers/cup/bottle,
 	),
 	CAT_PILLS = typecacheof(list(
 		/obj/item/reagent_containers/applicator/pill/style

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -579,7 +579,10 @@
 /obj/machinery/chem_master/condimaster/load_printable_containers()
 	var/static/list/containers
 	if(!length(containers))
-		containers = list(CAT_CONDIMENTS = GLOB.reagent_containers[CAT_CONDIMENTS])
+		containers = list(
+			CAT_TUBES = GLOB.reagent_containers[CAT_TUBES],
+			CAT_CONDIMENTS = GLOB.reagent_containers[CAT_CONDIMENTS],
+		)
 	return containers
 
 #undef MAX_CONTAINER_PRINT_AMOUNT


### PR DESCRIPTION
## About The Pull Request
Changes bottles to be into `CAT_TUBES`, instead of `CAT_CONDIMENTS`
## Why It's Good For The Game
Bottles are just like tubes, and are still in certain places, and they're printable from the condimaster for some reason?
## Changelog

:cl:
add: Added bottles to chemmasters, bottles for all.
/:cl: