### PR TITLE
Add EMP-proof protection examine tag desc

### DIFF
--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -23,4 +23,4 @@
 /datum/element/empprotection/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list["emp-proof"] = "It is shielded against electromagnetic pulses."
+	examine_list["EMP-proof"] = "It is shielded against electromagnetic pulses."

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -9,12 +9,18 @@
 		return ELEMENT_INCOMPATIBLE
 	flags = _flags
 	RegisterSignal(target, COMSIG_ATOM_PRE_EMP_ACT, PROC_REF(getEmpFlags))
+	RegisterSignal(target, COMSIG_ATOM_EXAMINE_TAGS, PROC_REF(get_examine_tags))
 
 /datum/element/empprotection/Detach(atom/target)
-	UnregisterSignal(target, COMSIG_ATOM_PRE_EMP_ACT)
+	UnregisterSignal(target, list(COMSIG_ATOM_PRE_EMP_ACT, COMSIG_ATOM_EXAMINE_TAGS))
 	return ..()
 
 /datum/element/empprotection/proc/getEmpFlags(datum/source, severity)
 	SIGNAL_HANDLER
 
 	return flags
+
+/datum/element/empprotection/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	examine_list["emp-proof"] = "It is shielded against electromagnetic pulses."

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -23,4 +23,5 @@
 /datum/element/empprotection/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list["EMP-proof"] = "It is shielded against electromagnetic pulses."
+	if(flags)
+		examine_list["EMP-proof"] = "It is shielded against electromagnetic pulses."


### PR DESCRIPTION

## About The Pull Request
Any objects that have the `/datum/element/empprotection` will get a new examine tag.

## Why It's Good For The Game
Better UI/UX.

<img width="607" height="144" alt="dreamseeker_bWgwbnjC5S" src="https://github.com/user-attachments/assets/580ddbfb-0306-4436-b7f3-8456a05e8272" />

## Changelog
:cl:
qol: Objects that are EMP-proof will now have it appear as a examine tag desc
/:cl:
