### PR TITLE
Allows health analysers to scan Cyborg MMIs and show a brain (or not)

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -190,7 +190,17 @@
 			render_list += "<span class='alert ml-1'>Fatigue level: [target.getStaminaLoss()]%.</span><br>"
 		else
 			render_list += "<span class='alert ml-1'>Subject appears to be suffering from fatigue.</span><br>"
-	if (!target.get_organ_slot(ORGAN_SLOT_BRAIN)) // kept exclusively for soul purposes
+	
+	// Check for brain - both organic (carbon) and synthetic (cyborg MMI)
+	var/has_brain = FALSE
+	if(target.get_organ_slot(ORGAN_SLOT_BRAIN))
+		has_brain = TRUE
+	else if(iscyborg(target))
+		var/mob/living/silicon/robot/cyborg_target = target
+		if(cyborg_target.mmi?.brain)
+			has_brain = TRUE
+	
+	if(!has_brain) // kept exclusively for soul purposes
 		render_list += "<span class='alert ml-1'>Subject lacks a brain.</span><br>"
 
 	if(iscarbon(target))

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -154,6 +154,13 @@
 	desc = "A heavily reinforced catwalk used to build bridges in hostile environments. It doesn't look like anything could make this budge."
 	resistance_flags = INDESTRUCTIBLE
 
+/obj/structure/lattice/catwalk/mining/attackby(obj/item/C, mob/user, list/modifiers, list/attack_modifiers)
+	// Allow cable placement even though we're indestructible
+	if(istype(C, /obj/item/stack/cable_coil))
+		var/turf/T = get_turf(src)
+		return T.attackby(C, user)
+	return ..()
+
 /obj/structure/lattice/catwalk/mining/deconstruction_hints(mob/user)
 	return
 

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -154,13 +154,6 @@
 	desc = "A heavily reinforced catwalk used to build bridges in hostile environments. It doesn't look like anything could make this budge."
 	resistance_flags = INDESTRUCTIBLE
 
-/obj/structure/lattice/catwalk/mining/attackby(obj/item/C, mob/user, list/modifiers, list/attack_modifiers)
-	// Allow cable placement even though we're indestructible
-	if(istype(C, /obj/item/stack/cable_coil))
-		var/turf/T = get_turf(src)
-		return T.attackby(C, user)
-	return ..()
-
 /obj/structure/lattice/catwalk/mining/deconstruction_hints(mob/user)
 	return
 


### PR DESCRIPTION
## About The Pull Request

Fixes #92892 may not need fixing as looking at the code the feature was only left in for soul

But I expanded it a little to work on Cyborgs/MMIs
## Why It's Good For The Game

- Preserves soul
## Changelog
:cl:
fix: Allows health analysers to scan Cyborg MMIs and show a brain (or not)
/:cl:
