### PR TITLE
Fix shower causing mood and status effects to non-carbon mobs

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -307,7 +307,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 		if(isopenturf(loc))
 			var/turf/open/tile = loc
 			tile.MakeSlippery(TURF_WET_WATER, min_wet_time = 5 SECONDS, wet_time_to_add = 1 SECONDS)
-		for(var/mob/living/showerer in loc)
+		for(var/mob/living/carbon/showerer in loc)
 			showerer.remove_status_effect(/datum/status_effect/washing_regen)
 	return TRUE
 

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -252,7 +252,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 /obj/machinery/shower/proc/on_exited(datum/source, atom/movable/exiter)
 	SIGNAL_HANDLER
 
-	if(!isliving(exiter))
+	if(!iscarbon(exiter))
 		return
 
 	var/obj/machinery/shower/locate_new_shower = locate() in get_turf(exiter)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -274,8 +274,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 	var/mob/living/living_target = target
 	check_heat(living_target)
 
-	living_target.apply_status_effect(/datum/status_effect/washing_regen, shower_reagent)
-	living_target.add_mood_event("shower", /datum/mood_event/shower, shower_reagent)
+	if(iscarbon(living_target))
+		living_target.apply_status_effect(/datum/status_effect/washing_regen, shower_reagent)
+		living_target.add_mood_event("shower", /datum/mood_event/shower, shower_reagent)
 
 /**
  * Toggle whether shower is actually on and outputting water.


### PR DESCRIPTION

## About The Pull Request
- Fixes #93147

Borgs and silicons were able to get mood effects and status effects from being in the shower.

## Why It's Good For The Game
Not intended.

## Changelog
:cl:
fix: Fix shower causing mood and status effects to non-carbon mobs
/:cl:
