### PR TITLE
Ensures personalities are loaded before prefs are loaded

### DIFF
--- a/code/controllers/subsystem/processing/personality.dm
+++ b/code/controllers/subsystem/processing/personality.dm
@@ -14,7 +14,8 @@ PROCESSING_SUBSYSTEM_DEF(personalities)
 	VAR_FINAL/list/processing_personalities
 
 /datum/controller/subsystem/processing/personalities/Initialize()
-	init_personalities()
+	if(!length(personalities_by_type))
+		init_personalities()
 	return SS_INIT_SUCCESS
 
 /// Initialized personality singletons

--- a/code/controllers/subsystem/processing/personality.dm
+++ b/code/controllers/subsystem/processing/personality.dm
@@ -14,12 +14,14 @@ PROCESSING_SUBSYSTEM_DEF(personalities)
 	VAR_FINAL/list/processing_personalities
 
 /datum/controller/subsystem/processing/personalities/Initialize()
-	if(!length(personalities_by_type))
-		init_personalities()
+	init_personalities()
 	return SS_INIT_SUCCESS
 
 /// Initialized personality singletons
 /datum/controller/subsystem/processing/personalities/proc/init_personalities()
+	if(length(personalities_by_type))
+		return // Already initialized
+
 	personalities_by_type = list()
 	personalities_by_key = list()
 	incompatibilities_by_group = list()

--- a/code/datums/personality/personality_preference.dm
+++ b/code/datums/personality/personality_preference.dm
@@ -20,6 +20,9 @@
 	if(!LAZYLEN(input))
 		return null
 
+	if(!SSpersonalities.initialized)
+		SSpersonalities.init_personalities()
+
 	var/list/input_sanitized
 	for(var/personality_key in input)
 		var/datum/personality/personality = SSpersonalities.personalities_by_key[personality_key]


### PR DESCRIPTION
## About The Pull Request

Aaaaa if you load fast personalities aren't instantiated so personality loading wipes everything out. 

I don't know the best way to ensure personalities are loaded before anyone could load in unfortunately, so I just threw it in. Will need to ask around.

## Changelog

:cl: Melbert
fix: Fixed personality wiping
/:cl:
