### PR TITLE
Fixes Pubby escape shuttle's seats

### DIFF
--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -165,7 +165,6 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aL" = (
@@ -173,7 +172,6 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aM" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -165,6 +165,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aL" = (
@@ -172,6 +173,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aM" = (
@@ -458,12 +460,10 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "fa" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
-/obj/machinery/light/directional/east,
+/obj/structure/chair/comfy/shuttle,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iy" = (


### PR DESCRIPTION

## About The Pull Request

The seats accidentally got rotated at some point, presumably due to copypaste, which also introduced two floating lights to the corridor.

<img width="652" height="306" alt="image" src="https://github.com/user-attachments/assets/76137f52-f1a1-4543-99f6-08f3fb5d1959" />

Fixed version

<img width="662" height="341" alt="image" src="https://github.com/user-attachments/assets/20ca99d8-2665-41a5-814f-d6b30a6b231c" />

## Changelog
:cl:
fix: Fixed some of Pubby's escape shuttle seats being incorrectly rotated and having floating lights over them
/:cl:
