### PR TITLE
Fixes a mispelling of the word 'adjust'

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -438,7 +438,7 @@
 			balloon_alert(toggler, "sensors shorted!")
 			return FALSE
 		if(NO_SENSORS)
-			balloon_alert(toggler, "no sensors to ajdust!")
+			balloon_alert(toggler, "no sensors to adjust!")
 			return FALSE
 
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

Words should be spelt right.

## Changelog
:cl:
spellcheck: You can no longer 'ajdust' your sensors. Adjusting hasn't changed, though.
/:cl:
