### PR TITLE
Removes Captain from the security department (still under sec in the ban panel)

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -326,7 +326,7 @@
 			var/department_name = department.department_name
 			output += "<div class='column'><label class='rolegroup [label_class]'>[tgui_fancy ? "<input type='checkbox' name='[label_class]' class='hidden' onClick='header_click_all_checkboxes(this)'>" : ""] \
 			[department_name]</label><div class='content'>"
-			for(var/datum/job/job_datum as anything in department.department_jobs)
+			for(var/datum/job/job_datum as anything in department.get_jobban_jobs())
 				if(break_counter > 0 && (break_counter % 3 == 0))
 					output += "<br>"
 				break_counter++

--- a/code/modules/jobs/departments/departments.dm
+++ b/code/modules/jobs/departments/departments.dm
@@ -43,6 +43,10 @@
 			job_datum.spawn_positions = 0
 			job_datum.total_positions = 0
 
+/// Returns all jobs that are in this category for jobbans
+/datum/job_department/proc/get_jobban_jobs()
+	return department_jobs.Copy()
+
 /// Returns a nation name for this department.
 /datum/job_department/proc/generate_nation_name()
 	var/static/list/nation_suffixes = list("stan", "topia", "land", "nia", "ca", "tova", "dor", "ador", "tia", "sia", "ano", "tica", "tide", "cis", "marea", "co", "taoide", "slavia", "stotzka")
@@ -92,6 +96,10 @@
 	associated_cargo_groups = list("Security", "Armory")
 	head_of_staff_access = ACCESS_HOS
 	department_access = REGION_ACCESS_SECURITY
+
+/datum/job_department/security/get_jobban_jobs()
+	// Captains often fulfill security duties so they are considered part of the security department for jobbans
+	return ..() | SSjob.get_job_type(/datum/job/captain)
 
 /datum/job_department/engineering
 	department_name = DEPARTMENT_ENGINEERING

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -30,7 +30,6 @@
 	department_for_prefs = /datum/job_department/captain
 	departments_list = list(
 		/datum/job_department/command,
-		/datum/job_department/security,
 	)
 
 	family_heirlooms = list(/obj/item/reagent_containers/cup/glass/flask/gold, /obj/item/toy/captainsaid/collector)


### PR DESCRIPTION
## About The Pull Request

Removes the security department from the Captain 

Captain still remains under Security in jobbans

<img width="436" height="74" alt="image" src="https://github.com/user-attachments/assets/ffac3488-282c-458e-80f1-82fd316fb006" />

## Why It's Good For The Game

There seemed to be a common misconception that the Captain was officially integrated into security as a consequence of the Captain gaining security department for the purpose of jobban sorting

However, Captain is *not* a member of Security.

## Changelog

:cl: Melbert
del: Captain's no longer sorted under Security in places such as the manifest or job selection
/:cl:
