### PR TITLE
Halves poly's speech frequency

### DIFF
--- a/code/modules/mob/living/basic/pets/parrot/poly.dm
+++ b/code/modules/mob/living/basic/pets/parrot/poly.dm
@@ -16,7 +16,7 @@
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
 	gold_core_spawnable = NO_SPAWN
-	speech_probability_rate = 13
+	speech_probability_rate = 3
 
 	/// Callback to save our memory at the end of the round.
 	var/datum/callback/roundend_callback = null
@@ -183,6 +183,9 @@
 	rustg_file_write(json_encode(file_data, JSON_PRETTY_PRINT), file_path)
 	memory_saved = TRUE
 	return TRUE
+
+/mob/living/basic/parrot/poly/setup_headset()
+	ears = new /obj/item/radio/headset/headset_eng(src)
 
 /mob/living/basic/parrot/poly/ghost
 	name = "The Ghost of Poly"

--- a/code/modules/mob/living/basic/pets/parrot/poly.dm
+++ b/code/modules/mob/living/basic/pets/parrot/poly.dm
@@ -184,9 +184,6 @@
 	memory_saved = TRUE
 	return TRUE
 
-/mob/living/basic/parrot/poly/setup_headset()
-	ears = new /obj/item/radio/headset/headset_eng(src)
-
 /mob/living/basic/parrot/poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."

--- a/code/modules/mob/living/basic/pets/parrot/poly.dm
+++ b/code/modules/mob/living/basic/pets/parrot/poly.dm
@@ -16,7 +16,7 @@
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
 	gold_core_spawnable = NO_SPAWN
-	speech_probability_rate = 3
+	speech_probability_rate = 6
 
 	/// Callback to save our memory at the end of the round.
 	var/datum/callback/roundend_callback = null


### PR DESCRIPTION
## About The Pull Request

Halves poly's speech rate.

Poly talks too damn much. A great majority of engineering messages are just poly, and this makes you ignore engineering comms unless it's someone with loudcomms. Even at a half of its current rate, Poly will still be taking up half of engicomms but at least there'll be a reasonable chance that an orange message will be useful.

## Why It's Good For The Game

I've accidentally ignored important communication because the orange text registers as poly and is thus ignored. I am certain I am not the only one, as engineering is the least-communicative department to play most of the time. Maybe if 80% of the messages in orange weren't useless, irrelevant nonsense, engineering radio would be more useful.

## Changelog
:cl:

balance: Poly talks less now

/:cl:
