### PR TITLE
Removing rogue decal in DeltaStation garden

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -47677,9 +47677,6 @@
 /area/station/engineering/atmos/mix)
 "lKk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/green/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

we hate bad decals :(

## Changelog

:cl:
fix: Removed rogue decal in DeltaStation garden
/:cl:
