### PR TITLE
[NO GBP] Fixes filter cache being infinitely expanded every time a filter is added

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -339,7 +339,7 @@
 		if (filter_info["name"] != name)
 			continue
 		filter_data -= filter_info
-		filter_cache -= filter_cache[index - 1]
+		filter_cache -= filter_cache[index]
 		break
 
 	BINARY_INSERT_DEFINE(list(copied_parameters), filter_data, SORT_VAR_NO_TYPE, copied_parameters, SORT_PRIORITY_INDEX, COMPARE_KEY)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -334,11 +334,13 @@
 	var/list/copied_parameters = params.Copy()
 	copied_parameters["name"] = name
 	copied_parameters["priority"] = priority
-	for (var/list/filter_info as anything in filter_data)
-		if (filter_info["name"] == name)
-			filter_data -= filter_info
-			filter_cache -= name
-			break
+	for (var/index in 1 to length(filter_data))
+		var/list/filter_info = filter_data[index]
+		if (filter_info["name"] != name)
+			continue
+		filter_data -= filter_info
+		filter_cache -= filter_cache[index - 1]
+		break
 
 	BINARY_INSERT_DEFINE(list(copied_parameters), filter_data, SORT_VAR_NO_TYPE, copied_parameters, SORT_PRIORITY_INDEX, COMPARE_KEY)
 


### PR DESCRIPTION

## About The Pull Request

filter_cache is not an assoc list, this is a holdover from when we tried to operate on the filter list directly instead of using the mirror cache we have now
Closes #93128

## Changelog
:cl:
fix: Fixed filter cache being infinitely expanded every time a filter is added
/:cl:
