### PR TITLE
Decal painter now correctly paints alpha for neutral decals

### DIFF
--- a/code/game/objects/items/tools/painter/paintable_decals.dm
+++ b/code/game/objects/items/tools/painter/paintable_decals.dm
@@ -170,7 +170,7 @@
 	category = "Tiles"
 	default_alpha = /obj/effect/turf_decal/tile::alpha
 	possible_colors = list(
-		"Neutral" = /obj/effect/turf_decal/tile/neutral::color,
+		"Neutral" = "#d4d4d432", // very lazy way to do transparent decal, should be remade in future
 		"White" = "#FFFFFF",
 		"Dark" = /obj/effect/turf_decal/tile/dark::color,
 		"Bar Burgundy" = /obj/effect/turf_decal/tile/bar::color,


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

because neutral decal use 50 alpha and decal painter ignored it, resulting in completely different appearance


## Changelog

:cl:
fix: Decal painter now pulls alpha value from neutral decal.
/:cl:
