### PR TITLE
Change thunder to not damage objects and smelt ores

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -427,19 +427,14 @@
 		to_chat(hit_mob, span_userdanger("You've been struck by lightning!"))
 		hit_mob.electrocute_act(50, "thunder", flags = SHOCK_TESLA|SHOCK_NOGLOVES)
 
-	for(var/obj/hit_thing in weather_turf)
-		if(QDELETED(hit_thing)) // stop, it's already dead
+	for(var/obj/item/stack/ore/hit_ore in weather_turf)
+		if(QDELETED(hit_ore))
 			continue
-		if(!hit_thing.uses_integrity)
-			continue
-		if(hit_thing.invisibility != INVISIBILITY_NONE)
-			continue
-		if(HAS_TRAIT(hit_thing, TRAIT_UNDERFLOOR))
-			continue
-		hit_thing.take_damage(20, BURN, ENERGY, FALSE)
+		hit_ore.fire_act(1000) // ores that get struck by thunder are smelted
+
 	playsound(weather_turf, 'sound/effects/magic/lightningbolt.ogg', 100, extrarange = 10, falloff_distance = 10)
 	weather_turf.visible_message(span_danger("A thunderbolt strikes [weather_turf]!"))
-	explosion(weather_turf, light_impact_range = 1, flame_range = 1, silent = TRUE, adminlog = FALSE)
+	new /obj/effect/hotspot(weather_turf)
 
 /**
  * Updates the overlays on impacted areas

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -430,7 +430,9 @@
 	for(var/obj/item/stack/ore/hit_ore in weather_turf)
 		if(QDELETED(hit_ore))
 			continue
-		hit_ore.fire_act(1000) // ores that get struck by thunder are smelted
+		// ores that get struck by thunder are smelted
+		// a bolt of lightning can reach temperatures of 30,000 Kelvin which is 5x hotter than the sun
+		hit_ore.fire_act(30000)
 
 	playsound(weather_turf, 'sound/effects/magic/lightningbolt.ogg', 100, extrarange = 10, falloff_distance = 10)
 	weather_turf.visible_message(span_danger("A thunderbolt strikes [weather_turf]!"))


### PR DESCRIPTION

## About The Pull Request
Thunder strikes were causing outside wires, pipes, and objects to be damaged, which was making certain stations inhabitable. This removes all object damage caused by thunder, however it gains a new niche ability to smelt ores into sheets, just like lava does. 

## Why It's Good For The Game
Lavaland and stations that use thunder, should have their outside areas safe from destruction or it causes long term problems.

## Changelog
:cl:
add: Thunder from weather will now smelt any mining ores it hits.
balance: Remove thunder exploding turfs and damaging objects however mobs will still be affected.
/:cl:
