### PR TITLE
Adds better chalk outlines

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -9,8 +9,9 @@
 	var/do_icon_rotate = TRUE
 	var/rotation = 0
 	var/paint_colour = COLOR_WHITE
+	var/color_strength
 
-/obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null, desc_override = null)
+/obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null, desc_override = null, color_strength)
 	. = ..()
 	if(isclosedturf(loc) && loc.density)
 		// allows for wall graffiti to be seen
@@ -34,6 +35,7 @@
 		src.transform = M
 	if(main)
 		paint_colour = main
+	src.color_strength = color_strength
 	add_atom_colour(paint_colour, FIXED_COLOUR_PRIORITY)
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, PROC_REF(on_painted))
 
@@ -47,6 +49,36 @@
 		cost *= 0.5
 	spraycan.use_charges(user, cost, requires_full = FALSE)
 	return DONT_USE_SPRAYCAN_CHARGES
+
+/**
+ * Using a given atom, gives this decal an outline of said atom, then masks the contents,
+ * leaving us with solely the outline.
+ * This also deletes the previous icon, so the decal turns into JUST an outline.
+ * Args:
+ * outlined_atom: Anything you wish to draw an outline of.
+ * add_mouse_opacity: Boolean on whether you want mouse opacity, which allows the outline to be clickable/examinable without the context menu.
+ */
+/obj/effect/decal/cleanable/crayon/proc/create_outline(atom/outlined_atom, add_mouse_opacity = FALSE)
+	icon = null
+	icon_state = null
+	if(add_mouse_opacity)
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
+
+	if(ishuman(outlined_atom))
+		//humans are special, we want to exclude things like wounds so the outline isn't animated.
+		var/mob/living/carbon/human/human_outline = outlined_atom
+		add_overlay(human_outline.get_overlays_copy(list(WOUND_LAYER, HALO_LAYER)))
+	else
+		icon = outlined_atom.icon
+		icon_state = outlined_atom.icon_state
+		copy_overlays(outlined_atom)
+	transform = outlined_atom.transform
+	dir = outlined_atom.dir
+	add_filter("batong_outline", 1, outline_filter(color_strength, paint_colour))
+	add_filter("alpha_mask", 2, alpha_mask_filter(
+		icon = getFlatIcon(outlined_atom.appearance, defdir = outlined_atom.dir, no_anim = TRUE),
+		flags = MASK_INVERSE,
+	))
 
 ///Common crayon decals in map.
 /obj/effect/decal/cleanable/crayon/rune4

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -9,6 +9,7 @@
 	var/do_icon_rotate = TRUE
 	var/rotation = 0
 	var/paint_colour = COLOR_WHITE
+	///Used by `create_outline` to determine how strong (how wide) the outline itself will be.
 	var/color_strength
 
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null, desc_override = null, color_strength)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -629,11 +629,10 @@
 	chalk_line.transform = pwned_human.transform
 	chalk_line.dir = pwned_human.dir
 
+	var/icon/image_filter = getFlatIcon(pwned_human.appearance, defdir = pwned_human.dir, no_anim = TRUE)
 	chalk_line.add_filter("batong_outline", 1, outline_filter(outline_strength, paint_color))
 	chalk_line.add_filter("alpha_mask", 2, alpha_mask_filter(
-		x = chalk_line.pixel_x,
-		y = chalk_line.pixel_y,
-		icon = getIconMask(pwned_human.appearance),//getFlatIcon(pwned_human.appearance, defdir = pwned_human.dir, no_anim = TRUE)
+		icon = image_filter,
 		flags = MASK_INVERSE,
 	))
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -610,9 +610,9 @@
 
 	interacting_with.balloon_alert(user, "drawing outline...")
 	if(!do_after(user, DRAW_TIME, target = pwned_human))
-		return NONE
+		return ITEM_INTERACT_FAILURE
 	if(!use_charges(user, 1))
-		return NONE
+		return ITEM_INTERACT_FAILURE
 
 	to_chat(user, span_notice("You draw a chalk outline around [pwned_human]."))
 	var/obj/effect/decal/cleanable/crayon/chalk_line = new(get_turf(pwned_human), paint_color, "body", "chalk outline", null, null, "A vaguely [pwned_human] shaped body outline.", outline_strength)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -615,12 +615,13 @@
 		return NONE
 
 	to_chat(user, span_notice("You draw a chalk outline around [pwned_human]."))
-	var/obj/effect/decal/cleanable/crayon/chalk_line = new(get_turf(pwned_human), paint_color, "body", "chalk outline", null, null, "A vaguely [pwned_human] shaped outline of a body.")
+	var/obj/effect/decal/cleanable/crayon/chalk_line = new(get_turf(pwned_human), paint_color, "body", "chalk outline", null, null, "A vaguely [pwned_human] shaped body outline.")
 	chalk_line.pixel_y = (pwned_human.pixel_y + pwned_human.pixel_z)
 	chalk_line.pixel_x = (pwned_human.pixel_x + pwned_human.pixel_w)
 
 	chalk_line.icon = null
 	chalk_line.icon_state = null
+	chalk_line.mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 	chalk_line.cut_overlays()
 	var/mob/living/carbon/human/human_target = interacting_with
@@ -632,8 +633,7 @@
 	chalk_line.add_filter("alpha_mask", 2, alpha_mask_filter(
 		x = chalk_line.pixel_x,
 		y = chalk_line.pixel_y,
-		icon = center_image(getFlatIcon(pwned_human.appearance, defdir = pwned_human.dir, no_anim = TRUE), \
-			x_dimension = ICON_SIZE_X, y_dimension = ICON_SIZE_Y),
+		icon = getIconMask(pwned_human.appearance),//getFlatIcon(pwned_human.appearance, defdir = pwned_human.dir, no_anim = TRUE)
 		flags = MASK_INVERSE,
 	))
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -618,23 +618,7 @@
 	var/obj/effect/decal/cleanable/crayon/chalk_line = new(get_turf(pwned_human), paint_color, "body", "chalk outline", null, null, "A vaguely [pwned_human] shaped body outline.")
 	chalk_line.pixel_y = (pwned_human.pixel_y + pwned_human.pixel_z)
 	chalk_line.pixel_x = (pwned_human.pixel_x + pwned_human.pixel_w)
-
-	chalk_line.icon = null
-	chalk_line.icon_state = null
-	chalk_line.mouse_opacity = MOUSE_OPACITY_OPAQUE
-
-	chalk_line.cut_overlays()
-	var/mob/living/carbon/human/human_target = interacting_with
-	chalk_line.add_overlay(human_target.get_overlays_copy(list(HANDS_LAYER, HANDCUFF_LAYER, LEGCUFF_LAYER, WOUND_LAYER, HALO_LAYER)))
-	chalk_line.transform = pwned_human.transform
-	chalk_line.dir = pwned_human.dir
-
-	var/icon/image_filter = getFlatIcon(pwned_human.appearance, defdir = pwned_human.dir, no_anim = TRUE)
-	chalk_line.add_filter("batong_outline", 1, outline_filter(outline_strength, paint_color))
-	chalk_line.add_filter("alpha_mask", 2, alpha_mask_filter(
-		icon = image_filter,
-		flags = MASK_INVERSE,
-	))
+	chalk_line.create_outline(pwned_human, add_mouse_opacity = TRUE)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/toy/crayon/get_writing_implement_details()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -695,31 +695,30 @@
 	chalk_line.pixel_y = (pwned_human.pixel_y + pwned_human.pixel_z)
 	chalk_line.pixel_x = (pwned_human.pixel_x + pwned_human.pixel_w)
 
+/*
 	var/mutable_appearance/appearance_copied = copy_appearance_filter_overlays(pwned_human.appearance)
+	appearance_copied.layer = FLOAT_LAYER
+	appearance_copied.appearance_flags = RESET_COLOR|RESET_ALPHA|KEEP_TOGETHER|PIXEL_SCALE
+	appearance_copied.color = paint_color
+*/
 
 	chalk_line.appearance = copy_appearance_filter_overlays(pwned_human.appearance)
 	chalk_line.layer = FLOAT_LAYER
 	chalk_line.appearance_flags = RESET_COLOR|RESET_ALPHA|KEEP_TOGETHER|PIXEL_SCALE
-	chalk_line.color = rgb(0,0,0,255)
-
+//	chalk_line.color = rgb(0,0,0,255)
+	chalk_line.add_filter("batong_outline", 1, outline_filter(1, COLOR_WHITE))
 	chalk_line.add_filter("alpha_mask", 1, alpha_mask_filter(
 		x = chalk_line.pixel_x,
 		y = chalk_line.pixel_y,
-		icon = appearance_copied,
+		icon = center_image(getFlatIcon(pwned_human.appearance, defdir = pwned_human.dir, no_anim = TRUE), \
+			x_dimension = ICON_SIZE_X, y_dimension = ICON_SIZE_Y),
 		flags = MASK_INVERSE,
 	))
-
-	appearance_copied.layer = FLOAT_LAYER
-	appearance_copied.appearance_flags = RESET_COLOR|RESET_ALPHA|KEEP_TOGETHER|PIXEL_SCALE
-	appearance_copied.color = paint_color
-
 /*
 	chalk_line.render_source = "Outline[REF(pwned_human)]"
 	appearance_copied.render_target = chalk_line.render_source
-*/
-	appearance_copied.add_filter("batong_outline", 1, outline_filter(1, COLOR_RED))
-
 	chalk_line.add_overlay(appearance_copied)
+*/
 
 /*
 	chalk_line.appearance = copy_appearance_filter_overlays(pwned_human.appearance)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -615,7 +615,7 @@
 		return NONE
 
 	to_chat(user, span_notice("You draw a chalk outline around [pwned_human]."))
-	var/obj/effect/decal/cleanable/crayon/chalk_line = new(get_turf(pwned_human), paint_color, "body", "chalk outline", null, null, "A vaguely [pwned_human] shaped body outline.")
+	var/obj/effect/decal/cleanable/crayon/chalk_line = new(get_turf(pwned_human), paint_color, "body", "chalk outline", null, null, "A vaguely [pwned_human] shaped body outline.", outline_strength)
 	chalk_line.pixel_y = (pwned_human.pixel_y + pwned_human.pixel_z)
 	chalk_line.pixel_x = (pwned_human.pixel_x + pwned_human.pixel_w)
 	chalk_line.create_outline(pwned_human, add_mouse_opacity = TRUE)


### PR DESCRIPTION
## About The Pull Request

Drawing an outline of someone now makes a proper outline of them, rather than a decal that faces their direction
<img width="401" height="446" alt="image" src="https://github.com/user-attachments/assets/4402e66a-2f77-4e45-95dd-1570a449ccd3" />

You can also use crayons to draw outlines now, but they won't be as strong visually
<img width="138" height="143" alt="image" src="https://github.com/user-attachments/assets/91f2fda8-cd84-46c3-bee9-b9f16efeb975" />

This unfortunately uses GFI, I've messed around with it a bit and couldn't find a good alternative that would work with humans. If there's anything better please lmk.

## Why It's Good For The Game

Been enjoying some Detective gameplay and thought it would be cool to make proper outlines of corpses to better visualize the crime scene rather than use what looks like graffiti.

## Changelog

:cl:
qol: You can use crayons to make chalk outlines, not just white ones.
qol: Chalk outlines are now properly outlines of the body you're outlining.
/:cl: