### PR TITLE
Reinforced floors stop explosions from affecting underfloor objects / posters aren't capable of blocking explosions / but machines can!

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -51,7 +51,7 @@
 	if(target == src)
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
-	if(severity < EXPLODE_DEVASTATE && is_shielded())
+	if(is_explosion_shielded(severity))
 		return FALSE
 
 	if(target)
@@ -86,9 +86,13 @@
 
 	return FALSE
 
-/turf/open/floor/is_shielded()
-	for(var/obj/structure/A in contents)
-		return 1
+/turf/open/floor/is_explosion_shielded(severity)
+	if(severity >= EXPLODE_DEVASTATE)
+		return FALSE
+	for(var/obj/blocker in src)
+		if(blocker.density)
+			return TRUE
+	return FALSE
 
 /turf/open/floor/blob_act(obj/structure/blob/B)
 	return

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -56,7 +56,7 @@
 	if(target == src)
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
-	if(severity < EXPLODE_DEVASTATE && is_shielded())
+	if(is_explosion_shielded(severity))
 		return FALSE
 
 	switch(severity)
@@ -75,6 +75,10 @@
 				ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
 	return TRUE
+
+// Contents *under* the reinforced flooring is protected from explosions (unless it's devastate level)
+/turf/open/floor/engine/can_propagate_explosion(atom/movable/some_thing, severity)
+	return severity == EXPLODE_DEVASTATE || !HAS_TRAIT(some_thing, TRAIT_UNDERFLOOR)
 
 /turf/open/floor/engine/singularity_pull(atom/singularity, current_size)
 	..()

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -43,7 +43,7 @@
 	if(target == src)
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
-	if(severity < EXPLODE_DEVASTATE && is_shielded())
+	if(is_explosion_shielded(severity))
 		return FALSE
 
 	if(target)
@@ -69,9 +69,13 @@
 
 	return TRUE
 
-/turf/open/misc/is_shielded()
-	for(var/obj/structure/A in contents)
-		return TRUE
+/turf/open/misc/is_explosion_shielded(severity)
+	if(severity >= EXPLODE_DEVASTATE)
+		return FALSE
+	for(var/obj/blocker in src)
+		if(blocker.density)
+			return TRUE
+	return FALSE
 
 /turf/open/misc/blob_act(obj/structure/blob/B)
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -562,13 +562,14 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/break_tile()
 	return
 
-/turf/proc/is_shielded()
-	return
+/// Checks if this turf is protected from an explosion by something
+/// Return TRUE to stop the explosion from affecting this turf
+/turf/proc/is_explosion_shielded(severity)
+	return FALSE
 
 /turf/contents_explosion(severity, target)
-	for(var/thing in contents)
-		var/atom/movable/movable_thing = thing
-		if(QDELETED(movable_thing))
+	for(var/atom/movable/movable_thing as anything in src)
+		if(QDELETED(movable_thing) || !can_propagate_explosion(movable_thing, severity))
 			continue
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
@@ -577,6 +578,11 @@ GLOBAL_LIST_EMPTY(station_turfs)
 				SSexplosions.med_mov_atom += movable_thing
 			if(EXPLODE_LIGHT)
 				SSexplosions.low_mov_atom += movable_thing
+
+/// Called when propagating an explosion through contents,.
+/// Return FALSE to prevent the passed object from being exploded.
+/turf/proc/can_propagate_explosion(atom/movable/some_thing, severity)
+	return TRUE
 
 /turf/narsie_act(force, ignore_mobs, probability = 20)
 	. = (prob(probability) || force)

--- a/code/modules/transport/tram/tram_floors.dm
+++ b/code/modules/transport/tram/tram_floors.dm
@@ -55,7 +55,7 @@
 	if(target == src)
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
-	if(severity < EXPLODE_DEVASTATE && is_shielded())
+	if(is_explosion_shielded(severity))
 		return FALSE
 
 	switch(severity)


### PR DESCRIPTION
## About The Pull Request

1. Reinforced floors will stop light and heavy explosions from affecting objects beneath the floor, ie cabling and piping

2. A poster alone is no longer strong enough to shield a turf from an explosion, only dense objects

3. Machines are now included as explosions blockers, rather than only tables

## Why It's Good For The Game

1. I always fought it very annoying when you reinforce the floor to detonate something, then you detonate something and all the cables are ripped up, now you have to rip up the floor and it SUCKS

2. I don't think it's intentional that any structure is capable of stopping a turf from being exploded

3. However it might make sense that machines are also capable of blocking explosions if structures are

## Changelog

:cl: Melbert
balance: Reinforced floors will stop light and heavy explosions from affecting objects beneath the floor, ie cabling and piping
balance: Explosions affecting floors are no longer blocked by *any structure*, such as posters. Only dense structures block them. 
balance: Machines can now block explosions from affecting floors, much like structures 
/:cl:
