### PR TITLE
Makes the regex for the 'fix' label detection a bit more lenient

### DIFF
--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -48,7 +48,7 @@ function check_body_for_labels(body) {
   const labels_to_add = [];
 
   // detect "fixes #1234" or "resolves #1234" in body
-  const fix_regex = /\b(?:fix(?:es|ed)?|resolve[sd]?)\s*#\d+\b/gim;
+  const fix_regex = /\b(?:fix(?:es|ed)?|resolve[sd]?)\s*(?:#\d+|https:\/\/github\.com\/\S+\/issues\/\d+)/gim;
   if (fix_regex.test(body)) {
     labels_to_add.push("Fix");
   }


### PR DESCRIPTION
## About The Pull Request

Currently, for detecting issue-closing fixes, the labeler regex matches strictly things like:

`Fixes #some_number_here`

but sometimes people will paste the full issues url, which github renders as the issue number. Problem is the raw text still has the url, so it will not match when passed through the rest api.

This PR just makes it a bit less restrictive, so that something like this:

``Fixes https://github.com/tgstation/tgstation/issues/some_number_here`

will correctly get registered as a fix.

## Why It's Good For The Game

More PRs getting autolabeled more correctly

## Changelog

Not player-facing