### PR TITLE
Fixes cell chargers runtiming and not updating their visuals when a cell is taken out

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -85,33 +85,29 @@
 	QDEL_NULL(charging)
 	return ..()
 
-/obj/machinery/cell_charger/proc/removecell()
+/obj/machinery/cell_charger/proc/removecell(new_loc)
+	. = charging
+	charging.update_appearance()
+	charging.forceMove(new_loc)
 	charging = null
 	update_appearance()
 
 /obj/machinery/cell_charger/attack_hand(mob/user, list/modifiers)
 	. = ..()
-	if(.)
-		return
-	if(!charging)
+	if(. || !charging)
 		return
 
 	charging.add_fingerprint(user)
 	user.visible_message(span_notice("[user] removes [charging] from [src]."), span_notice("You remove [charging] from [src]."))
-	charging.update_appearance()
-	user.put_in_hands(charging)
-	removecell()
+	user.put_in_hands(removecell(drop_location()))
 
 /obj/machinery/cell_charger/attack_tk(mob/user)
 	if(!charging)
 		return
 
 	to_chat(user, span_notice("You telekinetically remove [charging] from [src]."))
-	charging.update_appearance()
-	charging.forceMove(loc)
-	removecell()
+	removecell(drop_location())
 	return COMPONENT_CANCEL_ATTACK_CHAIN
-
 
 /obj/machinery/cell_charger/attack_ai(mob/user)
 	return

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -85,9 +85,8 @@
 	QDEL_NULL(charging)
 	return ..()
 
-/obj/machinery/cell_charger/proc/removecell(obj/item/stock_parts/power_store/cell/cell)
+/obj/machinery/cell_charger/proc/removecell()
 	charging = null
-	cell.update_appearance()
 	update_appearance()
 
 /obj/machinery/cell_charger/attack_hand(mob/user, list/modifiers)
@@ -99,19 +98,18 @@
 
 	charging.add_fingerprint(user)
 	user.visible_message(span_notice("[user] removes [charging] from [src]."), span_notice("You remove [charging] from [src]."))
-	var/obj/item/stock_parts/power_store/cell/cell = charging
+	charging.update_appearance()
 	user.put_in_hands(charging)
-	removecell(cell)
-
+	removecell()
 
 /obj/machinery/cell_charger/attack_tk(mob/user)
 	if(!charging)
 		return
 
-	var/obj/item/stock_parts/power_store/cell/cell = charging
 	to_chat(user, span_notice("You telekinetically remove [charging] from [src]."))
+	charging.update_appearance()
 	charging.forceMove(loc)
-	removecell(cell)
+	removecell()
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -85,9 +85,9 @@
 	QDEL_NULL(charging)
 	return ..()
 
-/obj/machinery/cell_charger/proc/removecell()
-	charging.update_appearance()
+/obj/machinery/cell_charger/proc/removecell(obj/item/stock_parts/power_store/cell/cell)
 	charging = null
+	cell.update_appearance()
 	update_appearance()
 
 /obj/machinery/cell_charger/attack_hand(mob/user, list/modifiers)
@@ -97,22 +97,21 @@
 	if(!charging)
 		return
 
-	user.put_in_hands(charging)
 	charging.add_fingerprint(user)
-
 	user.visible_message(span_notice("[user] removes [charging] from [src]."), span_notice("You remove [charging] from [src]."))
-
-	removecell()
+	var/obj/item/stock_parts/power_store/cell/cell = charging
+	user.put_in_hands(charging)
+	removecell(cell)
 
 
 /obj/machinery/cell_charger/attack_tk(mob/user)
 	if(!charging)
 		return
 
-	charging.forceMove(loc)
+	var/obj/item/stock_parts/power_store/cell/cell = charging
 	to_chat(user, span_notice("You telekinetically remove [charging] from [src]."))
-
-	removecell()
+	charging.forceMove(loc)
+	removecell(cell)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 


### PR DESCRIPTION

## About The Pull Request
#93094 caused cell removal to runtime and not update the charger visual, making it look like there's still a cell present inside

## Changelog
:cl:
fix: Fixed cell chargers runtiming and not updating their visuals when a cell is taken out
/:cl:
