### PR TITLE
Add more examine tags and fix ones not appearing

### DIFF
--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -99,7 +99,7 @@
 			.["flammable"] = "It looks like it could easily catch on fire."
 
 	if(flags_1 & HOLOGRAM_1)
-		.["hologram"] = "It looks like a hologram."
+		.["holographic"] = "It looks like a hologram."
 	if(flags_1 & IS_PLAYER_COLORABLE_1) // GAGs support for greyscale
 		.["recolorable"] = "It has a variety of colors that you can select from."
 

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -19,14 +19,17 @@
 		. += "<i>[desc]</i>"
 
 	var/list/tags_list = examine_tags(user)
+	var/list/post_descriptor = examine_post_descriptor(user)
+	var/post_desc_string = length(post_descriptor) ? " [jointext(post_descriptor, " ")]" : ""
 	if (length(tags_list))
 		var/tag_string = list()
 		for (var/atom_tag in tags_list)
 			tag_string += (isnull(tags_list[atom_tag]) ? atom_tag : span_tooltip(tags_list[atom_tag], atom_tag))
 		// some regex to ensure that we don't add another "and" if the final element's main text (not tooltip) has one
 		tag_string = english_list(tag_string, and_text = (findtext(tag_string[length(tag_string)], regex(@">.*?and .*?<"))) ? " " : " and ")
-		var/post_descriptor = examine_post_descriptor(user)
-		. += "[p_They()] [p_are()] a [tag_string] [examine_descriptor(user)][length(post_descriptor) ? " [jointext(post_descriptor, " ")]" : ""]."
+		. += "[p_They()] [p_are()] a [tag_string] [examine_descriptor(user)][post_desc_string]."
+	else if(post_desc_string)
+		. += "[p_They()] [p_are()] a [examine_descriptor(user)][post_desc_string]."
 
 	if(reagents)
 		var/user_sees_reagents = user.can_see_reagents()
@@ -76,6 +79,33 @@
 	. = list()
 	if(abstract_type == type)
 		.[span_hypnophrase("abstract")] = "This is an abstract concept, you should report this to a strange entity called GITHUB!"
+
+	if(resistance_flags & INDESTRUCTIBLE)
+		.["indestructible"] = "It is extremely robust! It'll probably withstand anything that could happen to it!"
+	else
+		if(resistance_flags & LAVA_PROOF)
+			.["lavaproof"] = "It is made of an extremely heat-resistant material, it'd probably be able to withstand lava!"
+		if(resistance_flags & (ACID_PROOF | UNACIDABLE))
+			.["acidproof"] = "It looks pretty robust! It'd probably be able to withstand acid!"
+		if(resistance_flags & FREEZE_PROOF)
+			.["freezeproof"] = "It is made of cold-resistant materials."
+		if(resistance_flags & FIRE_PROOF)
+			.["fireproof"] = "It is made of fire-retardant materials."
+		if(resistance_flags & SHUTTLE_CRUSH_PROOF)
+			.["crushproof"] = "It is extremely solid. It should be able to withstand being run over by a shuttle!"
+		if(resistance_flags & BOMB_PROOF)
+			.["bombproof"] = "It looks like it could survive an explosion!"
+		if(resistance_flags & FLAMMABLE)
+			.["flammable"] = "It looks like it could easily catch on fire."
+
+	if(flags_1 & HOLOGRAM_1)
+		.["hologram"] = "It looks like a hologram."
+	if(flags_1 & UNPAINTABLE_1)
+		.["unpaintable"] = "It appears to be unpaintable."
+	if(flags_1 & SUPERMATTER_IGNORES_1)
+		.["supermatter proof"] = "It is immune to the supermatter's effects and will not be dusted."
+	if(flags_1 & IS_PLAYER_COLORABLE_1) // GAGs support for greyscale
+		.["recolorable"] = "It has a variety of colors that you can select from."
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE_TAGS, user, .)
 

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -100,8 +100,6 @@
 
 	if(flags_1 & HOLOGRAM_1)
 		.["holographic"] = "It looks like a hologram."
-	if(flags_1 & IS_PLAYER_COLORABLE_1) // GAGs support for greyscale
-		.["recolorable"] = "It has a variety of colors that you can select from."
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE_TAGS, user, .)
 

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -84,17 +84,17 @@
 		.["indestructible"] = "It is extremely robust! It'll probably withstand anything that could happen to it!"
 	else
 		if(resistance_flags & LAVA_PROOF)
-			.["lavaproof"] = "It is made of an extremely heat-resistant material, it'd probably be able to withstand lava!"
+			.["lava-proof"] = "It is made of an extremely heat-resistant material, it'd probably be able to withstand lava!"
 		if(resistance_flags & (ACID_PROOF | UNACIDABLE))
-			.["acidproof"] = "It looks pretty robust! It'd probably be able to withstand acid!"
+			.["acid-proof"] = "It looks pretty robust! It'd probably be able to withstand acid!"
 		if(resistance_flags & FREEZE_PROOF)
-			.["freezeproof"] = "It is made of cold-resistant materials."
+			.["freeze-proof"] = "It is made of cold-resistant materials."
 		if(resistance_flags & FIRE_PROOF)
-			.["fireproof"] = "It is made of fire-retardant materials."
+			.["fire-proof"] = "It is made of fire-retardant materials."
 		if(resistance_flags & SHUTTLE_CRUSH_PROOF)
-			.["crushproof"] = "It is extremely solid. It should be able to withstand being run over by a shuttle!"
+			.["crush-proof"] = "It is extremely solid. It should be able to withstand being run over by a shuttle!"
 		if(resistance_flags & BOMB_PROOF)
-			.["bombproof"] = "It looks like it could survive an explosion!"
+			.["bomb-proof"] = "It looks like it could survive an explosion!"
 		if(resistance_flags & FLAMMABLE)
 			.["flammable"] = "It looks like it could easily catch on fire."
 

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -100,10 +100,6 @@
 
 	if(flags_1 & HOLOGRAM_1)
 		.["hologram"] = "It looks like a hologram."
-	if(flags_1 & UNPAINTABLE_1)
-		.["unpaintable"] = "It appears to be unpaintable."
-	if(flags_1 & SUPERMATTER_IGNORES_1)
-		.["supermatter proof"] = "It is immune to the supermatter's effects and will not be dusted."
 	if(flags_1 & IS_PLAYER_COLORABLE_1) // GAGs support for greyscale
 		.["recolorable"] = "It has a variety of colors that you can select from."
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -458,19 +458,6 @@
 	else if (siemens_coefficient <= 0.5)
 		.["partially insulated"] = "It is made from a poor insulator that will dampen (but not fully block) electric shocks passing through it."
 
-	if(resistance_flags & INDESTRUCTIBLE)
-		.["indestructible"] = "It is extremely robust! It'll probably withstand anything that could happen to it!"
-		return
-
-	if(resistance_flags & LAVA_PROOF)
-		.["lavaproof"] = "It is made of an extremely heat-resistant material, it'd probably be able to withstand lava!"
-	if(resistance_flags & (ACID_PROOF | UNACIDABLE))
-		.["acidproof"] = "It looks pretty robust! It'd probably be able to withstand acid!"
-	if(resistance_flags & FREEZE_PROOF)
-		.["freezeproof"] = "It is made of cold-resistant materials."
-	if(resistance_flags & FIRE_PROOF)
-		.["fireproof"] = "It is made of fire-retardant materials."
-
 /obj/item/examine_descriptor(mob/user)
 	return "item"
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -223,6 +223,8 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 	. = ..()
 	if(obj_flags & UNIQUE_RENAME)
 		.["renameable"] = "Use a pen on it to rename it or change its description."
+	if(obj_flags & CONDUCTS_ELECTRICITY)
+		.["conductive"] = "It appears to be a good conductor of electricity."
 
 /obj/analyzer_act(mob/living/user, obj/item/analyzer/tool)
 	if(atmos_scan(user=user, target=src, silent=FALSE))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -366,9 +366,9 @@
 	if (clothing_flags & CASTING_CLOTHES)
 		.["magical"] = "Allows magical beings to cast spells when wearing [src]."
 	if((clothing_flags & STOPSPRESSUREDAMAGE) || (visor_flags & STOPSPRESSUREDAMAGE))
-		.["pressureproof"] = "Protects the wearer from extremely low or high pressure, such as vacuum of space."
+		.["pressure-proof"] = "Protects the wearer from extremely low or high pressure, such as vacuum of space."
 	if(flags_cover & PEPPERPROOF)
-		.["pepperproof"] = "Protects the wearer from the effects of pepperspray."
+		.["pepper-proof"] = "Protects the wearer from the effects of pepperspray."
 	if (heat_protection || cold_protection)
 		var/heat_desc
 		var/cold_desc


### PR DESCRIPTION
## About The Pull Request
This fixes custom materials not appearing for things like structures. It also adds a bunch of new tags:
- bomb-proof
- flammable
- holograhic
- ~~unpaintable~~
- ~~supermatter proof~~
- ~~recolorable~~
- crush-proof
- conductive

Also use hyphens for multi-word examine tags.

## Why It's Good For The Game
Better UX

## Changelog
:cl:
qol: Add several new examine categories for objects descs that include: bomb-proof, flammable, holograhic, crush-proof, and conductive. Also use hyphens for multi-word examine tags.
fix: Fixes custom materials not appearing for things like structures when examined.
/:cl:
