### PR TITLE
Bump `tgui-core` & make chat tabs scrollable

### DIFF
--- a/tgui/bun.lock
+++ b/tgui/bun.lock
@@ -49,7 +49,7 @@
         "marked-smartypants": "^1.1.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "tgui-core": "^5.3.0",
+        "tgui-core": "^5.3.1",
         "tgui-dev-server": "workspace:*",
       },
     },
@@ -72,7 +72,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tgui": "workspace:*",
-        "tgui-core": "^5.3.0",
+        "tgui-core": "^5.3.1",
         "tgui-dev-server": "workspace:*",
       },
     },
@@ -84,7 +84,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tgui": "workspace:*",
-        "tgui-core": "^5.3.0",
+        "tgui-core": "^5.3.1",
       },
     },
     "packages/tgui-setup": {
@@ -991,7 +991,7 @@
 
     "tgui": ["tgui@workspace:packages/tgui"],
 
-    "tgui-core": ["tgui-core@5.3.0", "", { "dependencies": { "@floating-ui/react": "^0.27.16", "@nozbe/microfuzz": "^1.0.0" }, "peerDependencies": { "react": "^19.1.0", "react-dom": "^19.1.0" } }, "sha512-iqK0VmE/AGVpkhozr+jsOkuAPsBckxPfL9+rVI/erJHDwdEZshFOW8zkrZTyKTkSrhZVchQjiwuQ1ly6vV88dw=="],
+    "tgui-core": ["tgui-core@5.3.1", "", { "dependencies": { "@floating-ui/react": "^0.27.16", "@nozbe/microfuzz": "^1.0.0" }, "peerDependencies": { "react": "^19.1.0", "react-dom": "^19.1.0" } }, "sha512-+8dDM4R2G6T1SpzpkRXGYc7YD+9ohqYjTV/4Zgcqc1I4Ld8bJH9vKHCQVbEAsHTCIjHsTBW4xnOpKyAx1gRB5w=="],
 
     "tgui-dev-server": ["tgui-dev-server@workspace:packages/tgui-dev-server"],
 

--- a/tgui/bun.lock
+++ b/tgui/bun.lock
@@ -49,7 +49,7 @@
         "marked-smartypants": "^1.1.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "tgui-core": "^4.2.3",
+        "tgui-core": "^5.3.0",
         "tgui-dev-server": "workspace:*",
       },
     },
@@ -72,7 +72,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tgui": "workspace:*",
-        "tgui-core": "^4.2.3",
+        "tgui-core": "^5.3.0",
         "tgui-dev-server": "workspace:*",
       },
     },
@@ -84,7 +84,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tgui": "workspace:*",
-        "tgui-core": "^4.2.3",
+        "tgui-core": "^5.3.0",
       },
     },
     "packages/tgui-setup": {
@@ -107,13 +107,13 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.0.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.2", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw=="],
+    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
 
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.2", "", { "dependencies": { "@floating-ui/core": "^1.7.2", "@floating-ui/utils": "^0.2.10" } }, "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA=="],
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
 
-    "@floating-ui/react": ["@floating-ui/react@0.27.13", "", { "dependencies": { "@floating-ui/react-dom": "^2.1.4", "@floating-ui/utils": "^0.2.10", "tabbable": "^6.0.0" }, "peerDependencies": { "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-Qmj6t9TjgWAvbygNEu1hj4dbHI9CY0ziCMIJrmYoDIn9TUAH5lRmiIeZmRd4c6QEZkzdoH7jNnoNyoY1AIESiA=="],
+    "@floating-ui/react": ["@floating-ui/react@0.27.16", "", { "dependencies": { "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "tabbable": "^6.0.0" }, "peerDependencies": { "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g=="],
 
-    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.4", "", { "dependencies": { "@floating-ui/dom": "^1.7.2" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw=="],
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
@@ -991,7 +991,7 @@
 
     "tgui": ["tgui@workspace:packages/tgui"],
 
-    "tgui-core": ["tgui-core@4.3.3", "", { "dependencies": { "@floating-ui/react": "^0.27.13", "@nozbe/microfuzz": "^1.0.0" }, "peerDependencies": { "react": "^19.1.0", "react-dom": "^19.1.0" } }, "sha512-+eVCmmwbwH6X/SMSXBVGQwsPzIKI8Ho5+tFuIU82cxmWIlWyaJzlCb86+5yBGeeJy4+SCPo6Pv1WrCeHNQeJuw=="],
+    "tgui-core": ["tgui-core@5.3.0", "", { "dependencies": { "@floating-ui/react": "^0.27.16", "@nozbe/microfuzz": "^1.0.0" }, "peerDependencies": { "react": "^19.1.0", "react-dom": "^19.1.0" } }, "sha512-iqK0VmE/AGVpkhozr+jsOkuAPsBckxPfL9+rVI/erJHDwdEZshFOW8zkrZTyKTkSrhZVchQjiwuQ1ly6vV88dw=="],
 
     "tgui-dev-server": ["tgui-dev-server@workspace:packages/tgui-dev-server"],
 

--- a/tgui/packages/tgui-panel/Panel.tsx
+++ b/tgui/packages/tgui-panel/Panel.tsx
@@ -33,7 +33,7 @@ export const Panel = (props) => {
         <Stack.Item>
           <Section fitted>
             <Stack mr={1} align="center">
-              <Stack.Item grow overflowX="auto">
+              <Stack.Item grow>
                 <ChatTabs />
               </Stack.Item>
               <Stack.Item>

--- a/tgui/packages/tgui-panel/chat/ChatTabs.tsx
+++ b/tgui/packages/tgui-panel/chat/ChatTabs.tsx
@@ -23,7 +23,7 @@ export function ChatTabs(props) {
   return (
     <Stack align="center">
       <Stack.Item>
-        <Tabs textAlign="center">
+        <Tabs scrollable textAlign="center">
           {pages.map((page) => (
             <Tabs.Tab
               key={page.id}

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -8,7 +8,7 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"tgui": "workspace:*",
-		"tgui-core": "^5.3.0",
+		"tgui-core": "^5.3.1",
 		"tgui-dev-server": "workspace:*"
 	},
 	"private": true

--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -8,7 +8,7 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"tgui": "workspace:*",
-		"tgui-core": "^4.2.3",
+		"tgui-core": "^5.3.0",
 		"tgui-dev-server": "workspace:*"
 	},
 	"private": true

--- a/tgui/packages/tgui-say/package.json
+++ b/tgui/packages/tgui-say/package.json
@@ -6,7 +6,7 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"tgui": "workspace:*",
-		"tgui-core": "^4.2.3"
+		"tgui-core": "^5.3.0"
 	},
 	"private": true
 }

--- a/tgui/packages/tgui-say/package.json
+++ b/tgui/packages/tgui-say/package.json
@@ -6,7 +6,7 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"tgui": "workspace:*",
-		"tgui-core": "^5.3.0"
+		"tgui-core": "^5.3.1"
 	},
 	"private": true
 }

--- a/tgui/packages/tgui/interfaces/AtmosFilter.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosFilter.tsx
@@ -45,13 +45,14 @@ export const AtmosFilter = (props) => {
             <LabeledList.Item label="Transfer Rate">
               <NumberInput
                 animated
+                tickWhileDragging
                 step={1}
                 value={rate}
                 width="63px"
                 unit="L/s"
                 minValue={0}
                 maxValue={max_rate}
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('rate', {
                     rate: value,
                   })

--- a/tgui/packages/tgui/interfaces/AtmosMixer.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosMixer.tsx
@@ -70,6 +70,7 @@ export const AtmosMixer = (props) => {
             <LabeledList.Item label="Main Node" labelColor="green">
               <NumberInput
                 animated
+                tickWhileDragging
                 value={node1_concentration}
                 step={1}
                 unit="%"
@@ -77,7 +78,7 @@ export const AtmosMixer = (props) => {
                 minValue={0}
                 maxValue={100}
                 stepPixelSize={2}
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('node1', {
                     concentration: value,
                   })
@@ -87,6 +88,7 @@ export const AtmosMixer = (props) => {
             <LabeledList.Item label="Side Node" labelColor="blue">
               <NumberInput
                 animated
+                tickWhileDragging
                 value={node2_concentration}
                 step={1}
                 unit="%"
@@ -94,7 +96,7 @@ export const AtmosMixer = (props) => {
                 minValue={0}
                 maxValue={100}
                 stepPixelSize={2}
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('node2', {
                     concentration: value,
                   })

--- a/tgui/packages/tgui/interfaces/BluespaceSender.tsx
+++ b/tgui/packages/tgui/interfaces/BluespaceSender.tsx
@@ -72,13 +72,14 @@ export const BluespaceSender = (props) => {
               />
               <NumberInput
                 animated
+                tickWhileDragging
                 value={gas_transfer_rate}
                 step={0.01}
                 width="63px"
                 unit="moles/S"
                 minValue={0}
                 maxValue={1}
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('rate', {
                     rate: value,
                   })
@@ -130,12 +131,13 @@ const GasDisplay = (props: GasDisplayProps) => {
           <NumberInput
             animated
             fluid
+            tickWhileDragging
             value={price}
             step={1}
             unit="per mole"
             minValue={0}
             maxValue={100}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('price', {
                 gas_price: value,
                 gas_type: id,

--- a/tgui/packages/tgui/interfaces/BluespaceVendor.tsx
+++ b/tgui/packages/tgui/interfaces/BluespaceVendor.tsx
@@ -86,13 +86,14 @@ export const BluespaceVendor = (props) => {
                 <Stack.Item>
                   <NumberInput
                     animated
+                    tickWhileDragging
                     value={tank_filling_amount}
                     step={1}
                     width="63px"
                     unit="% tank filling goal"
                     minValue={0}
                     maxValue={100}
-                    onDrag={(value) =>
+                    onChange={(value) =>
                       act('pumping_rate', {
                         rate: value,
                       })

--- a/tgui/packages/tgui/interfaces/ChemHeater.tsx
+++ b/tgui/packages/tgui/interfaces/ChemHeater.tsx
@@ -224,6 +224,7 @@ export const ChemHeater = (props) => {
               <Table.Cell />
               <Table.Cell>
                 <NumberInput
+                  tickWhileDragging
                   width="45px"
                   unit="u"
                   step={1}
@@ -231,7 +232,7 @@ export const ChemHeater = (props) => {
                   value={dispenseVolume}
                   minValue={1}
                   maxValue={10}
-                  onDrag={(value) =>
+                  onChange={(value) =>
                     act('disp_vol', {
                       target: value,
                     })
@@ -245,6 +246,7 @@ export const ChemHeater = (props) => {
               </Table.Cell>
               <Table.Cell>
                 <NumberInput
+                  tickWhileDragging
                   width="65px"
                   unit="K"
                   step={10}
@@ -252,7 +254,7 @@ export const ChemHeater = (props) => {
                   value={round(targetTemp, 0.1)}
                   minValue={0}
                   maxValue={1000}
-                  onDrag={(value) =>
+                  onChange={(value) =>
                     act('temperature', {
                       target: value,
                     })

--- a/tgui/packages/tgui/interfaces/ChemMixingChamber.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMixingChamber.tsx
@@ -46,6 +46,7 @@ export const ChemMixingChamber = (props) => {
                   <Stack.Item mt={0.3}>{'Target:'}</Stack.Item>
                   <Stack.Item>
                     <NumberInput
+                      tickWhileDragging
                       width="65px"
                       unit="K"
                       step={10}
@@ -53,7 +54,7 @@ export const ChemMixingChamber = (props) => {
                       value={round(targetTemp, 0.1)}
                       minValue={0}
                       maxValue={1000}
-                      onDrag={(value) =>
+                      onChange={(value) =>
                         act('temperature', {
                           target: value,
                         })
@@ -119,13 +120,14 @@ export const ChemMixingChamber = (props) => {
                     </Stack.Item>
                     <Stack.Item>
                       <NumberInput
+                        tickWhileDragging
                         value={reagentQuantity}
                         minValue={1}
                         maxValue={100}
                         step={1}
                         stepPixelSize={3}
                         width="39px"
-                        onDrag={(value) => setReagentQuantity(value)}
+                        onChange={(value) => setReagentQuantity(value)}
                       />
                       <Box inline mr={1} />
                     </Stack.Item>

--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.tsx
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.tsx
@@ -50,6 +50,7 @@ export const ChemReactionChamber = (props) => {
                   <Stack.Item mt={0.3}>{'Target:'}</Stack.Item>
                   <Stack.Item>
                     <NumberInput
+                      tickWhileDragging
                       width="65px"
                       unit="K"
                       step={10}
@@ -57,7 +58,7 @@ export const ChemReactionChamber = (props) => {
                       value={round(targetTemp, 0.1)}
                       minValue={0}
                       maxValue={1000}
-                      onDrag={(value) =>
+                      onChange={(value) =>
                         act('temperature', {
                           target: value,
                         })
@@ -156,13 +157,14 @@ export const ChemReactionChamber = (props) => {
                   <LabeledList>
                     <LabeledList.Item label="Acidic pH limit">
                       <NumberInput
+                        tickWhileDragging
                         value={reagentAcidic}
                         minValue={0}
                         maxValue={14}
                         step={1}
                         stepPixelSize={3}
                         width="39px"
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('acidic', {
                             target: value,
                           })
@@ -171,13 +173,14 @@ export const ChemReactionChamber = (props) => {
                     </LabeledList.Item>
                     <LabeledList.Item label="Alkaline pH limit">
                       <NumberInput
+                        tickWhileDragging
                         value={reagentAlkaline}
                         minValue={0}
                         maxValue={14}
                         step={1}
                         stepPixelSize={3}
                         width="39px"
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('alkaline', {
                             target: value,
                           })
@@ -204,13 +207,14 @@ export const ChemReactionChamber = (props) => {
                     </Stack.Item>
                     <Stack.Item>
                       <NumberInput
+                        tickWhileDragging
                         value={reagentQuantity}
                         minValue={1}
                         maxValue={100}
                         step={1}
                         stepPixelSize={3}
                         width="39px"
-                        onDrag={(value) => setReagentQuantity(value)}
+                        onChange={(value) => setReagentQuantity(value)}
                       />
                       <Box inline mr={1} />
                     </Stack.Item>

--- a/tgui/packages/tgui/interfaces/ChemRecipeDebug.tsx
+++ b/tgui/packages/tgui/interfaces/ChemRecipeDebug.tsx
@@ -120,13 +120,14 @@ export const ChemRecipeDebug = (props) => {
                   <LabeledList>
                     <LabeledList.Item label="Temperature">
                       <NumberInput
+                        tickWhileDragging
                         width="65px"
                         step={1}
                         stepPixelSize={3}
                         value={forced_temp}
                         minValue={0}
                         maxValue={1000}
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('forced_temp', {
                             target: value,
                           })
@@ -167,13 +168,14 @@ export const ChemRecipeDebug = (props) => {
                   <LabeledList>
                     <LabeledList.Item label={<Box width="82px">PH:</Box>}>
                       <NumberInput
+                        tickWhileDragging
                         width="65px"
                         step={1}
                         stepPixelSize={3}
                         value={forced_ph}
                         minValue={0}
                         maxValue={14}
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('forced_ph', {
                             target: value,
                           })
@@ -200,13 +202,14 @@ export const ChemRecipeDebug = (props) => {
                   <LabeledList>
                     <LabeledList.Item label={<Box width="82px">Purity:</Box>}>
                       <NumberInput
+                        tickWhileDragging
                         width="65px"
                         step={0.01}
                         stepPixelSize={3}
                         value={forced_purity}
                         minValue={0}
                         maxValue={1}
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('forced_purity', {
                             target: value,
                           })
@@ -233,6 +236,7 @@ export const ChemRecipeDebug = (props) => {
                   <LabeledList>
                     <LabeledList.Item label="Volume Mulx">
                       <NumberInput
+                        tickWhileDragging
                         width="65px"
                         step={1}
                         stepPixelSize={3}
@@ -240,7 +244,7 @@ export const ChemRecipeDebug = (props) => {
                         minValue={1}
                         maxValue={1000}
                         unit="x"
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('volume_multiplier', {
                             target: value,
                           })
@@ -364,6 +368,7 @@ export const ChemRecipeDebug = (props) => {
                   <LabeledList>
                     <LabeledList.Item label={<Box width="57px">Value:</Box>}>
                       <NumberInput
+                        tickWhileDragging
                         width="65px"
                         step={0.1}
                         stepPixelSize={3}
@@ -371,7 +376,7 @@ export const ChemRecipeDebug = (props) => {
                         minValue={-1000}
                         maxValue={1000}
                         disabled={editReaction === null}
-                        onDrag={(value) =>
+                        onChange={(value) =>
                           act('edit_value', {
                             target: value,
                           })

--- a/tgui/packages/tgui/interfaces/ColorMatrixEditor.tsx
+++ b/tgui/packages/tgui/interfaces/ColorMatrixEditor.tsx
@@ -41,13 +41,14 @@ export const ColorMatrixEditor = (props) => {
                                 {`${PREFIXES[row]}${PREFIXES[col]}:`}
                               </Box>
                               <NumberInput
+                                tickWhileDragging
                                 minValue={-Infinity}
                                 maxValue={+Infinity}
                                 value={currentColor[row * 4 + col]}
                                 step={0.01}
                                 width="50px"
                                 format={(value) => toFixed(value, 2)}
-                                onDrag={(value) => {
+                                onChange={(value) => {
                                   const retColor = currentColor;
                                   retColor[row * 4 + col] = value;
                                   act('transition_color', {

--- a/tgui/packages/tgui/interfaces/Crystallizer.tsx
+++ b/tgui/packages/tgui/interfaces/Crystallizer.tsx
@@ -81,13 +81,14 @@ const Controls = (props) => {
         <LabeledList.Item label="Gas Input">
           <NumberInput
             animated
+            tickWhileDragging
             step={0.1}
             value={gas_input}
             width="63px"
             unit="moles/s"
             minValue={0}
             maxValue={250}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('gas_input', {
                 gas_input: value,
               })

--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleEnzymes.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleEnzymes.jsx
@@ -294,13 +294,14 @@ const PulseSettings = (props) => {
         <LabeledList.Item label="Output level">
           <NumberInput
             animated
+            tickWhileDragging
             width="32px"
             step={1}
             stepPixelSize={10}
             value={pulseStrength}
             minValue={1}
             maxValue={PULSE_STRENGTH_MAX}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('set_pulse_strength', {
                 val: value,
               })
@@ -310,13 +311,14 @@ const PulseSettings = (props) => {
         <LabeledList.Item label="Pulse duration">
           <NumberInput
             animated
+            tickWhileDragging
             width="32px"
             step={1}
             stepPixelSize={10}
             value={pulseDuration}
             minValue={1}
             maxValue={PULSE_DURATION_MAX}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('set_pulse_duration', {
                 val: value,
               })

--- a/tgui/packages/tgui/interfaces/Electropack.jsx
+++ b/tgui/packages/tgui/interfaces/Electropack.jsx
@@ -41,6 +41,7 @@ export const Electropack = (props) => {
             >
               <NumberInput
                 animate
+                tickWhileDragging
                 unit="kHz"
                 step={0.2}
                 stepPixelSize={6}
@@ -49,7 +50,7 @@ export const Electropack = (props) => {
                 value={frequency / 10}
                 format={(value) => toFixed(value, 1)}
                 width="80px"
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('freq', {
                     freq: value,
                   })
@@ -72,13 +73,14 @@ export const Electropack = (props) => {
             >
               <NumberInput
                 animate
+                tickWhileDragging
                 step={1}
                 stepPixelSize={6}
                 minValue={1}
                 maxValue={100}
                 value={code}
                 width="80px"
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('code', {
                     code: value,
                   })

--- a/tgui/packages/tgui/interfaces/Filteriffic.jsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.jsx
@@ -12,8 +12,7 @@ import {
   NumberInput,
   Section,
 } from 'tgui-core/components';
-import { toFixed } from 'tgui-core/math';
-import { numberOfDecimalDigits } from 'tgui-core/math';
+import { numberOfDecimalDigits, toFixed } from 'tgui-core/math';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
@@ -23,13 +22,14 @@ const FilterIntegerEntry = (props) => {
   const { act } = useBackend();
   return (
     <NumberInput
+      tickWhileDragging
       value={value || 0}
       minValue={-500}
       maxValue={500}
       step={1}
       stepPixelSize={5}
       width="39px"
-      onDrag={(value) =>
+      onChange={(value) =>
         act('modify_filter_value', {
           name: filterName,
           new_data: {
@@ -49,6 +49,7 @@ const FilterFloatEntry = (props) => {
   return (
     <>
       <NumberInput
+        tickWhileDragging
         value={value || 0}
         minValue={-500}
         maxValue={500}
@@ -56,7 +57,7 @@ const FilterFloatEntry = (props) => {
         step={step}
         format={(value) => toFixed(value, numberOfDecimalDigits(step))}
         width="80px"
-        onDrag={(value) =>
+        onChange={(value) =>
           act('transition_filter_value', {
             name: filterName,
             new_data: {

--- a/tgui/packages/tgui/interfaces/GhostMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GhostMenu.tsx
@@ -201,12 +201,12 @@ const GhostSettingsSection = (props) => {
             value={viewNumber}
             minValue={0}
             maxValue={max_extra_view}
-            onDrag={(newValue) => setviewNumber(newValue)}
-            onChange={(new_range) =>
+            onChange={(new_range) => {
+              setviewNumber(new_range);
               act('view_range', {
                 new_view_range: new_range,
-              })
-            }
+              });
+            }}
           />
         </Stack.Item>
       )}

--- a/tgui/packages/tgui/interfaces/HighLuminosityEyesMenu.tsx
+++ b/tgui/packages/tgui/interfaces/HighLuminosityEyesMenu.tsx
@@ -78,13 +78,14 @@ const RangeDisplay = (props) => {
       />
       <NumberInput
         animated
+        tickWhileDragging
         width="35px"
         step={1}
         stepPixelSize={5}
         value={range}
         minValue={0}
         maxValue={5}
-        onDrag={(value) =>
+        onChange={(value) =>
           act('set_range', {
             new_range: value,
           })

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.tsx
@@ -235,12 +235,13 @@ export const HypertorusWasteRemove = (props) => {
         >
           <NumberInput
             animated
+            tickWhileDragging
             value={mod_filtering_rate}
             unit="mol/s"
             step={1}
             minValue={5}
             maxValue={200}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('mod_filtering_rate', {
                 mod_filtering_rate: value,
               })

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.tsx
@@ -118,12 +118,13 @@ const GasList = (props: GasListProps) => {
         />
         <NumberInput
           animated
+          tickWhileDragging
           step={1}
           value={parseFloat(data[input_rate])}
           unit="mol/s"
           minValue={input_min}
           maxValue={input_max}
-          onDrag={(v) => act(input_rate, { [input_rate]: v })}
+          onChange={(v) => act(input_rate, { [input_rate]: v })}
         />
       </LabeledList.Item>
       {gases.map((gas) => {

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -652,6 +652,7 @@ const SnowflakeRadio = (props) => {
       <LabeledList.Item label="Frequency">
         <NumberInput
           animated
+          tickWhileDragging
           unit="kHz"
           step={0.2}
           stepPixelSize={10}
@@ -659,7 +660,7 @@ const SnowflakeRadio = (props) => {
           maxValue={maxFrequency / 10}
           value={frequency / 10}
           format={(value) => toFixed(value, 1)}
-          onDrag={(value) =>
+          onChange={(value) =>
             act('equip_act', {
               ref: ref,
               gear_action: 'set_frequency',
@@ -1040,7 +1041,7 @@ const SnowflakeOreScanner = (props) => {
   const { cooldown } = props.module.snowflake;
   return (
     <LabeledList.Item label="Vent Scanner">
-      <NoticeBox info={cooldown  <= 0}>
+      <NoticeBox info={cooldown <= 0}>
         {cooldown / 10 > 0 ? 'Recharging...' : 'Ready to scan vents'}
         <Button
           my={1}
@@ -1053,7 +1054,7 @@ const SnowflakeOreScanner = (props) => {
               gear_action: 'area_scan',
             })
           }
-          disabled={!(cooldown <= 0 )}
+          disabled={!(cooldown <= 0)}
         >
           Scan all nearby vents
         </Button>

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
@@ -46,11 +46,12 @@ export const EntryFloat = (props: EntryFloatProps) => {
       />
       <NumberInput
         animated
+        tickWhileDragging
         value={float}
         minValue={0}
         maxValue={Infinity}
         step={1}
-        onDrag={(value) =>
+        onChange={(value) =>
           act('edit', {
             var: var_name,
             new_value: value,
@@ -74,11 +75,12 @@ export const EntryCoord = (props: EntryCoordProps) => {
       />
       <NumberInput
         animated
+        tickWhileDragging
         minValue={-Infinity}
         maxValue={Infinity}
         step={1}
         value={coord?.[0] || 0}
-        onDrag={(value) =>
+        onChange={(value) =>
           act('edit', {
             var: var_name,
             new_value: [value, coord?.[1], coord?.[2]],
@@ -87,11 +89,12 @@ export const EntryCoord = (props: EntryCoordProps) => {
       />
       <NumberInput
         animated
+        tickWhileDragging
         minValue={-Infinity}
         maxValue={Infinity}
         step={1}
         value={coord?.[1] || 0}
-        onDrag={(value) =>
+        onChange={(value) =>
           act('edit', {
             var: var_name,
             new_value: [coord?.[0], value, coord?.[2]],
@@ -100,11 +103,12 @@ export const EntryCoord = (props: EntryCoordProps) => {
       />
       <NumberInput
         animated
+        tickWhileDragging
         minValue={-Infinity}
         maxValue={Infinity}
         step={1}
         value={coord?.[2] || 0}
-        onDrag={(value) =>
+        onChange={(value) =>
           act('edit', {
             var: var_name,
             new_value: [coord?.[0], coord?.[1], value],
@@ -258,12 +262,13 @@ export const EntryTransform = (props: EntryTransformProps) => {
           {transform?.map((value, index) => (
             <NumberInput
               animated
+              tickWhileDragging
               key={index}
               value={value}
               minValue={0}
               maxValue={1}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   new_value: transform!.map((x, i) =>
@@ -303,11 +308,12 @@ export const EntryIcon = (props: EntryIconStateProps) => {
               <Stack.Item>
                 <NumberInput
                   animated
+                  tickWhileDragging
                   minValue={0}
                   maxValue={Infinity}
                   step={1}
                   value={icon_state[icon_name]}
-                  onDrag={(value) =>
+                  onChange={(value) =>
                     act('edit', {
                       var: var_name,
                       var_mod: P_DATA_ICON_WEIGHT,
@@ -394,11 +400,12 @@ export const EntryIconState = (props: EntryIconStateProps) => {
               <Stack.Item>
                 <NumberInput
                   animated
+                  tickWhileDragging
                   minValue={0}
                   maxValue={Infinity}
                   step={1}
                   value={icon_state[iconstate]}
-                  onDrag={(value) =>
+                  onChange={(value) =>
                     act('edit', {
                       var: var_name,
                       new_value: editWeightOf(icon_state, iconstate, value),

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
@@ -54,11 +54,12 @@ export const FloatGenerator = (props: FloatGeneratorProps) => {
           <Stack.Item>
             <NumberInput
               animated
+              tickWhileDragging
               minValue={-Infinity}
               maxValue={Infinity}
               step={1}
               value={float || 0}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   new_value: value,
@@ -177,11 +178,12 @@ export const EntryGeneratorNumbersList = (
           <Stack.Item>
             <NumberInput
               animated
+              tickWhileDragging
               minValue={-Infinity}
               maxValue={Infinity}
               step={1}
               value={input || 0}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   new_value: value,
@@ -199,11 +201,12 @@ export const EntryGeneratorNumbersList = (
           <Stack.Item>
             <NumberInput
               animated
+              tickWhileDragging
               minValue={-Infinity}
               maxValue={Infinity}
               step={1}
               value={input[0]}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   new_value: [value, input![1], input![2]],
@@ -212,11 +215,12 @@ export const EntryGeneratorNumbersList = (
             />
             <NumberInput
               animated
+              tickWhileDragging
               minValue={-Infinity}
               maxValue={Infinity}
               step={1}
               value={input[1]}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   new_value: [input![0], value, input![2]],
@@ -226,11 +230,12 @@ export const EntryGeneratorNumbersList = (
             {allow_z ? (
               <NumberInput
                 animated
+                tickWhileDragging
                 minValue={-Infinity}
                 maxValue={Infinity}
                 step={1}
                 value={input[2]}
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('edit', {
                     var: var_name,
                     new_value: [input![0], input![1], value],

--- a/tgui/packages/tgui/interfaces/ParticleEdit/Generators.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/Generators.tsx
@@ -66,10 +66,11 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
         {typeof A === 'number' ? (
           <NumberInput
             animated
+            tickWhileDragging
             value={A}
             minValue={0}
             step={1}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('edit', {
                 var: var_name,
                 var_mod: P_DATA_GENERATOR,
@@ -82,9 +83,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
           <>
             <NumberInput
               animated
+              tickWhileDragging
               value={A[0]}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   var_mod: P_DATA_GENERATOR,
@@ -101,9 +103,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
             />
             <NumberInput
               animated
+              tickWhileDragging
               value={A[1]}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   var_mod: P_DATA_GENERATOR,
@@ -115,9 +118,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
             />
             <NumberInput
               animated
+              tickWhileDragging
               value={A[2]}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   var_mod: P_DATA_GENERATOR,
@@ -135,9 +139,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
         {typeof B === 'number' ? (
           <NumberInput
             animated
+            tickWhileDragging
             value={B}
             step={1}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('edit', {
                 var: var_name,
                 var_mod: P_DATA_GENERATOR,
@@ -151,9 +156,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
           <>
             <NumberInput
               animated
+              tickWhileDragging
               value={B[0]}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   var_mod: P_DATA_GENERATOR,
@@ -170,9 +176,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
             />
             <NumberInput
               animated
+              tickWhileDragging
               value={B[1]}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   var_mod: P_DATA_GENERATOR,
@@ -189,9 +196,10 @@ export const GeneratorListEntry = (props: GeneratorProps) => {
             />
             <NumberInput
               animated
+              tickWhileDragging
               value={B[2]}
               step={1}
-              onDrag={(value) =>
+              onChange={(value) =>
                 act('edit', {
                   var: var_name,
                   var_mod: P_DATA_GENERATOR,

--- a/tgui/packages/tgui/interfaces/Radio.tsx
+++ b/tgui/packages/tgui/interfaces/Radio.tsx
@@ -74,6 +74,7 @@ export const Radio = (props) => {
               )) || (
                 <NumberInput
                   animated
+                  tickWhileDragging
                   unit="kHz"
                   step={0.2}
                   stepPixelSize={10}
@@ -81,7 +82,7 @@ export const Radio = (props) => {
                   maxValue={maxFrequency / 10}
                   value={frequency / 10}
                   format={(value) => toFixed(value, 1)}
-                  onDrag={(value) =>
+                  onChange={(value) =>
                     act('frequency', {
                       adjust: value - frequency / 10,
                     })

--- a/tgui/packages/tgui/interfaces/Reagents/RecipeLibrary.tsx
+++ b/tgui/packages/tgui/interfaces/Reagents/RecipeLibrary.tsx
@@ -117,13 +117,14 @@ export function RecipeLibrary(props: ReagentsProps) {
             onClick={() => setPage(Math.max(page - 1, 1))}
           />
           <NumberInput
+            tickWhileDragging
             width="25px"
             step={1}
             stepPixelSize={3}
             value={page}
             minValue={1}
             maxValue={pageIndexMax}
-            onDrag={(value) => setPage(value)}
+            onChange={(value) => setPage(value)}
           />
           <Button
             icon="plus"

--- a/tgui/packages/tgui/interfaces/Reflector.tsx
+++ b/tgui/packages/tgui/interfaces/Reflector.tsx
@@ -142,13 +142,14 @@ export const Reflector = (props) => {
               <LabeledControls>
                 <LabeledControls.Item ml={0.5} label="Set rotation">
                   <NumberInput
+                    tickWhileDragging
                     value={rotation_angle}
                     unit="degrees"
                     minValue={0}
                     maxValue={359}
                     step={1}
                     stepPixelSize={1}
-                    onDrag={(value) =>
+                    onChange={(value) =>
                       act('rotate', {
                         rotation_angle: value,
                       })

--- a/tgui/packages/tgui/interfaces/SentienceFunBalloon.jsx
+++ b/tgui/packages/tgui/interfaces/SentienceFunBalloon.jsx
@@ -32,13 +32,14 @@ export const SentienceFunBalloon = (props) => {
               </LabeledList.Item>
               <LabeledList.Item label="Effect range">
                 <NumberInput
+                  tickWhileDragging
                   width="84px"
                   value={range}
                   minValue={1}
                   maxValue={100}
                   step={1}
                   stepPixelSize={15}
-                  onDrag={(value) =>
+                  onChange={(value) =>
                     act('effect_range', {
                       updated_range: value,
                     })

--- a/tgui/packages/tgui/interfaces/Signaler.tsx
+++ b/tgui/packages/tgui/interfaces/Signaler.tsx
@@ -36,6 +36,7 @@ export const SignalerContent = (props) => {
         <Stack.Item>
           <NumberInput
             animated
+            tickWhileDragging
             unit="kHz"
             step={0.2}
             stepPixelSize={6}
@@ -44,7 +45,7 @@ export const SignalerContent = (props) => {
             value={frequency / 10}
             format={(value) => toFixed(value, 1)}
             width="80px"
-            onDrag={(value) =>
+            onChange={(value) =>
               act('freq', {
                 freq: value,
               })
@@ -71,13 +72,14 @@ export const SignalerContent = (props) => {
         <Stack.Item>
           <NumberInput
             animated
+            tickWhileDragging
             step={1}
             stepPixelSize={6}
             minValue={1}
             maxValue={100}
             value={code}
             width="80px"
-            onDrag={(value) =>
+            onChange={(value) =>
               act('code', {
                 code: value,
               })

--- a/tgui/packages/tgui/interfaces/SolarControl.tsx
+++ b/tgui/packages/tgui/interfaces/SolarControl.tsx
@@ -152,6 +152,7 @@ export const SolarControl = (props) => {
               <Icon mr={1} name="arrow-up" rotation={azimuth_current} />
               {(tracking_state === 0 || tracking_state === 1) && (
                 <NumberInput
+                  tickWhileDragging
                   width="52px"
                   unit="°"
                   step={1}
@@ -159,11 +160,12 @@ export const SolarControl = (props) => {
                   minValue={-360}
                   maxValue={+720}
                   value={azimuth_current}
-                  onDrag={(value) => act('azimuth', { value })}
+                  onChange={(value) => act('azimuth', { value })}
                 />
               )}
               {tracking_state === 1 && (
                 <NumberInput
+                  tickWhileDragging
                   width="80px"
                   unit="°/m"
                   step={0.01}
@@ -175,7 +177,7 @@ export const SolarControl = (props) => {
                     const sign = Math.sign(rate) > 0 ? '+' : '-';
                     return sign + Math.abs(rate);
                   }}
-                  onDrag={(value) => act('azimuth_rate', { value })}
+                  onChange={(value) => act('azimuth_rate', { value })}
                 />
               )}
               {tracking_state === 2 && (

--- a/tgui/packages/tgui/interfaces/ThermoMachine.jsx
+++ b/tgui/packages/tgui/interfaces/ThermoMachine.jsx
@@ -48,6 +48,7 @@ export const ThermoMachine = (props) => {
             <LabeledList.Item label="Target Temperature">
               <NumberInput
                 animated
+                tickWhileDragging
                 value={Math.round(data.target)}
                 unit="K"
                 width="62px"
@@ -55,7 +56,7 @@ export const ThermoMachine = (props) => {
                 maxValue={Math.round(data.max)}
                 step={5}
                 stepPixelSize={3}
-                onDrag={(value) =>
+                onChange={(value) =>
                   act('target', {
                     target: value,
                   })

--- a/tgui/packages/tgui/interfaces/TurbineComputer.tsx
+++ b/tgui/packages/tgui/interfaces/TurbineComputer.tsx
@@ -47,12 +47,13 @@ const TurbineDisplay = (props) => {
         <LabeledList.Item label="Intake Regulator">
           <NumberInput
             animated
+            tickWhileDragging
             value={data.regulator * 100}
             unit="%"
             step={1}
             minValue={1}
             maxValue={100}
-            onDrag={(value) =>
+            onChange={(value) =>
               act('regulate', {
                 regulate: value * 0.01,
               })

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -14,7 +14,7 @@
 		"marked-smartypants": "^1.1.9",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
-		"tgui-core": "^5.3.0",
+		"tgui-core": "^5.3.1",
 		"tgui-dev-server": "workspace:*"
 	},
 	"private": true

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -14,7 +14,7 @@
 		"marked-smartypants": "^1.1.9",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
-		"tgui-core": "^4.2.3",
+		"tgui-core": "^5.3.0",
 		"tgui-dev-server": "workspace:*"
 	},
 	"private": true


### PR DESCRIPTION
## About The Pull Request
Bumping tgui-core from 4.2.3 to 5.3.1 (why no one update it earlier?)
See https://github.com/tgstation/tgui-core/compare/v4.2.3...v5.3.1

Makes chat tabs scrollable, which should improve the qol for players with a screen resolution of 1366x768.

https://github.com/user-attachments/assets/62da8115-3eb5-456f-8f88-907ec311b7a1


## Why It's Good For The Game
We are remember about poor players, with 2010 year laptops

## Changelog

:cl:
qol: Chat tabs are scrollable now (with your mouse wheel yeah) if they are too much or your screen resolution sucks
/:cl:

