### PR TITLE
Changes Wallet Priority: Priority goes left to right, instead of Command ID priority.

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -26,12 +26,10 @@
 	LAZYCLEARLIST(combined_access)
 
 	front_id = null
-	var/is_magnetic_found = FALSE
 	for(var/obj/item/card/id/id_card in contents)
 		// Certain IDs can forcibly jump to the front so they can disguise other cards in wallets. Chameleon/Agent ID cards are an example of this.
-		if(!is_magnetic_found && HAS_TRAIT(id_card, TRAIT_MAGNETIC_ID_CARD))
+		if(HAS_TRAIT(id_card, TRAIT_MAGNETIC_ID_CARD))
 			front_id = id_card
-			is_magnetic_found = TRUE
 
 		LAZYINITLIST(combined_access)
 		combined_access |= id_card.access

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -20,13 +20,12 @@
 /**
  * Calculates the new front ID.
  *
- * Picks the ID card that has the most combined command or higher tier accesses.
+ * Priorities ID cards with TRAIT_MAGNETIC_ID_CARD.
  */
 /obj/item/storage/wallet/proc/refreshID()
 	LAZYCLEARLIST(combined_access)
 
 	front_id = null
-	var/winning_tally = 0
 	var/is_magnetic_found = FALSE
 	for(var/obj/item/card/id/id_card in contents)
 		// Certain IDs can forcibly jump to the front so they can disguise other cards in wallets. Chameleon/Agent ID cards are an example of this.
@@ -34,16 +33,10 @@
 			front_id = id_card
 			is_magnetic_found = TRUE
 
-		if(!is_magnetic_found)
-			var/card_tally = SSid_access.tally_access(id_card, ACCESS_FLAG_COMMAND)
-			if(card_tally > winning_tally)
-				winning_tally = card_tally
-				front_id = id_card
-
 		LAZYINITLIST(combined_access)
 		combined_access |= id_card.access
 
-	// If we didn't pick a front ID - Maybe none of our cards have any command accesses? Just grab the first card (if we even have one).
+	// If we didn't pick a front ID - Maybe none of our cards have TRAIT_MAGNETIC_ID_CARD? Just grab the first card (if we even have one).
 	// We could also have no ID card in the wallet at all, which will mean we end up with a null front_id and that's fine too.
 	if(!front_id)
 		front_id = (locate(/obj/item/card/id) in contents)


### PR DESCRIPTION
## About The Pull Request

Before
<img width="95" height="96" alt="Screenshot 2025-10-04 132720" src="https://github.com/user-attachments/assets/04e4fba6-400b-4345-89bb-28c7ba8dc7f4" />

After
<img width="99" height="92" alt="Screenshot 2025-10-04 130740" src="https://github.com/user-attachments/assets/eda648ef-3043-44a4-bae7-9283ce402491" />

with ID order in a wallet
<img width="421" height="117" alt="Screenshot 2025-10-04 130747" src="https://github.com/user-attachments/assets/7b20c552-d85e-4282-8e0b-fe993b49b592" />

Before the PR, the IDs in a wallet priorities showing command IDs, instead of left to right.
This removes Command ID priority being shown (but still retaining access).
Chameleon/Agent IDs still uphold the 'spoofing' property, if desired.

Now you can choose what ID you'd like to show in your wallet, instead of Command IDs automatically being chosen and shown for you.

## Why It's Good For The Game

Allows Command to hide during revs, while keeping their ID access.
Allows Security to undercover, while keeping their ID access.
Allows Traitors to utilize IDs, without tediousness.

## Changelog

:cl: ArchBTW
balance: Removes Command ID priority in wallets. IDs in wallets now properly go in order from left to right.
/:cl: