### PR TITLE
Makes mapped-in quantum pads not runtime on first activation

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -93,7 +93,9 @@
 
 /obj/machinery/quantumpad/interact(mob/user, obj/machinery/quantumpad/target_pad = linked_pad)
 	if(!target_pad || QDELETED(target_pad))
-		if(!map_pad_link_id || !initMappedLink())
+		if(map_pad_link_id && initMappedLink())
+			target_pad = linked_pad
+		else
 			to_chat(user, span_warning("Target pad not found!"))
 			return
 

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -92,7 +92,7 @@
 	return ..()
 
 /obj/machinery/quantumpad/interact(mob/user, obj/machinery/quantumpad/target_pad = linked_pad)
-	if(!target_pad || QDELETED(target_pad))
+	if(QDELETED(target_pad))
 		if(map_pad_link_id && initMappedLink())
 			target_pad = linked_pad
 		else


### PR DESCRIPTION

## About The Pull Request

Makes sure that quantum pads interact proc properly sets the target pad to its pair after they get linked with mapping vars

Found in: https://github.com/IrisSS13/IrisStation/pull/670
Tested both in TG and There, both cases it runtimes. After this PR it doesn't

<details>
<summary>Screenshots of runtimes before/after the PR</summary>

Before:

<img width="1600" height="859" alt="image" src="https://github.com/user-attachments/assets/839f5745-fac3-4c28-9dc2-762b560cf355" />

After:

<img width="1600" height="859" alt="image" src="https://github.com/user-attachments/assets/d0b32746-1c9f-41e2-bfe9-bcf21b95a6d7" />

</details>

## Why It's Good For The Game

Runtimes bad

## Changelog

:cl:
fix: fixed mapped in quantum pads runtiming when trying to link with eachother
/:cl:
