### PR TITLE
Prosthetic Item arms no longer prevent ventcrawling

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -118,3 +118,5 @@
 #define INCLUDE_POCKETS (1<<0)
 #define INCLUDE_ACCESSORIES (1<<1)
 #define INCLUDE_HELD (1<<2)
+/// Include prosthetic item limbs (which are not flavoured as being equipped items)
+#define INCLUDE_PROSTHETICS (1<<3)

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -120,3 +120,5 @@
 #define INCLUDE_HELD (1<<2)
 /// Include prosthetic item limbs (which are not flavoured as being equipped items)
 #define INCLUDE_PROSTHETICS (1<<3)
+/// Include items that are not "real" items, such as hand items
+#define INCLUDE_ABSTRACT (1<<4)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -95,8 +95,12 @@
 /mob/proc/get_num_held_items()
 	. = 0
 	for(var/i in 1 to held_items.len)
-		if(held_items[i])
-			.++
+		if(!held_items[i])
+			continue
+		var/obj/item/gripped_item = held_items[i]
+		if(HAS_TRAIT_FROM(gripped_item, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)) //prostetic limbs are not held items, they are part of the body.
+			continue
+		.++
 
 //Sad that this will cause some overhead, but the alias seems necessary
 //*I* may be happy with a million and one references to "indexes" but others won't be
@@ -451,9 +455,12 @@
 	var/list/items = list()
 	for(var/obj/item/item_contents in contents)
 		if(item_contents.item_flags & IN_INVENTORY)
+			if(!(include_flags & INCLUDE_PROSTHETICS) && HAS_TRAIT_FROM(item_contents, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)) //prostetic limbs are not equipped items, they are part of the body.
+				continue
 			items += item_contents
 	if (!(include_flags & INCLUDE_HELD))
 		items -= held_items
+
 	return items
 
 /**

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -100,6 +100,8 @@
 		var/obj/item/gripped_item = held_items[i]
 		if(HAS_TRAIT_FROM(gripped_item, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)) //prostetic limbs are not held items, they are part of the body.
 			continue
+		if(gripped_item.item_flags & ABSTRACT) //not really flavoured as items
+			continue
 		.++
 
 //Sad that this will cause some overhead, but the alias seems necessary
@@ -456,6 +458,8 @@
 	for(var/obj/item/item_contents in contents)
 		if(item_contents.item_flags & IN_INVENTORY)
 			if(!(include_flags & INCLUDE_PROSTHETICS) && HAS_TRAIT_FROM(item_contents, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)) //prostetic limbs are not equipped items, they are part of the body.
+				continue
+			if(!(include_flags & INCLUDE_ABSTRACT) && (item_contents.item_flags & ABSTRACT)) //not really flavoured as items
 				continue
 			items += item_contents
 	if (!(include_flags & INCLUDE_HELD))


### PR DESCRIPTION
## About The Pull Request

This PR changes the procs for getting held and equipped items to not count prosthetically implanted items by default. 

As they are flavoured as being neither held nor equipped but rather being part of the owners body. 

This lets ventcrawling carbons ventcrawl even if they have a prosthetic item limb.

## Why It's Good For The Game

It helps further mechanically distinguish having an item prosthetic from just holding a no drop item. 

Synergizes with other extreme forms of body modifications like monkey mutation and rat infusion, letting player create, or turn them self into, more mobile abominations. 

There might be some balance concerns with some configurations but current sources of ventcrawling all have significant drawbacks.

## Changelog

:cl:
balance: prosthetic item limbs are no longer considered equipped items for most purposes such as ventcrawling. 
/:cl:

