### PR TITLE
Fixes an (at least) year old bug which prevented projectiles from making chat messages when hitting someone

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -30,11 +30,12 @@
 	var/fire_sound_volume = 50
 	var/dry_fire_sound = 'sound/items/weapons/gun/general/dry_fire.ogg'
 	var/dry_fire_sound_volume = 30
-	var/suppressed = null //whether or not a message is displayed when fired
+	/// Whether or not a message is displayed when fired
+	var/suppressed = SUPPRESSED_NONE
 	var/can_suppress = FALSE
 	var/suppressed_sound = 'sound/items/weapons/gun/general/heavy_shot_suppressed.ogg'
 	var/suppressed_volume = 60
-	/// whether a gun can be unsuppressed. for ballistics, also determines if it generates a suppressor overlay
+	/// Whether a gun can be unsuppressed. for ballistics, also determines if it generates a suppressor overlay
 	var/can_unsuppress = TRUE
 	var/recoil = 0 //boom boom shake the room
 	var/clumsy_check = TRUE
@@ -98,10 +99,7 @@
 /obj/item/gun/Destroy()
 	if(isobj(pin)) //Can still be the initial path, then we skip
 		QDEL_NULL(pin)
-	if(chambered) //Not all guns are chambered (EMP'ed energy guns etc)
-		QDEL_NULL(chambered)
-	if(isatom(suppressed)) //SUPPRESSED IS USED AS BOTH A TRUE/FALSE AND AS A REF, WHAT THE FUCKKKKKKKKKKKKKKKKK
-		QDEL_NULL(suppressed)
+	QDEL_NULL(chambered)
 	return ..()
 
 /obj/item/gun/apply_fantasy_bonuses(bonus)
@@ -133,14 +131,12 @@
 	if(gone == chambered)
 		chambered = null
 		update_appearance()
-	if(gone == suppressed)
-		clear_suppressor()
 
-///Clears var and updates icon. In the case of ballistic weapons, also updates the gun's weight.
+/// Clears var and updates icon.
 /obj/item/gun/proc/clear_suppressor()
 	if(!can_unsuppress)
 		return
-	suppressed = null
+	suppressed = SUPPRESSED_NONE
 	update_appearance()
 
 /obj/item/gun/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -455,7 +451,7 @@
 		else //Smart spread
 			sprd = round((((burst_spread_mult/burst_size) * iteration) - (0.5 + (burst_spread_mult * 0.25))) * (random_spread))
 		before_firing(target,user)
-		if(!chambered.fire_casing(target, user, params, ,suppressed, zone_override, sprd, src))
+		if(!chambered.fire_casing(target, user, params, 0, suppressed, zone_override, sprd, src))
 			shoot_with_empty_chamber(user)
 			firing_burst = FALSE
 			return FALSE
@@ -516,7 +512,7 @@
 					return
 			var/sprd = round((rand(0, 1) - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * total_random_spread)
 			before_firing(target,user)
-			if(!chambered.fire_casing(target, user, params, , suppressed, zone_override, sprd, src))
+			if(!chambered.fire_casing(target, user, params, 0, suppressed, zone_override, sprd, src))
 				shoot_with_empty_chamber(user)
 				return
 			else

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -140,6 +140,8 @@
 	var/burst_fire_selection = FALSE
 	/// If it has an icon for a selector switch indicating current firemode.
 	var/selector_switch_icon = FALSE
+	/// Suppressor attached to the gun, if any
+	var/obj/item/suppressor/suppressor = null
 
 /obj/item/gun/ballistic/Initialize(mapload)
 	. = ..()
@@ -162,7 +164,13 @@
 
 /obj/item/gun/ballistic/Destroy()
 	QDEL_NULL(magazine)
+	QDEL_NULL(suppressor)
 	return ..()
+
+/obj/item/gun/ballistic/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == suppressor)
+		clear_suppressor()
 
 /obj/item/gun/ballistic/add_weapon_description()
 	AddElement(/datum/element/weapon_description, attached_proc = PROC_REF(add_notes_ballistic))
@@ -528,8 +536,8 @@
 			balloon_alert(user, "not in hand!")
 			return ITEM_INTERACT_FAILURE
 
-		if(suppressed)
-			balloon_alert(user, "already has a supressor!")
+		if(suppressor)
+			balloon_alert(user, "already has a suppressor!")
 			return ITEM_INTERACT_FAILURE
 
 		if(!user.transferItemToLoc(tool, src))
@@ -590,27 +598,28 @@
 	return ..()
 
 ///Installs a new suppressor, assumes that the suppressor is already in the contents of src
-/obj/item/gun/ballistic/proc/install_suppressor(obj/item/suppressor/S)
-	suppressed = S
-	update_weight_class(w_class + S.w_class) //so pistols do not fit in pockets when suppressed
+/obj/item/gun/ballistic/proc/install_suppressor(obj/item/suppressor/new_suppressor)
+	suppressor = new_suppressor
+	suppressed = suppressor.suppression
+	update_weight_class(w_class + suppressor.w_class) //so pistols do not fit in pockets when suppressed
 	update_appearance()
 
 /obj/item/gun/ballistic/clear_suppressor()
 	if(!can_unsuppress)
 		return
-	if(isitem(suppressed))
-		var/obj/item/I = suppressed
-		update_weight_class(w_class - I.w_class)
-	return ..()
+	suppressed = SUPPRESSED_NONE
+	if(suppressor)
+		update_weight_class(w_class - suppressor.w_class)
+		suppressor = null
+	update_appearance()
 
 /obj/item/gun/ballistic/click_alt(mob/user)
 	if(!suppressed || !can_unsuppress)
 		return CLICK_ACTION_BLOCKING
-	var/obj/item/suppressor/S = suppressed
 	if(!user.is_holding(src))
 		return CLICK_ACTION_BLOCKING
-	balloon_alert(user, "[S.name] removed")
-	user.put_in_hands(S)
+	balloon_alert(user, "[suppressor.name] removed")
+	user.put_in_hands(suppressor)
 	clear_suppressor()
 	return CLICK_ACTION_SUCCESS
 
@@ -690,7 +699,7 @@
 		. += "It does not seem to have a round chambered."
 	if (bolt_locked)
 		. += "The [bolt_wording] is locked back and needs to be released before firing or de-fouling."
-	if (suppressed)
+	if (suppressor)
 		. += "It has a suppressor [can_unsuppress ? "attached that can be removed with <b>alt+click</b>." : "that is integral or can't otherwise be removed."]"
 	if(can_misfire)
 		. += span_danger("You get the feeling this might explode if you fire it...")
@@ -868,3 +877,5 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	icon = 'icons/obj/weapons/guns/ballistic.dmi'
 	icon_state = "suppressor"
 	w_class = WEIGHT_CLASS_TINY
+	/// How quiet should the gun be when we're installed?
+	var/suppression = SUPPRESSED_QUIET

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -536,7 +536,7 @@
 			balloon_alert(user, "not in hand!")
 			return ITEM_INTERACT_FAILURE
 
-		if(suppressor)
+		if(suppressed)
 			balloon_alert(user, "already has a suppressor!")
 			return ITEM_INTERACT_FAILURE
 

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -65,7 +65,7 @@
 	for an underbarrel-mounted disruptor, similar in operation to the standalone SC/FISHER. Chambered in 10mm."
 	desc_controls = "Right-click to use the underbarrel disruptor. Two shots maximum between self-charges."
 	icon_state = "pistol_evil_fisher"
-	suppressed = TRUE
+	suppressed = SUPPRESSED_QUIET
 	can_suppress = FALSE
 	can_unsuppress = FALSE
 	var/obj/item/gun/energy/recharge/fisher/underbarrel

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -106,7 +106,7 @@
 	no_charge_state = "crossbow_empty"
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
-	suppressed = TRUE
+	suppressed = SUPPRESSED_QUIET
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	recharge_time = 2 SECONDS
 	holds_charge = TRUE
@@ -131,7 +131,7 @@
 	no_charge_state = "crossbowlarge_empty"
 	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
-	suppressed = null
+	suppressed = SUPPRESSED_NONE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 
 /// A silly gun that does literally zero damage, but disrupts electrical sources of light, like flashlights.
@@ -144,7 +144,7 @@
 	dry_fire_sound_volume = 10
 	w_class = WEIGHT_CLASS_SMALL
 	holds_charge = TRUE
-	suppressed = TRUE
+	suppressed = SUPPRESSED_QUIET
 	recharge_time = 1.2 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/fisher)
 

--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -161,7 +161,7 @@
 	base_pixel_x = 0
 	pixel_x = 0
 	force = 2 //Also very weak because it's smaller
-	suppressed = TRUE //Softer fire sound
+	suppressed = SUPPRESSED_QUIET //Softer fire sound
 	can_unsuppress = FALSE //Permanently silenced
 	syringes = list(new /obj/item/reagent_containers/syringe())
 


### PR DESCRIPTION

## About The Pull Request

So, while working on #93275 I've noticed that suspiciously none of the projectiles made impact messages, the only ones I could see in chat were wounds, not hits. Turns out that because guns, for whatever ungodly reason, have been storing their suppression state and their suppressor in the same variable presumably since their inception, instead of SUPPRESSED_NONE (0) projectiles were assigned null, or if suppressed by an item the suppressor itself, both of which were treated as SUPPRESSED_VERY by impact message logic and skipped actually sending any messages to players' chats. 
I've split the variables and put suppressor onto ballistics (which are the only user of said mechanic), so now projectiles should actually inform players that they/someone nearby have been hit with a bullet.

## Changelog
:cl:
fix: Fixed a year old issue which prevented projectile hit messages from appearing if they've been shot from a gun.
/:cl:
