### PR TITLE
Nerfs cult hardsuit armour, also reduces the structure cooldown by half

### DIFF
--- a/code/modules/antagonists/cult/cult_armor.dm
+++ b/code/modules/antagonists/cult/cult_armor.dm
@@ -128,9 +128,9 @@
 
 /datum/armor/cultrobes_hardened
 	melee = 50
-	bullet = 40
-	laser = 50
-	energy = 60
+	bullet = 30
+	laser = 25
+	energy = 50
 	bomb = 50
 	bio = 100
 	fire = 100

--- a/code/modules/antagonists/cult/cult_armor.dm
+++ b/code/modules/antagonists/cult/cult_armor.dm
@@ -128,9 +128,9 @@
 
 /datum/armor/cultrobes_hardened
 	melee = 50
-	bullet = 30
-	laser = 25
-	energy = 50
+	bullet = 25
+	laser = 30
+	energy = 60
 	bomb = 50
 	bio = 100
 	fire = 100

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -7,7 +7,7 @@
 	light_power = 2
 	debris = list(/obj/item/stack/sheet/runed_metal = 1)
 	/// Length of the cooldown between uses.
-	var/use_cooldown_duration = 5 MINUTES
+	var/use_cooldown_duration = 3 MINUTES
 	/// If provided, a bonus tip displayed to cultists on examined.
 	var/cult_examine_tip
 	/// The cooldown for when items can be dispensed.


### PR DESCRIPTION
## About The Pull Request
This PR nerfs the ranged armour for cultists.
And reduces the cooldown timer on constructs from 5 to 3

## Why It's Good For The Game
Cult hardsuit is very strong and usually used by all cultists which makes them very annoying to fight against in a group aspect if everyone has captain tier armour thats also spaceproof with the ability to instant escape and stuff. and its the armour values ontop of the 50% blockchance swords. lowering their laser/bullet armour will make them lose a little bit of their ranged prowess will still be orginally as strong in melee as before.

Also reducing the construct timer from 5 to 3. 5 is alot for a average round requiring you to get alot of plasteel to really get pumping things out which is kinda dumb, this will let cult pump things out a little faster without being 1/6th of a round timewise

The armour values in comparision
<img width="271" height="191" alt="image" src="https://github.com/user-attachments/assets/5fd7abe3-93e4-4bbc-8f37-8718d49da433" />

<img width="263" height="180" alt="image" src="https://github.com/user-attachments/assets/3a6aeb64-9592-466c-a337-600366f37600" />


## Changelog

:cl: Ezel
balance: Reduces Laser and bullet armour on cult hardsuits
balance: Reduces cult construct timer cooldown from 5 to 3 minutes.
/:cl:
