### PR TITLE
Fixes metal-tipped telescopic batons being unable to be stolen by Spies

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -295,11 +295,10 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	steal_hint = "A self-defense weapon standard-issue for all heads of staffs barring the Head of Security. Rarely found off of their person."
 
 /datum/objective_item/steal/traitor/telebaton/check_special_completion(obj/item/thing)
-	return thing.type == /obj/item/melee/baton/telescopic
+	return !istype(thing, /obj/item/melee/baton/telescopic/contractor_baton)
 
 /obj/item/melee/baton/telescopic/add_stealing_item_objective()
-	if(type == /obj/item/melee/baton/telescopic)
-		return add_item_to_steal(src, /obj/item/melee/baton/telescopic)
+	return add_item_to_steal(src, /obj/item/melee/baton/telescopic)
 
 /datum/objective_item/steal/traitor/cargo_budget
 	name = "cargo's departmental budget"


### PR DESCRIPTION
## About The Pull Request

Fixes #93160.
## Why It's Good For The Game

![Capture](https://github.com/user-attachments/assets/1ee9d2d2-2c2f-472a-a843-ff89d3171c2b)

I was able to verify the issue on master, these changes will fix the issue for Spy gamers.

## Changelog
:cl:
fix: Metal-tipped telescopic batons now count for Spy's telescopic baton bounty.
/:cl:
