### PR TITLE
Assorted custom shuttle fixes

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -46,6 +46,7 @@
 /obj/machinery/power/shuttle_engine/on_construction(mob/user)
 	. = ..()
 	if(anchored)
+		engine_state = ENGINE_WRENCHED
 		connect_to_shuttle(port = SSshuttle.get_containing_shuttle(src)) //connect to a new ship, if needed
 		if(!connected_ship_ref?.resolve())
 			AddElement(/datum/element/connect_loc, connections)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -134,7 +134,7 @@
 		if(ENGINE_UNWRENCHED)
 			to_chat(user, span_warning("\The [src] needs to be wrenched to the floor!"))
 		if(ENGINE_WRENCHED)
-			if(!tool.tool_start_check(user, amount=round(ENGINE_WELDTIME / 5), heat_required = HIGH_TEMPERATURE_REQUIRED))
+			if(!tool.tool_start_check(user, heat_required = HIGH_TEMPERATURE_REQUIRED))
 				return TRUE
 
 			user.visible_message(span_notice("[user.name] starts to weld \the [src] to the floor."), \
@@ -147,7 +147,7 @@
 				alter_engine_power(engine_power)
 
 		if(ENGINE_WELDED)
-			if(!tool.tool_start_check(user, amount=round(ENGINE_WELDTIME / 5), heat_required = HIGH_TEMPERATURE_REQUIRED))
+			if(!tool.tool_start_check(user, heat_required = HIGH_TEMPERATURE_REQUIRED))
 				return TRUE
 
 			user.visible_message(span_notice("[user.name] starts to cut \the [src] free from the floor."), \

--- a/code/modules/shuttle/mobile_port/variants/custom/custom_consoles.dm
+++ b/code/modules/shuttle/mobile_port/variants/custom/custom_consoles.dm
@@ -91,6 +91,8 @@
 /obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/on_shuttle_expanded(obj/docking_port/mobile/source, list/turfs)
 	SIGNAL_HANDLER
 	recalculate_eye_view(source)
+	var/list/bounds = shuttle_port.return_coords(eyeobj.x - x_offset, eyeobj.y - y_offset, eyeobj.dir)
+	var/list/overlappers = SSshuttle.get_dock_overlap(bounds[1], bounds[2], bounds[3], bounds[4], eyeobj.z)
 	if(my_port)
 		var/here_x = source.x
 		var/here_y = source.y
@@ -122,7 +124,7 @@
 						target_x += offset_y
 						target_y -= offset_x
 				checked_turf = locate(target_x, target_y, target_z)
-			if(checkLandingTurf(checked_turf) != SHUTTLE_DOCKER_LANDING_CLEAR)
+			if(checkLandingTurf(checked_turf, overlappers) != SHUTTLE_DOCKER_LANDING_CLEAR)
 				if(docked)
 					my_port.unregister()
 					my_port.delete_after = TRUE

--- a/tgui/packages/tgui/interfaces/ShuttleBlueprints.tsx
+++ b/tgui/packages/tgui/interfaces/ShuttleBlueprints.tsx
@@ -320,13 +320,13 @@ const ShuttleConfiguration = () => {
               tooltip={
                 onShuttle
                   ? inDefaultArea
-                    ? null
-                    : 'You can only create a new area from the default area.'
+                    ? 'Designate a room within the shuttle as its own area.'
+                    : 'You can only designate a new area from the default area.'
                   : 'You must be on the linked shuttle to do this.'
               }
               onClick={() => act('createNewArea', { name: name })}
             >
-              Create New Area
+              Designate New Area
             </Button.Confirm>
           </Stack.Item>
           <Stack.Item>
@@ -393,14 +393,14 @@ const ShuttleConfiguration = () => {
             <Stack>
               <Stack.Item>
                 <Button.Confirm
-                  disabled={!(idle && onShuttleFrame && problems) || tooLarge}
+                  disabled={!(idle && onShuttleFrame) || problems || tooLarge}
                   tooltip={
                     <ProblemsTooltip
                       description="Expand the linked shuttle with an adjacent shuttle frame."
-                      problemHeader="The following problems prevent you from expanding the shuttle with this frame."
+                      problemHeader="The following problems prevent you from expanding the shuttle."
                       problems={problems ?? 0}
                       problemStrings={[
-                        'You are not on a shuttle frame.',
+                        'You must be standing on the shuttle frame you wish to expand the shuttle with.',
                         'This frame is not adjacent to the linked shuttle.',
                         'This frame is too large.',
                         'This frame includes the APC of a custom area, but does not enclose the entire area.\
@@ -412,7 +412,7 @@ const ShuttleConfiguration = () => {
                   }
                   onClick={() => act('expandWithFrame')}
                 >
-                  Expand With Shuttle Frame
+                  Expand Shuttle With Connected Frame
                 </Button.Confirm>
               </Stack.Item>
               <Stack.Item>
@@ -455,7 +455,7 @@ const ShuttleConfiguration = () => {
           }
           onClick={() => act('releaseArea')}
         >
-          Remove Area
+          Undesignate Area
         </Button.Confirm>
       </Stack.Item>
       <Stack.Item>


### PR DESCRIPTION
## About The Pull Request

This PR makes the following changes to code relevant to shuttle construction.
- (Un)welding shuttle engines now only checks if the tool has 1 fuel, which is how much is already used in the process.
- Constructed shuttle engines that were built from anchored machine frames start in the wrenched but unwelded state.
- Fixes a runtime that occurs when expanding shuttles.
- Fixes the incorrect logic in the shuttle blueprint UI responsible for #92986.
- Makes several changes to the wording of several functions of the shuttle blueprint UI in the hopes of better conveying what each button does.

## Why It's Good For The Game

Fixes #92986, as well as some other issues I may not have found in my brief search.

## Changelog

:cl:
fix: You no longer need 40 welding fuel to start welding or unwelding shuttle engines, despite only consuming 1.
fix: Shuttle engines constructed from anchored machine frames start in the wrenched-but-unwelded state.
fix: Expanding custom shuttles from shuttle frames is once again possible without href exploitation.
fix: Shuttle expansion now correctly checks for other shuttle docking ports the expanded shuttle's footprint would encroach upon.
qol: Tries to make some of the buttons in the custom shuttle UI more indicative of what they actually do.
/:cl:
