### PR TITLE
Fix blink animation for eyes with no eyelids

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -346,7 +346,7 @@
 	// If we crossed blinking brain damage thresholds either way, update our blinking
 	if (owner && ((prev_damage > BRAIN_DAMAGE_ASYNC_BLINKING && damage < BRAIN_DAMAGE_ASYNC_BLINKING) || (prev_damage < BRAIN_DAMAGE_ASYNC_BLINKING && damage > BRAIN_DAMAGE_ASYNC_BLINKING)))
 		var/obj/item/organ/eyes/eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
-		if(eyes && eyes.blink_animation)
+		if(eyes?.blink_animation)
 			eyes.animate_eyelids(owner)
 
 	// If we're not more injured than before, return without gambling for a trauma

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -346,7 +346,8 @@
 	// If we crossed blinking brain damage thresholds either way, update our blinking
 	if (owner && ((prev_damage > BRAIN_DAMAGE_ASYNC_BLINKING && damage < BRAIN_DAMAGE_ASYNC_BLINKING) || (prev_damage < BRAIN_DAMAGE_ASYNC_BLINKING && damage > BRAIN_DAMAGE_ASYNC_BLINKING)))
 		var/obj/item/organ/eyes/eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
-		eyes?.animate_eyelids(owner)
+		if(eyes && eyes.blink_animation)
+			eyes.animate_eyelids(owner)
 
 	// If we're not more injured than before, return without gambling for a trauma
 	if(damage <= prev_damage)


### PR DESCRIPTION

## About The Pull Request
There was a runtime with blink animation for mobs with no eyelids. This was due to a missing blink animation check when triggering the eyelid animation.

## Why It's Good For The Game
One less runtime.

## Changelog
:cl:
fix: Fix blink animation for eyes with no eyelids
/:cl:
