### PR TITLE
Various reagent-to-mob interactions have click cds again

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -198,6 +198,7 @@
 
 	to_chat(injectee, span_warning("You feel a tiny prick!"))
 	to_chat(user, span_notice("You inject [injectee] with the injector ([selected_reagent.name])."))
+	user.changeNext_move(CLICK_CD_MELEE)
 
 	if(injectee.reagents)
 		hypospray_injector.trans_to(injectee, amount_per_transfer_from_this, transferred_by = user, methods = INJECT)

--- a/code/modules/antagonists/heretic/items/eldritch_flask.dm
+++ b/code/modules/antagonists/heretic/items/eldritch_flask.dm
@@ -26,11 +26,12 @@
 		return NONE
 	if(!isliving(target))
 		return NONE
+	user.changeNext_move(CLICK_CD_MELEE)
 	var/mob/living/living_target = target
+	if(living_target == user)
+		return ITEM_INTERACT_BLOCKING
 	if(reagents.total_volume >= reagents.maximum_volume)
 		to_chat(user, span_notice("[src] is full."))
-		return ITEM_INTERACT_BLOCKING
-	if(living_target == user)
 		return ITEM_INTERACT_BLOCKING
 	if(living_target.can_block_magic(MAGIC_RESISTANCE_HOLY))
 		to_chat(user, span_warning("You are unable to draw any blood from [living_target]!"))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -150,6 +150,7 @@
 
 	var/punctuation = ismob(target) ? "!" : "."
 
+	user.changeNext_move(CLICK_CD_MELEE)
 	user.visible_message(
 		span_danger("[user] splashes the contents of [src] onto [target][punctuation]"),
 		span_danger("You splash the contents of [src] onto [target][punctuation]"),

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -31,6 +31,7 @@
 	if(!canconsume(target_mob, user))
 		return ITEM_INTERACT_BLOCKING
 
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(target_mob == user)
 		target_mob.visible_message(span_notice("[user] attempts to [apply_method] [src]."))
 		if(self_delay)

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -44,6 +44,7 @@
 	if(!canconsume(target, user))
 		return ITEM_INTERACT_BLOCKING
 
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(target == user)
 		user.visible_message(
 			span_notice("[user] swallows some of the contents of \the [src]."),

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -69,6 +69,7 @@
 	if(!canconsume(target_mob, user))
 		return ITEM_INTERACT_BLOCKING
 
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(target_mob != user)
 		target_mob.visible_message(
 			span_danger("[user] attempts to feed [target_mob] something from [src]."),

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -28,9 +28,9 @@
 		var/fraction = min(amount_per_transfer_from_this / reagents.total_volume, 1)
 
 		if(ismob(target))
+			user.changeNext_move(CLICK_CD_MELEE)
 			if(ishuman(target))
 				var/mob/living/carbon/human/victim = target
-
 				var/obj/item/safe_thing = victim.is_eyes_covered()
 
 				if(safe_thing)
@@ -45,13 +45,15 @@
 						to_chat(user, span_notice("You transfer [trans] unit\s of the solution."))
 					update_appearance()
 					return ITEM_INTERACT_BLOCKING
+
 			else if(isalien(target)) //hiss-hiss has no eyes!
 				to_chat(target, span_danger("[target] does not seem to have any eyes!"))
 				return ITEM_INTERACT_BLOCKING
 
-			target.visible_message(span_danger("[user] squirts something into [target]'s eyes!"), \
-									span_userdanger("[user] squirts something into your eyes!"))
-
+			target.visible_message(
+				span_danger("[user] squirts something into [target]'s eyes!"),
+				span_userdanger("[user] squirts something into your eyes!"),
+			)
 			SEND_SIGNAL(target, COMSIG_MOB_REAGENTS_DROPPED_INTO_EYES, user, src, reagents, fraction)
 			reagents.expose(target, TOUCH, fraction)
 			var/mob/M = target

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -42,6 +42,7 @@
 		injected += injected_reagent.name
 	var/contained = english_list(injected)
 	log_combat(user, affected_mob, "attempted to inject", src, "([contained])")
+	user.changeNext_move(CLICK_CD_MELEE)
 
 	if(!used_up && (ignore_flags || affected_mob.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
 		to_chat(affected_mob, span_warning("You feel a tiny prick!"))

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -44,6 +44,7 @@
 		to_chat(user, span_warning("[src] is empty!"))
 		return ITEM_INTERACT_BLOCKING
 
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(interacting_with == user)
 		interacting_with.visible_message(span_notice("[user] attempts to [apply_method] [src] on [user.p_them()]self."))
 		if(self_delay)


### PR DESCRIPTION
## About The Pull Request

Moving from `attack` to `item_interaction` and `interact_with_atom` accidentally made these click CD free

Which is probably a bad thing

So I re-added click CDs to reagent container -> mob interactions that were converted.
Reagent container -> item interactions have no CDs. 

## Changelog

:cl: Melbert
fix: Reagent container interactions with mobs have click cooldown again
/:cl:
