### PR TITLE
Fix shuttle movement spamming `/area/space/nearstation`

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 /turf/proc/copyTurf(turf/copy_to_turf, copy_air = FALSE, flags = null)
 	if(copy_to_turf.type != type)
-		copy_to_turf.ChangeTurf(type, flags)
+		copy_to_turf.ChangeTurf(type, null, flags)
 	if(copy_to_turf.icon_state != icon_state)
 		copy_to_turf.icon_state = icon_state
 	if(copy_to_turf.icon != icon)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -193,6 +193,9 @@ GLOBAL_LIST_EMPTY(starlight)
 	if (!. || isspaceturf(.))
 		return
 
+	if (flags & CHANGETURF_NO_AREA_CHANGE)
+		return
+
 	var/area/new_turf_area = get_area(.)
 	if (istype(new_turf_area, /area/space) && !istype(new_turf_area, /area/space/nearstation))
 		set_turf_to_area(., GLOB.areas_by_type[/area/space/nearstation])


### PR DESCRIPTION

## About The Pull Request
- Caused by #90660

Any shuttles that moved on/off space turfs would always spawn their area types as `/area/space/nearstation`, which messes with the static lighting settings for an area. Found this while I was working on: 
- #92853 

I was trying to get shuttles to save the areas and turfs underneath them when I noticed all the damn nearstations areas from flying a custom shuttle around a bunch of z-levels. 

## Why It's Good For The Game
No more nearspace spam please.

<img width="1920" height="1080" alt="StrongDMM_TYI7vWgSaX" src="https://github.com/user-attachments/assets/68aa7979-ba9d-4b9c-92f9-00596a14ed00" />


## Changelog
:cl:
fix: Fix shuttle movement spamming nearstation areas on space turfs
/:cl:
