### PR TITLE
Fixed possibility of creating a mineral turfs with assigned ore type yet with zero ore inside

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -303,8 +303,10 @@
 
 	. = ..()
 	var/dynamic_prob = mineralChance
+	var/ore_amount = rand(1,5)
 	if(proximity_based)
 		dynamic_prob = proximity_ore_chance() // We assign the chance of ore spawning based on probability.
+		ore_amount = scale_ore_to_vent()
 	if (prob(dynamic_prob))
 		var/list/spawn_chance_list = mineral_chances_by_type[type]
 		if (isnull(spawn_chance_list))
@@ -321,7 +323,7 @@
 			if(ismineralturf(T))
 				var/turf/closed/mineral/M = T
 				M.turf_type = src.turf_type
-				M.mineralAmt = scale_ore_to_vent()
+				M.mineralAmt = ore_amount
 				GLOB.post_ore_random["[M.mineralAmt]"] += 1
 				src = M
 				M.levelupdate()
@@ -332,8 +334,11 @@
 		else
 			Change_Ore(path, FALSE)
 			Spread_Vein(path)
-			mineralAmt = scale_ore_to_vent()
+			mineralAmt = ore_amount
 			GLOB.post_ore_manual["[mineralAmt]"] += 1
+
+	if(mineralType && !mineralAmt)
+		stack_trace("Mineral turf with mineralAmt being zero initialized at [src.x], [src.y], [src.z] ([get_area(src)])")
 
 /turf/closed/mineral/random/high_chance
 	icon_state = "rock_highchance"


### PR DESCRIPTION
## About The Pull Request
(https://github.com/NovaSector/NovaSector/issues/4305)

ArcMining changed how ore turfs distributed and how much ore each one gets. By being closer to vent you get more frequent and more abundant ore spawns. To bypass this behavious we have `proximity_based`. With it being set to false, you get ol behaviour of ores spawning everywhere uniformly. Which is exactly what we did on Nova. But, turns out, richness of ore tiles still tied to distance from vent. Which caused some edge case of ore being spawned to far from any existing vent, its `mineralType` being set to some ore yet `mineralAmt` is 0. And you get exactly what you get in linked issue. Problem is cause by `scale_ore_to_vent()` defaulting to 0 at great distances, but i decided to call it only for turfs that should be proximity based. 

Plus included some runtime error condition for any other edge case that may appear.
## Why It's Good For The Game
Imagine mining an ore and gettingnothing. And nothing. And nothing, constantly.

closes #91050
## Changelog
:cl:
fix: Fixed an edge case of mineral turfs being generated with 0 amount of ore in it.
/:cl:
