### PR TITLE
Fixes harddels and UI-breaking runtimes from open_containers

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -240,6 +240,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	throw_icon = null
 	resist_icon = null
 	QDEL_LIST(infodisplay)
+	open_containers = null
 
 	healths = null
 	stamina = null

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -701,9 +701,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	SIGNAL_HANDLER
 
 	for(var/mob/user as anything in is_using)
-		if(user.client)
-			var/client/cuser = user.client
-			cuser.screen -= gone
+		user.hud_used?.open_containers -= gone
+		if(!user.client)
+			continue
+		var/client/cuser = user.client
+		cuser.screen -= gone
 
 	reset_item(gone)
 	refresh_views()
@@ -1082,10 +1084,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	is_using -= to_hide
 
 	if(to_hide.client)
-		to_hide.hud_used.open_containers -= storage_interfaces[to_hide].list_ui_elements()
 		to_hide.client.screen -= storage_interfaces[to_hide].list_ui_elements()
-		to_hide.hud_used.open_containers -=  real_location.contents
 		to_hide.client.screen -= real_location.contents
+	if(to_hide.hud_used)
+		to_hide.hud_used.open_containers -= storage_interfaces[to_hide].list_ui_elements()
+		to_hide.hud_used.open_containers -=  real_location.contents
 	QDEL_NULL(storage_interfaces[to_hide])
 	storage_interfaces -= to_hide
 


### PR DESCRIPTION
## About The Pull Request

Closes #93221 as it incorporates a better version of the fix in said PR. hud_used could exist without a client (such as if the player logged out temporarily) and the elements in the list were not removed when an item was taken out of storage. This could result in harddels, which would fill the list with nulls and lead to the following runtime which would prevent all further UI updates on the mob, including planemaster rebuilds

```js
The following runtime has occurred 161 time(s).
runtime error: wrong type of value for list
proc name: show hud (/datum/hud/proc/show_hud)
  source file: code/_onclick/hud/hud.dm,347
  usr: Doctors-The-Smiles (/mob/living/carbon/human)
  src: /datum/hud/human (/datum/hud/human)
```

Fixes #93212

~~This is ***not*** a solution to #93212 (or at least I think so, there is a separate filter issue), but it could also break planemasters on a mob.~~

## Changelog
:cl:
fix: Fixed harddels and UI-breaking runtimes from open_containers
/:cl:
