### PR TITLE
readds the MOD hydraulic clamp to the mining MODsuit's pins

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -138,6 +138,7 @@
 	default_pins = list(
 		/obj/item/mod/module/gps,
 		/obj/item/mod/module/drill,
+		/obj/item/mod/module/clamp,
 		/obj/item/mod/module/orebag,
 		/obj/item/mod/module/sphere_transform,
 	)


### PR DESCRIPTION
## About The Pull Request
exactly what it says on the tin (readds the MOD clamp to the mining MOD's pins)

## Why It's Good For The Game
originally it was removed but then readded last minute but smartkar forgot to put it back in the suit's default pins. if it's part of the default kit it should probably have a dedicated button

## Changelog

:cl:
fix: Nanotrasen has released a firmware patch for their mining MODs that readds the default hydraulic clamp to the suit's default pinned modules.
/:cl:
