### PR TITLE
fire extinguisher buffs

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -207,7 +207,6 @@
 	)
 	sprite_name = "foam_extinguisher"
 	precision = TRUE
-	max_water = 150
 
 /obj/item/extinguisher/advanced/empty
 	starting_water = FALSE

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -23,7 +23,7 @@
 	resistance_flags = FIRE_PROOF
 	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
 	/// The max amount of water this extinguisher can hold.
-	var/max_water = 50
+	var/max_water = 100
 	/// Does the welder extinguisher start with water.
 	var/starting_water = TRUE
 	/// Cooldown between uses.

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -207,7 +207,7 @@
 	)
 	sprite_name = "foam_extinguisher"
 	precision = TRUE
-	max_water = 100
+	max_water = 150
 
 /obj/item/extinguisher/advanced/empty
 	starting_water = FALSE


### PR DESCRIPTION
## About The Pull Request
normal extinguishers: 100u 2x of what it was before.
advanced fire extinguishers: 100u 2x of what it was before.
## Why It's Good For The Game
now that fire extinguishers are bulky, a pocket fire extinguisher is almost always a better choice considering it's 20 units of different, while a pocket one can fit into a box, with this it'll be more of a sidegrade.
## Changelog
:cl:
balance: fire extinguishers now hold 100 units of water.
/:cl:
