### PR TITLE
Fixes delayed viewport fitting on server join/init

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -566,6 +566,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	set_fullscreen(logging_in = TRUE)
 	view_size.resetFormat()
 	view_size.setZoomMode()
+	view_size.apply()
 	Master.UpdateTickRate()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CLIENT_CONNECT, src)
 	fully_created = TRUE

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -420,10 +420,9 @@ ADMIN_VERB(reset_ooc_color, R_FUN, "Reset Player OOC Color", "Returns player OOC
 /client/proc/attempt_auto_fit_viewport()
 	if (!prefs?.read_preference(/datum/preference/toggle/auto_fit_viewport))
 		return
+	// No need to attempt to fit the viewport on non-initialized clients as they'll auto-fit viewport right before finishing init
 	if(fully_created)
 		INVOKE_ASYNC(src, VERB_REF(fit_viewport))
-	else //Delayed to avoid wingets from Login calls.
-		addtimer(CALLBACK(src, VERB_REF(fit_viewport), 1 SECONDS))
 
 /client/verb/policy()
 	set name = "Show Policy"


### PR DESCRIPTION

## About The Pull Request

#91419 removed change_view in mob login for un-inited clients, which leaves 1 second delayed fit_viewport calls from attempt_auto_fit_viewport as the only way for new clients to adjust their viewport from the default square (which is also only ran once all subsystems finish initializing).
Just calling apply() after applying our prefs to the view_size is enough to make it work, also we don't need the said second delay in attempt_auto_fit_viewport anymore either.

## Changelog
:cl:
fix: Fixed delayed viewport fitting on server join/init
/:cl:
