### PR TITLE
Prevent containers from closing on HUD updates

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/list/always_visible_inventory = list()
 	var/list/inv_slots[SLOTS_AMT] // /atom/movable/screen/inventory objects, ordered by their slot ID.
 	var/list/hand_slots // /atom/movable/screen/inventory/hand objects, assoc list of "[held_index]" = object
-
+	var/list/open_containers = list()
 	/// Assoc list of key => "plane master groups"
 	/// This is normally just the main window, but it'll occasionally contain things like spyglasses windows
 	var/list/datum/plane_master_group/master_groups = list()
@@ -342,7 +342,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 				screenmob.client.screen += infodisplay
 			if(always_visible_inventory.len)
 				screenmob.client.screen += always_visible_inventory
-
+			if(open_containers.len && screenmob.active_storage)
+				screenmob.client.screen += open_containers
 			screenmob.client.screen += toggle_palette
 
 			if(action_intent)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/list/always_visible_inventory = list()
 	var/list/inv_slots[SLOTS_AMT] // /atom/movable/screen/inventory objects, ordered by their slot ID.
 	var/list/hand_slots // /atom/movable/screen/inventory/hand objects, assoc list of "[held_index]" = object
+	/// storages (and its content) currently open by mob
 	var/list/open_containers = list()
 	/// Assoc list of key => "plane master groups"
 	/// This is normally just the main window, but it'll occasionally contain things like spyglasses windows
@@ -342,7 +343,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 				screenmob.client.screen += infodisplay
 			if(always_visible_inventory.len)
 				screenmob.client.screen += always_visible_inventory
-			if(open_containers.len && screenmob.active_storage)
+			if(open_containers.len)
 				screenmob.client.screen += open_containers
 			screenmob.client.screen += toggle_palette
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1055,7 +1055,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	is_using |= to_show
 
+	to_show.hud_used.open_containers |= storage_interfaces[to_show].list_ui_elements()
 	to_show.client.screen |= storage_interfaces[to_show].list_ui_elements()
+	to_show.hud_used.open_containers |= real_location.contents
 	to_show.client.screen |= real_location.contents
 
 	return TRUE
@@ -1080,7 +1082,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	is_using -= to_hide
 
 	if(to_hide.client)
+		to_hide.hud_used.open_containers -= storage_interfaces[to_hide].list_ui_elements()
 		to_hide.client.screen -= storage_interfaces[to_hide].list_ui_elements()
+		to_hide.hud_used.open_containers -=  real_location.contents
 		to_hide.client.screen -= real_location.contents
 	QDEL_NULL(storage_interfaces[to_hide])
 	storage_interfaces -= to_hide


### PR DESCRIPTION
## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/92260
When players do things that make the HUD change (like lie down (_yes, sleep button also counts_), change the HUD style with F12...), the open inventories (backpacks, belts, etc.) close. This is because the show_hud() thing does a whole screen redraw (???) and doesn't save the open inventory things.
## Why It's Good For The Game
Players don't need to open the inventory window again and again.
## Changelog
:cl:
fix: containers no longer close unexpectedly when the HUD refreshes (e.g., when lying down/getting up)
/:cl:
