### PR TITLE
Dormant DNA activator fix

### DIFF
--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -57,7 +57,7 @@
 			var/datum/mutation/mutation = carbon.get_random_mutation_path((NEGATIVE|MINOR_NEGATIVE|POSITIVE) & ~excludemuts)
 			if(!mutation)
 				return
-			carbon.dna.add_mutation((mutation.quality & mutadone_proof) ? MUTATION_SOURCE_GENE_SYMPTOM : MUTATION_SOURCE_ACTIVATED)
+			carbon.dna.add_mutation(mutation, (mutation.quality & mutadone_proof) ? MUTATION_SOURCE_GENE_SYMPTOM : MUTATION_SOURCE_ACTIVATED)
 
 /datum/symptom/genetic_mutation/End(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -58,6 +58,8 @@
 			if(!mutation)
 				return
 			carbon.dna.add_mutation(mutation, (mutation.quality & mutadone_proof) ? MUTATION_SOURCE_GENE_SYMPTOM : MUTATION_SOURCE_ACTIVATED)
+			var/datum/mutation/given_mutation = carbon.dna.get_mutation(mutation)
+			given_mutation?.scrambled = TRUE
 
 /datum/symptom/genetic_mutation/End(datum/disease/advance/A)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

1. Literally didn't pass the mutation to mutate

2. This used to use `easy_random_mutate`, so it should set scrambled for parity

## Changelog

:cl: Melbert
fix: Fixes dormant DNA activator
/:cl:
