### PR TITLE
mining bags now scoop up ores that get moved under you without you having to shuffle back and forth

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -1338,8 +1338,9 @@
 
 /datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
-	for(var/obj/item/stack/ore/O in orange(3, drinker))
-		step_towards(O, get_turf(drinker))
+	var/turf/drinker_turf = get_turf(drinker)
+	for(var/obj/item/stack/ore/ore in orange(3, drinker))
+		step_towards(ore, drinker_turf)
 
 //Another reference. Heals those in critical condition extremely quickly.
 /datum/reagent/consumable/ethanol/hearty_punch
@@ -2894,7 +2895,7 @@
 	quality = DRINK_VERYGOOD
 	taste_description = "the aloha state"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	
+
 /datum/reagent/consumable/ethanol/boston_sour
 	name = "Boston Sour"
 	description = "Whiskey sour texturally elevated by an egg white."
@@ -2985,7 +2986,7 @@
 	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick) //removes disgust, same with sol dry
 	if(affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5 * REM * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
 		return UPDATE_MOB_HEALTH
-		
+
 /datum/reagent/consumable/ethanol/blue_blazer
 	name = "Blue Blazer"
 	description = "The signature drink of a legendary bartender from the 19th century. While remembered for how he innovated the art of bartending, at the end of the day this drink is really just warmed and sweetened whiskey."
@@ -2994,7 +2995,7 @@
 	quality = DRINK_NICE
 	taste_description = "scorched sweet whiskey"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	
+
 /datum/reagent/consumable/ethanol/blue_blazer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	affected_mob.adjust_bodytemperature(25 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/Monkestation/Monkestation2.0/pull/8355

this makes it so ores than get moved under you somehow (such as the magnet effect from fetching fizz) when u have a mining bag will get scooped into said bag, without you needed to move off and back onto the tile.

https://github.com/user-attachments/assets/96bb7190-331b-4ce7-826a-50f3e4069224

## Why It's Good For The Game

less annoying

## Changelog
:cl:
qol: Mining bags now scoop up ores that get moved under you without you having to shuffle back and forth. Rejoice, fetching fizz enjoyers.
/:cl:
