### PR TITLE
The direction of your character changes when moving inside a cardboard box

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -44,7 +44,8 @@
 		return
 	move_delay = TRUE
 	var/oldloc = loc
-	try_step_multiz(direction);
+	try_step_multiz(direction)
+	user.setDir(dir)
 	if(oldloc != loc)
 		addtimer(CALLBACK(src, PROC_REF(ResetMoveDelay)), CONFIG_GET(number/movedelay/walk_delay) * move_speed_multiplier)
 	else


### PR DESCRIPTION
## About The Pull Request
Since you can see the contents inside of the closet, crate or box you're in, it breaks the immersion to see the player's direction stay the same.

## Why It's Good For The Game
Immersion.

## Changelog

:cl:
qol: The direction of your character changes when moving inside a cardboard box.
/:cl:
