### PR TITLE
Fix cryo visuals on multiz maps

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -20,6 +20,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pixel_y = 22
 	appearance_flags = KEEP_TOGETHER
+	vis_flags = VIS_INHERIT_PLANE
 	/// The current occupant being presented
 	var/mob/living/occupant
 


### PR DESCRIPTION
## About The Pull Request

It needs to match parent plane

## Changelog

:cl: Melbert
fix: Multi-z map cryo no longer makes locked fighting game characters
/:cl:


