### PR TITLE
Fixes damp rag runtime

### DIFF
--- a/code/modules/forensics/forensics_helpers.dm
+++ b/code/modules/forensics/forensics_helpers.dm
@@ -112,7 +112,7 @@
 	if (QDELETED(src))
 		return
 	. = ..()
-	if (isnull(blood_DNA_to_add))
+	if (isnull(blood_DNA_to_add) || !length(blood_DNA_to_add))
 		return .
 	if (!islist(blood_DNA_to_add))
 		CRASH("add_blood_DNA on [src] ([type]) has been passed a non-list blood_DNA_to_add ([blood_DNA_to_add])!")

--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -145,7 +145,8 @@
 			fire_act(500, 100)
 
 	// FINALLY add the dna to us
-	add_blood_DNA(all_blood_dna)
+	if(length(all_blood_dna))
+		add_blood_DNA(all_blood_dna)
 	update_appearance()
 	if(blood_level >= 10)
 		to_chat(cleaner, span_warning("[src] is too dirty to clean anything else! Wash it first!"))


### PR DESCRIPTION
## About The Pull Request

<img width="564" height="75" alt="image" src="https://github.com/user-attachments/assets/539de6b9-4c4e-40cd-9ebf-d891db25ede2" />

Seems to be caused by add_blood_dna() being passed an empty list (which happens by default with rags). 

<details><summary> see here </summary>

<img width="591" height="518" alt="image" src="https://github.com/user-attachments/assets/9c1e6863-8707-4768-87ac-a2e0874fd34d" />

`all_blood_dna` is not null but an empty list to start, so we need our proc to be able to handle such cases

</details>

So anytime you clean something that doesn't have blood dna you will get this runtime.

## Why It's Good For The Game

If someone is cleaning these really can build up. Less runtime log pollution so we notice important issues.

## Changelog

N/A