### PR TITLE
Sleeping Carp and Cain & Abel no longer tell you about armor penetration when you reflect projectiles with them

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
@@ -14,7 +14,7 @@
 #define COMSIG_ATOM_EMP_ACT "atom_emp_act"
 ///from base of atom/fire_act(): (exposed_temperature, exposed_volume)
 #define COMSIG_ATOM_FIRE_ACT "atom_fire_act"
-///from base of atom/bullet_act(): (/obj/proj, def_zone, piercing_hit, blocked)
+///from base of atom/bullet_act(): (/obj/proj, def_zone, piercing_hit)
 #define COMSIG_ATOM_PRE_BULLET_ACT "pre_atom_bullet_act"
 	/// All this does is prevent default bullet on_hit from being called, [BULLET_ACT_HIT] being return is implied
 	#define COMPONENT_BULLET_ACTED (1<<0)

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -86,6 +86,7 @@
 
 /atom/proc/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE, blocked = null)
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_ATOM_PRE_BULLET_ACT, hitting_projectile, def_zone, piercing_hit)
+
 	if(sigreturn & COMPONENT_BULLET_PIERCED)
 		return BULLET_ACT_FORCE_PIERCE
 	if(sigreturn & COMPONENT_BULLET_BLOCKED)

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -85,8 +85,17 @@
  */
 
 /atom/proc/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE, blocked = null)
+	var/sigreturn = SEND_SIGNAL(src, COMSIG_ATOM_PRE_BULLET_ACT, hitting_projectile, def_zone, piercing_hit)
+	if(sigreturn & COMPONENT_BULLET_PIERCED)
+		return BULLET_ACT_FORCE_PIERCE
+	if(sigreturn & COMPONENT_BULLET_BLOCKED)
+		return BULLET_ACT_BLOCK
+	if(sigreturn & COMPONENT_BULLET_ACTED)
+		return BULLET_ACT_HIT
+
 	if (isnull(blocked))
 		blocked = check_projectile_armor(def_zone, hitting_projectile)
+
 	return bullet_act(hitting_projectile, def_zone, piercing_hit, blocked)
 
 /**
@@ -100,15 +109,6 @@
  */
 /atom/proc/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE, blocked = 0)
 	SHOULD_CALL_PARENT(TRUE)
-
-	var/sigreturn = SEND_SIGNAL(src, COMSIG_ATOM_PRE_BULLET_ACT, hitting_projectile, def_zone, piercing_hit, blocked)
-	if(sigreturn & COMPONENT_BULLET_PIERCED)
-		return BULLET_ACT_FORCE_PIERCE
-	if(sigreturn & COMPONENT_BULLET_BLOCKED)
-		return BULLET_ACT_BLOCK
-	if(sigreturn & COMPONENT_BULLET_ACTED)
-		return BULLET_ACT_HIT
-
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, hitting_projectile, def_zone, piercing_hit, blocked)
 	if(QDELETED(hitting_projectile)) // Signal deleted it?
 		return BULLET_ACT_BLOCK

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -1239,7 +1239,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 /obj/machinery/porta_turret/lasertag/bullet_act(obj/projectile/projectile)
 	. = ..()
-	if(!on)
+	if(!on || . != BULLET_ACT_HIT)
 		return
 	if(team_color == "blue" && istype(projectile, /obj/projectile/beam/lasertag/redtag))
 		set_disabled(10 SECONDS)

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -82,8 +82,7 @@
 /obj/effect/dummy/phased_mob/ex_act()
 	return FALSE
 
-/obj/effect/dummy/phased_mob/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE)
-	SHOULD_CALL_PARENT(FALSE)
+/obj/effect/dummy/phased_mob/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
 	return BULLET_ACT_FORCE_PIERCE
 
 /obj/effect/dummy/phased_mob/relaymove(mob/living/user, direction)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -135,10 +135,10 @@
 		return ..()
 	return BULLET_ACT_FORCE_PIERCE
 
-/obj/effect/portal/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
-	if (!teleport(hitting_projectile, force = TRUE))
-		return ..()
-	return BULLET_ACT_FORCE_PIERCE
+/obj/effect/portal/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if (teleport(hitting_projectile, force = TRUE))
+		return BULLET_ACT_FORCE_PIERCE
+	return ..()
 
 /obj/effect/portal/proc/teleport(atom/movable/moving, force = FALSE)
 	if(!force && (!istype(moving) || iseffect(moving) || (ismecha(moving) && !mech_sized) || (!isobj(moving) && !ismob(moving)))) //Things that shouldn't teleport.

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -98,7 +98,6 @@
 /obj/item/latexballoon/bullet_act(obj/projectile/projectile)
 	if(projectile.damage > 0)
 		burst()
-
 	return ..()
 
 /obj/item/latexballoon/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -27,7 +27,7 @@
 
 	return TRUE
 
-/obj/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE)
+/obj/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE, blocked = null)
 	. = ..()
 	if(. != BULLET_ACT_HIT)
 		return .

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -94,8 +94,8 @@
 /obj/structure/closet/crate/necropolis/colossus
 	name = "colossus chest"
 
-/obj/structure/closet/crate/necropolis/colossus/bullet_act(obj/projectile/proj)
-	if(istype(proj, /obj/projectile/colossus))
+/obj/structure/closet/crate/necropolis/colossus/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if(istype(hitting_projectile, /obj/projectile/colossus))
 		return BULLET_ACT_FORCE_PIERCE
 	return ..()
 

--- a/code/modules/mob/living/basic/cult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/basic/cult/constructs/juggernaut.dm
@@ -36,20 +36,19 @@
 	smashes_walls = FALSE
 	melee_attack_cooldown = 2 SECONDS
 
-/mob/living/basic/construct/juggernaut/bullet_act(obj/projectile/bullet)
-	if(!istype(bullet, /obj/projectile/energy) && !istype(bullet, /obj/projectile/beam))
+/mob/living/basic/construct/juggernaut/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if(!istype(hitting_projectile, /obj/projectile/energy) && !istype(hitting_projectile, /obj/projectile/beam))
 		return ..()
-	if(!prob(40 - round(bullet.damage / 3))) // reflect chance
+	if(!prob(40 - round(hitting_projectile.damage / 3))) // reflect chance
 		return ..()
 
-	apply_damage(bullet.damage * 0.5, bullet.damage_type)
+	apply_damage(hitting_projectile.damage * 0.5, hitting_projectile.damage_type)
 	visible_message(
-		span_danger("\The [bullet] is reflected by [src]'s armored shell!"),
-		span_userdanger("\The [bullet] is reflected by your armored shell!"),
+		span_danger("\The [hitting_projectile] is reflected by [src]'s armored shell!"),
+		span_userdanger("\The [hitting_projectile] is reflected by your armored shell!"),
 	)
 
-	bullet.reflect(src)
-
+	hitting_projectile.reflect(src)
 	return BULLET_ACT_FORCE_PIERCE // complete projectile permutation
 
 // Alternate juggernaut themes

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -299,7 +299,7 @@
 /mob/living/basic/revenant/narsie_act()
 	return //most humans will now be either bones or harvesters, but we're still un-alive.
 
-/mob/living/basic/revenant/bullet_act()
+/mob/living/basic/revenant/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
 	if(!HAS_TRAIT(src, TRAIT_REVENANT_REVEALED) || dormant)
 		return BULLET_ACT_FORCE_PIERCE
 	return ..()

--- a/code/modules/mob/living/basic/trooper/syndicate.dm
+++ b/code/modules/mob/living/basic/trooper/syndicate.dm
@@ -37,9 +37,9 @@
 	r_hand = /obj/item/knife/combat/survival
 	var/projectile_deflect_chance = 0
 
-/mob/living/basic/trooper/syndicate/melee/bullet_act(obj/projectile/projectile)
+/mob/living/basic/trooper/syndicate/melee/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
 	if(prob(projectile_deflect_chance))
-		visible_message(span_danger("[src] blocks [projectile] with its shield!"))
+		visible_message(span_danger("[src] blocks [hitting_projectile] with its shield!"))
 		return BULLET_ACT_BLOCK
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -39,30 +39,31 @@
 			covering_part += equipped
 	return covering_part
 
-/mob/living/carbon/human/bullet_act(obj/projectile/bullet, def_zone, piercing_hit = FALSE)
-	if(bullet.firer == src && bullet.original == src) //can't block or reflect when shooting yourself
+/mob/living/carbon/human/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if(hitting_projectile.firer == src && hitting_projectile.original == src) //can't block or reflect when shooting yourself
 		return ..()
 
-	if(bullet.reflectable)
-		if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
-			visible_message(
-				span_danger("\The [bullet] gets reflected by [src]!"),
-				span_userdanger("\The [bullet] gets reflected by [src]!"),
-			)
-			// Finds and plays the block_sound of item which reflected
-			for(var/obj/item/held_item in held_items)
-				if(held_item.IsReflect(def_zone))
-					playsound(src, held_item.block_sound, BLOCK_SOUND_VOLUME, TRUE)
-			// Find a turf near or on the original location to bounce to
-			if(!isturf(loc)) //Open canopy mech (ripley) check. if we're inside something and still got hit
-				return loc.projectile_hit(bullet, def_zone, piercing_hit)
-			bullet.reflect(src)
-			return BULLET_ACT_FORCE_PIERCE // complete projectile permutation
+	// The projectile cannot be reflected or you failed to pass a reflection% check
+	if (!hitting_projectile.reflectable || !check_reflect(def_zone))
+		return ..()
 
+	visible_message(
+		span_danger("\The [hitting_projectile] gets reflected by [src]!"),
+		span_userdanger("\The [hitting_projectile] gets reflected by [src]!"),
+	)
+	// Finds and plays the block_sound of item which reflected
+	for(var/obj/item/held_item in held_items)
+		if(held_item.IsReflect(def_zone))
+			playsound(src, held_item.block_sound, BLOCK_SOUND_VOLUME, TRUE)
+	// Find a turf near or on the original location to bounce to
+	if(!isturf(loc)) // Open canopy mech (ripley) check. if we're inside something and still got hit
+		return loc.projectile_hit(hitting_projectile, def_zone, piercing_hit, blocked)
+	hitting_projectile.reflect(src)
+	return BULLET_ACT_FORCE_PIERCE // complete projectile permutation
+
+/mob/living/carbon/human/bullet_act(obj/projectile/bullet, def_zone, piercing_hit, blocked)
 	if(check_block(bullet, bullet.damage, "\the [bullet]", PROJECTILE_ATTACK, bullet.armour_penetration, bullet.damage_type))
-		bullet.on_hit(src, 100, def_zone, piercing_hit)
-		return BULLET_ACT_HIT
-
+		return ..(bullet, def_zone, piercing_hit, 100)
 	return ..()
 
 ///Reflection checks for anything in your l_hand, r_hand, or wear_suit based on the reflection chance of the object

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -298,9 +298,9 @@ Difficulty: Hard
 	if(.)
 		recovery_time = world.time + 20 // can only attack melee once every 2 seconds but rapid_melee gives higher priority
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/projectile/proj)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
 	if(BUBBLEGUM_IS_ENRAGED)
-		visible_message(span_danger("[src] deflects the [proj]! [p_They()] can't be hit with ranged weapons while enraged!"), span_userdanger("You deflect the projectile!"))
+		visible_message(span_danger("[src] deflects the [hitting_projectile]! [p_They()] can't be hit with ranged weapons while enraged!"), span_userdanger("You deflect the projectile!"))
 		playsound(src, SFX_BULLET_MISS, 300, TRUE)
 		return BULLET_ACT_BLOCK
 	return ..()

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -401,15 +401,15 @@
 			timetokill += seconds_per_tick
 
 
-/obj/structure/chrono_field/bullet_act(obj/projectile/projectile)
-	if(istype(projectile, /obj/projectile/energy/chrono_beam))
-		var/obj/projectile/energy/chrono_beam/beam = projectile
-		var/obj/item/mod/module/tem/linked_tem = beam.tem_weakref.resolve()
-		if(linked_tem && istype(linked_tem))
-			linked_tem.field_connect(src)
-		return BULLET_ACT_HIT
+/obj/structure/chrono_field/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if(!istype(hitting_projectile, /obj/projectile/energy/chrono_beam))
+		return ..()
 
-	return ..()
+	var/obj/projectile/energy/chrono_beam/beam = hitting_projectile
+	var/obj/item/mod/module/tem/linked_tem = beam.tem_weakref.resolve()
+	if(linked_tem && istype(linked_tem))
+		linked_tem.field_connect(src)
+	return BULLET_ACT_HIT
 
 /obj/structure/chrono_field/assume_air()
 	return FALSE

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -201,7 +201,7 @@
 // "Stun" weapons can cause minor damage to components (short-circuits?)
 // "Burn" damage is equally strong against internal components and exterior casing
 // "Brute" damage mostly damages the casing.
-/obj/machinery/modular_computer/bullet_act(obj/projectile/proj)
-	return cpu?.projectile_hit(proj) || ..()
+/obj/machinery/modular_computer/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	return cpu?.projectile_hit(hitting_projectile, def_zone, piercing_hit, blocked) || ..()
 
 #undef CPU_INTERACTABLE

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -112,11 +112,11 @@
 	smoke.set_up(0, holder = src, location = src)
 	smoke.start()
 
-/obj/vehicle/ridden/atv/bullet_act(obj/projectile/proj)
+/obj/vehicle/ridden/atv/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
 	if(prob(50) || !LAZYLEN(buckled_mobs))
 		return ..()
 	for(var/mob/buckled_mob as anything in buckled_mobs)
-		return buckled_mob.projectile_hit(proj)
+		return buckled_mob.projectile_hit(hitting_projectile)
 	return ..()
 
 /obj/vehicle/ridden/atv/atom_destruction()

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -82,12 +82,10 @@
 	shield.setDir(dir)
 
 //Redirects projectiles to the shield if defense_check decides they should be blocked and returns true.
-/obj/vehicle/sealed/mecha/durand/bullet_act(obj/projectile/source, def_zone, mode)
-	if(defense_check(source.loc) && shield)
-		return shield.projectile_hit(source, def_zone, mode)
+/obj/vehicle/sealed/mecha/durand/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if(defense_check(hitting_projectile.loc) && shield)
+		return shield.projectile_hit(hitting_projectile, def_zone, piercing_hit, blocked)
 	return ..()
-
-
 
 /**Checks if defense mode is enabled, and if the attacker is standing in an area covered by the shield.
 Expects a turf. Returns true if the attack should be blocked, false if not.*/

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -97,9 +97,9 @@
 	return ..()
 
 //bullets will have a 60% chance to hit any riders
-/obj/vehicle/ridden/secway/bullet_act(obj/projectile/proj)
+/obj/vehicle/ridden/secway/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
 	if(!buckled_mobs || prob(40))
 		return ..()
 	for(var/mob/rider as anything in buckled_mobs)
-		return rider.projectile_hit(proj)
+		return rider.projectile_hit(hitting_projectile)
 	return ..()


### PR DESCRIPTION

## About The Pull Request

Projectile refactor pulled armor check above the pre-hit comsig, this fixes that. No need to check armor before you're hit when you potentially will not be.

## Changelog
:cl:
fix: Sleeping Carp and Cain & Abel no longer tell you about armor penetration when you reflect projectiles with them
/:cl:
