### PR TITLE
Prevent apcs from showing a blue screen when their screen is not visible

### DIFF
--- a/code/modules/power/apc/apc_appearance.dm
+++ b/code/modules/power/apc/apc_appearance.dm
@@ -109,6 +109,8 @@
 
 // Shows a dark-blue interface for a moment. Shouldn't appear on cameras.
 /obj/machinery/power/apc/proc/flicker_hacked_icon()
+	if(opened != APC_COVER_CLOSED)
+		return
 	var/image/hacker_image = image(icon = 'icons/obj/machines/wallmounts.dmi', loc = src, icon_state = "apcemag", layer = FLOAT_LAYER)
 	var/list/mobs_to_show = list()
 	// Collecting mobs the APC can see for this animation, rather than mobs that can see the APC. Important distinction, intended such that mobs on camera / with XRAY cannot see the flicker.


### PR DESCRIPTION

## About The Pull Request

Prevents flicker_hacked_icon() from doing anything unless the apc is closed

## Why It's Good For The Game

fixes this

https://github.com/user-attachments/assets/f066f98e-65a9-4d02-8a4a-ffc51d565218



## Changelog
:cl:

fix: Apcs will no longer bluescreen without a screen

/:cl:
