### PR TITLE
The Roidening: Getting swole improves your unarmed damage floor and possible stagger combo outcome.

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -325,7 +325,7 @@
 	desc = "The user's muscles slightly expand. Commonly seen in top-ranking boxers."
 	quality = POSITIVE
 	text_gain_indication = span_notice("You feel strong.")
-	instability = POSITIVE_INSTABILITY_MINI
+	instability = POSITIVE_INSTABILITY_MINOR
 	difficulty = 16
 	mutation_traits = list(TRAIT_STRENGTH)
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -883,8 +883,19 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	//Someone in a grapple is much more vulnerable to being harmed by punches.
 	var/grappled = (target.pulledby && target.pulledby.grab_state >= GRAB_AGGRESSIVE)
 
-	var/damage = rand(attacking_bodypart.unarmed_damage_low, attacking_bodypart.unarmed_damage_high)
+	// Our lower and upper unarmed damage values. Damage is rolled between these two values.
+	var/lower_unarmed_damage = attacking_bodypart.unarmed_damage_low
+	var/upper_unarmed_damage = attacking_bodypart.unarmed_damage_high
+
+	// Out athletics skill is used to set our potential base damage roll. It won't increase our potential damage roll, but will make our unarmed attack more consistent.
+	// For a normal human arm, this would cap at 10, and for a normal human leg, this would go up to 14.
+	lower_unarmed_damage =  clamp(lower_unarmed_damage + (user.mind ? user.mind.get_skill_level(/datum/skill/athletics) : 0), lower_unarmed_damage, upper_unarmed_damage)
+
+	// The actual damage roll. May still be augmented by further factors.
+	var/damage = rand(lower_unarmed_damage, upper_unarmed_damage)
+	// Limb accuracy is used to determine miss probabilities (higher the value, the less likely you are to miss), armor penetration (if entitled) and the possible result from a stagger combo hit.
 	var/limb_accuracy = attacking_bodypart.unarmed_effectiveness
+	// Limb sharpness determines the type of wounds this unarmed strike could possibly roll. By default, most limbs are blunt and have no sharpness.
 	var/limb_sharpness = attacking_bodypart.unarmed_sharpness
 
 	if(grappled)
@@ -923,7 +934,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/obj/item/bodypart/affecting = target.get_bodypart(hit_zone)
 
 	var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases
-	if(attacking_bodypart.unarmed_damage_low)
+	if(lower_unarmed_damage)
 		if((target.body_position == LYING_DOWN) || HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) || staggered || user_drunkenness && HAS_TRAIT(user, TRAIT_DRUNKEN_BRAWLER)) //kicks and attacks against staggered targets never miss (provided your species deals more than 0 damage). Drunken brawlers while drunk also don't miss
 			miss_chance = 0
 		else
@@ -1008,8 +1019,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 /// Handles the stagger combo effect of our punch. Follows the same logic as the above proc, target is our owner, user is our attacker.
 /datum/species/proc/stagger_combo(mob/living/carbon/human/user, mob/living/carbon/human/target, atk_verb = "hit", limb_accuracy = 0, armor_block = 0)
-	// Randomly determines the effects of our punch. Limb accuracy is a bonus, armor block is a defense
-	var/roll_them_bones = rand(-20, 20) + limb_accuracy - armor_block
+	// Randomly determines the effects of our punch. Limb accuracy is a bonus, armor block is a defense, attacker athletics provides a minor to significant bonus.
+	var/roll_them_bones = rand(-20, 20) + limb_accuracy - armor_block + (user.mind ? (user.mind.get_skill_modifier(/datum/skill/athletics, SKILL_RANDS_MODIFIER)/2) : 0)
 
 	switch(roll_them_bones)
 		if (-INFINITY to 0) //Mostly a gimmie, this one just keeps them staggered briefly

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -887,6 +887,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/lower_unarmed_damage = attacking_bodypart.unarmed_damage_low
 	var/upper_unarmed_damage = attacking_bodypart.unarmed_damage_high
 
+	// The presence of TRAIT_STRENGTH increases our upper unarmed damage. This is a damage cap increase.
+	upper_unarmed_damage += HAS_TRAIT(user, TRAIT_STRENGTH) ? 2 : 0
+
 	// Out athletics skill is used to set our potential base damage roll. It won't increase our potential damage roll, but will make our unarmed attack more consistent.
 	// For a normal human arm, this would cap at 10, and for a normal human leg, this would go up to 14.
 	lower_unarmed_damage =  clamp(lower_unarmed_damage + (user.mind ? user.mind.get_skill_level(/datum/skill/athletics) : 0), lower_unarmed_damage, upper_unarmed_damage)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1023,7 +1023,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /// Handles the stagger combo effect of our punch. Follows the same logic as the above proc, target is our owner, user is our attacker.
 /datum/species/proc/stagger_combo(mob/living/carbon/human/user, mob/living/carbon/human/target, atk_verb = "hit", limb_accuracy = 0, armor_block = 0)
 	// Randomly determines the effects of our punch. Limb accuracy is a bonus, armor block is a defense, attacker athletics provides a minor to significant bonus.
-	var/roll_them_bones = rand(-20, 20) + limb_accuracy - armor_block + (user.mind ? (user.mind.get_skill_modifier(/datum/skill/athletics, SKILL_RANDS_MODIFIER)/2) : 0)
+	var/roll_them_bones = rand(-20, 20) + limb_accuracy - armor_block + ((user.mind?.get_skill_modifier(/datum/skill/athletics, SKILL_RANDS_MODIFIER) / 2) || 0)
 
 	switch(roll_them_bones)
 		if (-INFINITY to 0) //Mostly a gimmie, this one just keeps them staggered briefly

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -892,7 +892,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	// Out athletics skill is used to set our potential base damage roll. It won't increase our potential damage roll, but will make our unarmed attack more consistent.
 	// For a normal human arm, this would cap at 10, and for a normal human leg, this would go up to 14.
-	lower_unarmed_damage =  clamp(lower_unarmed_damage + (user.mind ? user.mind.get_skill_level(/datum/skill/athletics) : 0), lower_unarmed_damage, upper_unarmed_damage)
+	lower_unarmed_damage =  min(lower_unarmed_damage + (user.mind?.get_skill_level(/datum/skill/athletics) || 0), upper_unarmed_damage)
 
 	// The actual damage roll. May still be augmented by further factors.
 	var/damage = rand(lower_unarmed_damage, upper_unarmed_damage)


### PR DESCRIPTION

## About The Pull Request

Increases the minimum possible damage an unarmed attack can inflict by your athletics level. 

For a normal human punch, you would typically roll between 5 and 10 damage. For a legendary athlete, they will always roll 10 damage.

For a normal human kick, you would typically roll between 7 and 15. For a legendary athlete, they will instead roll between 14 and 15.

This alteration cannot increase your maximum potential damage. Only improve the floor. If your arm has a max value of 1, it will be still 1 even if you're a legendary athlete.

TRAIT_STRENGTH increases the maximum possible damage you can roll by 2, regardless of limb values. You still need to roll that damage, and this is not a flat increase to the damage you deal.

The Strength gene has a higher instability due to its new functionality. (5 > 10)

Your athletics skill also improves the possible outcomes of a stagger combo.

## Why It's Good For The Game

Kryson has been nudging about this for weeks at this point so I'm taking him up on his offer and implementing athletics benefits to standard unarmed attacks.

Damage consistency does improve the average unarmed damage output of the standard spaceman's humble fist, but it still keeps it within a particular damage bound. Effects that increase the actual damage are still gated behind temporary buffs, limb improvements or genetics, which mostly means you're interacting with other players in some fashion or will need to interact with other players to get the full monty of possible unarmed improvements.

It also just _feels_ right. Improving fitness gives a lot of minor imrpovements, but this one seems obvious for what it otherwise thematically should be doing. If you appear to be strong, getting punched by you probably will hurt and you are probably pretty good at hitting with a particular kind of explosive power consistently. 

## Changelog
:cl:
balance: Unarmed attacks deal more consistent damage and more impactful against staggered opponents the more athletic you are.
balance: The strength gene now improves your unarmed upper potential damage a bit. It increases instability slightly more as a result.
/:cl:
