### PR TITLE
Adds insulated gloves in WawaStation tech storage

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -45211,6 +45211,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/iron/textured,
 /area/station/engineering/storage/tech)
 "pEk" = (


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

because every station has insuls in tech storage and i think that part was missed on wawa

## Changelog

:cl:
fix: Added missing insulated gloves in WawaStation tech storage
/:cl:
