### PR TITLE
Consistency for the manifest.ckey column

### DIFF
--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -19,10 +19,17 @@ In any query remember to add a prefix to the table names if you use one.
 ---
 
 Version 5.33, 28 September 2025, by Atlanta-Ned
-Modify manifest ckey column to be consistent with other ckey columns
+Modifies manifest ckey column to be consistent with other ckey columns
 
 ```sql
 ALTER TABLE manifest
+	MODIFY ckey VARCHAR(32) NOT NULL;
+```
+
+The prefixed connection log SQL schema also specified a `varchar(45)` ckey column. This SQL will modify that:
+
+```sql
+ALTER TABLE connection_log
 	MODIFY ckey VARCHAR(32) NOT NULL;
 ```
 

--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -2,19 +2,29 @@ Any time you make a change to the schema files, remember to increment the databa
 
 Make sure to also update `DB_MAJOR_VERSION` and `DB_MINOR_VERSION`, which can be found in `code/__DEFINES/subsystem.dm`.
 
-The latest database version is 5.32; The query to update the schema revision table is:
+The latest database version is 5.33; The query to update the schema revision table is:
 
 ```sql
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 32);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 33);
 ```
 
 or
 
 ```sql
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 32);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 33);
 ```
 
 In any query remember to add a prefix to the table names if you use one.
+
+---
+
+Version 5.33, 28 September 2025, by Atlanta-Ned
+Modify manifest ckey column to be consistent with other ckey columns
+
+```sql
+ALTER TABLE manifest
+	MODIFY ckey VARCHAR(32) NOT NULL;
+```
 
 ---
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -137,7 +137,7 @@ CREATE TABLE `connection_log` (
   `server_ip` int(10) unsigned NOT NULL,
   `server_port` smallint(5) unsigned NOT NULL,
   `round_id` int(11) unsigned NULL,
-  `ckey` varchar(45) DEFAULT NULL,
+  `ckey` varchar(32) DEFAULT NULL,
   `ip` int(10) unsigned NOT NULL,
   `computerid` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`id`)
@@ -305,7 +305,7 @@ CREATE TABLE `manifest` (
   `server_ip` int(10) unsigned NOT NULL,
   `server_port` smallint(5) NOT NULL,
   `round_id` int(11) NOT NULL,
-  `ckey` text NOT NULL,
+  `ckey` varchar(45) NOT NULL,
   `character_name` text NOT NULL,
   `job` text NOT NULL,
   `special` text DEFAULT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -305,7 +305,7 @@ CREATE TABLE `manifest` (
   `server_ip` int(10) unsigned NOT NULL,
   `server_port` smallint(5) NOT NULL,
   `round_id` int(11) NOT NULL,
-  `ckey` varchar(45) NOT NULL,
+  `ckey` varchar(32) NOT NULL,
   `character_name` text NOT NULL,
   `job` text NOT NULL,
   `special` text DEFAULT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -304,7 +304,7 @@ CREATE TABLE `SS13_manifest` (
   `server_ip` int(10) unsigned NOT NULL,
   `server_port` smallint(5) NOT NULL,
   `round_id` int(11) NOT NULL,
-  `ckey` text NOT NULL,
+  `ckey` varchar(32) NOT NULL,
   `character_name` text NOT NULL,
   `job` text NOT NULL,
   `special` text DEFAULT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -137,7 +137,7 @@ CREATE TABLE `SS13_connection_log` (
   `server_ip` int(10) unsigned NOT NULL,
   `server_port` smallint(5) unsigned NOT NULL,
   `round_id` int(11) unsigned NOT NULL,
-  `ckey` varchar(45) DEFAULT NULL,
+  `ckey` varchar(32) DEFAULT NULL,
   `ip` int(10) unsigned NOT NULL,
   `computerid` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
## About The Pull Request

Hey look I'm touching the manifest sql again. 

I noticed that the ckey column should be `varchar(32)` and not `text`, so this fixes that.

## Why It's Good For The Game

Its for 3rd party tools mostly.