### PR TITLE
[NO GBP] recipe speed fix

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -4,7 +4,7 @@
 #define CONTENTS_STRUCTURES "structures"
 #define CONTENTS_REQS_COUNT "reqs_count"
 #define CONTENTS_TOOL_BEHAVIOUR "tool_behaviour"
-#define CONTENTS_WITHIN_SOURCE "within_source"
+#define CONTENTS_POSSIBLE_TOOLS "tool_instances"
 
 /// The portion of time spent crafting that recipe dependant on the speed of the tools
 #define RECIPE_DYNAMIC_TIME_COEFF 0.85
@@ -175,7 +175,7 @@
 		if(current_tool_speed < item.toolspeed)
 			.[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour] = item.toolspeed
 
-	.[CONTENTS_WITHIN_SOURCE] = within_source //These may be used as tools, but not components for the recipe.
+	.[CONTENTS_POSSIBLE_TOOLS] = flatten_list(.[CONTENTS_INSTANCES]) + within_source //These may be used as tools, not components for the recipe.
 
 /// Returns a boolean on whether the tool requirements of the input recipe are satisfied by the input source and surroundings.
 /datum/component/personal_crafting/proc/check_tools(atom/source, datum/crafting_recipe/recipe, list/surroundings, final_check = FALSE)
@@ -186,13 +186,12 @@
 		if(!(required_quality in surroundings[CONTENTS_TOOL_BEHAVIOUR]))
 			return FALSE
 
-	var/list/all_possible_tool_instances = surroundings[CONTENTS_INSTANCES] + surroundings[CONTENTS_WITHIN_SOURCE]
+	var/list/possible_tool_instances = surroundings[CONTENTS_POSSIBLE_TOOLS]
 	for(var/required_path in recipe.tool_paths)
-
-		if(!(locate(required_path) in all_possible_tool_instances))
+		if(!(locate(required_path) in possible_tool_instances))
 			return FALSE
 
-	return recipe.check_tools(source, all_possible_tool_instances, final_check)
+	return recipe.check_tools(source, possible_tool_instances, final_check)
 
 /datum/component/personal_crafting/proc/construct_item(atom/crafter, datum/crafting_recipe/recipe)
 	if(!crafter)
@@ -219,10 +218,10 @@
 			//Then divide it by the number of tools used in the recipe, and recalculate it.
 			dynamic_recipe_time /= tools_used
 
-			var/list/all_possible_tool_instances = contents[CONTENTS_INSTANCES] + contents[CONTENTS_WITHIN_SOURCE]
+			var/list/possible_tool_instances = surroundings[CONTENTS_POSSIBLE_TOOLS]
 			for(var/tool in recipe.tool_paths)
 				var/best_speed = 10 //failsafe-ish
-				for(var/obj/item/item as anything in all_possible_tool_instances)
+				for(var/obj/item/item as anything in possible_tool_instances)
 					if(!istype(item, tool) || best_speed < item.toolspeed)
 						continue
 					best_speed = item.toolspeed
@@ -739,4 +738,4 @@
 #undef CONTENTS_REQS_COUNT
 #undef CONTENTS_TOOL_BEHAVIOUR
 #undef RECIPE_DYNAMIC_TIME_COEFF
-#undef CONTENTS_WITHIN_SOURCE
+#undef CONTENTS_POSSIBLE_TOOLS

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -218,7 +218,7 @@
 			//Then divide it by the number of tools used in the recipe, and recalculate it.
 			dynamic_recipe_time /= tools_used
 
-			var/list/possible_tool_instances = surroundings[CONTENTS_POSSIBLE_TOOLS]
+			var/list/possible_tool_instances = contents[CONTENTS_POSSIBLE_TOOLS]
 			for(var/tool in recipe.tool_paths)
 				var/best_speed = 10 //failsafe-ish
 				for(var/obj/item/item as anything in possible_tool_instances)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -2,8 +2,9 @@
 #define CONTENTS_INSTANCES "instances"
 #define CONTENTS_MACHINERY "machinery"
 #define CONTENTS_STRUCTURES "structures"
-#define CONTENTS_REAGENTS "reagents"
+#define CONTENTS_REQS_COUNT "reqs_count"
 #define CONTENTS_TOOL_BEHAVIOUR "tool_behaviour"
+#define CONTENTS_WITHIN_SOURCE "within_source"
 
 /// The portion of time spent crafting that recipe dependant on the speed of the tools
 #define RECIPE_DYNAMIC_TIME_COEFF 0.85
@@ -61,7 +62,7 @@
 	var/list/item_instances = contents[CONTENTS_INSTANCES]
 	var/list/machines = contents[CONTENTS_MACHINERY]
 	var/list/structures = contents[CONTENTS_STRUCTURES]
-	contents = contents[CONTENTS_REAGENTS]
+	contents = contents[CONTENTS_REQS_COUNT]
 
 
 	var/list/requirements_list = list()
@@ -132,81 +133,66 @@
 				continue
 		. += AM
 
-/datum/component/personal_crafting/proc/get_surroundings(atom/a, list/blacklist=null)
+/datum/component/personal_crafting/proc/get_surroundings(atom/source, list/blacklist=null)
 	. = list()
 	.[CONTENTS_TOOL_BEHAVIOUR] = list()
-	.[CONTENTS_REAGENTS] = list()
+	.[CONTENTS_REQS_COUNT] = list()
 	.[CONTENTS_INSTANCES] = list()
 	.[CONTENTS_MACHINERY] = list()
 	.[CONTENTS_STRUCTURES] = list()
-	for(var/obj/object in get_environment(a, blacklist))
+	for(var/obj/object in get_environment(source, blacklist))
 		if(isitem(object))
 			var/obj/item/item = object
 			LAZYADDASSOCLIST(.[CONTENTS_INSTANCES], item.type, item)
 			if(isstack(item))
 				var/obj/item/stack/stack = item
-				.[CONTENTS_REAGENTS][item.type] += stack.amount
+				.[CONTENTS_REQS_COUNT][item.type] += stack.amount
 			else
-				.[CONTENTS_REAGENTS][item.type] += 1
+				.[CONTENTS_REQS_COUNT][item.type] += 1
 				if(is_reagent_container(item) && item.is_drainable() && length(item.reagents.reagent_list)) //some container that has some reagents inside it that can be drained
 					var/obj/item/reagent_containers/container = item
 					for(var/datum/reagent/reagent as anything in container.reagents.reagent_list)
-						.[CONTENTS_REAGENTS][reagent.type] += reagent.volume
-				else //a reagent container that is empty can also be used as a tool. e.g. glass bottle can be used as a rolling pin
-					if(item.tool_behaviour)
-						var/current_tool_speed = .[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour]
-						if(current_tool_speed < item.toolspeed)
-							.[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour] = item.toolspeed
+						.[CONTENTS_REQS_COUNT][reagent.type] += reagent.volume
+			if(item.tool_behaviour)
+				var/current_tool_speed = .[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour]
+				if(current_tool_speed < item.toolspeed)
+					.[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour] = item.toolspeed
 		else if (ismachinery(object))
 			LAZYADDASSOCLIST(.[CONTENTS_MACHINERY], object.type, object)
 		else if (isstructure(object))
 			LAZYADDASSOCLIST(.[CONTENTS_STRUCTURES], object.type, object)
+
+	var/list/within_source = list()
+	for(var/obj/item/item in source.contents)
+		within_source += item
+		if(item.atom_storage)
+			within_source += item.contents
+
+	for(var/obj/item/item as anything in within_source)
+		if(!item.tool_behaviour)
+			continue
+		var/current_tool_speed = .[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour]
+		if(current_tool_speed < item.toolspeed)
+			.[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour] = item.toolspeed
+
+	.[CONTENTS_WITHIN_SOURCE] = within_source //These may be used as tools, but not components for the recipe.
 
 /// Returns a boolean on whether the tool requirements of the input recipe are satisfied by the input source and surroundings.
 /datum/component/personal_crafting/proc/check_tools(atom/source, datum/crafting_recipe/recipe, list/surroundings, final_check = FALSE)
 	if(!length(recipe.tool_behaviors) && !length(recipe.tool_paths))
 		return TRUE
 
-	var/list/available_tools = list()
-	var/list/present_qualities = list()
-
-	var/list/all_instances = list()
-	for(var/atom/movable/movable as anything in source.contents)
-		all_instances += movable
-		if(movable.atom_storage)
-			all_instances += movable.contents
-
-	for(var/obj/item/contained_item in all_instances) //fill the available tools list with available tool types and behaviours
-		available_tools[contained_item.type] = TRUE
-		if(contained_item.tool_behaviour)
-			present_qualities[contained_item.tool_behaviour] = TRUE
-
-	for(var/quality in surroundings[CONTENTS_TOOL_BEHAVIOUR])
-		present_qualities[quality] = TRUE
-
-	for(var/path in surroundings[CONTENTS_REAGENTS])
-		available_tools[path] = TRUE
-
 	for(var/required_quality in recipe.tool_behaviors)
-		if(!present_qualities[required_quality])
+		if(!(required_quality in surroundings[CONTENTS_TOOL_BEHAVIOUR]))
 			return FALSE
 
+	var/list/all_possible_tool_instances = surroundings[CONTENTS_INSTANCES] + surroundings[CONTENTS_WITHIN_SOURCE]
 	for(var/required_path in recipe.tool_paths)
-		var/found_this_tool = FALSE
-		for(var/tool_path in available_tools)
-			if(!ispath(tool_path, required_path))
-				continue
-			found_this_tool = TRUE
-			break
-		if(!found_this_tool)
+
+		if(!(locate(required_path) in all_possible_tool_instances))
 			return FALSE
 
-	//add the contents of the assoc list of the surrounding instances to all_instances for the recipe.check_tools() call
-	var/list/surrounding_instances = surroundings[CONTENTS_INSTANCES]
-	for(var/type_key in surrounding_instances)
-		all_instances |= surrounding_instances[type_key]
-
-	return recipe.check_tools(source, all_instances, final_check)
+	return recipe.check_tools(source, all_possible_tool_instances, final_check)
 
 /datum/component/personal_crafting/proc/construct_item(atom/crafter, datum/crafting_recipe/recipe)
 	if(!crafter)
@@ -233,10 +219,10 @@
 			//Then divide it by the number of tools used in the recipe, and recalculate it.
 			dynamic_recipe_time /= tools_used
 
-			var/instances = contents[CONTENTS_INSTANCES]
+			var/list/all_possible_tool_instances = contents[CONTENTS_INSTANCES] + contents[CONTENTS_WITHIN_SOURCE]
 			for(var/tool in recipe.tool_paths)
 				var/best_speed = 10 //failsafe-ish
-				for(var/obj/item/item as anything in instances)
+				for(var/obj/item/item as anything in all_possible_tool_instances)
 					if(!istype(item, tool) || best_speed < item.toolspeed)
 						continue
 					best_speed = item.toolspeed
@@ -750,6 +736,7 @@
 #undef CONTENTS_INSTANCES
 #undef CONTENTS_MACHINERY
 #undef CONTENTS_STRUCTURES
-#undef CONTENTS_REAGENTS
+#undef CONTENTS_REQS_COUNT
 #undef CONTENTS_TOOL_BEHAVIOUR
 #undef RECIPE_DYNAMIC_TIME_COEFF
+#undef CONTENTS_WITHIN_SOURCE

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -175,7 +175,10 @@
 		if(current_tool_speed < item.toolspeed)
 			.[CONTENTS_TOOL_BEHAVIOUR][item.tool_behaviour] = item.toolspeed
 
-	.[CONTENTS_POSSIBLE_TOOLS] = flatten_list(.[CONTENTS_INSTANCES]) + within_source //These may be used as tools, not components for the recipe.
+	var/list/instances = .[CONTENTS_INSTANCES]
+	for(var/item_type in instances)
+		.[CONTENTS_POSSIBLE_TOOLS] += instances[item_type]
+	.[CONTENTS_POSSIBLE_TOOLS] += within_source
 
 /// Returns a boolean on whether the tool requirements of the input recipe are satisfied by the input source and surroundings.
 /datum/component/personal_crafting/proc/check_tools(atom/source, datum/crafting_recipe/recipe, list/surroundings, final_check = FALSE)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -25,7 +25,7 @@
 	age_restricted = TRUE // wrryy can't set an init value to see if drink_type contains ALCOHOL so here we go
 	///Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	var/bottle_knockdown_duration = BOTTLE_KNOCKDOWN_DEFAULT_DURATION
-	tool_behaviour = TOOL_ROLLINGPIN // Used to knock out the Chef.
+	tool_behaviour = TOOL_ROLLINGPIN // Glass bottles can be used as rolling pins when empty
 	toolspeed = 1.3 //it's a little awkward to use, but it's a cylinder alright.
 	/// A contained piece of paper, a photo, or space cash, that we can use as a message or gift to future spessmen.
 	var/obj/item/message_in_a_bottle
@@ -50,6 +50,13 @@
 		context[SCREENTIP_CONTEXT_RMB] = "Toss message"
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE
+
+/obj/item/reagent_containers/cup/glass/bottle/on_reagent_change(datum/reagents/holder, ...)
+	. = ..()
+	if(!reagents?.total_volume)
+		tool_behaviour = TOOL_ROLLINGPIN // Glass bottles can be used as rolling pins when empty
+	else
+		tool_behaviour = null
 
 /obj/item/reagent_containers/cup/glass/bottle/Exited(atom/movable/gone, atom/newloc)
 	if(gone == message_in_a_bottle)


### PR DESCRIPTION
## About The Pull Request
This PR aims to fix another issue with #92577. The main problem is that the list of instances we get from `get_surroundings()` doesn't contain items that are found within the person that's crafting the recipe, since those are checked separately in `check_tools()`. This ends up making the recipe hella slower because the appropriate tool couldn't be found in the checks for calculating the duration of the craft.

This also trims a few lines of code and other small things worth of a small refactor.

EDIT: Found out the real problem. the list of instances was an assoc list of type -> instances, while I thought otherwise.

## Why It's Good For The Game
Fixing some recipes taking too long to make. Fixes https://github.com/tgstation/tgstation/issues/93003

## Changelog

:cl:
fix: Fixed some recipes taking too long to make.
/:cl:
