### PR TITLE
Holograms objects will fade away when affected by EMPs

### DIFF
--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -77,7 +77,8 @@
 			// avoid spamming messages for anything inside the holodeck directly
 			if(!istype(get_area(src), /area/station/holodeck))
 				visible_message(span_warning("[src] fades away!"))
-			qdel(src)
+			animate(alpha = 0, time = 1 SECONDS)
+			QDEL_IN(src, 1 SECONDS)
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EMP_ACT, severity, protection)
 	return protection // Pass the protection value collected here upwards

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -72,6 +72,13 @@
 	if(!(protection & EMP_PROTECT_WIRES) && istype(wires))
 		wires.emp_pulse()
 
+	if(flags_1 & HOLOGRAM_1) // holograms should ignore EMP_PROTECT flags (since the protection itself is also a hologram)
+		if(prob(75 / severity))
+			// avoid spamming messages for anything inside the holodeck directly
+			if(!istype(get_area(src), /area/station/holodeck))
+				visible_message(span_warning("[src] fades away!"))
+			qdel(src)
+
 	SEND_SIGNAL(src, COMSIG_ATOM_EMP_ACT, severity, protection)
 	return protection // Pass the protection value collected here upwards
 


### PR DESCRIPTION

## About The Pull Request
EMPs can now affect any hologram items from the holodeck. The stronger the EMP, the higher chance for an object to fade away. Also there is no visible message for objects fading away while they are already inside the holodeck to avoid message spam.

## Why It's Good For The Game
Consistency. This also gives an increased risk to using holodeck equipment in combat when the holodeck is emagged.

## Changelog
:cl:
add: Holograms objects will fade away when affected by EMPs.
/:cl:
