### PR TITLE
Fixed suit sensors only working on laundered clothes 

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -165,9 +165,10 @@
 
 /obj/item/clothing/under/equipped(mob/living/user, slot)
 	..()
-	if((slot & ITEM_SLOT_ICLOTHING) && freshly_laundered)
-		freshly_laundered = FALSE
-		user.add_mood_event("fresh_laundry", /datum/mood_event/fresh_laundry)
+	if(slot & ITEM_SLOT_ICLOTHING)
+		if(freshly_laundered)
+			freshly_laundered = FALSE
+			user.add_mood_event("fresh_laundry", /datum/mood_event/fresh_laundry)
 		update_wearer_status()
 
 /obj/item/clothing/under/dropped(mob/living/user)


### PR DESCRIPTION
## About The Pull Request

I don't think I need to explain anything

## Changelog

:cl: Melbert
fix: Equipping clothes adds you to suit sensors correctly if your clothes are unlaundered
/:cl:
