### PR TITLE
Adds an emag function to door control remotes

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -1,6 +1,8 @@
 #define WAND_OPEN "open"
 #define WAND_BOLT "bolt"
 #define WAND_EMERGENCY "emergency"
+#define WAND_SHOCK "shock"
+#define WAND_DEPOWER "depower"
 
 /obj/item/door_remote
 	icon_state = "remote"
@@ -50,14 +52,30 @@
 			return TRUE
 	return FALSE
 
+/obj/item/door_remote/emag_act(mob/user, obj/item/card/emag/emag_card)
+	. = ..()
+	if(obj_flags & EMAGGED)
+		return FALSE
+	balloon_alert(user, "restricted functions unlocked")
+	obj_flags |= EMAGGED
+	update_icon_state()
+	return TRUE
+
 /obj/item/door_remote/attack_self(mob/user)
-	var/static/list/ops = list(WAND_OPEN = "Open Door", WAND_BOLT = "Toggle Bolts", WAND_EMERGENCY = "Toggle Emergency Access")
+	var/static/list/ops = list(WAND_OPEN = "Open Door", WAND_BOLT = "Toggle Bolts", WAND_EMERGENCY = "Toggle Emergency Access", WAND_SHOCK = "Shock Door", WAND_DEPOWER = "Depower Door")
 	switch(mode)
 		if(WAND_OPEN)
 			mode = WAND_BOLT
 		if(WAND_BOLT)
 			mode = WAND_EMERGENCY
 		if(WAND_EMERGENCY)
+			if(!(obj_flags & EMAGGED))
+				mode = WAND_OPEN
+			else
+				mode = WAND_SHOCK
+		if(WAND_SHOCK)
+			mode = WAND_DEPOWER
+		if(WAND_DEPOWER)
 			mode = WAND_OPEN
 	update_icon_state()
 	balloon_alert(user, "mode: [ops[mode]]")
@@ -176,6 +194,7 @@
 				door.open()
 			else
 				door.close()
+
 		if (WAND_BOLT)
 			if (!istype(airlock))
 				interacting_with.balloon_alert(user, "only airlocks!")
@@ -187,6 +206,7 @@
 			else
 				airlock.bolt()
 				log_combat(user, airlock, "bolted", src)
+
 		if (WAND_EMERGENCY)
 			if (!istype(airlock))
 				interacting_with.balloon_alert(user, "only airlocks!")
@@ -195,17 +215,39 @@
 			airlock.emergency = !airlock.emergency
 			airlock.update_appearance(UPDATE_ICON)
 
+		if (WAND_SHOCK)
+			if (!istype(airlock))
+				interacting_with.balloon_alert(user, "only airlocks!")
+				return ITEM_INTERACT_BLOCKING
+			if (airlock.isElectrified())
+				interacting_with.balloon_alert(user, "already electrified!")
+			else
+				airlock.set_electrified(30, user)
+
+		if (WAND_DEPOWER)
+			if (!istype(airlock))
+				interacting_with.balloon_alert(user, "only airlocks!")
+				return ITEM_INTERACT_BLOCKING
+			// First hit disrupts main power, backup comes back in ten seconds, if you stick around you can hit backup for 60 more seconds of downtime.
+			if (!airlock.main_power_timer)
+				airlock.loseMainPower()
+			else if (!airlock.backup_power_time)
+				airlock.loseBackupPower()
+
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/door_remote/update_icon_state()
 	var/icon_state_mode
-	switch(mode)
-		if(WAND_OPEN)
-			icon_state_mode = "open"
-		if(WAND_BOLT)
-			icon_state_mode = "bolt"
-		if(WAND_EMERGENCY)
-			icon_state_mode = "emergency"
+	if(!(obj_flags & EMAGGED))
+		switch(mode)
+			if(WAND_OPEN)
+				icon_state_mode = "open"
+			if(WAND_BOLT)
+				icon_state_mode = "bolt"
+			if(WAND_EMERGENCY)
+				icon_state_mode = "emergency"
+	else
+		icon_state_mode = "emergency"
 
 	icon_state = "[base_icon_state]_[department]_[icon_state_mode]"
 	return ..()
@@ -213,3 +255,5 @@
 #undef WAND_OPEN
 #undef WAND_BOLT
 #undef WAND_EMERGENCY
+#undef WAND_SHOCK
+#undef WAND_DEPOWER

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -33,6 +33,7 @@
 		/area/station/ai_monitored/turret_protected/ai_upload_foyer,	// but sometimes mappers might misconfig
 		/area/station/ai_monitored/turret_protected/ai_upload,			// their doors with our several dozen access helpers
 	)
+	COOLDOWN_DECLARE(shock_cooldown)
 
 /obj/item/door_remote/Initialize(mapload)
 	. = ..()
@@ -219,10 +220,14 @@
 			if (!istype(airlock))
 				interacting_with.balloon_alert(user, "only airlocks!")
 				return ITEM_INTERACT_BLOCKING
+			if (!COOLDOWN_FINISHED(src, shock_cooldown))
+				interacting_with.balloon_alert(user, "shock pulse resetting!")
+				return ITEM_INTERACT_BLOCKING
 			if (airlock.isElectrified())
 				interacting_with.balloon_alert(user, "already electrified!")
 			else
 				airlock.set_electrified(MACHINE_DEFAULT_ELECTRIFY_TIME, user)
+				COOLDOWN_START(src, shock_cooldown, 10 SECONDS)
 
 		if (WAND_DEPOWER)
 			if (!istype(airlock))

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -222,7 +222,7 @@
 			if (airlock.isElectrified())
 				interacting_with.balloon_alert(user, "already electrified!")
 			else
-				airlock.set_electrified(30, user)
+				airlock.set_electrified(MACHINE_DEFAULT_ELECTRIFY_TIME, user)
 
 		if (WAND_DEPOWER)
 			if (!istype(airlock))


### PR DESCRIPTION
## About The Pull Request

Taken from https://forums.tgstation13.org/viewtopic.php?t=30905

Adds an emag function to door remotes. When emagged, the remotes will gain the ability to shock and depower doors that they have access to. The shock function shocks the door for 30 seconds, the default electrify time. This function has a cooldown of ten seconds. The depower function works as if you were multitooling it, as in the first hit depowers the main supply, and the backup power comes back on in ten seconds. You can then hit it again to disable the backup power for the full sixty seconds of downtime.

To be clear, neither of these are toggles. They can shock and depower, but they cannot unshock or repower. No unsabotaging.

## Why It's Good For The Game

Currently, the AI's the only person who gets real utility out of shocking doors. Engineers can do it, but it's too slow and obvious to be useful, and isn't often seen. I think that this would support the rather rare gimmick of humans doing door antagonism, and that that gimmick may be interesting.

I believe that there is some policy to avoid making emagged items especially useful to non-antagonist crew, and I don't believe that this is overstepping that much. It certainly doesn't seem as useful(to me) as the numerous interactions with reagent dispensers, consoles and the like. If this is a great point of contention, however, I believe it would be remedied by simply removing some or all of the standard modes of the door remote.

## Changelog

:cl:

add: Added an emag interaction to door control remotes. Emagged remotes can shock and depower doors.

/:cl:
