### PR TITLE
Fix poppy plant interaction breaking spades

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -53,6 +53,8 @@
 #define TRAIT_HALVES_YIELD (1<<0)
 /// Doesn't get bonuses from tray yieldmod
 #define TRAIT_NO_POLLINATION (1<<1)
+/// Shows description on examine
+#define TRAIT_SHOW_EXAMINE (1<<2)
 
 /// -- Trait IDs. Plants that match IDs cannot be added to the same plant. --
 /// Plants that glow.

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -15,45 +15,9 @@
 	growing_icon = 'icons/obj/service/hydroponics/growing_flowers.dmi'
 	icon_grow = "poppy-grow"
 	icon_dead = "poppy-dead"
-	genes = list(/datum/plant_gene/trait/preserved)
+	genes = list(/datum/plant_gene/trait/preserved, /datum/plant_gene/trait/opium_production)
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/poppy/lily)
 	reagents_add = list(/datum/reagent/medicine/c2/libital = 0.2, /datum/reagent/consumable/nutriment = 0.05)
-	/// Determines if the plant has been sliced with a sharp tool to extract substances like saps.
-	var/extracted = FALSE
-
-/obj/item/seeds/poppy/on_planted(obj/machinery/hydroponics/parent)
-	RegisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(try_extract))
-
-/obj/item/seeds/poppy/on_unplanted(obj/machinery/hydroponics/parent)
-	UnregisterSignal(parent, COMSIG_ATOM_ITEM_INTERACTION)
-
-/// Redirect tray item interaction so we can have custom extracting behavior
-/obj/item/seeds/poppy/proc/try_extract(obj/machinery/hydroponics/source, mob/living/user, obj/item/tool, ...)
-	SIGNAL_HANDLER
-
-	if(!tool.sharpness || tool.tool_behaviour == TOOL_SHOVEL)
-		return NONE
-
-	if(source.age < 10)
-		to_chat(user, span_warning("The [plantname] are too young to extract sap from!"))
-		return ITEM_INTERACT_FAILURE
-	if(source.age > 19)
-		to_chat(user, span_warning("The [plantname] are too old to extract sap from!"))
-		return ITEM_INTERACT_FAILURE
-	if(extracted)
-		to_chat(user, span_warning("The [plantname] have already been harvested for sap!"))
-		return ITEM_INTERACT_FAILURE
-
-	extracted = TRUE
-	new /obj/item/food/drug/opium/raw(source.drop_location(), potency)
-	playsound(src, 'sound/effects/bubbles/bubbles.ogg', 30, TRUE)
-	playsound(tool, 'sound/items/weapons/bladeslice.ogg', 30, TRUE)
-	user.visible_message(
-		span_notice("[user] carefully slices open a poppy pod, extracting a sap."),
-		span_notice("You carefully slice the poppy's pod, collecting the fragrant, alluring sap."),
-		visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
-	)
-	return ITEM_INTERACT_SUCCESS
 
 /obj/item/food/grown/poppy
 	seed = /obj/item/seeds/poppy
@@ -78,6 +42,7 @@
 	growing_icon = 'icons/obj/service/hydroponics/growing_flowers.dmi'
 	icon_grow = "lily-grow"
 	icon_dead = "lily-dead"
+	genes = list(/datum/plant_gene/trait/preserved)
 	mutatelist = list(/obj/item/seeds/poppy/lily/trumpet)
 
 /obj/item/food/grown/poppy/lily
@@ -107,7 +72,7 @@
 	icon_grow = "spacemanstrumpet-grow"
 	icon_dead = "spacemanstrumpet-dead"
 	mutatelist = null
-	genes = list(/datum/plant_gene/reagent/preset/polypyr, /datum/plant_gene/trait/preserved)
+	genes = list(/datum/plant_gene/trait/preserved, /datum/plant_gene/reagent/preset/polypyr)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
 	rarity = 30
 	graft_gene = /datum/plant_gene/reagent/preset/polypyr
@@ -132,6 +97,7 @@
 	growing_icon = 'icons/obj/service/hydroponics/growing_flowers.dmi'
 	icon_grow = "geranium-grow"
 	icon_dead = "geranium-dead"
+	genes = list(/datum/plant_gene/trait/preserved)
 	mutatelist = list(/obj/item/seeds/poppy/geranium/fraxinella)
 
 /obj/item/food/grown/poppy/geranium

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -529,16 +529,14 @@
 
 ///Sets a new value for the myseed variable, which is the seed of the plant that's growing inside the tray.
 /obj/machinery/hydroponics/proc/set_seed(obj/item/seeds/new_seed, delete_old_seed = TRUE)
-	var/obj/item/seeds/old_seed = myseed
+	var/old_seed = myseed
 	myseed = new_seed
-	old_seed?.on_unplanted(src)
 	if(old_seed && delete_old_seed)
 		qdel(old_seed)
 	set_plant_status(new_seed ? HYDROTRAY_PLANT_GROWING : HYDROTRAY_NO_PLANT) //To make sure they can't just put in another seed and insta-harvest it
 	if(myseed && myseed.loc != src)
 		myseed.forceMove(src)
 	SEND_SIGNAL(src, COMSIG_HYDROTRAY_SET_SEED, new_seed)
-	myseed?.on_planted(src)
 	age = 0
 	update_appearance()
 	if(isnull(myseed))
@@ -940,21 +938,6 @@
 			to_chat(user, span_warning("This plot is completely devoid of weeds! It doesn't need uprooting."))
 			return
 
-	else if(O.tool_behaviour == TOOL_SHOVEL)
-		if(!myseed && !weedlevel)
-			to_chat(user, span_warning("[src] doesn't have any plants or weeds!"))
-			return
-		user.visible_message(span_notice("[user] starts digging out [src]'s plants..."),
-			span_notice("You start digging out [src]'s plants..."))
-		if(O.use_tool(src, user, 50, volume=50) || (!myseed && !weedlevel))
-			user.visible_message(span_notice("[user] digs out the plants in [src]!"), span_notice("You dig out all of [src]'s plants!"))
-			if(myseed) //Could be that they're just using it as a de-weeder
-				set_plant_health(0, update_icon = FALSE, forced = TRUE)
-				lastproduce = 0
-				set_seed(null)
-			set_weedlevel(0) //Has a side effect of cleaning up those nasty weeds
-			return
-
 	else if(istype(O, /obj/item/secateurs))
 		if(!myseed)
 			to_chat(user, span_notice("This plot is empty."))
@@ -1034,6 +1017,20 @@
 			set_seed(null)
 		return
 
+	else if(O.tool_behaviour == TOOL_SHOVEL)
+		if(!myseed && !weedlevel)
+			to_chat(user, span_warning("[src] doesn't have any plants or weeds!"))
+			return
+		user.visible_message(span_notice("[user] starts digging out [src]'s plants..."),
+			span_notice("You start digging out [src]'s plants..."))
+		if(O.use_tool(src, user, 50, volume=50) || (!myseed && !weedlevel))
+			user.visible_message(span_notice("[user] digs out the plants in [src]!"), span_notice("You dig out all of [src]'s plants!"))
+			if(myseed) //Could be that they're just using it as a de-weeder
+				set_plant_health(0, update_icon = FALSE, forced = TRUE)
+				lastproduce = 0
+				set_seed(null)
+			set_weedlevel(0) //Has a side effect of cleaning up those nasty weeds
+			return
 	else if(istype(O, /obj/item/gun/energy/floragun))
 		var/obj/item/gun/energy/floragun/flowergun = O
 		if(flowergun.cell.charge < flowergun.cell.maxcharge)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -531,14 +531,16 @@
 /obj/machinery/hydroponics/proc/set_seed(obj/item/seeds/new_seed, delete_old_seed = TRUE)
 	var/obj/item/seeds/old_seed = myseed
 	myseed = new_seed
-	old_seed?.on_unplanted(src)
+	for(var/datum/plant_gene/trait/gene in old_seed?.genes)
+		gene.on_unplanted_from_tray(src, old_seed)
 	if(old_seed && delete_old_seed)
 		qdel(old_seed)
 	set_plant_status(new_seed ? HYDROTRAY_PLANT_GROWING : HYDROTRAY_NO_PLANT) //To make sure they can't just put in another seed and insta-harvest it
 	if(myseed && myseed.loc != src)
 		myseed.forceMove(src)
 	SEND_SIGNAL(src, COMSIG_HYDROTRAY_SET_SEED, new_seed)
-	myseed?.on_planted(src)
+	for(var/datum/plant_gene/trait/gene in myseed?.genes)
+		gene.on_plant_in_tray(src, myseed)
 	age = 0
 	update_appearance()
 	if(isnull(myseed))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -529,14 +529,16 @@
 
 ///Sets a new value for the myseed variable, which is the seed of the plant that's growing inside the tray.
 /obj/machinery/hydroponics/proc/set_seed(obj/item/seeds/new_seed, delete_old_seed = TRUE)
-	var/old_seed = myseed
+	var/obj/item/seeds/old_seed = myseed
 	myseed = new_seed
+	old_seed?.on_unplanted(src)
 	if(old_seed && delete_old_seed)
 		qdel(old_seed)
 	set_plant_status(new_seed ? HYDROTRAY_PLANT_GROWING : HYDROTRAY_NO_PLANT) //To make sure they can't just put in another seed and insta-harvest it
 	if(myseed && myseed.loc != src)
 		myseed.forceMove(src)
 	SEND_SIGNAL(src, COMSIG_HYDROTRAY_SET_SEED, new_seed)
+	myseed?.on_planted(src)
 	age = 0
 	update_appearance()
 	if(isnull(myseed))
@@ -938,11 +940,20 @@
 			to_chat(user, span_warning("This plot is completely devoid of weeds! It doesn't need uprooting."))
 			return
 
-	else if(O.sharpness) // Allows for the extraction (for opium or sap) interaction if a seed has it.
-		if(myseed && !myseed.extracted)
-			myseed.interact_with_atom(O, user, src)
-		else
-			return ..()
+	else if(O.tool_behaviour == TOOL_SHOVEL)
+		if(!myseed && !weedlevel)
+			to_chat(user, span_warning("[src] doesn't have any plants or weeds!"))
+			return
+		user.visible_message(span_notice("[user] starts digging out [src]'s plants..."),
+			span_notice("You start digging out [src]'s plants..."))
+		if(O.use_tool(src, user, 50, volume=50) || (!myseed && !weedlevel))
+			user.visible_message(span_notice("[user] digs out the plants in [src]!"), span_notice("You dig out all of [src]'s plants!"))
+			if(myseed) //Could be that they're just using it as a de-weeder
+				set_plant_health(0, update_icon = FALSE, forced = TRUE)
+				lastproduce = 0
+				set_seed(null)
+			set_weedlevel(0) //Has a side effect of cleaning up those nasty weeds
+			return
 
 	else if(istype(O, /obj/item/secateurs))
 		if(!myseed)
@@ -1023,20 +1034,6 @@
 			set_seed(null)
 		return
 
-	else if(O.tool_behaviour == TOOL_SHOVEL)
-		if(!myseed && !weedlevel)
-			to_chat(user, span_warning("[src] doesn't have any plants or weeds!"))
-			return
-		user.visible_message(span_notice("[user] starts digging out [src]'s plants..."),
-			span_notice("You start digging out [src]'s plants..."))
-		if(O.use_tool(src, user, 50, volume=50) || (!myseed && !weedlevel))
-			user.visible_message(span_notice("[user] digs out the plants in [src]!"), span_notice("You dig out all of [src]'s plants!"))
-			if(myseed) //Could be that they're just using it as a de-weeder
-				set_plant_health(0, update_icon = FALSE, forced = TRUE)
-				lastproduce = 0
-				set_seed(null)
-			set_weedlevel(0) //Has a side effect of cleaning up those nasty weeds
-			return
 	else if(istype(O, /obj/item/gun/energy/floragun))
 		var/obj/item/gun/energy/floragun/flowergun = O
 		if(flowergun.cell.charge < flowergun.cell.maxcharge)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -529,18 +529,21 @@
 
 ///Sets a new value for the myseed variable, which is the seed of the plant that's growing inside the tray.
 /obj/machinery/hydroponics/proc/set_seed(obj/item/seeds/new_seed, delete_old_seed = TRUE)
-	var/old_seed = myseed
+	var/obj/item/seeds/old_seed = myseed
 	myseed = new_seed
+	old_seed?.on_unplanted(src)
 	if(old_seed && delete_old_seed)
 		qdel(old_seed)
 	set_plant_status(new_seed ? HYDROTRAY_PLANT_GROWING : HYDROTRAY_NO_PLANT) //To make sure they can't just put in another seed and insta-harvest it
 	if(myseed && myseed.loc != src)
 		myseed.forceMove(src)
 	SEND_SIGNAL(src, COMSIG_HYDROTRAY_SET_SEED, new_seed)
+	myseed?.on_planted(src)
 	age = 0
 	update_appearance()
 	if(isnull(myseed))
 		remove_shared_particles(/particles/pollen)
+
 
 /*
  * Setter proc to set a tray to a new self_sustaining state and update all values associated with it.

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -123,7 +123,7 @@
 	/// Flag - Traits that share an ID cannot be placed on the same plant.
 	var/trait_ids
 	/// Flag - Modifications made to the final product.
-	var/trait_flags
+	var/trait_flags = TRAIT_SHOW_EXAMINE
 	/// A blacklist of seeds that a trait cannot be attached to.
 	var/list/obj/item/seeds/seed_blacklist
 
@@ -178,9 +178,28 @@
 		return FALSE
 
 	// Add on any bonus lines on examine
-	if(description)
+	if(description && (trait_flags & TRAIT_SHOW_EXAMINE))
 		RegisterSignal(our_plant, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
 	return TRUE
+
+/**
+ * on_plant_in_tray is called when a seed with this trait is placed in a hydroponics tray
+ *
+ * * tray - the hydroponics tray the seed is placed in
+ * * seed - the seed being placed in the tray
+ */
+/datum/plant_gene/trait/proc/on_plant_in_tray(obj/machinery/hydroponics/tray, obj/item/seeds/seed)
+	return
+
+/**
+ * on_unplanted_from_tray is called when a seed with this trait is removed from a hydroponics tray
+ * (this can be done from being harvested, being uprooted, etc.)
+ *
+ * * tray - the hydroponics tray the seed is removed from
+ * * seed - the seed being removed from the tray
+ */
+/datum/plant_gene/trait/proc/on_unplanted_from_tray(obj/machinery/hydroponics/tray, obj/item/seeds/seed)
+	return
 
 /// Add on any unique examine text to the plant's examine text.
 /datum/plant_gene/trait/proc/examine(obj/item/our_plant, mob/examiner, list/examine_list)
@@ -499,7 +518,7 @@
 	description = "The reagent volume is doubled, halving the plant yield instead."
 	icon = FA_ICON_FLASK_VIAL
 	rate = 2
-	trait_flags = TRAIT_HALVES_YIELD
+	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/maxchem/on_new_plant(obj/item/our_plant, newloc)
@@ -895,7 +914,7 @@
 	description = "It consumes nutriments to heat up other reagents, halving the yield."
 	icon = FA_ICON_TEMPERATURE_ARROW_UP
 	trait_ids = TEMP_CHANGE_ID
-	trait_flags = TRAIT_HALVES_YIELD
+	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /**
@@ -907,7 +926,7 @@
 	description = "It consumes nutriments to cool down other reagents, halving the yield."
 	icon = FA_ICON_TEMPERATURE_ARROW_DOWN
 	trait_ids = TEMP_CHANGE_ID
-	trait_flags = TRAIT_HALVES_YIELD
+	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /// Prevents species mutation, while still allowing wild mutation harvest and Floral Somatoray species mutation.  Trait acts as a tag for hydroponics.dm to recognise.

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -63,8 +63,6 @@
 	var/graft_gene
 	///Determines if the plant should be allowed to mutate early at 30+ instability.
 	var/seed_flags = MUTATE_EARLY
-	///Determines if the plant has been sliced with a sharp tool to extract substances like saps.
-	var/extracted = 0
 
 /obj/item/seeds/Initialize(mapload, nogenes = FALSE)
 	. = ..()
@@ -660,3 +658,11 @@
 			plant_overlay.icon_state = "[icon_grow][t_growthstate]"
 	plant_overlay.pixel_z = plant_icon_offset
 	return plant_overlay
+
+/// Called when the seed is set in a tray
+/obj/item/seeds/proc/on_planted(obj/machinery/hydroponics/parent)
+	return
+
+/// Called when the seed is removed from a tray - possibly from being harvested, possibly from being uprooted
+/obj/item/seeds/proc/on_unplanted(obj/machinery/hydroponics/parent)
+	return


### PR DESCRIPTION
## About The Pull Request

This unassuming line was added in the middle of tray attackby to allow for sharp objects to extract poppy sap

https://github.com/tgstation/tgstation/blob/71c49cb4d1024515c98fe6de531620010cdf4334/code/modules/hydroponics/hydroponics.dm#L941-L945

Unfortunately, spades are sharp, and the shovel interaction followed lower in the chain. This also isn't proper use of `interact_with_atom` so we can fix two birds with one stone here. 

Now, poppy seeds hook the `COMSIG_ATOM_ITEM_INTERACTION` signal on the tray when planted, so we can run snowflake checks on the seed itself. 

## Changelog

:cl: Melbert
fix: Spades work on trays again
qol: Poppy seeds now give better feedback when unable to harvest
qol: Poppy seeds now have an immutable gene indicating they can be sliced for sap
del: Lilys and Geraniums can no longer be tapped for sap
/:cl:
