### PR TITLE
Fixes some Filteriffic issues and implements colorspace/blend mode controls

### DIFF
--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -30,6 +30,8 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"alpha" = 255
 		)
 	),
+	// Not fully implemented, but if this isn't uncommented some windows will just error
+	// Needs either a proper matrix editor, or just a hook to our existing one
 	"color" = list(
 		"defaults" = list(
 			"color" = matrix(),

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"y" = 0,
 			"icon" = ICON_NOT_SET,
 			"render_source" = "",
-			"flags" = 0
+			"flags" = NONE
 		),
 		"flags" = list(
 			"MASK_INVERSE" = MASK_INVERSE,
@@ -30,14 +30,18 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"alpha" = 255
 		)
 	),
-	// Not implemented, but if this isn't uncommented some windows will just error
-	// Needs either a proper matrix editor, or just a hook to our existing one
-	// Issue is filterrific assumes variables will have the same value type if they share the same name, which this violates
-	// Gotta refactor this sometime
 	"color" = list(
 		"defaults" = list(
 			"color" = matrix(),
 			"space" = FILTER_COLOR_RGB
+		),
+		"options" = list(
+			"space" = list(
+				"FILTER_COLOR_RGB" = FILTER_COLOR_RGB,
+				"FILTER_COLOR_HSV" = FILTER_COLOR_HSV,
+				"FILTER_COLOR_HSL" = FILTER_COLOR_HSL,
+				"FILTER_COLOR_HCY" = FILTER_COLOR_HCY
+			)
 		)
 	),
 	"displace" = list(
@@ -46,7 +50,11 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"y" = 0,
 			"size" = null,
 			"icon" = ICON_NOT_SET,
-			"render_source" = ""
+			"render_source" = "",
+			"flags" = NONE
+		),
+		"flags" = list(
+			"FILTER_OVERLAY" = FILTER_OVERLAY
 		)
 	),
 	"drop_shadow" = list(
@@ -70,10 +78,24 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"icon" = ICON_NOT_SET,
 			"render_source" = "",
 			"flags" = FILTER_OVERLAY,
-			"color" = "",
+			"color" = COLOR_WHITE,
 			"transform" = null,
 			"blend_mode" = BLEND_DEFAULT
+		),
+		"flags" = list(
+			"FILTER_OVERLAY" = FILTER_OVERLAY,
+		),
+		"options" = list(
+			"blend_mode" = list(
+				"BLEND_DEFAULT" = BLEND_DEFAULT,
+				"BLEND_OVERLAY" = BLEND_OVERLAY,
+				"BLEND_ADD" = BLEND_ADD,
+				"BLEND_SUBTRACT" = BLEND_SUBTRACT,
+				"BLEND_MULTIPLY" = BLEND_MULTIPLY,
+				"BLEND_INSET_OVERLAY" = BLEND_INSET_OVERLAY
+			)
 		)
+
 	),
 	"motion_blur" = list(
 		"defaults" = list(

--- a/code/modules/admin/verbs/plane_debugger.dm
+++ b/code/modules/admin/verbs/plane_debugger.dm
@@ -154,8 +154,7 @@
 			this_relay["blend_mode"] = GLOB.blend_names["[relay.blend_mode]"]
 			relays += list(this_relay)
 
-		for (var/filter_id in plane.filter_data)
-			var/list/filter = plane.filter_data[filter_id]
+		for (var/list/filter in plane.filter_data)
 			if(!filter["render_source"])
 				continue
 

--- a/code/modules/admin/verbs/plane_debugger.dm
+++ b/code/modules/admin/verbs/plane_debugger.dm
@@ -159,8 +159,7 @@
 				continue
 
 			var/list/filter_info = filter.Copy()
-			filter_info["name"] = filter_id
-			filter_info["our_ref"] = "[plane.plane]-[filter_id]"
+			filter_info["our_ref"] = "[plane.plane]-[filter_info["name"]]"
 			filters += list(filter_info)
 
 		this_plane["relays"] = relays

--- a/tgui/packages/tgui/interfaces/Filteriffic.jsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.jsx
@@ -28,7 +28,7 @@ const FilterIntegerEntry = (props) => {
       step={1}
       stepPixelSize={5}
       width="39px"
-      onDrag={(value) =>
+      onChange={(value) =>
         act('modify_filter_value', {
           name: filterName,
           new_data: {
@@ -55,7 +55,7 @@ const FilterFloatEntry = (props) => {
         step={step}
         format={(value) => toFixed(value, numberOfDecimalDigits(step))}
         width="80px"
-        onDrag={(value) =>
+        onChange={(value) =>
           act('transition_filter_value', {
             name: filterName,
             new_data: {

--- a/tgui/packages/tgui/interfaces/Filteriffic.jsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.jsx
@@ -219,6 +219,7 @@ const FilterDataEntry = (props) => {
     radius: 'int',
     falloff: 'float',
     density: 'int',
+    alpha: 'int',
     threshold: { rays: 'float', bloom: 'color' },
     factor: 'float',
     repeat: 'int',
@@ -229,7 +230,7 @@ const FilterDataEntry = (props) => {
 
   let filterInputType = filterEntryMap[name];
   // i hate javascript, this checks if its a dict
-  if (filterInputType.constructor === Object) {
+  if (filterInputType !== undefined && filterInputType.constructor === Object) {
     filterInputType = filterInputType[filterType] || filterInputType.default;
   }
 


### PR DESCRIPTION
## About The Pull Request

- Fixes filteriffic erroring out when trying to edit a filter
- Implements plugs for color/transform matrix editing rather than just displaying an error
- Fixes bloom threshold displaying as a float rather than a color due to an overlap with rays filter
- Displace filter flags can now be controlled
- Color matrix filter now allows the user to change the colorspace (not really that useful considering you still can't edit the matrix)
- Layering filter now allows the user to control its blending mode (actually useful this time)

## Changelog
:cl:
fix: Fixed filteriffic runtiming when editing filters, and claiming that bloom threshold is a number
admin: Filteriffic got a few new options (you should still avoid using it)
/:cl:
