### PR TITLE
Buffs the torsion ratchet MOD module a bit

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -767,7 +767,7 @@
 ///A module that recharges the suit by an itsy tiny bit whenever the user takes a step. Originally called "magneto module" but the videogame reference sounds cooler.
 /obj/item/mod/module/joint_torsion
 	name = "MOD joint torsion ratchet module"
-	desc = "A compact, weak AC generator that charges the suit's internal cell through the power of deambulation. It doesn't work in zero G."
+	desc = "A compact, weak AC generator that charges the suit's internal cell through the power of deambulation. It doesn't work in zero G. More than one can be installed."
 	icon_state = "joint_torsion"
 	complexity = 1
 	required_slots = list(ITEM_SLOT_FEET)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -770,9 +770,8 @@
 	desc = "A compact, weak AC generator that charges the suit's internal cell through the power of deambulation. It doesn't work in zero G."
 	icon_state = "joint_torsion"
 	complexity = 1
-	incompatible_modules = list(/obj/item/mod/module/joint_torsion)
 	required_slots = list(ITEM_SLOT_FEET)
-	var/power_per_step = DEFAULT_CHARGE_DRAIN * 0.3
+	var/power_per_step = DEFAULT_CHARGE_DRAIN * 0.45
 
 /obj/item/mod/module/joint_torsion/on_part_activation()
 	if(!(mod.wearer.movement_type & (FLOATING|FLYING)))


### PR DESCRIPTION
## About The Pull Request
I was a little too conservative with the recharge values when I made the module. This PR also allows for multiple instances of the the MOD module to be installed in a modsuit, since it isn't like they're going to conflict with one another anyway.

## Why It's Good For The Game
Making a niche MOD module I made a long time ago better.

## Changelog

:cl:
balance: Buffed the torsion ratchet MOD module (from that bepis node with several modsuit mod designs in it). You can also have more than one at a time.
/:cl:
