### PR TITLE
Allows ventcrawling creatures to leave disconnected vents by resisting

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -50,3 +50,7 @@
 		nodes[1] = null
 	if(parents[1])
 		nullify_pipenet(parents[1])
+
+/obj/machinery/atmospherics/components/unary/container_resist_act(mob/living/user)
+	user.handle_ventcrawl(src)
+	return

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -60,7 +60,7 @@
 
 	if(!(vent_movement & VENTCRAWL_ENTRANCE_ALLOWED))
 		if(provide_feedback)
-			to_chat(src, span_warning("You can't enter this vent!"))
+			to_chat(src, span_warning("You can't move through this vent!"))
 		return
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

When you resist inside a vent, it now calls `handle_ventcrawl()` as if you had just moved into the vent, allowing creatures to leave vents even if they can't move away and back. Also changes the wording of the feedback of `can_enter_vent()`'s response for machinery you can't ventcrawl through to cover both entering and exiting failures.

## Why It's Good For The Game

closes #66243

## Changelog
:cl:

qol: Ventcrawling creatures can now leave disconnected vents by resisting.

/:cl:
