### PR TITLE
Cycler shotgun fixing

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -12,7 +12,7 @@
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/tube/fire
-	ammo_type = /obj/projectile/bullet/incendiary/shotgun/no_trail
+	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/no_trail
 
 /obj/item/ammo_box/magazine/internal/shot/tube/buckshot
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -50,13 +50,15 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE
-	//component for seclight attachment
+
+//component for seclight attachment
 /obj/item/gun/ballistic/shotgun/riot/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
 		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
 		light_overlay = "flight", \
 		overlay_x = 20, \
 		overlay_y = 11)
+
 // Automatic Shotguns//
 
 /obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user)
@@ -71,6 +73,7 @@
 	projectile_damage_multiplier = 1.5
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
+
 //component for seclight attachment
 /obj/item/gun/ballistic/shotgun/automatic/combat/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -78,6 +81,7 @@
 		light_overlay = "flight", \
 		overlay_x = 20, \
 		overlay_y = 11)
+
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	name = "compact combat shotgun"
 	desc = "A compact version of the semi automatic combat shotgun. Lower magazine capacity, but more easily carried."
@@ -85,6 +89,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
+
 //component for seclight attachment
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -92,6 +97,7 @@
 		light_overlay = "flight", \
 		overlay_x = 16, \
 		overlay_y = 11)
+
 //Dual Feed Shotgun
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube
@@ -105,7 +111,6 @@
 	inhand_y_dimension = 32
 	worn_icon_state = "cshotgun"
 	w_class = WEIGHT_CLASS_HUGE
-	semi_auto = TRUE
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
 	/// If defined, the secondary tube is this type, if you want different shell loads
@@ -138,7 +143,7 @@
 	return ..()
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/attack_self(mob/living/user)
-	if(!chambered && magazine.contents.len)
+	if(!chambered && get_ammo())
 		rack()
 	else
 		toggle_tube(user)
@@ -278,6 +283,7 @@
 
 /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
 	pin = /obj/item/firing_pin
+
 /////////////////////////////
 // DOUBLE BARRELED SHOTGUN //
 /////////////////////////////


### PR DESCRIPTION

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/93214
- Fixed the cycler shotgun consuming two rounds per shot.
- Fixed racking action on the cycler shotgun.
- Bounty hunter cycler shotgun now correctly uses incendiary rounds in its secondary tube.
## Changelog
:cl:
fix: fixed cycler shotgun double ammo consumption
fix: fixed racking action on the cycler shotgun
fix: bounty hunter cycler shotgun now properly fires incendiary rounds from secondary tube
/:cl:
