### PR TITLE
Adds hotkey to close all UIs

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -28,6 +28,7 @@
 #define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
 #define COMSIG_KB_CLIENT_FULLSCREEN_DOWN "keybinding_client_fullscreen_down"
 #define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"
+#define COMSIG_KB_CLIENT_CLOSEUI_DOWN "keybinding_client_closeui_down"
 
 //Communication
 

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -59,3 +59,17 @@
 		return
 	user.mob.button_pressed_F12()
 	return TRUE
+
+/datum/keybinding/client/close_every_ui
+	hotkey_keys = list("Northwest") // HOME key
+	name = "close_every_ui"
+	full_name = "Close Open UIs"
+	description = "Closes all UI windows you have open."
+	keybind_signal = COMSIG_KB_CLIENT_CLOSEUI_DOWN
+
+/datum/keybinding/client/close_every_ui/down(client/user, turf/target)
+	. = ..()
+	if(.)
+		return
+	SStgui.close_user_uis(user.mob)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

Adds hotkey which closes all open TGUI uis. Bound to home by default.

## Why It's Good For The Game

You ever be in the middle of something busy and have like 5 UIs open and then you get attacked and you're just like GET THESE UIS OFF MY SCREEN? This gives you an easy way to do that

Unfortunately it only works on TGUI uis, not sure if it's possible for plain browsers, else it'd be suuuuuuper handy for admins

## Changelog

:cl: Melbert
qol: Adds hotkey to close all open uis, bound to "home" by default
/:cl:

