### PR TITLE
[BALANCE] add delay fire to ion gun

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -9,6 +9,7 @@
 	obj_flags = CONDUCTS_ELECTRICITY
 	slot_flags = ITEM_SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/ion)
+	fire_delay = 1.5 SECONDS
 
 /obj/item/gun/energy/ionrifle/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This is a simple change that incorporates some delay to fire for the stock ion rifle that comes in the armory. The MkII rifle remains unchanged.
## Why It's Good For The Game

Still useful in its intended role but, currently it can chew through something like a dark gygax too quickly. This small delay makes the time to kill feel more right in line with the threat a mech should be, while still being a reliable counter to it.
## Changelog
:cl:

balance: adds 1.5s fire delay to ion gun.

/:cl:
