### PR TITLE
repaths lava lattices to lava catwalks

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -157,25 +157,20 @@
 /obj/structure/lattice/catwalk/mining/deconstruction_hints(mob/user)
 	return
 
-/obj/structure/lattice/lava
-	name = "heatproof support lattice"
-	desc = "A specialized support beam for building across lava. Watch your step."
+/obj/structure/lattice/catwalk/lava
+	name = "heatproof catwalk"
+	desc = "A specialized catwalk for building across lava. Watch your step."
 	icon = 'icons/obj/smooth_structures/catwalk.dmi'
 	icon_state = "catwalk-0"
 	base_icon_state = "catwalk"
 	number_of_mats = 1
 	color = "#5286b9ff"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = SMOOTH_GROUP_LATTICE + SMOOTH_GROUP_OPEN_FLOOR
-	canSmoothWith = SMOOTH_GROUP_LATTICE
-	obj_flags = CAN_BE_HIT | BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
-	give_turf_traits = list(TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED, TRAIT_IMMERSE_STOPPED, TRAIT_HYPERSPACE_STOPPED)
 
-/obj/structure/lattice/lava/deconstruction_hints(mob/user)
+/obj/structure/lattice/catwalk/lava/deconstruction_hints(mob/user)
 	return span_notice("The rods look like they could be <b>cut</b>, but the <i>heat treatment will shatter off</i>. There's space for a <i>tile</i>.")
 
-/obj/structure/lattice/lava/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/structure/lattice/catwalk/lava/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
 	if(!ismetaltile(attacking_item))
 		return

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -215,14 +215,14 @@
 	..()
 	if(istype(C, /obj/item/stack/rods/lava))
 		var/obj/item/stack/rods/lava/R = C
-		var/obj/structure/lattice/lava/H = locate(/obj/structure/lattice/lava, src)
+		var/obj/structure/lattice/catwalk/lava/H = locate(/obj/structure/lattice/catwalk/lava, src)
 		if(H)
 			to_chat(user, span_warning("There is already a lattice here!"))
 			return
 		if(R.use(1))
 			to_chat(user, span_notice("You construct a lattice."))
 			playsound(src, 'sound/items/weapons/genhit.ogg', 50, TRUE)
-			new /obj/structure/lattice/lava(locate(x, y, z))
+			new /obj/structure/lattice/catwalk/lava(locate(x, y, z))
 		else
 			to_chat(user, span_warning("You need one rod to build a heatproof lattice."))
 		return

--- a/tools/UpdatePaths/Scripts/92994_lava_lattices_to_lava_catwalks.txt
+++ b/tools/UpdatePaths/Scripts/92994_lava_lattices_to_lava_catwalks.txt
@@ -1,0 +1,1 @@
+/obj/structure/lattice/lava : /obj/structure/lattice/catwalk/lava


### PR DESCRIPTION
## About The Pull Request
Changes heatproof support lattices to heatproof _catwalks_, both in name and in code. This allows them to inherit all the turf traits given by catwalks, including the part where you don't get slowed down by turf slowdown (e.g. lava's turf slowdown).

## Why It's Good For The Game

No longer are you inexplicably slow while running on lava catwalks. (Look, I was just gonna update the given turf traits but then I figured why not just repath it, so...)

## Changelog

:cl:
fix: Lava no longer slows you down while running on heatproof catwalks. Also, heatproof support lattices are heatproof catwalks now, which is more accurate to their sprites.
/:cl:
