### PR TITLE
box of XL shotgun darts no longer has an XL name

### DIFF
--- a/code/game/objects/items/storage/boxes/security_boxes.dm
+++ b/code/game/objects/items/storage/boxes/security_boxes.dm
@@ -219,7 +219,7 @@
 
 /obj/item/storage/box/large_dart
 	name = "box of XL shotgun darts"
-	name = "A box full of shotgun darts with increased chemical storage capacity."
+	desc = "A box full of shotgun darts with increased chemical storage capacity."
 	icon_state = "shotdart_box"
 	illustration = null
 


### PR DESCRIPTION
## About The Pull Request

Fixes the name of XL shotgun darts

## Why It's Good For The Game

"A box full of shotgun darts with increased chemical storage capacity" barely fits on the screen as a tooltip

## Changelog

:cl: LT3
fix: 'a box full of shotgun darts with increased chemical storage capacity' now has a shorter name
/:cl:
