### PR TITLE
Accessories (waistcoats, pins etc.) other than the first are now shown on worn clothing

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -290,8 +290,6 @@
 	LAZYADD(attached_accessories, accessory)
 	accessory.forceMove(src)
 
-	update_accessory_overlay()
-
 	// Allow for accessories to react to the acccessory list now
 	accessory.successful_attach(src)
 
@@ -327,17 +325,12 @@
 
 /// Handles creating, updating and cutting the worn overlay mutable appearance.
 /obj/item/clothing/under/proc/update_accessory_overlay()
-	if(accessory_overlay)
-		cut_overlay(accessory_overlay)
 	if(!length(attached_accessories))
 		accessory_overlay = null
 		return
 	accessory_overlay = mutable_appearance()
 	for(var/obj/item/clothing/accessory/accessory as anything in attached_accessories)
-		var/mutable_appearance/appearance = mutable_appearance(accessory.worn_icon, accessory.icon_state)
-		appearance.alpha = accessory.alpha
-		appearance.color = accessory.color
-		accessory_overlay.overlays += appearance
+		accessory_overlay.overlays += accessory.generate_accessory_overlay(src)
 	update_appearance() // so we update the suit inventory overlay too
 
 /obj/item/clothing/under/Exited(atom/movable/gone, direction)

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -329,7 +329,7 @@
 /obj/item/clothing/under/proc/update_accessory_overlay()
 	if(accessory_overlay)
 		cut_overlay(accessory_overlay)
-	if(!legth(attached_accessories))
+	if(!length(attached_accessories))
 		accessory_overlay = null
 		return
 	accessory_overlay = mutable_appearance()

--- a/code/modules/clothing/under/accessories/_accessories.dm
+++ b/code/modules/clothing/under/accessories/_accessories.dm
@@ -111,6 +111,10 @@
 /obj/item/clothing/accessory/proc/successful_attach(obj/item/clothing/under/attached_to)
 	SHOULD_CALL_PARENT(TRUE)
 
+	if(!attached_to.accessory_overlay)
+		attached_to.accessory_overlay = mutable_appearance()
+	attached_to.accessory_overlay.overlays += generate_accessory_overlay(attached_to) //uniform appearance will be updated by the caller
+
 	// Do on-equip effects if we're already equipped
 	var/mob/worn_on = attached_to.loc
 	if(istype(worn_on))
@@ -118,6 +122,13 @@
 
 	SEND_SIGNAL(src, COMSIG_ACCESSORY_ATTACHED, attached_to)
 	SEND_SIGNAL(attached_to, COMSIG_CLOTHING_ACCESSORY_ATTACHED, src)
+
+/obj/item/clothing/accessory/proc/generate_accessory_overlay(obj/item/clothing/under/attached_to)
+	SHOULD_CALL_PARENT(TRUE)
+	var/mutable_appearance/appearance = mutable_appearance(worn_icon, icon_state)
+	appearance.alpha = alpha
+	appearance.color = color
+	return appearance
 
 /**
  * Detach this accessory from the passed clothing article


### PR DESCRIPTION
## About The Pull Request
Right now, only the first accessory is shown. Layering aside, that isn't a good thing and I don't see a reason why it should be this way. This PR also updates the code for the creation of worn overlays a little.

## Why It's Good For The Game
I don't have the time to code offsets for worn icons for medals, otherwise I would for the funny gimmicks, but for now this is a small step toward a world where all accessories are rightfully displayed.

## Changelog

:cl:
qol: Accessories other than the first are now displayed on worn clothing.
/:cl:
