### PR TITLE
Fixes permanent colour-blindness with no cure after welding without eye-protection

### DIFF
--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -63,8 +63,8 @@
 		return
 	currently_blind = TRUE
 	owner.overlay_fullscreen(id, /atom/movable/screen/fullscreen/blind)
-	// Apply colorblind filter - force=TRUE prevents conflicts with fade animations
-	owner.add_client_colour(/datum/client_colour/monochrome, REF(src), force = TRUE)
+	// Apply instant colorblind filter to prevent animation conflicts
+	owner.add_client_colour(/datum/client_colour/monochrome/blindness, REF(src))
 
 /datum/status_effect/grouped/blindness/proc/make_unblind()
 	if(!currently_blind)

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -210,6 +210,11 @@
 /datum/client_colour/monochrome/glasses
 	priority = CLIENT_COLOR_GLASSES_PRIORITY
 
+/// Instant version of monochrome for blindness
+/datum/client_colour/monochrome/blindness
+	fade_in = 0
+	fade_out = 0
+
 /datum/client_colour/bloodlust
 	priority = CLIENT_COLOR_IMPORTANT_PRIORITY
 	color = list(0,0,0,0,0,0,0,0,0,1,0,0) // pure red


### PR DESCRIPTION

## About The Pull Request

Fixes  #93279 

The game applies a filter when you're blind. This filter has a 2-second fade animation.

When your blindness status changed rapidly (like when healing eye damage), multiple filter operations would conflict with each other, causing the colorblind filter to get "stuck" permanently.

- State tracking - A currently_blind flag prevents duplicate filter operations
- Force parameter - Using force = TRUE when applying the filter bypasses the fade animations

This is so when you heal welding eye damage the colorblind filter is properly removed and your vision returns to normal colors.
## Why It's Good For The Game

- In theory less immersive without the animation but permanent filter issues that even admin abuse cannot fix is bad
## Changelog
:cl:
fix: Fixes permanent colour-blindness with no cure after welding without eye-protection, Though you really should wear masks for this!
/:cl:
