### PR TITLE
Removes the random emagged portal spawn and lowers the export price of the monocloning jumperfish.

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -88,7 +88,6 @@ GLOBAL_LIST_INIT(mystery_magic, list(
 GLOBAL_LIST_INIT(mystery_fishing, list(
 	/obj/item/storage/toolbox/fishing/master,
 	/obj/item/storage/box/fish_revival_kit,
-	/obj/item/circuitboard/machine/fishing_portal_generator/emagged,
 	/obj/item/fishing_rod/telescopic/master,
 	/obj/item/bait_can/super_baits,
 	/obj/item/storage/fish_case/tiziran,

--- a/code/modules/fishing/fish/types/syndicate.dm
+++ b/code/modules/fishing/fish/types/syndicate.dm
@@ -69,7 +69,7 @@
 
 /obj/item/fish/jumpercable/get_export_price(price, elasticity_percent)
 	//without this, they'd sell for over 6000 each, minimum. That's a lot for a fish that requires no maintance nor partner to farm.
-	return ..() * 0.4
+	return ..() * 0.04
 
 /obj/item/fish/jumpercable/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] hooks both ends of [src] to their chest! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
## About The Pull Request

The export multiplier for monocloning jumpercable fish has been lowered by an order of magnitude, making each one sell for a value in the ballpark of 200-300 credits each, in-line with a free crate as opposed to... buying a whole crate for free.

The emagged fishing portal board has been removed from the treasure chest loot table.

## Why It's Good For The Game

**The emagged fishing portal can still be obtained by emagging a fishing portal as usual and intended.**

Currently, the ocean portal can spawn in a treasure chest, `/obj/structure/mystery_box/fishing`. It's a time-gated rare item from the ocean portal, which has a rare chance to spawn. The issue with the fishing treasure chest is primarily that one of it's rewards is the emagged fishing portal. Additionally, the treasure chest functions like the christmas tree, one free gift per mind per box. On a decent pop you run pretty good odds of getting the emagged fishing portal.

As a result, the fishing portal has been obtained a particularly large number of times, far more than expected based on export data. I know this due to the chart.

### Arcane what do you mean "the chart".
I mean the **chart.**
<img width="1550" height="274" alt="image" src="https://github.com/user-attachments/assets/82e5dfd6-9f96-478b-b4f1-8259c5d4f905" />
This is a chart of the top most exported items based on all superset, blackbox data. Number one, the monocloning jumpercable, aka `/obj/item/fish/jumpercable`. On current patch, they have an average export value in the ballbark of 2k-3k credits for each fish caught, with a 25% chance to be caught from an emagged portal. As their name suggests, they can clone themselves without a breeding pair, and breed up to a tank maximum of 12 of themselves.

These fish make up 4x more export value than all sales across the stock market, and believe me, I *already know* how unilaterally broken the stock market is right now.

Keeping these as-is would be extremely unhealthy for game health. This isn't just me being an asshole about balance as usual.

**The emagged fishing portal can still be obtained by emagging a fishing portal as usual and intended.**

## Changelog

:cl:
del: You can no longer obtain an emagged fishing portal board from treasure chests. You can still, however, emag fishing portals.
balance: Monocloning Jumpercable fish have had their export values decreased. Their cloning capacity and electrical output remain the same.
/:cl: