### PR TITLE
spawner legion corpses disappear in storms

### DIFF
--- a/code/datums/components/storm_hating.dm
+++ b/code/datums/components/storm_hating.dm
@@ -9,6 +9,9 @@
 		/datum/weather/void_storm,
 	)
 
+	/// Does this element delete itself if someone logs in?
+	var/clears_on_login = TRUE
+
 /datum/component/storm_hating/Initialize()
 	. = ..()
 	if (!isatom(parent))
@@ -19,6 +22,7 @@
 	. = ..()
 	RegisterSignal(parent, COMSIG_ENTER_AREA, PROC_REF(on_area_entered))
 	RegisterSignal(parent, COMSIG_EXIT_AREA, PROC_REF(on_area_exited))
+	RegisterSignal(parent, COMSIG_MOB_LOGIN, PROC_REF(on_login))
 
 /datum/component/storm_hating/UnregisterFromParent()
 	. = ..()
@@ -45,4 +49,10 @@
 	if (!isturf(parent_atom.loc))
 		return
 	parent_atom.fade_into_nothing(life_time = 3 SECONDS, fade_time = 2 SECONDS)
+	qdel(src)
+
+/datum/component/storm_hating/proc/on_login(datum/source)
+	SIGNAL_HANDLER
+	if(!clears_on_login)
+		return
 	qdel(src)

--- a/code/datums/components/storm_hating.dm
+++ b/code/datums/components/storm_hating.dm
@@ -9,9 +9,6 @@
 		/datum/weather/void_storm,
 	)
 
-	/// Does this element delete itself if someone logs in?
-	var/clears_on_login = TRUE
-
 /datum/component/storm_hating/Initialize()
 	. = ..()
 	if (!isatom(parent))
@@ -53,6 +50,4 @@
 
 /datum/component/storm_hating/proc/on_login(datum/source)
 	SIGNAL_HANDLER
-	if(!clears_on_login)
-		return
 	qdel(src)

--- a/code/modules/mob_spawn/corpses/mining_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mining_corpses.dm
@@ -137,6 +137,7 @@
 /obj/effect/mob_spawn/corpse/human/legioninfested/skeleton/charred/special(mob/living/carbon/human/spawned_human)
 	. = ..()
 	spawned_human.color = "#454545"
+	spawned_human.AddComponent(/datum/component/storm_hating)
 
 
 /datum/outfit/consumed_miner


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin. Corpses from spawner legions (e.g. vent legions, tendril legions) have the storm-hating component, which means that when a storm starts the body is deleted.

Also makes it so that the `storm_hating` component clears itself when the atom it's attached to is logged into, so skeletons you do decide to brainswap into/bodyjack/etc. won't Thanos snap and turn into dust if you get stormed on.

## Why It's Good For The Game

Ashes to ashes, dust to dust. Prevents corpses from piling up that badly. I swear this was a feature but I don't know whatever happened to it.

## Changelog

:cl:
qol: The skeletal corpses left from spawner legions (e.g. from ore vent defenses and legion necropolis tendrils) now disappear during ash storms. This does not apply if the body gets brainswapped into.
/:cl:

