### PR TITLE
Add GPS debug tool to admin debug box

### DIFF
--- a/code/game/objects/items/storage/boxes/engineering_boxes.dm
+++ b/code/game/objects/items/storage/boxes/engineering_boxes.dm
@@ -39,9 +39,10 @@
 		/obj/item/storage/bag/sheetsnatcher/debug=1,
 		/obj/item/uplink/debug=1,
 		/obj/item/uplink/nuclear/debug=1,
-		/obj/item/clothing/ears/earmuffs/debug = 1,
+		/obj/item/clothing/ears/earmuffs/debug=1,
+		/obj/item/gps/visible_debug=1,
 		)
-	generate_items_inside(items_inside,src)
+	generate_items_inside(items_inside, src)
 
 /obj/item/storage/box/plastic
 	name = "plastic box"


### PR DESCRIPTION

## About The Pull Request
This adds the existing GPS debug tool to the admin debug box that displays x, y, z coordinates on a turf that is somewhat useful when testing z-level boundaries.

<img width="1920" height="1080" alt="dreamseeker_NyC1iJ4SPK" src="https://github.com/user-attachments/assets/a7153fa5-5195-4500-8aa7-57584d19fe85" />

## Why It's Good For The Game
Easier debug tools for testing.

## Changelog
:cl:
qol: The GPS debug tool will now spawn with the admin outfit apart of the debug tools
admin: Add GPS debug tool to admin debug box
/:cl:
