### PR TITLE
You can no longer die from eating an entire box of donk pockets

### DIFF
--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -23,7 +23,7 @@
 	/// The upper end for how long it takes to bake
 	var/baking_time_long = 30 SECONDS
 	/// The amount of omnizine added when it's cooked.
-	var/omnizine_to_add = 6
+	var/omnizine_to_add = 5
 
 /obj/item/food/donkpocket/make_bakeable()
 	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), positive_result, TRUE, list(/datum/reagent/medicine/omnizine = omnizine_to_add))
@@ -37,7 +37,7 @@
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
 		/datum/reagent/consumable/nutriment/protein = 2,
-		/datum/reagent/medicine/omnizine = 6,
+		/datum/reagent/medicine/omnizine = 5,
 	)
 	tastes = list("umami" = 2, "dough" = 2, "laziness" = 1)
 	foodtypes = GRAIN

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -37,7 +37,7 @@
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
 		/datum/reagent/consumable/nutriment/protein = 2,
-		/datum/reagent/medicine/omnizine = 5,
+		/datum/reagent/medicine/omnizine = /obj/item/food/donkpocket::omnizine_to_add,
 	)
 	tastes = list("umami" = 2, "dough" = 2, "laziness" = 1)
 	foodtypes = GRAIN


### PR DESCRIPTION
## About The Pull Request

Reduces the omnizine in warmed donk pockets from 6u to 5u. 

Total omnizine in every donk box reduced from 35u to 30u

## Why It's Good For The Game

Omnizine overdose is lethal unless treated. It's kind of a noob trap, who would assume eating an entire box of something would kill you? 

It's not very consistent, either. Sometimes the tick rate is that you just hit under the overdose threshold when you finish eating all the pockets, and sometimes it doesn't.

More reasonable that eating more than a box (you fat fuck) should kill you. 

## Changelog
:cl:
balance: Reduces omnizine in warm donk pockets from 6u to 5u
/:cl:
