### PR TITLE
[NO GBP] Cyborg inducer fix... fix

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -267,7 +267,7 @@
 	return NONE
 
 /obj/item/inducer/cyborg/interact_with_atom(atom/movable/interacting_with, mob/living/user, list/modifiers)
-	. = ..()
 	if(iscyborg(user) && iscyborg(interacting_with))
 		balloon_alert(user, "can't charge this!")
 		return ITEM_INTERACT_FAILURE
+	return ..()


### PR DESCRIPTION
## About The Pull Request
#93096 made it possible for cyborgs to recharge themselves (or each other) with inducers once again, when they shouldn't. It was my fault for merging it seconds before that realization

## Why It's Good For The Game
The parent call should be by the end of the override, not at the start.

## Changelog
N/A