### PR TITLE
Dynamic Tester differentiates lights and heavies

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_testing.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_testing.dm
@@ -13,8 +13,10 @@ ADMIN_VERB(dynamic_tester, R_DEBUG, "Dynamic Tester", "See dynamic probabilities
 
 	/// A formatted report of the weights of each roundstart ruleset, refreshed occasionally and sent to the UI.
 	var/list/roundstart_ruleset_report = list()
-	/// A formatted report of the weights of each midround ruleset, refreshed occasionally and sent to the UI.
-	var/list/midround_ruleset_report = list()
+	/// A formatted report of the weights of each light midround ruleset, refreshed occasionally and sent to the UI.
+	var/list/light_midround_ruleset_report = list()
+	/// A formatted report of the weights of each heavy midround ruleset, refreshed occasionally and sent to the UI.
+	var/list/heavy_midround_ruleset_report = list()
 
 	/// What is the tier we are testing?
 	var/tier = 1
@@ -58,7 +60,8 @@ ADMIN_VERB(dynamic_tester, R_DEBUG, "Dynamic Tester", "See dynamic probabilities
 	data["tier"] = tier
 	data["num_players"] = num_players
 	data["roundstart_ruleset_report"] = flatten_list(roundstart_ruleset_report)
-	data["midround_ruleset_report"] = flatten_list(midround_ruleset_report)
+	data["light_midround_ruleset_report"] = flatten_list(light_midround_ruleset_report)
+	data["heavy_midround_ruleset_report"] = flatten_list(heavy_midround_ruleset_report)
 
 	return data
 
@@ -98,14 +101,16 @@ ADMIN_VERB(dynamic_tester, R_DEBUG, "Dynamic Tester", "See dynamic probabilities
 			"comment" = comment,
 		)
 
-	midround_ruleset_report.Cut()
+	light_midround_ruleset_report.Cut()
+	heavy_midround_ruleset_report.Cut()
 	for(var/datum/dynamic_ruleset/midround/ruleset as anything in midround_rulesets)
-		midround_ruleset_report[ruleset] = list(
+		var/list/list_to_add = ruleset.midround_type == LIGHT_MIDROUND ? light_midround_ruleset_report : heavy_midround_ruleset_report
+		list_to_add[ruleset] = list(
 			"name" = ruleset.name,
 			"weight" = ruleset.get_weight(num_players, tier),
 			"max_candidates" = ruleset.get_antag_cap(num_players, ruleset.max_antag_cap || ruleset.min_antag_cap),
 			"min_candidates" = ruleset.get_antag_cap(num_players, ruleset.min_antag_cap),
-			"comment" = ruleset.midround_type,
 		)
+
 
 	update_static_data_for_all_viewers()

--- a/tgui/packages/tgui/interfaces/DynamicTester.tsx
+++ b/tgui/packages/tgui/interfaces/DynamicTester.tsx
@@ -24,12 +24,14 @@ type Data = {
   tier: number;
   num_players: number;
   roundstart_ruleset_report: RulesetReport[];
-  midround_ruleset_report: RulesetReport[];
+  light_midround_ruleset_report: RulesetReport[];
+  heavy_midround_ruleset_report: RulesetReport[];
 };
 
 enum TABS {
   Roundstart = 'Roundstart',
-  Midrounds = 'Midrounds',
+  LightMidrounds = 'LightMidrounds',
+  HeavyMidrounds = 'HeavyMidrounds',
 }
 
 export const DynamicTester = () => {
@@ -38,7 +40,8 @@ export const DynamicTester = () => {
     tier,
     num_players,
     roundstart_ruleset_report,
-    midround_ruleset_report,
+    light_midround_ruleset_report,
+    heavy_midround_ruleset_report,
   } = data;
 
   const [tab, setTab] = useState(Object.keys(TABS)[0]);
@@ -46,14 +49,17 @@ export const DynamicTester = () => {
   const ruleset_report =
     tab === TABS.Roundstart
       ? roundstart_ruleset_report
-      : midround_ruleset_report;
+      : tab === TABS.LightMidrounds
+        ? light_midround_ruleset_report
+        : heavy_midround_ruleset_report;
 
   const total_weight = ruleset_report.reduce(
     (acc, report) => acc + report.weight,
     0,
   );
   const rulesets_with_weight_percentages = ruleset_report.map((report) => {
-    const percentage = Math.round((report.weight / total_weight) * 100);
+    const percentage =
+      total_weight === 0 ? 0 : Math.round((report.weight / total_weight) * 100);
     return {
       ...report,
       percentage,
@@ -96,7 +102,7 @@ export const DynamicTester = () => {
                     selected={tab === tabName}
                     onClick={() => setTab(tabName)}
                   >
-                    {tabName}
+                    {TABS[tabName]}
                   </Tabs.Tab>
                 ))}
               </Tabs>
@@ -110,31 +116,33 @@ export const DynamicTester = () => {
                   <Table.Cell>Max Antags</Table.Cell>
                   <Table.Cell>Min Antags</Table.Cell>
                 </Table.Row>
-                {rulesets_with_weight_percentages.map((report) => (
-                  <Table.Row key={report.name}>
-                    {report.comment ? (
-                      <Table.Cell>
-                        <Tooltip content={report.comment} position="right">
-                          <Box
-                            inline
-                            style={{
-                              borderBottom:
-                                '2px dotted rgba(255, 255, 255, 0.8)',
-                            }}
-                          >
-                            {report.name}
-                          </Box>
-                        </Tooltip>
-                      </Table.Cell>
-                    ) : (
-                      <Table.Cell>{report.name}</Table.Cell>
-                    )}
-                    <Table.Cell>{report.weight}</Table.Cell>
-                    <Table.Cell>{report.percentage}%</Table.Cell>
-                    <Table.Cell>{report.max_candidates}</Table.Cell>
-                    <Table.Cell>{report.min_candidates}</Table.Cell>
-                  </Table.Row>
-                ))}
+                {rulesets_with_weight_percentages
+                  .sort((a, b) => (a.name > b.name ? 1 : -1))
+                  .map((report) => (
+                    <Table.Row key={`${report.name}-${TABS[tab]}`}>
+                      {report.comment ? (
+                        <Table.Cell>
+                          <Tooltip content={report.comment} position="right">
+                            <Box
+                              inline
+                              style={{
+                                borderBottom:
+                                  '2px dotted rgba(255, 255, 255, 0.8)',
+                              }}
+                            >
+                              {report.name}
+                            </Box>
+                          </Tooltip>
+                        </Table.Cell>
+                      ) : (
+                        <Table.Cell>{report.name}</Table.Cell>
+                      )}
+                      <Table.Cell>{report.weight}</Table.Cell>
+                      <Table.Cell>{report.percentage}%</Table.Cell>
+                      <Table.Cell>{report.max_candidates}</Table.Cell>
+                      <Table.Cell>{report.min_candidates}</Table.Cell>
+                    </Table.Row>
+                  ))}
               </Table>
             </Stack.Item>
           </Stack>


### PR DESCRIPTION
## About The Pull Request

Dynamic Tester puts lights and heavies in two different tabs

<img width="285" height="303" alt="image" src="https://github.com/user-attachments/assets/d179f0ad-078d-412b-beb2-1fb9863f1f12" />

Also now sorts alphabetically.

## Why It's Good For The Game

Honestly don't remember why it was the way it is - likely due to it being created early into iteration?

## Changelog

:cl: Melbert
admin: Dynamic Tester differentiates lights and heavies
/:cl:
