### PR TITLE
PAI leashes can be toggled on or off by owners

### DIFF
--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -122,6 +122,7 @@
 		name = pai.name,
 		transmit = pai.can_transmit,
 		receive = pai.can_receive,
+		leashed = pai.leash,
 		range = pai.leash?.distance,
 	)
 	return data
@@ -155,6 +156,9 @@
 			return TRUE
 		if("toggle_holo")
 			pai.toggle_holo()
+			return TRUE
+		if("toggle_leash")
+			pai.toggle_leash()
 			return TRUE
 		if("toggle_radio")
 			pai.toggle_radio(params["option"])

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -217,15 +217,22 @@
 		pai_card.set_personality(src)
 	card = pai_card
 	forceMove(pai_card)
-	leash = AddComponent(/datum/component/leash, pai_card, HOLOFORM_DEFAULT_RANGE, force_teleport_out_effect = /obj/effect/temp_visual/guardian/phase/out)
+	toggle_leash()
 	addtimer(VARSET_WEAK_CALLBACK(src, holochassis_ready, TRUE), HOLOCHASSIS_INIT_TIME)
 	if(!holoform)
 		add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), PAI_FOLDED)
 	update_appearance(UPDATE_DESC)
-
 	RegisterSignal(src, COMSIG_LIVING_CULT_SACRIFICED, PROC_REF(on_cult_sacrificed))
 	RegisterSignals(src, list(COMSIG_LIVING_ADJUST_BRUTE_DAMAGE, COMSIG_LIVING_ADJUST_BURN_DAMAGE), PROC_REF(on_shell_damaged))
 	RegisterSignal(src, COMSIG_LIVING_ADJUST_STAMINA_DAMAGE, PROC_REF(on_shell_weakened))
+
+/mob/living/silicon/pai/proc/toggle_leash()
+	if(isnull(card))
+		return
+	if(leash)
+		QDEL_NULL(leash)
+	else
+		leash = AddComponent(/datum/component/leash, card, HOLOFORM_DEFAULT_RANGE, force_teleport_out_effect = /obj/effect/temp_visual/guardian/phase/out)
 
 /mob/living/silicon/pai/create_modularInterface()
 	if(!modularInterface)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -346,9 +346,7 @@
 	master_dna = "Untraceable Signature"
 	// Sets supplemental directive to this
 	add_supplied_law(0, "Do not interfere with the operations of the Syndicate.")
-	QDEL_NULL(leash) // Freedom!!!
 	to_chat(src, span_danger("ALERT: Foreign software detected."))
-	to_chat(src, span_danger("WARN: Holochasis range restrictions disabled."))
 	return TRUE
 
 /mob/living/silicon/pai/on_saboteur(datum/source, disrupt_duration)
@@ -476,9 +474,6 @@
 
 /// Updates the distance we can be from our pai card
 /mob/living/silicon/pai/proc/increment_range(increment_amount)
-	if(emagged)
-		return
-
 	var/new_distance = leash.distance + increment_amount
 	if (new_distance < HOLOFORM_MIN_RANGE || new_distance > HOLOFORM_MAX_RANGE)
 		return

--- a/tgui/packages/tgui/interfaces/PaiCard.tsx
+++ b/tgui/packages/tgui/interfaces/PaiCard.tsx
@@ -36,6 +36,7 @@ type Pai = {
   name: string;
   transmit: BooleanLike;
   receive: BooleanLike;
+  leashed: BooleanLike;
   range: number;
 };
 
@@ -162,6 +163,7 @@ const PaiOptions = (props) => {
       name,
       transmit,
       receive,
+      leashed,
       range,
     },
   } = data;
@@ -192,6 +194,15 @@ const PaiOptions = (props) => {
             selected={can_holo}
           >
             Toggle
+          </Button>
+        </LabeledList.Item>
+        <LabeledList.Item label="Leash">
+          <Button
+            icon={leashed ? 'toggle-on' : 'toggle-off'}
+            onClick={() => act('toggle_leash')}
+            selected={leashed}
+          >
+            {leashed ? 'Unleash' : 'Leash'}
           </Button>
         </LabeledList.Item>
         <LabeledList.Item label="Holoform Range">

--- a/tgui/packages/tgui/interfaces/PaiCard.tsx
+++ b/tgui/packages/tgui/interfaces/PaiCard.tsx
@@ -206,9 +206,6 @@ const PaiOptions = (props) => {
           </Button>
         </LabeledList.Item>
         <LabeledList.Item label="Holoform Range">
-          {emagged ? (
-            '∞'
-          ) : (
             <Stack>
               <Stack.Item>
                 <Button
@@ -226,7 +223,6 @@ const PaiOptions = (props) => {
                 />
               </Stack.Item>
             </Stack>
-          )}
         </LabeledList.Item>
         <LabeledList.Item label="Transmit">
           <Button


### PR DESCRIPTION

## About The Pull Request
PAI leashes can be toggled on or off by owners

## Why It's Good For The Game
i do agree with the idea of tying PAIs to their owners considering what the P stands for and i wish it had worked out the way it was intended, but it has sort of deterred a lot of people from playing the role. even as the PAI owner in shifts where very little was going on, i did sort of find it socially exhausting to have to be tied to my PAI for the entire round and a massive responsibility since the fun the other player was having was solely depending on me. i found myself wishing we could have a little break from each other every now and then </3. i realize most of these are my own shortcomings, but i speculate atleast a few other pai owners may go through the same things which may tie into why very few pai devices are being picked up

## Changelog
:cl:
feature: PAI leashes can now be turned on or off by pai owners. (they are on by default)
/:cl:
