### PR TITLE
Changes bolt light wire to feedback wire, which disables both lights and feedback sounds

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -42,7 +42,7 @@
 #define WIRE_BACKUP1 "Auxiliary Power 1"
 #define WIRE_BACKUP2 "Auxiliary Power 2"
 #define WIRE_BEACON "Beacon"
-#define WIRE_BOLTLIGHT "Bolt Lights"
+#define WIRE_FEEDBACK "Feedback"
 #define WIRE_BOLTS "Bolts"
 #define WIRE_BOOM "Boom Wire"
 #define WIRE_CAMERA "Camera"

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -49,7 +49,7 @@
 		WIRE_BACKUP2,
 		WIRE_BOLTS,
 		WIRE_IDSCAN,
-		WIRE_BOLTLIGHT,
+		WIRE_FEEDBACK,
 		WIRE_OPEN,
 		WIRE_POWER1,
 		WIRE_POWER2,
@@ -146,8 +146,8 @@
 				A.close()
 		if(WIRE_TIMING)
 			A.normalspeed = !A.normalspeed
-		if(WIRE_BOLTLIGHT)
-			A.lights = !A.lights
+		if(WIRE_FEEDBACK)
+			A.feedback = !A.feedback
 			A.update_appearance()
 		if(WIRE_UNRESTRICTED_EXIT) // Pulse to switch the direction around by 180 degrees (North goes to South, East goes to West, vice-versa)
 			if(!A.unres_sensor) //only works if the "sensor" is installed (a variable that we assign to the door either upon creation of a door with unrestricted directions or if an unrestricted helper is added to a door in mapping)
@@ -210,8 +210,8 @@
 			A.autoclose = mend
 			if(A.autoclose && !A.density)
 				INVOKE_ASYNC(A, TYPE_PROC_REF(/obj/machinery/door/airlock, close))
-		if(WIRE_BOLTLIGHT) // Cut to disable lights, mend to re-enable.
-			A.lights = mend
+		if(WIRE_FEEDBACK) // Cut to disable lights and sounds, mend to re-enable.
+			A.feedback = mend
 			A.update_appearance()
 		if(WIRE_ZAP1, WIRE_ZAP2) // Ouch.
 			if(isliving(usr))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -106,8 +106,8 @@
 	var/backup_power_timer = 0
 	/// Paired with backup_power_timer. Records its remaining time when something happens to interrupt power regen
 	var/backup_power_time
-	/// Bolt lights show by default
-	var/lights = TRUE
+	/// Lights and sounds enabled by default
+	var/feedback = TRUE
 	var/aiDisabledIdScanner = FALSE
 	var/aiHacking = FALSE
 	/// Cyclelinking for airlocks that aren't on the same x or y coord as the target.
@@ -593,7 +593,7 @@
 	else
 		. += get_airlock_overlay("fill_[frame_state]", icon, src, em_block = TRUE)
 
-	if(lights && hasPower() && light_state)
+	if(feedback && hasPower() && light_state)
 		. += get_airlock_overlay("lights_[light_state]", overlays_file, src, em_block = FALSE)
 
 	if(panel_open)
@@ -663,7 +663,8 @@
 			use_energy(50 JOULES)
 			playsound(src, soundin = doorClose, vol = 30, vary = TRUE)
 		if(DOOR_DENY_ANIMATION)
-			playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
+			if(feedback)
+				playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
 			addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/proc/handle_deny_end()
@@ -1516,7 +1517,7 @@
 	if(!open())
 		set_airlock_state(AIRLOCK_CLOSED)
 	obj_flags |= EMAGGED
-	lights = FALSE
+	feedback = FALSE
 	locked = TRUE
 	loseMainPower()
 	loseBackupPower()
@@ -1711,7 +1712,7 @@
 	data["id_scanner"] = !aiDisabledIdScanner
 	data["emergency"] = emergency // access
 	data["locked"] = locked // bolted
-	data["lights"] = lights // bolt lights
+	data["feedback"] = feedback // lights and sounds
 	data["safe"] = safe // safeties
 	data["speed"] = normalspeed // safe speed
 	data["welded"] = welded // welded
@@ -1725,7 +1726,7 @@
 	wire["shock"] = !wires.is_cut(WIRE_SHOCK)
 	wire["id_scanner"] = !wires.is_cut(WIRE_IDSCAN)
 	wire["bolts"] = !wires.is_cut(WIRE_BOLTS)
-	wire["lights"] = !wires.is_cut(WIRE_BOLTLIGHT)
+	wire["feedback"] = !wires.is_cut(WIRE_FEEDBACK)
 	wire["safe"] = !wires.is_cut(WIRE_SAFETY)
 	wire["timing"] = !wires.is_cut(WIRE_TIMING)
 
@@ -1773,7 +1774,7 @@
 			toggle_bolt(usr)
 			. = TRUE
 		if("light-toggle")
-			lights = !lights
+			feedback = !feedback
 			update_appearance()
 			. = TRUE
 		if("safe-toggle")

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -179,7 +179,7 @@
 				qdel(src)
 				return
 			if(9 to 11)
-				airlock.lights = FALSE
+				airlock.feedback = FALSE
 				// These do not use airlock.bolt() because we want to pretend it was always locked. That means no sound effects.
 				airlock.locked = TRUE
 			if(12 to 15)

--- a/tgui/packages/tgui/interfaces/AiAirlock.jsx
+++ b/tgui/packages/tgui/interfaces/AiAirlock.jsx
@@ -142,19 +142,19 @@ export const AiAirlock = (props) => {
               {!data.wires.bolts && '[Wires have been cut!]'}
             </LabeledList.Item>
             <LabeledList.Item
-              label="Door Bolt Lights"
+              label="Door Feedback"
               color="bad"
               buttons={
                 <Button
-                  icon={data.lights ? 'power-off' : 'times'}
-                  content={data.lights ? 'Enabled' : 'Disabled'}
-                  selected={data.lights}
-                  disabled={!data.wires.lights}
+                  icon={data.feedback ? 'power-off' : 'times'}
+                  content={data.feedback ? 'Enabled' : 'Disabled'}
+                  selected={data.feedback}
+                  disabled={!data.wires.feedback}
                   onClick={() => act('light-toggle')}
                 />
               }
             >
-              {!data.wires.lights && '[Wires have been cut!]'}
+              {!data.wires.feedback && '[Wires have been cut!]'}
             </LabeledList.Item>
             <LabeledList.Item
               label="Door Force Sensors"


### PR DESCRIPTION
## About The Pull Request

Changes the "Bolt Lights" wire to a "Feedback" wire, which as well as disabling the door's lights also disables the deny access sound. Sounds that happen because the door is actually moving or bolting are unchanged. 

## Why It's Good For The Game

closes #65244
Justification is mostly in mentioned issue, primarily the accessibility issue of denied door feedback being sound-only when the lights are cut. Also, "Bolt Lights" is just inaccurate, as it controls all of the lights on the door.

## Changelog
:cl:

balance: The "Bolt Lights" wire is now the "Feedback" wire, and controls both lights and sounds for the airlock.

/:cl:
