### PR TITLE
Prevent dead mobs interacting or attacking with objects/players

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -15,6 +15,8 @@
  * (Potentially) gives feedback to the mob if they cannot.
  */
 /mob/living/proc/can_unarmed_attack()
+	if(stat == DEAD)
+		return FALSE
 	return !HAS_TRAIT(src, TRAIT_HANDS_BLOCKED)
 
 /mob/living/carbon/can_unarmed_attack()

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -342,7 +342,14 @@ multiple modular subtrees with behaviors
 ///Can this pawn interact with objects?
 /datum/ai_controller/proc/ai_can_interact()
 	SHOULD_CALL_PARENT(TRUE)
-	return !QDELETED(pawn)
+	if(QDELETED(pawn))
+		return FALSE
+	// Dead mobs should not be able to interact with objects
+	if(isliving(pawn))
+		var/mob/living/living_pawn = pawn
+		if(living_pawn.stat == DEAD)
+			return FALSE
+	return TRUE
 
 ///Interact with objects
 /datum/ai_controller/proc/ai_interact(target, combat_mode, list/modifiers)

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -39,6 +39,9 @@
 		var/mob/living/pawn = controller.pawn
 		if (world.time < pawn.next_move)
 			return AI_BEHAVIOR_INSTANT
+		// Dead mobs should not be able to attack
+		if (pawn.stat == DEAD)
+			return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 
 	var/datum/targeting_strategy/targeting_strategy = GET_TARGETING_STRATEGY(controller.blackboard[targeting_strategy_key])
 	if(!targeting_strategy.can_attack(controller.pawn, target))
@@ -87,6 +90,9 @@
 
 /datum/ai_behavior/basic_ranged_attack/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	var/mob/living/basic/basic_mob = controller.pawn
+	// Dead mobs should not be able to attack
+	if(basic_mob.stat == DEAD)
+		return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 	//targeting strategy will kill the action if not real anymore
 	var/atom/target = controller.blackboard[target_key]
 	var/datum/targeting_strategy/targeting_strategy = GET_TARGETING_STRATEGY(controller.blackboard[targeting_strategy_key])

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -39,9 +39,6 @@
 		var/mob/living/pawn = controller.pawn
 		if (world.time < pawn.next_move)
 			return AI_BEHAVIOR_INSTANT
-		// Dead mobs should not be able to attack
-		if (pawn.stat == DEAD)
-			return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 
 	var/datum/targeting_strategy/targeting_strategy = GET_TARGETING_STRATEGY(controller.blackboard[targeting_strategy_key])
 	if(!targeting_strategy.can_attack(controller.pawn, target))
@@ -90,9 +87,6 @@
 
 /datum/ai_behavior/basic_ranged_attack/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	var/mob/living/basic/basic_mob = controller.pawn
-	// Dead mobs should not be able to attack
-	if(basic_mob.stat == DEAD)
-		return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 	//targeting strategy will kill the action if not real anymore
 	var/atom/target = controller.blackboard[target_key]
 	var/datum/targeting_strategy/targeting_strategy = GET_TARGETING_STRATEGY(controller.blackboard[targeting_strategy_key])

--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -14,6 +14,10 @@
 	if(isnull(our_controller))
 		return FALSE
 
+	// Dead mobs should not attack anything
+	if(living_mob.stat == DEAD)
+		return FALSE
+
 	if(isturf(the_target) || isnull(the_target)) // bail out on invalids
 		return FALSE
 

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -231,6 +231,9 @@
 	. += span_deadsay("Upon closer examination, [p_they()] appear[p_s()] to be [HAS_MIND_TRAIT(user, TRAIT_NAIVE) ? "asleep" : "dead"].")
 
 /mob/living/basic/proc/melee_attack(atom/target, list/modifiers, ignore_cooldown = FALSE)
+	// Dead mobs should not be able to attack
+	if(stat == DEAD)
+		return FALSE
 	if(!early_melee_attack(target, modifiers, ignore_cooldown))
 		return FALSE
 	var/result = target.attack_basic_mob(src, modifiers)


### PR DESCRIPTION

## About The Pull Request

Should fix #92999 is the hope.

Explicitly prevents dead mobs from using basic attacks or interacting with things while they are dead
## Why It's Good For The Game

- Fix of unintended thing
## Changelog
:cl:
fix: Prevent dead mobs interacting or attacking with objects/players
/:cl:
