### PR TITLE
fix hyper-noblium formation when bz is null

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -815,7 +815,7 @@
 	var/list/tritium = cached_gases[/datum/gas/tritium]
 	/// List of gases we will assert, and possibly garbage collect.
 	var/list/asserted_gases = list(/datum/gas/hypernoblium, /datum/gas/bz)
-	var/list/bz = cached_gases[/datum/gas/bz]
+	var/list/bz = cached_gases[/datum/gas/bz] || list(MOLES = 0)
 	air.assert_gases(arglist(asserted_gases))
 	var/reduction_factor = clamp(tritium[MOLES] / (tritium[MOLES] + bz[MOLES]), 0.001 , 1) //reduces trit consumption in presence of bz upward to 0.1% reduction
 	var/nob_formed = min((nitrogen[MOLES] + tritium[MOLES]) * 0.01, tritium[MOLES] * INVERSE(5 * reduction_factor), nitrogen[MOLES] * INVERSE(10))

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -815,8 +815,8 @@
 	var/list/tritium = cached_gases[/datum/gas/tritium]
 	/// List of gases we will assert, and possibly garbage collect.
 	var/list/asserted_gases = list(/datum/gas/hypernoblium, /datum/gas/bz)
-	var/list/bz = cached_gases[/datum/gas/bz] || list(MOLES = 0)
 	air.assert_gases(arglist(asserted_gases))
+	var/list/bz = cached_gases[/datum/gas/bz]
 	var/reduction_factor = clamp(tritium[MOLES] / (tritium[MOLES] + bz[MOLES]), 0.001 , 1) //reduces trit consumption in presence of bz upward to 0.1% reduction
 	var/nob_formed = min((nitrogen[MOLES] + tritium[MOLES]) * 0.01, tritium[MOLES] * INVERSE(5 * reduction_factor), nitrogen[MOLES] * INVERSE(10))
 


### PR DESCRIPTION
## About The Pull Request
Hyper-Noblium formation is able to occur with or without BZ as a moderator. The BZ-less formation reaction is commonly used in Ordnance for high-yield tests. Currently, it throws an error when attempting to perform the reaction without BZ present because it attempts a list lookup on the null BZ variable. This results in the TTV failing to detonate when the valve opens, which is capable of creating impossible tank states. 
<img width="334" height="199" alt="image" src="https://github.com/user-attachments/assets/74b689c1-9566-47e7-8378-6c3aeeb50be2" />

I believe issue #93064 is actually a result of the error this PR fixes. Comments in that issue also mention a case that I have encountered, where the TTV was signaled, failed to detonate, and then detonated instantly in-hand when one of the tanks was removed. Those comments also mention the Blast Cannon not working with the hyper-noblium reaction, which is exactly what prompted me to make this fix, and is working with this fix in place. 
## Why It's Good For The Game

Misfired TTVs loaded with maxcaps that detonate unexpectedly is quite funny, but also very frustrating for the player who properly constructed the device.
## Changelog
:cl:
fix: fixed error during hyper-noblium formation reaction when bz is not present
/:cl:
