### PR TITLE
Microwave add context now shows that you can dump a storage into it.

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -130,6 +130,10 @@
 		context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Unsecure" : "Install/Secure"]"
 		return CONTEXTUAL_SCREENTIP_SET
 
+	if(held_item?.atom_storage)
+		context[SCREENTIP_CONTEXT_RMB] = "Dump contents"
+		return CONTEXTUAL_SCREENTIP_SET
+
 	if(broken > NOT_BROKEN)
 		if(broken == REALLY_BROKEN && held_item?.tool_behaviour == TOOL_WIRECUTTER)
 			context[SCREENTIP_CONTEXT_LMB] = "Repair"


### PR DESCRIPTION

## About The Pull Request
You can right click with a storage item to mass transfer it to the microwave so I added it to the context
## Why It's Good For The Game
qol
## Changelog
:cl:
qol: Microwave context shows that you can right click to dump a storage into it
/:cl:
