### PR TITLE
Fix for stacks transforming into other stacks when removed from the Protolathe/Techfab.

### DIFF
--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -720,7 +720,7 @@
 			continue
 		//now we can merge since we are done with it
 		for(var/obj/item/stack/item_stack in target)
-			if(item_stack == new_stack || new_stack.type != type_to_retrieve) //don't merge with self or different type
+			if(item_stack == new_stack || item_stack.type != type_to_retrieve) //don't merge with self or different type
 				continue
 			//speed merge
 			var/merge_amount = min(item_stack.amount, new_stack.max_amount - new_stack.get_amount())


### PR DESCRIPTION
## About The Pull Request

I *think* this should be all that's required to fix this, it looks like it's just the variable that iterates over all available stacks on the dropturf needed to compare against the iterator's type as opposed to the stack we're about to create otherwise.

Fixes #93256 

## Why It's Good For The Game

Prevents a tiiiiny little material transformation/duplication bug.

## Changelog

:cl:
fix: Sheets removed from the protolathe/techfab will properly remove the correct quantity and merge into the right material.
/:cl:
