### PR TITLE
anti, low and high, gravity fields no longer have the same particles effect

### DIFF
--- a/code/datums/proximity_monitor/fields/gravity.dm
+++ b/code/datums/proximity_monitor/fields/gravity.dm
@@ -95,7 +95,7 @@
 		if(-INFINITY to -1)
 			particle_type = /particles/grav_field_up
 	if (particle_type)
-		add_shared_particles(/particles/grav_field_down/strong)
+		add_shared_particles(particle_type)
 		color = particle_type::color
 	RegisterSignal(src, COMSIG_ATOM_SMOOTHED_ICON, PROC_REF(smoothed))
 


### PR DESCRIPTION
## About The Pull Request
Noticed this minor mistake while checking the file.

## Why It's Good For The Game
`particle_type` now actually does something

## Changelog

:cl:
fix: anti, low and high, gravity fields no longer have the same particles effect.
/:cl:
