### PR TITLE
Fishing Portal Machine Changes

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1426,7 +1426,7 @@
 		/datum/stock_part/matter_bin = 2,
 		/datum/stock_part/capacitor = 2,
 		/datum/stock_part/micro_laser = 1,
-		/obj/item/stack/sheet/mineral/bluespace_crystal = 2)
+		/obj/item/stack/sheet/bluespace_crystal = 2)
 	needs_anchored = TRUE
 
 /obj/item/circuitboard/machine/fishing_portal_generator/emagged

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1424,8 +1424,10 @@
 	build_path = /obj/machinery/fishing_portal_generator
 	req_components = list(
 		/datum/stock_part/matter_bin = 2,
-		/datum/stock_part/capacitor = 1)
-	needs_anchored = FALSE
+		/datum/stock_part/capacitor = 2,
+		/datum/stock_part/micro_laser = 1,
+		/obj/item/stack/sheet/mineral/bluespace_crystal = 2)
+	needs_anchored = TRUE
 
 /obj/item/circuitboard/machine/fishing_portal_generator/emagged
 	name = "Emagged Fishing Portal Generator"

--- a/code/modules/experisci/experiment/types/scanning_fish.dm
+++ b/code/modules/experisci/experiment/types/scanning_fish.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(scanned_fish_by_techweb)
 	allowed_experimentors = list(/obj/item/experi_scanner, /obj/machinery/destructive_scanner, /obj/item/fishing_rod/tech, /obj/item/fish_analyzer)
 	traits = EXPERIMENT_TRAIT_TYPECACHE
 	points_reward = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS )
-	required_atoms = list(/obj/item/fish = 3)
+	required_atoms = list(/obj/item/fish = 5)
 	scan_message = "Scan different species of fish"
 	///Further experiments added to the techweb when this one is completed.
 	var/list/next_experiments = list(/datum/experiment/scanning/fish/second)
@@ -81,7 +81,7 @@ GLOBAL_LIST_EMPTY(scanned_fish_by_techweb)
 	name = "Fish Scanning Experiment 2"
 	description = "An experiment requiring more fish species to be scanned to unlock the 'Ocean' setting for the fishing portal."
 	points_reward = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS )
-	required_atoms = list(/obj/item/fish = 7)
+	required_atoms = list(/obj/item/fish = 10)
 	next_experiments = list(/datum/experiment/scanning/fish/third)
 	fish_source_reward = /datum/fish_source/portal/ocean
 
@@ -89,7 +89,7 @@ GLOBAL_LIST_EMPTY(scanned_fish_by_techweb)
 	name = "Fish Scanning Experiment 3"
 	description = "An experiment requiring even more fish species to be scanned to unlock the 'Chasm' setting for the fishing portal."
 	points_reward = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS )
-	required_atoms = list(/obj/item/fish = 11)
+	required_atoms = list(/obj/item/fish = 15)
 	next_experiments = list(/datum/experiment/scanning/fish/fourth, /datum/experiment/scanning/fish/holographic)
 	fish_source_reward = /datum/fish_source/portal/chasm
 
@@ -111,6 +111,6 @@ GLOBAL_LIST_EMPTY(scanned_fish_by_techweb)
 	name = "Fish Scanning Experiment 4"
 	description = "An experiment requiring lotsa fish species to unlock the 'Hyperspace' setting for the fishing portal."
 	points_reward = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS )
-	required_atoms = list(/obj/item/fish = 17)
+	required_atoms = list(/obj/item/fish = 25)
 	next_experiments = null
 	fish_source_reward = /datum/fish_source/portal/hyperspace

--- a/code/modules/fishing/fishing_portal_machine.dm
+++ b/code/modules/fishing/fishing_portal_machine.dm
@@ -3,8 +3,8 @@
 	desc = "Fishing anywhere, anytime... anyway what was I talking about?"
 	icon = 'icons/obj/fishing.dmi'
 	icon_state = "portal"
-	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
-	anchored = FALSE
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 10
+	anchored = TRUE
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/fishing_portal_generator
 
@@ -20,6 +20,10 @@
 	var/all_destinations = FALSE
 	/// If the current active fishing spot is from multitool linkage, this value is the atom it would originally belong to.
 	var/atom/current_linked_atom
+	/// Cooldown timer for fishing portal usage to prevent spam
+	var/portal_cooldown_time = 30 SECONDS
+	/// When the portal was last used for fishing
+	var/last_fishing_time = 0
 
 /obj/machinery/fishing_portal_generator/Initialize(mapload)
 	. = ..()

--- a/code/modules/fishing/sources/subtypes/fishing_portal_machine.dm
+++ b/code/modules/fishing/sources/subtypes/fishing_portal_machine.dm
@@ -17,6 +17,34 @@
 	///The name of this option shown in the radial menu on the fishing portal generator
 	var/radial_name = "Aquarium"
 
+/// Portal sources have a cooldown system to prevent spam fishing
+/datum/fish_source/portal/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	. = ..()
+	if(.)
+		return .
+
+	if(istype(parent, /obj/machinery/fishing_portal_generator))
+		var/obj/machinery/fishing_portal_generator/portal = parent
+
+		// Check if portal is anchored
+		if(!portal.anchored)
+			return "The portal must be anchored to maintain dimensional stability for fishing."
+
+		// Check cooldown
+		var/time_since_last = world.time - portal.last_fishing_time
+		if(time_since_last < portal.portal_cooldown_time)
+			var/remaining_cooldown = (portal.portal_cooldown_time - time_since_last) / 10
+			return "The portal is recharging, [remaining_cooldown] seconds remaining."
+
+	return null
+
+/// Update the last fishing time when starting to fish
+/datum/fish_source/portal/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	. = ..()
+	if(istype(parent, /obj/machinery/fishing_portal_generator))
+		var/obj/machinery/fishing_portal_generator/portal = parent
+		portal.last_fishing_time = world.time
+
 /datum/fish_source/portal/beach
 	fish_table = list(
 		FISHING_DUD = 7,
@@ -96,17 +124,17 @@
 /datum/fish_source/portal/hyperspace
 	background = "background_space"
 	fish_table = list(
-		FISHING_DUD = 5,
+		FISHING_DUD = 10, // Increased from 5 to 10
 		/obj/item/fish/starfish = 6,
 		/obj/item/fish/baby_carp = 6,
-		/obj/item/stack/ore/bluespace_crystal = 2,
-		/mob/living/basic/carp = 2,
+		/obj/item/stack/ore/bluespace_crystal = 1, // Reduced from 2 to 1
+		/mob/living/basic/carp = 1, // Reduced from 2 to 1
 	)
 	fish_counts = list(
-		/obj/item/stack/ore/bluespace_crystal = 10,
+		/obj/item/stack/ore/bluespace_crystal = 5, // Reduced from 10 to 5
 	)
 	catalog_description = "Hyperspace dimension (Fishing portal generator)"
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 20
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 35 // Increased from 20 to 35
 	radial_name = "Hyperspace"
 	overlay_state = "portal_hyperspace"
 	radial_state = "space_rocket"
@@ -116,24 +144,24 @@
 /datum/fish_source/portal/syndicate
 	background = "background_lavaland"
 	fish_table = list(
-		FISHING_DUD = 5,
+		FISHING_DUD = 10, // Increased from 5 to 10
 		/obj/item/fish/donkfish = 5,
-		/obj/item/fish/emulsijack = 5,
-		/obj/item/fish/jumpercable = 5,
-		/obj/item/fish/chainsawfish = 2,
-		/obj/item/fish/pike/armored = 2,
+		/obj/item/fish/emulsijack = 3, // Reduced from 5 to 3
+		/obj/item/fish/jumpercable = 3, // Reduced from 5 to 3
+		/obj/item/fish/chainsawfish = 1, // Reduced from 2 to 1
+		/obj/item/fish/pike/armored = 1, // Reduced from 2 to 1
 	)
 	fish_counts = list(
 		/obj/item/fish/chainsawfish = 1,
 		/obj/item/fish/pike/armored = 1,
 	)
 	fish_count_regen = list(
-		/obj/item/fish/chainsawfish = 7 MINUTES,
-		/obj/item/fish/pike/armored = 7 MINUTES,
+		/obj/item/fish/chainsawfish = 15 MINUTES, // Increased from 7 to 15 minutes
+		/obj/item/fish/pike/armored = 15 MINUTES, // Increased from 7 to 15 minutes
 	)
 	catalog_description = "Syndicate dimension (Fishing portal generator)"
 	radial_name = "Syndicate"
-	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 25
+	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 40 // Increased from 25 to 40
 	overlay_state = "portal_syndicate"
 	radial_state = "syndi_snake"
 	associated_safe_turfs = list(/turf/open/water)


### PR DESCRIPTION
## New comments = https://github.com/tgstation/tgstation/pull/93019#issuecomment-3307746459 

## About The Pull Request

Fishing Portal Machine Changes

**Construction:**

- Requires 2 matter bins, 2 capacitors, 1 micro laser, and 2 bluespace crystals (was just 2 matter bins + 1 capacitor)
- Must be anchored to function
- 5x higher power consumption

**Using it:**

- 30-second cooldown between fishing attempts
- Research requirements increased (fish species for all portals)

**Rewards:**

- Less bluespace crystals, higher difficulty
- Reduced rare fish rates, longer respawn times
- Both portals have more duds and higher difficulty
## Why It's Good For The Game

The fishing portal was overpowered! Too cheap to build and gave easy access to rare materials and combat fish. These changes make it a proper end-game tool that requires investment and can't be spammed, while keeping it useful for dedicated fishermen.

This is a compromise which nerfs something but also allows it to be end game side content for players to unlock if they want to.
## Changelog
:cl:
balance: Fishing Portal now costs more, takes longer to unlock, has cooldowns, and gives fewer rare rewards. Still good, just not broken.
/:cl:
