### PR TITLE
Names the ice cream status effect

### DIFF
--- a/code/datums/status_effects/buffs/food/chilling.dm
+++ b/code/datums/status_effects/buffs/food/chilling.dm
@@ -8,6 +8,7 @@
 		owner.adjust_bodytemperature(-2.75 * strength * seconds_between_ticks, min_temp = minimum_temp)
 
 /atom/movable/screen/alert/status_effect/icecream_chilling
+	name = "Cooling Off"
 	desc = "Nothing beats a cup of ice cream during hot, plasma-floody day..."
 	icon_state = "food_icecream"
 


### PR DESCRIPTION

## About The Pull Request

There was no name for the eating ice cream status effect so it defaults to the curse of mundanity. This gives it the name "Cooling Off"

## Why It's Good For The Game

Dispels the curse
Makes it at least vaguely clear what the status effect actually does. 

## Changelog
:cl:

qol: Eating ice cream no longer curses you

/:cl:
