### PR TITLE
Botany genes no longer show on examine by default

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -640,6 +640,7 @@
 	icon = FA_ICON_SYRINGE
 	trait_ids = REAGENT_TRANSFER_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/stinging/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()
@@ -876,6 +877,7 @@
 	icon = FA_ICON_BANDAGE
 	trait_ids = THROW_IMPACT_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/sticky/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -856,9 +856,10 @@
  */
 /datum/plant_gene/trait/eyes
 	name = "Oculary Mimicry"
-	description = "It will watch after you."
+	description = "It watches after you."
 	icon = FA_ICON_EYE
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
+	trait_flags = TRAIT_SHOW_EXAMINE
 	/// Our googly eyes appearance.
 	var/mutable_appearance/googly
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -123,7 +123,7 @@
 	/// Flag - Traits that share an ID cannot be placed on the same plant.
 	var/trait_ids
 	/// Flag - Modifications made to the final product.
-	var/trait_flags = TRAIT_SHOW_EXAMINE
+	var/trait_flags = NONE
 	/// A blacklist of seeds that a trait cannot be attached to.
 	var/list/obj/item/seeds/seed_blacklist
 
@@ -375,6 +375,7 @@
 	icon = FA_ICON_LIGHTBULB
 	rate = 0.03
 	description = "It emits a soft glow."
+	trait_flags = TRAIT_SHOW_EXAMINE
 	trait_ids = GLOW_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 	/// The color of our bioluminescence.
@@ -403,6 +404,7 @@
 	name = "Shadow Emission"
 	rate = 0.04
 	glow_color = COLOR_BIOLUMINESCENCE_SHADOW
+	description = "It absorbs light around it."
 
 /datum/plant_gene/trait/glow/shadow/glow_power(obj/item/seeds/seed)
 	return -max(seed.potency*(rate*0.2), 0.2)
@@ -518,7 +520,7 @@
 	description = "The reagent volume is doubled, halving the plant yield instead."
 	icon = FA_ICON_FLASK_VIAL
 	rate = 2
-	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD
+	trait_flags = TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/maxchem/on_new_plant(obj/item/our_plant, newloc)
@@ -914,7 +916,7 @@
 	description = "It consumes nutriments to heat up other reagents, halving the yield."
 	icon = FA_ICON_TEMPERATURE_ARROW_UP
 	trait_ids = TEMP_CHANGE_ID
-	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD
+	trait_flags = TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /**
@@ -926,7 +928,7 @@
 	description = "It consumes nutriments to cool down other reagents, halving the yield."
 	icon = FA_ICON_TEMPERATURE_ARROW_DOWN
 	trait_ids = TEMP_CHANGE_ID
-	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD
+	trait_flags = TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /// Prevents species mutation, while still allowing wild mutation harvest and Floral Somatoray species mutation.  Trait acts as a tag for hydroponics.dm to recognise.

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -110,6 +110,7 @@
 	force_multiplier = 0.2
 	degrades_after_hit = TRUE
 	degradation_noun = "petals"
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/attack/novaflower_attack/attack_effect(obj/item/our_plant, mob/living/target, mob/living/user)
 	if(!istype(target))
@@ -191,6 +192,7 @@
 	name = "Rose Thorns"
 	description = "The stem has a lot of thorns."
 	traits_to_check = list(TRAIT_PIERCEIMMUNE)
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/backfire/rose_thorns/backfire_effect(obj/item/our_plant, mob/living/carbon/user)
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
@@ -207,6 +209,7 @@
 	name = "Burning Stem"
 	description = "The stem may burn your hand."
 	cancel_action_on_backfire = TRUE
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/backfire/novaflower_heat/backfire_effect(obj/item/our_plant, mob/living/carbon/user)
 	to_chat(user, span_danger("[our_plant] singes your bare hand!"))
@@ -217,6 +220,7 @@
 /datum/plant_gene/trait/backfire/nettle_burn
 	name = "Stinging Stem"
 	description = "The stem may sting your hand."
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/backfire/nettle_burn/backfire_effect(obj/item/our_plant, mob/living/carbon/user)
 	to_chat(user, span_danger("[our_plant] burns your bare hand!"))
@@ -239,7 +243,8 @@
 /// Ghost-Chili heating up on backfire
 /datum/plant_gene/trait/backfire/chili_heat
 	name = "Active Capsicum Glands"
-	description = "You may survive a cold winter with this in hand."
+	description = "It emits a strong heat when handled."
+	trait_flags = TRAIT_SHOW_EXAMINE
 	genes_to_check = list(/datum/plant_gene/trait/chem_heating)
 	/// The mob currently holding the chili.
 	var/datum/weakref/held_mob
@@ -457,6 +462,7 @@
 	name = "Large Bites"
 	description = "You can't hold off from eating this in one bite!"
 	icon = FA_ICON_DRUMSTICK_BITE
+	trait_flags = TRAIT_SHOW_EXAMINE
 
 /datum/plant_gene/trait/one_bite/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()
@@ -685,14 +691,13 @@
 	name = "Complex Harvest"
 	description = "Halves the maximum yield of the plant, and prevents it from benefiting from pollination's yield bonus."
 	icon = FA_ICON_SLASH
-	trait_flags = TRAIT_SHOW_EXAMINE|TRAIT_HALVES_YIELD|TRAIT_NO_POLLINATION
+	trait_flags = TRAIT_HALVES_YIELD|TRAIT_NO_POLLINATION
 	mutability_flags = NONE
 
 /// Poppy's unique trait that allows slicing for sap
 /datum/plant_gene/trait/opium_production
 	name = "Sap Buds"
 	description = "Using a knife or other sharp object on the plant between ages 200 seconds to 400 seconds will yield a sap."
-	trait_flags = NONE
 	icon = FA_ICON_PILLS
 	/// Has parent plant been harvested for sap already?
 	var/extracted = FALSE


### PR DESCRIPTION
## About The Pull Request

Removes `TRAIT_SHOW_EXAMINE` from default botany trait flags, keeps it for only a handful of traits that you could sensibly see or intuit at a glance

## Why It's Good For The Game

In the beginning, only like three genes showed on examine, this was handled by the "description" var

But when a bunch of nice QoL was added to botany (explaining how traits work in game), it used the same "description" var, making every plant examine box a mess of text that spoils every aspect of the plant 

Here's bluespace tomato, for example

<img width="415" height="245" alt="image" src="https://github.com/user-attachments/assets/9509e810-7689-4161-b576-d47263a0e1a6" />

I think this is
1. Really spammy. The more complex plants may have 10-12 traits, and it fills out the text box rapidly
2. Really ugly. Examining a plant just to see if it's a fruit or vege gives you a bunch of stuff most people don't care about
3. Really spoilery. You know at a glance everything a botany plant is capable of, even stuff which is meant to be less than obvious (backfire effects).

So I went through and basically made it so visual traits show on examine:
- Hypodermic Prickles
- Prickly Adhesion 
- Bioluminescence (All forms + Shadow)
- Heated Petals
- Rose Thorns
- Burning Stem
- Stinging Stem / Aggressive Stinging Stem
- Active Capsicum Glands

I also figured some "POV" effects would make sense on examine, such as: 
- Large Bites
- Oculary Mimicry

IF the general opinion is that "Seeing these traits on examine is good actually because I want to differentiate a death plant from a normal plant", then I will instead just split "Plant analyzer description" from "Examine description" so we can have more appropriate examine text for many of these genes

Alternatively, this might be an appropriate use of examine tags. `It is small, slippery, and liquid.`

## Changelog

:cl: Melbert
del: A bunch of botany genes no longer indicate their presence on examine
/:cl:

