### PR TITLE
Adds RD computers on Catwalk

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -36027,12 +36027,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
 "kpz" = (
-/obj/structure/rack,
-/obj/item/aicard,
-/obj/item/pai_card,
-/obj/item/circuitboard/aicore,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/modular_computer/preset/research,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "kpC" = (
@@ -40037,6 +40034,10 @@
 /area/station/commons/fitness/recreation)
 "lAu" = (
 /obj/structure/cable,
+/obj/structure/rack,
+/obj/item/aicard,
+/obj/item/pai_card,
+/obj/item/circuitboard/aicore,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "lAE" = (
@@ -82617,7 +82618,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "xZp" = (
-/obj/machinery/computer/rdconsole,
+/obj/machinery/modular_computer/preset/research,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
 "xZG" = (


### PR DESCRIPTION
## About The Pull Request

adds rd computer to rd office and replaces one of two rnd consoles on bridge with rd computer

## Why It's Good For The Game

rd has rd computer by default + bridge has 2 rnd consoles that were placed by mistake i guess

## Changelog

:cl:
fix: Added missing RD computer in RD office (Catwalk)
map: Replaced one of RND consoles on bridge with RD computer (Catwalk)
/:cl:
