### PR TITLE
Fixes unable to place power cables on reinforced catwalk in Lavaland

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -154,6 +154,13 @@
 	desc = "A heavily reinforced catwalk used to build bridges in hostile environments. It doesn't look like anything could make this budge."
 	resistance_flags = INDESTRUCTIBLE
 
+/obj/structure/lattice/catwalk/mining/attackby(obj/item/C, mob/user, list/modifiers, list/attack_modifiers)
+	// Allow cable placement even though we're indestructible
+	if(istype(C, /obj/item/stack/cable_coil))
+		var/turf/T = get_turf(src)
+		return T.attackby(C, user)
+	return ..()
+
 /obj/structure/lattice/catwalk/mining/deconstruction_hints(mob/user)
 	return
 


### PR DESCRIPTION

<img width="443" height="217" alt="image" src="https://github.com/user-attachments/assets/70968561-5ce4-44d2-b731-fcde46728881" />
<img width="288" height="143" alt="image" src="https://github.com/user-attachments/assets/8d4784ef-25d7-4fc5-88e4-2dbadce71623" />



## About The Pull Request

Great success for #92975 

	resistance_flags = INDESTRUCTIBLE

Prevented cables being placed on that reinforced catwalk
Allowed just cables to be placed but the things are still unable to be damaged in testing

I also made sure it does not affect regular catwalks
| Cannot place cables still | Need to remove cover |
|--------|--------|
| <img width="183" height="366" alt="image" src="https://github.com/user-attachments/assets/d3a3704f-25ed-4567-85eb-e058aa1071fc" /> | <img width="189" height="362" alt="image" src="https://github.com/user-attachments/assets/80c73a19-d699-4a91-89f2-77e3c4434ed7" />| 
## Why It's Good For The Game

- Allows you to fix wire / power issues on Lavaland
## Changelog
:cl:
fix: Fixes unable to place power cables on reinforced catwalk in Lavaland
/:cl:
