### PR TITLE
Removes smart tracking from the AI's Crew Monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -254,7 +254,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			entry["burndam"] = rand(0,175)
 			entry["brutedam"] = rand(0,175)
 			entry["health"] = -50
-			entry["can_track"] = tracked_living_mob.can_track()
 			results[++results.len] = entry
 			continue
 
@@ -275,9 +274,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Location
 		if (sensor_mode >= SENSOR_COORDS)
 			entry["area"] = get_area_name(tracked_living_mob, format_text = TRUE)
-
-		// Trackability
-		entry["can_track"] = tracked_living_mob.can_track()
 
 		results[++results.len] = entry
 

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -133,7 +133,6 @@ type CrewSensor = {
   brutedam: number;
   area: string | undefined;
   health: number;
-  can_track: BooleanLike;
   ref: string;
 };
 
@@ -234,7 +233,6 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
     burndam,
     brutedam,
     area,
-    can_track,
   } = sensor_data;
 
   return (
@@ -289,7 +287,6 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
       {!!link_allowed && (
         <Table.Cell collapsing>
           <Button
-            disabled={!can_track}
             onClick={() =>
               act('select_person', {
                 name: name,


### PR DESCRIPTION
## About The Pull Request

Listen dude I just really hate those fucking sandbraine- 
In order to auto-disable tracking if a mob is not well, trackable (read, wrong z, out of camera sight), we need to well, check if the mob is in sight of a camera.

This requires cameras to update if they're marked dirty (which they will be since any opacity change (read: airlocks closing) does this), sooooo once every 10 seconds when the ui updates we have to update what like 60 camera chunks pessimistically?

That eats a variable amount of cost, somewhere between 300% and 600% of the tick on catwalk in the round I'm observing, tho it kind of depends on both the amount of z levels and pop count and so on.

Anyway so instead of doing that let's just not tell them if it's disabled (like we do for every other button that does this). It's a UX hit but I cannot come up with an acceptable solution, and it can ALREADY be wrong because it's behind a timer, so like...

## Why It's Good For The Game

Hopefully significantly less random lagspikes at anything above lowpop

<img width="901" height="29" alt="image" src="https://github.com/user-attachments/assets/936a6d91-aab9-4686-98e6-cd93b586227c" />

<img width="895" height="51" alt="image" src="https://github.com/user-attachments/assets/bb6782c9-9e67-42dd-a241-cc5bf795744b" />

## Changelog
:cl:
balance: AIs viewing the crew monitor will no longer be told ahead of time if they cannot jump to a player.
/:cl:
