### PR TITLE
Prevents station MODules from providing illegal tech(or being contraband)

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -723,6 +723,7 @@
 	item = /obj/item/mod/module/injector
 	cost = 2
 	purchasable_from = (UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
+	uplink_item_flags = NONE
 
 /datum/uplink_item/suits/holster
 	name = "MODsuit Holster Module"
@@ -730,6 +731,7 @@
 	item = /obj/item/mod/module/holster
 	cost = 2
 	purchasable_from = (UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
+	uplink_item_flags = NONE
 
 /datum/uplink_item/device_tools/medgun_mod
 	name = "Medbeam Gun Module"


### PR DESCRIPTION

## About The Pull Request

Removes the illegal tech and contraband flags from the MOD injector module and the MOD holster module, preventing these station-buildable MODules from tripping contraband scans or providing the illegal technology techweb node.

## Why It's Good For The Game

fixes #92929

## Changelog
:cl:

fix: Station MODules no longer provide illegal technology

/:cl:
