### PR TITLE
Replaces CE normal welder with the upgraded variant.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -56,7 +56,7 @@
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
 	SSwardrobe.provide_type(/obj/item/screwdriver, src)
 	SSwardrobe.provide_type(/obj/item/wrench, src)
-	SSwardrobe.provide_type(/obj/item/weldingtool, src)
+	SSwardrobe.provide_type(/obj/item/weldingtool/hugetank, src)
 	SSwardrobe.provide_type(/obj/item/crowbar, src)
 	SSwardrobe.provide_type(/obj/item/wirecutters, src)
 	SSwardrobe.provide_type(/obj/item/multitool, src)
@@ -66,7 +66,7 @@
 	var/list/to_preload = list() //Yes this is a pain. Yes this is the point
 	to_preload += /obj/item/screwdriver
 	to_preload += /obj/item/wrench
-	to_preload += /obj/item/weldingtool
+	to_preload += /obj/item/weldingtool/hugetank
 	to_preload += /obj/item/crowbar
 	to_preload += /obj/item/wirecutters
 	to_preload += /obj/item/multitool


### PR DESCRIPTION
## About The Pull Request

This pr changes the normal welder to a upgraded welder with 80 capicity(not the expirimental one) 


## Why It's Good For The Game

Gives a CE as a head a little more of a luxery of longer welder sessions, while its not something giantic like a full powertool set its still something of luxery as its a head of position, normally these welders can just be bought from the vendors.

If maintainers don't agree with this i will change it to industrial welders, because CE gets a normal welder instead of a industrial one which is a downgrade from normal engineers

## Changelog
:cl: Ezel
balance: CE now gets upgraded welders instead of normal
/:cl:
