### PR TITLE
Makes shuttle engines no longer use weakrefs (and more minorly makes them actually give engine power)

### DIFF
--- a/code/modules/shuttle/mobile_port/mobile_port.dm
+++ b/code/modules/shuttle/mobile_port/mobile_port.dm
@@ -96,6 +96,8 @@
 	unregister()
 	destination = null
 	previous = null
+	for(var/obj/machinery/power/shuttle_engine/engine as anything in engine_list)
+		engine.unsync_ship()
 	if(!QDELETED(assigned_transit))
 		qdel(assigned_transit, force = TRUE)
 		assigned_transit = null


### PR DESCRIPTION
## About The Pull Request

- Makes shuttle engines no longer use weakrefs, they now use normal references
- Makes shuttle engines no longer give negative initial engine power on being unconnected

## Why It's Good For The Game

> Makes shuttle engines no longer use weakrefs, they now use normal references
- Weakrefs are for when we care about an object but it does not care about us, shuttles literally have a list of engines. I think they do kind of care about us and are going to hard-delete if the engines aren't deleted first. So might aswell ignore the more expensive weakrefs and use normal ones instead.
> Makes shuttle engines no longer give negative initial engine power on being unconnected
- So imagine this:
> I wrench in the engine, cool its now connected to the shuttle
> I weld the engine, fun it now provides shuttle power
> I unweld the engine, damn it now does not provide shuttle power
> I unwrench the engine, unsyncing it. It now provides negative power because unsyncing it made it give less power again
> I cry
> My shuttle now needs twice the engines it needed before

Not fun, so unsyncing no longer takes away engine power.

## Changelog

:cl:
fix: shuttle engines no longer provide negative power to your shuttles if you unwrench them.
/:cl:
