### PR TITLE
Let Nuke/Lone Ops buy infiltrator modsuit

### DIFF
--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -19,7 +19,6 @@
 			as well as causing significant demoralization amongst Nanotrasen crew."
 	item = /obj/item/mod/control/pre_equipped/infiltrator
 	cost = 6
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
 /datum/uplink_item/suits/space_suit
 	name = "Syndicate Space Suit"


### PR DESCRIPTION
## About The Pull Request

This PR let syndicate operative buy infiltrator modsuit for they evil objection.

## Why It's Good For The Game

When I play as a nuclear operative, I always use Mechs, which makes purchasing the Mech Support Bundle an essential part of my strategy. So what's the problem?

I'll tell you - it's the back slot. It's always occupied by a MODsuit to provide at least some protection against the crew or fauna. This leads to a rather obvious problem: "Hey, I can't pick up the freshly purchased duffel bag full of ammo - I have to return to the ship every time to restock my war crime machine's ammunition, seriously?"

Enter the... Infiltrator MODsuit, which is now available for purchase by nuclear operatives. A MODsuit that fits in the belt slot provides exactly the same protection as a regular spacesuit, except it lacks space protection - sounds shitty, right? But for a mech pilot, this isn't a problem - they're already protected from space and pressure. Also in this MOD installed diagnostic visor module, I think this is a hint to its intended purpose.

If emergency repairs are needed, you can always use a regular Modular Suit with the MODsuit Plate Compression Module installed, which thanks to this new addition gains new purpose, as it will fit in the duffel bag.

Overall, this PR could be discussed at length, but I believe this item should be made available for purchase. 

## Changelog

Nuke/Lone Ops now can buy infiltrator MODsuit

:cl:
balance: Nuke/Lone Ops now can buy infiltrator MODsuit
/:cl:
