### PR TITLE
Makes Kickflips force you to catch the board

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -168,8 +168,8 @@
 	if (over_object == skater)
 		pick_up_board(skater)
 
-/obj/vehicle/ridden/scooter/skateboard/proc/pick_up_board(mob/living/carbon/skater)
-	if (skater.incapacitated || !Adjacent(skater))
+/obj/vehicle/ridden/scooter/skateboard/proc/pick_up_board(mob/living/carbon/skater, forced = FALSE)
+	if ((skater.incapacitated || !Adjacent(skater)) && !forced)
 		return
 	if(has_buckled_mobs())
 		to_chat(skater, span_warning("You can't lift this up when somebody's on it."))

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -410,7 +410,7 @@
 	animate(pixel_z = -6, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE)
 	board.unbuckle_mob(rider)
 	rider.Immobilize(0.5 SECONDS)
-	addtimer(CALLBACK(board, TYPE_PROC_REF(/obj/vehicle/ridden/scooter/skateboard, pick_up_board), rider), 0.5 SECONDS)  // so the board can still handle "picking it up"
+	addtimer(CALLBACK(board, TYPE_PROC_REF(/obj/vehicle/ridden/scooter/skateboard, pick_up_board), rider, TRUE), 0.5 SECONDS)  // so the board can still handle "picking it up"
 
 
 

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -409,6 +409,7 @@
 	animate(board, pixel_z = 6, time = 0.3 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 	animate(pixel_z = -6, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE)
 	board.unbuckle_mob(rider)
+	rider.Immobilize(0.5 SECONDS)
 	addtimer(CALLBACK(board, TYPE_PROC_REF(/obj/vehicle/ridden/scooter/skateboard, pick_up_board), rider), 0.5 SECONDS)  // so the board can still handle "picking it up"
 
 


### PR DESCRIPTION
## About The Pull Request

The kickflip text says you kickflip and catch the board, but you don't catch the board if you move after clicking it. This forces you in place while you kickflip so the kickflip always does what it says it does.

## Why It's Good For The Game

The current action text and chat text is sometimes innacurate, and there's already a button to get off the board.
This also appears to fix an unrelated bug where if you kickflipped off a hoverboard in mid-air, you'd get looney tunes hovering.

## Changelog
:cl:

fix: Kickflippers now catch their board every time

/:cl:
