### PR TITLE
airlocks affected by dimensional anomalies retain their access

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -156,7 +156,7 @@
 		if(istype(new_object, /obj/machinery/door/airlock)) //carry over access-related and adjacent variables. The rest is not as important
 			var/obj/machinery/door/airlock/airlock = object
 			var/obj/machinery/door/new_airlock = new_object
-			new_airlock.unres_sides == airlock.unres_sides
+			new_airlock.unres_sides = airlock.unres_sides
 			new_airlock.req_access = airlock.req_access.Copy()
 			new_airlock.req_one_access = airlock.req_one_access.Copy()
 			new_airlock.locked = airlock.locked

--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -153,6 +153,15 @@
 	var/obj/new_object = new replace_path(object.loc)
 	new_object.setDir(object.dir)
 	if(istype(object, /obj/machinery/door/airlock))
+		if(istype(new_object, /obj/machinery/door/airlock)) //carry over access-related and adjacent variables. The rest is not as important
+			var/obj/machinery/door/airlock/airlock = object
+			var/obj/machinery/door/new_airlock = new_object
+			new_airlock.unres_sides == airlock.unres_sides
+			new_airlock.req_access = airlock.req_access.Copy()
+			new_airlock.req_one_access = airlock.req_one_access.Copy()
+			new_airlock.locked = airlock.locked
+			new_airlock.emergency = airlock.emergency
+			new_airlock.update_appearance()
 		new_object.name = object.name
 	qdel(object)
 


### PR DESCRIPTION
## About The Pull Request
I'm not sure if to classify this as a fix or small balance detail, but I don't think dimensional anomalies should nuke airlock access and other things, such as unrestricted sides, locks and emergency access, when transformed it into another airlock.

## Why It's Good For The Game
Dimensional anomalies are supposed to fuck up with the aesthetics of the room. This is more of a side effect of the fact "transformed" objects are actually deleted and new ones placed in their stead. This also extends to dimensional bomb cores. Dimensional reactive armors don't fuck with doors and objects, only spawn some cades and change turfs.

## Changelog

:cl:
balance: airlocks affected by dimensional anomalies retain their access, as well as access-adjacent attributes such as emergency access and unrestricted sides.
/:cl:

