### PR TITLE
Fixes BSOD when clicking table row buttons in controller overview window

### DIFF
--- a/tgui/packages/tgui/interfaces/ControllerOverview/OverviewSection.tsx
+++ b/tgui/packages/tgui/interfaces/ControllerOverview/OverviewSection.tsx
@@ -17,7 +17,7 @@ export function OverviewSection(props) {
   let overallOverrun = 0;
   for (let i = 0; i < subsystems.length; i++) {
     avgUsage += subsystems[i].usage_per_tick;
-    overallOverrun += subsystems[i].tick_overrun;
+    overallOverrun += subsystems[i].overtime;
   }
 
   return (

--- a/tgui/packages/tgui/interfaces/ControllerOverview/SubsystemDialog.tsx
+++ b/tgui/packages/tgui/interfaces/ControllerOverview/SubsystemDialog.tsx
@@ -23,7 +23,7 @@ export function SubsystemDialog(props: Props) {
     last_fire,
     name,
     next_fire,
-    tick_overrun,
+    overtime,
     tick_usage,
     usage_per_tick,
   } = subsystem;
@@ -54,7 +54,7 @@ export function SubsystemDialog(props: Props) {
             {usage_per_tick.toFixed(2)}%
           </LabeledList.Item>
           <LabeledList.Item label="Tick Overrun">
-            {tick_overrun.toFixed(2)}%
+            {overtime.toFixed(2)}%
           </LabeledList.Item>
           {initialization_failure_message && (
             <LabeledList.Item color="bad">

--- a/tgui/packages/tgui/interfaces/ControllerOverview/index.tsx
+++ b/tgui/packages/tgui/interfaces/ControllerOverview/index.tsx
@@ -1,9 +1,8 @@
 import { useReducer, useState } from 'react';
 import { Button, Dropdown, Input, Section, Stack } from 'tgui-core/components';
-
 import { Window } from '../../layouts';
 import { SORTING_TYPES } from './contants';
-import { FilterAction, filterReducer, type FilterState } from './filters';
+import { FilterAction, type FilterState, filterReducer } from './filters';
 import { OverviewSection } from './OverviewSection';
 import { SubsystemDialog } from './SubsystemDialog';
 import { SubsystemViews } from './SubsystemViews';

--- a/tgui/packages/tgui/interfaces/ControllerOverview/types.ts
+++ b/tgui/packages/tgui/interfaces/ControllerOverview/types.ts
@@ -11,7 +11,7 @@ export type SubsystemData = {
   name: string;
   next_fire: number;
   ref: string;
-  tick_overrun: number;
+  overtime: number;
   tick_usage: number;
   usage_per_tick: number;
 };


### PR DESCRIPTION
## About The Pull Request
Broken by #92556. `tick_overrun` was not properly renamed to `overtime` in all places


## Changelog
:cl:
fix: no BSOD when clicking table row buttons in controller overview window
/:cl:

