### PR TITLE
Fix admin debug gps to be toggable and reset the affected turfs

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -12,6 +12,9 @@
 	slot_flags = ITEM_SLOT_BELT
 	obj_flags = UNIQUE_RENAME
 	var/gpstag
+	var/tracking_on = TRUE
+	var/debug_mode = FALSE
+	var/overlay_icon = "working"
 
 /obj/item/gps/Initialize(mapload)
 	. = ..()
@@ -19,7 +22,7 @@
 
 /// Adds the GPS component to this item.
 /obj/item/gps/proc/add_gps_component()
-	AddComponent(/datum/component/gps/item, gpstag)
+	AddComponent(/datum/component/gps/item, gpstag, tracking_on, overlay_state = overlay_icon, debug = debug_mode)
 
 /obj/item/gps/spaceruin
 	gpstag = SPACE_SIGNAL_GPSTAG
@@ -60,33 +63,8 @@
 	name = "visible GPS"
 	gpstag = "ADMIN"
 	desc = "This admin-spawn GPS unit leaves the coordinates visible \
-		on any turf that it passes over, for debugging. Especially useful \
+		on any turf that it passes over while being dragged on the floor. Especially useful \
 		for marking the area around the transition edges."
-	var/list/turf/tagged
-
-/obj/item/gps/visible_debug/Initialize(mapload)
-	. = ..()
-	tagged = list()
-	START_PROCESSING(SSfastprocess, src)
-
-/obj/item/gps/visible_debug/process()
-	var/turf/T = get_turf(src)
-	if(T)
-		// I assume it's faster to color,tag and OR the turf in, rather
-		// then checking if its there
-		T.color = RANDOM_COLOUR
-		T.maptext = MAPTEXT("[T.x],[T.y],[T.z]")
-		tagged |= T
-
-/obj/item/gps/visible_debug/proc/clear()
-	while(tagged.len)
-		var/turf/T = pop(tagged)
-		T.color = initial(T.color)
-		T.maptext = initial(T.maptext)
-
-/obj/item/gps/visible_debug/Destroy()
-	if(tagged)
-		clear()
-	tagged = null
-	STOP_PROCESSING(SSfastprocess, src)
-	. = ..()
+	tracking_on = FALSE
+	debug_mode = TRUE
+	overlay_icon = FALSE


### PR DESCRIPTION

## About The Pull Request
This fixes the admin debug gps tool so that it must be turned on to activate. (it spawns off now) Also when it is toggled on/off, it resets the colored turfs to their initial state.

## Why It's Good For The Game
When someone would equip the admin outfit, the debug gps would start processing immediately, despite it not being in your hand, or even turned on. This adds some restrictions so that you have to manually activate it and allows the turfs to reset.

## Changelog
:cl:
fix: The admin debug gps is now turned off by default and toggling it will reset the affected turfs.
admin: Equipping the admin outfit will no longer automatically trigger the debug gps effect.
/:cl:
