### PR TITLE
Improves/fixes plasma flower MOD core visuals

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -480,10 +480,14 @@
 	SIGNAL_HANDLER
 	if(mod.active)
 		particle_effect = new(mod.wearer, /particles/pollen, PARTICLE_ATTACH_MOB)
-		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, spawn_types=list(spawned_mob_type), spawn_time=5 SECONDS, max_spawned=3, faction=mod.wearer.faction)
+		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, \
+			spawn_types = list(spawned_mob_type), \
+			spawn_time = 5 SECONDS, \
+			max_spawned = 3, \
+			faction = mod.wearer.faction, \
+		)
 		RegisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED, PROC_REF(new_mob))
 		RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(spread_flowers))
-
 	else
 		QDEL_NULL(particle_effect)
 		UnregisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED)
@@ -499,6 +503,9 @@
 
 /obj/item/mod/core/plasma/lavaland/proc/spread_flowers(atom/source, atom/oldloc, dir, forced)
 	SIGNAL_HANDLER
+	if (!isturf(oldloc))
+		return
+
 	var/static/list/possible_flower_types = list(
 		/obj/structure/flora/bush/lavendergrass/style_random,
 		/obj/structure/flora/bush/flowers_yw/style_random,
@@ -506,7 +513,7 @@
 		/obj/structure/flora/bush/flowers_pp/style_random,
 	)
 	var/chosen_type = pick(possible_flower_types)
-	var/flower_boots = new chosen_type(get_turf(mod.wearer))
+	var/flower_boots = new chosen_type(oldloc)
 	animate(flower_boots, alpha = 0, 1 SECONDS)
 	QDEL_IN(flower_boots, 1 SECONDS)
 

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -466,6 +466,7 @@
 
 /obj/item/mod/core/plasma/lavaland/Destroy()
 	QDEL_NULL(particle_effect)
+	QDEL_NULL(mob_spawner)
 	return ..()
 
 /obj/item/mod/core/plasma/lavaland/install(obj/item/mod/control/mod_unit)
@@ -488,13 +489,14 @@
 		)
 		RegisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED, PROC_REF(new_mob))
 		RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(spread_flowers))
-	else
-		QDEL_NULL(particle_effect)
-		UnregisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED)
-		UnregisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED)
-		for(var/datum/mob in mob_spawner.spawned_things)
-			qdel(mob)
-		qdel(mob_spawner)
+		return
+
+	QDEL_NULL(particle_effect)
+	UnregisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED)
+	UnregisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED)
+	for(var/datum/mob in mob_spawner.spawned_things)
+		qdel(mob)
+	QDEL_NULL(mob_spawner)
 
 /obj/item/mod/core/plasma/lavaland/proc/new_mob(spawner, mob/living/basic/butterfly/lavaland/temporary/spawned)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Currently plasma flower MOD cores spawn grass trails on the tile you step on, but the proc itself is actually called before the mob ends up visually moving to the said tile, which makes the effect look rather weird. I swapped it to spawn trails on the user's previous tile, which makes it look a bit better.

## Why It's Good For The Game

Looks better

## Changelog
:cl:
fix: Plasma flower MOD core grass trails no longer appear in front of the user rather than behind them
/:cl:
