### PR TITLE
Sets the book tgui window to have the same dimensions as the paper tgui window.

### DIFF
--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -13,7 +13,7 @@ type MarkdownViewerData = {
 export const MarkdownViewer = (_: any) => {
   const { data } = useBackend<MarkdownViewerData>();
   return (
-    <Window theme="paper" title={data.title} width={300} height={300}>
+    <Window theme="paper" title={data.title} width={420} height={500}>
       <Window.Content scrollable backgroundColor={'#FFFFFF'}>
         <MarkdownRenderer content={data.content} />
       </Window.Content>


### PR DESCRIPTION

## About The Pull Request

This simply just matches the height/width of the book markdown viewer to match that of the paper sheet viewer, so books are no longer crunched up less readable versions of their paperwork counterparts by default.
## Why It's Good For The Game

It's really wonky whenever you finish writing something in paper, and you turn it into a book, and woe, all your formatting is wrong because you assumed an entirely different window size.
## Changelog
:cl:
fix: The tgui window for reading books is no longer compressed, and has the same dimensions as the window for reading paper.
/:cl:
