### PR TITLE
Special version of hulk (wizard, warlord superhuman powers) no longer suffer recoil damage from breaking walls. Recoil actually uses wound rolls and not forced wounds

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -19,10 +19,7 @@
 #define POSITIVE_INSTABILITY_MAJOR 35
 
 /datum/mutation
-	var/name
-
-/datum/mutation
-	name = "mutation"
+	var/name = "mutation"
 	/// Description of the mutation
 	var/desc = "A mutation."
 	/// Is this mutation currently locked?

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -13,7 +13,8 @@
 	var/scream_delay = 50
 	var/last_scream = 0
 	var/bodypart_color = COLOR_DARK_LIME
-	/// List of traits to add/remove when someone gets this mutation.
+	/// Determines whether or not our version of hulk breaks their arm when destroying walls.
+	var/no_recoil = TRUE
 	mutation_traits = list(
 		TRAIT_CHUNKYFINGERS,
 		TRAIT_HULK,
@@ -60,30 +61,6 @@
 
 /datum/mutation/hulk/proc/scream_attack(mob/living/carbon/human/source)
 	source.say("WAAAAAAAAAAAAAAGH!", forced="hulk")
-
-/**
- *Checks damage of a hulk's arm and applies bone wounds as necessary.
- *
- *Called by specific atoms being attacked, such as walls. If an atom
- *does not call this proc, than punching that atom will not cause
- *arm breaking (even if the atom deals recoil damage to hulks).
- *Arguments:
- *arg1 is the arm to evaluate damage of and possibly break.
- */
-/datum/mutation/hulk/proc/break_an_arm(obj/item/bodypart/arm)
-	var/severity
-	switch(arm.brute_dam)
-		if(45 to 50)
-			severity = WOUND_SEVERITY_CRITICAL
-		if(41 to 45)
-			severity = WOUND_SEVERITY_SEVERE
-		if(35 to 41)
-			severity = WOUND_SEVERITY_MODERATE
-
-	if (isnull(severity))
-		return
-
-	owner.cause_wound_of_type_and_severity(WOUND_BLUNT, arm, severity, wound_source = "hulk smashing")
 
 /datum/mutation/hulk/on_life(seconds_per_tick, times_fired)
 	if(owner.health < owner.crit_threshold)
@@ -264,7 +241,7 @@
 	health_req = 0
 	instability = 0
 	scream_delay = 2.5 SECONDS // halved to be more annoying (spell doesn't last long anyways)
-	/// List of traits to add/remove when someone gets this mutation.
+	no_recoil = FALSE
 	mutation_traits = list(
 		TRAIT_HULK,
 		TRAIT_PUSHIMMUNE,
@@ -275,7 +252,7 @@
 	name = "Hulk (Super)"
 	health_req = 0
 	instability = 0
-	/// List of traits to add/remove when someone gets this mutation.
+	no_recoil = FALSE
 	mutation_traits = list(
 		TRAIT_CHUNKYFINGERS,
 		TRAIT_HULK,

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -180,7 +180,7 @@
 	var/datum/mutation/hulk/smasher = locate(/datum/mutation/hulk) in hulkman.dna.mutations
 	if(!smasher || !damage || smasher.no_recoil) //sanity check but also snow and wood walls deal no recoil damage, so no arm breaky. Also, if our type of hulk doesn't cause recoil damage, return.
 		return
-	hulkman.apply_damage(damage, BRUTE, arm, wound_bonus = damage/2) //enough damage to regularly result in at least a breakage.
+	hulkman.apply_damage(damage, BRUTE, arm, wound_bonus = 0) //enough damage to regularly result in at least a breakage.
 
 /turf/closed/wall/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -170,19 +170,17 @@
  *Deals damage back to the hulk's arm.
  *
  *When a hulk manages to break a wall using their hulk smash, this deals back damage to the arm used.
- *This is in its own proc just to be easily overridden by other wall types. Default allows for three
- *smashed walls per arm. Also, we use CANT_WOUND here because wounds are random. Wounds are applied
- *by hulk code based on arm damage and checked when we call break_an_arm().
+ *This is in its own proc just to be easily overridden by other wall types. Default will likely cause a
+ *critical bone wound in at least three punches.
  *Arguments:
  **arg1 is the arm to deal damage to.
  **arg2 is the hulk
  */
 /turf/closed/wall/proc/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, damage = 20)
-	hulkman.apply_damage(damage, BRUTE, arm, wound_bonus = CANT_WOUND)
 	var/datum/mutation/hulk/smasher = locate(/datum/mutation/hulk) in hulkman.dna.mutations
-	if(!smasher || !damage) //sanity check but also snow and wood walls deal no recoil damage, so no arm breaky
+	if(!smasher || !damage || smasher.no_recoil) //sanity check but also snow and wood walls deal no recoil damage, so no arm breaky. Also, if our type of hulk doesn't cause recoil damage, return.
 		return
-	smasher.break_an_arm(arm)
+	hulkman.apply_damage(damage, BRUTE, arm, wound_bonus = damage/2) //enough damage to regularly result in at least a breakage.
 
 /turf/closed/wall/attack_hand(mob/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

### Special versions are no longer vulnerable to recoil

There are two versions of hulk that are not available under normal circumstances. The version given by wizard's Transformation, and the version that Warlord pirates spawn with. These versions no longer break their arms when destroying walls.

Normal versions, like the genetic hulks and the orc variant, still suffer this effect.

### oof ow my bones

Hulk recoil damage now utilizes RNG wound determination. This allows for the wound to escalate normally if the wound meets the threshold. The damage passed means that there is a roughly 50/50 chance to cause a dislocation, a very slim chance to roll a fracture, and this probability will grow worse once the arm is wounded and threshold penalties start to take effect.

This also means that the mutation respects wound resistance and wound vulnerability, where as the previous behavior did not.

### Cleans up some mutation code a smidge

There is clearly some leftovers from prior refactors still littered through mutation code, so I did some maintenance while I was here.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/pull/51389 introduced this weakness to dissuade hulks from flattening walls all the way to the armory (for the fuckbillionth time). However, it applies to all versions of hulk, including instances where it is an antagonist's ability or power. Rather than have antagonists suffer from balance considerations largely aimed at crew/tiders, we make them exempt so that they can SMASH to their heart's content.

Hulk wound determination was kind of weird. For one, it relied heavily on the arm health consistently being 50. When it wasn't, you started getting into less reliable behaviour. In addition, it does not at all respect any kind of vulnerability or resistance to wounding.

It is possible that utilizing this system was so that the wounding effects would be staggered out rather than sporadic, and so slightly fairer on the user by being more reliable. However, I think letting it operate similarly to how our natural wound determination effects work provides some more interesting outcomes for those who might want to use the mutation in an earnest fashion, and still otherwise limits those people who are just looking to low effort grief.

I think in retrospect this might have been a pretty heavy-handed nerf, but I'm not wholly reversing it, I'm just making it...different. Outcomes should be largely the same.

## Changelog
:cl:
balance: Special versions of hulk, such as the wizard's transformation spell and the pirate warlord's superhuman powers, no longer suffer from arm breakage like normal hulks do.
balance: Hulk arm breaking now uses natural wound determination over forced wound effects at arm health thresholds.
code: Cleans up some of the mutation code.
/:cl:
