### PR TITLE
Print 30 Cable Coil instead of 5 in lathes

### DIFF
--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -154,11 +154,11 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/cable_coil
-	name = "Cable (x5)"
+	name = "Cable Coil"
 	id = "cable_coil"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*0.5)
-	build_path = /obj/item/stack/cable_coil/five
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*3, /datum/material/glass = SMALL_MATERIAL_AMOUNT*3)
+	build_path = /obj/item/stack/cable_coil/thirty
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,


### PR DESCRIPTION
## About The Pull Request

[Previous PR](https://github.com/tgstation/tgstation/pull/83601)
Prints 30 (A Full Stack) Cable Coil instead of 5.

## Why It's Good For The Game

5+5 are not common factors of 30 (printing 5x = 25).
It lead to tediousness when wanting to print a full stack of cable coil

## Changelog

:cl: ArchBTW
qol: lathes print 30 cablecoil instead of 5
/:cl:
