### PR TITLE
Honorifics are not taken into account for voice activators

### DIFF
--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -162,7 +162,12 @@
 /atom/proc/get_name_chaser(mob/user, list/name_chaser = list())
 	return name_chaser
 
-/// Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face. By default just returns the atom's name. add_id_name will control whether or not we append "(as [id_name])".
-/// force_real_name will always return real_name and add (as face_name/id_name) if it doesn't match their appearance
-/atom/proc/get_visible_name(add_id_name, force_real_name)
+/**
+ * Used by mobs to determine the name for someone wearing a mask, or with a disfigured or missing face.
+ * By default just returns the atom's name.
+ *
+ * * add_id_name - If TRUE, ID information such as honorifics or name (if mismatched) are appended
+ * * force_real_name - If TRUE, will always return real_name and add (as face_name/id_name) if it doesn't match their appearance
+ */
+/atom/proc/get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
 	return name

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1453,7 +1453,7 @@
 	. = ..()
 	AddElement(/datum/element/toy_talk)
 
-/obj/item/toy/dummy/get_voice()
+/obj/item/toy/dummy/get_voice(add_id_name)
 	return doll_name
 
 /obj/item/toy/seashell

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -319,14 +319,21 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return "2"
 	return "0"
 
-/// Get what this atom sounds like when speaking
-/atom/proc/get_voice()
+/**
+ * Get what this atom sounds like when speaking
+ *
+ * * add_id_name - If TRUE, ID information such as honorifics are added into the voice
+ */
+/atom/proc/get_voice(add_id_name = FALSE)
 	return "[src]" //Returns the atom's name, prepended with 'The' if it's not a proper noun
 
-/// Get what this atom appears like in chat when speaking
-/// visible_name - If TRUE, returns the visible name rather than the voice
+/**
+ * Get what this atom appears like in chat when speaking
+ *
+ * * visible_name - If TRUE, returns the visible name rather than the voice
+ */
 /atom/proc/get_message_voice(visible_name)
-	return visible_name ? get_visible_name() : get_voice()
+	return visible_name ? get_visible_name(add_id_name = TRUE) : get_voice(add_id_name = TRUE)
 
 //HACKY VIRTUALSPEAKER STUFF BEYOND THIS POINT
 //these exist mostly to deal with the AIs hrefs and job stuff.
@@ -349,7 +356,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 	radio = _radio
 	source = M
 	if(istype(M))
-		name = radio.anonymize ? "Unknown" : M.get_voice()
+		name = radio.anonymize ? "Unknown" : M.get_voice(add_id_name = TRUE)
 		verb_say = M.get_default_say_verb()
 		verb_ask = M.verb_ask
 		verb_exclaim = M.verb_exclaim

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -90,7 +90,7 @@
 	return FALSE
 
 /obj/item/assembly/voice/proc/send_pulse()
-	visible_message("clicks", visible_message_flags = EMOTE_MESSAGE)
+	visible_message("clicks.", visible_message_flags = EMOTE_MESSAGE)
 	playsound(src, 'sound/effects/whirthunk.ogg', 30)
 	addtimer(CALLBACK(src, PROC_REF(pulse)), 2 SECONDS)
 

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -29,7 +29,7 @@
 		return "gurgles"
 	return  tongue.temp_say_mod || tongue.say_mod || ..()
 
-/mob/living/carbon/human/get_voice(add_id_name)
+/mob/living/carbon/human/get_voice(add_id_name = FALSE)
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN_VOICE))
 		return "Unknown"
 	var/id_name = get_id_name("")
@@ -37,7 +37,7 @@
 		return id_name
 	if(override_voice)
 		return override_voice
-	if(real_name == id_name) // Allows for "Captain John" to have the voice "Captain Join" and not "John"
+	if(add_id_name && real_name == id_name) // Allows for "Captain John" to have the voice "Captain Join" and not "John"
 		return get_id_name("", honorifics = TRUE)
 	return real_name
 

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -29,7 +29,7 @@
 		return "gurgles"
 	return  tongue.temp_say_mod || tongue.say_mod || ..()
 
-/mob/living/carbon/human/get_voice()
+/mob/living/carbon/human/get_voice(add_id_name)
 	if(HAS_TRAIT(src, TRAIT_UNKNOWN_VOICE))
 		return "Unknown"
 	var/id_name = get_id_name("")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1093,10 +1093,9 @@
 	.[/datum/job/ai::title] = minutes
 
 /mob/living/silicon/ai/get_voice(add_id_name)
-	. = ..()
-	if(ai_voicechanger && ai_voicechanger.changing_voice)
+	if(ai_voicechanger?.changing_voice)
 		return ai_voicechanger.say_name
-	return
+	return ..()
 
 /mob/living/silicon/ai/proc/set_control_disabled(control_disabled)
 	SEND_SIGNAL(src, COMSIG_SILICON_AI_SET_CONTROL_DISABLED, control_disabled)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1092,7 +1092,7 @@
 	. = ..()
 	.[/datum/job/ai::title] = minutes
 
-/mob/living/silicon/ai/get_voice()
+/mob/living/silicon/ai/get_voice(add_id_name)
 	. = ..()
 	if(ai_voicechanger && ai_voicechanger.changing_voice)
 		return ai_voicechanger.say_name

--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -24,7 +24,7 @@
 	var/namepart = name
 	// If carbon, use voice to account for voice changers
 	if(iscarbon(src))
-		namepart = get_voice()
+		namepart = get_voice(add_id_name = TRUE)
 
 	// AI in carbon body should still have its real name
 	var/obj/item/organ/brain/cybernetic/ai/brain = get_organ_slot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -210,7 +210,7 @@
 	. = ..()
 	AddElement(/datum/element/toy_talk)
 
-/obj/item/bodypart/head/get_voice()
+/obj/item/bodypart/head/get_voice(add_id_name)
 	return "The head of [real_name]"
 
 /obj/item/bodypart/head/update_bodypart_damage_state()


### PR DESCRIPTION
## About The Pull Request

After refactoring this, I realized that baking honorifics into all voices had side effects

Honorifics only needs to be included in voice when speaking, not when, say, storing names for later use

## Changelog

:cl: Melbert
fix: Honorifics will no longer interfere with voice detectors and similar things
/:cl:

