### PR TITLE
Gives Security Sec-EVA Access

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -42025,7 +42025,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/station/security/eva)
 "mat" = (
@@ -57089,7 +57089,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/eva)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39629,7 +39629,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10017,7 +10017,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security EVA"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth,
 /area/station/security/brig/upper)
@@ -50455,7 +50455,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security EVA"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56832,7 +56832,7 @@
 "pXk" = (
 /obj/machinery/door/window/brigdoor/right/directional/north{
 	name = "Flash Storage";
-	req_access = list("armory")
+	req_access = list("brig")
 	},
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/smooth,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4750,10 +4750,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/science/research)
-"bHi" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/space/basic,
-/area/space)
 "bHr" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -76849,7 +76845,7 @@ aaa
 aaa
 aaa
 aaa
-bHi
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4707,7 +4707,7 @@
 	name = "Security E.V.A. Storage"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -4750,6 +4750,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/science/research)
+"bHi" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/space/basic,
+/area/space)
 "bHr" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -76845,7 +76849,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bHi
 aaa
 aaa
 aaa

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -4586,7 +4586,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security E.V.A. Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)


### PR DESCRIPTION
## About The Pull Request

Gives Security Sec-EVA Access (replaced: .../all/security/armory -> .../all/security/brig)
Nebulastation is generally 'unchanged', essentially already had Sec access.

## Why It's Good For The Game

Too inaccessible to Security during critical emergencies, when EVA is needed the most to survive (bombings, floods (usually by ai), brig bombed, stealth nukeops, surrounded by revs/cult outside brig, etc).

In most situations it is already too late, or not possible to ask for basic necessity to survive, or face otherwise immediate inaccessible station-wide threats.

The ordinary sec modsuits are slowdown armor (trivially easy to outrun indoors, and movement speed is vitally important in this game), andso sec would be kneecapping themselves if commonly using their modsuits without an immediate inaccessible threat or necessity to survive.

## Changelog

:cl: ArchBTW
balance: Gives Security Sec-EVA Access
/:cl: