### PR TITLE
Refactors filters to utilize binary insertion instead of timSort

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -234,6 +234,40 @@
 		};\
 	} while(FALSE)
 
+/****
+	* Somehow even more custom binary search sorted insert, which uses list values to sort nested lists
+	* INPUT: Object to be inserted
+	* LIST: List to insert object into
+	* COMPARE: The object to compare against, usualy the same as INPUT
+	* COMPARISON: The index of a value in the objects to compare
+	* COMPTYPE: How should the values be compared? Either COMPARE_KEY or COMPARE_VALUE.
+	*/
+#define BINARY_INSERT_LIST(INPUT, LIST, COMPARE, COMPARISON, COMPTYPE) \
+	do {\
+		var/list/__BIN_LIST = LIST;\
+		var/__BIN_CTTL = length(__BIN_LIST);\
+		if(!__BIN_CTTL) {\
+			__BIN_LIST += INPUT;\
+		} else {\
+			var/__BIN_LEFT = 1;\
+			var/__BIN_RIGHT = __BIN_CTTL;\
+			var/__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
+			var/list/__BIN_ITEM;\
+			while(__BIN_LEFT < __BIN_RIGHT) {\
+				__BIN_ITEM = COMPTYPE;\
+				if(__BIN_ITEM[##COMPARISON] <= COMPARE[##COMPARISON]) {\
+					__BIN_LEFT = __BIN_MID + 1;\
+				} else {\
+					__BIN_RIGHT = __BIN_MID;\
+				};\
+				__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
+			};\
+			__BIN_ITEM = COMPTYPE;\
+			__BIN_MID = __BIN_ITEM[##COMPARISON] > COMPARE[##COMPARISON] ? __BIN_MID : __BIN_MID + 1;\
+			__BIN_LIST.Insert(__BIN_MID, INPUT);\
+		};\
+	} while(FALSE)
+
 ///Returns a list in plain english as a string
 /proc/english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
 	var/total = length(input)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -197,6 +197,7 @@
 	} while(FALSE)
 
 #define SORT_FIRST_INDEX(list) (list[1])
+#define SORT_PRIORITY_INDEX(list) (list["priority"])
 #define SORT_COMPARE_DIRECTLY(thing) (thing)
 #define SORT_VAR_NO_TYPE(varname) var/varname
 /****
@@ -230,40 +231,6 @@
 			};\
 			__BIN_ITEM = COMPTYPE;\
 			__BIN_MID = ##COMPARISON(__BIN_ITEM) > ##COMPARISON(COMPARE) ? __BIN_MID : __BIN_MID + 1;\
-			__BIN_LIST.Insert(__BIN_MID, INPUT);\
-		};\
-	} while(FALSE)
-
-/****
-	* Somehow even more custom binary search sorted insert, which uses list values to sort nested lists
-	* INPUT: Object to be inserted
-	* LIST: List to insert object into
-	* COMPARE: The object to compare against, usualy the same as INPUT
-	* COMPARISON: The index of a value in the objects to compare
-	* COMPTYPE: How should the values be compared? Either COMPARE_KEY or COMPARE_VALUE.
-	*/
-#define BINARY_INSERT_LIST(INPUT, LIST, COMPARE, COMPARISON, COMPTYPE) \
-	do {\
-		var/list/__BIN_LIST = LIST;\
-		var/__BIN_CTTL = length(__BIN_LIST);\
-		if(!__BIN_CTTL) {\
-			__BIN_LIST += INPUT;\
-		} else {\
-			var/__BIN_LEFT = 1;\
-			var/__BIN_RIGHT = __BIN_CTTL;\
-			var/__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
-			var/list/__BIN_ITEM;\
-			while(__BIN_LEFT < __BIN_RIGHT) {\
-				__BIN_ITEM = COMPTYPE;\
-				if(__BIN_ITEM[##COMPARISON] <= COMPARE[##COMPARISON]) {\
-					__BIN_LEFT = __BIN_MID + 1;\
-				} else {\
-					__BIN_RIGHT = __BIN_MID;\
-				};\
-				__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
-			};\
-			__BIN_ITEM = COMPTYPE;\
-			__BIN_MID = __BIN_ITEM[##COMPARISON] > COMPARE[##COMPARISON] ? __BIN_MID : __BIN_MID + 1;\
 			__BIN_LIST.Insert(__BIN_MID, INPUT);\
 		};\
 	} while(FALSE)

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -31,10 +31,10 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	return returned_planes
 
 ///Full override so we can just use filterrific
-/atom/movable/plane_master_controller/add_filter(name, priority, list/params)
+/atom/movable/plane_master_controller/add_filter(name, priority, list/params, update = TRUE)
 	. = ..()
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
-		pm_iterator.add_filter(name, priority, params)
+		pm_iterator.add_filter(name, priority, params, update)
 
 ///Full override so we can just use filterrific
 /atom/movable/plane_master_controller/remove_filter(name_or_names)

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -42,10 +42,10 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
 		pm_iterator.remove_filter(name_or_names)
 
-/atom/movable/plane_master_controller/update_filters()
+/atom/movable/plane_master_controller/update_filters(start_index = null)
 	. = ..()
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
-		pm_iterator.update_filters()
+		pm_iterator.update_filters(start_index)
 
 ///Gets all filters for this controllers plane masters
 /atom/movable/plane_master_controller/proc/get_filters(name)

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -37,10 +37,10 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		pm_iterator.add_filter(name, priority, params, update)
 
 ///Full override so we can just use filterrific
-/atom/movable/plane_master_controller/remove_filter(name_or_names)
+/atom/movable/plane_master_controller/remove_filter(name_or_names, update = TRUE)
 	. = ..()
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
-		pm_iterator.remove_filter(name_or_names)
+		pm_iterator.remove_filter(name_or_names, update)
 
 /atom/movable/plane_master_controller/update_filters(start_index = null)
 	. = ..()

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -367,8 +367,11 @@
 /datum/proc/update_filters(start_index = null)
 	ASSERT(isatom(src) || isimage(src))
 	var/atom/atom_cast = src // filters only work with images or atoms.
-	if (!start_index)
+	if (start_index)
+		filter_cache.Cut(start_index)
+	else
 		atom_cast.filters = null
+		filter_cache.Cut()
 
 	for (var/index in start_index || 1 to length(filter_data))
 		var/list/filter_info = filter_data[index]
@@ -376,8 +379,9 @@
 		arguments -= "priority"
 		if (start_index) // See https://www.byond.com/forum/post/2980598 as to why we cannot just override the existing filter
 			atom_cast.filters -= filter_info["name"] // We're trapped in the belly of this horrible machine
-		atom_cast.filters += filter(arglist(arguments)) // And the machine is bleeding to death
+		filter_cache += filter(arglist(arguments)) // And the machine is bleeding to death
 
+	atom_cast.filters = filter_cache
 	UNSETEMPTY(filter_data)
 
 /obj/item/update_filters(start_index = null)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -359,7 +359,7 @@
 	ASSERT(isatom(src) || isimage(src))
 	var/atom/atom_cast = src // filters only work with images or atoms.
 	for (var/list/individual_filter as anything in filters)
-		add_filter(individual_filter["name"], individual_filter["priority"], individual_filter, update = FALSE)
+		add_filter(individual_filter["name"], individual_filter["priority"], individual_filter["params"], update = FALSE)
 	if (update)
 		atom_cast.filters = filter_cache
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -349,6 +349,7 @@
 		var/list/arguments = filter_info.Copy()
 		arguments -= "priority"
 		filter_cache.Insert(index, filter(arglist(arguments)))
+		break
 
 	if (update)
 		atom_cast.filters = filter_cache

--- a/code/modules/admin/view_variables/filterrific.dm
+++ b/code/modules/admin/view_variables/filterrific.dm
@@ -74,8 +74,7 @@
 		if("modify_icon_value")
 			var/icon/new_icon = input("Pick icon:", "Icon") as null|icon
 			if(new_icon)
-				target.filter_data[params["name"]]["icon"] = new_icon
-				target.update_filters()
+				target.modify_filter(params["name"], list("icon" = new_icon))
 				. = TRUE
 		if("mass_apply")
 			if(!check_rights_for(usr.client, R_FUN))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -472,25 +472,23 @@ Striking a noncultist, however, will tear their flesh."}
 
 	// on bound
 	if(bound)
+		remove_filter("unbound_ray", update = FALSE)
 		add_filter("bind_glow", 2, list("type" = "outline", "color" = h_color, "size" = 0.1))
-		remove_filter("unbound_ray")
-		update_filters()
-	// on unbound
-	else
-		// we re-add this every time it's picked up or dropped
-		remove_filter("unbound_ray")
-		add_filter(name = "unbound_ray", priority = 1, params = list(
-			type = "rays",
-			size = 16,
-			color = COLOR_HERETIC_GREEN, // the sickly green of the heretic leaking through
-			density = 16,
-		))
-		// because otherwise the animations stack and it looks ridiculous
-		var/ray_filter = get_filter("unbound_ray")
-		animate(ray_filter, offset = 100, time = 2 MINUTES, loop = -1, flags = ANIMATION_PARALLEL) // Absurdly long animate so nobody notices it hitching when it loops
-		animate(offset = 0, time = 2 MINUTES) // I sure hope duration of animate doesnt have any performance effect
+		return
 
-	update_filters()
+	// on unbound
+	// we re-add this every time it's picked up or dropped
+	remove_filter("bind_glow", update = FALSE)
+	add_filter(name = "unbound_ray", priority = 1, params = list(
+		type = "rays",
+		size = 16,
+		color = COLOR_HERETIC_GREEN, // the sickly green of the heretic leaking through
+		density = 16,
+	))
+	// because otherwise the animations stack and it looks ridiculous
+	var/ray_filter = get_filter("unbound_ray")
+	animate(ray_filter, offset = 100, time = 2 MINUTES, loop = -1, flags = ANIMATION_PARALLEL) // Absurdly long animate so nobody notices it hitching when it loops
+	animate(offset = 0, time = 2 MINUTES) // I sure hope duration of animate doesnt have any performance effect
 
 /obj/item/melee/cultblade/haunted/proc/start_glow_loop()
 	var/filter = get_filter("bind_glow")

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -48,10 +48,7 @@
 	pointed_atom_appearance.pixel_x = 0
 	pointed_atom_appearance.pixel_y = 0
 	thought_bubble.overlays += pointed_atom_appearance
-
-	var/hover_outline_index = pointed_atom.get_filter_index(HOVER_OUTLINE_FILTER)
-	if (!isnull(hover_outline_index))
-		pointed_atom_appearance.filters.Cut(hover_outline_index, hover_outline_index + 1)
+	pointed_atom_appearance.remove_filter(HOVER_OUTLINE_FILTER)
 
 	thought_bubble.pixel_w = 16
 	thought_bubble.pixel_z = 32

--- a/code/modules/unit_tests/plane_double_transform.dm
+++ b/code/modules/unit_tests/plane_double_transform.dm
@@ -33,8 +33,7 @@
 				consider making a new render plate that they can both draw to instead, or something of that nature.")
 
 		// Now we walk for filters that take from us
-		for(var/filter_id in plane.filter_data)
-			var/list/filter = plane.filter_data[filter_id]
+		for(var/list/filter in plane.filter_data)
 			if(!filter["render_source"])
 				continue
 			var/atom/movable/screen/plane_master/target = render_target_to_plane[filter["render_source"]]


### PR DESCRIPTION
## About The Pull Request

update_filters() is more expensive than it should be due to running timSort every time a filter is added or removed, plus we wipe re-initialize the entire atom filter list every time we call it. I swapped it to use binary insertion into the main list, and we can cut down on the amount of filter churn by storing filters in a separate list which we can use Insert on, which allows us to stop constantly deleting and recreating filters completely.

## Why It's Good For The Game

Server CPU consumption go down

## Changelog
:cl:
refactor: Refactored filters to utilize binary insertion instead of timSort. The server should run somewhat faster now, hopefully.
/:cl:
