### PR TITLE
Cyborgs can use intercomms

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -102,6 +102,9 @@
 /obj/item/radio/intercom/attack_ai(mob/user)
 	interact(user)
 
+/obj/item/radio/intercom/attack_robot(mob/user)
+	interact(user)
+
 /obj/item/radio/intercom/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request
Fixes Cyborgs not being able to interact with station intercoms Ai and Humans
## Why It's Good For The Game
Seems like a bug no? Silicon Remote interaction should be the same for Ai and Cyborgs.
## Changelog
:cl:
fix: Intercomms work for Cyborgs
/:cl:
