### PR TITLE
Changes detective hat candy corn text to be correct when not on your head

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -220,12 +220,12 @@
 /// Now to solve where all these keep coming from
 /obj/item/clothing/head/fedora/det_hat/click_alt(mob/user)
 	if(!COOLDOWN_FINISHED(src, candy_cooldown))
-		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
+		to_chat(user, span_warning("A candy corn was just taken! You should wait a couple minutes, lest you burn through the stash."))
 		return CLICK_ACTION_BLOCKING
 
 	var/obj/item/food/candy_corn/sweets = new /obj/item/food/candy_corn(src)
 	user.put_in_hands(sweets)
-	to_chat(user, span_notice("You slip a candy corn from your hat."))
+	to_chat(user, span_notice("You slip a candy corn from \the [src]."))
 	COOLDOWN_START(src, candy_cooldown, CANDY_CD_TIME)
 
 	return CLICK_ACTION_SUCCESS


### PR DESCRIPTION

## About The Pull Request

Currently, the det hat candy corn taking and can't take text assumes its on your head, but it doesn't have to be for you to do it, nor should it. This changes the text to language that works whether or not it's "your" hat. 

## Why It's Good For The Game

More often correct text

## Changelog
:cl:

spellcheck: Changed det hat candy corn text to more neutral language

/:cl:
