### PR TITLE
[NO GBP] Fixes ore bags only picking one item per holder's move

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -164,8 +164,10 @@
 
 	var/show_message = FALSE
 	for(var/atom/thing as anything in tile)
-		if(is_type_in_typecache(thing, atom_storage.can_hold))
-			show_message ||= pickup_ore(thing, user, box)
+		if(!is_type_in_typecache(thing, atom_storage.can_hold))
+			continue
+		if(pickup_ore(thing, user, box))
+			show_message = TRUE
 
 	if (!show_message)
 		spam_protection = FALSE


### PR DESCRIPTION

## About The Pull Request

Small oversight, ``||=`` ends up not running if show_message is TRUE, so it only picks up one item at a time per move

## Changelog
:cl:
fix: Fixed ore bags only picking one item per holder's move
/:cl:
