### PR TITLE
allows mailbags to hold bounty cubes

### DIFF
--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -260,7 +260,8 @@
 	set_holdable(list(
 		/obj/item/mail,
 		/obj/item/delivery/small,
-		/obj/item/paper
+		/obj/item/paper,
+		/obj/item/bounty_cube,
 	))
 
 ///Garment bag


### PR DESCRIPTION
## About The Pull Request
Allows mail bags to hold bounty cubes for optimal manual carrying of bounty cubes to the cargo shuttle.

## Why It's Good For The Game

if i'm going to run like 10 bounties i don't want to have to carry them onto the shuttle one by one. alternatively if there's a lot of people running bounties i'd like to consolidate them into one inventory slot and not have to lug around a crate to sell it all off

## Changelog

:cl:
qol: Mail bags can now hold bounty cubes.
/:cl:
