### PR TITLE
Emp prot tags are more specific, also no longer leak stealthy emp protection

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -240,6 +240,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define EMP_PROTECT_CONTENTS (1<<1)
 ///EMP will protect the wires.
 #define EMP_PROTECT_WIRES (1<<2)
+///Don't indicate EMP protection in examine text.
+#define EMP_NO_EXAMINE (1<<3)
 
 ///Protects against all EMP types.
 #define EMP_PROTECT_ALL (EMP_PROTECT_SELF | EMP_PROTECT_CONTENTS | EMP_PROTECT_WIRES)

--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -234,13 +234,13 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ZAP_FUSION_FLAGS ZAP_OBJ_DAMAGE | ZAP_MOB_DAMAGE | ZAP_MOB_STUN
 #define ZAP_SUPERMATTER_FLAGS ZAP_GENERATES_POWER
 
-///EMP will protect itself.
+///Object will protect itself.
 #define EMP_PROTECT_SELF (1<<0)
-///EMP will protect the contents from also being EMPed.
+///Object will protect its contents from being EMPed.
 #define EMP_PROTECT_CONTENTS (1<<1)
-///EMP will protect the wires.
+///Object will protect its wiring from being EMPed.
 #define EMP_PROTECT_WIRES (1<<2)
-///Don't indicate EMP protection in examine text.
+///Don't indicate EMP protection in object examine text.
 #define EMP_NO_EXAMINE (1<<3)
 
 ///Protects against all EMP types.

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -30,11 +30,11 @@
 	if(flags & EMP_PROTECT_SELF)
 		examine_list["EMP resilient"] = "[source.p_They()] [source.p_are()] unaffected by electromagnetic pulses."
 
-	if(flags & (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRING) == (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRING))
+	if(flags & (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRES) == (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRES))
 		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring and contents from electromagnetic pulses."
 
 	else if(flags & EMP_PROTECT_CONTENTS)
 		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] contents from electromagnetic pulses."
 
-	else if(flags & EMP_PROTECT_WIRING)
+	else if(flags & EMP_PROTECT_WIRES)
 		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring from electromagnetic pulses."

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -18,10 +18,13 @@
 /datum/element/empprotection/proc/getEmpFlags(datum/source, severity)
 	SIGNAL_HANDLER
 
-	return flags
+	return (flags & EMP_PROTECT_ALL)
 
 /datum/element/empprotection/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
+
+	if(flags & EMP_NO_EXAMINE)
+		return
 
 	if(flags & EMP_PROTECT_ALL == EMP_PROTECT_ALL)
 		examine_list["EMP proof"] = "[source.p_They()] [source.p_are()] unaffected by electromagnetic pulses, and shields [source.p_their()] contents and wiring from them."

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -23,5 +23,18 @@
 /datum/element/empprotection/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	if(flags)
-		examine_list["EMP-proof"] = "It is shielded against electromagnetic pulses."
+	if(flags & EMP_PROTECT_ALL == EMP_PROTECT_ALL)
+		examine_list["EMP proof"] = "[source.p_They()] [source.p_are()] unaffected by electromagnetic pulses, and shields [source.p_their()] contents and wiring from them."
+		return
+
+	if(flags & EMP_PROTECT_SELF)
+		examine_list["EMP resilient"] = "[source.p_They()] [source.p_are()] unaffected by electromagnetic pulses."
+
+	if(flags & (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRING) == (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRING))
+		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring and contents from electromagnetic pulses."
+
+	else if(flags & EMP_PROTECT_CONTENTS)
+		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] contents from electromagnetic pulses."
+
+	else if(flags & EMP_PROTECT_WIRING)
+		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring from electromagnetic pulses."

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -149,15 +149,15 @@
 /obj/machinery/camera/proc/upgradeEmpProof(malf_upgrade, ignore_malf_upgrades)
 	if(isEmpProof(ignore_malf_upgrades)) //pass a malf upgrade to ignore_malf_upgrades so we can replace the malf module with the normal one
 		return //that way if someone tries to upgrade an already malf-upgraded camera, it'll just upgrade it to a normal version.
-	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
 	if(malf_upgrade)
 		malf_emp_firmware_active = TRUE //don't add parts to drop, update icon, ect. reconstructing it will also retain the upgrade.
 		malf_emp_firmware_present = TRUE //so the upgrade is retained after incompatible parts are removed.
+		AddElement(/datum/element/empprotection, EMP_PROTECT_ALL|EMP_NO_EXAMINE)
 
 	else if(!emp_module) //only happens via upgrading in camera/attackby()
 		emp_module = new(src)
-		if(malf_emp_firmware_active)
-			malf_emp_firmware_active = FALSE //make it appear like it's just normally upgraded so the icons and examine texts are restored.
+		malf_emp_firmware_active = FALSE //make it appear like it's just normally upgraded so the icons and examine texts are restored.
+		AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
 
 	camera_upgrade_bitflags |= CAMERA_UPGRADE_EMP_PROOF
 
@@ -165,6 +165,7 @@
 	if(ignore_malf_upgrades) //don't downgrade it if malf software is forced onto it.
 		return
 	RemoveElement(/datum/element/empprotection, EMP_PROTECT_ALL)
+	RemoveElement(/datum/element/empprotection, EMP_PROTECT_ALL|EMP_NO_EXAMINE)
 	camera_upgrade_bitflags &= ~CAMERA_UPGRADE_EMP_PROOF
 
 /obj/machinery/camera/proc/isXRay(ignore_malf_upgrades)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -58,7 +58,7 @@
 
 /obj/structure/emergency_shield/regenerating/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_NO_EXAMINE)
 
 /obj/structure/emergency_shield/regenerating/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -84,7 +84,7 @@
 
 /obj/structure/emergency_shield/cult/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_NO_EXAMINE)
 
 /obj/structure/emergency_shield/cult/narsie
 	name = "sanguine barrier"

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -885,7 +885,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 
 /datum/ai_module/malf/upgrade/upgrade_turrets/upgrade(mob/living/silicon/ai/AI)
 	for(var/obj/machinery/porta_turret/ai/turret as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/porta_turret/ai))
-		turret.AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
+		turret.AddElement(/datum/element/empprotection, EMP_PROTECT_ALL|EMP_NO_EXAMINE)
 		turret.max_integrity = 200
 		turret.repair_damage(200)
 		turret.lethal_projectile = /obj/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.

--- a/code/modules/clothing/chameleon/chameleon_gun.dm
+++ b/code/modules/clothing/chameleon/chameleon_gun.dm
@@ -16,7 +16,7 @@
 
 /obj/item/gun/energy/laser/chameleon/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
 	// Init order shenanigans dictate we have to do this last so we can't just use `active_type`
 	var/datum/action/item_action/chameleon/change/gun/gun_action = locate() in actions
 	gun_action?.update_look(default_look)

--- a/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
+++ b/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
@@ -3,7 +3,7 @@
 do { \
 	var/datum/action/item_action/chameleon/change/_action = locate() in item.actions; \
 	_action?.emp_randomise(INFINITY); \
-	item.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF); \
+	item.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_NO_EXAMINE); \
 } while(FALSE)
 
 // Cham jumpsuit

--- a/code/modules/mining/lavaland/mining_loot/megafauna/colossus.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/colossus.dm
@@ -373,7 +373,7 @@
 	if(isanimal_or_basicmob(loc))
 		holder_animal = loc
 		RegisterSignal(holder_animal, COMSIG_LIVING_DEATH, PROC_REF(on_holder_animal_death))
-	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL|EMP_NO_EXAMINE)
 
 /obj/structure/closet/stasis/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -48,3 +48,6 @@
 			. += span_deadsay("[p_They()] look[p_s()] like its system is corrupted and requires a reset.")
 
 	. += ..()
+
+/mob/living/silicon/robot/examine_descriptor(mob/user)
+	return "cyborg"

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -39,7 +39,7 @@
 		return
 	add_lightning_overlay(30 SECONDS)
 	playsound(organ_owner, 'sound/items/eshield_recharge.ogg', 40)
-	organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS)
+	organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
 	RegisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION), PROC_REF(activate_survival))
 	RegisterSignal(organ_owner, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 
@@ -48,7 +48,7 @@
 	if(!core)
 		return
 	UnregisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION))
-	organ_owner.RemoveElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS)
+	organ_owner.RemoveElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
 	tesla_zap(source = organ_owner, zap_range = 20, power = 2.5e5, cutoff = 1e3)
 	qdel(src)
 

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -195,10 +195,10 @@
 
 /obj/item/mecha_parts/mecha_equipment/armor/antiemp_armor_booster/attach(obj/vehicle/sealed/mecha/new_mecha, attach_right)
 	. = ..()
-	chassis.AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
+	chassis.AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES|EMP_NO_EXAMINE)
 
 /obj/item/mecha_parts/mecha_equipment/armor/antiemp_armor_booster/detach(atom/moveto)
-	chassis.RemoveElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
+	chassis.RemoveElement(/datum/element/empprotection, EMP_PROTECT_WIRES|EMP_NO_EXAMINE)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/armor/antiemp_armor_booster/clandestine


### PR DESCRIPTION
## About The Pull Request

Fixes #93199

EMP protection now specifies what it protects

Adds an EMP flag for things which should definitely not indicate they are EMP proof

## Changelog

:cl: Melbert
fix: EMP proof objects now specify what they protect rather than only implying it's 100% emp proof
fix: Some objects meant to stealthily be emp proof no longer broadcast they are emp proof on examine
/:cl:
