### PR TITLE
"Finger on the Eject Button" achievement for killing yourself within 10 minutes of roundstart

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -60,6 +60,7 @@
 #define MEDAL_CIGARETTES "Cigarettes"
 #define MEDAL_SHARKDRAGON "Sharkdragon"
 #define MEDAL_THEORETICAL_LIMITS "All Within Theoretical Limits"
+#define MEDAL_QUITTER "Finger on the Eject Button"
 
 //Skill medal hub IDs
 #define MEDAL_LEGENDARY_MINER "Legendary Miner"

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -244,3 +244,9 @@
 	desc = "Nutritionists often recommend a balanced and varied diet. However that clearly isn't the case for some creatures."
 	database_id = MEDAL_SHARKDRAGON
 	icon_state = "dragon_plus_fish"
+
+/datum/award/achievement/misc/finger_on_the_eject_button
+	name = "Finger on the Eject Button"
+	desc = "When the going gets rough, you always have a little trap door out of here!"
+	database_id = MEDAL_QUITTER
+	icon_state = "default"

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -90,6 +90,8 @@
 	var/obj/item/organ/brain/userbrain = get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(userbrain)
 		userbrain.suicided = suicide_state
+	if(ROUND_TIME < 10 MINUTES)
+		src.client?.give_award(/datum/award/finger_on_the_eject_button, src)
 
 /mob/living/carbon/can_suicide()
 	if(!..())

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -90,7 +90,7 @@
 	var/obj/item/organ/brain/userbrain = get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(userbrain)
 		userbrain.suicided = suicide_state
-	if(ROUND_TIME < 10 MINUTES)
+	if(ROUND_TIME() < 10 MINUTES)
 		src.client?.give_award(/datum/award/finger_on_the_eject_button, src)
 
 /mob/living/carbon/can_suicide()

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -90,8 +90,8 @@
 	var/obj/item/organ/brain/userbrain = get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(userbrain)
 		userbrain.suicided = suicide_state
-	if(ROUND_TIME() < 10 MINUTES)
-		src.client?.give_award(/datum/award/finger_on_the_eject_button, src)
+	if(STATION_TIME_PASSED() < 10 MINUTES)
+		src.client?.give_award(/datum/award/achievement/misc/finger_on_the_eject_button, src)
 
 /mob/living/carbon/can_suicide()
 	if(!..())


### PR DESCRIPTION

## About The Pull Request
I don't know how to test it to make sure it works but, ideally, this is an "achievement" for using the suicide verb within 10 minutes of the round starting. It's a Disco Elysium reference.

## Why It's Good For The Game
It's meant to be both morbidly humorous and slightly mocking of people who kill themselves so early into the round. I think that's soulful.

## Changelog
:cl: Bisar
add: Killing yourself very early into the round now comes with a mark of distinguishment.
/:cl:
