### PR TITLE
Fixes a stupidly old bug that made husks glow in space

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1142,23 +1142,22 @@
 	// For some reason this was applied as an overlay on the aux image and limb image before.
 	// I am very sure that this is unnecessary, and i need to treat it as part of the return list
 	// to be able to mask it proper in case this limb is a leg.
-	if(!is_husked)
-		var/atom/location = loc || owner || src
-		if(blocks_emissive != EMISSIVE_BLOCK_NONE)
-			var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
-			. += limb_em_block
+	var/atom/location = loc || owner || src
+	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
+		var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
+		. += limb_em_block
 
-			if(aux_zone)
-				var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
-				. += aux_em_block
+		if(aux_zone)
+			var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
+			. += aux_em_block
 
-		if(is_emissive)
-			var/mutable_appearance/limb_em = emissive_appearance(limb.icon, "[limb.icon_state]_e", location, layer = limb.layer, alpha = limb.alpha)
-			. += limb_em
+	if(!is_husked && is_emissive)
+		var/mutable_appearance/limb_em = emissive_appearance(limb.icon, "[limb.icon_state]_e", location, layer = limb.layer, alpha = limb.alpha)
+		. += limb_em
 
-			if(aux_zone)
-				var/mutable_appearance/aux_em = emissive_appearance(aux.icon, "[aux.icon_state]_e", location, layer = aux.layer, alpha = aux.alpha)
-				. += aux_em
+		if(aux_zone)
+			var/mutable_appearance/aux_em = emissive_appearance(aux.icon, "[aux.icon_state]_e", location, layer = aux.layer, alpha = aux.alpha)
+			. += aux_em
 	//EMISSIVE CODE END
 
 	//No need to handle leg layering if dropped, we only face south anyways


### PR DESCRIPTION

## About The Pull Request

Emissive blockers should be present on husks too. This caused them to let emissive overlays through, which made them glow in space from parallax backlight. This bug is at least 2 years old.

## Changelog
:cl:
fix: Husks no longer glow in space.
/:cl:
