### PR TITLE
Adds several holopads to wawastation

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2195,6 +2195,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "aKi" = (
@@ -24649,6 +24650,7 @@
 /area/station/maintenance/department/cargo)
 "iCM" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "iCT" = (
@@ -32935,6 +32937,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/carpet/purple,
 /area/station/service/library)
 "lpF" = (
@@ -34120,6 +34123,14 @@
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"lKN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "lKY" = (
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
@@ -35250,6 +35261,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"mgz" = (
+/obj/machinery/holopad,
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/station/asteroid)
 "mgH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -35548,6 +35563,7 @@
 "mld" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "mlf" = (
@@ -38192,6 +38208,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -41188,6 +41205,7 @@
 /area/station/maintenance/department/bridge)
 "olR" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/library)
 "olW" = (
@@ -52272,6 +52290,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "rWZ" = (
@@ -52559,6 +52578,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/hos)
 "sas" = (
@@ -56534,6 +56554,7 @@
 /area/station/maintenance/department/cargo)
 "trz" = (
 /obj/effect/turf_decal/box/corners,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "trK" = (
@@ -59518,6 +59539,7 @@
 /area/station/engineering/main)
 "urh" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "url" = (
@@ -66440,6 +66462,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/office)
 "wPP" = (
@@ -68239,6 +68262,7 @@
 "xvU" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/pharmacy)
 "xvZ" = (
@@ -70481,6 +70505,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ylj" = (
+/obj/machinery/holopad,
 /turf/open/floor/circuit,
 /area/station/science/robotics/lab)
 "ylm" = (
@@ -115177,7 +115202,7 @@ tLh
 dlE
 soW
 wqB
-rxn
+lKN
 rRO
 mIa
 moe
@@ -174013,7 +174038,7 @@ hhX
 hhX
 hhX
 fYe
-mNZ
+mgz
 vfJ
 riv
 vpK


### PR DESCRIPTION

## About The Pull Request

Adds several holopads to wawastation, in places precedented by other maps

## Why It's Good For The Game

There's not enough holopads on wawastation. There's currently one in all of science, and it's in the RD's office. Not even one in robotics. There's five in engi, but four of them are in locations rarely visited. There isn't a holopad in the HOP's, CE's, or HOS's offices. Only two holopads in security. Holopads are fun, and the coverage is lacking. 

## Changelog
:cl:

map: increases holopad coverage on wawastation

/:cl:
