### PR TITLE
Adds a safety to uplink discounts, preventing the amount of sales from exceeding the amount of categories.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -9,7 +9,7 @@
 			per_category[possible_sale.category] = list()
 		per_category[possible_sale.category] += possible_sale
 
-	for (var/i in 1 to num)
+	for (var/i in 1 to min(length(per_category), num))
 		var/datum/uplink_category/item_category = pick(per_category)
 		var/datum/uplink_item/taken_item = pick(per_category[item_category])
 		per_category -= item_category


### PR DESCRIPTION

## About The Pull Request
Adds a safety to uplink discounts, preventing the amount of sales from exceeding the amount of categories.
The way discounts work, is that it pulls 1 item from each category, removing the category afterwards.
Which means that if you try to add more discounts than the amount of categories, you end up with BSOD uplink and that's not good.
## Why It's Good For The Game
Prevents uplink from being bricked.
## Changelog
Nothing player-facing
