### PR TITLE
[NO GBP] Fixing issues with sand

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	AddComponent(/datum/component/storm_hating)
 
 /obj/item/stack/ore/glass/on_orm_collection() //we need to smelt the glass beforehand because the silo and orm don't accept sand mats
-	var/obj/item/stack/sheet/glass = new refined_type(null, amount) //spawned in null loc, otherwise the newly spawned glass would be collected separately, causing issues.
+	var/obj/item/stack/sheet/glass = new refined_type(drop_location(), amount, merge = FALSE) //The newly spawned glass should not merge with other stacks on the turf, else it could cause issues.
 	qdel(src)
 	return glass
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -109,6 +109,7 @@
 	singular_name = "sand pile"
 	points = 1
 	mats_per_unit = list(/datum/material/sand = SHEET_MATERIAL_AMOUNT)
+	material_type = /datum/material/sand
 	refined_type = /obj/item/stack/sheet/glass
 	w_class = WEIGHT_CLASS_TINY
 	mine_experience = 0 //its sand
@@ -125,7 +126,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	AddComponent(/datum/component/storm_hating)
 
 /obj/item/stack/ore/glass/on_orm_collection() //we need to smelt the glass beforehand because the silo and orm don't accept sand mats
-	var/obj/item/stack/sheet/glass = new refined_type(drop_location(), amount)
+	var/obj/item/stack/sheet/glass = new refined_type(null, amount) //spawned in null loc, otherwise the newly spawned glass would be collected separately, causing issues.
 	qdel(src)
 	return glass
 


### PR DESCRIPTION
## About The Pull Request
Shout outs to Syncit for fixing/adding the item interaction in https://github.com/tgstation/tgstation/pull/92991. All that's left is setting the material_type of sand to allow people to make custom material stuff like carving blocks and toilets again, and a little nit with the `on_orm_collection()` proc for sand.

## Why It's Good For The Game
Fixing stuff

## Changelog

:cl:
fix: You can once again craft custom material stuff like carving blocks and toilets made of sand once again.
/:cl:
