### PR TITLE
Ensures uniform distribution of minerals across ore vents & non zero material boulders

### DIFF
--- a/code/controllers/subsystem/ore_generation.dm
+++ b/code/controllers/subsystem/ore_generation.dm
@@ -25,22 +25,12 @@ SUBSYSTEM_DEF(ore_generation)
 
 /datum/controller/subsystem/ore_generation/Initialize()
 	//Basically, we're going to round robin through the list of ore vents and assign a mineral to them until complete.
-	while(length(ore_vent_minerals) > 0) //Keep looping if there's more to assign
-		var/stallbreaker = 0
-		for(var/obj/structure/ore_vent/vent as anything in possible_vents)
-			if(length(ore_vent_minerals) <= 0) //But break early if there's none left.
-				break
-			if(vent.unique_vent)
-				continue //Ya'll already got your minerals.
-			if(length(difflist(first = ore_vent_minerals, second = vent.mineral_breakdown, skiprep = 1)))
-				vent.generate_mineral_breakdown(new_minerals = 1, map_loading = TRUE)
-			else
-				stallbreaker++
-				if(stallbreaker >= length(possible_vents))
-					break //We've done all we can here. break inner loop
-				continue
-		if(stallbreaker >= length(possible_vents))
-			break //We've done all we can here. break outer loop
+	for(var/obj/structure/ore_vent/vent as anything in possible_vents)
+		if(length(ore_vent_minerals) <= 0) //But break early if there's none left.
+			break
+		if(vent.unique_vent)
+			continue //Ya'll already got your minerals.
+		vent.generate_mineral_breakdown(map_loading = TRUE)
 
 	/// Handles roundstart logging
 	logger.Log(

--- a/code/controllers/subsystem/ore_generation.dm
+++ b/code/controllers/subsystem/ore_generation.dm
@@ -21,13 +21,9 @@ SUBSYSTEM_DEF(ore_generation)
 	 */
 	var/list/ore_vent_minerals = list()
 
-	/// A tracker of how many of each ore vent size we have in the game. Useful for tracking purposes.
-
 /datum/controller/subsystem/ore_generation/Initialize()
 	//Basically, we're going to round robin through the list of ore vents and assign a mineral to them until complete.
 	for(var/obj/structure/ore_vent/vent as anything in possible_vents)
-		if(length(ore_vent_minerals) <= 0) //But break early if there's none left.
-			break
 		if(vent.unique_vent)
 			continue //Ya'll already got your minerals.
 		vent.generate_mineral_breakdown(map_loading = TRUE)

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -185,7 +185,7 @@
 			available_minerals -= mineral
 		else
 			mineral = mineral || pick_weight(GLOB.ore_vent_minerals_lavaland)
-		picked_minerals += mineral
+		picked_minerals |= mineral
 
 	mineral_breakdown.Cut()
 	for(var/datum/material/mineral as anything in picked_minerals)

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -178,18 +178,19 @@
 
 	var/list/datum/material/picked_minerals = list()
 	for(var/_ in 1 to new_minerals)
-		if(length(mineral_breakdown))
-			picked_minerals += pick_weight(mineral_breakdown)
+		var/datum/material/mineral
+		if(map_loading)
+			if(length(mineral_breakdown))
+				mineral = pick_weight(mineral_breakdown)
+			if(!mineral || !available_minerals.Find(mineral))
+				mineral = pick(available_minerals)
+			available_minerals -= mineral
 		else
-			picked_minerals += map_loading ? pick(available_minerals) : pick_weight(GLOB.ore_vent_minerals_lavaland)
+			mineral = length(mineral_breakdown) ? pick_weight(mineral_breakdown) : pick_weight(GLOB.ore_vent_minerals_lavaland)
+		picked_minerals += mineral
 
 	mineral_breakdown.Cut()
 	for(var/datum/material/mineral as anything in picked_minerals)
-		if(map_loading)
-			if(mineral in available_minerals)
-				available_minerals -= mineral
-			else
-				continue
 		mineral_breakdown[mineral] = rand(1, 4)
 
 /**

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -178,15 +178,13 @@
 
 	var/list/datum/material/picked_minerals = list()
 	for(var/_ in 1 to new_minerals)
-		var/datum/material/mineral
+		var/datum/material/mineral = length(mineral_breakdown) ? pick_weight(mineral_breakdown) : null
 		if(map_loading)
-			if(length(mineral_breakdown))
-				mineral = pick_weight(mineral_breakdown)
 			if(!mineral || !available_minerals.Find(mineral))
 				mineral = pick(available_minerals)
 			available_minerals -= mineral
 		else
-			mineral = length(mineral_breakdown) ? pick_weight(mineral_breakdown) : pick_weight(GLOB.ore_vent_minerals_lavaland)
+			mineral = mineral || pick_weight(GLOB.ore_vent_minerals_lavaland)
 		picked_minerals += mineral
 
 	mineral_breakdown.Cut()

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -202,7 +202,7 @@
 	//assign random weights to picked minerals
 	mineral_breakdown.Cut()
 	for(var/datum/material/mineral as anything in picked_minerals)
-		mineral_breakdown[mineral] = rand(1, 4)
+		mineral_breakdown[mineral] = rand(1, new_minerals)
 
 /**
  * Returns the quantity of mineral sheets in each ore vent's boulder contents roll.


### PR DESCRIPTION
## About The Pull Request
- Fixes #92972

There were multiple problems with code that I can't be asked to explain but here is the intended output(`ore_vent_minerals` contains the copy of the list `ore_vent_minerals_lavaland` which we actually modify & not the global list itself)

<img width="481" height="241" alt="Screenshot (512)" src="https://github.com/user-attachments/assets/ed4d2659-b78c-4b99-ae68-e6fad4f116e4" />

All ore vents will now have at most 4 minerals but because we use an associative list it is possible for a mineral to get picked more than once in the same iteration resulting in old values getting replaced which isn't a problem but just a point to be known so you don't always get vents with 4 minerals

Another problem i ran into debugging is that some vents churn out 0 material boulders. That had to do with rounding down of the logarithmic function which returned 0. We now ensure that never happens

## Changelog
:cl:
fix: ore vents have unique distribution of at most 4 minerals without rare ones being repeated
fix: ore vents should no longer be produce 0 material boulders
/:cl:

