### PR TITLE
Removes Medical Doctor access from Pharmacy

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -784,17 +784,17 @@
 	department_color = COLOR_MEDICAL_BLUE
 	subdepartment_color = COLOR_MEDICAL_BLUE
 	sechud_icon_state = SECHUD_MEDICAL_DOCTOR
-	extra_access = list(
-		ACCESS_PLUMBING,
-		)
 	minimal_access = list(
 		ACCESS_MECH_MEDICAL,
 		ACCESS_MEDICAL,
 		ACCESS_MINERAL_STOREROOM,
 		ACCESS_MORGUE,
-		ACCESS_PHARMACY,
 		ACCESS_SURGERY,
 		ACCESS_VIROLOGY,
+		)
+	extra_access = list(
+		ACCESS_PHARMACY,
+		ACCESS_PLUMBING,
 		)
 	template_access = list(
 		ACCESS_CAPTAIN,


### PR DESCRIPTION
## About The Pull Request

Removes Medical Doctor access to Pharmacy. Medical Doctors still retain access on low-pop.

## Why It's Good For The Game

[1] As it stands at the moment, the Chemist role is lacking any purpose - Medical Doctors have full access to a Chemist's Chemistry gameplay, alongside the rest of Medical Department, besides the plumbing room. Chemists have far less access and incentive than Medical Doctors (No viro, morgue, surgery). There is simply little reason not to go Medical Doctor, and little reason for chemists to exist at the moment, as a whole. I believe their identity and purpose should be bought back.

[2] Chemists have less roleplay and interaction with crew, for things such as chem requests. This stems from the fact that any Medical Doctor may simply enter and do their job for them, instead of an actual chemist doing something that is supposed to be their job. It doesn't feel great to have someone doing your job for you, even though you signed up to do Chemistry.

[3] Chemists at the moment are incentivized to sit in an the isolated chemlab, it leads to antisocial gameplay.

[4] Chems produced with this PR will now be known that one of the 2 chemists more than likely made it, not just any Medical Doctor, making the Chemists feel rewarded due to praise/thanks from the crew.

[5] Scientists have no access to Geneticists/Robotics, Engineers have no access to Atmos, Sec have no access to Armory - Consistent similar use-case applied here.

[6] Other similar codebases/servers manage the concept nicely - I believe the only reason TG gave MD access was only because of circumstance (plumbing happened), not actually because of balance.

I believe this PR will help give Chemists indentity, purpose, more interaction, more roleplay, and feel as though their role isn't just some cosmetic thing for 'aura'.

## Changelog

:cl:
balance: Removes Medical Doctor access to Pharmacy. Medical Doctors still retain access on low-pop.
/:cl: