### PR TITLE
Removed duplicate scream emote.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -66,7 +66,7 @@
 	specific_emote_audio_cooldown = 10 SECONDS
 	vary = FALSE
 
-/datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)
+/datum/emote/living/carbon/human/screech/get_sound(mob/living/carbon/human/user)
 	return user.dna.species.get_scream_sound(user)
 
 /datum/emote/living/carbon/human/pale

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -57,36 +57,21 @@
 	message_mime = "mumbles silently!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 
-/datum/emote/living/carbon/human/scream
-	key = "scream"
-	key_third_person = "screams"
-	message = "screams!"
-	message_mime = "acts out a scream!"
-	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
-	specific_emote_audio_cooldown = 10 SECONDS
-	vary = TRUE
-
-/datum/emote/living/carbon/human/scream/can_run_emote(mob/user, status_check = TRUE , intentional, params)
-	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))
-		return FALSE
-	return ..()
-
-/datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)
-	if(!istype(user))
-		return
-	return user.dna.species.get_scream_sound(user)
-
-/datum/emote/living/carbon/human/scream/screech //If a human tries to screech it'll just scream.
+/datum/emote/living/carbon/human/screech // Those with the primitive trait (monkeys and ashwalkers) can run this.
 	key = "screech"
 	key_third_person = "screeches"
 	message = "screeches!"
 	message_mime = "screeches silently."
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
+	specific_emote_audio_cooldown = 10 SECONDS
 	vary = FALSE
 
-/datum/emote/living/carbon/human/scream/screech/should_play_sound(mob/user, intentional)
-	if(ismonkey(user))
-		return TRUE
+/datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)
+	return user.dna.species.get_scream_sound(user)
+
+/datum/emote/living/carbon/human/screech/can_run_emote(mob/user, status_check = TRUE , intentional, params)
+	if(intentional && !HAS_TRAIT(user, TRAIT_PRIMITIVE))
+		return FALSE
 	return ..()
 
 /datum/emote/living/carbon/human/pale

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -57,7 +57,7 @@
 	message_mime = "mumbles silently!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 
-/datum/emote/living/carbon/human/screech // Those with the primitive trait (monkeys and ashwalkers) can run this.
+/datum/emote/living/carbon/human/screech // basically scream 2.0
 	key = "screech"
 	key_third_person = "screeches"
 	message = "screeches!"
@@ -68,11 +68,6 @@
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)
 	return user.dna.species.get_scream_sound(user)
-
-/datum/emote/living/carbon/human/screech/can_run_emote(mob/user, status_check = TRUE , intentional, params)
-	if(intentional && !HAS_TRAIT(user, TRAIT_PRIMITIVE))
-		return FALSE
-	return ..()
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -416,8 +416,10 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
-	mob_type_blacklist_typecache = list(/mob/living/brain, /mob/living/carbon/human)
+	mob_type_blacklist_typecache = list(/mob/living/brain)
 	sound_wall_ignore = TRUE
+	specific_emote_audio_cooldown = 10 SECONDS
+	vary = TRUE
 
 /datum/emote/living/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
 	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))
@@ -428,6 +430,12 @@
 	. = ..()
 	if(!intentional && isanimal_or_basicmob(user))
 		return "makes a loud and pained whimper."
+
+/datum/emote/living/scream/get_sound(mob/living/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/humie = user
+	return humie.dna.species.get_scream_sound(user)
 
 /datum/emote/living/scowl
 	key = "scowl"


### PR DESCRIPTION
## About The Pull Request
We have two different *scream emote types, not counting the *screech subtype, and it's a bit of a copypasta, so I merged the two together, and made the *screech its own type, only usable by human mobs ~~with the primitive traits, aka monkeys and ashwalkers~~ like before.

## Why It's Good For The Game
Less copypasta. You'll probably have to reset your scream hotkey after this is merged.

~~Also screeching is simply another emote that played the scream sound, and human scream stock sounds barely fit it anyway, so we're not losing much by locking it to monkeys and ashwalkers.~~ Screeching is once more back on the menu

## Changelog

:cl:
code: Merged the human and living versions of the scream emote. Remember to reset your scream hotkey if it is ever unset.
/:cl:
