### PR TITLE
MAP - Catwalk - First rework for service department

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -1055,6 +1055,14 @@
 	dir = 1
 	},
 /area/station/science/ordnance/storage)
+"aqg" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "aqj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -2354,6 +2362,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aLd" = (
@@ -4940,15 +4951,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/openspace,
 /area/station/hallway/primary/central)
-"bAg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "bAh" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer"
@@ -8705,6 +8707,16 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"cBc" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "cBf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -9931,7 +9943,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -11172,6 +11183,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/court,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port)
+"dnE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "dnH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -13331,6 +13354,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"dVj" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "dVm" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15741,7 +15770,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
@@ -18715,7 +18743,6 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "fyp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/smartfridge/drying,
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -22805,6 +22832,19 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
+"gDQ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Community Center"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "gDU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23771,15 +23811,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gSq" = (
-/obj/structure/sign/plaques/kiddie{
-	desc = "A certificate of psychology, indicating that the person's a psychologist.";
-	name = "Psychology Degree";
-	pixel_x = -32
-	},
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
 "gSG" = (
@@ -25303,14 +25335,11 @@
 /turf/closed/wall,
 /area/station/medical/abandoned)
 "hqD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/service/kitchen)
 "hqL" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/openspace,
@@ -25627,6 +25656,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"hvX" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "hwn" = (
 /obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/plating,
@@ -29845,12 +29884,12 @@
 "iEH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/airlock{
 	name = "Kitchen"
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iEI" = (
@@ -32730,7 +32769,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -33990,15 +34029,6 @@
 /obj/item/restraints/legcuffs/beartrap/prearmed,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port)
-"jKm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark/end{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/hallway/secondary/service)
 "jKo" = (
 /obj/structure/table/wood,
 /obj/item/lighter{
@@ -34919,6 +34949,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
+"jYS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "jZc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35632,6 +35671,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"kle" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/light/directional/east,
+/obj/structure/table,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "kll" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -38044,7 +38089,6 @@
 /area/station/security/detectives_office/private_investigators_office)
 "kUI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -42156,19 +42200,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"mep" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Psychology Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "meE" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -44818,6 +44849,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "mVm" = (
@@ -47492,6 +47524,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"nHt" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "nHy" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/turf_decal/siding/wood{
@@ -53169,7 +53206,6 @@
 /area/station/engineering/main)
 "por" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "pot" = (
@@ -63022,7 +63058,6 @@
 /turf/closed/wall,
 /area/station/commons/vacant_room/office)
 "shv" = (
-/obj/structure/cable,
 /obj/structure/closet/crate,
 /obj/item/book/manual/chef_recipes,
 /obj/item/hand_labeler,
@@ -64533,12 +64568,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "sGS" = (
-/obj/machinery/light_switch/directional/east,
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/smartfridge/food,
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "sGV" = (
@@ -66621,7 +66655,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
@@ -68417,6 +68451,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"tPH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "tPI" = (
 /obj/structure/table/glass,
 /obj/structure/railing/corner{
@@ -72400,6 +72443,15 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"uTk" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/smartfridge/food,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "uTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
@@ -74202,12 +74254,9 @@
 /turf/open/floor/glass,
 /area/station/science/zoo)
 "vua" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "vuc" = (
@@ -76475,6 +76524,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"wcy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "wcJ" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 4;
@@ -175825,7 +175880,7 @@ nPN
 qBh
 qYM
 rft
-jKm
+rxI
 ouK
 hRX
 dEH
@@ -176856,7 +176911,7 @@ hBY
 taF
 tfK
 tfK
-por
+tfK
 jLY
 reh
 qwF
@@ -177623,9 +177678,9 @@ bOk
 bOk
 laD
 hRX
-hRX
-hRX
-hRX
+uTk
+aqg
+nHt
 hRX
 jFI
 cqj
@@ -177877,13 +177932,13 @@ qrz
 rBm
 hsG
 bOk
-jBk
+jYS
 juq
 hqD
-bAg
-uCF
-uCF
-dBm
+nHt
+dVj
+kle
+hRX
 jEv
 cor
 oLo
@@ -178136,11 +178191,11 @@ uZu
 bOk
 aLa
 bOk
-bOk
-mep
-bOk
-bOk
 dBm
+dBm
+dBm
+dBm
+hRX
 dEN
 kSZ
 dUb
@@ -178391,10 +178446,10 @@ xXa
 xXa
 ige
 haE
-rIi
+dnE
 dCp
 dEN
-tnu
+dEN
 gSq
 ikR
 klJ
@@ -178648,7 +178703,7 @@ xLf
 ito
 qRA
 spO
-hyS
+hvX
 uii
 dYi
 vua
@@ -178905,11 +178960,11 @@ hOO
 hOO
 qRA
 oVO
-hyS
-uii
-dEN
+cBc
+gDQ
+tPH
 tnu
-dEN
+wcy
 sbd
 ukT
 vIw

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -109,7 +109,11 @@
 	},
 /obj/structure/table,
 /obj/item/storage/bag/tray,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "abI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -562,13 +566,11 @@
 	pixel_x = -5;
 	pixel_y = 12
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ajI" = (
 /obj/structure/table,
@@ -695,6 +697,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "akW" = (
@@ -960,7 +963,11 @@
 /area/station/ai_monitored/command/storage/eva)
 "apf" = (
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "api" = (
 /obj/effect/decal/cleanable/dirt,
@@ -971,10 +978,10 @@
 /turf/open/openspace,
 /area/station/command/corporate_showroom)
 "apu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "apA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -1194,17 +1201,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/landmark/start/cook,
 /turf/open/floor/glass,
-/area/station/service/kitchen)
-"aso" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchen_service"
-	},
-/turf/open/floor/plating,
 /area/station/service/kitchen)
 "asx" = (
 /obj/structure/lattice/catwalk,
@@ -2194,7 +2190,8 @@
 	},
 /obj/structure/table/wood/poker,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "aIO" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
@@ -2204,7 +2201,7 @@
 	},
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "aIP" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -3458,7 +3455,6 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "bbY" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -3466,8 +3462,11 @@
 	codes_txt = "delivery;dir=8";
 	location = "Restaurant"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "bcc" = (
 /obj/structure/table/reinforced,
@@ -4078,13 +4077,18 @@
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "bmH" = (
 /obj/machinery/barsign{
 	pixel_y = 32
 	},
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "bmI" = (
 /obj/machinery/door/window/brigdoor/security/holding/left/directional/south{
@@ -4485,7 +4489,10 @@
 	pixel_x = -7;
 	pixel_y = 15
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "btb" = (
 /obj/machinery/roulette,
@@ -5097,7 +5104,7 @@
 	},
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "bCv" = (
 /obj/structure/railing{
@@ -5183,6 +5190,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bDv" = (
@@ -5533,25 +5541,6 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
-"bIe" = (
-/obj/item/vending_refill/boozeomat{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/vending_refill/cytopro{
-	pixel_x = 11;
-	pixel_y = 11
-	},
-/obj/item/vending_refill/hotdog{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/structure/sign/poster/contraband/borg_fancy_1/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "bIi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -5787,7 +5776,10 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "bKX" = (
 /obj/effect/turf_decal/tile/purple/full,
@@ -6137,7 +6129,13 @@
 /obj/machinery/vending/boozeomat,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "bRa" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -6611,7 +6609,10 @@
 /area/station/cargo/miningoffice)
 "bXy" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "bXA" = (
 /turf/closed/wall/r_wall,
@@ -6879,7 +6880,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "cba" = (
 /turf/open/openspace,
@@ -8003,16 +8004,12 @@
 /turf/open/space/basic,
 /area/station/maintenance/solars/port/aft)
 "crB" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/bar,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
 "crE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8082,16 +8079,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/commons/lounge)
 "csm" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/machinery/door/airlock/wood{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
 	name = "Service Hall"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "cst" = (
@@ -8167,10 +8165,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"csM" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
-/area/station/commons/lounge)
 "csN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -8313,7 +8307,10 @@
 "cvY" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/item/storage/box/rubbershot,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "cwf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8414,7 +8411,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "cxQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8605,18 +8602,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "czK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock/wood{
-	name = "Kitchen"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "czN" = (
 /turf/open/openspace,
@@ -8803,7 +8798,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "cCq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -9204,17 +9199,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/starboard/lesser)
-"cHO" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchen_service"
-	},
-/turf/open/floor/plating,
-/area/station/service/kitchen)
 "cHP" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -9508,8 +9492,8 @@
 /area/station/construction/storage_wing)
 "cLi" = (
 /obj/structure/chair/sofa/corner/brown,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/carpet,
+/obj/structure/sign/clock/directional/east,
+/turf/open/floor/carpet/black,
 /area/station/medical/psychology)
 "cLm" = (
 /obj/structure/table/reinforced,
@@ -9757,12 +9741,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
 "cQF" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "cQP" = (
 /obj/structure/lattice/catwalk,
@@ -9946,7 +9932,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "cTf" = (
 /obj/structure/disposalpipe/segment{
@@ -10198,8 +10189,17 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "cWt" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/wood/parquet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/station/commons/lounge)
 "cWG" = (
 /obj/machinery/vending/cola/pwr_game,
@@ -10290,7 +10290,11 @@
 	pixel_x = 9;
 	pixel_y = -3
 	},
-/turf/open/floor/glass,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "cYq" = (
 /obj/structure/table/reinforced,
@@ -10692,6 +10696,12 @@
 	pixel_x = 14
 	},
 /obj/structure/table,
+/obj/machinery/button/curtain{
+	pixel_x = -6;
+	name = "Privacy Curtains";
+	id = "psychpriv";
+	pixel_y = 30
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "dfD" = (
@@ -10768,7 +10778,7 @@
 "dgD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/black,
 /area/station/medical/psychology)
 "dgR" = (
 /obj/structure/table/reinforced,
@@ -10969,6 +10979,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
+"djA" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "djC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11321,6 +11337,16 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"dpV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "dqj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -12034,7 +12060,7 @@
 /obj/structure/table/wood,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "dBe" = (
 /obj/item/kirbyplants/photosynthetic,
@@ -12201,7 +12227,12 @@
 /obj/machinery/light/warm/dim/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "dEu" = (
 /obj/structure/cable,
@@ -12228,9 +12259,10 @@
 /obj/machinery/microwave{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "dEN" = (
 /turf/open/floor/wood/large,
@@ -12769,7 +12801,10 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "dMM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -12836,6 +12871,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"dNI" = (
+/obj/structure/sign/poster/contraband/borg_fancy_1/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "dNL" = (
 /obj/item/bouquet/sunflower{
 	pixel_y = 4
@@ -13304,8 +13343,10 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
 "dVn" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "dVs" = (
@@ -13420,12 +13461,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/lesser)
-"dXd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "dXh" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
@@ -13520,7 +13555,7 @@
 "dXP" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "dXU" = (
 /obj/structure/cable,
@@ -13635,7 +13670,7 @@
 "dZA" = (
 /obj/structure/table/wood,
 /obj/item/gun/magic/wand/nothing,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "dZF" = (
 /obj/structure/ladder,
@@ -14821,7 +14856,7 @@
 "eqp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "eqt" = (
 /obj/machinery/camera/autoname/directional/south,
@@ -15107,11 +15142,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"evq" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "evv" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/layer5{
 	dir = 8;
@@ -15599,13 +15629,6 @@
 	luminosity = 2
 	},
 /area/station/ai_monitored/command/nuke_storage)
-"eEs" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/commons/lounge)
 "eEv" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -15719,7 +15742,11 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "eGt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16729,10 +16756,7 @@
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
 "eUr" = (
 /obj/structure/cable,
@@ -16842,9 +16866,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "eVF" = (
-/obj/machinery/door/airlock/wood{
-	name = "Psychology Office"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -16852,10 +16873,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/medical{
+	name = "Psychology"
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "eVW" = (
@@ -17499,9 +17520,6 @@
 "fhm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
@@ -18193,7 +18211,10 @@
 "fqL" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "fqO" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
@@ -18693,11 +18714,14 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "fyp" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/smartfridge/drying,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "fyw" = (
 /obj/machinery/newscaster/directional/north,
@@ -18951,7 +18975,8 @@
 	pixel_y = 13
 	},
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "fBh" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -18995,6 +19020,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fBU" = (
 /obj/machinery/photocopier/prebuilt,
+/obj/structure/sign/clock/directional/east,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "fBX" = (
@@ -19221,12 +19247,15 @@
 /area/station/security/checkpoint/science)
 "fGj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "fGm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19344,7 +19373,7 @@
 "fHv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "fHG" = (
 /obj/structure/lattice,
@@ -19781,7 +19810,10 @@
 	pixel_x = 13;
 	pixel_y = -1
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "fPi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -20164,6 +20196,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/lesser)
+"fUv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "fUE" = (
 /obj/machinery/vending/clothing,
 /obj/machinery/status_display/evac/directional/east,
@@ -20283,9 +20322,11 @@
 /area/station/command/heads_quarters/hop)
 "fVC" = (
 /obj/structure/chair/stool/bar/directional/west,
-/obj/machinery/light/warm/dim/directional/south,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -20374,10 +20415,11 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
 "fWV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -20981,6 +21023,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "gfc" = (
@@ -21019,7 +21064,7 @@
 /area/station/maintenance/disposal/incinerator)
 "gft" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "gfz" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -21034,10 +21079,8 @@
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
 "gfG" = (
 /obj/machinery/light/directional/west,
@@ -21182,7 +21225,7 @@
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "ghA" = (
 /obj/structure/lattice/catwalk,
@@ -21310,7 +21353,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "giB" = (
 /obj/machinery/camera/directional/east{
@@ -21907,7 +21950,7 @@
 /area/station/service/library/printer)
 "gpv" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "gpx" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -21951,7 +21994,7 @@
 /obj/item/mop,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "gqb" = (
 /obj/structure/cable,
@@ -22051,13 +22094,10 @@
 /area/station/maintenance/starboard/aft)
 "grJ" = (
 /obj/item/kirbyplants/random,
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
-"grW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "grX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22311,7 +22351,7 @@
 /area/station/engineering/storage/tech)
 "gwv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "gwx" = (
 /obj/machinery/door/airlock/external{
@@ -22377,7 +22417,7 @@
 "gyd" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/light/floor,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "gyg" = (
 /obj/structure/cable,
@@ -22448,6 +22488,12 @@
 /obj/machinery/air_sensor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
+"gyL" = (
+/obj/structure/chair/stool/bar/directional/west,
+/obj/machinery/light/warm/dim/directional/south,
+/obj/effect/turf_decal/siding/wood/end,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "gyN" = (
 /obj/structure/table/glass,
 /obj/item/storage/briefcase/secure,
@@ -23048,10 +23094,11 @@
 	pixel_x = -4;
 	pixel_y = 13
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "gHK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24798,22 +24845,30 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "hkm" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
 "hkq" = (
-/obj/machinery/light/warm/dim/directional/south,
 /mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "hkv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hkw" = (
 /obj/structure/lattice/catwalk,
@@ -25385,7 +25440,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/button/door/directional/south{
 	id = "psychology_shutters";
 	name = "psychology shutters control";
@@ -25600,8 +25654,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/black,
 /area/station/medical/psychology)
 "hwU" = (
 /obj/machinery/door/airlock/maintenance,
@@ -25616,7 +25669,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "hwW" = (
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hxa" = (
 /obj/structure/cable,
@@ -25991,7 +26047,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hCe" = (
 /obj/structure/table/wood/poker,
@@ -26427,7 +26487,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "hHK" = (
 /obj/machinery/computer/atmos_alert{
@@ -26539,6 +26599,16 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
 /area/station/ai_monitored/command/storage/eva)
+"hJz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/hallway/secondary/service)
 "hJA" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L8"
@@ -26905,7 +26975,7 @@
 	dir = 4
 	},
 /obj/machinery/smoke_machine,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "hNC" = (
 /obj/structure/stairs/west,
@@ -27083,7 +27153,11 @@
 	pixel_x = -6;
 	pixel_y = 14
 	},
-/turf/open/floor/glass,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hQE" = (
 /obj/structure/railing{
@@ -27347,7 +27421,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "hTK" = (
 /obj/structure/cable,
@@ -27856,7 +27933,7 @@
 "ibw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "iby" = (
 /obj/structure/railing/corner/end,
@@ -28384,6 +28461,7 @@
 	pixel_x = 12;
 	pixel_y = 10
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "ikK" = (
@@ -28488,7 +28566,7 @@
 /area/station/maintenance/starboard/central)
 "imB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "imJ" = (
 /obj/structure/railing/corner{
@@ -28502,7 +28580,10 @@
 	pixel_y = -12
 	},
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "imQ" = (
 /obj/structure/table,
@@ -28562,7 +28643,7 @@
 "inG" = (
 /obj/structure/sign/poster/official/get_your_legs/directional/west,
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "inI" = (
 /obj/machinery/shower/directional/west,
@@ -28651,7 +28732,7 @@
 "ioC" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "ioK" = (
 /obj/structure/sign/warning/cold_temp/directional/east,
@@ -28844,9 +28925,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "ire" = (
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/machinery/restaurant_portal/bar,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
 	},
 /obj/machinery/light/warm/dim/directional/west,
 /turf/open/floor/wood/large,
@@ -29290,7 +29371,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "iyn" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -29341,7 +29422,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "iyE" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -29766,10 +29847,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/airlock/wood{
+/obj/machinery/door/airlock{
 	name = "Kitchen"
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iEI" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -30899,23 +30981,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"iUf" = (
-/obj/item/vending_refill/donksnackvendor{
-	pixel_y = 15
-	},
-/obj/item/vending_refill/sovietsoda{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/item/vending_refill/coffee{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "iUj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -31093,7 +31158,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
@@ -31189,6 +31253,7 @@
 /area/station/hallway/primary/starboard)
 "iYJ" = (
 /obj/structure/sink/kitchen/directional/west,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "iYK" = (
@@ -31282,6 +31347,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "jal" = (
@@ -32080,17 +32148,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"jlq" = (
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/digital_clock/directional/west,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	name = "Psychologist's Office Curtains";
-	id = "psychpriv"
-	},
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "jlB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -32262,6 +32319,13 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
+"joE" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "joI" = (
 /obj/machinery/power/emitter{
 	dir = 4
@@ -32323,7 +32387,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "jpA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32631,11 +32698,12 @@
 	pixel_x = 6;
 	req_access = list("kitchen")
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "juo" = (
 /obj/effect/turf_decal/siding{
@@ -33279,7 +33347,7 @@
 "jBU" = (
 /obj/item/reagent_containers/cup/glass/mug/tea,
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "jBW" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -33393,7 +33461,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "jCW" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -33532,6 +33599,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "jEv" = (
@@ -33922,6 +33990,15 @@
 /obj/item/restraints/legcuffs/beartrap/prearmed,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port)
+"jKm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/hallway/secondary/service)
 "jKo" = (
 /obj/structure/table/wood,
 /obj/item/lighter{
@@ -35850,11 +35927,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
 "koM" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/cas/black,
 /obj/machinery/light/directional/south,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "koU" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -37812,11 +37888,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
-"kRS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "kSc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine/hull/air,
@@ -37975,7 +38046,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/table,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kUO" = (
 /turf/open/openspace,
@@ -38725,7 +38800,7 @@
 /area/station/engineering/lobby)
 "lgi" = (
 /obj/structure/chair/office,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "lgo" = (
 /obj/item/storage/box/silver_ids{
@@ -38922,7 +38997,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/bartender,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "ljx" = (
 /obj/structure/tank_holder/extinguisher,
@@ -39061,7 +39139,7 @@
 	pixel_y = 4
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/black,
 /area/station/medical/psychology)
 "lmc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -39675,9 +39753,9 @@
 /area/station/engineering/atmos/upper)
 "lxh" = (
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/deepfryer,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "lxl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39947,7 +40025,10 @@
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood,
 /obj/machinery/light/warm/dim/directional/south,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "lAG" = (
 /obj/structure/railing{
@@ -40019,7 +40100,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "lBg" = (
 /obj/machinery/door/airlock/external{
@@ -40035,7 +40117,7 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/machinery/firealarm/directional/south,
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "lBi" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -40652,6 +40734,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"lJM" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/fake,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "lJQ" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -42166,8 +42255,9 @@
 /area/station/maintenance/port/greater)
 "mfA" = (
 /obj/item/kirbyplants/potty,
-/obj/machinery/light/warm/dim/directional/south,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "mfD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42815,10 +42905,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mqJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "mqK" = (
@@ -42843,6 +42931,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
+"mqU" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "mqY" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -43259,6 +43356,15 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"mwn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "mwr" = (
 /turf/closed/wall,
 /area/station/security/evidence)
@@ -43560,7 +43666,10 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "mBY" = (
 /obj/structure/lattice/catwalk,
@@ -43600,6 +43709,9 @@
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -44128,9 +44240,12 @@
 "mKO" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sink/kitchen/directional/west,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "mKV" = (
 /obj/structure/disposalpipe/segment,
@@ -44250,7 +44365,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/janitor,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "mNp" = (
 /obj/structure/lattice/catwalk,
@@ -44544,7 +44659,7 @@
 "mSt" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/mime,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "mSA" = (
 /obj/structure/bed,
@@ -44699,8 +44814,11 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "mVm" = (
 /obj/machinery/door/airlock/maintenance,
@@ -44857,7 +44975,10 @@
 "mXV" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "mXW" = (
 /obj/structure/disposalpipe/segment{
@@ -45108,11 +45229,13 @@
 /area/station/science/robotics/lab)
 "nbo" = (
 /obj/machinery/holopad,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "nbC" = (
 /obj/machinery/restaurant_portal/restaurant,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "nbY" = (
@@ -45177,7 +45300,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "ndl" = (
-/obj/machinery/camera/autoname/directional/north,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/module_duplicator,
 /turf/open/floor/iron/dark/smooth_edge,
@@ -45289,7 +45411,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "neJ" = (
 /obj/structure/cable,
@@ -45573,21 +45696,6 @@
 "njk" = (
 /turf/closed/wall,
 /area/station/engineering/main)
-"njv" = (
-/obj/effect/turf_decal/trimline/dark/arrow_cw{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/arrow_cw{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "njA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46750,7 +46858,8 @@
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/storage/photo_album/bar,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "nyG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -46772,6 +46881,14 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/commons/fitness/recreation)
+"nyI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/commons/lounge)
 "nyY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48255,10 +48372,8 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "nUE" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/item/radio/intercom/directional/south,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "nUV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48360,6 +48475,9 @@
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/landmark/navigate_destination/kitchen,
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "nWO" = (
@@ -49280,7 +49398,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "oky" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -49890,15 +50007,16 @@
 "ouE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
 /area/station/hallway/secondary/service)
 "ouH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50236,9 +50354,14 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "ozL" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "ozN" = (
 /obj/structure/lattice/catwalk,
@@ -50268,7 +50391,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/structure/musician/piano/random_piano,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "oAz" = (
 /obj/structure/cable,
@@ -50354,10 +50477,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "oBM" = (
@@ -50476,7 +50599,11 @@
 /obj/item/rag{
 	pixel_x = -4
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "oDc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -50775,15 +50902,9 @@
 /area/space/nearstation)
 "oIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "oIv" = (
-/obj/machinery/button/curtain{
-	pixel_x = -6;
-	name = "Privacy Curtains";
-	id = "psychpriv";
-	pixel_y = 30
-	},
 /obj/structure/table,
 /obj/item/flashlight/lamp{
 	pixel_y = 4
@@ -52049,7 +52170,7 @@
 /area/station/engineering/main)
 "oZX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "pac" = (
 /obj/machinery/door/airlock/security{
@@ -52106,7 +52227,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "pbp" = (
 /obj/machinery/door/airlock/maintenance{
@@ -52598,12 +52722,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
-"pgO" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "pgQ" = (
 /obj/structure/table,
 /obj/effect/spawner/random/bureaucracy/paper,
@@ -52739,13 +52857,14 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Kitchen"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "pje" = (
 /obj/structure/closet/firecloset,
@@ -52929,7 +53048,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/end{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
 "pmV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53047,7 +53169,6 @@
 /area/station/engineering/main)
 "por" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/glass,
 /area/station/service/kitchen)
@@ -53746,6 +53867,7 @@
 /obj/item/key/janitor,
 /obj/vehicle/ridden/janicart,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "pBI" = (
@@ -53849,7 +53971,15 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "pDR" = (
 /obj/effect/landmark/firealarm_sanity,
@@ -53982,6 +54112,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"pFR" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "pFX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -54167,6 +54304,14 @@
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/lesser)
+"pHR" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "pIf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54732,7 +54877,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/commons/lounge)
 "pON" = (
 /obj/structure/sign/poster/official/safety_report/directional/south,
@@ -55068,6 +55216,14 @@
 "pRO" = (
 /turf/closed/wall,
 /area/station/commons/dorms)
+"pRQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/station/commons/lounge)
 "pRS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -55159,9 +55315,6 @@
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "pTu" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -55171,7 +55324,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/janitor,
-/turf/open/floor/wood,
+/obj/machinery/door/airlock{
+	name = "Custodial Closet"
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "pTw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -55322,7 +55478,7 @@
 /area/station/security/lockers)
 "pWr" = (
 /obj/structure/cable,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "pWC" = (
 /obj/structure/table,
@@ -55375,7 +55531,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "pXM" = (
 /obj/structure/railing/corner,
@@ -55444,12 +55600,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"qak" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "qam" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
@@ -56168,7 +56318,7 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "qki" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -56486,12 +56636,18 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "qoU" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/open/floor/wood,
+/obj/machinery/door/airlock/glass{
+	name = "Bar"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "qoX" = (
 /obj/machinery/mineral/stacking_machine{
@@ -56844,10 +57000,11 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "quB" = (
-/obj/machinery/computer/records/medical/laptop{
-	pixel_y = 4
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
 	},
-/obj/structure/table,
+/obj/effect/landmark/start/psychologist,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "quD" = (
@@ -57646,7 +57803,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood/parquet,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "qGG" = (
 /obj/structure/cable,
@@ -58121,7 +58279,12 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "qNW" = (
 /obj/item/trash/ready_donk,
@@ -58348,13 +58511,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"qRC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "qRL" = (
 /obj/effect/turf_decal/siding,
 /obj/effect/turf_decal/trimline/white/corner{
@@ -58849,15 +59005,15 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
 "qYU" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood,
+/obj/machinery/door/airlock{
+	name = "Bar Backroom"
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "qYW" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -59538,7 +59694,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "rki" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -59558,7 +59714,7 @@
 "rkD" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "rkF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -59633,7 +59789,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/librarian,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "rlE" = (
 /obj/structure/hedge,
@@ -60465,8 +60621,10 @@
 "rxI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
 /area/station/hallway/secondary/service)
 "rxM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -60949,9 +61107,6 @@
 /area/station/medical/cryo)
 "rFm" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/fax{
@@ -62359,10 +62514,12 @@
 /area/station/hallway/primary/central)
 "sbh" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "sbn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62865,11 +63022,7 @@
 /turf/closed/wall,
 /area/station/commons/vacant_room/office)
 "shv" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/crate,
 /obj/item/book/manual/chef_recipes,
 /obj/item/hand_labeler,
@@ -62880,7 +63033,11 @@
 /obj/item/storage/box/papersack{
 	icon_state = "paperbag_NanotrasenStandard_closed"
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "shx" = (
 /turf/closed/wall/r_wall,
@@ -62962,7 +63119,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "siP" = (
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "siX" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -62978,6 +63135,9 @@
 "sjb" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "sjq" = (
@@ -62999,6 +63159,9 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/command)
+"sjE" = (
+/turf/open/floor/carpet/stellar,
+/area/station/service/library)
 "sjI" = (
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
@@ -63087,7 +63250,7 @@
 /area/station/commons/locker)
 "skQ" = (
 /obj/machinery/light/floor,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "skR" = (
 /obj/structure/table/wood,
@@ -63098,7 +63261,10 @@
 	pixel_y = -32
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "skS" = (
 /obj/structure/table/glass,
@@ -63196,7 +63362,12 @@
 	id = "kitchen_counter";
 	req_access = list("kitchen")
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "smk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63305,6 +63476,9 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "soH" = (
@@ -63570,7 +63744,7 @@
 	pixel_x = -9;
 	pixel_y = 11
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "ssV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63771,7 +63945,10 @@
 	pixel_y = 11
 	},
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "swJ" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -63824,7 +64001,7 @@
 	pixel_y = -2
 	},
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "sxh" = (
 /obj/machinery/door/firedoor,
@@ -64040,7 +64217,7 @@
 /area/station/security/prison)
 "sBj" = (
 /obj/effect/landmark/start/clown,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "sBk" = (
 /obj/structure/disposalpipe/junction{
@@ -64361,7 +64538,8 @@
 	dir = 1
 	},
 /obj/machinery/smartfridge/food,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "sGV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64411,7 +64589,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "sIl" = (
 /obj/structure/railing{
@@ -64625,6 +64803,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "sKM" = (
@@ -64858,8 +65040,12 @@
 /obj/structure/rack,
 /obj/item/stack/package_wrap,
 /obj/item/holosign_creator/robot_seat/restaurant,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/light/warm/dim/directional/east,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "sON" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -64884,8 +65070,11 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 6
+	},
+/obj/machinery/light/warm/dim/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "sPj" = (
 /obj/machinery/rnd/production/protolathe/department/science,
@@ -65008,10 +65197,13 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "sQI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "sQJ" = (
 /obj/effect/landmark/start/hangover,
@@ -65629,7 +65821,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "taG" = (
 /obj/structure/chair/sofa/corp/left,
@@ -65653,6 +65850,25 @@
 	dir = 1
 	},
 /area/station/medical/pharmacy)
+"taX" = (
+/obj/item/vending_refill/boozeomat{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/vending_refill/cytopro{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/item/vending_refill/hotdog{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "tbd" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "SM_shutters";
@@ -65797,7 +66013,7 @@
 	},
 /obj/structure/sign/poster/official/get_your_legs/directional/north,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/black,
 /area/station/medical/psychology)
 "tdx" = (
 /obj/structure/cable,
@@ -65954,12 +66170,11 @@
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "tfR" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "tfT" = (
 /obj/structure/table/wood/poker,
@@ -66363,7 +66578,10 @@
 /area/station/command/heads_quarters/hos)
 "tmV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "tna" = (
 /obj/structure/fermenting_barrel/gunpowder,
@@ -66371,13 +66589,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "tnb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tnf" = (
 /obj/effect/turf_decal/siding/wood{
@@ -66415,9 +66631,6 @@
 /area/station/service/chapel)
 "tnM" = (
 /obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67102,7 +67315,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "tAK" = (
 /obj/structure/table/reinforced,
@@ -67265,11 +67481,10 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "tCz" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 4
+/obj/structure/table,
+/obj/machinery/computer/records/medical/laptop{
+	pixel_y = 4
 	},
-/obj/effect/landmark/start/psychologist,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "tCE" = (
@@ -67457,7 +67672,13 @@
 	name = "Kitchen's Words";
 	pixel_y = 32
 	},
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "tES" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -68057,17 +68278,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"tNC" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchen_service"
-	},
-/turf/open/floor/plating,
-/area/station/service/kitchen)
 "tNG" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/commons/toilet/restrooms)
@@ -68112,7 +68322,7 @@
 /area/station/engineering/hallway)
 "tOj" = (
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "tOr" = (
 /obj/structure/closet/secure_closet/hydroponics,
@@ -68245,14 +68455,11 @@
 /turf/open/floor/wood,
 /area/station/command/gateway)
 "tRc" = (
-/obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/restraints/handcuffs/fake,
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
 	pixel_x = -5;
 	pixel_y = 16
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "tRd" = (
 /obj/structure/cable/layer3,
@@ -68550,11 +68757,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tVP" = (
-/obj/machinery/door/airlock/wood{
-	name = "Kitchen"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
 /turf/open/floor/wood,
 /area/station/service/kitchen)
 "tVR" = (
@@ -68641,7 +68848,10 @@
 	pixel_x = -4;
 	pixel_y = -4
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "tWR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69279,7 +69489,7 @@
 /area/station/medical/morgue)
 "ugn" = (
 /obj/structure/table/wood/poker,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "ugo" = (
 /obj/machinery/power/port_gen/pacman,
@@ -69311,9 +69521,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
-"ugw" = (
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "ugE" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/airalarm/directional/north,
@@ -69363,6 +69570,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"uhd" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/service/kitchen)
 "uhg" = (
 /obj/structure/table,
 /obj/item/hfr_box/body/moderator_input{
@@ -69540,7 +69753,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "uki" = (
 /obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "ukk" = (
 /obj/effect/turf_decal/bot_white,
@@ -69573,12 +69786,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
-"uku" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/glass,
-/area/station/service/kitchen)
 "uky" = (
 /obj/structure/cable/layer3,
 /obj/structure/sign/poster/official/ion_rifle/directional/east,
@@ -70268,7 +70475,6 @@
 /area/station/security/processing)
 "utq" = (
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/item/stock_parts/power_store/cell/high,
 /obj/machinery/cell_charger,
@@ -70368,6 +70574,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/siding/green/end{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/service)
 "uuk" = (
@@ -70628,6 +70837,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "uxo" = (
@@ -71269,10 +71482,11 @@
 /area/station/security/office)
 "uGf" = (
 /obj/effect/landmark/start/bartender,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "uGj" = (
 /obj/structure/lattice/catwalk,
@@ -71410,6 +71624,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"uHo" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/station/commons/lounge)
 "uHy" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71589,13 +71816,15 @@
 /area/station/hallway/primary/port)
 "uKp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/station/commons/lounge)
 "uKt" = (
 /obj/structure/lattice/catwalk,
@@ -71667,7 +71896,7 @@
 /obj/effect/landmark/start/psychologist,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/black,
 /area/station/medical/psychology)
 "uLi" = (
 /obj/structure/table,
@@ -71859,7 +72088,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "uOS" = (
@@ -72149,7 +72377,7 @@
 	pixel_y = 27
 	},
 /obj/effect/landmark/start/janitor,
-/turf/open/floor/wood,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "uTc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -72614,7 +72842,10 @@
 	pixel_x = 4
 	},
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "vbe" = (
 /obj/structure/railing,
@@ -73055,7 +73286,10 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "vht" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -73594,7 +73828,13 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_green/end{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
 "vpd" = (
 /obj/structure/lattice/catwalk,
@@ -73800,11 +74040,10 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "vsh" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "vsm" = (
 /obj/effect/spawner/random/entertainment/arcade{
@@ -73895,6 +74134,9 @@
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "vsT" = (
@@ -74525,6 +74767,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/xenobiology/hallway)
+"vBU" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "vBX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -75761,6 +76012,13 @@
 /obj/effect/turf_decal/tile/brown/full,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/lesser)
+"vTu" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "vTv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -75928,7 +76186,7 @@
 /area/station/medical/medbay/central)
 "vXh" = (
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "vXt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -76150,7 +76408,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/sink/directional/west,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/wood,
+/turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "wbk" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -76281,6 +76539,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"wdf" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/commons/lounge)
 "wdn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/botanical_waste,
@@ -76695,7 +76963,10 @@
 /area/station/security/courtroom)
 "wik" = (
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "wiq" = (
 /obj/structure/railing,
@@ -76736,7 +77007,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "wiK" = (
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "wiO" = (
 /obj/machinery/door/airlock/maintenance{
@@ -76755,7 +77026,7 @@
 "wji" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "wju" = (
 /obj/effect/decal/cleanable/dirt,
@@ -76807,7 +77078,10 @@
 /area/station/construction/storage_wing)
 "wjW" = (
 /obj/machinery/light/warm/dim/directional/east,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "wjX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77025,10 +77299,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "wny" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
 	},
-/turf/open/floor/wood/parquet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/station/commons/lounge)
 "wnA" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -77055,10 +77331,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/construction/mining/aux_base)
 "wnO" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 8
-	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "wnY" = (
@@ -77085,7 +77357,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/sign/poster/official/work_for_a_future/directional/west,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/black,
 /area/station/service/library/private)
 "wom" = (
 /obj/effect/decal/cleanable/dirt,
@@ -77494,7 +77766,7 @@
 "wvc" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/dice,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "wve" = (
 /obj/effect/decal/cleanable/dirt,
@@ -77507,7 +77779,10 @@
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
 	name = "HoochMaster Deluxe"
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "wvw" = (
 /obj/machinery/conveyor{
@@ -77644,8 +77919,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light/warm/dim/directional/east,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "wwV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -78008,11 +78288,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/hallway/secondary/exit/departure_lounge)
-"wCJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "wCP" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -78711,7 +78986,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/port)
 "wPG" = (
-/turf/open/floor/carpet,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "wPI" = (
 /obj/machinery/firealarm/directional/east,
@@ -79297,8 +79572,8 @@
 /area/station/command/corporate_showroom)
 "wYP" = (
 /obj/structure/chair/stool/bar/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -79375,12 +79650,12 @@
 /area/station/engineering/storage_shared)
 "wZN" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/machinery/door/airlock/wood{
-	name = "Psychology Office"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical{
+	name = "Psychology"
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "wZW" = (
@@ -79928,6 +80203,24 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/openspace,
 /area/station/science/explab)
+"xjm" = (
+/obj/item/vending_refill/donksnackvendor{
+	pixel_y = 15
+	},
+/obj/item/vending_refill/sovietsoda{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/item/vending_refill/coffee{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "xjq" = (
 /obj/structure/table/reinforced,
 /obj/item/rcl/pre_loaded{
@@ -79973,7 +80266,6 @@
 /area/station/service/chapel)
 "xjT" = (
 /obj/structure/disposalpipe/junction/flip,
-/obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "xjV" = (
@@ -80042,6 +80334,15 @@
 	},
 /turf/closed/wall,
 /area/station/commons/storage/art)
+"xlm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "xln" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/warm/dim/directional/west,
@@ -80326,11 +80627,11 @@
 /area/station/maintenance/disposal/incinerator)
 "xpV" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/bartender,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
 /area/station/service/bar)
 "xqa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80748,7 +81049,11 @@
 "xvy" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/turf/open/floor/glass,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "xvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81875,6 +82180,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
+"xOl" = (
+/obj/item/radio/intercom/directional/south,
+/obj/structure/chair/stool/bar/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "xOm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -82094,7 +82405,8 @@
 "xRU" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "xRZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -82495,9 +82807,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xXu" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/restaurant_portal/bar,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "xXv" = (
 /obj/effect/spawner/random/structure/grille,
@@ -105352,7 +105668,7 @@ gPW
 lry
 tDy
 bNt
-ooY
+taX
 ssg
 siX
 ssg
@@ -105609,7 +105925,7 @@ gPW
 oNA
 lXf
 bNt
-ssg
+xjm
 ssg
 ssg
 nDt
@@ -105868,7 +106184,7 @@ eDl
 bNt
 siX
 ssg
-ssg
+ooY
 nDt
 bNt
 tDy
@@ -106123,7 +106439,7 @@ gPW
 ong
 ong
 bNt
-bNt
+sDX
 bda
 bda
 bNt
@@ -107918,14 +108234,14 @@ jBd
 lOd
 gPW
 pBH
-dXd
+gse
 pmS
 dSJ
 lMf
 aep
 fWY
 dMK
-apu
+mwn
 bXy
 vaO
 fWY
@@ -108177,12 +108493,12 @@ gPW
 rFm
 tnM
 ars
-nDm
+fUv
 nDm
 voY
 qoU
-apu
-apu
+mwn
+mwn
 sQI
 lAF
 fWY
@@ -108439,10 +108755,10 @@ fWY
 uzI
 fWY
 wvi
-ugw
-sQI
+mwn
+pFR
 bQU
-bNt
+fWY
 bNt
 czs
 wAx
@@ -108696,10 +109012,10 @@ ire
 ofE
 hjL
 fPh
-ugw
+mwn
 uGf
 tWQ
-bNt
+fWY
 uXZ
 aDO
 bJt
@@ -108953,10 +109269,10 @@ sKL
 hDk
 xpV
 jpy
-apu
+mwn
 apu
 bsW
-bNt
+fWY
 bNt
 aHO
 bNt
@@ -109205,15 +109521,15 @@ peX
 kgN
 sWI
 own
-siP
+vTu
 uxl
 moE
 tmV
 tAJ
-qak
+apu
 hkq
 fWY
-bNt
+fWY
 bNt
 bNt
 bNt
@@ -109469,8 +109785,8 @@ hDk
 vsf
 fXf
 hDk
-bNt
-tDy
+fWY
+dNI
 hrh
 tpj
 tTO
@@ -109717,16 +110033,16 @@ gPW
 own
 own
 rxI
-kRS
+gse
 csm
-wCJ
+vTu
 fWV
 mCw
-eEs
+fVC
 geO
 fVC
-bNt
-bIe
+gyL
+mSd
 tDy
 bNt
 gnp
@@ -109982,9 +110298,9 @@ bbY
 sbh
 fGj
 xXu
-bNt
-iUf
-tDy
+pHR
+mSd
+tTO
 bNt
 xPU
 wEX
@@ -110230,17 +110546,17 @@ oNa
 cGK
 hRX
 dEq
-hwW
+vBU
 smc
 fob
 wYP
 wny
-siP
-siP
+nyI
+nyI
 uKp
 tRc
-bNt
-tTO
+lJM
+mSd
 tDy
 iGB
 iGB
@@ -110491,13 +110807,13 @@ abF
 hwW
 mTx
 sjb
-siP
+wdf
 rkD
 uki
 pOM
 nUE
-bNt
-bNt
+xOl
+mSd
 wYU
 iGB
 pxv
@@ -110748,13 +111064,13 @@ oCX
 hwW
 bcc
 vsQ
-siP
+wdf
 jBU
 jBU
 csk
 pWr
 nyB
-bNt
+mSd
 bUQ
 iGB
 hSA
@@ -111005,13 +111321,13 @@ lAW
 pbk
 mTx
 nWN
-siP
+wdf
 dXP
 wji
 pOM
 siP
 mfA
-bNt
+mSd
 tTO
 iGB
 sAn
@@ -111263,12 +111579,12 @@ hkv
 bcc
 vsQ
 cWt
-siP
-pWr
-csk
+pRQ
+pRQ
+uHo
 tOj
 aIL
-bNt
+mSd
 tDy
 iGB
 mpt
@@ -111519,13 +111835,13 @@ leB
 hkv
 mTx
 sjb
+mqU
+nUE
 siP
-csM
-pWr
 qGF
 ioC
 fBd
-bNt
+mSd
 mWQ
 iGB
 lcO
@@ -111777,12 +112093,12 @@ qNV
 mTx
 nbC
 wjW
-siP
-pWr
-qGF
-tOj
+djA
+djA
+dpV
+joE
 sPg
-bNt
+mSd
 wqI
 dBm
 dBm
@@ -112039,7 +112355,7 @@ crB
 gfC
 jVI
 xdV
-bNt
+mSd
 sDX
 dBm
 iMH
@@ -112285,14 +112601,14 @@ sDu
 byY
 kzM
 bIi
-bIi
+xML
 hWd
 xjT
-xML
+bIi
 bIi
 gtZ
 mBb
-qRC
+nPW
 akU
 fLr
 fLr
@@ -112540,7 +112856,7 @@ hWb
 uPu
 fEc
 byY
-grW
+wcQ
 wcQ
 byY
 byY
@@ -115617,7 +115933,7 @@ pwT
 cte
 nYp
 tAT
-njv
+pPb
 tAT
 pPb
 rTH
@@ -175000,7 +175316,7 @@ wMn
 uOR
 nPN
 iYJ
-wMn
+hJz
 cce
 oky
 uuj
@@ -175509,7 +175825,7 @@ nPN
 qBh
 qYM
 rft
-qBh
+jKm
 ouK
 hRX
 dEH
@@ -176540,7 +176856,7 @@ hBY
 taF
 tfK
 tfK
-uku
+por
 jLY
 reh
 qwF
@@ -176794,7 +177110,7 @@ fkX
 wko
 hRX
 sLd
-cFa
+uhd
 mUY
 mKO
 shv
@@ -177055,10 +177371,10 @@ cFa
 sGS
 hRX
 xTc
-tNC
-cHO
-cHO
-aso
+xTc
+xTc
+xTc
+xTc
 xTc
 hRX
 gMI
@@ -179103,7 +179419,7 @@ rlE
 rlE
 qRA
 mvH
-evq
+hyS
 umH
 hTr
 eVF
@@ -179368,7 +179684,7 @@ grJ
 umH
 kPH
 tCz
-jlq
+sXd
 dUb
 dUb
 fDE
@@ -179615,8 +179931,8 @@ qJK
 tIO
 sJR
 ikG
-aTt
-aTt
+hoj
+hoj
 dVn
 umH
 ipQ
@@ -179871,9 +180187,9 @@ tYt
 qMm
 lTx
 sJR
-aTt
-aTt
-pgO
+hyS
+sjE
+vsh
 vsh
 umH
 onj
@@ -180128,7 +180444,7 @@ dZH
 ggN
 qeq
 sJR
-aTt
+hyS
 lgi
 wvc
 koM
@@ -180385,7 +180701,7 @@ qLF
 typ
 scf
 sJR
-aTt
+hyS
 lgi
 ugn
 tfR
@@ -180643,8 +180959,8 @@ pWC
 jXC
 eZt
 sow
-hoj
-hoj
+xlm
+xlm
 mqJ
 umH
 cLi

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -7789,6 +7789,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"cox" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "coI" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
@@ -9763,6 +9771,7 @@
 	name = "Service Hall"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/service/kitchen)
 "cQP" = (
@@ -12201,6 +12210,7 @@
 "dEq" = (
 /obj/machinery/light/warm/dim/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "dEu" = (
@@ -14856,6 +14866,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"eqZ" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "erj" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/stairs{
@@ -28405,6 +28423,7 @@
 /area/station/science/xenobiology)
 "ikR" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
 "ikZ" = (
@@ -35612,6 +35631,9 @@
 /area/station/medical/medbay/central)
 "klJ" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
 "kmh" = (
@@ -36384,6 +36406,12 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"kvF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "kvH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/security{
@@ -38803,6 +38831,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
+"lhE" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "lhX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -55464,6 +55500,12 @@
 /obj/machinery/wall_healer/directional/south,
 /turf/open/floor/iron,
 /area/station/science/research)
+"qaA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "qaI" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -62335,6 +62377,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "sbd" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
 "sbh" = (
@@ -68540,6 +68583,7 @@
 	name = "Kitchen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/service/kitchen)
 "tVR" = (
@@ -77061,6 +77105,9 @@
 "wog" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/sign/departments/psychology/directional/east,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
 "woh" = (
@@ -178063,8 +178110,8 @@ tnu
 gSq
 ikR
 klJ
-dEN
-kSZ
+kvF
+lhE
 dUb
 dUb
 dUb
@@ -178321,7 +178368,7 @@ dEN
 sbd
 pzb
 vNc
-kSZ
+cox
 dUb
 dUb
 fDE
@@ -178578,7 +178625,7 @@ dEN
 sbd
 ukT
 vIw
-kSZ
+cox
 dUb
 dUb
 fDE
@@ -178833,9 +178880,9 @@ dEN
 scT
 dEN
 wog
-dEN
-dEN
-kSZ
+qaA
+qaA
+eqZ
 dUb
 dUb
 fDE

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -48994,7 +48994,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "ofE" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
 	},
@@ -177337,7 +177336,7 @@ laD
 hRX
 hRX
 hRX
-bnZ
+hRX
 bnZ
 jFI
 cqj

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -12767,6 +12767,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "dMM" = (
@@ -19747,9 +19748,27 @@
 /turf/open/openspace,
 /area/station/cargo/storage)
 "fPh" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/storage/box/coffeepack{
+	pixel_x = 15;
+	pixel_y = 10
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = 15;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 13;
+	pixel_y = -1
 	},
 /turf/open/floor/carpet,
 /area/station/service/bar)
@@ -24749,19 +24768,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"hiV" = (
-/obj/structure/table/wood,
-/obj/machinery/coffeemaker/impressa,
-/obj/item/storage/box/coffeepack{
-	pixel_x = 15;
-	pixel_y = 10
-	},
-/obj/item/storage/box/coffeepack{
-	pixel_x = 15;
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/station/service/bar)
 "hja" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -24773,8 +24779,11 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/construction)
 "hjL" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "hkm" = (
@@ -31524,13 +31533,6 @@
 "jes" = (
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/science)
-"jez" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/wood,
-/area/station/service/bar)
 "jeA" = (
 /obj/structure/railing{
 	dir = 8
@@ -64822,6 +64824,7 @@
 /obj/structure/rack,
 /obj/item/stack/package_wrap,
 /obj/item/holosign_creator/robot_seat/restaurant,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "sON" = (
@@ -69274,6 +69277,9 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
+"ugw" = (
+/turf/open/floor/wood,
+/area/station/service/bar)
 "ugE" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/airalarm/directional/north,
@@ -108140,7 +108146,7 @@ nDm
 nDm
 voY
 qoU
-jez
+apu
 apu
 sQI
 lAF
@@ -108397,8 +108403,8 @@ fWY
 fWY
 uzI
 fWY
-fWY
 wvi
+ugw
 sQI
 bQU
 bNt
@@ -108655,7 +108661,7 @@ uxl
 ofE
 hjL
 fPh
-hiV
+ugw
 uGf
 tWQ
 bNt

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -39777,11 +39777,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"lyq" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "lys" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/engine,
@@ -114350,7 +114345,7 @@ bfw
 kHv
 uPu
 ojU
-lyq
+llv
 cnv
 lDE
 tjg

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -48010,16 +48010,10 @@
 /area/station/service/chapel)
 "nOt" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/turf_decal/tile/green/full,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hydropony_shutters";
-	name = "Hydropony's Shutters"
-	},
+/obj/machinery/door/airlock/hydroponics,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "nOw" = (
@@ -63453,16 +63447,10 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "slN" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hydropony_shutters";
-	name = "Hydroponics Shutters"
-	},
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "slP" = (
@@ -72458,11 +72446,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/turf_decal/tile/green/full,
+/obj/machinery/door/airlock/hydroponics,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "uSg" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -4169,10 +4169,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"bnZ" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/service/kitchen)
 "boh" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/lattice/catwalk,
@@ -40504,11 +40500,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lHE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/machinery/holopad,
-/turf/open/floor/wood/large,
+/turf/open/floor/glass,
 /area/station/service/kitchen)
 "lHK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42691,7 +42684,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "moE" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /turf/open/floor/wood/large,
@@ -62940,14 +62932,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"sic" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "sik" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -108977,7 +108961,7 @@ gse
 own
 bmH
 sKL
-sic
+hDk
 xpV
 jpy
 apu
@@ -177337,7 +177321,7 @@ hRX
 hRX
 hRX
 hRX
-bnZ
+hRX
 jFI
 cqj
 qeX

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -262,10 +262,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "aep" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "aeq" = (
@@ -1141,6 +1140,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "arv" = (
@@ -1941,9 +1944,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "aEG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/emcloset,
 /turf/open/floor/wood,
@@ -2363,7 +2363,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "aKY" = (
 /obj/machinery/light_switch/directional/south{
 	pixel_y = -24
@@ -3492,9 +3492,6 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "bbY" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	location = "44444"
@@ -3505,6 +3502,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "bcc" = (
@@ -4847,12 +4845,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"byy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/closed/wall,
-/area/station/service/library)
 "byA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6616,6 +6608,18 @@
 	},
 /turf/open/floor/glass,
 /area/station/maintenance/starboard/fore)
+"bXn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "bXp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -7132,6 +7136,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"ceb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "ced" = (
 /obj/structure/sign/departments/lawyer/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -8103,6 +8111,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "cst" = (
@@ -9476,9 +9485,6 @@
 /turf/open/space/basic,
 /area/space)
 "cKg" = (
-/obj/effect/turf_decal/trimline/red/filled/mid_joiner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -9786,6 +9792,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/mail_sorting/service/theater,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "cQP" = (
@@ -10352,6 +10359,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"cYJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "cYN" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/delivery,
@@ -11553,6 +11569,18 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
+"drR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "drW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 9
@@ -13212,10 +13240,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "dSJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /obj/structure/sign/poster/official/cleanliness/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "dSS" = (
@@ -13385,6 +13413,20 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"dVh" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "dVj" = (
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/structure/cable,
@@ -13680,6 +13722,12 @@
 /obj/machinery/computer/mechpad,
 /turf/open/floor/iron/smooth,
 /area/station/science/robotics)
+"dYI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "dYY" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -14177,9 +14225,8 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "eeW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "efh" = (
@@ -14342,10 +14389,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Blue Base"
 	},
-/turf/open/floor/light{
-	name = "Blue Base Floor";
-	light_power = 3
-	},
+/turf/open/floor/circuit,
 /area/station/maintenance/hallway/abandoned_recreation)
 "egX" = (
 /obj/structure/disposalpipe/segment{
@@ -15732,6 +15776,17 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"eEV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "actualcommissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "eEW" = (
 /obj/machinery/light/directional/north,
 /obj/structure/lattice/catwalk,
@@ -15831,10 +15886,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"eGC" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "eGE" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
@@ -20237,15 +20288,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
-"fUm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/dark/end{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen,
-/area/station/hallway/secondary/service)
 "fUu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20253,13 +20295,12 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/lesser)
 "fUv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "fUE" = (
@@ -21985,7 +22026,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "gph" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23177,6 +23218,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "gHK" = (
@@ -23250,9 +23292,6 @@
 	},
 /turf/open/openspace,
 /area/station/medical/cryo)
-"gJu" = (
-/turf/open/floor/wood,
-/area/station/maintenance/port/fore)
 "gJT" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/meson,
@@ -23861,6 +23900,7 @@
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "gSK" = (
@@ -24485,7 +24525,7 @@
 	name = "Community Center"
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "hcD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24592,10 +24632,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/light{
-	name = "Blue Base Floor";
-	light_power = 3
-	},
+/turf/open/floor/circuit,
 /area/station/maintenance/hallway/abandoned_recreation)
 "hei" = (
 /obj/structure/chair{
@@ -24912,13 +24949,11 @@
 /area/station/hallway/secondary/construction)
 "hjL" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
 /obj/machinery/light/warm/dim/directional/west,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "hkm" = (
@@ -25649,14 +25684,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"huW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "hvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -25753,6 +25780,16 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"hxc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/eighties,
+/area/station/maintenance/hallway/abandoned_recreation)
 "hxd" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -29579,10 +29616,10 @@
 /area/station/maintenance/starboard/aft)
 "izF" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "izI" = (
@@ -31059,6 +31096,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
+"iTM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "iTW" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table,
@@ -31347,7 +31391,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iYJ" = (
-/obj/structure/sink/kitchen/directional/west,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
@@ -32324,7 +32367,7 @@
 "jmZ" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "jna" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
@@ -33676,6 +33719,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "jDW" = (
@@ -35631,7 +35680,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "kjH" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/box/red,
@@ -35757,12 +35806,6 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/machinery/requests_console/directional/south{
-	department = "Kitchen";
-	name = "Kitchen Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kll" = (
@@ -37133,9 +37176,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
@@ -41029,10 +41069,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "lMf" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/sink/directional/east,
+/obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
 	},
-/obj/structure/sink/directional/east,
+/obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "lMt" = (
@@ -42684,12 +42725,7 @@
 /obj/item/banner/red{
 	inspiration_available = 0
 	},
-/turf/open/floor/light{
-	name = "Red Base Floor";
-	light_power = 3;
-	icon_state = "light_on-2";
-	light_system = 2
-	},
+/turf/open/floor/circuit/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "mke" = (
 /obj/structure/table,
@@ -43857,9 +43893,6 @@
 /area/station/maintenance/port/aft)
 "mCw" = (
 /obj/structure/chair/stool/bar/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -43989,6 +44022,18 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
+/area/station/hallway/primary/central)
+"mEk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "mEv" = (
 /obj/structure/lattice/catwalk,
@@ -46114,7 +46159,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "nnB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -47358,11 +47403,13 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
 "nDm" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light/warm/dim/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "nDt" = (
@@ -47874,7 +47921,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "nLn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/glass/reinforced,
@@ -49256,15 +49303,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "ofE" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "ofL" = (
@@ -50537,6 +50580,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "ozN" = (
@@ -51052,13 +51096,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"oIe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "oIi" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 5
@@ -51782,9 +51819,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "oSI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
@@ -53214,13 +53248,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/siding/end{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /turf/open/floor/iron/checker,
@@ -53835,12 +53869,10 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/directional/west,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "pyd" = (
@@ -55348,6 +55380,8 @@
 	dir = 10
 	},
 /obj/machinery/light/dim/directional/south,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "pRx" = (
@@ -55692,9 +55726,12 @@
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
 "pXb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "pXt" = (
@@ -56813,6 +56850,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "qoX" = (
@@ -56886,9 +56924,6 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos/upper)
 "qpP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
@@ -56937,9 +56972,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -57528,6 +57560,11 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/abandoned)
+"qzN" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit,
+/area/station/maintenance/hallway/abandoned_recreation)
 "qzQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59531,7 +59568,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "rdx" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/large,
@@ -62293,6 +62330,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
+"rUj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "rUp" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -62344,9 +62391,6 @@
 	pixel_y = 11
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "rVc" = (
@@ -62748,6 +62792,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
@@ -65376,10 +65423,10 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "sQY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "sQZ" = (
@@ -65745,6 +65792,12 @@
 /area/station/construction/storage_wing)
 "sWI" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "sWJ" = (
@@ -65805,10 +65858,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Blue Base"
 	},
-/turf/open/floor/light{
-	name = "Blue Base Floor";
-	light_power = 3
-	},
+/turf/open/floor/circuit,
 /area/station/maintenance/hallway/abandoned_recreation)
 "sXL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66302,9 +66352,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "tfr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /obj/structure/railing{
 	dir = 10
 	},
@@ -66440,12 +66487,7 @@
 	name = "Laser Tag"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/light{
-	name = "Red Base Floor";
-	light_power = 3;
-	icon_state = "light_on-2";
-	light_system = 2
-	},
+/turf/open/floor/circuit/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "tid" = (
 /obj/structure/transit_tube/junction{
@@ -66797,6 +66839,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "tnS" = (
@@ -66956,7 +67001,7 @@
 	name = "Curator Office"
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/fore)
+/area/station/hallway/primary/central)
 "tqQ" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
@@ -67831,6 +67876,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/warm/dim/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "tES" = (
@@ -71724,16 +71772,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningoffice)
-"uGO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/library,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "uGP" = (
 /obj/effect/turf_decal/siding/purple/corner,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -72431,6 +72469,18 @@
 /obj/item/trash/boritos,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
+"uRy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "uRz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
@@ -73623,14 +73673,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/openspace,
 /area/station/engineering/atmos/project)
-"vjP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/eighties,
-/area/station/maintenance/hallway/abandoned_recreation)
 "vjS" = (
 /obj/structure/transit_tube,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -73889,16 +73931,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"vno" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/eighties,
-/area/station/maintenance/hallway/abandoned_recreation)
 "vnp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti,
@@ -74020,16 +74052,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/theater,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_green/end{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
 "vpd" = (
@@ -74421,6 +74450,9 @@
 /area/station/maintenance/starboard/central)
 "vuo" = (
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -75050,12 +75082,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Red Base"
 	},
-/turf/open/floor/light{
-	name = "Red Base Floor";
-	light_power = 3;
-	icon_state = "light_on-2";
-	light_system = 2
-	},
+/turf/open/floor/circuit/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "vCP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -76119,12 +76146,6 @@
 	},
 /turf/open/openspace,
 /area/station/command/gateway)
-"vSp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
 "vSq" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -76356,6 +76377,17 @@
 /obj/structure/broken_flooring/pile/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
+"vWa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/mail_sorting/service/theater,
+/obj/effect/mapping_helpers/mail_sorting/service/library,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "vWe" = (
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -76542,6 +76574,13 @@
 "vZG" = (
 /turf/open/openspace/coldroom,
 /area/station/medical/coldroom)
+"vZI" = (
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "vZM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/artistic{
@@ -77003,6 +77042,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "wfY" = (
@@ -80468,6 +80510,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"xiX" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/hallway/abandoned_recreation)
 "xjc" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/openspace,
@@ -80534,8 +80581,8 @@
 /turf/open/floor/wood,
 /area/station/service/chapel)
 "xjT" = (
-/obj/structure/disposalpipe/junction/flip,
 /obj/structure/sign/poster/contraband/robust_softdrinks/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "xka" = (
@@ -80740,6 +80787,12 @@
 /area/station/security/prison)
 "xns" = (
 /obj/machinery/light/warm/dim/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "xnt" = (
@@ -80900,9 +80953,6 @@
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "xqa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/random/directional/north,
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -81548,6 +81598,12 @@
 /area/station/science/xenobiology)
 "xAt" = (
 /obj/machinery/wall_healer/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "xAu" = (
@@ -108245,7 +108301,7 @@ oLN
 vwl
 ilE
 chu
-vjP
+wNu
 sQY
 aHS
 pMT
@@ -108502,12 +108558,12 @@ jBd
 kDQ
 ilE
 jBd
-vma
 jBd
-lOd
+vma
+xiX
 gPW
 pBH
-gse
+dYI
 pmS
 dSJ
 lMf
@@ -108759,8 +108815,8 @@ lLI
 nHy
 vGC
 jOh
-vno
 jOh
+hxc
 lYe
 gPW
 rFm
@@ -108770,8 +108826,8 @@ fUv
 nDm
 voY
 qoU
-mwn
-mwn
+rUj
+uRy
 sQI
 lAF
 fWY
@@ -109028,7 +109084,7 @@ own
 uzI
 fWY
 wvi
-mwn
+drR
 pFR
 bQU
 fWY
@@ -109277,15 +109333,15 @@ dol
 gPW
 xRU
 gse
-eeW
+gse
 xAt
 own
 wik
 ire
 ofE
 hjL
-apu
-mwn
+vZI
+bXn
 uGf
 tWQ
 fWY
@@ -109791,7 +109847,7 @@ vZQ
 gPW
 drC
 peX
-eeW
+gse
 sWI
 own
 vTu
@@ -110048,12 +110104,12 @@ gPW
 gPW
 atD
 dso
-eeW
+ceb
 pXb
 own
 apf
 uxl
-huW
+hDk
 nHo
 vsf
 fXf
@@ -110305,8 +110361,8 @@ jQe
 gPW
 own
 own
-fUm
-wfV
+rxI
+cYJ
 csm
 jDO
 fWV
@@ -112099,7 +112155,7 @@ anm
 anm
 anm
 anm
-gJu
+byY
 aKV
 jmZ
 hRX
@@ -112358,7 +112414,7 @@ jJl
 gNr
 goW
 aKV
-gJu
+byY
 hRX
 sOJ
 wwR
@@ -112373,7 +112429,7 @@ joE
 sPg
 kAY
 wqI
-dBm
+mSd
 dBm
 dBm
 dBm
@@ -112629,8 +112685,8 @@ gfC
 jVI
 xdV
 mSd
-eGC
-dBm
+xdV
+mSd
 iMH
 eha
 dBm
@@ -113904,7 +113960,7 @@ tUX
 tUX
 lDE
 lDE
-vSp
+lDE
 lDE
 lDE
 lDE
@@ -114420,10 +114476,10 @@ lDE
 rkN
 dhq
 sbD
-oHw
-eVl
+iTM
+eEV
 gSG
-vMU
+mEk
 fLr
 fOe
 qTG
@@ -114680,7 +114736,7 @@ vcR
 qkF
 eVl
 hZD
-vMU
+iLm
 fLr
 dWp
 okC
@@ -115698,11 +115754,11 @@ wPG
 bfw
 kHv
 izF
-byy
+gNr
 tfr
-oIe
-oIe
-oIe
+llv
+llv
+llv
 ayD
 lkj
 lkj
@@ -116211,7 +116267,7 @@ tAT
 pPb
 rTH
 gQA
-rTH
+dVh
 bUf
 lRP
 ofi
@@ -116468,13 +116524,13 @@ yeA
 qWj
 qWj
 qWj
-qWj
+vWa
 qWj
 qWj
 oxa
 qWj
 qWj
-uGO
+qWj
 qST
 qST
 ipt
@@ -174041,7 +174097,7 @@ adC
 gaP
 dex
 cKs
-lOd
+qzN
 gPW
 dpo
 bOk
@@ -179682,7 +179738,7 @@ xVy
 bOk
 bOk
 cQP
-sJR
+bOk
 bOk
 tBt
 oZJ

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -960,7 +960,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "apf" = (
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "api" = (
 /obj/effect/decal/cleanable/dirt,
@@ -974,7 +974,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "apA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -2194,7 +2194,7 @@
 	},
 /obj/structure/table/wood/poker,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "aIO" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
@@ -3467,7 +3467,7 @@
 	location = "Restaurant"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "bcc" = (
 /obj/structure/table/reinforced,
@@ -3552,7 +3552,7 @@
 /area/station/ai_monitored/security/armory)
 "bdu" = (
 /obj/machinery/light/warm/dim/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "bdw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4088,7 +4088,7 @@
 /obj/machinery/barsign{
 	pixel_y = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "bmI" = (
 /obj/machinery/door/window/brigdoor/security/holding/left/directional/south{
@@ -4493,7 +4493,7 @@
 	pixel_x = -7;
 	pixel_y = 15
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "btb" = (
 /obj/machinery/roulette,
@@ -6145,7 +6145,7 @@
 /obj/machinery/vending/boozeomat,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "bRa" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -6619,7 +6619,7 @@
 /area/station/cargo/miningoffice)
 "bXy" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "bXA" = (
 /turf/closed/wall/r_wall,
@@ -8013,7 +8013,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "crE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8083,7 +8083,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "csm" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
@@ -8170,7 +8170,7 @@
 /area/station/cargo/storage)
 "csM" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "csN" = (
 /obj/structure/lattice/catwalk,
@@ -10200,7 +10200,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "cWt" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "cWG" = (
 /obj/machinery/vending/cola/pwr_game,
@@ -12769,7 +12769,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "dMM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15595,7 +15595,10 @@
 /area/station/ai_monitored/command/nuke_storage)
 "eEs" = (
 /obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "eEv" = (
 /turf/open/floor/plating,
@@ -16723,7 +16726,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "eUr" = (
 /obj/structure/cable,
@@ -18942,7 +18945,7 @@
 	pixel_y = 13
 	},
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "fBh" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -19217,7 +19220,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "fGm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19772,7 +19775,7 @@
 	pixel_x = 13;
 	pixel_y = -1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "fPi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -20275,7 +20278,10 @@
 "fVC" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/light/warm/dim/directional/south,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "fVD" = (
 /turf/closed/wall,
@@ -20364,7 +20370,10 @@
 "fWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "fWW" = (
 /obj/item/cigbutt{
@@ -20393,7 +20402,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "fXh" = (
 /obj/item/flashlight/lamp{
@@ -20963,7 +20972,10 @@
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "gfc" = (
 /obj/structure/chair/sofa/left/brown{
@@ -21019,7 +21031,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "gfG" = (
 /obj/machinery/light/directional/west,
@@ -24785,7 +24797,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "hkm" = (
 /turf/closed/wall/r_wall,
@@ -24794,7 +24806,7 @@
 /obj/machinery/light/warm/dim/directional/south,
 /mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "hkv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25526,7 +25538,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "hvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26075,7 +26087,7 @@
 "hDk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/turf/open/space/basic,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "hDp" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -28518,10 +28530,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
-"ine" = (
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "inh" = (
 /turf/open/openspace,
 /area/station/command/bridge)
@@ -28643,7 +28651,7 @@
 "ioC" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "ioK" = (
 /obj/structure/sign/warning/cold_temp/directional/east,
@@ -32308,7 +32316,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "jpA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39375,11 +39383,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"lqO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
-/area/station/service/bar)
 "lqS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/north,
@@ -39925,7 +39928,7 @@
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood,
 /obj/machinery/light/warm/dim/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "lAG" = (
 /obj/structure/railing{
@@ -42148,7 +42151,7 @@
 "mfA" = (
 /obj/item/kirbyplants/potty,
 /obj/machinery/light/warm/dim/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "mfD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42655,7 +42658,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "moI" = (
 /obj/structure/cable,
@@ -43580,7 +43583,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "mCM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -45091,7 +45097,8 @@
 /area/station/service/library/private)
 "nbC" = (
 /obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "nbY" = (
 /obj/structure/table,
@@ -46728,7 +46735,7 @@
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/storage/photo_album/bar,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "nyG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -48236,7 +48243,7 @@
 /obj/structure/chair/stool/bar/directional/west,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "nUV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48337,7 +48344,8 @@
 "nWN" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/landmark/navigate_destination/kitchen,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "nWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48963,7 +48971,7 @@
 	pixel_y = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "ofL" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -50216,7 +50224,7 @@
 "ozL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "ozN" = (
 /obj/structure/lattice/catwalk,
@@ -54711,7 +54719,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "pON" = (
 /obj/structure/sign/poster/official/safety_report/directional/south,
@@ -55301,7 +55309,7 @@
 /area/station/security/lockers)
 "pWr" = (
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "pWC" = (
 /obj/structure/table,
@@ -55427,7 +55435,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "qam" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57619,7 +57627,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "qGG" = (
 /obj/structure/cable,
@@ -62334,7 +62342,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "sbn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62896,7 +62904,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "sik" = (
 /obj/machinery/door/airlock/maintenance,
@@ -62942,7 +62950,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "siP" = (
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "siX" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -62955,6 +62963,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"sjb" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "sjq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64597,7 +64610,10 @@
 "sKL" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "sKM" = (
 /obj/effect/spawner/structure/window,
@@ -64857,7 +64873,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light_switch/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "sPj" = (
 /obj/machinery/rnd/production/protolathe/department/science,
@@ -64983,7 +64999,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "sQJ" = (
 /obj/effect/landmark/start/hangover,
@@ -66334,9 +66350,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "tmV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "tna" = (
 /obj/structure/fermenting_barrel/gunpowder,
@@ -67073,7 +67088,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "tAK" = (
 /obj/structure/table/reinforced,
@@ -67428,7 +67443,7 @@
 	name = "Kitchen's Words";
 	pixel_y = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "tES" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -68083,7 +68098,7 @@
 /area/station/engineering/hallway)
 "tOj" = (
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "tOr" = (
 /obj/structure/closet/secure_closet/hydroponics,
@@ -68223,7 +68238,7 @@
 	pixel_x = -5;
 	pixel_y = 16
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "tRd" = (
 /obj/structure/cable/layer3,
@@ -68611,7 +68626,7 @@
 	pixel_x = -4;
 	pixel_y = -4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "tWR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69282,7 +69297,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "ugw" = (
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "ugE" = (
 /obj/effect/turf_decal/siding/dark,
@@ -70595,7 +70610,10 @@
 /area/station/maintenance/port/aft)
 "uxl" = (
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "uxo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -71239,7 +71257,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "uGj" = (
 /obj/structure/lattice/catwalk,
@@ -71562,7 +71580,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "uKt" = (
 /obj/structure/lattice/catwalk,
@@ -72581,7 +72599,7 @@
 	pixel_x = 4
 	},
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vbe" = (
 /obj/structure/railing,
@@ -73764,7 +73782,7 @@
 	pixel_y = 15
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vsh" = (
 /obj/effect/turf_decal/siding/wood,
@@ -73861,7 +73879,8 @@
 "vsQ" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "vsT" = (
 /obj/machinery/holopad,
@@ -76661,7 +76680,7 @@
 /area/station/security/courtroom)
 "wik" = (
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "wiq" = (
 /obj/structure/railing,
@@ -76773,7 +76792,7 @@
 /area/station/construction/storage_wing)
 "wjW" = (
 /obj/machinery/light/warm/dim/directional/east,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "wjX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76994,7 +77013,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "wnA" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -77470,7 +77489,7 @@
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
 	name = "HoochMaster Deluxe"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "wvw" = (
 /obj/machinery/conveyor{
@@ -79261,7 +79280,10 @@
 /area/station/command/corporate_showroom)
 "wYP" = (
 /obj/structure/chair/stool/bar/directional/north,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "wYS" = (
 /obj/machinery/door/airlock/maintenance,
@@ -80291,7 +80313,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/bartender,
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "xqa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80621,12 +80643,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
-"xtX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "xut" = (
 /turf/closed/wall,
 /area/station/service/abandoned_gambling_den)
@@ -81421,9 +81437,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"xHc" = (
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "xHi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -82465,7 +82478,7 @@
 "xXu" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/restaurant_portal/bar,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "xXv" = (
 /obj/effect/spawner/random/structure/grille,
@@ -109433,7 +109446,7 @@ own
 apf
 uxl
 huW
-lqO
+hDk
 vsf
 fXf
 hDk
@@ -110203,8 +110216,8 @@ smc
 fob
 wYP
 wny
-xHc
-xHc
+siP
+siP
 uKp
 tRc
 bNt
@@ -110458,8 +110471,8 @@ hgu
 abF
 hwW
 mTx
-wYP
-xHc
+sjb
+siP
 rkD
 uki
 pOM
@@ -110716,7 +110729,7 @@ oCX
 hwW
 bcc
 vsQ
-xHc
+siP
 jBU
 jBU
 csk
@@ -110973,7 +110986,7 @@ lAW
 pbk
 mTx
 nWN
-xHc
+siP
 dXP
 wji
 pOM
@@ -111231,8 +111244,8 @@ hkv
 bcc
 vsQ
 cWt
-xHc
-ine
+siP
+pWr
 csk
 tOj
 aIL
@@ -111486,10 +111499,10 @@ mrp
 leB
 hkv
 mTx
-wYP
-xHc
+sjb
+siP
 csM
-ine
+pWr
 qGF
 ioC
 fBd
@@ -111747,7 +111760,7 @@ nbC
 wjW
 siP
 pWr
-xtX
+qGF
 tOj
 sPg
 bNt

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -104,10 +104,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "abF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/service/theater)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "abI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/shaft_miner,
@@ -259,6 +262,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "aeq" = (
@@ -559,6 +565,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "ajI" = (
@@ -686,7 +695,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "akW" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -950,15 +959,9 @@
 /turf/open/floor/wood,
 /area/station/ai_monitored/command/storage/eva)
 "apf" = (
-/obj/machinery/light/warm/dim/directional/north,
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "api" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/snow,
@@ -967,6 +970,12 @@
 "apo" = (
 /turf/open/openspace,
 /area/station/command/corporate_showroom)
+"apu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "apA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -1112,9 +1121,8 @@
 "ars" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/camera/autoname/directional/east,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "arv" = (
@@ -1184,19 +1192,19 @@
 /area/station/science/ordnance)
 "ask" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/railing/corner,
 /obj/effect/landmark/start/cook,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "aso" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchen_service"
+	},
+/turf/open/floor/plating,
 /area/station/service/kitchen)
 "asx" = (
 /obj/structure/lattice/catwalk,
@@ -1323,10 +1331,6 @@
 "aum" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/sofa/right/brown{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "aun" = (
@@ -1828,13 +1832,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"aCV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "aDh" = (
 /obj/structure/rack,
 /obj/item/cardboard_cutout{
@@ -1969,13 +1966,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"aFo" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "aFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2194,15 +2184,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aIL" = (
-/obj/effect/spawner/random/entertainment/gambling{
-	pixel_x = 6;
-	pixel_y = 3
+/obj/item/stack/spacecash/c200{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/deck{
 	pixel_x = -7;
-	pixel_y = 13
+	pixel_y = 9
 	},
+/obj/structure/table/wood/poker,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "aIO" = (
@@ -2227,6 +2218,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"aJg" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/service/theater_dressing)
 "aJh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2348,20 +2346,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "aKV" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "aLa" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aLd" = (
@@ -2382,8 +2377,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "aLu" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/openspace,
+/obj/item/paint/white{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/turf/open/floor/glass/reinforced,
 /area/station/service/library)
 "aLJ" = (
 /turf/open/floor/carpet,
@@ -2695,9 +2693,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -2956,8 +2951,12 @@
 /turf/open/floor/carpet,
 /area/station/ai_monitored/command/storage/eva)
 "aUU" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
+/obj/structure/closet/crate/freezer,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
 /turf/open/floor/wood,
 /area/station/service/library)
 "aUV" = (
@@ -3075,15 +3074,11 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port/fore)
 "aWa" = (
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/chair/sofa/left/brown{
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
+/turf/open/floor/glass/reinforced,
 /area/station/service/library)
 "aWb" = (
 /obj/structure/disposalpipe/segment,
@@ -3260,6 +3255,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/range)
+"aYw" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/skill_station,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/service/library)
 "aYy" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3465,6 +3468,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
+"bcc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/wood,
+/area/station/service/kitchen)
 "bcg" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 1
@@ -3472,12 +3484,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"bcj" = (
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/warm/dim/directional/east,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "bcl" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -3544,10 +3550,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "bdu" = (
-/obj/machinery/vending/boozeomat,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/light/warm/dim/directional/north,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bdw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3665,8 +3671,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "bfw" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/table,
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bfx" = (
@@ -3692,17 +3697,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"bfO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "actualcommissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
 "bgm" = (
 /obj/structure/stairs/south,
 /turf/open/floor/plating,
@@ -3996,15 +3990,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"blA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/bar,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "blD" = (
 /obj/structure/closet/crate/engineering/electrical,
 /obj/item/stack/sheet/glass/fifty,
@@ -4097,15 +4082,15 @@
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
-/turf/open/floor/wood,
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "bmH" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/barsign{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bmI" = (
 /obj/machinery/door/window/brigdoor/security/holding/left/directional/south{
 	id = "Holding Cell";
@@ -4486,6 +4471,31 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
+"bsW" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/tequila{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/glass/bottle/absinthe{
+	pixel_x = 5;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/cup/glass/bottle/rum{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/cup/glass/bottle/cognac{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "btb" = (
 /obj/machinery/roulette,
 /turf/open/floor/engine,
@@ -4497,20 +4507,6 @@
 /obj/item/hand_labeler_refill,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
-"btf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
-"bti" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "btj" = (
 /obj/machinery/vending/donksnack,
 /turf/open/floor/iron/dark,
@@ -4596,12 +4592,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"buV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "buZ" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -4622,16 +4612,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"bvq" = (
-/obj/structure/closet/crate/medical,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/cautery,
-/obj/item/hemostat,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "bvt" = (
 /obj/machinery/telecomms/server/presets/security,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -5183,19 +5163,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"bDf" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	canhear_range = 6;
-	frequency = 1421;
-	name = "Floor's Words"
-	},
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "bDm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance,
@@ -6131,12 +6098,6 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/wood,
 /area/station/command/teleporter)
-"bQi" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/hydroponics)
 "bQt" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/engine/hull/reinforced/air,
@@ -6181,6 +6142,12 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/solars/starboard/aft)
+"bQU" = (
+/obj/machinery/vending/boozeomat,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "bRa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/wood,
@@ -6299,6 +6266,21 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/eva)
+"bSu" = (
+/obj/item/paint/red{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/paint/black{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/item/paint/blue{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "bSv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6390,16 +6372,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
-"bTt" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "bTF" = (
 /obj/structure/closet/crate/secure/trashcart/filled,
 /turf/open/floor/plating,
@@ -6457,9 +6429,7 @@
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -6648,6 +6618,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"bXy" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "bXA" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
@@ -6741,16 +6715,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/science/explab)
-"bZm" = (
-/obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
-	name = "Commissary"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
 "bZo" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner,
@@ -6842,30 +6806,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/hallway)
-"bZW" = (
-/obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = 2;
-	pixel_y = 15
-	},
-/obj/item/multitool/circuit{
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/item/multitool/circuit{
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/effect/turf_decal/siding/dark/inner_corner,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
-	},
-/area/station/service/library)
 "cac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -6915,6 +6855,7 @@
 "caF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "caO" = (
@@ -6942,6 +6883,14 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"caV" = (
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/service/theater)
 "cba" = (
 /turf/open/openspace,
 /area/station/hallway/primary/port)
@@ -7155,6 +7104,10 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"cdy" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "cdP" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/crayon{
@@ -7572,6 +7525,16 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"cjv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/medical/psychology)
 "cjE" = (
 /obj/machinery/computer/rdconsole,
 /turf/open/floor/wood,
@@ -7600,10 +7563,7 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood/large,
+/turf/open/floor/glass,
 /area/station/service/kitchen)
 "ckE" = (
 /obj/machinery/hydroponics/soil,
@@ -7721,21 +7681,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "cmf" = (
-/obj/item/cardboard_cutout{
-	pixel_x = 14;
-	pixel_y = 9
-	},
-/obj/item/cardboard_cutout{
-	pixel_x = 14;
-	pixel_y = 4
-	},
-/obj/item/cardboard_cutout{
-	pixel_x = 14;
-	pixel_y = -1
-	},
-/obj/effect/landmark/start/mime,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
+/obj/item/radio/intercom/directional/north,
+/turf/open/openspace,
+/area/station/service/kitchen)
 "cmh" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -7833,15 +7781,8 @@
 /area/space/nearstation)
 "cor" = (
 /obj/structure/railing/corner,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "cot" = (
 /obj/machinery/atmospherics/components/trinary/filter/layer2{
 	dir = 8
@@ -8065,8 +8006,16 @@
 /area/station/maintenance/solars/port/aft)
 "crB" = (
 /obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/bar,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "crE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -8137,6 +8086,16 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
+"csm" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/machinery/door/airlock/wood{
+	name = "Service Hall"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "cst" = (
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 1
@@ -8234,15 +8193,15 @@
 /turf/open/floor/glass/reinforced,
 /area/station/command/heads_quarters/rd)
 "cte" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -8660,10 +8619,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock_note_placer{
-	note_info = "The balcony to the right is for the bar bots; to feed the station place the food on the central table and lower down.";
-	note_name = "Kitchen Instructions"
-	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "czN" = (
@@ -8840,6 +8795,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"cCj" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/bowl/soup/stew{
+	desc = "Exactly what it says on the tin.";
+	initial_reagent = /datum/reagent/consumable/condensedcapsaicin;
+	name = "6 seconds blinding stew";
+	pixel_y = 12
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/theater)
 "cCq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -9158,7 +9127,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/wood/large,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/service/library)
 "cGQ" = (
 /obj/item/cigbutt{
@@ -9233,11 +9209,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/starboard/lesser)
 "cHO" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood/large,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchen_service"
+	},
+/turf/open/floor/plating,
 /area/station/service/kitchen)
 "cHP" = (
 /obj/machinery/computer/atmos_alert{
@@ -9478,11 +9458,11 @@
 /turf/open/space/basic,
 /area/space)
 "cKg" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
@@ -9530,16 +9510,6 @@
 /obj/effect/spawner/random/structure/chair_flipped,
 /turf/open/floor/plating,
 /area/station/construction/storage_wing)
-"cLf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/machinery/barsign{
-	pixel_y = 32
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "cLi" = (
 /obj/structure/chair/sofa/corner/brown,
 /obj/machinery/camera/autoname/directional/east,
@@ -9785,11 +9755,18 @@
 "cQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
+"cQF" = (
+/obj/machinery/door/airlock/wood{
+	name = "Service Hall"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/wood,
+/area/station/service/kitchen)
 "cQP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9845,8 +9822,8 @@
 	},
 /area/station/medical/morgue)
 "cRN" = (
-/obj/machinery/bookbinder,
-/turf/open/floor/wood/large,
+/obj/machinery/component_printer,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/library)
 "cRO" = (
 /obj/structure/cable,
@@ -9966,11 +9943,14 @@
 /turf/open/floor/carpet,
 /area/station/security/courtroom)
 "cTc" = (
+/obj/structure/railing{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "cTf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -10296,6 +10276,25 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"cYo" = (
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/rag{
+	pixel_x = 10;
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/cup/bowl{
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/condiment/honey{
+	pixel_x = 9;
+	pixel_y = -3
+	},
+/turf/open/floor/glass,
+/area/station/service/kitchen)
 "cYq" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight{
@@ -10569,6 +10568,7 @@
 	pixel_x = -7;
 	pixel_y = 15
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "ddM" = (
@@ -10683,9 +10683,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
 "dfC" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/landmark/start/hangover,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/pen/fountain{
+	pixel_x = 14
+	},
+/obj/structure/table,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "dfD" = (
@@ -10760,8 +10769,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/processing)
 "dgB" = (
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "dgD" = (
@@ -12024,25 +12034,21 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "dBd" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_y = 32
+/obj/item/clothing/head/costume/sombrero{
+	pixel_y = 8
 	},
-/obj/structure/easel,
-/obj/item/canvas/twentythree_twentythree{
-	pixel_x = 4;
-	pixel_y = 10
+/obj/item/soap{
+	pixel_y = 2
 	},
-/obj/structure/sign/painting/large/library,
+/obj/structure/table/wood,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "dBe" = (
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"dBh" = (
-/obj/structure/sink/kitchen/directional/east,
-/turf/open/floor/glass,
-/area/station/service/kitchen)
 "dBk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -12169,10 +12175,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/upper)
-"dDX" = (
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "dEg" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/item/flashlight,
@@ -12186,18 +12188,29 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
-"dEs" = (
-/obj/structure/railing{
-	dir = 8
+"dEo" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/camera/autoname/directional/east,
+/obj/structure/closet/crate/wooden,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/camera,
+/obj/item/pai_card,
+/obj/item/toy/plush/moth{
+	name = "Spare Sani"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/curtain/cloth/fancy/mechanical{
+	name = "Psychologist's Office Curtains";
+	id = "psychpriv"
 	},
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/landmark/start/hangover,
-/obj/effect/landmark/navigate_destination/kitchen,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
+/turf/open/floor/wood/large,
+/area/station/medical/psychology)
+"dEq" = (
+/obj/machinery/light/warm/dim/directional/west,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "dEu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12223,14 +12236,13 @@
 /obj/machinery/microwave{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/condiment/honey{
-	pixel_x = 9;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
+"dEN" = (
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "dEW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -12336,17 +12348,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/morgue)
-"dGr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "dGu" = (
 /obj/structure/frame/computer{
 	anchored = 1
@@ -12363,11 +12364,6 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
-"dGx" = (
-/obj/effect/mapping_helpers/trapdoor_placer,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/plating,
-/area/station/service/theater)
 "dGy" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
@@ -12425,18 +12421,6 @@
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
-"dHs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "dHC" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight,
@@ -12515,6 +12499,13 @@
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/floor/plating,
 /area/station/construction/storage_wing)
+"dIW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/hallway/abandoned_recreation)
 "dJb" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
@@ -12541,14 +12532,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"dJB" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "abandonedcafe";
-	name = "Maintenance Cafe Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/medical/psychology)
 "dJC" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay"
@@ -12587,6 +12570,15 @@
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"dJV" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "dJW" = (
 /turf/open/floor/glass/reinforced/airless,
 /area/station/solars/starboard/aft)
@@ -12774,6 +12766,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"dMK" = (
+/obj/structure/table/wood,
+/obj/item/instrument/guitar{
+	pixel_y = 12
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "dMM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -13119,6 +13118,15 @@
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"dSJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "dSS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
@@ -13414,13 +13422,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/lesser)
-"dWX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sink/directional/west,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "dXd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13564,7 +13565,7 @@
 "dYi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/large,
-/area/station/medical/psychology)
+/area/station/hallway/primary/central)
 "dYl" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/machinery/airalarm/directional/north,
@@ -13605,17 +13606,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dZm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/trimline/green/filled/mid_joiner{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/hydroponics)
 "dZs" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/fluff/paper/stack{
@@ -13645,16 +13635,12 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "dZA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/obj/item/storage/crayons{
-	pixel_x = -2;
-	pixel_y = 1
-	},
+/obj/structure/table/wood,
+/obj/item/gun/magic/wand/nothing,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "dZF" = (
 /obj/structure/ladder,
 /obj/machinery/door/window/brigdoor/right/directional/east{
@@ -13665,29 +13651,11 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "dZH" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = 13
-	},
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/book/manual/wiki/surgery{
-	pixel_x = -14;
-	pixel_y = 6
-	},
-/obj/item/book/manual/wiki/research_and_development{
-	pixel_x = 12;
-	pixel_y = 10
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/machinery/light/directional/north,
-/turf/open/openspace,
-/area/station/service/library)
+/obj/structure/dresser,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "dZM" = (
 /obj/structure/girder/reinforced,
 /obj/structure/grille,
@@ -13810,12 +13778,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/upper)
-"ebf" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "ebj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -14080,14 +14042,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
-"eep" = (
-/obj/structure/table,
-/obj/item/chisel{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/library)
 "eeq" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -14140,6 +14094,7 @@
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random/fullysynthetic,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/eighties/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "efA" = (
@@ -14158,10 +14113,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "efD" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/reagent_containers/spray/pepper,
+/obj/structure/closet/secure_closet/psychology,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "efJ" = (
@@ -14279,10 +14237,10 @@
 /area/station/science/genetics)
 "egU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Laser Tag"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/public/glass{
+	name = "Blue Base"
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
 "egX" = (
@@ -14351,16 +14309,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
-"eie" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "eij" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -14817,15 +14765,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
-"epI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "epR" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 4
@@ -14886,7 +14825,6 @@
 "eqp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
 "eqt" = (
@@ -14986,17 +14924,25 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/lesser)
 "erM" = (
-/obj/structure/table/wood,
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/machinery/vending/autodrobe,
+/obj/item/clothing/head/cone{
+	pixel_x = 18;
+	pixel_y = 7
 	},
-/obj/item/statuebust{
-	desc = "Scribbled on its bottom there are the words 'FEARTHEVAPORWAVE'.";
-	pixel_y = 12
+/obj/item/clothing/head/cone{
+	pixel_x = 18;
+	pixel_y = 7
 	},
-/turf/open/openspace,
-/area/station/service/library)
+/obj/item/clothing/head/cone{
+	pixel_x = 18;
+	pixel_y = 7
+	},
+/obj/item/plunger{
+	pixel_x = 12;
+	pixel_y = -7
+	},
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "esb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -15159,7 +15105,7 @@
 /area/station/commons/storage/primary)
 "evq" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/hedge,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "evv" = (
@@ -15567,6 +15513,15 @@
 /obj/effect/spawner/random/structure/closet_empty/crate,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/hallway/abandoned_recreation)
+"eCl" = (
+/obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/station/commons/lounge)
 "eCu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -15754,10 +15709,16 @@
 /turf/open/openspace,
 /area/station/engineering/break_room)
 "eGs" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/west,
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "eGt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16228,13 +16189,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"eNI" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "eNO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16768,6 +16722,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"eUp" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "eUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16883,6 +16847,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "eVW" = (
@@ -16968,6 +16939,14 @@
 	dir = 1
 	},
 /area/station/science/robotics)
+"eXx" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "eXF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -17054,12 +17033,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "eZt" = (
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
+/turf/closed/wall,
+/area/station/service/theater_dressing)
 "eZA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17107,10 +17085,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
-"eZW" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/service/theater)
 "fai" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -17979,6 +17953,18 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"fob" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "foj" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -18178,9 +18164,6 @@
 /area/station/maintenance/starboard/fore)
 "fqC" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/railing{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -18529,11 +18512,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/artistic{
-	pixel_x = 1;
-	pixel_y = 10
-	},
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/wood,
 /area/station/service/library)
 "fvu" = (
@@ -18712,21 +18691,10 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "fyp" = (
-/obj/machinery/griddle,
-/obj/machinery/elevator_control_panel/directional/east{
-	linked_elevator_id = "catwalk_cafe";
-	name = "Feeding Elevator Controller";
-	pixel_x = 0;
-	pixel_y = 26;
-	preset_destination_names = list("2"="Lower        Deck","3"="Upper        Deck")
-	},
-/obj/structure/sign/directions/upload/directional/north{
-	desc = "It stands for Up Le Dable";
-	dir = 2;
-	name = "Button Indicator";
-	pixel_y = 40
-	},
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/smartfridge/drying,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "fyw" = (
@@ -18758,7 +18726,7 @@
 	codes_txt = "patrol;next_patrol=9-Bridge";
 	location = "8-Kitchen"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "fyD" = (
 /obj/structure/cable,
@@ -18918,6 +18886,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology/hallway)
+"fzV" = (
+/obj/structure/railing,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
+	},
+/area/station/hallway/primary/central)
 "fAb" = (
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
 	dir = 8
@@ -18962,14 +18943,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
 "fBd" = (
-/obj/item/cigarette/cigar{
-	pixel_x = 4
-	},
 /obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c20{
-	pixel_x = -8;
-	pixel_y = 8
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_x = -7;
+	pixel_y = 13
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "fBh" = (
@@ -19013,9 +18992,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fBU" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/photocopier/prebuilt,
-/turf/open/floor/plating,
+/turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "fBX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -19051,16 +19029,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"fCK" = (
-/obj/effect/turf_decal/siding/dark/inner_corner{
-	dir = 1
-	},
-/obj/machinery/module_duplicator,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/smooth_corner,
-/area/station/service/library)
 "fCL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/rack,
@@ -19142,6 +19110,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"fEc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Community Center"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/station/service/library)
 "fEs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -19364,12 +19339,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "fHv" = (
-/obj/item/paint/white{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "fHG" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname/directional/north,
@@ -19379,6 +19352,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/toolbox/artistic{
+	pixel_x = 1;
+	pixel_y = 10
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "fHW" = (
@@ -19488,6 +19466,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "fJL" = (
@@ -19608,10 +19587,6 @@
 /obj/structure/closet/crate/engineering/electrical,
 /turf/open/floor/glass/reinforced,
 /area/station/solars/starboard/fore)
-"fLM" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "fLX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/crayons{
@@ -19645,15 +19620,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"fMS" = (
-/obj/effect/turf_decal/siding/dark/inner_corner{
-	dir = 8
-	},
-/obj/machinery/component_printer,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/station/service/library)
 "fNa" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -19778,21 +19744,22 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"fPb" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "fPf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/openspace,
 /area/station/cargo/storage)
 "fPh" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar{
-	pixel_y = 12
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/item/instrument/eguitar{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/machinery/light/warm/dim/directional/south,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "fPi" = (
@@ -20385,6 +20352,8 @@
 "fWV" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "fWW" = (
@@ -20409,6 +20378,10 @@
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/random/entertainment/cigarette{
 	pixel_x = -5
+	},
+/obj/item/lighter{
+	pixel_x = 8;
+	pixel_y = 4
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
@@ -20552,17 +20525,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"fZp" = (
-/obj/item/toy/plush/moth{
-	name = "Spare Sani"
-	},
-/obj/structure/closet/crate/wooden,
-/obj/item/pai_card,
-/obj/item/camera,
-/obj/item/taperecorder,
-/obj/item/tape,
-/turf/open/floor/plating,
-/area/station/medical/psychology)
 "fZq" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/head/costume/foilhat,
@@ -21027,16 +20989,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "gft" = (
-/obj/item/paint/yellow{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/paint/violet{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "gfz" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/disposalpipe/segment,
@@ -21046,8 +21001,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
+"gfG" = (
+/obj/machinery/light/directional/west,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "gfH" = (
 /obj/structure/railing/corner,
 /obj/structure/railing{
@@ -21055,7 +21024,9 @@
 	},
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/service/library)
 "gfU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -21133,6 +21104,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/openspace,
 /area/station/medical/virology)
+"ggN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "ggQ" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
@@ -21172,13 +21150,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ghz" = (
-/obj/structure/easel,
-/obj/item/canvas/twentythree_nineteen{
-	pixel_x = 3;
-	pixel_y = 10
-	},
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "ghA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -21298,6 +21274,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/atmos/project)
+"giz" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/service/theater)
 "giB" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Secure Tech Storage"
@@ -21456,7 +21443,7 @@
 /area/station/commons/vacant_room/office)
 "glj" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/glass,
 /area/station/service/kitchen)
@@ -21620,11 +21607,6 @@
 	},
 /turf/open/openspace,
 /area/station/construction/storage_wing)
-"gmA" = (
-/obj/structure/mirror/directional/north,
-/obj/structure/sink/directional/south,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "gmE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21705,6 +21687,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/security/checkpoint/supply)
+"gnA" = (
+/obj/structure/stairs/east,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
+	},
+/area/station/hallway/primary/central)
 "gnI" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Space Access Airlock"
@@ -21860,16 +21850,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "goW" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
-"gpd" = (
-/obj/structure/window/spawner/directional/south,
-/obj/machinery/smoke_machine,
 /turf/open/floor/wood,
-/area/station/service/theater)
+/area/station/maintenance/port/fore)
 "gph" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22039,9 +22024,13 @@
 /area/station/maintenance/starboard/aft)
 "grJ" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
+"grW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "grX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22160,12 +22149,9 @@
 /area/station/maintenance/starboard/lesser)
 "gtZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/wood{
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/stairs/medium,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "gug" = (
 /obj/machinery/door/airlock{
@@ -22272,18 +22258,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
-"gvr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "gvI" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/iron/dark/smooth_large,
@@ -22308,6 +22282,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"gwv" = (
+/obj/machinery/door/window/right/directional/west{
+	name = "Theater Stage";
+	req_access = list("theatre")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/service/theater)
 "gwx" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat Space Access Airlock"
@@ -22338,9 +22320,6 @@
 /turf/open/floor/engine/hull/air,
 /area/station/security/courtroom)
 "gxl" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
@@ -22372,6 +22351,11 @@
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
+"gyd" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "gyg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/arrow_ccw{
@@ -22729,11 +22713,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/captain/private)
-"gDe" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "gDs" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -23056,18 +23035,6 @@
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
 /area/station/construction/storage_wing)
-"gHR" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/button/door/directional/south{
-	id = "psychology_shutters";
-	name = "psychology shutters control";
-	pixel_x = -6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "gHU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -23135,12 +23102,7 @@
 /turf/open/openspace,
 /area/station/medical/cryo)
 "gJu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "gJT" = (
 /obj/structure/rack,
@@ -23216,13 +23178,6 @@
 /obj/machinery/light/red/dim/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
-"gLf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "gLp" = (
 /obj/machinery/holopad/secure,
 /obj/structure/cable/layer3,
@@ -23308,23 +23263,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison/safe)
 "gMI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/door/window/left/directional/west{
-	req_access = list("hydroponics");
-	name = "Hydroponics Desk"
-	},
+/obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hydropony_shutters";
 	name = "Hydroponics Shutters"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/service/hydroponics)
 "gMO" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -23348,10 +23292,6 @@
 "gNi" = (
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"gNj" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/stairs/medium,
-/area/station/hallway/primary/central)
 "gNq" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
@@ -23605,9 +23545,9 @@
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -23761,26 +23701,25 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gSq" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
 /obj/structure/sign/plaques/kiddie{
 	desc = "A certificate of psychology, indicating that the person's a psychologist.";
 	name = "Psychology Degree";
 	pixel_x = -32
 	},
-/obj/effect/landmark/start/psychologist,
 /obj/machinery/light/directional/west,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "gSG" = (
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "gSK" = (
@@ -23903,6 +23842,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"gUx" = (
+/obj/structure/chair{
+	dir = 8;
+	pixel_y = -2
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/service/library)
 "gUQ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Nanotrasen Museum"
@@ -23983,21 +23930,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
-"gWq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/glass,
-/area/station/service/kitchen)
 "gWu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -24218,20 +24150,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
-"gZv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/item/toy/crayon/spraycan{
-	pixel_x = 15;
-	pixel_y = 18
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/clown,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
 "gZy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/airalarm/directional/south,
@@ -24326,6 +24244,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "haN" = (
@@ -24422,19 +24341,19 @@
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "hcC" = (
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/public/glass{
+	name = "Community Center"
+	},
+/turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "hcD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "hcH" = (
@@ -24514,6 +24433,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
+"hdX" = (
+/obj/machinery/light/dim/directional/north,
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/briefcase/secure,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "hea" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/engine/hull,
@@ -24614,27 +24543,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "hgu" = (
-/obj/structure/table/wood,
-/obj/item/toy/crayon/spraycan/lubecan{
-	charges = 5;
-	pixel_x = -6;
-	pixel_y = 13
+/obj/structure/sign/poster/contraband/eat/directional/north,
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
 	},
-/obj/item/toy/crayon/spraycan/mimecan{
-	charges = 5;
-	pixel_x = 3;
-	pixel_y = 13
-	},
-/obj/item/toy/figure/clown{
-	pixel_x = 5
-	},
-/obj/item/toy/figure/mime{
-	pixel_x = -5
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "hgv" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 9
@@ -24846,6 +24759,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"hiV" = (
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/storage/box/coffeepack{
+	pixel_x = 15;
+	pixel_y = 10
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = 15;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "hja" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -24857,34 +24783,25 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/construction)
 "hjL" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/bottle/tequila{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/cup/glass/bottle/absinthe{
-	pixel_x = 5;
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/cup/glass/bottle/cognac{
-	pixel_x = -7;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/cup/glass/bottle/vodka{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/cup/glass/bottle/rum{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/machinery/camera/autoname/directional/west,
-/obj/item/radio/intercom/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "hkm" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
+"hkq" = (
+/obj/machinery/light/warm/dim/directional/south,
+/obj/machinery/light_switch/directional/east,
+/mob/living/carbon/human/species/monkey/punpun,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/wood,
+/area/station/service/bar)
+"hkv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "hkw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -24906,24 +24823,6 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"hkO" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/artistic{
-	pixel_x = 9;
-	pixel_y = 9
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/item/trapdoor_remote/preloaded{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
 "hkZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -25114,12 +25013,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "hni" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "hnk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -25136,31 +25038,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "hnt" = (
-/obj/structure/table/wood,
-/obj/item/food/pie/cream{
-	pixel_y = 9
+/obj/structure/stairs/east,
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
 	},
-/obj/item/food/pie/cream{
-	pixel_y = 9
-	},
-/obj/item/food/pie/cream{
-	pixel_y = 9
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -14;
-	pixel_y = 6
-	},
-/obj/item/bikehorn/airhorn{
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "hny" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -25310,10 +25192,6 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/hydroponics)
-"hpR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "hqf" = (
@@ -25469,6 +25347,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison/rec)
+"hsG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "hsI" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/fluff/shower_drain,
@@ -25480,6 +25368,15 @@
 "hsL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/button/door/directional/south{
+	id = "psychology_shutters";
+	name = "psychology shutters control";
+	pixel_x = -6
 	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -25626,7 +25523,6 @@
 "huW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25703,23 +25599,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hwV" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/item/newspaper{
-	pixel_y = 2
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
-"hwW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/wood,
-/area/station/service/theater)
+/area/station/hallway/primary/central)
+"hwW" = (
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "hxa" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -25857,18 +25742,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "hyS" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"hyZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "hzo" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -25970,6 +25846,16 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
+"hAm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock{
+	id_tag = "commissarydoor";
+	name = "Commissary"
+	},
+/turf/open/floor/plating,
+/area/station/commons/vacant_room/commissary)
 "hAq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -26075,11 +25961,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hBY" = (
-/obj/structure/dresser,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/machinery/elevator_control_panel/directional/east{
+	linked_elevator_id = "catwalk_cafe";
+	name = "Feeding Elevator Controller";
+	pixel_x = 0;
+	pixel_y = 26;
+	preset_destination_names = list("2"="Lower        Deck","3"="Upper        Deck")
+	},
+/obj/structure/sign/directions/upload/directional/north{
+	desc = "It stands for Up Le Dable";
+	dir = 2;
+	name = "Button Indicator";
+	pixel_y = 40
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "hCe" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck{
@@ -26443,6 +26343,23 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"hGP" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
+	},
+/area/station/hallway/primary/central)
 "hGR" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -26457,26 +26374,6 @@
 /obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/central)
-"hHm" = (
-/obj/machinery/vending/autodrobe,
-/obj/item/clothing/head/cone{
-	pixel_x = 18;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = 18;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = 18;
-	pixel_y = 7
-	},
-/obj/item/plunger{
-	pixel_x = 12;
-	pixel_y = -7
-	},
-/turf/open/floor/wood/large,
-/area/station/service/theater)
 "hHr" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 10
@@ -26986,15 +26883,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/processing)
 "hNy" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Community Center"
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/smoke_machine,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "hNC" = (
 /obj/structure/stairs/west,
 /turf/open/floor/plating,
@@ -27056,6 +26952,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"hOO" = (
+/obj/structure/table/wood,
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "hOQ" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -27113,11 +27013,6 @@
 	},
 /turf/open/floor/iron/stairs/left,
 /area/station/engineering/lobby)
-"hPQ" = (
-/obj/structure/table/wood,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
 "hPU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27163,15 +27058,16 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "hQk" = (
-/obj/structure/table,
 /obj/item/reagent_containers/cup/soup_pot{
 	pixel_x = 6;
 	pixel_y = 16
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -6;
+	pixel_y = 14
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/glass,
 /area/station/service/kitchen)
 "hQE" = (
 /obj/structure/railing{
@@ -27329,18 +27225,9 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "hSd" = (
-/obj/structure/table,
-/obj/item/compact_remote{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 9;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/siding/dark,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark/smooth_edge,
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
 /area/station/service/library)
 "hSh" = (
 /obj/item/radio/intercom/directional/west,
@@ -27407,6 +27294,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"hTr" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "psychology_shutters";
+	name = "Psychologist's Office Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/medical/psychology)
 "hTs" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
@@ -27533,23 +27429,18 @@
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "hWb" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/structure/chair{
+	dir = 1;
+	pixel_y = -2
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
 /area/station/service/library)
 "hWd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "hWk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
@@ -27559,22 +27450,6 @@
 /obj/structure/railing,
 /turf/open/floor/grass,
 /area/station/science/zoo)
-"hWu" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "hWw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/wood,
@@ -27805,15 +27680,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"hZl" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/service/library)
 "hZq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/ai/directional/east,
@@ -27822,6 +27688,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"hZx" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight{
+	pixel_y = 8
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/carpet/stellar,
+/area/station/maintenance/hallway/abandoned_recreation)
 "hZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -27835,13 +27710,13 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "hZD" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/mid_joiner{
+	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "hZE" = (
@@ -27913,10 +27788,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
-"ibb" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/station/service/theater)
 "ibc" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/structure/closet/boxinggloves,
@@ -27924,13 +27795,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"ibf" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
 "ibj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/light/directional/south,
@@ -28395,10 +28259,17 @@
 /turf/open/floor/iron/white/textured_corner,
 /area/station/science/robotics)
 "iib" = (
-/obj/structure/lattice/catwalk,
-/obj/item/kirbyplants/random,
-/turf/open/openspace,
-/area/station/service/library)
+/obj/structure/table,
+/obj/item/storage/box/hug{
+	pixel_y = 9
+	},
+/obj/item/bikehorn{
+	pixel_y = -1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "iis" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain/private)
@@ -28474,11 +28345,30 @@
 /turf/open/openspace,
 /area/station/medical/morgue)
 "ikq" = (
-/obj/machinery/light/floor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/wood,
+/area/station/service/library)
+"ikG" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = 13
+	},
+/obj/item/book/manual/wiki/research_and_development{
+	pixel_x = 12;
+	pixel_y = 10
+	},
+/turf/open/floor/wood/large,
 /area/station/service/library)
 "ikK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28497,21 +28387,9 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "ikR" = (
-/obj/structure/table/wood,
-/obj/item/folder/white{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain{
-	pixel_x = 14
-	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "ikZ" = (
 /turf/open/floor/eighties,
 /area/station/maintenance/starboard/fore)
@@ -28564,17 +28442,10 @@
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
 "imo" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_y = 9
-	},
-/obj/item/bikehorn{
-	pixel_y = -1
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
+/obj/effect/landmark/event_spawn,
+/obj/machinery/light/directional/north,
+/turf/open/openspace,
+/area/station/service/kitchen)
 "imq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28598,6 +28469,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"imB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "imJ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -28672,7 +28547,6 @@
 	},
 /area/station/medical/abandoned)
 "inG" = (
-/obj/structure/cable,
 /obj/structure/sign/poster/official/get_your_legs/directional/west,
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/large,
@@ -28762,9 +28636,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "ioC" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/landmark/start/hangover,
-/obj/machinery/firealarm/directional/east,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ioK" = (
@@ -29104,6 +28977,13 @@
 /obj/structure/transport/linear,
 /turf/open/openspace,
 /area/station/engineering/break_room)
+"ito" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "itq" = (
 /turf/open/floor/engine/hull/air,
 /area/station/engineering/lobby)
@@ -29190,6 +29070,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
+"iuO" = (
+/obj/effect/landmark/transport/transport_id{
+	specific_transport_id = "catwalk_cafe"
+	},
+/obj/structure/transport/linear/public,
+/obj/structure/table,
+/obj/item/plate{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/service/kitchen)
 "iuR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -29410,12 +29302,27 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/starboard/fore)
 "iyA" = (
-/obj/machinery/vending/games,
-/obj/structure/sign/painting/library_secure{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/toy/crayon/spraycan/lubecan{
+	charges = 5;
+	pixel_x = -6;
+	pixel_y = 13
 	},
+/obj/item/toy/crayon/spraycan/mimecan{
+	charges = 5;
+	pixel_x = 3;
+	pixel_y = 13
+	},
+/obj/item/toy/figure/clown{
+	pixel_x = 5
+	},
+/obj/item/toy/figure/mime{
+	pixel_x = -5
+	},
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "iyE" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -29620,9 +29527,6 @@
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
@@ -30521,7 +30425,10 @@
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
 "iMH" = (
-/obj/structure/stairs/north,
+/obj/structure/stairs/north{
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /obj/structure/sign/departments/botany/alt2/directional/west,
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/central)
@@ -30742,7 +30649,18 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
 	},
-/turf/open/floor/wood/large,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 9;
+	pixel_y = 1
+	},
+/obj/item/compact_remote{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/service/library)
 "iQA" = (
 /obj/effect/turf_decal/siding/blue{
@@ -30972,6 +30890,10 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/item/vending_refill/coffee{
+	pixel_x = 5;
+	pixel_y = 12
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "iUj" = (
@@ -31120,13 +31042,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
-"iWl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "iWo" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -31618,8 +31533,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/east,
+/obj/structure/table/wood,
+/obj/item/instrument/eguitar{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
-/area/station/hallway/secondary/service)
+/area/station/service/bar)
 "jeA" = (
 /obj/structure/railing{
 	dir = 8
@@ -31805,16 +31727,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"jgL" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "jgR" = (
 /obj/structure/bonfire/dense,
 /turf/open/floor/plating,
@@ -32015,7 +31927,21 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
-/turf/open/floor/wood/large,
+/obj/structure/rack,
+/obj/item/pai_card{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/integrated_circuit/loaded/speech_relay{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/integrated_circuit/loaded/hello_world{
+	pixel_x = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/service/library)
 "jjG" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -32065,27 +31991,6 @@
 "jkr" = (
 /turf/closed/wall,
 /area/station/science/lab)
-"jkx" = (
-/obj/structure/closet/crate/wooden{
-	desc = "Used for storing props for a stage play!.";
-	name = "Space Station 27 Props"
-	},
-/obj/item/clothing/under/costume/lobster,
-/obj/item/clothing/head/collectable/captain,
-/obj/item/disk/nuclear/fake/obvious,
-/obj/item/clothing/head/collectable/hos,
-/obj/item/toy/gun,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/item/clothing/head/collectable/xenom,
-/obj/item/clothing/head/collectable/hardhat,
-/obj/item/clothing/head/collectable/police,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
 "jkz" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -32170,10 +32075,13 @@
 /area/station/engineering/storage/tech)
 "jlq" = (
 /obj/structure/railing,
-/obj/structure/chair,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/landmark/start/hangover,
+/obj/machinery/digital_clock/directional/west,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	name = "Psychologist's Office Curtains";
+	id = "psychpriv"
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "jlB" = (
@@ -32254,6 +32162,14 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
+"jmZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "jna" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
@@ -32397,11 +32313,9 @@
 /turf/open/floor/plating,
 /area/station/security/lockers)
 "jpy" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
-	},
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "jpA" = (
@@ -32473,7 +32387,7 @@
 "jqO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/event_spawn,
+/obj/machinery/vatgrower,
 /turf/open/floor/engine,
 /area/station/service/hydroponics)
 "jqR" = (
@@ -32562,7 +32476,7 @@
 /area/station/engineering/lobby)
 "jrz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "jrK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32683,19 +32597,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
-"jug" = (
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/fifty{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/stack/sheet/cardboard/fifty{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
 "juh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -32716,10 +32617,17 @@
 	pixel_y = 7
 	},
 /obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+/obj/machinery/light/directional/south,
+/obj/machinery/button/door/directional/south{
+	id = "kitchen_service";
+	name = "Window Shutters";
+	pixel_x = 6;
+	req_access = list("kitchen")
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "juo" = (
@@ -33162,10 +33070,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"jzi" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/service/library)
 "jzx" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/machinery/firealarm/directional/east,
@@ -33366,17 +33270,9 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
 "jBU" = (
-/obj/structure/transport/linear/public,
-/obj/structure/table,
-/obj/item/plate{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/plate{
-	pixel_x = -11;
-	pixel_y = -2
-	},
-/turf/open/floor/plating/elevatorshaft,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/glass/mug/tea,
+/turf/open/floor/carpet,
 /area/station/commons/lounge)
 "jBW" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -33631,6 +33527,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
+"jEv" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "jEw" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron/dark,
@@ -33720,13 +33620,9 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "jFI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "jFU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -34176,9 +34072,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "jMi" = (
@@ -34192,13 +34085,6 @@
 "jMr" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
-"jMw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/railing,
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "jMy" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/start/hangover,
@@ -34313,19 +34199,6 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"jOW" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "jPa" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -34351,13 +34224,6 @@
 /obj/effect/spawner/random/maintenance/no_decals,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jPA" = (
-/obj/structure/chair/sofa/left/brown{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "jPC" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -34386,6 +34252,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/blacklight/directional/south,
 /obj/item/kirbyplants/random/fullysynthetic,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/stellar,
 /area/station/maintenance/hallway/abandoned_recreation)
 "jQn" = (
@@ -34709,9 +34576,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/commons/lounge)
 "jVP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -34850,19 +34717,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/qm)
-"jXx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "jXC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/structure/table,
+/obj/item/instrument/eguitar{
+	pixel_y = 5
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood/large,
-/area/station/service/library)
+/area/station/service/theater_dressing)
 "jXX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -34921,10 +34784,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jYE" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/item/storage/toolbox/fishing,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -8;
+	pixel_y = 1
 	},
-/obj/machinery/light/small/dim/directional/north,
+/obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/station/maintenance/port/fore)
 "jYG" = (
@@ -35415,6 +35282,12 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
+"kgN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/modular_computer/preset/cargochat/service,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "khi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35585,12 +35458,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
-"kki" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "kkn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/urinal/directional/north,
@@ -35683,11 +35550,11 @@
 /area/station/science/xenobiology)
 "kll" = (
 /obj/effect/turf_decal/siding/wood/end{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 9
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "klp" = (
@@ -35744,17 +35611,9 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "klJ" = (
-/obj/machinery/light/small/directional/south{
-	dir = 8
-	},
-/obj/machinery/fax{
-	fax_name = "Psychology Office";
-	name = "Psychology Office Fax Machine"
-	},
-/obj/structure/table,
-/obj/machinery/digital_clock/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/large,
-/area/station/medical/psychology)
+/area/station/hallway/primary/central)
 "kmh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner/end/flip{
@@ -35767,19 +35626,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"kmx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
-"kmy" = (
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
 "kmD" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -35884,6 +35730,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
+"kns" = (
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "kny" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -36387,9 +36238,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/landmark/start/cook,
 /turf/open/floor/glass,
 /area/station/service/kitchen)
@@ -36755,22 +36603,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/construction/mining/aux_base)
-"kyo" = (
-/obj/structure/rack,
-/obj/item/pai_card{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/integrated_circuit/loaded/hello_world{
-	pixel_x = 4
-	},
-/obj/item/integrated_circuit/loaded/speech_relay{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/library)
 "kyq" = (
 /obj/structure/ladder,
 /obj/machinery/airalarm/directional/west,
@@ -36851,6 +36683,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"kzC" = (
+/obj/structure/chair{
+	dir = 4;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "kzD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -36869,6 +36708,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research)
+"kzM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "kzX" = (
 /obj/effect/spawner/random/contraband/prison,
 /obj/structure/rack,
@@ -37051,17 +36897,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
-"kCO" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = -8;
-	pixel_y = 1
-	},
-/obj/item/storage/toolbox/fishing,
-/obj/effect/spawner/random/maintenance,
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "kCP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37173,6 +37008,18 @@
 	dir = 8
 	},
 /area/station/tcommsat/server)
+"kEn" = (
+/obj/structure/stairs/east,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
+	},
+/area/station/hallway/primary/central)
 "kEq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -37308,6 +37155,12 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"kHv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "kHw" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -37493,6 +37346,13 @@
 "kLD" = (
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"kLF" = (
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/structure/chair/sofa/middle/brown{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "kLH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -37716,8 +37576,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "kPH" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/firealarm/directional/west,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "kPI" = (
@@ -37842,7 +37702,11 @@
 /obj/structure/sign/picture_frame/portrait{
 	pixel_y = 33
 	},
-/turf/open/floor/wood/large,
+/obj/machinery/computer/libraryconsole{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/library)
 "kQy" = (
 /obj/structure/disposalpipe/segment{
@@ -38008,6 +37872,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"kSZ" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "kTi" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
@@ -38068,7 +37937,7 @@
 "kTW" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "kUf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -38087,6 +37956,12 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office/private_investigators_office)
+"kUI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/table,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "kUO" = (
 /turf/open/openspace,
 /area/station/security/courtroom)
@@ -38664,11 +38539,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
-"ldk" = (
-/obj/effect/turf_decal/siding/dark,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/library)
 "ldv" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/structure/closet/emcloset,
@@ -38684,6 +38554,11 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos/upper)
+"ldN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/oven/range,
+/turf/open/openspace,
+/area/station/service/kitchen)
 "ldX" = (
 /obj/machinery/door/airlock{
 	id_tag = "commissarydoor";
@@ -38733,6 +38608,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"leB" = (
+/obj/structure/transport/linear/public,
+/obj/structure/table,
+/obj/item/plate{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/plate{
+	pixel_x = -11;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/service/kitchen)
 "leD" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
@@ -38821,9 +38709,6 @@
 /turf/open/floor/wood,
 /area/station/engineering/lobby)
 "lgi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/structure/chair/office,
 /turf/open/floor/wood/large,
 /area/station/service/library)
@@ -39052,6 +38937,11 @@
 /obj/structure/closet/crate/cardboard,
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"lkj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/water,
+/area/station/maintenance/port/fore)
 "lkt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39355,10 +39245,6 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"loW" = (
-/obj/item/cigbutt,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "lpc" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/ferny/style_random,
@@ -39500,10 +39386,6 @@
 /area/station/science/xenobiology)
 "lqO" = (
 /obj/structure/table/reinforced,
-/obj/item/lighter{
-	pixel_x = 8;
-	pixel_y = 4
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/service/bar)
@@ -39672,12 +39554,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/secondary/construction)
-"luf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "lul" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -39780,9 +39656,9 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos/upper)
 "lxh" = (
-/obj/machinery/griddle,
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/deepfryer,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "lxl" = (
@@ -39845,6 +39721,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
+"lxS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/blacklight/directional/north,
+/turf/open/floor/carpet/stellar,
+/area/station/maintenance/hallway/abandoned_recreation)
 "lxW" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -39870,8 +39751,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"lyq" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/station/maintenance/port/fore)
 "lys" = (
-/obj/machinery/vatgrower,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/engine,
 /area/station/service/hydroponics)
@@ -40046,11 +39931,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lAF" = (
-/obj/machinery/modular_computer/preset/cargochat/service{
-	dir = 1
-	},
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
+/obj/machinery/light/warm/dim/directional/south,
 /turf/open/floor/wood,
-/area/station/hallway/secondary/service)
+/area/station/service/bar)
 "lAG" = (
 /obj/structure/railing{
 	dir = 8
@@ -40118,10 +40003,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lAW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "lBg" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -40414,9 +40300,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "lEJ" = (
@@ -40594,6 +40477,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "lHK" = (
@@ -40764,6 +40648,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"lKa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "lKb" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -40882,6 +40773,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/sink/directional/east,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "lMt" = (
@@ -41281,12 +41176,6 @@
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"lRF" = (
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/light/directional/north,
-/obj/machinery/deepfryer,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "lRP" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
@@ -41338,11 +41227,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"lSN" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "lSP" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/wood,
@@ -41365,6 +41249,28 @@
 /obj/effect/turf_decal/tile/dark_blue,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"lTx" = (
+/obj/structure/closet/crate/wooden{
+	desc = "Used for storing props for a stage play!.";
+	name = "Space Station 27 Props"
+	},
+/obj/item/clothing/under/costume/lobster,
+/obj/item/clothing/head/collectable/captain,
+/obj/item/disk/nuclear/fake/obvious,
+/obj/item/clothing/head/collectable/hos,
+/obj/item/toy/gun,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/item/clothing/head/collectable/xenom,
+/obj/item/clothing/head/collectable/hardhat,
+/obj/item/clothing/head/collectable/police,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "lTA" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
@@ -41500,25 +41406,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "lVv" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/closet/crate/medical,
-/obj/item/stamp{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/fax{
+	fax_name = "Psychology Office";
+	name = "Psychology Office Fax Machine"
 	},
-/obj/item/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/pen/red{
-	pixel_y = 10
-	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "lVA" = (
 /obj/machinery/meter,
@@ -42170,10 +42064,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "meE" = (
@@ -42261,19 +42155,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "mfA" = (
-/obj/machinery/light_switch/directional/south,
+/obj/item/kirbyplants/potty,
 /obj/machinery/light/warm/dim/directional/south,
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/deck{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/item/stack/spacecash/c200{
-	pixel_x = 8;
-	pixel_y = 2
-	},
 /turf/open/floor/wood,
-/area/station/maintenance/port/greater)
+/area/station/commons/lounge)
 "mfD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -42639,7 +42524,6 @@
 	c_tag = "Holodeck - Fore";
 	name = "holodeck camera"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -42670,6 +42554,13 @@
 /obj/machinery/light/small/broken,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central)
+"mmU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/painting/large/library,
+/turf/open/openspace,
+/area/station/maintenance/port/fore)
 "mmX" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 1
@@ -42771,14 +42662,6 @@
 /area/station/maintenance/port/fore)
 "moE" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/bartender,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/bar,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "moI" = (
@@ -42924,6 +42807,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "mqK" = (
@@ -42971,15 +42855,21 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "mrp" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/wood,
-/area/station/service/theater)
+/obj/structure/transport/linear/public,
+/obj/structure/table,
+/obj/item/plate{
+	pixel_x = 6
+	},
+/obj/item/plate{
+	pixel_x = -13;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/service/kitchen)
 "mrq" = (
 /obj/structure/chair/sofa/corner/brown{
 	dir = 1
@@ -43328,7 +43218,7 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "mvH" = (
-/obj/structure/hedge,
+/obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "mwd" = (
@@ -43358,18 +43248,6 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"mwo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/autoname/directional/east,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "mwr" = (
 /turf/closed/wall,
 /area/station/security/evidence)
@@ -43705,10 +43583,10 @@
 /area/station/maintenance/port/aft)
 "mCw" = (
 /obj/structure/chair/stool/bar/directional/west,
-/obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "mCM" = (
@@ -43825,6 +43703,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
+"mDZ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "mEv" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/firealarm_sanity,
@@ -43898,8 +43783,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "mGx" = (
@@ -43969,6 +43852,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"mHJ" = (
+/obj/structure/table,
+/obj/item/paint_palette{
+	pixel_y = 11
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "mHK" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 8
@@ -44170,14 +44060,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"mJI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/vending_refill/coffee{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "mJL" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating/airless,
@@ -44229,18 +44111,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
-"mKU" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/assistant,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
+"mKO" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "mKV" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -44366,16 +44243,6 @@
 /obj/structure/ladder,
 /turf/open/space/basic,
 /area/space/nearstation)
-"mNx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
 "mNC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/warning/radiation/rad_area/directional/south,
@@ -44516,7 +44383,6 @@
 	c_tag = "Holodeck - Aft";
 	name = "holodeck camera"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -44662,10 +44528,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "mSt" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/machinery/holopad,
+/obj/effect/landmark/start/mime,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "mSA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/qm,
@@ -44735,11 +44601,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "mTx" = (
-/obj/structure/table/wood,
-/obj/item/gun/magic/wand/nothing,
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/wood,
-/area/station/service/theater)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "mTz" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -44813,24 +44682,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "mUY" = (
-/obj/structure/table,
-/obj/item/grenade/chem_grenade/teargas/moustache{
-	pixel_x = 6;
-	pixel_y = 7
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/grenade/chem_grenade/glitter/pink{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/grenade/smokebomb{
-	pixel_y = 3
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood,
-/area/station/service/theater)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "mVm" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -45184,11 +45041,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "naC" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hydropony_shutters";
 	name = "Hydroponics Shutters"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "naR" = (
@@ -45239,6 +45096,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
+"nbC" = (
+/obj/machinery/restaurant_portal/restaurant,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "nbY" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/wood{
@@ -45301,10 +45162,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "ndl" = (
-/obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/autoname/directional/north,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/wood/large,
+/obj/machinery/module_duplicator,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/library)
 "ndo" = (
 /obj/structure/table,
@@ -45394,16 +45255,27 @@
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "neF" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/north,
-/obj/item/reagent_containers/cup/bowl/soup/stew{
-	desc = "Exactly what it says on the tin.";
-	initial_reagent = /datum/reagent/consumable/condensedcapsaicin;
-	name = "6 seconds blinding stew";
-	pixel_y = 12
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/obj/machinery/elevator_control_panel/directional/east{
+	linked_elevator_id = "catwalk_cafe";
+	name = "Feeding Elevator Controller";
+	pixel_x = 0;
+	pixel_y = 26;
+	preset_destination_names = list("2"="Lower        Deck","3"="Upper        Deck")
+	},
+/obj/structure/sign/directions/upload/directional/north{
+	desc = "It stands for Up Le Dable";
+	dir = 2;
+	name = "Button Indicator";
+	pixel_y = 40
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "neJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45661,13 +45533,6 @@
 /obj/item/plunger,
 /turf/open/floor/wood,
 /area/station/medical/medbay/central)
-"niC" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "niN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -45694,16 +45559,16 @@
 /turf/closed/wall,
 /area/station/engineering/main)
 "njv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -45883,6 +45748,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"nmn" = (
+/obj/structure/window/spawner/directional/east,
+/turf/open/floor/wood,
+/area/station/service/library)
 "nmu" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/item/radio/intercom/directional/south,
@@ -46330,15 +46199,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
-"nrf" = (
-/obj/structure/lattice/catwalk,
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/north,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/station/service/library)
 "nrg" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -46647,6 +46507,9 @@
 "nvR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
 "nvS" = (
@@ -46846,6 +46709,9 @@
 /obj/structure/sign/poster/contraband/missing_gloves/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"nyq" = (
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/service/library)
 "nyz" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -46867,9 +46733,10 @@
 "nyB" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/item/kirbyplants/potty,
+/obj/structure/table/reinforced,
+/obj/item/storage/photo_album/bar,
 /turf/open/floor/wood,
-/area/station/maintenance/port/greater)
+/area/station/commons/lounge)
 "nyG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -46890,11 +46757,6 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/commons/fitness/recreation)
-"nyX" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "nyY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47208,9 +47070,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
 "nDm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
@@ -47517,20 +47376,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
-"nHV" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/structure/railing/corner/end{
-	dir = 8
-	},
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/service/library)
 "nIo" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters"
@@ -48276,6 +48121,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"nTw" = (
+/obj/structure/easel,
+/obj/item/canvas/twentythree_twentythree{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "nTA" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -48488,6 +48341,11 @@
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"nWN" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/landmark/navigate_destination/kitchen,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "nWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
@@ -48605,14 +48463,15 @@
 /area/station/command/corporate_showroom)
 "nYp" = (
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/edge{
 	dir = 8
@@ -49099,9 +48958,11 @@
 /area/station/medical/cryo)
 "ofE" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "ofL" = (
@@ -49163,16 +49024,6 @@
 /obj/item/newspaper,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"ogY" = (
-/obj/structure/sign/poster/official/random/directional/south,
-/obj/structure/chair/sofa/left/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "ohb" = (
 /obj/machinery/airalarm/directional/south,
 /obj/item/toy/crayon/white{
@@ -49548,10 +49399,10 @@
 /area/station/engineering/hallway)
 "onj" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "onm" = (
@@ -49774,11 +49625,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "oqi" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hydropony_shutters";
 	name = "Hydroponics Shutters"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "oqq" = (
@@ -49927,6 +49778,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
+"osO" = (
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/station/holodeck/rec_center)
 "osS" = (
 /obj/structure/table/glass,
 /obj/item/clothing/head/costume/festive,
@@ -50127,21 +49983,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"oww" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/service/library)
 "owz" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/glass,
@@ -50401,9 +50242,13 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
 "oAp" = (
-/obj/structure/chair,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/window/spawner/directional/west,
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "oAz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50599,11 +50444,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "oCX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/mime,
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/rag{
+	pixel_x = -4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "oDc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50835,11 +50688,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
-"oGS" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/photo_album/bar,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "oGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50887,10 +50735,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "oIe" = (
-/obj/structure/railing,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/water,
 /area/station/maintenance/port/fore)
 "oIi" = (
@@ -50907,10 +50757,16 @@
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
 "oIv" = (
-/obj/structure/railing,
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/directional/north,
+/obj/machinery/button/curtain{
+	pixel_x = -6;
+	name = "Privacy Curtains";
+	id = "psychpriv";
+	pixel_y = 30
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_y = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "oII" = (
@@ -50930,6 +50786,21 @@
 	luminosity = 2
 	},
 /area/station/ai_monitored/command/nuke_storage)
+"oIU" = (
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/twentythree_twentythree{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/closet/crate,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "oJd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -51137,9 +51008,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/smartfridge/drying,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "oLt" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -51283,18 +51153,15 @@
 /obj/structure/closet/lasertag/red,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/color/red,
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/blacklight/directional/south,
 /turf/open/floor/eighties/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "oNi" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/turf/open/floor/glass/reinforced,
 /area/station/service/library)
 "oNp" = (
 /obj/effect/landmark/start/assistant,
@@ -51597,11 +51464,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"oSw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/plating,
-/area/station/service/theater)
 "oSE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -51609,6 +51471,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"oSI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "oST" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52061,6 +51930,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"oYP" = (
+/obj/structure/easel,
+/obj/item/canvas/twentythree_nineteen{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "oZh" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -52166,11 +52043,7 @@
 /area/station/hallway/primary/starboard)
 "pag" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/glass,
 /area/station/service/kitchen)
 "paq" = (
@@ -52205,9 +52078,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "pbk" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "pbp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
@@ -52468,16 +52343,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "pef" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/costume/sombrero{
-	pixel_y = 8
+/obj/structure/transport/linear/public,
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -6;
+	pixel_y = 13
 	},
-/obj/item/soap{
-	pixel_y = 2
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -1;
+	pixel_y = 13
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/obj/item/plate{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/barsign{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/service/kitchen)
 "pem" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Cryogenics Room"
@@ -52551,9 +52435,6 @@
 /area/station/hallway/secondary/service)
 "pfd" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/glass,
@@ -52826,15 +52707,10 @@
 /obj/item/flashlight{
 	pixel_y = 8
 	},
-/obj/structure/light_construct/directional/east,
+/obj/machinery/light/small/blacklight/directional/north,
 /turf/open/floor/eighties/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "pjd" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = -4;
-	pixel_y = 6
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Kitchen"
 	},
@@ -52842,6 +52718,8 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "pje" = (
@@ -52942,6 +52820,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
+"pmg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "pmn" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/machinery/shower/directional/east,
@@ -53005,15 +52889,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/vending/cigarette,
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "pmS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53138,11 +53021,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "por" = (
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/disposal/bin/tagger,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/glass,
 /area/station/service/kitchen)
 "pot" = (
 /obj/structure/disposalpipe/segment{
@@ -53391,11 +53273,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "ptt" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/cable_coil/five,
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "ptC" = (
@@ -53597,10 +53482,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"pxk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/library)
 "pxv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/wood,
@@ -53666,19 +53547,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
-"pyk" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "pyw" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/random/maintenance/no_decals,
@@ -53693,9 +53561,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "pzb" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "pzg" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -53857,6 +53727,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/table/wood,
+/obj/item/statuebust{
+	desc = "Scribbled on its bottom there are the words 'FEARTHEVAPORWAVE'.";
+	pixel_y = 12
+	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "pBJ" = (
@@ -53886,12 +53761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/range)
-"pBW" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "pCb" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage)
@@ -53951,13 +53820,18 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "pDO" = (
+/obj/structure/railing{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
-/obj/machinery/holopad,
 /turf/open/floor/wood/large,
-/area/station/service/theater)
+/area/station/service/kitchen)
+"pDR" = (
+/obj/effect/landmark/firealarm_sanity,
+/obj/structure/lattice/catwalk,
+/obj/machinery/griddle,
+/turf/open/openspace,
+/area/station/service/kitchen)
 "pDT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -54114,6 +53988,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine/hull/air,
 /area/station/engineering/atmos/project)
+"pGn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/medical/psychology)
 "pGr" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow{
@@ -54730,6 +54610,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "pNg" = (
@@ -54822,15 +54703,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pOM" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/structure/chair/stool/bar/directional/north,
-/obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -54863,18 +54736,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "pPb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark/arrow_cw{
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -55257,17 +55125,11 @@
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/port/aft)
 "pTi" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/structure/railing,
-/obj/item/kirbyplants/random,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/curtain/cloth/fancy/mechanical{
+	name = "Psychologist's Office Curtains";
+	id = "psychpriv"
 	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -55362,14 +55224,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
-"pUM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "pUV" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/machinery/light/cold/directional/south,
@@ -55394,6 +55248,15 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"pVw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/maintenance/hallway/abandoned_recreation)
 "pVy" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/large,
@@ -55436,6 +55299,19 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"pWC" = (
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/fifty{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/cardboard/fifty{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "pWF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
@@ -55471,21 +55347,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "pXE" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_y = 32
-	},
-/obj/structure/closet/crate,
-/obj/item/canvas/twentythree_twentythree{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/twentythree_nineteen,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "pXM" = (
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark,
@@ -55554,9 +55420,8 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "qak" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
@@ -55810,6 +55675,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"qeq" = (
+/obj/effect/mapping_helpers/trapdoor_placer,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/plating,
+/area/station/service/theater_dressing)
 "qez" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56244,12 +56114,31 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/central)
 "qjZ" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/food/pie/cream{
+	pixel_y = 9
 	},
-/obj/machinery/skill_station,
+/obj/item/food/pie/cream{
+	pixel_y = 9
+	},
+/obj/item/food/pie/cream{
+	pixel_y = 9
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/obj/item/bikehorn/airhorn{
+	pixel_x = 9;
+	pixel_y = 2
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
-/area/station/service/library)
+/area/station/service/theater)
 "qki" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -56285,6 +56174,12 @@
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"qkF" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "qkM" = (
 /obj/structure/sign/warning/radiation/rad_area{
 	dir = 1
@@ -56633,8 +56528,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "qpY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -56909,10 +56805,10 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "quB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/machinery/computer/records/medical/laptop{
+	pixel_y = 4
 	},
-/obj/effect/landmark/firealarm_sanity,
+/obj/structure/table,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "quD" = (
@@ -57019,6 +56915,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
+"qvM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair{
+	dir = 4;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "qvU" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -57060,9 +56966,6 @@
 /area/space/nearstation)
 "qwF" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -57411,17 +57314,10 @@
 /turf/open/openspace,
 /area/station/medical/storage)
 "qBl" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/item/stack/sheet/iron/five,
-/obj/item/stack/cable_coil/five,
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/light/dim/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/obj/structure/closet/emcloset,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "qBm" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -57694,12 +57590,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/black,
 /area/station/maintenance/hallway/abandoned_recreation)
-"qGm" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "qGv" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
@@ -57864,11 +57754,12 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "qJo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "qJu" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/cleanable/dirt,
@@ -57886,9 +57777,11 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/hallway/abandoned_recreation)
 "qJK" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "qJL" = (
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white/smooth_large,
@@ -58008,25 +57901,23 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/bomb)
 "qLF" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/medicine{
-	pixel_x = -4;
-	pixel_y = 14
+/obj/structure/table,
+/obj/item/storage/toolbox/artistic{
+	pixel_x = 9;
+	pixel_y = 9
 	},
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 10
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 9;
+	pixel_y = 2
 	},
-/obj/item/book/manual/wiki/plumbing{
+/obj/item/trapdoor_remote/preloaded{
 	pixel_x = -6;
-	pixel_y = 6
+	pixel_y = 2
 	},
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/openspace,
-/area/station/service/library)
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "qLZ" = (
 /obj/structure/grille,
 /turf/open/openspace,
@@ -58045,6 +57936,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"qMm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "qMr" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -58144,6 +58043,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"qNw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "qNy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -58173,6 +58078,12 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"qNV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "qNW" = (
 /obj/item/trash/ready_donk,
 /turf/open/floor/plating,
@@ -58324,17 +58235,6 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/space_hut)
-"qQK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/wood{
-	name = "Event Storage"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood/large,
-/area/station/service/theater)
 "qQM" = (
 /obj/machinery/conveyor_switch{
 	id = "raveyard"
@@ -58414,7 +58314,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "qRL" = (
 /obj/effect/turf_decal/siding,
@@ -58767,6 +58667,15 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"qWW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/medical/psychology)
 "qXj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -59210,6 +59119,8 @@
 	pixel_x = -8;
 	pixel_y = 9
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "rdl" = (
@@ -59233,6 +59144,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
+"rdu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Community Center"
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "rdx" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/large,
@@ -59269,10 +59189,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"reh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/glass,
+/area/station/service/kitchen)
 "rei" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"req" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/large,
+/area/station/hallway/primary/central)
 "rey" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera/autoname/directional/north,
@@ -59432,18 +59368,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/lesser)
-"ria" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
 "rih" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central)
@@ -59460,11 +59384,12 @@
 /area/station/maintenance/port)
 "riE" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 5
-	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "riI" = (
@@ -59473,6 +59398,9 @@
 /turf/open/openspace,
 /area/station/engineering/break_room)
 "riR" = (
+/obj/structure/railing{
+	dir = 6
+	},
 /turf/open/openspace,
 /area/station/service/library)
 "riV" = (
@@ -59527,19 +59455,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
-"rjy" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "rjz" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/drugs,
@@ -59572,6 +59487,14 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
+"rjU" = (
+/obj/item/storage/crayons{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/structure/table,
+/turf/open/floor/wood,
+/area/station/service/library)
 "rkf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
@@ -59594,21 +59517,9 @@
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/construction)
 "rkD" = (
-/obj/structure/transport/linear/public,
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -1;
-	pixel_y = 13
-	},
-/obj/item/plate{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/turf/open/floor/plating/elevatorshaft,
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/carpet,
 /area/station/commons/lounge)
 "rkF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -59641,16 +59552,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "rkN" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/briefcase/secure,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/dim/directional/north,
+/obj/item/newspaper{
+	pixel_y = 2
+	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "rkW" = (
@@ -59686,6 +59596,10 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
+"rlE" = (
+/obj/structure/hedge,
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "rlR" = (
 /obj/item/storage/box/snappops{
 	pixel_x = 6;
@@ -60098,12 +60012,6 @@
 /obj/structure/ladder,
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
-"rre" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/trash/janitor_supplies,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "rrj" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "courtlockdown";
@@ -60145,15 +60053,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
-"rrv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/glass,
-/area/station/service/kitchen)
 "rrz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -60291,14 +60190,6 @@
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/hallway/primary/central)
-"rui" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "ruq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -61078,13 +60969,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"rFC" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "rFF" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -61114,6 +60998,15 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"rGn" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "abandonedcafe";
+	name = "Psychologist's Office Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/medical/psychology)
 "rGp" = (
 /obj/structure/railing{
 	dir = 8
@@ -61397,12 +61290,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
-"rKw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "rKz" = (
 /obj/machinery/atmospherics/pipe/multiz/yellow/visible{
 	name = "N20 Multideck Adapter";
@@ -62020,9 +61907,6 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -62079,6 +61963,18 @@
 /obj/machinery/disposal/bin,
 /turf/open/openspace,
 /area/station/science/xenobiology)
+"rUC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/effect/landmark/event_spawn,
+/obj/item/chisel{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "rUE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -62111,47 +62007,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"rVj" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/holosign_creator/robot_seat/restaurant,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/item/book/manual/chef_recipes,
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "rVs" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
-"rVw" = (
-/obj/structure/closet/secure_closet/psychology,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "rVx" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
@@ -62375,6 +62236,16 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"rYV" = (
+/obj/machinery/door/airlock/wood{
+	name = "Service Hall"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/theater)
 "rZl" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -62416,20 +62287,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "saE" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Community Center"
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/library,
 /turf/open/floor/wood,
 /area/station/service/library)
-"saQ" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_y = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "saR" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -62460,13 +62323,12 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "sbd" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "sbh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
@@ -62589,17 +62451,36 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "scf" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/structure/table,
+/obj/item/grenade/chem_grenade/teargas/moustache{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/item/grenade/chem_grenade/glitter/pink{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
+/obj/item/grenade/smokebomb{
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/station/service/theater_dressing)
 "sch" = (
-/obj/machinery/light/directional/north,
-/turf/open/openspace,
+/obj/structure/table/wood,
+/obj/item/storage/crayons{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/paint_palette{
+	pixel_y = 11
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/glass/reinforced,
 /area/station/service/library)
 "scq" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
@@ -62656,10 +62537,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "sdf" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
@@ -62951,12 +62833,20 @@
 /turf/closed/wall,
 /area/station/commons/vacant_room/office)
 "shv" = (
-/obj/machinery/oven/range,
-/obj/item/reagent_containers/cup/bowl{
-	pixel_y = 17
-	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate,
+/obj/item/book/manual/chef_recipes,
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
+/obj/item/storage/box/papersack{
+	icon_state = "paperbag_NanotrasenStandard_closed"
+	},
+/obj/item/storage/box/papersack{
+	icon_state = "paperbag_NanotrasenStandard_closed"
 	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
@@ -62996,12 +62886,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
+"sic" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/service/bar)
 "sik" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
 "siz" = (
@@ -63155,6 +63054,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
+"skQ" = (
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "skR" = (
 /obj/structure/table/wood,
 /obj/item/vending_refill/cigarette{
@@ -63227,6 +63130,19 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"slN" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hydropony_shutters";
+	name = "Hydroponics Shutters"
+	},
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/hydroponics)
 "slP" = (
 /obj/structure/railing{
 	dir = 4
@@ -63243,11 +63159,14 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
-"smd" = (
-/obj/machinery/newscaster/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+"smc" = (
+/obj/machinery/button/door/directional/west{
+	name = "Kitchen Counter Shutters Control";
+	id = "kitchen_counter";
+	req_access = list("kitchen")
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "smk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63350,6 +63269,13 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/openspace,
 /area/station/hallway/primary/central)
+"sow" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "soH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -63398,14 +63324,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/lesser)
-"spy" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/air_sensor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "spC" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -63436,10 +63354,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/chair/sofa/left/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "sql" = (
@@ -63656,11 +63570,6 @@
 "stm" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
-"stn" = (
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "stq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -63678,14 +63587,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/security/checkpoint/science)
-"stu" = (
-/obj/machinery/ticket_machine/directional/north{
-	id = "ticket_machine_comissary"
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "stv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -64143,21 +64044,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos/upper)
-"sBT" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
-	},
-/area/station/service/library)
 "sCx" = (
 /turf/open/openspace,
 /area/station/command/meeting_room/council)
@@ -64197,10 +64083,12 @@
 /turf/open/floor/iron/freezer,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "sDu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/door/airlock/public/glass{
+	name = "Community Center"
 	},
-/turf/closed/wall,
+/obj/effect/landmark/navigate_destination/library,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
 /area/station/service/library)
 "sDX" = (
 /obj/machinery/door/airlock/maintenance,
@@ -64437,14 +64325,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "sGS" = (
-/obj/structure/table,
-/obj/item/instrument/eguitar{
-	pixel_y = 5
+/obj/machinery/light_switch/directional/east,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/light/directional/south,
+/obj/machinery/smartfridge/food,
 /turf/open/floor/wood/large,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "sGV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -64649,6 +64536,9 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
+"sJR" = (
+/turf/closed/wall,
+/area/station/service/theater_dressing)
 "sJX" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
@@ -64798,6 +64688,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
+"sMp" = (
+/obj/item/paint/violet{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/paint/yellow{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "sMt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64910,6 +64811,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
+"sOJ" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/stack/package_wrap,
+/obj/item/holosign_creator/robot_seat/restaurant,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "sON" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -64920,6 +64831,22 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"sPg" = (
+/obj/structure/table/wood/poker,
+/obj/item/cigarette/cigar{
+	pixel_x = 4
+	},
+/obj/item/stack/spacecash/c20{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "sPj" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/iron/dark,
@@ -65040,6 +64967,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
+"sQI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "sQJ" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -65450,13 +65383,11 @@
 /area/station/maintenance/disposal)
 "sXd" = (
 /obj/structure/railing,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/obj/structure/curtain/cloth/fancy/mechanical{
+	name = "Psychologist's Office Curtains";
+	id = "psychpriv"
 	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -65498,17 +65429,6 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/port)
-"sXZ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "sYc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -65609,15 +65529,6 @@
 /obj/structure/table,
 /turf/open/floor/glass,
 /area/station/science/zoo)
-"sZB" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "sZL" = (
 /obj/structure/marker_beacon/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -65674,13 +65585,12 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/qm)
 "taF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/railing{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/theater)
+/area/station/service/kitchen)
 "taG" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/item/pai_card,
@@ -65735,6 +65645,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"tbw" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "tbz" = (
 /obj/structure/closet/lasertag,
 /obj/effect/decal/cleanable/dirt,
@@ -65780,6 +65697,15 @@
 "tce" = (
 /turf/closed/wall,
 /area/station/service/kitchen/abandoned)
+"tcf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/central)
 "tci" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65958,6 +65884,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/light/small/dim/directional/north,
 /turf/open/water,
 /area/station/maintenance/port/fore)
 "tfv" = (
@@ -66000,16 +65930,6 @@
 	icon_state = "carpet-38"
 	},
 /area/station/service/abandoned_gambling_den)
-"tfX" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/service/library)
 "tgp" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
@@ -66100,9 +66020,6 @@
 	name = "Laser Tag"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
 "tid" = (
@@ -66142,11 +66059,14 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tjg" = (
-/obj/structure/railing{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/turf/open/water,
-/area/station/maintenance/port/fore)
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "tji" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66403,8 +66323,6 @@
 /area/station/command/heads_quarters/hos)
 "tmV" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/bartender,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet,
 /area/station/service/bar)
@@ -66450,21 +66368,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "tnv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"tnA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "tnM" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -66556,13 +66465,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
-"toH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/turf/open/floor/wood,
-/area/station/service/library)
 "toI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
@@ -66668,6 +66570,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"tsd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "tse" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -66686,7 +66598,11 @@
 /area/station/hallway/secondary/entry)
 "tsI" = (
 /obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
@@ -67007,6 +66923,20 @@
 /obj/structure/fluff/paper/corner,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"typ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = 15;
+	pixel_y = 18
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/clown,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "tyw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -67129,7 +67059,6 @@
 /area/station/maintenance/port/aft)
 "tAJ" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/bar)
@@ -67152,15 +67081,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "tAT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -67220,6 +67147,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
+"tBt" = (
+/obj/machinery/light/directional/east,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "tBJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/photosynthetic,
@@ -67289,6 +67223,11 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "tCz" = (
 /obj/item/radio/intercom/directional/west,
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 4
+	},
+/obj/effect/landmark/start/psychologist,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "tCE" = (
@@ -67468,6 +67407,16 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"tER" = (
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	canhear_range = 6;
+	frequency = 1421;
+	name = "Kitchen's Words";
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "tES" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -67736,6 +67685,11 @@
 /obj/effect/spawner/random/trash/soap,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
+"tIO" = (
+/obj/structure/closet/crate/wooden/toy,
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "tIT" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron{
@@ -67837,12 +67791,6 @@
 /obj/structure/railing,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"tKl" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "tKq" = (
 /obj/machinery/computer/crew,
 /obj/structure/sign/poster/official/science/directional/north,
@@ -68068,13 +68016,15 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "tNC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/wood/large,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchen_service"
+	},
+/turf/open/floor/plating,
 /area/station/service/kitchen)
 "tNG" = (
 /turf/open/floor/iron/stairs/medium,
@@ -68124,6 +68074,13 @@
 /area/station/commons/lounge)
 "tOr" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/button/door/directional/north{
+	id = "hydropony_shutters";
+	name = "hydroponics shutters control";
+	pixel_x = 10;
+	pixel_y = 30;
+	req_access = list("hydroponics")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "tOw" = (
@@ -68550,6 +68507,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"tVP" = (
+/obj/machinery/door/airlock/wood{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/wood,
+/area/station/service/kitchen)
 "tVR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -68625,9 +68589,17 @@
 /turf/open/openspace,
 /area/station/command/gateway)
 "tWQ" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "tWR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -68674,8 +68646,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/closed/wall,
+/area/station/service/kitchen)
 "tXl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/engine,
@@ -68780,25 +68752,24 @@
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/command/nuke_storage)
 "tYt" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 9;
-	pixel_y = 12
-	},
-/obj/item/book/manual/wiki/engineering_construction{
+/obj/item/cardboard_cutout{
+	pixel_x = 14;
 	pixel_y = 9
 	},
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/item/cardboard_cutout{
+	pixel_x = 14;
+	pixel_y = 4
 	},
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/openspace,
-/area/station/service/library)
+/obj/item/cardboard_cutout{
+	pixel_x = 14;
+	pixel_y = -1
+	},
+/obj/effect/landmark/start/mime,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "tYz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/brown{
@@ -69101,12 +69072,19 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "udE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/wood{
+	name = "Event Storage"
 	},
-/turf/open/openspace,
-/area/station/service/library)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/theater_dressing)
 "udF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -69149,12 +69127,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"ued" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "uen" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -69407,13 +69379,12 @@
 /turf/open/openspace,
 /area/station/cargo/storage)
 "uii" = (
-/obj/machinery/door/airlock/wood{
-	name = "Psychology Office"
+/obj/machinery/door/airlock/public/glass{
+	name = "Community Center"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/large,
-/area/station/medical/psychology)
+/area/station/service/library)
 "uik" = (
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/effect/decal/cleanable/dirt,
@@ -69468,19 +69439,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"ujy" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/item/wirecutters,
-/obj/item/screwdriver{
-	pixel_y = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
 "ujD" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -69538,16 +69496,8 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/nuke_storage)
 "uki" = (
-/obj/effect/landmark/transport/transport_id{
-	specific_transport_id = "catwalk_cafe"
-	},
-/obj/structure/transport/linear/public,
-/obj/structure/table,
-/obj/item/plate{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/turf/open/floor/plating/elevatorshaft,
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/carpet,
 /area/station/commons/lounge)
 "ukk" = (
 /obj/effect/turf_decal/bot_white,
@@ -69581,10 +69531,10 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
 "uku" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/oven/range,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/glass,
 /area/station/service/kitchen)
 "uky" = (
 /obj/structure/cable/layer3,
@@ -69693,11 +69643,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"ulx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/wood,
+/area/station/service/library)
 "ulM" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light/small/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "ulP" = (
@@ -69805,12 +69768,11 @@
 /area/station/engineering/supermatter/room)
 "umA" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -4;
-	pixel_y = -4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "umD" = (
@@ -70273,7 +70235,22 @@
 "utq" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/light/directional/north,
-/turf/open/floor/wood/large,
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger,
+/obj/item/multitool/circuit{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/item/multitool/circuit{
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/item/multitool/circuit{
+	pixel_x = 2;
+	pixel_y = 15
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/library)
 "uts" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -70367,6 +70344,10 @@
 "uum" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
+	},
+/obj/machinery/door/window/right/directional/east{
+	name = "Theater Stage";
+	req_access = list("theatre")
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
@@ -70609,13 +70590,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "uxl" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "uxo" = (
@@ -70767,6 +70745,15 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"uyw" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight{
+	pixel_y = 8
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/eighties/red,
+/area/station/maintenance/hallway/abandoned_recreation)
 "uyD" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 10
@@ -70841,15 +70828,19 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
 "uzI" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/service/bar,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/airlock/wood{
+	name = "Service Hall"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "uzM" = (
@@ -71253,9 +71244,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "uGf" = (
-/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "uGj" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/start/hangover,
@@ -71327,6 +71321,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/lab)
+"uGT" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/closet/crate/medical,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/stamp{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/item/pen/red{
+	pixel_y = 10
+	},
+/obj/structure/curtain/cloth/fancy/mechanical{
+	name = "Psychologist's Office Curtains";
+	id = "psychpriv"
+	},
+/turf/open/floor/wood/large,
+/area/station/medical/psychology)
 "uGV" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -71436,6 +71456,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"uIA" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/service/library)
 "uIG" = (
 /obj/item/poster/random_official,
 /obj/effect/decal/cleanable/blood/old,
@@ -71505,7 +71531,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
@@ -71539,12 +71564,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uKp" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -71573,6 +71592,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"uKN" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/item/wirecutters,
+/obj/item/screwdriver{
+	pixel_y = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room/commissary)
 "uKP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -71608,8 +71640,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/psychologist,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "uLi" = (
@@ -71986,6 +72019,36 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
+"uRU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/medicine{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/book/manual/wiki/plumbing{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 9;
+	pixel_y = 12
+	},
+/obj/item/book/manual/wiki/engineering_construction{
+	pixel_y = 9
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "uRV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72522,16 +72585,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vaO" = (
-/obj/structure/table,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
-"vbd" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	pixel_x = 4
 	},
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
-/turf/open/floor/wood/large,
-/area/station/service/library)
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "vbe" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -72870,7 +72930,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "vgh" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/lattice/catwalk,
+/obj/machinery/griddle,
 /turf/open/openspace,
 /area/station/service/kitchen)
 "vgo" = (
@@ -73805,6 +73866,11 @@
 /obj/structure/sign/poster/contraband/gorlex_recruitment,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port)
+"vsQ" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "vsT" = (
 /obj/machinery/holopad,
 /turf/open/floor/glass/reinforced,
@@ -73868,17 +73934,13 @@
 /turf/open/floor/glass,
 /area/station/science/zoo)
 "vua" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/records/medical/laptop{
-	pixel_y = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "vuc" = (
 /obj/item/banner/cargo/mundane,
@@ -73887,6 +73949,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"vuo" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "vuu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -74107,7 +74175,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/service/library)
 "vxk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -74249,13 +74317,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
-"vzY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/station/medical/psychology)
 "vAa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -74510,7 +74571,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Red Base"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
 "vCP" = (
@@ -74874,15 +74934,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"vJi" = (
-/obj/structure/chair{
-	dir = 1;
-	pixel_y = -2
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/library)
 "vJz" = (
 /obj/structure/railing{
 	dir = 4
@@ -75180,9 +75231,21 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
+"vMU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/large,
+/area/station/hallway/primary/central)
 "vNc" = (
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "vNf" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -75438,11 +75501,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "vRc" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "vRd" = (
@@ -75563,6 +75627,15 @@
 	},
 /turf/open/openspace,
 /area/station/command/gateway)
+"vSp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/commons/vacant_room/commissary)
 "vSq" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -75626,12 +75699,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
-"vSN" = (
-/obj/structure/stairs/west,
-/turf/open/floor/iron/stairs/medium{
-	dir = 4
-	},
-/area/station/hallway/primary/central)
 "vSS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -75715,6 +75782,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
+"vUd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair{
+	dir = 8;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "vUi" = (
 /obj/structure/chair/pew/left{
 	dir = 8
@@ -76041,7 +76118,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/storage/satellite)
 "waU" = (
-/obj/effect/landmark/start/hangover,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -76136,6 +76212,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/science/explab)
+"wcQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "wcT" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/autoname/directional/west,
@@ -76540,16 +76620,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/large,
 /area/station/science/cytology)
-"whN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/obj/item/paint_palette{
-	pixel_y = 11
-	},
-/turf/open/floor/wood,
-/area/station/service/library)
 "whR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -76601,12 +76671,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/courtroom)
 "wik" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_x = 4
-	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "wiq" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -76646,7 +76714,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "wiK" = (
-/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
 "wiO" = (
@@ -76664,14 +76731,8 @@
 /turf/open/openspace,
 /area/station/commons/dorms)
 "wji" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/chair/stool/bar/directional/west,
-/obj/effect/landmark/start/hangover,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "wju" = (
@@ -76716,22 +76777,16 @@
 /obj/effect/spawner/random/bureaucracy/paper,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"wjU" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "wjV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
+"wjW" = (
+/obj/machinery/light/warm/dim/directional/east,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "wjX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -76853,25 +76908,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
-"wmd" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/rag{
-	pixel_x = 10;
-	pixel_y = 17
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "wmm" = (
 /obj/structure/railing{
 	dir = 4
@@ -76966,17 +77002,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
-"wnu" = (
-/obj/structure/sign/poster/contraband/space_cola/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "wny" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "wnA" = (
@@ -77004,7 +77033,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/construction/mining/aux_base)
 "wnO" = (
-/turf/open/openspace,
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "wnY" = (
 /obj/structure/lattice/catwalk,
@@ -77019,13 +77052,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wog" = (
-/obj/machinery/firealarm/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/camera/autoname/directional/east,
+/obj/structure/sign/departments/psychology/directional/east,
+/turf/open/floor/wood/large,
+/area/station/hallway/primary/central)
 "woh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /obj/structure/sign/poster/official/work_for_a_future/directional/west,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood/large,
@@ -77092,17 +77124,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"wpc" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychology"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "wpd" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/closet/firecloset/full,
@@ -77112,12 +77133,6 @@
 "wps" = (
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"wpt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "wpw" = (
 /obj/structure/flora/bush/flowers_pp/style_3,
 /obj/structure/flora/bush/flowers_yw/style_2,
@@ -77132,8 +77147,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
-/area/station/service/library)
+/turf/closed/wall,
+/area/station/service/theater_dressing)
 "wpG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -77181,22 +77196,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"wqC" = (
-/obj/item/paint/black{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/obj/item/paint/blue{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/paint/red{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/station/service/library)
 "wqI" = (
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
@@ -77480,6 +77479,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/hallway)
+"wvi" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "wvw" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -77496,6 +77502,10 @@
 /obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"wvx" = (
+/obj/structure/cable,
+/turf/open/floor/iron/stairs,
+/area/station/service/library)
 "wvy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77608,14 +77618,12 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/hallway/abandoned_recreation)
 "wwR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/wood{
-	name = "Event Storage"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
-/turf/open/floor/plating,
-/area/station/service/theater)
+/obj/machinery/light/warm/dim/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "wwV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -77908,7 +77916,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "wCa" = (
@@ -78000,12 +78008,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
-"wDn" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/large,
-/area/station/service/library)
 "wDs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/rack,
@@ -78022,6 +78024,19 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"wDu" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/closet/crate/medical,
+/obj/item/hemostat,
+/obj/item/cautery,
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/turf/open/floor/wood/large,
+/area/station/medical/psychology)
 "wDQ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -78210,15 +78225,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/construction/mining/aux_base)
-"wHn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "wHp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78463,9 +78469,6 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"wLO" = (
-/turf/open/floor/carpet,
-/area/station/service/bar)
 "wLU" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -78684,19 +78687,6 @@
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/port)
-"wPx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname/directional/east,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "wPG" = (
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/carpet,
@@ -78801,7 +78791,10 @@
 "wQS" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/wood/large,
+/obj/machinery/bookbinder,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/service/library)
 "wRa" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -78978,8 +78971,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "wUb" = (
-/obj/structure/sign/departments/psychology/directional/north,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "wUk" = (
 /obj/structure/ladder,
@@ -79276,19 +79274,7 @@
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
 "wYP" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/food/grown/tomato,
-/obj/item/food/grown/tomato,
-/obj/item/food/grown/tomato,
-/obj/item/food/grown/tomato,
-/obj/item/food/grown/tomato,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	canhear_range = 6;
-	frequency = 1421;
-	name = "Kitchen's Words";
-	pixel_y = 32
-	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wYS" = (
@@ -79363,12 +79349,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "wZN" = (
-/obj/machinery/door/airlock/wood{
-	name = "Psychology Storage"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/wood{
+	name = "Psychology Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "wZW" = (
 /obj/machinery/recharge_station,
@@ -79642,9 +79630,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "xdV" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/commons/lounge)
 "xdZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/ce,
@@ -79822,17 +79810,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"xhl" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "xhn" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -79852,18 +79829,25 @@
 	},
 /area/station/science/ordnance/storage)
 "xhO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hydropony_shutters";
 	name = "Hydroponics Shutters"
 	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/west{
+	req_access = list("hydroponics");
+	name = "Hydroponics Desk"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "xhX" = (
@@ -79965,8 +79949,8 @@
 "xjT" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/machinery/light/small/dim/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "xjV" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/food_or_drink/booze{
@@ -80219,6 +80203,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/service/hydroponics)
 "xor" = (
@@ -80317,6 +80302,9 @@
 "xpV" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/bartender,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "xqa" = (
@@ -80467,6 +80455,14 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"xrl" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "xrx" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
@@ -80640,13 +80636,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "xtX" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "xut" = (
@@ -80734,6 +80726,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"xvy" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/glass,
+/area/station/service/kitchen)
 "xvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81636,6 +81633,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
+"xLf" = (
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/chair/sofa/middle/brown{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "xLj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -81729,9 +81733,9 @@
 /area/station/medical/virology)
 "xML" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "xMS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -82119,6 +82123,15 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
+"xSO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "xSR" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/rack,
@@ -82141,9 +82154,12 @@
 /turf/open/openspace,
 /area/station/hallway/primary/port)
 "xTc" = (
-/obj/machinery/smartfridge/food,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/large,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchen_service"
+	},
+/turf/open/floor/plating,
 /area/station/service/kitchen)
 "xTd" = (
 /obj/effect/spawner/random/structure/girder,
@@ -82443,6 +82459,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/art)
+"xXe" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/service/library)
 "xXr" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb,
@@ -82576,7 +82596,7 @@
 "xYm" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/siding/thinplating/corner,
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/service/library)
 "xYn" = (
 /obj/structure/table/wood,
@@ -83055,18 +83075,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"yfP" = (
-/obj/structure/transport/linear/public,
-/obj/structure/table,
-/obj/item/plate{
-	pixel_x = 6
-	},
-/obj/item/plate{
-	pixel_x = -13;
-	pixel_y = 8
-	},
-/turf/open/floor/plating/elevatorshaft,
-/area/station/commons/lounge)
 "yge" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -83154,13 +83162,6 @@
 /obj/structure/musician/piano/unanchored,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"yhD" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/wood/large,
-/area/station/medical/psychology)
 "yhJ" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -83183,18 +83184,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"yhT" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/service/kitchen)
 "yhW" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver{
@@ -107909,15 +107898,15 @@ gPW
 pBH
 dXd
 pmS
-lMf
+dSJ
 lMf
 aep
-hyZ
-gse
-jez
-gse
+fWY
+dMK
+apu
+bXy
 vaO
-own
+fWY
 xHv
 kfO
 xya
@@ -108169,12 +108158,12 @@ ars
 nDm
 nDm
 voY
-dWX
+fWY
 jez
-pUM
-gse
+apu
+sQI
 lAF
-own
+fWY
 vGi
 iLe
 tAM
@@ -108428,9 +108417,9 @@ fWY
 uzI
 fWY
 fWY
-fWY
-lSN
-bNt
+wvi
+sQI
+bQU
 bNt
 bNt
 czs
@@ -108685,7 +108674,7 @@ uxl
 ofE
 hjL
 fPh
-fWY
+hiV
 uGf
 tWQ
 bNt
@@ -108938,13 +108927,13 @@ xAj
 gse
 own
 bmH
-wLO
-ofE
+lqO
+sic
 xpV
 jpy
-fWY
-fWY
-tTO
+apu
+apu
+bsW
 bNt
 bNt
 aHO
@@ -109191,7 +109180,7 @@ vZQ
 gPW
 drC
 peX
-xAj
+kgN
 sWI
 own
 bdu
@@ -109200,9 +109189,9 @@ moE
 tmV
 tAJ
 qak
+hkq
 fWY
-wnu
-tDy
+bNt
 bNt
 bNt
 bNt
@@ -109459,7 +109448,7 @@ vsf
 fXf
 fWY
 bNt
-bUQ
+tDy
 hrh
 tpj
 tTO
@@ -109706,9 +109695,9 @@ gPW
 own
 own
 rxI
-gse
-own
-aFo
+kRS
+csm
+wCJ
 fWV
 mCw
 dXP
@@ -109961,11 +109950,11 @@ oNa
 oNa
 xaQ
 own
-gmA
-xAj
-kRS
-wjU
-wCJ
+hRX
+cQF
+own
+own
+tER
 ozL
 bbY
 sbh
@@ -110217,19 +110206,19 @@ hxC
 oNa
 oNa
 cGK
-aXe
-aXe
-rjy
-aXe
-aXe
+hRX
+dEq
+hwW
+smc
+fob
 wYP
 wny
-mKU
-sXZ
+xHc
+xHc
 uKp
 tRc
 bNt
-mJI
+tTO
 tDy
 iGB
 iGB
@@ -110470,17 +110459,17 @@ bRv
 bxT
 wIa
 gPW
-hxC
+hZx
 oNa
 oNa
 cGK
-aXe
+hRX
 hgu
 abF
 hwW
 mTx
-siP
-jMw
+wYP
+xHc
 rkD
 uki
 pOM
@@ -110728,19 +110717,19 @@ kpS
 uME
 gPW
 gPW
-oNa
+lxS
 oNa
 cGK
-aXe
+hRX
 hnt
 oCX
-ibb
-wPG
-siP
-jMw
-yfP
+hwW
+bcc
+vsQ
+xHc
 jBU
-pOM
+jBU
+eCl
 pWr
 nyB
 bNt
@@ -110988,17 +110977,17 @@ gPW
 egU
 gPW
 gPW
-aXe
+hRX
 neF
 lAW
 pbk
-wPG
-siP
-jgL
-dEs
+mTx
+nWN
+xHc
+dXP
 wji
-pyk
-tOj
+pOM
+siP
 mfA
 bNt
 tTO
@@ -111245,17 +111234,17 @@ tpU
 nny
 kjF
 nLl
-aXe
+hRX
 pef
-lAW
-sBj
-wPG
-siP
+iuO
+hkv
+bcc
+vsQ
 cWt
 xHc
 ine
 csk
-stn
+tOj
 aIL
 bNt
 tDy
@@ -111499,16 +111488,16 @@ anm
 anm
 anm
 anm
-bOk
+gJu
 aKV
-bOk
-aXe
+jmZ
+hRX
 mrp
-abF
-iWl
-gpd
-bcj
-oGS
+leB
+hkv
+mTx
+wYP
+xHc
 csM
 ine
 qGF
@@ -111757,20 +111746,20 @@ ouW
 jJl
 gNr
 goW
-kmx
+aKV
 gJu
-aXe
-aXe
+hRX
+sOJ
 wwR
-aXe
-aXe
-mSd
-mSd
-cLf
-blA
+qNV
+mTx
+nbC
+wjW
+siP
+pWr
 xtX
-mSd
-mSd
+tOj
+sPg
 bNt
 wqI
 dBm
@@ -112014,16 +112003,16 @@ qkU
 uPu
 gNr
 gNr
-bOk
+rdu
 hcC
 tXg
-rre
-mgu
-mFZ
-bOk
-vSN
+hRX
+hRX
+tVP
+hRX
+xdV
 mSd
-byY
+eUp
 crB
 gfC
 jVI
@@ -112266,24 +112255,24 @@ gPW
 gfH
 qHg
 svW
+kzC
+qvM
 uPu
-haB
-fCK
-fMS
+uPu
 sDu
-bOk
-bOk
-btf
-wpt
+byY
+kzM
+bIi
+bIi
 hWd
 xjT
 xML
-wPx
-gtZ
 bIi
+gtZ
+mBb
 qRC
 akU
-ued
+fLr
 fLr
 rfU
 fLr
@@ -112522,25 +112511,25 @@ gPW
 ndl
 vxh
 jjC
-hZl
-uPu
+svW
+rjU
 fHR
 hWb
-ldk
-gNr
-bti
-bOk
-fQL
-lDE
-lDE
+uPu
+fEc
+byY
+grW
+wcQ
+byY
+byY
 qpP
-lDE
-lDE
-lDE
+qNw
+qNw
+mDZ
 jrz
 fyz
 bmD
-wHn
+fUb
 fUb
 fUb
 fUb
@@ -112777,27 +112766,27 @@ iUx
 gPW
 gPW
 utq
-aTt
+nyq
 wQS
-hZl
-uPu
-haB
-nHV
-kyo
+svW
+mHJ
+rUC
+fFe
+xHK
 gNr
-tUX
-tUX
-fSt
-lDE
+bOk
+bOk
+lKa
+bOk
 qBl
-rUE
-pxZ
-pRw
-lDE
-stu
-epI
-tnA
-ebf
+oSI
+hGP
+fzV
+xrl
+fLr
+pzy
+gxP
+fLr
 fLr
 fLr
 fLr
@@ -113034,26 +113023,26 @@ sHT
 bGF
 gPW
 kQn
-aTt
-wQS
-tfX
+xXe
+aYw
+svW
+gUx
+vUd
 uPu
-haB
-oww
 hSd
 gNr
 mFZ
 tUX
 fQL
-lDE
+bOk
 hwV
-dhq
-sbD
-oHw
-eVl
-gvr
-dHs
-ebf
+oSI
+kEn
+gnA
+dJV
+fLr
+pzy
+fLr
 jGw
 bpl
 oGG
@@ -113293,22 +113282,22 @@ gPW
 cRN
 xYm
 iQw
-hZl
-uPu
+svW
+lSP
 haB
-sBT
-bZW
+uPu
+kYN
 gNr
 knM
 tUX
 fSt
 lDE
-ujy
-lio
-vcR
-kmy
-bfO
-bTt
+lDE
+vSp
+lDE
+lDE
+lDE
+fLr
 pzy
 fLr
 fOe
@@ -113549,11 +113538,11 @@ xKQ
 gPW
 gPW
 cGO
-qHg
-svW
-uPu
+wvx
+fPb
+vRM
 haB
-kYN
+uPu
 hgL
 gNr
 gNr
@@ -113561,12 +113550,12 @@ xTd
 fQL
 lDE
 ptt
-pJD
-kSo
-oHw
-eVl
+rUE
+pxZ
+pRw
+lDE
 cKg
-fjt
+vMU
 fLr
 jwI
 dwf
@@ -113806,24 +113795,24 @@ cZo
 oLO
 gPW
 gPW
-gNr
+ulx
 uum
-uPu
+nmn
 ikq
-vRM
-vRM
+kHv
+kHv
 ktd
 gNr
-bOk
+kns
 fSt
 lDE
 rkN
-mNx
-uIt
-cfp
-lDE
+dhq
+sbD
+oHw
+eVl
 gSG
-fjt
+vMU
 fLr
 fOe
 qTG
@@ -114062,26 +114051,26 @@ xKQ
 gPW
 pOt
 nHS
-gPW
+aXe
 iyA
-uPu
+gwv
 oAp
 dZA
 fvk
-vJi
+kHv
 aUU
 gNr
 eAT
 cnv
 lDE
-lDE
-bZm
-lDE
-lDE
-lDE
+uKN
+lio
+vcR
+qkF
+eVl
 hZD
-xhl
-rKw
+vMU
+fLr
 dWp
 okC
 ams
@@ -114319,26 +114308,26 @@ gqn
 gPW
 gPW
 vKt
-gPW
+aXe
 qjZ
-lSP
+imB
 mSt
-whN
+wPG
 bfw
-fFe
+kHv
 uPu
 ojU
-llv
+lyq
 cnv
-tKl
+lDE
 tjg
-hni
-dBm
-vSN
-dBm
+pJD
+kSo
+oHw
+eVl
 wUb
-rui
-byY
+vMU
+fLr
 vuO
 vuO
 pPt
@@ -114364,7 +114353,7 @@ qDM
 rdk
 mrj
 ddz
-fLr
+ckZ
 iLm
 fLr
 pEO
@@ -114575,27 +114564,27 @@ pPf
 gqp
 nmO
 gPW
-oLO
-gPW
+dIW
+rYV
 pXE
 fHv
-oAp
-toH
-eep
-fFe
+skQ
+wPG
+bfw
+tbw
 scE
 gNr
-kCO
+llv
 rjK
-rjK
-rjK
+lDE
+hdX
 hni
-dBm
-mwo
-gNj
-byY
-rui
-dDX
+uIt
+cfp
+lDE
+req
+vMU
+jMi
 vuO
 ugN
 tGb
@@ -114832,27 +114821,27 @@ hPY
 qiz
 pje
 gPW
-pOt
-gPW
+pVw
+aXe
 dBd
 gft
-uPu
-haB
-jzi
-uPu
+gyd
+wPG
+bfw
+kHv
 xHK
 gNr
 jYE
-qGm
-rFC
-pBW
-hni
-dBm
-dBm
-dBm
+cnv
+lDE
+lDE
+hAm
+lDE
+lDE
+lDE
 kTW
-rui
-byY
+vMU
+fLr
 hRd
 bUO
 aqo
@@ -115090,26 +115079,26 @@ gqp
 pUr
 gPW
 nvR
-gPW
+aXe
 ghz
-wqC
-uPu
-haB
-uPu
-uPu
+gft
+sBj
+wPG
+bfw
+kHv
 izF
 byy
 tfr
-tfr
-tfr
+oIe
+oIe
 oIe
 ayD
-llv
-llv
+lkj
+lkj
 caF
-luf
-dGr
-luf
+ckZ
+vMU
+fLr
 hRd
 jCt
 xSk
@@ -115347,14 +115336,14 @@ mrM
 jMr
 gPW
 sik
-gPW
-gNr
-gNr
-dCp
+aXe
+cCj
+caV
+giz
 hNy
 saE
-dCp
-gNr
+xSO
+vuo
 gNr
 bOk
 bOk
@@ -115605,11 +115594,11 @@ flH
 pwT
 cte
 nYp
-hWu
+tAT
 njv
 tAT
 pPb
-tAT
+rTH
 gQA
 rTH
 bUf
@@ -119703,16 +119692,16 @@ eHF
 eHF
 heR
 ixf
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 ixf
 jcz
 bIS
@@ -119960,16 +119949,16 @@ eHF
 cOu
 cOu
 ixf
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
 waU
+osO
+osO
 kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
 ixf
 jcz
 bIS
@@ -120217,16 +120206,16 @@ eHF
 heR
 heR
 ixf
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 ixf
 lOh
 bIS
@@ -120474,16 +120463,16 @@ dcE
 heR
 dcE
 ixf
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 ixf
 jcz
 bIS
@@ -120732,14 +120721,14 @@ cOu
 cOu
 bPW
 mmi
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 mPB
 bPW
 jkR
@@ -120988,16 +120977,16 @@ dcE
 heR
 dcE
 ixf
+osO
+osO
+osO
+osO
+osO
 kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
 ixf
 lOh
 uVY
@@ -121245,16 +121234,16 @@ eHF
 heR
 heR
 ixf
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 ixf
 jcz
 bIS
@@ -121502,16 +121491,16 @@ eHF
 cOu
 cOu
 ixf
+osO
 kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 ixf
 jcz
 bIS
@@ -121759,16 +121748,16 @@ eHF
 eHF
 heR
 ixf
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
-kEx
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
+osO
 ixf
 lOh
 bIS
@@ -170612,7 +170601,7 @@ gPW
 gPW
 gPW
 gPW
-rVJ
+uyw
 tcb
 tcb
 ban
@@ -175504,7 +175493,7 @@ hRX
 dEH
 pjd
 glj
-dBh
+tfK
 gHJ
 ajG
 hRX
@@ -175753,14 +175742,14 @@ oIk
 bOk
 bOk
 iRH
-aXe
-aXe
-qQK
-aXe
+hRX
+hRX
+iEH
+hRX
 hRX
 lxh
 ask
-gWq
+aQu
 aQu
 pfd
 ckp
@@ -176010,20 +175999,20 @@ ibw
 bOk
 bTF
 jBk
-aXe
-hHm
+hRX
+cFa
 cTc
 eGs
-hRX
+kUI
 fyp
 pag
-sLd
-cFa
+pDR
+ldN
 fqC
 tfK
 cKX
 ofL
-hpR
+xyF
 pME
 nkh
 hPV
@@ -176267,20 +176256,20 @@ rkf
 bOk
 uLb
 jBk
-oSw
+hRX
 cmf
 pDO
-jkx
-hRX
+tfK
+tfK
 por
-rrv
+pag
 vgh
-cFa
+ldN
 fqC
 tfK
 rtd
 taJ
-bQi
+mKZ
 pME
 mKZ
 xyF
@@ -176524,17 +176513,17 @@ oIk
 bOk
 uJI
 jBk
-aXe
+hRX
 hBY
 taF
-dGx
-hRX
+tfK
+tfK
 uku
 jLY
-qwF
+reh
 qwF
 ktL
-wmd
+tfK
 mek
 ofL
 mKZ
@@ -176781,20 +176770,20 @@ bOk
 bOk
 fkX
 wko
-aXe
-hkO
-gZv
-mUY
 hRX
+sLd
+cFa
+mUY
+mKO
 shv
 lHE
-tfK
-tfK
+xvy
+cYo
 hQk
 jui
 hRX
 wBR
-dZm
+lFj
 ptT
 lFj
 pMZ
@@ -177038,23 +177027,23 @@ bOk
 opB
 uCF
 laD
-aXe
+hRX
 imo
-jug
+cFa
 sGS
 hRX
-lRF
+xTc
 tNC
-bDf
+cHO
 cHO
 aso
 xTc
 hRX
-aad
-aad
+gMI
+slN
 xhO
 gMI
-oqi
+aad
 aad
 aad
 aad
@@ -177288,26 +177277,26 @@ uRd
 bOk
 pBI
 rIi
-riR
+uIA
 riR
 oBH
 bOk
 bOk
 bOk
 laD
-aXe
-aXe
-aXe
-eZW
+hRX
+hRX
+hRX
+bnZ
 bnZ
 jFI
-sZB
-niC
-spy
-aCV
-buV
+cqj
+qeX
+qeX
+qeX
+qeX
 qJo
-iEH
+pmg
 iBZ
 oDC
 upV
@@ -177548,23 +177537,23 @@ lEG
 qrz
 qrz
 rBm
-rIi
+hsG
 bOk
 jBk
 juq
 hqD
 bAg
-hGg
-bvq
-hRX
-cFa
+uCF
+uCF
+dBm
+jEv
 cor
-yhT
-yhT
-rVj
+oLo
+oLo
+oLo
 oLo
 pmN
-hRX
+tcf
 mGh
 axr
 jOe
@@ -177799,10 +177788,10 @@ pev
 aVT
 bOk
 bOk
-riR
-riR
+gfG
+oZJ
 riE
-eie
+hoj
 luw
 hoj
 uZu
@@ -177813,9 +177802,9 @@ bOk
 mep
 bOk
 bOk
-hRX
-hRX
-hRX
+dBm
+dEN
+kSZ
 dUb
 dUb
 dUb
@@ -178056,23 +178045,23 @@ pev
 cQP
 bOk
 sch
-riR
-riR
-riR
-oNi
 oZJ
-oZJ
+cdy
+tsd
+rlE
+rlE
+rlE
 ige
 haE
 rIi
-umH
-gDe
+dCp
+dEN
 tnu
 gSq
 ikR
 klJ
-saQ
-umH
+dEN
+kSZ
 dUb
 dUb
 dUb
@@ -178312,24 +178301,24 @@ bOk
 pev
 aVT
 bOk
-riR
+oIU
 aLu
-riR
-riR
+oZJ
+tsd
 aWa
-oZJ
-oZJ
+xLf
+ito
 qRA
 spO
 hyS
 uii
 dYi
 vua
-hPQ
+dEN
 sbd
 pzb
 vNc
-dJB
+kSZ
 dUb
 dUb
 fDE
@@ -178567,26 +178556,26 @@ sUx
 sUx
 bOk
 pev
-cQP
+mmU
 bOk
-riR
-riR
-riR
-riR
-oNi
+nTw
+sMp
 oZJ
-oZJ
+tsd
+hOO
+hOO
+hOO
 qRA
-fLM
-wDn
-umH
-nyX
-ria
-ibf
-ibf
-kki
-loW
-dJB
+aTt
+hyS
+uii
+dEN
+tnu
+dEN
+sbd
+ukT
+vIw
+kSZ
 dUb
 dUb
 fDE
@@ -178826,24 +178815,24 @@ bOk
 pev
 cQP
 bOk
-sch
-riR
-riR
-riR
+oYP
+bSu
+oZJ
+tsd
 oNi
-oZJ
-oZJ
+kLF
+eXx
 qRA
-vbd
-ogY
-umH
-rVw
+aTt
+hyS
+dCp
+dEN
 scT
-smd
+dEN
 wog
-yhD
-gHR
-umH
+dEN
+dEN
+kSZ
 dUb
 dUb
 fDE
@@ -179082,21 +179071,21 @@ xVy
 bOk
 bOk
 cQP
+sJR
 bOk
-bOk
-riR
-riR
+tBt
+oZJ
 kll
-jOW
-oZJ
-oZJ
-gLf
+rlE
+rlE
+rlE
+qRA
 mvH
 evq
 umH
-umH
+rGn
 eVF
-umH
+hTr
 umH
 umH
 umH
@@ -179341,18 +179330,18 @@ bOk
 cQP
 cQP
 bOk
-bOk
-nrf
+sJR
+sJR
 udE
 wpA
-oZJ
-oZJ
-qRA
-jPA
+sJR
+uRU
+nmS
+aTt
 aum
 umH
 ipQ
-flY
+qWW
 grJ
 umH
 kPH
@@ -179598,20 +179587,20 @@ bOk
 anY
 cQP
 cQP
-bOk
+sJR
 erM
 qJK
-wpA
-oZJ
-oZJ
-qRA
+tIO
+sJR
+ikG
+aTt
 aTt
 dVn
 umH
 ipQ
-xuQ
+cjv
 hsL
-wpc
+umH
 dfC
 quB
 sXd
@@ -179855,13 +179844,13 @@ bOk
 bOk
 bOk
 cQP
-bOk
+aJg
 tYt
-qJK
-wpA
-oZJ
-oZJ
-qRA
+qMm
+lTx
+sJR
+aTt
+aTt
 pgO
 vsh
 umH
@@ -180112,12 +180101,12 @@ uRt
 tGM
 bOk
 cQP
-bOk
+sJR
 dZH
-qJK
-wpA
-oZJ
-oZJ
+ggN
+qeq
+sJR
+aTt
 lgi
 wvc
 koM
@@ -180126,9 +180115,9 @@ llY
 uLf
 ulM
 umH
-umH
-umH
-umH
+wDu
+pGn
+uGT
 sRG
 dUb
 fDE
@@ -180369,13 +180358,13 @@ xqd
 cHp
 bOk
 cQP
-bOk
+sJR
 qLF
-qJK
+typ
 scf
-jXx
-jXx
-nmS
+sJR
+aTt
+lgi
 ugn
 tfR
 umH
@@ -180383,9 +180372,9 @@ tdt
 dgD
 hcD
 wZN
-vzY
-fZp
-umH
+flY
+xuQ
+dEo
 dUb
 dUb
 fDE
@@ -180626,14 +180615,14 @@ xqd
 oNs
 hFT
 cQP
-bOk
+sJR
 iib
-qJK
+pWC
 jXC
 eZt
+sow
 hoj
 hoj
-eNI
 mqJ
 umH
 cLi
@@ -180883,15 +180872,15 @@ xqd
 fua
 bOk
 bOk
-bOk
-gNr
+sJR
+sJR
+sJR
+sJR
+sJR
+dCp
+dCp
+dCp
 lEB
-gNr
-gNr
-pxk
-pxk
-gNr
-gNr
 umH
 umH
 umH

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -266,9 +266,6 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "aeq" = (
@@ -697,6 +694,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
@@ -1138,6 +1137,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/east,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "arv" = (
@@ -1766,9 +1766,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/vending/dinnerware,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/machinery/computer/order_console/cook,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "aBV" = (
 /obj/effect/spawner/random/structure/crate,
@@ -1936,6 +1937,14 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"aEG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/emcloset,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "aEO" = (
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
@@ -2188,17 +2197,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aIL" = (
-/obj/item/stack/spacecash/c200{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
-/obj/effect/spawner/random/entertainment/deck{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/structure/table/wood/poker,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "aIO" = (
@@ -2209,6 +2211,9 @@
 	},
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "aIP" = (
@@ -2356,6 +2361,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"aKY" = (
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "aLa" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2609,6 +2619,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/science/explab)
+"aOX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "aPg" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table,
@@ -3423,6 +3439,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
+"baL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/ladder,
+/turf/open/space/basic,
+/area/station/maintenance/port/fore)
 "bba" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner{
@@ -3471,12 +3492,14 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
-	location = "Restaurant"
+	location = "44444"
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "bcc" = (
@@ -3486,7 +3509,13 @@
 	id = "kitchen_counter";
 	name = "Kitchen Counter Shutters"
 	},
-/turf/open/floor/wood,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/wood/large,
 /area/station/service/kitchen)
 "bcg" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
@@ -4479,29 +4508,12 @@
 /area/station/medical/chemistry)
 "bsW" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/bottle/tequila{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/cup/glass/bottle/vodka{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/cup/glass/bottle/absinthe{
-	pixel_x = 5;
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/cup/glass/bottle/rum{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/cup/glass/bottle/cognac{
-	pixel_x = -7;
-	pixel_y = 15
-	},
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
+	},
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -5106,6 +5118,9 @@
 	},
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "bCv" = (
@@ -5771,8 +5786,6 @@
 /area/station/security/office)
 "bKL" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
 /obj/item/wrench,
 /obj/item/crowbar/red,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -6128,7 +6141,6 @@
 /turf/open/floor/plating,
 /area/station/solars/starboard/aft)
 "bQU" = (
-/obj/machinery/vending/boozeomat,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -6137,6 +6149,8 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "bRa" = (
@@ -6614,6 +6628,7 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "bXA" = (
@@ -6877,13 +6892,6 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
-"caV" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/black,
-/area/station/service/theater)
 "cba" = (
 /turf/open/openspace,
 /area/station/hallway/primary/port)
@@ -7735,12 +7743,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
-"cnv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "cnw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -8007,10 +8009,9 @@
 /area/station/maintenance/solars/port/aft)
 "crB" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Bar"
+	name = "Bar & Restaurant"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/bar,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
 "crE" = (
@@ -8077,14 +8078,14 @@
 /area/station/security/office)
 "csk" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/mug/tea,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "csm" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
@@ -8092,6 +8093,9 @@
 /obj/machinery/door/airlock{
 	name = "Service Hall"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "cst" = (
@@ -8800,17 +8804,32 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cCj" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/bowl/soup/stew{
-	desc = "Exactly what it says on the tin.";
-	initial_reagent = /datum/reagent/consumable/condensedcapsaicin;
-	name = "6 seconds blinding stew";
-	pixel_y = 12
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/food/pie/cream{
+	pixel_y = 9
+	},
+/obj/item/food/pie/cream{
+	pixel_y = 9
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/obj/item/bikehorn/airhorn{
+	pixel_x = 9;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "cCq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -10207,7 +10226,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -11331,6 +11349,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dpr" = (
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/checker,
+/area/station/service/bar)
 "dpv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -11367,6 +11392,8 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
@@ -12074,16 +12101,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "dBd" = (
-/obj/item/clothing/head/costume/sombrero{
-	pixel_y = 8
-	},
-/obj/item/soap{
-	pixel_y = 2
-	},
-/obj/structure/table/wood,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/carpet/black,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "dBe" = (
 /obj/item/kirbyplants/photosynthetic,
@@ -12872,6 +12893,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/service)
 "dNu" = (
@@ -12894,10 +12918,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"dNI" = (
-/obj/structure/sign/poster/contraband/borg_fancy_1/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "dNL" = (
 /obj/item/bouquet/sunflower{
 	pixel_y = 4
@@ -13182,9 +13202,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/sign/poster/official/cleanliness/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "dSS" = (
@@ -13697,8 +13715,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "dZA" = (
-/obj/structure/table/wood,
-/obj/item/gun/magic/wand/nothing,
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
 "dZF" = (
@@ -13711,9 +13728,9 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "dZH" = (
-/obj/structure/dresser,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/wood/large,
 /area/station/service/theater_dressing)
 "dZM" = (
@@ -14020,6 +14037,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"edl" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/water,
+/area/station/maintenance/port/fore)
 "eds" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14141,6 +14163,12 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"eeW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "efh" = (
 /obj/item/cigbutt{
 	pixel_x = -9;
@@ -14301,7 +14329,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Blue Base"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/light/colour_cycle,
 /area/station/maintenance/hallway/abandoned_recreation)
 "egX" = (
 /obj/structure/disposalpipe/segment{
@@ -15764,16 +15792,12 @@
 /area/station/engineering/break_room)
 "eGs" = (
 /obj/machinery/airalarm/directional/west,
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "eGt" = (
@@ -15791,6 +15815,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"eGC" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "eGE" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
@@ -16027,6 +16055,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"eKz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "eKF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -16779,13 +16811,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"eUp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/herringbone,
-/area/station/commons/lounge)
 "eUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18996,14 +19021,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
 "fBd" = (
-/obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/deck{
 	pixel_x = -7;
 	pixel_y = 13
 	},
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "fBh" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -19209,6 +19233,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"fEW" = (
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "fFe" = (
 /obj/structure/chair{
 	dir = 1;
@@ -19236,6 +19264,10 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/surgery)
+"fFq" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/openspace,
+/area/station/hallway/secondary/service)
 "fFA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -19277,11 +19309,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "fGm" = (
@@ -19397,11 +19429,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
-"fHv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
 "fHG" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname/directional/north,
@@ -19814,34 +19841,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/openspace,
 /area/station/cargo/storage)
-"fPh" = (
-/obj/structure/table/wood,
-/obj/machinery/coffeemaker/impressa,
-/obj/item/storage/box/coffeepack{
-	pixel_x = 15;
-	pixel_y = 10
-	},
-/obj/item/storage/box/coffeepack{
-	pixel_x = 15;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = 13;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = 13;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = 13;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/bar)
 "fPi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/catwalk_floor,
@@ -19939,9 +19938,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/explab)
 "fQL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fQQ" = (
@@ -20081,11 +20079,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
-"fSt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "fSF" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/turf_decal/siding/dark,
@@ -20183,6 +20176,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "fUd" = (
@@ -20217,6 +20211,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
+"fUm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/hallway/secondary/service)
 "fUu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20228,6 +20231,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "fUE" = (
@@ -20468,9 +20474,6 @@
 /turf/closed/wall,
 /area/station/service/bar)
 "fXf" = (
-/obj/effect/spawner/random/entertainment/cigarette{
-	pixel_x = -5
-	},
 /obj/item/lighter{
 	pixel_x = 8;
 	pixel_y = 4
@@ -20554,6 +20557,12 @@
 /obj/effect/turf_decal/tile/brown/full,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/lesser)
+"fYd" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "fYq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -21043,22 +21052,17 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "geO" = (
-/obj/structure/cable,
 /obj/structure/chair/stool/bar/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/bar,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "gfc" = (
-/obj/structure/chair/sofa/left/brown{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/microwave/directional/south,
 /turf/open/floor/plating,
@@ -21089,10 +21093,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"gft" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
 "gfz" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/disposalpipe/segment,
@@ -21103,9 +21103,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
-	name = "Bar"
+	name = "Bar & Restaurant"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/lounge)
@@ -21249,10 +21251,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ghz" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/carpet/black,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood,
+/obj/item/soap{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/bowl/soup/stew{
+	desc = "Exactly what it says on the tin.";
+	initial_reagent = /datum/reagent/consumable/condensedcapsaicin;
+	name = "6 seconds blinding stew";
+	pixel_y = 12
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "ghA" = (
 /obj/structure/lattice/catwalk,
@@ -21376,9 +21387,6 @@
 "giz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
@@ -21748,10 +21756,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gnp" = (
+/obj/structure/showcase/machinery/tv,
 /obj/structure/table,
-/obj/structure/showcase/machinery/tv/broken{
-	pixel_y = 8
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gnt" = (
@@ -21948,8 +21954,10 @@
 /area/station/engineering/supermatter/room)
 "goW" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "gph" = (
@@ -21977,6 +21985,9 @@
 /area/station/service/library/printer)
 "gpv" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "gpx" = (
@@ -22021,6 +22032,9 @@
 /obj/item/mop,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "gqb" = (
@@ -22376,10 +22390,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"gwv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/black,
-/area/station/service/theater)
 "gwx" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat Space Access Airlock"
@@ -22443,8 +22453,7 @@
 /area/station/service/library/private)
 "gyd" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "gyg" = (
 /obj/structure/cable,
@@ -22516,9 +22525,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
 "gyL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /obj/structure/chair/stool/bar/directional/west,
-/obj/machinery/light/warm/dim/directional/south,
-/obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "gyN" = (
@@ -24442,9 +24455,6 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "hcC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Community Center"
 	},
@@ -24872,7 +24882,6 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/construction)
 "hjL" = (
-/obj/machinery/light_switch/directional/west,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -24880,6 +24889,7 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/machinery/light/warm/dim/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "hkm" = (
@@ -24887,7 +24897,6 @@
 /area/station/maintenance/starboard/fore)
 "hkq" = (
 /mob/living/carbon/human/species/monkey/punpun,
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
@@ -25372,12 +25381,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"hrh" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "hri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/snackvend,
@@ -25705,6 +25708,7 @@
 /area/station/maintenance/starboard/fore)
 "hwV" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "hwW" = (
@@ -26251,6 +26255,7 @@
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/hop_office,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "hEf" = (
@@ -26525,6 +26530,9 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
@@ -27013,7 +27021,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/smoke_machine,
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
 /area/station/service/theater)
 "hNC" = (
@@ -27410,7 +27418,6 @@
 /area/station/medical/surgery)
 "hSA" = (
 /obj/machinery/light/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/wood,
 /area/station/commons/storage/tools)
@@ -27568,11 +27575,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/service/library)
-"hWd" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "hWk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
@@ -28603,10 +28605,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"imB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
 "imJ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -28769,8 +28767,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "ioC" = (
-/obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "ioK" = (
@@ -29128,6 +29126,14 @@
 "itq" = (
 /turf/open/floor/engine/hull/air,
 /area/station/engineering/lobby)
+"itr" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "itt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
@@ -29461,7 +29467,10 @@
 	pixel_x = -5
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "iyE" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -30953,6 +30962,16 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port)
+"iSW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/carpet/orange,
+/area/station/commons/lounge)
 "iSX" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -31122,6 +31141,13 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"iVA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/commons/lounge)
 "iVT" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -32266,12 +32292,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "jmZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "jna" = (
 /obj/structure/disposalpipe/junction/flip,
@@ -32359,9 +32381,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "joE" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
@@ -32429,6 +32453,7 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "jpA" = (
@@ -33261,6 +33286,14 @@
 	},
 /turf/open/openspace,
 /area/station/engineering/break_room)
+"jAh" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "jAo" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -33558,6 +33591,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/main)
+"jDn" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "jDq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/trunk/multiz/down{
@@ -33596,6 +33638,16 @@
 	dir = 1
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"jDO" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "jDW" = (
 /obj/structure/table,
 /obj/item/burner/fuel{
@@ -35405,12 +35457,6 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
-"kgN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/modular_computer/preset/cargochat/service,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "khi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35427,6 +35473,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"kho" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/maintenance/hallway/abandoned_recreation)
 "khC" = (
 /obj/machinery/plumbing/receiver{
 	dir = 1
@@ -35675,6 +35725,10 @@
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/machinery/light/directional/east,
 /obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kll" = (
@@ -35973,8 +36027,11 @@
 /area/station/medical/virology)
 "koM" = (
 /obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck/cas/black,
 /obj/machinery/light/directional/south,
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "koU" = (
@@ -36845,13 +36902,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research)
-"kzM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "kzX" = (
 /obj/effect/spawner/random/contraband/prison,
 /obj/structure/rack,
@@ -36927,6 +36977,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"kAY" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/light/warm/dim/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "kAZ" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light/directional/north,
@@ -37362,6 +37423,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kIy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "kIz" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/comfy/brown{
@@ -37988,6 +38056,11 @@
 	},
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
+"kSP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/hallway/abandoned_recreation)
 "kSS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -38089,11 +38162,11 @@
 /area/station/security/detectives_office/private_investigators_office)
 "kUI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kUO" = (
@@ -39809,6 +39882,11 @@
 "lxn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box/corners,
+/obj/item/toy/crayon/spraycan,
+/obj/effect/spawner/random/food_or_drink/booze{
+	spawn_random_offset = 1
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "lxs" = (
@@ -40066,12 +40144,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lAF" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
 /obj/machinery/light/warm/dim/directional/south,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "lAG" = (
@@ -40145,6 +40222,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/holopad,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "lBg" = (
@@ -40161,6 +40239,9 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/machinery/firealarm/directional/south,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "lBi" = (
@@ -40779,10 +40860,9 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
 "lJM" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs/fake,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "lJQ" = (
@@ -40791,13 +40871,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"lKa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "lKb" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -40916,9 +40989,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/sink/directional/east,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
@@ -41014,6 +41084,10 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"lNg" = (
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "lNj" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -42285,9 +42359,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "mfA" = (
-/obj/item/kirbyplants/potty,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "mfD" = (
@@ -42966,9 +43040,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "mqY" = (
@@ -43111,6 +43182,10 @@
 /obj/structure/sign/poster/official/soft_cap_pop_art/directional/west,
 /turf/open/openspace,
 /area/station/maintenance/starboard/fore)
+"mth" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/station/service/library)
 "mtl" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/toy/plush/moth{
@@ -43913,11 +43988,6 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"mFZ" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "mGb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -44396,6 +44466,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/janitor,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "mNp" = (
@@ -44688,9 +44761,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "mSt" = (
-/obj/machinery/holopad,
 /obj/effect/landmark/start/mime,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "mSA" = (
 /obj/structure/bed,
@@ -44931,10 +45003,18 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "mWQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/eat/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/machinery/light/warm/dim/directional/south,
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "mWV" = (
 /obj/machinery/door/airlock/virology{
 	name = "Cytology Lab"
@@ -46886,11 +46966,7 @@
 	},
 /area/station/ai_monitored/command/nuke_storage)
 "nyB" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/item/storage/photo_album/bar,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "nyG" = (
@@ -47235,6 +47311,10 @@
 /area/station/maintenance/department/medical)
 "nDm" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light/warm/dim/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "nDt" = (
@@ -47524,6 +47604,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"nHo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -5
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "nHt" = (
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/structure/cable,
@@ -47735,7 +47823,7 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -48409,8 +48497,10 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "nUE" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/commons/lounge)
 "nUV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -49136,9 +49226,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
@@ -49338,6 +49425,18 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
+"oiW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/desk_bell{
+	pixel_x = -7
+	},
+/turf/open/floor/wood/large,
+/area/station/service/kitchen)
 "ojb" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -50398,6 +50497,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "ozN" = (
@@ -50423,13 +50524,6 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
-"oAp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/musician/piano/random_piano,
-/turf/open/floor/carpet/black,
-/area/station/service/theater)
 "oAz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50629,17 +50723,18 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/rag{
-	pixel_x = -4
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/item/holosign_creator/robot_seat/restaurant{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/stack/package_wrap,
+/obj/item/rag{
+	pixel_x = -4
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "oDc" = (
@@ -50924,8 +51019,6 @@
 	dir = 2
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/water,
 /area/station/maintenance/port/fore)
 "oIi" = (
@@ -52195,6 +52288,7 @@
 /obj/structure/railing/corner/end{
 	dir = 8
 	},
+/obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "oZV" = (
@@ -53088,6 +53182,9 @@
 /obj/effect/turf_decal/siding/end{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
 "pmV" = (
@@ -53525,6 +53622,11 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lab)
+"puJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/contraband/eat/directional/west,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central)
 "puR" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/directional/south,
@@ -53903,7 +54005,7 @@
 /obj/item/key/janitor,
 /obj/vehicle/ridden/janicart,
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "pBI" = (
@@ -54340,14 +54442,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/lesser)
-"pHR" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/commons/lounge)
 "pIf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54909,14 +55003,14 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pOM" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "pON" = (
 /obj/structure/sign/poster/official/safety_report/directional/south,
@@ -55363,6 +55457,9 @@
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "pTw" = (
@@ -55441,6 +55538,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
+"pUH" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/dice,
+/obj/item/stack/spacecash/c20{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "pUV" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/machinery/light/cold/directional/south,
@@ -55567,7 +55673,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/carpet/black,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "pXM" = (
 /obj/structure/railing/corner,
@@ -56331,30 +56438,15 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/central)
 "qjZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
-/obj/item/food/pie/cream{
-	pixel_y = 9
+/obj/item/clothing/head/costume/sombrero{
+	pixel_y = 8
 	},
-/obj/item/food/pie/cream{
-	pixel_y = 9
-	},
-/obj/item/food/pie/cream{
-	pixel_y = 9
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -14;
-	pixel_y = 6
-	},
-/obj/item/bikehorn/airhorn{
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet/black,
+/obj/item/gun/magic/wand/nothing,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "qki" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -57205,6 +57297,14 @@
 	},
 /turf/open/floor/glass,
 /area/station/service/kitchen)
+"qwJ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "qwX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -57545,11 +57645,6 @@
 	},
 /turf/open/openspace,
 /area/station/medical/storage)
-"qBl" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/wood,
-/area/station/hallway/primary/central)
 "qBm" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -57839,6 +57934,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
@@ -58199,6 +58296,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"qMI" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "qMK" = (
 /obj/structure/railing{
 	dir = 4
@@ -58320,6 +58423,7 @@
 	},
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "qNW" = (
@@ -58762,6 +58866,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"qVj" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "qVm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59376,11 +59486,11 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
 "rdu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Community Center"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
@@ -59705,12 +59815,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
-"rjK" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/water,
-/area/station/maintenance/port/fore)
 "rjO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/full,
@@ -60603,8 +60707,6 @@
 /area/station/command/heads_quarters/captain/private)
 "rwU" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -61143,18 +61245,8 @@
 /area/station/medical/cryo)
 "rFm" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/fax{
-	fax_name = "Service";
-	name = "Service Fax Machine"
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/table/reinforced,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "rFq" = (
@@ -62458,13 +62550,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rYV" = (
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/service/theatre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Theater Backstage"
+	},
 /turf/open/floor/plating,
 /area/station/service/theater)
 "rZl" = (
@@ -62555,6 +62647,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "sbn" = (
@@ -63283,10 +63377,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
-"skQ" = (
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
 "skR" = (
 /obj/structure/table/wood,
 /obj/item/vending_refill/cigarette{
@@ -64036,6 +64126,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "sxh" = (
@@ -64192,6 +64285,7 @@
 "sAn" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet,
 /area/station/commons/storage/tools)
 "sAp" = (
@@ -64252,7 +64346,7 @@
 /area/station/security/prison)
 "sBj" = (
 /obj/effect/landmark/start/clown,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "sBk" = (
 /obj/structure/disposalpipe/junction{
@@ -64326,11 +64420,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "sDu" = (
+/obj/effect/landmark/navigate_destination/library,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Community Center"
 	},
-/obj/effect/landmark/navigate_destination/library,
-/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/service/library)
 "sDX" = (
@@ -64622,6 +64716,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
@@ -65068,18 +65165,14 @@
 /area/station/science/breakroom)
 "sOJ" = (
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/stack/package_wrap,
-/obj/item/holosign_creator/robot_seat/restaurant,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/machinery/light/warm/dim/directional/east,
-/turf/open/floor/iron/kitchen,
+/obj/structure/transport/linear/public,
+/obj/machinery/smartfridge/food,
+/turf/open/floor/plating/elevatorshaft,
 /area/station/service/kitchen)
 "sON" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -65092,22 +65185,13 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "sPg" = (
-/obj/structure/table/wood/poker,
-/obj/item/cigarette/cigar{
-	pixel_x = 4
-	},
-/obj/item/stack/spacecash/c20{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/effect/spawner/random/entertainment/gambling{
-	pixel_x = 6;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/light/warm/dim/directional/south,
+/obj/structure/chair/stool/bar/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "sPj" = (
@@ -65160,9 +65244,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/computer/order_console/cook,
 /obj/structure/cable,
-/turf/open/floor/wood/large,
+/obj/machinery/modular_computer/preset/cargochat/service,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "sPC" = (
 /obj/machinery/holopad,
@@ -65681,7 +65768,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Blue Base"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/light/colour_cycle,
 /area/station/maintenance/hallway/abandoned_recreation)
 "sXL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66126,6 +66213,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"tev" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood,
+/area/station/service/library)
 "tey" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -66135,7 +66226,7 @@
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
 "teC" = (
-/obj/structure/chair/sofa/middle/brown{
+/obj/structure/chair/sofa/left/brown{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -66610,13 +66701,6 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"tmV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/bar)
 "tna" = (
 /obj/structure/fermenting_barrel/gunpowder,
 /obj/effect/decal/cleanable/greenglow,
@@ -66664,12 +66748,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "tnM" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "tnS" = (
@@ -66795,6 +66877,10 @@
 "tpj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/grey_tide/directional/west,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/booze{
+	spawn_random_offset = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "tpl" = (
@@ -67345,15 +67431,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"tAJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/bar)
 "tAK" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red{
@@ -67699,19 +67776,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "tER" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	canhear_range = 6;
-	frequency = 1421;
-	name = "Kitchen's Words";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/warm/dim/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "tES" = (
@@ -67983,8 +68057,8 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
 "tIO" = (
-/obj/structure/closet/crate/wooden/toy,
 /obj/machinery/light/directional/south,
+/obj/machinery/vending/clothing,
 /turf/open/floor/wood/large,
 /area/station/service/theater_dressing)
 "tIT" = (
@@ -68157,6 +68231,11 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
+"tLp" = (
+/obj/effect/turf_decal/siding/wood/end,
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "tLq" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -68355,8 +68434,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/hallway)
 "tOj" = (
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
 /area/station/commons/lounge)
 "tOr" = (
 /obj/structure/closet/secure_closet/hydroponics,
@@ -68502,7 +68586,13 @@
 	pixel_x = -5;
 	pixel_y = 16
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/station/commons/lounge)
 "tRd" = (
 /obj/structure/cable/layer3,
@@ -68799,14 +68889,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"tVP" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
-/turf/open/floor/wood,
-/area/station/service/kitchen)
 "tVR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -68882,7 +68964,6 @@
 /turf/open/openspace,
 /area/station/command/gateway)
 "tWQ" = (
-/obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
 	pixel_x = -6;
 	pixel_y = 9
@@ -68894,6 +68975,8 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/structure/table/wood,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "tWR" = (
@@ -69796,6 +69879,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "uki" = (
 /obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/orange,
 /area/station/commons/lounge)
 "ukk" = (
@@ -70617,7 +70701,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/siding/green/end{
+/obj/effect/turf_decal/siding/green{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -70786,9 +70870,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood/large,
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	fax_name = "Service";
+	name = "Service Fax Machine"
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "uwn" = (
 /obj/structure/cable,
@@ -71020,6 +71109,14 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"uyq" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "uyr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71122,7 +71219,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/station/service/bar)
+/area/station/hallway/secondary/service)
 "uzM" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -71525,7 +71622,6 @@
 /area/station/security/office)
 "uGf" = (
 /obj/effect/landmark/start/bartender,
-/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
@@ -71668,16 +71764,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "uHo" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
 	},
 /area/station/commons/lounge)
 "uHy" = (
@@ -71718,6 +71815,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"uHV" = (
+/obj/structure/chair/stool/bar/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "uHY" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
@@ -71858,15 +71966,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uKp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
 	},
 /area/station/commons/lounge)
 "uKt" = (
@@ -72420,6 +72530,9 @@
 	pixel_y = 27
 	},
 /obj/effect/landmark/start/janitor,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "uTc" = (
@@ -72445,12 +72558,9 @@
 /area/space)
 "uTk" = (
 /obj/structure/railing{
-	dir = 8
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/dark_blue,
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/smartfridge/food,
-/turf/open/floor/iron/kitchen,
+/turf/open/openspace,
 /area/station/service/kitchen)
 "uTy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -73918,6 +74028,12 @@
 /obj/structure/transport/linear,
 /turf/open/openspace,
 /area/station/science/robotics/lab)
+"vpO" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "vpS" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -74068,6 +74184,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"vrA" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "vrC" = (
 /obj/machinery/light/directional/east,
 /turf/open/openspace,
@@ -74081,14 +74204,11 @@
 /area/station/maintenance/starboard/lesser)
 "vsf" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/desk_bell{
 	pixel_x = 6;
 	pixel_y = 15
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "vsh" = (
@@ -74127,6 +74247,11 @@
 	dir = 1
 	},
 /area/station/service/chapel)
+"vsz" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "vsC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/photocopier/prebuilt,
@@ -74897,7 +75022,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Red Base"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/light/colour_cycle,
 /area/station/maintenance/hallway/abandoned_recreation)
 "vCP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -76457,6 +76582,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/sink/directional/west,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "wbk" = (
@@ -76549,7 +76677,7 @@
 /turf/open/openspace,
 /area/station/science/explab)
 "wcQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "wcT" = (
@@ -76599,7 +76727,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -76831,6 +76958,12 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"wfV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "wfY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/structure/tank_dispenser,
@@ -77358,7 +77491,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/commons/lounge)
 "wnA" = (
@@ -77547,9 +77679,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wqI" = (
-/obj/effect/spawner/random/trash/botanical_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/item/cigarette/cigar{
+	pixel_x = 4
+	},
+/obj/structure/chair/stool/bar/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark/end,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "wqN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -77820,7 +77957,7 @@
 /area/station/maintenance/starboard/lesser)
 "wvc" = (
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/dice,
+/obj/item/storage/dice,
 /turf/open/floor/carpet/stellar,
 /area/station/service/library)
 "wve" = (
@@ -77830,13 +77967,28 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/hallway)
 "wvi" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
-	},
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = 13;
+	pixel_y = 10
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "wvw" = (
@@ -77979,7 +78131,9 @@
 	},
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "wwV" = (
@@ -78457,8 +78611,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "wEX" = (
-/obj/structure/table,
-/obj/effect/spawner/random/entertainment/musical_instrument,
 /obj/structure/sign/poster/contraband/hacking_guide/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -78566,6 +78718,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai)
+"wGN" = (
+/obj/machinery/light/warm/dim/directional/south,
+/obj/item/kirbyplants/potty,
+/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "wGS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -79049,7 +79210,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/port)
 "wPG" = (
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/carpet/black,
 /area/station/service/theater)
 "wPI" = (
 /obj/machinery/firealarm/directional/east,
@@ -79594,6 +79755,10 @@
 	dir = 8
 	},
 /area/station/tcommsat/server)
+"wYo" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/orange,
+/area/station/commons/lounge)
 "wYw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -79647,12 +79812,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "wYU" = (
-/obj/item/vending_refill/games{
-	pixel_x = 6;
-	pixel_y = -4
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "wZb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -80329,16 +80495,9 @@
 /area/station/service/chapel)
 "xjT" = (
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/sign/poster/contraband/robust_softdrinks/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
-"xjV" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/food_or_drink/booze{
-	spawn_random_offset = 1
-	},
-/obj/item/toy/crayon/spraycan,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "xka" = (
 /obj/structure/table,
 /obj/item/cultivator{
@@ -80539,6 +80698,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
+"xns" = (
+/obj/machinery/light/warm/dim/directional/south,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "xnt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -80689,20 +80852,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xpV" = (
-/obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/bartender,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "xqa" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "xqd" = (
@@ -81838,10 +81999,6 @@
 /obj/item/storage/medkit/brute,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"xHK" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/wood,
-/area/station/service/library)
 "xHP" = (
 /obj/structure/chair{
 	dir = 1;
@@ -82244,9 +82401,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
 "xOl" = (
-/obj/item/radio/intercom/directional/south,
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/item/restraints/handcuffs/fake,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "xOm" = (
@@ -82261,10 +82417,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"xOn" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "xOt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -82319,11 +82471,7 @@
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
 "xPU" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/booze{
-	spawn_random_offset = 1
-	},
-/obj/structure/sign/poster/contraband/space_cube/directional/north,
+/obj/structure/sign/poster/contraband/space_cube/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xQf" = (
@@ -82468,7 +82616,9 @@
 "xRU" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/rnd/production/techfab/department/service,
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "xRZ" = (
@@ -82654,6 +82804,14 @@
 /obj/structure/sign/poster/contraband/communist_state/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"xUu" = (
+/obj/effect/turf_decal/box/red,
+/obj/item/vending_refill/games{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "xUv" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -82772,6 +82930,14 @@
 	},
 /turf/open/openspace,
 /area/station/engineering/break_room)
+"xVJ" = (
+/obj/machinery/firealarm/directional/south,
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/commons/lounge)
 "xVL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -82869,15 +83035,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"xXu" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/commons/lounge)
 "xXv" = (
 /obj/effect/spawner/random/structure/grille,
 /obj/structure/lattice,
@@ -108570,7 +108727,7 @@ iLe
 tAM
 ssg
 nQd
-iLe
+xUu
 bNt
 iCe
 qWk
@@ -108811,10 +108968,10 @@ gPW
 gPW
 gPW
 xqa
-gse
+wfV
 own
-fWY
-fWY
+own
+own
 uzI
 fWY
 wvi
@@ -109066,15 +109223,15 @@ jxg
 dol
 gPW
 xRU
-xOn
-xAj
+gse
+eeW
 xAt
 own
 wik
 ire
 ofE
 hjL
-fPh
+apu
 mwn
 uGf
 tWQ
@@ -109324,8 +109481,8 @@ vYH
 cFL
 xAj
 rPC
-xAj
-gse
+eeW
+xns
 own
 bmH
 sKL
@@ -109581,22 +109738,22 @@ vZQ
 gPW
 drC
 peX
-kgN
+eeW
 sWI
 own
 vTu
 uxl
 moE
-tmV
-tAJ
+apu
+apu
 apu
 hkq
+dpr
 fWY
-fWY
 bNt
 bNt
 bNt
-xjV
+bUQ
 ssg
 ubo
 bNt
@@ -109838,21 +109995,21 @@ gPW
 gPW
 atD
 dso
-xAj
+eeW
 pXb
 own
 apf
 uxl
 huW
-hDk
+nHo
 vsf
 fXf
 hDk
-fWY
-dNI
-hrh
+qwJ
+mSd
+bNt
 tpj
-tTO
+aOX
 tDy
 gfc
 bNt
@@ -110095,18 +110252,18 @@ jQe
 gPW
 own
 own
-rxI
-gse
+fUm
+wfV
 csm
-vTu
+jDO
 fWV
 mCw
 fVC
 geO
-fVC
+uHV
 gyL
-mSd
-tDy
+tLp
+wGN
 bNt
 gnp
 nuw
@@ -110360,11 +110517,11 @@ ozL
 bbY
 sbh
 fGj
-xXu
-pHR
-mSd
-tTO
-bNt
+qMI
+qMI
+qMI
+vrA
+fYd
 xPU
 wEX
 gBE
@@ -110619,8 +110776,8 @@ nyI
 uKp
 tRc
 lJM
-mSd
-tDy
+pWr
+qVj
 iGB
 iGB
 iGB
@@ -110868,15 +111025,15 @@ hRX
 hgu
 abF
 hwW
-mTx
-sjb
+oiW
+jDn
 wdf
 rkD
 uki
 pOM
 nUE
 xOl
-mSd
+siP
 wYU
 iGB
 pxv
@@ -111126,15 +111283,15 @@ hnt
 oCX
 hwW
 bcc
-vsQ
+sjb
 wdf
 jBU
-jBU
+wYo
 csk
-pWr
+nUE
 nyB
-mSd
-bUQ
+siP
+itr
 iGB
 hSA
 nwo
@@ -111387,11 +111544,11 @@ nWN
 wdf
 dXP
 wji
-pOM
-siP
+iSW
+iVA
 mfA
-mSd
-tTO
+siP
+aKY
 iGB
 sAn
 wWm
@@ -111647,8 +111804,8 @@ pRQ
 uHo
 tOj
 aIL
-mSd
-tDy
+uyq
+xVJ
 iGB
 mpt
 wWm
@@ -111881,7 +112038,7 @@ ixF
 eQj
 rAc
 gPW
-oLO
+kSP
 anm
 aQc
 anm
@@ -111899,12 +112056,12 @@ hkv
 mTx
 sjb
 mqU
-nUE
-siP
+vsz
+eKz
 qGF
 ioC
 fBd
-mSd
+pUH
 mWQ
 iGB
 lcO
@@ -112161,7 +112318,7 @@ djA
 dpV
 joE
 sPg
-mSd
+kAY
 wqI
 dBm
 dBm
@@ -112408,18 +112565,18 @@ rdu
 hcC
 tXg
 hRX
+jAh
 hRX
-tVP
 hRX
 xdV
 mSd
-eUp
+crB
 crB
 gfC
 jVI
 xdV
 mSd
-sDX
+eGC
 dBm
 iMH
 eha
@@ -112659,15 +112816,15 @@ svW
 kzC
 qvM
 uPu
-uPu
+tev
 sDu
-byY
-kzM
+kIy
+bIi
 bIi
 xML
-hWd
-xjT
 bIi
+xjT
+puJ
 bIi
 gtZ
 mBb
@@ -112917,9 +113074,9 @@ rjU
 fHR
 hWb
 uPu
-fEc
+dCp
 byY
-wcQ
+byY
 wcQ
 byY
 byY
@@ -113173,13 +113330,13 @@ svW
 mHJ
 rUC
 fFe
-xHK
-gNr
-bOk
-bOk
-lKa
-bOk
-qBl
+uPu
+fEc
+byY
+lNg
+byY
+byY
+byY
 oSI
 hGP
 fzV
@@ -113429,15 +113586,15 @@ aYw
 svW
 gUx
 vUd
-uPu
+mth
 hSd
 gNr
-mFZ
-tUX
+bOk
+bOk
 fQL
 bOk
 hwV
-oSI
+aEG
 kEn
 gnA
 dJV
@@ -113691,7 +113848,7 @@ kYN
 gNr
 knM
 tUX
-fSt
+tUX
 lDE
 lDE
 vSp
@@ -113948,7 +114105,7 @@ hgL
 gNr
 gNr
 xTd
-fQL
+tUX
 lDE
 ptt
 rUE
@@ -114205,7 +114362,7 @@ kHv
 ktd
 gNr
 kns
-fSt
+uCF
 lDE
 rkN
 dhq
@@ -114449,20 +114606,20 @@ jHV
 qcx
 ixF
 xKQ
-gPW
+kho
 pOt
 nHS
 aXe
 iyA
-gwv
-oAp
+dZA
+wPG
 dZA
 fvk
 kHv
 aUU
 gNr
 eAT
-cnv
+llv
 lDE
 uKN
 lio
@@ -114711,7 +114868,7 @@ gPW
 vKt
 aXe
 qjZ
-imB
+wPG
 mSt
 wPG
 bfw
@@ -114719,7 +114876,7 @@ kHv
 uPu
 ojU
 llv
-cnv
+llv
 lDE
 tjg
 pJD
@@ -114968,15 +115125,15 @@ gPW
 dIW
 rYV
 pXE
-fHv
-skQ
+wPG
+wPG
 wPG
 bfw
 tbw
 scE
 gNr
+edl
 llv
-rjK
 lDE
 hdX
 hni
@@ -115225,7 +115382,7 @@ gPW
 pVw
 aXe
 dBd
-gft
+wPG
 gyd
 wPG
 bfw
@@ -115233,7 +115390,7 @@ kHv
 woT
 gNr
 jYE
-cnv
+llv
 lDE
 lDE
 hAm
@@ -115482,7 +115639,7 @@ gPW
 nvR
 aXe
 ghz
-gft
+wPG
 sBj
 wPG
 bfw
@@ -115739,7 +115896,7 @@ gPW
 sik
 aXe
 cCj
-caV
+hNy
 giz
 hNy
 saE
@@ -175115,7 +175272,7 @@ lOd
 ohU
 tLK
 gPW
-gjH
+fFq
 gjH
 aBR
 qJS
@@ -177426,7 +177583,7 @@ iWo
 myx
 bOk
 opB
-uCF
+fEW
 laD
 hRX
 imo
@@ -177688,7 +177845,7 @@ laD
 hRX
 uTk
 aqg
-nHt
+vpO
 hRX
 jFI
 cqj
@@ -179985,7 +180142,7 @@ kJO
 sUx
 kdl
 bOk
-anY
+baL
 cQP
 cQP
 sJR

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -78174,6 +78174,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"wAB" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "wAO" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/storage/toolbox/mechanical/old,
@@ -178191,10 +178199,10 @@ uZu
 bOk
 aLa
 bOk
-dBm
-dBm
-dBm
-dBm
+hRX
+wAB
+hRX
+hRX
 hRX
 dEN
 kSZ

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -4517,7 +4517,7 @@
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
 	dir = 1;
-	pixel_y = 6
+	pixel_y = 3
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -6150,7 +6150,7 @@
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
 	pixel_x = -6;
-	pixel_y = 9
+	pixel_y = 6
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -9792,7 +9792,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/mail_sorting/service/theater,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "cQP" = (
@@ -11381,7 +11380,7 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_x = -4;
-	pixel_y = 7
+	pixel_y = 5
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -29615,9 +29614,8 @@
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
 "izF" = (
-/obj/machinery/disposal/bin,
 /obj/machinery/firealarm/directional/south,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -62907,6 +62905,10 @@
 "scE" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "scH" = (
@@ -69064,7 +69066,7 @@
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 1;
-	pixel_y = 6
+	pixel_y = 3
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -71712,10 +71714,6 @@
 /obj/effect/landmark/start/bartender,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -4;
-	pixel_y = -4
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -77685,6 +77683,9 @@
 "woT" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "woV" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -8168,7 +8168,6 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "csM" = (
-/obj/structure/chair/stool/bar/directional/north,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -3550,7 +3550,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "bdu" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/light/warm/dim/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -4085,7 +4084,6 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
 "bmH" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/barsign{
 	pixel_y = 32
 	},
@@ -10768,12 +10766,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/processing)
-"dgB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
-/area/station/service/bar)
 "dgD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12771,6 +12763,11 @@
 /obj/item/instrument/guitar{
 	pixel_y = 12
 	},
+/obj/item/instrument/eguitar{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "dMM" = (
@@ -15604,6 +15601,10 @@
 	luminosity = 2
 	},
 /area/station/ai_monitored/command/nuke_storage)
+"eEs" = (
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/carpet,
+/area/station/commons/lounge)
 "eEv" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -20350,7 +20351,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
 "fWV" = (
-/obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20374,8 +20374,6 @@
 /turf/closed/wall,
 /area/station/service/bar)
 "fXf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/effect/spawner/random/entertainment/cigarette{
 	pixel_x = -5
 	},
@@ -20383,6 +20381,8 @@
 	pixel_x = 8;
 	pixel_y = 4
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "fXh" = (
@@ -24784,6 +24784,7 @@
 /area/station/hallway/secondary/construction)
 "hjL" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "hkm" = (
@@ -24791,7 +24792,6 @@
 /area/station/maintenance/starboard/fore)
 "hkq" = (
 /obj/machinery/light/warm/dim/directional/south,
-/obj/machinery/light_switch/directional/east,
 /mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
@@ -26072,6 +26072,11 @@
 "hDg" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
+"hDk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/space/basic,
+/area/station/service/bar)
 "hDp" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -31534,12 +31539,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/east,
-/obj/structure/table/wood,
-/obj/item/instrument/eguitar{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "jeA" = (
@@ -42662,6 +42661,8 @@
 /area/station/maintenance/port/fore)
 "moE" = (
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "moI" = (
@@ -48963,6 +48964,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "ofL" = (
@@ -56454,6 +56461,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/lab)
+"qoU" = (
+/obj/machinery/door/airlock/wood{
+	name = "Service Hall"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "qoX" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 2;
@@ -62881,6 +62896,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "sik" = (
@@ -64579,6 +64596,11 @@
 	},
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/lesser)
+"sKL" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/commons/lounge)
 "sKM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -69757,15 +69779,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"umA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet,
-/area/station/service/bar)
 "umD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -70581,12 +70594,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "uxl" = (
-/obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/carpet,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "uxo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70819,20 +70829,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
 "uzI" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/door/airlock/wood{
-	name = "Service Hall"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/station/service/bar)
 "uzM" = (
 /obj/structure/table/wood,
@@ -76662,7 +76663,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/courtroom)
 "wik" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -108149,7 +108149,7 @@ ars
 nDm
 nDm
 voY
-fWY
+qoU
 jez
 apu
 sQI
@@ -108918,7 +108918,7 @@ xAj
 gse
 own
 bmH
-lqO
+sKL
 sic
 xpV
 jpy
@@ -109175,7 +109175,7 @@ kgN
 sWI
 own
 bdu
-dgB
+uxl
 moE
 tmV
 tAJ
@@ -109432,12 +109432,12 @@ xAj
 pXb
 own
 apf
-umA
+uxl
 huW
 lqO
 vsf
 fXf
-fWY
+hDk
 bNt
 tDy
 hrh
@@ -109691,7 +109691,7 @@ csm
 wCJ
 fWV
 mCw
-dXP
+eEs
 geO
 fVC
 bNt

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -14343,7 +14343,10 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Blue Base"
 	},
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/light{
+	name = "Blue Base Floor";
+	light_power = 3
+	},
 /area/station/maintenance/hallway/abandoned_recreation)
 "egX" = (
 /obj/structure/disposalpipe/segment{
@@ -24590,7 +24593,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/eighties,
+/turf/open/floor/light{
+	name = "Blue Base Floor";
+	light_power = 3
+	},
 /area/station/maintenance/hallway/abandoned_recreation)
 "hei" = (
 /obj/structure/chair{
@@ -25501,6 +25507,7 @@
 	name = "psychology shutters control";
 	pixel_x = -6
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "hsR" = (
@@ -34282,9 +34289,6 @@
 /turf/open/openspace,
 /area/station/commons/vacant_room/office)
 "jML" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -42681,7 +42685,12 @@
 /obj/item/banner/red{
 	inspiration_available = 0
 	},
-/turf/open/floor/eighties,
+/turf/open/floor/light{
+	name = "Red Base Floor";
+	light_power = 3;
+	icon_state = "light_on-2";
+	light_system = 2
+	},
 /area/station/maintenance/hallway/abandoned_recreation)
 "mke" = (
 /obj/structure/table,
@@ -48578,12 +48587,6 @@
 "nVE" = (
 /turf/closed/wall/r_wall,
 /area/station/service/abandoned_gambling_den)
-"nVT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "nWe" = (
 /obj/structure/cable,
 /obj/machinery/power/emitter/welded{
@@ -65796,7 +65799,10 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Blue Base"
 	},
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/light{
+	name = "Blue Base Floor";
+	light_power = 3
+	},
 /area/station/maintenance/hallway/abandoned_recreation)
 "sXL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66428,7 +66434,12 @@
 	name = "Laser Tag"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/wood,
+/turf/open/floor/light{
+	name = "Red Base Floor";
+	light_power = 3;
+	icon_state = "light_on-2";
+	light_system = 2
+	},
 /area/station/maintenance/hallway/abandoned_recreation)
 "tid" = (
 /obj/structure/transit_tube/junction{
@@ -70053,7 +70064,6 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "ulM" = (
-/obj/machinery/light/small/directional/south,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -75035,7 +75045,12 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Red Base"
 	},
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/light{
+	name = "Red Base Floor";
+	light_power = 3;
+	icon_state = "light_on-2";
+	light_system = 2
+	},
 /area/station/maintenance/hallway/abandoned_recreation)
 "vCP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -77209,7 +77224,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "wiF" = (
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -170411,7 +170425,7 @@ nlm
 nlm
 bOk
 wiF
-nVT
+uCF
 jML
 tUX
 eAV

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -51730,6 +51730,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"oVO" = (
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood/large,
+/area/station/service/library)
 "oVY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82446,6 +82450,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/art)
+"xXa" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "xXe" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark/smooth_half,
@@ -178035,9 +178043,9 @@ sch
 oZJ
 cdy
 tsd
-rlE
-rlE
-rlE
+xXa
+xXa
+xXa
 ige
 haE
 rIi
@@ -178553,7 +178561,7 @@ hOO
 hOO
 hOO
 qRA
-aTt
+oVO
 hyS
 uii
 dEN
@@ -179324,7 +179332,7 @@ wpA
 sJR
 uRU
 nmS
-aTt
+oVO
 aum
 umH
 ipQ

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -6879,7 +6879,6 @@
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
 "caV" = (
-/obj/structure/window/spawner/directional/east,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -8798,7 +8797,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cCj" = (
-/obj/structure/window/spawner/directional/east,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/bowl/soup/stew{
 	desc = "Exactly what it says on the tin.";
@@ -13641,8 +13639,6 @@
 "dZA" = (
 /obj/structure/table/wood,
 /obj/item/gun/magic/wand/nothing,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "dZF" = (
@@ -21312,7 +21308,6 @@
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/atmos/project)
 "giz" = (
-/obj/structure/window/spawner/directional/east,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -22319,10 +22314,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "gwv" = (
-/obj/machinery/door/window/right/directional/west{
-	name = "Theater Stage";
-	req_access = list("theatre")
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -26914,8 +26905,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/processing)
 "hNy" = (
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/east,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -29347,7 +29336,6 @@
 /obj/item/toy/figure/mime{
 	pixel_x = -5
 	},
-/obj/structure/window/spawner/directional/west,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -50275,7 +50263,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/window/spawner/directional/west,
 /obj/effect/spawner/random/structure/musician/piano/random_piano,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -78718,7 +78705,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/port)
 "wPG" = (
-/obj/structure/window/spawner/directional/south,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "wPI" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -15509,15 +15509,6 @@
 /obj/effect/spawner/random/structure/closet_empty/crate,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/hallway/abandoned_recreation)
-"eCl" = (
-/obj/structure/cable,
-/obj/structure/chair/stool/bar/directional/north,
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/commons/lounge)
 "eCu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -33268,8 +33259,8 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
 "jBU" = (
-/obj/structure/table/glass,
 /obj/item/reagent_containers/cup/glass/mug/tea,
+/obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "jBW" = (
@@ -110719,7 +110710,7 @@ vsQ
 xHc
 jBU
 jBU
-eCl
+csk
 pWr
 nyB
 bNt

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -60998,15 +60998,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"rGn" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "abandonedcafe";
-	name = "Psychologist's Office Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/medical/psychology)
 "rGp" = (
 /obj/structure/railing{
 	dir = 8
@@ -179083,7 +179074,7 @@ qRA
 mvH
 evq
 umH
-rGn
+hTr
 eVF
 hTr
 umH

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -21287,7 +21287,6 @@
 /area/station/engineering/atmos/project)
 "giz" = (
 /obj/structure/window/spawner/directional/east,
-/obj/structure/window/spawner/directional/east,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -37928,7 +37927,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "kTW" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
@@ -69095,9 +69093,6 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/theater_dressing)
 "udF" = (
@@ -75628,9 +75623,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/closed/wall,
 /area/station/commons/vacant_room/commissary)
 "vSq" = (
@@ -77112,6 +77104,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
+"woT" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/station/service/library)
 "woV" = (
 /obj/structure/broken_flooring/pile/directional/south,
 /turf/open/floor/plating,
@@ -77138,13 +77135,6 @@
 	},
 /turf/open/floor/grass/fairy,
 /area/station/maintenance/hallway/abandoned_recreation)
-"wpA" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/station/service/theater_dressing)
 "wpG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -114829,7 +114819,7 @@ gyd
 wPG
 bfw
 kHv
-xHK
+woT
 gNr
 jYE
 cnv
@@ -179333,7 +179323,7 @@ bOk
 sJR
 sJR
 udE
-wpA
+sJR
 sJR
 uRU
 nmS

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -7249,7 +7249,7 @@
 /area/station/maintenance/port/aft)
 "cfp" = (
 /obj/machinery/button/door/directional/east{
-	id = "actualcommissarydoor";
+	id = "commissarydoor";
 	name = "Commissary Door Lock";
 	normaldoorcontrol = 1;
 	pixel_x = 23;
@@ -7277,9 +7277,7 @@
 /obj/machinery/button/door/directional/east{
 	id = "actualcommissaryshutter";
 	name = "Commissary Shutters";
-	normaldoorcontrol = 1;
-	pixel_x = 34;
-	specialfunctions = 4
+	pixel_x = 34
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark,
@@ -10845,6 +10843,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "dhx" = (
@@ -59913,7 +59912,6 @@
 /area/station/science/xenobiology/hallway)
 "rkK" = (
 /obj/structure/table/reinforced,
-/obj/item/paper/guides/jobs/hydroponics,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -59922,6 +59920,14 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hydropony_shutters";
 	name = "Hydropony's Shutters"
+	},
+/obj/item/paper{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -73129,7 +73135,6 @@
 "vcR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "vcT" = (
@@ -80899,6 +80904,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/random/directional/north,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/hand_labeler{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/pen{
+	pixel_x = 5;
+	pixel_y = 2
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "xqd" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -3466,6 +3466,7 @@
 	codes_txt = "delivery;dir=8";
 	location = "Restaurant"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "bcc" = (
@@ -19215,6 +19216,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "fGm" = (
@@ -20362,7 +20364,6 @@
 "fWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "fWW" = (
@@ -20961,6 +20962,7 @@
 /obj/structure/cable,
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "gfc" = (
@@ -48962,6 +48964,7 @@
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 8
 	},
+/obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "ofL" = (
@@ -62332,6 +62335,7 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
 "sbn" = (
@@ -67070,6 +67074,7 @@
 "tAJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "tAK" = (
@@ -70832,7 +70837,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/closed/wall,
 /area/station/service/bar)
 "uzM" = (
@@ -73764,6 +73768,7 @@
 	pixel_x = 6;
 	pixel_y = 15
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "vsh" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -1060,6 +1060,9 @@
 	},
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "aqj" = (
@@ -2362,7 +2365,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "aKY" = (
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/light_switch/directional/south{
+	pixel_y = -24
+	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
@@ -3442,7 +3447,7 @@
 "baL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ladder,
-/turf/open/space/basic,
+/turf/open/openspace,
 /area/station/maintenance/port/fore)
 "bba" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4511,9 +4516,10 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
@@ -6150,7 +6156,10 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/reagentgrinder{
+	pixel_x = -6;
+	pixel_y = 9
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "bRa" = (
@@ -11354,6 +11363,11 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/south,
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -4;
+	pixel_y = 7
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "dpv" = (
@@ -18343,6 +18357,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"frM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "frP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32758,7 +32782,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/button/door/directional/south{
 	id = "kitchen_service";
-	name = "Window Shutters";
+	name = "Kitchen Window Shutters";
 	pixel_x = 6;
 	req_access = list("kitchen")
 	},
@@ -33787,6 +33811,7 @@
 /area/station/science/lab)
 "jFI" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
 "jFU" = (
@@ -35729,6 +35754,12 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
+/obj/machinery/requests_console/directional/south{
+	department = "Kitchen";
+	name = "Kitchen Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kll" = (
@@ -40148,7 +40179,16 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
-/obj/machinery/vending/boozeomat,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Bar";
+	name = "Bar Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "lAG" = (
@@ -48013,7 +48053,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/turf_decal/tile/green/full,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Hydroponics"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "nOw" = (
@@ -63450,7 +63492,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/airlock/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Hydroponics"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "slP" = (
@@ -65153,10 +65197,6 @@
 /area/station/science/breakroom)
 "sOJ" = (
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue,
 /obj/machinery/light/warm/dim/directional/east,
 /obj/structure/transport/linear/public,
 /obj/machinery/smartfridge/food,
@@ -68952,19 +68992,15 @@
 /turf/open/openspace,
 /area/station/command/gateway)
 "tWQ" = (
-/obj/machinery/reagentgrinder{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -4;
-	pixel_y = -4
-	},
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
-/obj/structure/table/wood,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "tWR" = (
@@ -71613,6 +71649,10 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "uGj" = (
@@ -72448,7 +72488,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/turf_decal/tile/green/full,
-/obj/machinery/door/airlock/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Hydroponics Lab"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "uSg" = (
@@ -72542,12 +72584,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"uTk" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/openspace,
-/area/station/service/kitchen)
 "uTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
@@ -72985,14 +73021,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vaO" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_x = 4
-	},
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
 "vbe" = (
@@ -74014,12 +74047,6 @@
 /obj/structure/transport/linear,
 /turf/open/openspace,
 /area/station/science/robotics/lab)
-"vpO" = (
-/obj/effect/turf_decal/tile/dark_blue,
-/obj/structure/cable,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "vpS" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -75838,6 +75865,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/lesser)
+"vPX" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "vQd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -177827,11 +177862,11 @@ oBH
 bOk
 bOk
 bOk
-laD
+frM
 hRX
-uTk
+cFa
 aqg
-vpO
+nHt
 hRX
 jFI
 cqj
@@ -178086,7 +178121,7 @@ bOk
 jYS
 juq
 hqD
-nHt
+vPX
 dVj
 kle
 hRX

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -3550,10 +3550,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
-"bdu" = (
-/obj/machinery/light/warm/dim/directional/north,
-/turf/open/floor/wood/parquet,
-/area/station/commons/lounge)
 "bdw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -18133,11 +18129,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Event Storage"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/wood{
+	name = "Curator Office"
+	},
 /turf/open/floor/wood,
 /area/station/service/library/printer)
 "fqj" = (
@@ -21972,7 +21968,7 @@
 /area/station/commons/dorms)
 "gqj" = (
 /obj/machinery/door/airlock/wood{
-	name = "Event Storage"
+	name = "Curator Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/library,
 /obj/machinery/door/firedoor,
@@ -25331,10 +25327,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "hsh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
+/obj/machinery/door/airlock/wood{
+	name = "Curator Office"
+	},
 /turf/open/floor/wood/large,
 /area/station/maintenance/hallway/abandoned_recreation)
 "hsi" = (
@@ -28847,6 +28843,14 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"ire" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/warm/dim/directional/west,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "irh" = (
 /turf/closed/wall,
 /area/station/medical/cryo)
@@ -30092,11 +30096,11 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
 "iIJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Service Hall Maintenance"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /obj/structure/cable,
+/obj/machinery/door/airlock/wood{
+	name = "Curator Office"
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/hallway/abandoned_recreation)
 "iIL" = (
@@ -66566,11 +66570,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "tpU" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/wood{
+	name = "Curator Office"
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "tqQ" = (
@@ -80846,7 +80852,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "xxZ" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Curator Office"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -108684,7 +108692,7 @@ xAj
 xAt
 own
 wik
-uxl
+ire
 ofE
 hjL
 fPh
@@ -109197,7 +109205,7 @@ peX
 kgN
 sWI
 own
-bdu
+siP
 uxl
 moE
 tmV


### PR DESCRIPTION

## About The Pull Request

Video = **https://youtu.be/U_74c5BlrH4**


Layout overhaul of Catwalk service area, designed to encourage more interaction, better flow and linkage between the service department areas.
## Why It's Good For The Game

- More space for kitchen/bar
- More space for people
- More movement flow
- More chance for random chaos
## Changelog
:cl:
map: CATWALK - Kitchen now has more space and a downstairs serving area, also shutters for chef sanity
map: CATWALK - Bar now has more space & can now serve coffee
map: CATWALK - Community Centre/Library has had a re-design, now includes a theatre!
map: CATWALK - Public walkway linking Library/Psych/Kitchen/Botany with better stairwells
map: CATWALK - Laser tag arena now open to all, Red versus Blue, Cameras kept out of it so the AI does not panic
map: CATWALK - Botany made more prominent and easier to find
map: CATWALK - Central APC for hallways re-located to be easier to find and fix
map: CATWALK - Psychologist office made smaller but now has windows/curtains and shutters
map: CATWALK - Reinforced windows for service swapped out for standard
/:cl:
