### PR TITLE
fix elvis mutation constructor copy paste

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -204,7 +204,7 @@
 	text_gain_indication = span_notice("You feel pretty good, honeydoll.")
 	text_lose_indication = span_notice("You feel a little less conversation would be great.")
 
-/datum/mutation/chav/New(datum/mutation/copymut)
+/datum/mutation/elvis/New(datum/mutation/copymut)
 	. = ..()
 	AddComponent(/datum/component/speechmod, replacements = strings("elvis_replacement.json", "elvis"))
 


### PR DESCRIPTION
## About The Pull Request

fixed copy paste mistake where there are 2 constructors for chav, 1 below elvis since it was copy pasted without being changed

## Why It's Good For The Game

chav accent might have been using the elvis word replacements and elvis didn't replace words at all??

## Changelog
nobody will notice this :trollface: