### PR TITLE
Climbing desc is now an examine tag

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -21,18 +21,20 @@
 	src.climb_stun = climb_stun
 
 	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, PROC_REF(attack_hand))
-	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(target, COMSIG_ATOM_EXAMINE_TAGS, PROC_REF(get_examine_tags))
 	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, PROC_REF(mousedrop_receive))
 	ADD_TRAIT(target, TRAIT_CLIMBABLE, ELEMENT_TRAIT(type))
 
 /datum/element/climbable/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_EXAMINE, COMSIG_MOUSEDROPPED_ONTO, COMSIG_ATOM_BUMPED))
+	UnregisterSignal(target, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_EXAMINE_TAGS, COMSIG_MOUSEDROPPED_ONTO, COMSIG_ATOM_BUMPED))
 	REMOVE_TRAIT(target, TRAIT_CLIMBABLE, ELEMENT_TRAIT(type))
 	return ..()
 
-/datum/element/climbable/proc/on_examine(atom/source, mob/user, list/examine_texts)
+///Someone inspected our embeddable item
+/datum/element/climbable/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
-	examine_texts += span_notice("[source] looks climbable.")
+
+	examine_list["climbable"] = "It looks like it can be climbed on."
 
 /datum/element/climbable/proc/can_climb(atom/source, mob/user)
 	if (!user.CanReach(source))


### PR DESCRIPTION
## About The Pull Request
The climbing element used a seperate line in the description examine text to indicate it was climbable. This transfers that information to a examine tag to cut down on excessive desc text spam.

This also could be replicated for lots of other things like anchoring, welding, etc.

## Why It's Good For The Game
Better UX/UI

<img width="603" height="494" alt="dreamseeker_fHDHUJd45F" src="https://github.com/user-attachments/assets/9086458d-a8a8-4b4c-815c-74e9d9dba1d5" />


## Changelog
:cl:
qol: Climbable objects now show up as an examine tag.
/:cl:
