### PR TITLE
makes scythe mobs immune to lava

### DIFF
--- a/code/game/objects/items/soulscythe.dm
+++ b/code/game/objects/items/soulscythe.dm
@@ -261,7 +261,7 @@
 
 /mob/living/basic/soulscythe/Initialize(mapload)
 	. = ..()
-	add_traits(list(TRAIT_ASHSTORM_IMMUNE, TRAIT_SNOWSTORM_IMMUNE), ROUNDSTART_TRAIT)
+	add_traits(list(TRAIT_ASHSTORM_IMMUNE, TRAIT_SNOWSTORM_IMMUNE, TRAIT_LAVA_IMMUNE), INNATE_TRAIT)
 	RegisterSignal(src, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
 /mob/living/basic/soulscythe/proc/on_life(datum/source, seconds_per_tick, times_fired) // done like this because there's no need to go through all of life since the item does the work anyways


### PR DESCRIPTION

## About The Pull Request
the scythe item is not affected by lava, so i figured for the sake of consistency, the mob shouldnt be damaged by it either.

## Why It's Good For The Game
bit more consistent logic. im not sure if this was an oversight, but im marking it as balance

## Changelog
:cl:
balance: scythe mobs are no longer damaged by lava
/:cl:
