### PR TITLE
Fixes omens not giving proper damage mod increase

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -46,7 +46,7 @@
 	if(src.luck_mod > luck_mod)
 		src.luck_mod += luck_mod * 0.5
 	if(src.damage_mod > damage_mod)
-		src.luck_mod += luck_mod * 0.5
+		src.damage_mod += damage_mod * 0.5
 	// This means that if you had a strong temporary omen and it was replaced by a weaker but permanent omen, the latter is made worse.
 	// Feature!
 


### PR DESCRIPTION

## About The Pull Request
Fixes a copy paste error in omen's InheritComponent to properly give you the increased damage of the original omen if it was more damaging than the newer one.

numbers for easy explanation:

Before:
You have an omen with incident 1, luck 2, damage 2. 
You inherit one with incident 10, luck 1, damage 1. 
You now have incident 10, luck 3, damage 2.

Now:
You have an omen with incident 1, luck 2, damage 2. 
You inherit one with incident 10, luck 1, damage 1.
You now have incident 10, luck 2.5, damage 2.5
## Why It's Good For The Game
No longer can you have an omen with a massive damage modifier and get a longer lasting, weaker omen and have it double add your luck mod while leaving your damage mod untouched.
## Changelog
:cl:
fix: Omens properly transfer their damage modifier when multiple are applied.
/:cl:
