### PR TITLE
Flash and flasher refactor/rework (simple mobs no longer immune edition)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -227,12 +227,12 @@
 
 ///from living/flash_act(), when a mob is successfully flashed.
 #define COMSIG_MOB_FLASHED "mob_flashed"
-/// from /obj/item/assembly/flash/flash_carbon, to the mob being flashed
+/// from /obj/item/assembly/flash/flash_mob, to the mob being flashed
 #define COMSIG_MOB_FLASH_OVERRIDE_CHECK "mob_flash_override_check"
 	/// Has the flash effect been overridden?
 	#define FLASH_OVERRIDDEN (1<<0)
 /// from /obj/item/assembly/flash/flash_carbon, to the mob flashing another carbon
-#define COMSIG_MOB_PRE_FLASHED_CARBON "mob_pre_flashed_carbon"
+#define COMSIG_MOB_PRE_FLASHED_MOB "mob_pre_flashed_mob"
 	/// Return to override deviation to be full deviation (fail the flash, usually)
 	#define DEVIATION_OVERRIDE_FULL (1<<0)
 	/// Return to override deviation to be partial deviation
@@ -241,9 +241,9 @@
 	#define DEVIATION_OVERRIDE_NONE (1<<2)
 	/// Return to stop the flash entirely
 	#define STOP_FLASH (1<<3)
-/// from /obj/item/assembly/flash/flash_carbon, to the mob flashing another carbon
+/// from /obj/item/assembly/flash/flash_mob, to the mob flashing another carbon
 /// (mob/living/carbon/flashed, obj/item/assembly/flash/flash, deviation (from code/__DEFINES/mobs.dm))
-#define COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON "mob_success_flashed_carbon"
+#define COMSIG_MOB_SUCCESSFUL_FLASHED_MOB "mob_success_flashed_mob"
 
 /// from mob/get_status_tab_items(): (list/items)
 #define COMSIG_MOB_GET_STATUS_TAB_ITEMS "mob_get_status_tab_items"

--- a/code/datums/components/can_flash_from_behind.dm
+++ b/code/datums/components/can_flash_from_behind.dm
@@ -10,10 +10,10 @@
 		return COMPONENT_INCOMPATIBLE
 
 /datum/component/can_flash_from_behind/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_MOB_PRE_FLASHED_CARBON, PROC_REF(on_pre_flashed_carbon))
+	RegisterSignal(parent, COMSIG_MOB_PRE_FLASHED_MOB, PROC_REF(on_pre_flashed_carbon))
 
 /datum/component/can_flash_from_behind/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_MOB_PRE_FLASHED_CARBON)
+	UnregisterSignal(parent, COMSIG_MOB_PRE_FLASHED_MOB)
 
 /datum/component/can_flash_from_behind/proc/on_pre_flashed_carbon(source, flashed, flash, deviation)
 	SIGNAL_HANDLER

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -120,7 +120,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 		if (get_dist(src, living_mob) > flash_range)
 			continue
 
-		if(bulb.flash_mob(living_mob, confusion_duration = strength * 2, extra_log =  "by [src]"))
+		if(bulb.flash_mob(living_mob, confusion_duration = strength * 1.5, extra_log =  "by [src]"))
 			living_mob.Paralyze(strength)
 			flashed = TRUE
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -16,7 +16,7 @@
 	var/flash_range = 2 //this is roughly the size of a brig cell.
 
 	/// How strong Paralyze()'d targets are when flashed.
-	var/strength = 10 SECONDS
+	var/strength = 5 SECONDS
 
 	COOLDOWN_DECLARE(flash_cooldown)
 	/// Duration of time between flashes.
@@ -120,7 +120,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 		if (get_dist(src, living_mob) > flash_range)
 			continue
 
-		if(bulb.flash_mob(living_mob, extra_log =  "by [src]"))
+		if(bulb.flash_mob(living_mob, confusion_duration = strength * 2, extra_log =  "by [src]"))
 			living_mob.Paralyze(strength)
 			flashed = TRUE
 
@@ -160,7 +160,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 	icon = 'icons/obj/machines/sec.dmi'
 	icon_state = "pflash1-p"
 	base_icon_state = "pflash"
-	strength = 8 SECONDS
+	strength = 4 SECONDS
 	anchored = FALSE
 	density = TRUE
 	///Proximity monitor associated with this atom, needed for proximity checks.

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -120,8 +120,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 		if (get_dist(src, living_mob) > flash_range)
 			continue
 
-		if(living_mob.flash_act(affect_silicon = TRUE))
-			living_mob.log_message("was AOE flashed by an automated portable flasher", LOG_ATTACK)
+		if(bulb.flash_mob(living_mob, extra_log =  "by [src]"))
 			living_mob.Paralyze(strength)
 			flashed = TRUE
 
@@ -175,10 +174,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 	if(!COOLDOWN_FINISHED(src, flash_cooldown))
 		return
 
-	if(iscarbon(proximity_check_mob))
-		var/mob/living/carbon/proximity_carbon = proximity_check_mob
-		if (proximity_carbon.move_intent != MOVE_INTENT_WALK && anchored)
-			flash()
+	if(!isliving(proximity_check_mob))
+		return
+
+	var/mob/living/proximity_living = proximity_check_mob
+	if (proximity_living.move_intent != MOVE_INTENT_WALK && anchored)
+		flash()
 
 /obj/machinery/flasher/portable/vv_edit_var(vname, vval)
 	. = ..()

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -54,7 +54,7 @@
 	if (!istype(carbon_owner))
 		return
 	carbon_owner.AddComponentFrom(REF(src), /datum/component/can_flash_from_behind)
-	RegisterSignal(carbon_owner, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON, PROC_REF(on_mob_successful_flashed_carbon))
+	RegisterSignal(carbon_owner, COMSIG_MOB_SUCCESSFUL_FLASHED_MOB, PROC_REF(on_mob_successful_flashed_mob))
 
 /// Take away the ability to add more brothers
 /datum/antagonist/brother/proc/remove_conversion_skills()
@@ -62,12 +62,12 @@
 		return
 	var/mob/living/carbon/carbon_owner = owner.current
 	carbon_owner.RemoveComponentSource(REF(src), /datum/component/can_flash_from_behind)
-	UnregisterSignal(carbon_owner, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON)
+	UnregisterSignal(carbon_owner, COMSIG_MOB_SUCCESSFUL_FLASHED_MOB)
 
-/datum/antagonist/brother/proc/on_mob_successful_flashed_carbon(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash)
+/datum/antagonist/brother/proc/on_mob_successful_flashed_mob(mob/living/source, mob/living/flashed, obj/item/assembly/flash/flash)
 	SIGNAL_HANDLER
 
-	if (flashed.stat == DEAD)
+	if (flashed.stat == DEAD || issilicon(flashed) || isdrone(flashed))
 		return
 
 	if (flashed.stat != CONSCIOUS)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -180,20 +180,20 @@
 	. = ..()
 	var/mob/living/real_mob = mob_override || owner.current
 	real_mob.AddComponentFrom(REF(src), /datum/component/can_flash_from_behind)
-	RegisterSignal(real_mob, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON, PROC_REF(on_flash_success))
+	RegisterSignal(real_mob, COMSIG_MOB_SUCCESSFUL_FLASHED_MOB, PROC_REF(on_flash_success))
 
 /datum/antagonist/rev/head/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/real_mob = mob_override || owner.current
 	real_mob.RemoveComponentSource(REF(src), /datum/component/can_flash_from_behind)
-	UnregisterSignal(real_mob, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON)
+	UnregisterSignal(real_mob, COMSIG_MOB_SUCCESSFUL_FLASHED_MOB)
 
-/// Signal proc for [COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON].
+/// Signal proc for [COMSIG_MOB_SUCCESSFUL_FLASHED_MOB].
 /// Bread and butter of revolution conversion, successfully flashing a carbon will make them a revolutionary
-/datum/antagonist/rev/head/proc/on_flash_success(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash, deviation)
+/datum/antagonist/rev/head/proc/on_flash_success(mob/living/source, mob/living/flashed, obj/item/assembly/flash/flash, deviation)
 	SIGNAL_HANDLER
 
-	if(flashed.stat == DEAD)
+	if(flashed.stat == DEAD || issilicon(flashed) || isdrone(flashed))
 		return
 	if(flashed.stat != CONSCIOUS)
 		to_chat(source, span_warning("[flashed.p_They()] must be conscious before you can convert [flashed.p_them()]!"))

--- a/code/modules/antagonists/sentient_creature/sentient_creature.dm
+++ b/code/modules/antagonists/sentient_creature/sentient_creature.dm
@@ -23,6 +23,11 @@
 	var/mob/living/master = owner.enslaved_to?.resolve()
 	if(master)
 		owner.current.copy_languages(master, LANGUAGE_MASTER)
+		ADD_TRAIT(owner, TRAIT_UNCONVERTABLE, REF(src))
+	return ..()
+
+/datum/antagonist/sentient_creature/on_removal()
+	REMOVE_TRAIT(owner, TRAIT_UNCONVERTABLE, REF(src))
 	return ..()
 
 /datum/antagonist/sentient_creature/ui_static_data(mob/user)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -226,18 +226,24 @@
 	if(HAS_TRAIT(victim, TRAIT_SPINNING))
 		return DEVIATION_NONE
 
+	// I don't want to mess with cyborgs' deep-rooted weakness to fleshes
+	if(issilicon(victim))
+		return DEVIATION_NONE
+
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
 		if(carbon_victim.get_eye_protection() < FLASH_PROTECTION_SENSITIVE) // If we have really bad flash sensitivity, usually due to really sensitive eyes, we get flashed from all directions
 			return DEVIATION_NONE
 
+	var/turf/attacker_turf = get_turf(atttacker)
+
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.
-	if(victim.loc == attacker.loc)
+	if(victim.loc == attacker_turf)
 		return DEVIATION_PARTIAL
 
 	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
-	var/victim_to_attacker = get_dir(victim, attacker)
+	var/victim_to_attacker = get_dir(victim, attacker_turf)
 	// The victim's dir is necessarily a cardinal value.
 	var/victim_dir = victim.dir
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -235,7 +235,7 @@
 		if(carbon_victim.get_eye_protection() < FLASH_PROTECTION_SENSITIVE) // If we have really bad flash sensitivity, usually due to really sensitive eyes, we get flashed from all directions
 			return DEVIATION_NONE
 
-	var/turf/attacker_turf = get_turf(atttacker)
+	var/turf/attacker_turf = get_turf(attacker)
 
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -223,7 +223,7 @@
 	if(HAS_TRAIT(victim, TRAIT_SPINNING))
 		return DEVIATION_NONE
 
-	// I don't want to mess with cyborgs' deep-rooted weakness to fleshes
+	// I don't want to mess with cyborgs' deep-rooted weakness to flashes
 	if(issilicon(victim))
 		return DEVIATION_NONE
 

--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -295,3 +295,6 @@
 	if(built_in_camera?.can_use())
 		return TRUE
 	return ..()
+
+/mob/living/basic/drone/hypnosis_vulnerable()
+	return FALSE //It obeys its laws

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1077,18 +1077,6 @@
 /mob/living/carbon/can_resist()
 	return bodyparts.len > 2 && ..()
 
-/mob/living/carbon/proc/hypnosis_vulnerable()
-	if(HAS_MIND_TRAIT(src, TRAIT_UNCONVERTABLE))
-		return FALSE
-	if(has_status_effect(/datum/status_effect/hallucination) || has_status_effect(/datum/status_effect/drugginess))
-		return TRUE
-	if(IsSleeping() || IsUnconscious())
-		return TRUE
-	if(HAS_TRAIT(src, TRAIT_DUMB))
-		return TRUE
-	if(mob_mood.sanity < SANITY_UNSTABLE)
-		return TRUE
-
 /mob/living/carbon/wash(clean_types)
 	. = ..()
 	// Wash equipped stuff that cannot be covered

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -822,3 +822,15 @@
 		return SUCCESSFUL_BLOCK
 
 	return FAILED_BLOCK
+
+/mob/living/proc/hypnosis_vulnerable()
+	if(HAS_MIND_TRAIT(src, TRAIT_UNCONVERTABLE))
+		return FALSE
+	if(has_status_effect(/datum/status_effect/hallucination) || has_status_effect(/datum/status_effect/drugginess))
+		return TRUE
+	if(IsSleeping() || IsUnconscious())
+		return TRUE
+	if(HAS_TRAIT(src, TRAIT_DUMB))
+		return TRUE
+	if(mob_mood && mob_mood.sanity < SANITY_UNSTABLE)
+		return TRUE

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -159,3 +159,6 @@
 	apply_status_effect(/datum/status_effect/borg_slow, damage_done / 60)
 
 #undef CYBORG_SLOWDOWN_THRESHOLD
+
+/mob/living/silicon/hypnosis_vulnerable()
+	return FALSE //It obeys its laws

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -2,6 +2,9 @@
 #define TUMOR_ACTIVE 1
 #define TUMOR_PASSIVE 2
 
+// Makes the elite mob weaker on victory so they don't just go and trash the station with a dangerous, big health pool
+#define ELITE_POST_BATTLE_HEALTH_MULTIPLIER 0.4
+
 //Elite mining mobs
 /mob/living/simple_animal/hostile/asteroid/elite
 	name = "elite"
@@ -30,6 +33,7 @@
 	. = ..()
 	AddComponent(/datum/component/seethrough_mob)
 	grant_actions_by_list(attack_action_types)
+	ADD_TRAIT(src, TRAIT_UNCONVERTABLE) //You cannot convert them while they're battling.
 
 //Prevents elites from attacking members of their faction (can't hurt themselves either) and lets them mine rock with an attack despite not being able to smash walls.
 /mob/living/simple_animal/hostile/asteroid/elite/AttackingTarget(atom/attacked_target)
@@ -226,7 +230,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 	mychild.revive(HEAL_ALL)
 	if(boosted)
-		mychild.maxHealth = mychild.maxHealth * 2
+		mychild.maxHealth *= 1 / ELITE_POST_BATTLE_HEALTH_MULTIPLIER //we multiply it back to its original value
 		mychild.health = mychild.maxHealth
 		notify_ghosts(
 			"\A [mychild] has been challenged in \the [get_area(src)]!",
@@ -235,6 +239,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 			notify_flags = NOTIFY_CATEGORY_NOFLASH,
 		)
 	mychild.log_message("has been challenged by [key_name(activator)]!", LOG_GAME, color="#960000")
+	ADD_TRAIT(mychild, TRAIT_UNCONVERTABLE, INNATE_TRAIT)
 
 /obj/structure/elite_tumor/Initialize(mapload)
 	. = ..()
@@ -344,7 +349,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	mychild.revive(HEAL_ALL)
 	if(boosted)
 		times_won++
-		mychild.maxHealth = mychild.maxHealth * 0.4
+		mychild.maxHealth *= ELITE_POST_BATTLE_HEALTH_MULTIPLIER.4
 		mychild.health = mychild.maxHealth
 	if(times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
@@ -355,6 +360,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 			Bear in mind, if anyone interacts with your tumor, you'll be resummoned here to carry out another fight. In such a case, you will regain your full max health.\n\
 			Also, be weary of your fellow inhabitants, they likely won't be happy to see you!</b>")
 		to_chat(mychild, span_boldbig("Note that you are a lavaland monster, and thus not allied to the station. You should not cooperate or act friendly with any station crew unless under extreme circumstances!"))
+	REMOVE_TRAIT(mychild, TRAIT_UNCONVERTABLE, INNATE_TRAIT)
 
 /obj/item/tumor_shard
 	name = "tumor shard"
@@ -373,20 +379,21 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	if(!istype(interacting_with, /mob/living/simple_animal/hostile/asteroid/elite))
 		return NONE
 
-	var/mob/living/simple_animal/hostile/asteroid/elite/E = interacting_with
-	if(E.stat != DEAD || E.sentience_type != SENTIENCE_BOSS || !E.key)
+	var/mob/living/simple_animal/hostile/asteroid/elite/elite = interacting_with
+	if(elite.stat != DEAD || elite.sentience_type != SENTIENCE_BOSS || !elite.key)
 		user.visible_message(span_notice("It appears [E] is unable to be revived right now. Perhaps try again later."))
 		return ITEM_INTERACT_BLOCKING
-	E.faction = list("[REF(user)]")
-	E.revive(HEAL_ALL)
-	user.visible_message(span_notice("[user] stabs [E] with [src], reviving it."))
-	E.playsound_local(get_turf(E), 'sound/effects/magic.ogg', 40, 0)
-	to_chat(E, span_userdanger("You have been revived by [user]. While you can't speak to them, you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk."))
-	to_chat(E, span_boldbig("Note that you now share the loyalties of [user].  You are expected not to intentionally sabotage their faction unless commanded to!"))
-	E.maxHealth = E.maxHealth * 0.4
-	E.health = E.maxHealth
-	E.desc = "[E.desc] However, this one appears to be less wild in nature, and calmer around people."
-	E.sentience_type = SENTIENCE_ORGANIC
+	elite.faction = list("[REF(user)]")
+	elite.revive(HEAL_ALL)
+	user.visible_message(span_notice("[user] stabs [elite] with [src], reviving it."))
+	elite.playsound_local(get_turf(E), 'sound/effects/magic.ogg', 40, 0)
+	to_chat(elite, span_userdanger("You have been revived by [user]. While you can't speak to them, you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk."))
+	to_chat(elite, span_boldbig("Note that you now share the loyalties of [user].  You are expected not to intentionally sabotage their faction unless commanded to!"))
+	elite.maxHealth *= ELITE_POST_BATTLE_HEALTH_MULTIPLIER
+	elite.health = elite.maxHealth
+	elite.desc = "[elite.desc] However, this one appears to be less wild in nature, and calmer around people."
+	elite.sentience_type = SENTIENCE_ORGANIC
+	REMOVE_TRAIT(elite, TRAIT_UNCONVERTABLE, INNATE_TRAIT)
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 
@@ -422,6 +429,8 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	. = ..()
 	if(mover == ourelite_ref.resolve() || mover == activator_ref.resolve())
 		return FALSE
+
+#undef ELITE_POST_BATTLE_HEALTH_MULTIPLIER
 
 #undef TUMOR_ACTIVE
 #undef TUMOR_INACTIVE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -33,7 +33,7 @@
 	. = ..()
 	AddComponent(/datum/component/seethrough_mob)
 	grant_actions_by_list(attack_action_types)
-	ADD_TRAIT(src, TRAIT_UNCONVERTABLE) //You cannot convert them while they're battling.
+	ADD_TRAIT(src, TRAIT_UNCONVERTABLE, INNATE_TRAIT) //You cannot convert them while they're battling.
 
 //Prevents elites from attacking members of their faction (can't hurt themselves either) and lets them mine rock with an attack despite not being able to smash walls.
 /mob/living/simple_animal/hostile/asteroid/elite/AttackingTarget(atom/attacked_target)
@@ -349,7 +349,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	mychild.revive(HEAL_ALL)
 	if(boosted)
 		times_won++
-		mychild.maxHealth *= ELITE_POST_BATTLE_HEALTH_MULTIPLIER.4
+		mychild.maxHealth *= ELITE_POST_BATTLE_HEALTH_MULTIPLIER
 		mychild.health = mychild.maxHealth
 	if(times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
@@ -360,6 +360,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 			Bear in mind, if anyone interacts with your tumor, you'll be resummoned here to carry out another fight. In such a case, you will regain your full max health.\n\
 			Also, be weary of your fellow inhabitants, they likely won't be happy to see you!</b>")
 		to_chat(mychild, span_boldbig("Note that you are a lavaland monster, and thus not allied to the station. You should not cooperate or act friendly with any station crew unless under extreme circumstances!"))
+
 	REMOVE_TRAIT(mychild, TRAIT_UNCONVERTABLE, INNATE_TRAIT)
 
 /obj/item/tumor_shard

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -382,12 +382,12 @@ While using this makes the system rely on OnFire, it still gives options for tim
 
 	var/mob/living/simple_animal/hostile/asteroid/elite/elite = interacting_with
 	if(elite.stat != DEAD || elite.sentience_type != SENTIENCE_BOSS || !elite.key)
-		user.visible_message(span_notice("It appears [E] is unable to be revived right now. Perhaps try again later."))
+		user.visible_message(span_notice("It appears [elite] is unable to be revived right now. Perhaps try again later."))
 		return ITEM_INTERACT_BLOCKING
 	elite.faction = list("[REF(user)]")
 	elite.revive(HEAL_ALL)
 	user.visible_message(span_notice("[user] stabs [elite] with [src], reviving it."))
-	elite.playsound_local(get_turf(E), 'sound/effects/magic.ogg', 40, 0)
+	elite.playsound_local(get_turf(elite), 'sound/effects/magic.ogg', 40, 0)
 	to_chat(elite, span_userdanger("You have been revived by [user]. While you can't speak to them, you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk."))
 	to_chat(elite, span_boldbig("Note that you now share the loyalties of [user].  You are expected not to intentionally sabotage their faction unless commanded to!"))
 	elite.maxHealth *= ELITE_POST_BATTLE_HEALTH_MULTIPLIER


### PR DESCRIPTION
## About The Pull Request
I've refactored flashes so that they can be used on basic mobs as well. Most basics are generally impervious to most knockdowns anyway, but the stamina damage still applies, as well as the white overlay flashing on the player's screen.

Most of the logic remains the same, except with the typechecks for carbon mobs removed. This means flashes can be used to convert most player-controlled mobs by a head revolutionary or a blood brother. A few checks have been added to make borgs and drones unable to be converted by these antagonists, because it would fundamentally conflict with their laws most times.

Flashers now use the flashes installed within them to stun their targets. Yes, this means you can an hypnoflash with a portable flasher to pacify and maybe put people in a trance (including player-controlled basics). Yes, this means it can stun borgs with them. No, you cannot hypnotise borgs with them.

## Why It's Good For The Game
I'm not a fan of these sort of typechecks that restrict some features to carbon mobs, and features that could be more interesting without such restrictions that are generally half a dozen years old at this point.

I cannot guarantee that there won't be problems. We've ton of simple mobs, some of which would be better off being immune to flashes at all. We'll sort them out.

## Changelog

:cl:
refactor: Refactored flash and flashers. Report any issue about it
balance: Flashes now affect basic mobs as well. Yes, this extends to the hypno-flash. Yes, this includes converting them as a headrev / blood bro
balance: Flashers now actually use the flashes that they're installed with, and the portable version is also triggered by nearby basic mobs and cyborgs passing through.
balance: Elite mobs cannot be converted while they're busy battling their challenger.
balance: Mobs that have been given sentience potions to are unconvertable. They answer to their master (the one that gave them the potion in the first place) anyway.
/:cl:
