### PR TITLE
Updates bluespace anomaly detonation proc

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bluespace.dm
@@ -27,8 +27,8 @@
 	new /obj/effect/temp_visual/circle_wave/bluespace(get_turf(src))
 	playsound(src, 'sound/effects/magic/cosmic_energy.ogg', vol = 50)
 
-	var/turf/T = pick(get_area_turfs(impact_area))
-	if(!T)
+	var/turf/impact_turf = pick(get_area_turfs(impact_area))
+	if(!impact_turf)
 		return
 
 	// Calculate new position (searches through beacons in world)
@@ -51,39 +51,31 @@
 		return
 
 	// Calculate previous position for transition
-	var/turf/FROM = T // the turf of origin we're travelling FROM
-	var/turf/TO = get_turf(chosen) // the turf of origin we're travelling TO
+	var/turf/beacon_turf = get_turf(chosen) // the turf of origin we're travelling TO
 
-	playsound(TO, 'sound/effects/phasein.ogg', 100, TRUE)
+	playsound(beacon_turf, 'sound/effects/phasein.ogg', 100, TRUE)
 	priority_announce("Massive bluespace translocation detected.", "Anomaly Alert")
 
 	var/list/flashers = list()
-	for(var/mob/living/carbon/C in viewers(TO, null))
-		if(C.flash_act())
-			flashers += C
+	for(var/mob/living/living in viewers(beacon_turf, null))
+		if(living.flash_act(affect_silicon = TRUE, visual = TRUE, type = /atom/movable/screen/fullscreen/bluespace_sparkle, length = 2 SECONDS))
+			flashers += living
 
-	var/y_distance = TO.y - FROM.y
-	var/x_distance = TO.x - FROM.x
-	for (var/atom/movable/A in urange(12, FROM )) // iterate thru list of mobs in the area
-		if(istype(A, /obj/item/beacon))
-			continue // don't teleport beacons because that's just insanely stupid
-		if(iseyemob(A))
-			continue // Don't mess with AI eye, blob eye, xenobio or advanced cameras
-		if(A.anchored)
-			continue
+	var/y_distance = beacon_turf.y - impact_turf.y
+	var/x_distance = beacon_turf.x - impact_turf.x
+	var/list/available_turfs = RANGE_TURFS(12, beacon_turf)
+	for (var/atom/movable/movable in urange(12, impact_turf )) // iterate thru list of mobs in the area
+		if(istype(movable, /obj/item/beacon) || iseffect(movable) || iseyemob(movable))
+			continue // Don't mess with beacons, effects or camera mobs (blob, AI eye etc...)
+		if(movable.anchored)
+			continue // do_teleport doesn't check if the item is anchored or not.
 
-		var/turf/newloc = locate(A.x + x_distance, A.y + y_distance, TO.z) // calculate the new place
-		if(!A.Move(newloc) && newloc) // if the atom, for some reason, can't move, FORCE them to move! :) We try Move() first to invoke any movement-related checks the atom needs to perform after moving
-			A.forceMove(newloc)
+		var/turf/newloc = locate(movable.x + x_distance, movable.y + y_distance, beacon_turf.z) || pick(available_turfs) // calculate the new place, or pick a random one as fallback
+		do_teleport(movable, newloc, no_effects = TRUE)
 
-		if(ismob(A) && !(A in flashers)) // don't flash if we're already doing an effect
-			var/mob/give_sparkles = A
-			if(give_sparkles.client)
-				blue_effect(give_sparkles)
-
-/obj/effect/anomaly/bluespace/proc/blue_effect(mob/make_sparkle)
-	make_sparkle.overlay_fullscreen("bluespace_flash", /atom/movable/screen/fullscreen/bluespace_sparkle, 1)
-	addtimer(CALLBACK(make_sparkle, TYPE_PROC_REF(/mob/, clear_fullscreen), "bluespace_flash"), 2 SECONDS)
+		if(isliving(movable) && !(movable in flashers)) // don't flash if we're already doing an effect
+			var/mob/living/give_sparkles = movable
+			give_sparkles.flash_act(affect_silicon = TRUE, visual = TRUE, type = /atom/movable/screen/fullscreen/bluespace_sparkle, length = 2 SECONDS)
 
 /obj/effect/anomaly/bluespace/stabilize(anchor, has_core)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The bluespace anomaly had some problems with teleporting mobs that it shouldn't teleport. Also it relied on `Move()` and `ForceMove()` directly rather than `do_teleport()`. This PR also updates its code a little.

## Why It's Good For The Game
This should fix https://github.com/tgstation/tgstation/issues/77261.

## Changelog

:cl:
fix: Bluespace anomalies should no longer teleport 'un-teleportable' mobs like anchored AIs or megafauna.
/:cl:

