### PR TITLE
Fixes riot shotgun unintentional melee when point blank shooting

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -59,6 +59,10 @@
 	/// If FALSE it will just try to fire at ourselves straight up.
 	var/doafter_self_shoot = TRUE
 
+	/// If TRUE, will fire ITEM_INTERACT_BLOCKING (melee, etc) if the gun has a round already in the chamber, and is waiting to be fired (but cant, usually due to waiting on fire_delay).
+	/// If FALSE, nothing changed.
+	var/chambered_attack_block = FALSE
+
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
 
@@ -302,6 +306,8 @@
 /obj/item/gun/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(try_fire_gun(interacting_with, user, list2params(modifiers)))
 		return ITEM_INTERACT_SUCCESS
+	if(chambered_attack_block == TRUE && can_shoot() && isliving(interacting_with))
+		return ITEM_INTERACT_BLOCKING // block melee (etc), usually if waiting on fire delay
 	return NONE
 
 /obj/item/gun/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -50,6 +50,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE
+	chambered_attack_block = TRUE // necessary for riot shotgun due to fire_delay and wanting to shoot point blank without accidental melee
 
 //component for seclight attachment
 /obj/item/gun/ballistic/shotgun/riot/add_seclight_point()


### PR DESCRIPTION
## About The Pull Request

Due to 'fire_delay = 8', when pump racking a riot shotgun (with a live shotgun bullet in it) it will instead melee when you try to point blank shoot at someone (tldr - click fast enough after pumping a riot shotgun will result in an annoying melee).
This PR fixes that by blocking melee, on the condition that you pump racked the riot shotgun and it is about to be ready to fire.

You still melee with LMB if you have no ammo pump racked/didn't pump rack the shotgun, and if you have ammo pump racked, you can use RMB as intended.

tldr Melee combat functionality for riot shotgun remains unchanged, the PR only fixes the unintentional melee attack.

## Why It's Good For The Game

The PR fixes unintentional tediousness when wanting to fire at someone point blank with a riot shotgun - It will no longer melee, which is good, because otherwise it makes arbitrarily make riot shotgun cooldown longer due to an unintentional melee attack.

## Changelog

:cl: ArchBTW
fix: Fixes riot shotgun unintentional melee when point blank shooting
/:cl: