### PR TITLE
[NO GBP] Fixes USB cables infinitely recursing when snapped.

### DIFF
--- a/code/datums/components/shuttle_move_deferred_checks.dm
+++ b/code/datums/components/shuttle_move_deferred_checks.dm
@@ -40,8 +40,6 @@
 	targets -= movable
 	moving_targets -= movable
 	UnregisterSignal(movable, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_BEFORE_SHUTTLE_MOVE, COMSIG_ATOM_AFTER_SHUTTLE_MOVE, COMSIG_QDELETING))
-	if(!length(moving_targets) && length(targets))
-		call_check()
 	return ..()
 
 /datum/component/shuttle_move_deferred_checks/proc/call_check()

--- a/code/datums/components/shuttle_move_deferred_checks.dm
+++ b/code/datums/components/shuttle_move_deferred_checks.dm
@@ -38,8 +38,11 @@
 	if(!istype(movable))
 		return
 	targets -= movable
+	var/had_moving_targets = length(moving_targets)
 	moving_targets -= movable
 	UnregisterSignal(movable, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_BEFORE_SHUTTLE_MOVE, COMSIG_ATOM_AFTER_SHUTTLE_MOVE, COMSIG_QDELETING))
+	if(had_moving_targets && !length(moving_targets) && length(targets))
+		call_check()
 	return ..()
 
 /datum/component/shuttle_move_deferred_checks/proc/call_check()

--- a/code/datums/components/shuttle_move_deferred_checks.dm
+++ b/code/datums/components/shuttle_move_deferred_checks.dm
@@ -38,11 +38,8 @@
 	if(!istype(movable))
 		return
 	targets -= movable
-	var/had_moving_targets = length(moving_targets)
 	moving_targets -= movable
 	UnregisterSignal(movable, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_BEFORE_SHUTTLE_MOVE, COMSIG_ATOM_AFTER_SHUTTLE_MOVE, COMSIG_QDELETING))
-	if(had_moving_targets && !length(moving_targets) && length(targets))
-		call_check()
 	return ..()
 
 /datum/component/shuttle_move_deferred_checks/proc/call_check()


### PR DESCRIPTION
## About The Pull Request

Removes running the check when removing a source from `shuttle_move_deferred_checks`, preventing infinite recursion.

## Why It's Good For The Game

Fixes #93217

## Changelog

:cl:
fix: Snapping USB cables by dragging the attached objects too far away from each other will no longer crash the server.
/:cl:
