### PR TITLE
Fix food-tray -> oven-tray interaction

### DIFF
--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -26,8 +26,7 @@
 
 /obj/item/plate/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!IS_EDIBLE(tool))
-		balloon_alert(user, "not food!")
-		return ITEM_INTERACT_BLOCKING
+		return NONE
 	if(tool.w_class > biggest_w_class)
 		balloon_alert(user, "too big!")
 		return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION
## About The Pull Request

This `IS_EDIBLE` is a bit overzealous, preventing all interaction on plates (Oven trays are subtypes of plates) if inedible.

Strictly speaking I don't think it's super necessary to alert players that non-food items cannot go on plates, however if that behavior is desired I can just reverse the checks to subtypes handle their stuff first.

## Changelog

:cl: Melbert
fix: Food-tray-to-oven-tray transfer works again
/:cl:
