### PR TITLE
Fixes stationside MODules granting illegal tech.

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -722,6 +722,7 @@
 	desc = "An injector module for a MODsuit. It is an extendable piercing injector with 30u capacity."
 	item = /obj/item/mod/module/injector
 	cost = 2
+	uplink_item_flags = null
 	purchasable_from = (UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
 
 /datum/uplink_item/suits/holster
@@ -729,6 +730,7 @@
 	desc = "A holster module for a MODsuit. It can stealthily store any not too heavy gun inside it."
 	item = /obj/item/mod/module/holster
 	cost = 2
+	uplink_item_flags = null
 	purchasable_from = (UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
 
 /datum/uplink_item/device_tools/medgun_mod


### PR DESCRIPTION
## About The Pull Request

The injector module (Present roundstart in the CMO modsuit)
and
the holster module (Available via the Sec MODsuit node basically roundstart)
no longer provide illegaltech

## Why It's Good For The Game

I probably don't need to explain why the funny tech should not be granted by NT modules you just get stationside with no effort involved. And why this is probably an oversight and not a balance change.

Also we really need a better way to make something illegal than this weird pass through all uplink items because it's prone to these kinds of mistakes and errors.

## Changelog
:cl:
fix: The MOD injector and MOD holster modules no longer give illegaltech
/:cl:
