### PR TITLE
Allows kinetic crusher to pick up trophies without being wielded

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher.dm
@@ -208,6 +208,14 @@
 	SEND_SIGNAL(user, COMSIG_LIVING_CRUSHER_DETONATE, target, src, backstabbed)
 	target.apply_damage(combined_damage, BRUTE, blocked = def_check)
 
+/obj/item/kinetic_crusher/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!istype(interacting_with, /obj/item/crusher_trophy))
+		return NONE
+	var/obj/item/crusher_trophy/new_trophy = interacting_with
+	if(new_trophy.add_to(src, user))
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING
+
 /obj/item/kinetic_crusher/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
 		balloon_alert(user, "wield it first!")

--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher_trophies.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher_trophies.dm
@@ -25,11 +25,6 @@
 	SHOULD_CALL_PARENT(FALSE)
 	return "errors"
 
-/obj/item/crusher_trophy/attackby(obj/item/attacking_item, mob/living/user)
-	if(!istype(attacking_item, /obj/item/kinetic_crusher))
-		return ..()
-	add_to(attacking_item, user)
-
 /// Tries to add the trophy to our crusher
 /obj/item/crusher_trophy/proc/add_to(obj/item/kinetic_crusher/crusher, mob/living/user)
 	for(var/obj/item/crusher_trophy/trophy as anything in crusher.trophies)


### PR DESCRIPTION

## About The Pull Request

You can now attach trophies to PKC by clicking onto them with it without needing to wield it.

## Why It's Good For The Game

I don't see why you'd need to wield a club to attach something to it from the ground, I'd expect the exact opposite in fact. This behavior makes it clunky to attach trophies whenever you unwield your crusher for whatever reason, and I don't see a reason why it should stay.

## Changelog
:cl:
qol: You can now pick up trophies with PKC without needing to wield it
/:cl:
