### PR TITLE
Clearly you don't own an air fryer: optimizes /datum/gas_mixture/turf/heat_capacity by ~32%

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/turf/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
-	for(var/id,gas_data in cached_gases)
+	for(var/_id, gas_data in cached_gases)
 		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 	if(!.)
 		. += HEAT_CAPACITY_VACUUM //we want vacuums in turfs to have the same heat capacity as space

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -87,8 +87,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/proc/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
-	for(var/id in cached_gases)
-		var/gas_data = cached_gases[id]
+	for(var/_id, gas_data in cached_gases)
 		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 
 /// Same as above except vacuums return HEAT_CAPACITY_VACUUM

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -95,8 +95,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/turf/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
-	for(var/id in cached_gases)
-		var/gas_data = cached_gases[id]
+	for(var/id,gas_data in cached_gases)
 		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 	if(!.)
 		. += HEAT_CAPACITY_VACUUM //we want vacuums in turfs to have the same heat capacity as space


### PR DESCRIPTION

## About The Pull Request
I just changed to use the 516 key-value for loop syntax. That's all I did. I took pictures.

### Tracy profile on master
<img width="1920" height="1027" alt="heat cap average without change" src="https://github.com/user-attachments/assets/20f3da62-aa72-4de0-9214-7f8ddb081a6d" />

### Tracy profile using the for var/id,gas_data syntax
<img width="1920" height="1025" alt="heat cap average with change" src="https://github.com/user-attachments/assets/e5649d02-07c5-4bb2-82b6-51239d203bf9" />


### Benchmarking from the BYONDcord
<img width="823" height="576" alt="bench 1" src="https://github.com/user-attachments/assets/feb114c8-821f-485f-8206-4314b2df0f09" />
<img width="918" height="464" alt="bench 2" src="https://github.com/user-attachments/assets/dc140389-a713-4c63-9139-0f8f6b1e46a1" />

### Rigorous testing environment for tracy profiling (5 canisters of plasma, 2 canisters of oxygen)
<img width="1920" height="1032" alt="rigorous testing" src="https://github.com/user-attachments/assets/591fe33a-0690-42c3-97e6-d02c18f96439" />
<img width="1920" height="1018" alt="rigorous testing 2" src="https://github.com/user-attachments/assets/99d9ed08-83d2-40d5-bb81-c71f2a470f82" />


## Why It's Good For The Game
haha, processing time number went down

## Changelog
:cl: Bisar
code: Heat capacity calculation for gas mixtures has been slightly optimized.
/:cl:
