### PR TITLE
Removes 2 power sinks

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -24,7 +24,8 @@
 	icon = 'icons/obj/machines/atmospherics/unary_devices.dmi'
 	icon_state = "airlock_pump"
 	pipe_state = "airlock_pump"
-	use_power = ACTIVE_POWER_USE
+	use_power = IDLE_POWER_USE
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
 	can_unwrench = TRUE
 	welded = FALSE
@@ -291,6 +292,7 @@
 	if(on || !cycling_set_up || airlocks_animating || !powered())
 		return FALSE
 
+	update_use_power(ACTIVE_POWER_USE)
 	pump_direction = cycle_direction
 
 	for(var/obj/machinery/door/airlock/airlock as anything in (internal_airlocks + external_airlocks))
@@ -342,6 +344,7 @@
 	if(!on)
 		return FALSE
 	set_on(FALSE)
+	update_use_power(IDLE_POWER_USE)
 
 	// In case we can open both sides safe_dock will do it for us
 	// it also handles its own messages. If we can't - procceed

--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -123,7 +123,10 @@
 	. = ..()
 	if(mapload)
 		can_unwrench = FALSE
-
+	var/datum/gas_mixture/distro_air = airs[1]
+	var/datum/gas_mixture/waste_air = airs[2]
+	distro_air.volume = 1000
+	waste_air.volume = 1000
 
 /obj/machinery/atmospherics/components/unary/airlock_pump/post_machine_initialize()
 	. = ..()
@@ -154,14 +157,6 @@
 			tile_air_pressure = max(0, local_turf.return_air().return_pressure())
 		on_dock_request(tile_air_pressure)
 
-/obj/machinery/atmospherics/components/unary/airlock_pump/Initialize(mapload)
-	. = ..()
-	var/datum/gas_mixture/distro_air = airs[1]
-	var/datum/gas_mixture/waste_air = airs[2]
-	distro_air.volume = 1000
-	waste_air.volume = 1000
-
-
 /obj/machinery/atmospherics/components/unary/airlock_pump/on_deconstruction(disassembled)
 	. = ..()
 	if(cycling_set_up)
@@ -177,6 +172,12 @@
 		to_chat(user, span_warning("You cannot unwrench [src], wait for the cycle completion!"))
 		return FALSE
 
+/obj/machinery/atmospherics/components/unary/airlock_pump/set_on(active)
+	. = ..()
+	if(active)
+		update_use_power(ACTIVE_POWER_USE)
+	else
+		update_use_power(IDLE_POWER_USE)
 
 /obj/machinery/atmospherics/components/unary/airlock_pump/process_atmos()
 	if(!on)
@@ -292,7 +293,6 @@
 	if(on || !cycling_set_up || airlocks_animating || !powered())
 		return FALSE
 
-	update_use_power(ACTIVE_POWER_USE)
 	pump_direction = cycle_direction
 
 	for(var/obj/machinery/door/airlock/airlock as anything in (internal_airlocks + external_airlocks))
@@ -338,13 +338,11 @@
 
 	return TRUE
 
-
 ///Complete/Abort cycle with the passed message
 /obj/machinery/atmospherics/components/unary/airlock_pump/proc/stop_cycle(message = null, unbolt_only = FALSE)
 	if(!on)
 		return FALSE
 	set_on(FALSE)
-	update_use_power(IDLE_POWER_USE)
 
 	// In case we can open both sides safe_dock will do it for us
 	// it also handles its own messages. If we can't - procceed

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -12,6 +12,9 @@
 	icon_state = "miner"
 	density = FALSE
 	resistance_flags = INDESTRUCTIBLE|ACID_PROOF|FIRE_PROOF
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 1.5
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 1.25
+	initialize_directions = NONE
 	var/spawn_id = null
 	var/spawn_temp = T20C
 	/// Moles of gas to spawn per second
@@ -26,9 +29,6 @@
 	var/power_draw_dynamic_kpa_coeff = 0.5
 	var/broken = FALSE
 	var/broken_message = "ERROR"
-	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 1.5
-	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
-	initialize_directions = NONE
 
 /obj/machinery/atmospherics/miner/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Lowers the power needed for the unary vents & gas miners by making unary vents respect going idle and gas miners taking 7.5kW power less since it doesn't really have a way to "turn off".

## Why It's Good For The Game

These machines are straight up power sinks that sucks up a lot of power away from ghost roles & arrivals. The unary vents is quite a big issue as on Metastation arrivals loses power about 3-4 minutes in and prevents the rest of the station to charge their APCs, significantly cutting the 15 minute delay Engineering gets to set up power.

## Changelog

:cl:
fix: Arrivals won't lose power on roundstart anymore.
qol: Ghost roles with gas miners will now suddenly have a lot more available power.
/:cl: