### PR TITLE
Large beakers & large beaker sidegrades (meta, x-large, bluespace) are now NORMAL size, standard beakers are now SMALL size, cups are now SMALL size, patches are now SMALL size

### DIFF
--- a/code/datums/storage/subtypes/boxes.dm
+++ b/code/datums/storage/subtypes/boxes.dm
@@ -3,7 +3,6 @@
 	max_specific_storage = WEIGHT_CLASS_SMALL
 	open_sound = 'sound/items/handling/cardboard_box/cardboard_box_open.ogg'
 	rustle_sound = 'sound/items/handling/cardboard_box/cardboard_box_rustle.ogg'
-	max_total_storage = WEIGHT_CLASS_SMALL * 4
 
 ///Debug tools box
 /datum/storage/box/debug

--- a/code/datums/storage/subtypes/boxes.dm
+++ b/code/datums/storage/subtypes/boxes.dm
@@ -3,6 +3,7 @@
 	max_specific_storage = WEIGHT_CLASS_SMALL
 	open_sound = 'sound/items/handling/cardboard_box/cardboard_box_open.ogg'
 	rustle_sound = 'sound/items/handling/cardboard_box/cardboard_box_rustle.ogg'
+	max_total_storage = WEIGHT_CLASS_SMALL * 4
 
 ///Debug tools box
 /datum/storage/box/debug

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -10,6 +10,7 @@
 	desc = "Just your average condiment bottle."
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "bottle"
+	w_class = WEIGHT_CLASS_SMALL
 	inhand_icon_state = "beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/items/drinks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/drinks_righthand.dmi'

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -1,6 +1,7 @@
 /obj/item/reagent_containers/cup
 	name = "open container"
 	amount_per_transfer_from_this = 10
+	w_class = WEIGHT_CLASS_SMALL
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
 	volume = 50
 	reagent_flags = OPENCONTAINER | DUNKABLE
@@ -234,6 +235,7 @@
 	name = "beaker"
 	desc = "A beaker. It can hold up to 50 units."
 	icon = 'icons/obj/medical/chemical.dmi'
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "beaker"
 	inhand_icon_state = "beaker"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
@@ -261,6 +263,7 @@
 /obj/item/reagent_containers/cup/beaker/large
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 100 units."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "beakerlarge"
 	custom_materials = list(/datum/material/glass= SHEET_MATERIAL_AMOUNT*1.25)
 	volume = 100
@@ -271,6 +274,7 @@
 /obj/item/reagent_containers/cup/beaker/plastic
 	name = "x-large beaker"
 	desc = "An extra-large beaker. Can hold up to 120 units."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "beakerwhite"
 	custom_materials = list(/datum/material/glass=SHEET_MATERIAL_AMOUNT*1.25, /datum/material/plastic=SHEET_MATERIAL_AMOUNT * 1.5)
 	volume = 120
@@ -281,6 +285,7 @@
 /obj/item/reagent_containers/cup/beaker/meta
 	name = "metamaterial beaker"
 	desc = "A large beaker. Can hold up to 180 units."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "beakergold"
 	custom_materials = list(/datum/material/glass=SHEET_MATERIAL_AMOUNT*1.25, /datum/material/plastic=SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/gold=HALF_SHEET_MATERIAL_AMOUNT, /datum/material/titanium=HALF_SHEET_MATERIAL_AMOUNT)
 	volume = 180
@@ -293,6 +298,7 @@
 	desc = "A cryostasis beaker that allows for chemical storage without \
 		reactions. Can hold up to 50 units."
 	icon_state = "beakernoreact"
+	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 1.5)
 	reagent_flags = OPENCONTAINER | NO_REACT
 	volume = 50
@@ -304,6 +310,7 @@
 		and Element Cuban combined with the Compound Pete. Can hold up to \
 		300 units."
 	icon_state = "beakerbluespace"
+	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/plasma =SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/diamond =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =HALF_SHEET_MATERIAL_AMOUNT)
 	volume = 300
 	amount_per_transfer_from_this = 10

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -9,6 +9,7 @@
 /obj/item/reagent_containers/cup/soda_cans
 	name = "soda can"
 	icon = 'icons/obj/drinks/soda.dmi'
+	w_class = WEIGHT_CLASS_TINY
 	icon_state = "cola"
 	icon_state_preview = "cola"
 	reagent_flags = NONE

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -3,6 +3,7 @@
 	desc = "A chemical patch for touch based applications."
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "bandaid_blank"
+	w_class = WEIGHT_CLASS_SMALL
 	inhand_icon_state = null
 	possible_transfer_amounts = list()
 	volume = 40


### PR DESCRIPTION
## About The Pull Request
This makes an adjustment to the sizes of various reagent containers, primarily, as well as to the total storage capacity of boxes. That's uh, that's about it.

Worth mentioning; soda cans remain at size TINY.

### For reference:
TINY = 1 unit
SMALL = 2 units
NORMAL = 3 units

## Why It's Good For The Game
Primarily this is meant to be a cooling effect on chemistry demigods and, to a lesser degree, nested MOBA loadout box maxxing. The quip about "demigods" for chemistry is only very slightly an exaggeration: reagents are stupendously powerful and the undisputed most broken shit in the entire game. This PR will in all likelihood have a meagre effect on the state of chemistry gaming, but it is meant to force a moment of consideration when deciding what chems you will carry, rather than having 4 boxes of bluespace beakers, each with a maxcap inside at the touch of a lighter, along with a couple of extra pocket beakers full of wolverine healing mixes.

The box change is most strongly motivated by the accompanying chemistry changes, but also serves to meaningfully lower the amount of storage space one person can have on them, with the intent to make your average tider or powerfully gaming antagonist less of a complete lone wolf, or at least needing to set up caches of equipment or god forbid carrying a bag in-hand.

## Changelog
:cl: Bisar
balance: Large beakers and large beaker sidegrades (metamaterial, x-large, bluespace) are now NORMAL size, up from TINY.
balance: Beakers are now SMALL size, up from TINY.
balance: Cups are now SMALL size, up from TINY.
balance: Patches are now SMALL size, up from TINY.
/:cl:
