### PR TITLE
Fixes "Can't Rotate!" being repeated infinitely for reflector boxes

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -292,6 +292,7 @@
 		return
 	if(!can_rotate)
 		user.balloon_alert(user, "can't rotate!")
+		ui?.close()
 		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)


### PR DESCRIPTION

## About The Pull Request

Fixes this

https://github.com/user-attachments/assets/d4d69a64-77d6-46b0-a0cc-4117c0271d96

by making the rotate ui close the first time it says you can't rotate

## Why It's Good For The Game

Fixes above video

## Changelog
:cl:

fix: Locked reflector boxes no longer repeat "can't rotate" forever

/:cl:
