### PR TITLE
Visual and balance changes to brimdust sacks and rush glands

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -5,8 +5,10 @@
 	var/can_be_driven = TRUE
 	/// If TRUE, this creature's abilities can be triggered by the rider while mounted
 	var/can_use_abilities = FALSE
-	/// shall we require riders to go through the riding minigame if they arent in our friends list
+	/// Shall we require riders to go through the riding minigame if they arent in our friends list
 	var/require_minigame = FALSE
+	/// Do we use vehicle_move_delay or default to mob's own movespeed?
+	var/uses_native_speed = FALSE
 	/// unsharable abilities that we will force to be shared anyway
 	var/list/override_unsharable_abilities = list()
 	/// abilities that are always blacklisted from sharing
@@ -103,8 +105,12 @@
 	formerly_ridden.layer = MOB_LAYER
 	return ..()
 
+/datum/component/riding/creature/Process_Spacemove(direction, continuous_move)
+	var/mob/living/living_parent = parent
+	return override_allow_spacemove || living_parent.Process_Spacemove(direction, continuous_move)
+
 /datum/component/riding/creature/driver_move(atom/movable/movable_parent, mob/living/user, direction)
-	if(!COOLDOWN_FINISHED(src, vehicle_move_cooldown) || !Process_Spacemove())
+	if(!COOLDOWN_FINISHED(src, vehicle_move_cooldown) || !Process_Spacemove(direction))
 		return COMPONENT_DRIVER_BLOCK_MOVE
 	if(!keycheck(user))
 		if(ispath(keytype, /obj/item))
@@ -113,7 +119,7 @@
 		return COMPONENT_DRIVER_BLOCK_MOVE
 	var/mob/living/living_parent = parent
 	step(living_parent, direction)
-	var/modified_move_delay = vehicle_move_delay
+	var/modified_move_delay = uses_native_speed ? living_parent.cached_multiplicative_slowdown - get_cached_movespeed_modifier(living_parent.get_move_intent_slowdown()) : vehicle_move_delay
 	if(HAS_TRAIT(user, TRAIT_ROUGHRIDER)) // YEEHAW!
 		switch(HAS_TRAIT(user, TRAIT_PRIMITIVE) ? SANITY_LEVEL_GREAT : user.mob_mood?.sanity_level)
 			if(SANITY_LEVEL_GREAT)
@@ -494,7 +500,7 @@
 
 /datum/component/riding/creature/goliath
 	keytype = /obj/item/key/lasso
-	vehicle_move_delay = 4
+	uses_native_speed = TRUE
 	rider_traits = list(TRAIT_NO_FLOATING_ANIM, TRAIT_TENTACLE_IMMUNE)
 
 /datum/component/riding/creature/goliath/deathmatch
@@ -570,6 +576,17 @@
 	return charger.summoner == user
 
 /datum/component/riding/creature/goldgrub
+	uses_native_speed = TRUE
+
+/datum/component/riding/creature/goldgrub/Initialize(mob/living/riding_mob, force, ride_check_flags)
+	. = ..()
+	var/mob/living/basic/mining/goldgrub/goldgrub = parent
+	goldgrub.add_movespeed_modifier(/datum/movespeed_modifier/goldgrub_mount)
+
+/datum/component/riding/creature/goldgrub/Destroy(force)
+	var/mob/living/basic/mining/goldgrub/goldgrub = parent
+	goldgrub.remove_movespeed_modifier(/datum/movespeed_modifier/goldgrub_mount)
+	return ..()
 
 /datum/component/riding/creature/goldgrub/get_rider_offsets_and_layers(pass_index, mob/offsetter)
 	return list(
@@ -626,6 +643,7 @@
 
 /datum/component/riding/creature/raptor
 	require_minigame = TRUE
+	uses_native_speed = TRUE
 	ride_check_flags = RIDER_NEEDS_ARM | UNBUCKLE_DISABLED_RIDER
 
 /datum/component/riding/creature/raptor/Initialize(mob/living/riding_mob, force, ride_check_flags)
@@ -682,9 +700,6 @@
 	var/mob/living/basic/raptor/raptor = parent
 	if (istype(raptor))
 		raptor.adjust_offsets(dir)
-
-/datum/component/riding/creature/raptor/fast
-	vehicle_move_delay = 1.5
 
 /datum/component/riding/creature/raptor/combat
 	ai_behavior_while_ridden = RIDING_PAUSE_AI_MOVEMENT

--- a/code/game/objects/effects/particles/brimdust.dm
+++ b/code/game/objects/effects/particles/brimdust.dm
@@ -1,0 +1,17 @@
+/particles/brimdust
+	icon = 'icons/effects/particles/generic.dmi'
+	icon_state = "cross"
+	width = 100
+	height = 100
+	count = 1000
+	color = "#88304e"
+	spawning = 1
+	lifespan = 0.7 SECONDS
+	fade = 1 SECONDS
+	velocity = list(0, 0)
+	position = generator(GEN_CIRCLE, 0, 16, NORMAL_RAND)
+	drift = generator(GEN_VECTOR, list(-0.2, 0), list(0.2, 0))
+	gravity = list(0, -0.5)
+	scale = generator(GEN_VECTOR, list(0.3, 0.3), list(1,1), NORMAL_RAND)
+	rotation = 30
+	spin = generator(GEN_NUM, -20, 20)

--- a/code/game/objects/effects/particles/brimdust.dm
+++ b/code/game/objects/effects/particles/brimdust.dm
@@ -5,7 +5,7 @@
 	height = 100
 	count = 1000
 	color = "#88304e"
-	spawning = 1
+	spawning = 3
 	lifespan = 0.7 SECONDS
 	fade = 1 SECONDS
 	velocity = list(0, 0)

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -245,8 +245,10 @@
 		setDir(mimiced_atom.dir)
 		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-/obj/effect/temp_visual/decoy/fading/Initialize(mapload, atom/mimiced_atom)
+/obj/effect/temp_visual/decoy/fading/Initialize(mapload, atom/mimiced_atom, start_alpha)
 	. = ..()
+	if (start_alpha)
+		alpha = start_alpha
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/temp_visual/decoy/fading/threesecond

--- a/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
+++ b/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
@@ -4,6 +4,8 @@
 #define BRIMDUST_STACKS_ON_LIFE 1
 /// Number of stacks to add if you activate the item in hand
 #define BRIMDUST_STACKS_ON_USE 3
+/// Overlay alpha per effect stack
+#define BRIMDUST_ALPHA_PER_STACK 75
 
 /**
  * Gives you three stacks of Brimdust Coating, when you get hit by anything it will make a short ranged explosion.
@@ -89,7 +91,8 @@
 /atom/movable/screen/alert/status_effect/brimdust_coating
 	name = "Brimdust Coating"
 	desc = "You %STACKS% explosive dust, kinetic impacts will cause it to detonate! \
-		The explosion will not harm you as long as you're not under atmospheric pressure."
+		The explosion will not harm you as long as you're not under atmospheric pressure. \
+		Click this alert to shake off the dust."
 
 /atom/movable/screen/alert/status_effect/brimdust_coating/MouseEntered(location,control,params)
 	desc = initial(desc)
@@ -106,6 +109,21 @@
 	desc = replacetext(desc, "%STACKS%", dust_amount_string)
 	return ..()
 
+/atom/movable/screen/alert/status_effect/brimdust_coating/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return
+	if(!owner.can_resist())
+		return
+	owner.balloon_alert(owner, "shaking off the dust...")
+	var/datum/status_effect/stacking/brimdust_coating/dust = attached_effect
+	if (!do_after(owner, dust.stacks * 1.5 SECONDS, owner))
+		return
+	dust.explode()
+	// The effect can get deleted from exploding and reducing stacks
+	if (!QDELETED(dust))
+		qdel(dust)
+
 /datum/status_effect/stacking/brimdust_coating/refresh(effect, stacks_to_add)
 	. = ..()
 	add_stacks(stacks_to_add)
@@ -115,6 +133,10 @@
 	if (stacks == 0)
 		return
 	linked_alert.icon_state = "brimdemon_[stacks]"
+	if (dust_overlay)
+		owner.cut_overlay(dust_overlay)
+		dust_overlay.alpha = stacks * BRIMDUST_ALPHA_PER_STACK
+		owner.add_overlay(dust_overlay)
 
 /datum/status_effect/stacking/brimdust_coating/on_creation(mob/living/new_owner, stacks_to_apply)
 	. = ..()
@@ -122,16 +144,19 @@
 
 /datum/status_effect/stacking/brimdust_coating/on_apply()
 	. = ..()
-
 	dust_overlay = mutable_appearance('icons/effects/weather_effects.dmi', "ash_storm")
+	dust_overlay.alpha = stacks * BRIMDUST_ALPHA_PER_STACK
+	dust_overlay.color = COLOR_RED_LIGHT
 	dust_overlay.blend_mode = BLEND_INSET_OVERLAY
 	owner.add_overlay(dust_overlay)
+	owner.add_shared_particles(/particles/brimdust)
 	RegisterSignal(owner, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(on_cleaned))
 	RegisterSignal(owner, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_take_damage))
 
 /datum/status_effect/stacking/brimdust_coating/on_remove()
 	. = ..()
 	owner.cut_overlay(dust_overlay)
+	owner.remove_shared_particles(/particles/brimdust)
 	UnregisterSignal(owner, list(COMSIG_MOB_APPLY_DAMAGE, COMSIG_COMPONENT_CLEAN_ACT))
 
 /// When you are cleaned, wash off the buff
@@ -162,14 +187,14 @@
 	new /obj/effect/temp_visual/explosion/fast(origin_turf)
 
 	var/damage_dealt = blast_damage
-	var/list/possible_targets = range(1, origin_turf)
-	if(lavaland_equipment_pressure_check(origin_turf))
-		possible_targets -= owner
-	else
+	var/safe_explosion = lavaland_equipment_pressure_check(origin_turf)
+	if(!safe_explosion)
 		damage_dealt *= pressure_modifier
 		owner.apply_status_effect(/datum/status_effect/brimdust_concussion)
 
-	for(var/mob/living/target in possible_targets)
+	for(var/mob/living/target in range(1, origin_turf) - (safe_explosion ? list(owner, owner.buckled) : null))
+		if (safe_explosion && owner.faction_check_atom(target))
+			continue
 		var/armor = target.run_armor_check(attack_flag = BOMB)
 		target.apply_damage(damage_dealt, damagetype = BURN, blocked = armor, spread_damage = TRUE)
 
@@ -202,3 +227,4 @@
 #undef BRIMDUST_LIFE_APPLY_COOLDOWN
 #undef BRIMDUST_STACKS_ON_LIFE
 #undef BRIMDUST_STACKS_ON_USE
+#undef BRIMDUST_ALPHA_PER_STACK

--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -2,7 +2,7 @@
 #define HEALTH_DANGER_ZONE 30
 
 /**
- * On use in hand, makes you run really fast for 5 seconds and ignore injury movement decrease.
+ * On use in hand, makes you run faster for a bit and ignore injury movement decrease.
  * On use when implanted, run for longer and ignore all negative movement. Automatically triggers if health is low (to escape).
  */
 /obj/item/organ/monster_core/rush_gland
@@ -37,13 +37,13 @@
 	INVOKE_ASYNC(src, PROC_REF(trigger_organ_action))
 
 /**
- * Status effect: Makes you run really fast and ignore speed penalties for a short duration.
+ * Status effect: Makes you run faster and ignore speed penalties for a short duration.
  * If you run into a wall indoors you will fall over and lose the buff.
  * If you run into someone you both fall over.
  */
 /datum/status_effect/lobster_rush
 	id = "lobster_rush"
-	duration = 3 SECONDS
+	duration = 30 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/lobster_rush
 	show_duration = TRUE
 	var/spawned_last_move = FALSE
@@ -55,50 +55,58 @@
 
 /datum/status_effect/lobster_rush/on_apply()
 	. = ..()
-	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(on_move))
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(owner, COMSIG_MOVABLE_BUMP, PROC_REF(on_bump))
-	owner.add_traits(list(TRAIT_IGNORESLOWDOWN, TRAIT_TENTACLE_IMMUNE), TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_TENTACLE_IMMUNE, TRAIT_STATUS_EFFECT(id))
+	owner.add_movespeed_mod_immunities(id, /datum/movespeed_modifier/damage_slowdown)
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/lobster_rush)
 	to_chat(owner, span_notice("You feel your blood pumping!"))
 
 /datum/status_effect/lobster_rush/on_remove()
 	. = ..()
-	UnregisterSignal(owner, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOVABLE_BUMP))
-	owner.remove_traits(list(TRAIT_IGNORESLOWDOWN, TRAIT_TENTACLE_IMMUNE), TRAIT_STATUS_EFFECT(id))
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_BUMP))
+	REMOVE_TRAIT(owner, TRAIT_TENTACLE_IMMUNE, TRAIT_STATUS_EFFECT(id))
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/status_effect/lobster_rush)
+	owner.remove_movespeed_mod_immunities(id, /datum/movespeed_modifier/damage_slowdown)
 	to_chat(owner, span_notice("Your pulse returns to normal."))
 
 /// Spawn an afterimage every other step, because every step was too many
-/datum/status_effect/lobster_rush/proc/on_move()
+/datum/status_effect/lobster_rush/proc/on_move(datum/source, atom/old_loc, dir)
 	SIGNAL_HANDLER
+	if (!isturf(old_loc) || !isturf(owner.loc))
+		return
 	if (!spawned_last_move)
-		new /obj/effect/temp_visual/decoy/fading(owner.loc, owner)
+		new /obj/effect/temp_visual/decoy/fading(old_loc, owner, 150)
 	spawned_last_move = !spawned_last_move
 
 /datum/status_effect/lobster_rush/proc/on_bump(mob/living/source, atom/target)
 	SIGNAL_HANDLER
 	if (!target.density)
 		return
-	if (isliving(target))
-		source.visible_message(span_warning("[source] crashes into [target]!"))
-		smack_into(source)
-		smack_into(target)
-		qdel(src)
-		return
 	if (lavaland_equipment_pressure_check(get_turf(source)))
 		return
 	smack_into(source)
 	source.visible_message(span_warning("[source] crashes into [target]!"))
+	if (isliving(target))
+		smack_into(target)
 	qdel(src)
 
 /datum/status_effect/lobster_rush/proc/smack_into(mob/living/target)
-	target.Knockdown(5 SECONDS)
-	target.apply_damage(40, STAMINA)
-	target.apply_damage(20, BRUTE, spread_damage = TRUE)
+	target.Knockdown(2 SECONDS)
+	target.apply_damage(30, STAMINA)
+	target.apply_damage(10, BRUTE, spread_damage = TRUE)
 
 /// You get a longer buff if you take the time to implant it in yourself
 /datum/status_effect/lobster_rush/extended
-	duration = 5 SECONDS
+	duration = 60 SECONDS
+
+/datum/status_effect/lobster_rush/extended/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_IGNORESLOWDOWN, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/lobster_rush/extended/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_IGNORESLOWDOWN, TRAIT_STATUS_EFFECT(id))
 
 /// Action used by the rush gland
 /datum/action/cooldown/monster_core_action/adrenal_boost
@@ -106,6 +114,6 @@
 	desc = "Pump your rush gland to give yourself a boost of speed. \
 		Impacts with objects can be dangerous under atmospheric pressure."
 	button_icon_state = "lobster_gland_stable"
-	cooldown_time = 90 SECONDS
+	cooldown_time = 180 SECONDS
 
 #undef HEALTH_DANGER_ZONE

--- a/code/modules/mining/equipment/monster_organs/rush_gland.dm
+++ b/code/modules/mining/equipment/monster_organs/rush_gland.dm
@@ -37,7 +37,7 @@
 	INVOKE_ASYNC(src, PROC_REF(trigger_organ_action))
 
 /**
- * Status effect: Makes you run faster and ignore speed penalties for a short duration.
+ * Status effect: Makes you run faster and ignore damage speed penalties for a short duration.
  * If you run into a wall indoors you will fall over and lose the buff.
  * If you run into someone you both fall over.
  */

--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -83,7 +83,7 @@
 	if(stat != CONSCIOUS)
 		return COMPONENT_BULLET_PIERCED
 
-	///high penetration bullets should still go through. No goldgrub can save you from the colossus' death bolts.
+	/// High penetration bullets should still go through. No goldgrub can save you from the colossus' death bolts.
 	if(prob(hitting_projectile.armour_penetration))
 		return NONE
 
@@ -94,6 +94,7 @@
 	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 	for(var/obj/item/stack/ore/ore in src)
 		ore.forceMove(loc)
+
 	if(!gibbed)
 		visible_message(span_danger("[src] spits out its consumed ores!"))
 

--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -299,8 +299,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	icon_dead = "raptor_black_dead"
 	maxHealth = 400
 	health = 400
-	speed = 1
-	ridable_component = /datum/component/riding/creature/raptor/fast
+	speed = 1.5
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	raptor_color = RAPTOR_BLACK
@@ -312,8 +311,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 	icon_state = "raptor_yellow"
 	icon_living = "raptor_yellow"
 	icon_dead = "raptor_yellow_dead"
-	ridable_component = /datum/component/riding/creature/raptor/fast
-	speed = 1
+	speed = 1.5
 	raptor_color = RAPTOR_YELLOW
 	dex_description = "This breed possesses greasy fast speed, DEMON speed, making light work of long pilgrimages. It's said that a thunderclap could be heard when this breed reaches its maximum speed."
 	child_path = /mob/living/basic/raptor/baby_raptor/yellow

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -73,7 +73,12 @@
 	return ..()
 
 /mob/living/proc/update_move_intent_slowdown()
-	add_movespeed_modifier((move_intent == MOVE_INTENT_WALK)? /datum/movespeed_modifier/config_walk_run/walk : /datum/movespeed_modifier/config_walk_run/run)
+	add_movespeed_modifier(get_move_intent_slowdown())
+
+/mob/living/proc/get_move_intent_slowdown()
+	if(move_intent == MOVE_INTENT_WALK)
+		return /datum/movespeed_modifier/config_walk_run/walk
+	return /datum/movespeed_modifier/config_walk_run/run
 
 /mob/living/proc/update_turf_movespeed(turf/open/turf)
 	if(isopenturf(turf) && !HAS_TRAIT(turf, TRAIT_TURF_IGNORE_SLOWDOWN))

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -165,6 +165,9 @@
 /datum/movespeed_modifier/goliath_mount
 	multiplicative_slowdown = -26
 
+/datum/movespeed_modifier/goldgrub_mount
+	multiplicative_slowdown = -3
+
 /datum/movespeed_modifier/settler
 	multiplicative_slowdown = 0.2
 	blacklisted_movetypes = FLOATING|FLYING

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -23,7 +23,7 @@
 	multiplicative_slowdown = 4
 
 /datum/movespeed_modifier/status_effect/lobster_rush
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -0.2
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/brimdust_concussion

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2419,6 +2419,7 @@
 #include "code\game\objects\effects\effect_system\fluid_spread\effects_smoke.dm"
 #include "code\game\objects\effects\landmarks\atmospherics_sanity_landmarks.dm"
 #include "code\game\objects\effects\particles\acid.dm"
+#include "code\game\objects\effects\particles\brimdust.dm"
 #include "code\game\objects\effects\particles\echo.dm"
 #include "code\game\objects\effects\particles\fire.dm"
 #include "code\game\objects\effects\particles\food.dm"


### PR DESCRIPTION
## About The Pull Request

Brimdust sacks have received a minor visual upgrade with particles and fainter reddish overlay (with alpha scaling with stacks), as well as the capability for the user to shake the dust off, causing a blast after a do_after and removing the status, in case they want to get rid of it for whatever reason. They also no longer hurt owner's mount or allies in lavaland pressure, which should make them not actively detrimental to use if you have a raptor, drones or an allied miner next to you.

![dreamseeker_zpZ4gkWtas](https://github.com/user-attachments/assets/23ded520-f64c-4084-9cff-7e92084b631b)

Rush glands have had their speed boost reduced down to -0.2 from -0.5, being equal to that of diamond golem buff rather than kronkaine or stimulants, but had their duration increased tenfold to 30 seconds. However, they no longer grant full slowdown immunity by default and only protect you from damage slowdown. Implanted cores keep the full slowdown immunity and had their duration increased to 60 seconds, at an increased 180 second cooldown.
Rush glands can also now be applied to your mounts to speed them up, more specifically raptors, goliaths and goldgrubs (did you know you could tame and ride those?). They also are now affected by all other slowdowns and speed boosts while ridden. (currently due to how riding is implemented, none of the mobs actually utilize their own speed, instead relying on a hardcoded value of the component. Due to balance concerns and possible oversights, I am currently only switching those three to utilizing their own speed value)

## Why It's Good For The Game

Brimdust sacks are a sort-of-useful effect which can save you from a bad pack of legion skulls or help you a bit during a fight, but at the same time is capable of teamkills if you have any allies, be it mobs or other miners. As cooperation between miners is something we want to incentivize and make easier, this seems highly counterproductive. Friendly fire still persists within the station atmosphere as the explosion also damages the user themselves there, so it makes sense that it wouldn't distinguish between allies and foes. Being able to shake off the dust is just a nice thing to do before going up to the station, as otherwise you need to find something to hit you a few times to get it off.

Rush glands on the other hand, are almost completely useless - 3 seconds of a mediocre speed boost is a joke, and carrying them around is a waste of inventory space. Only case where they can be useful is if there's a lobstrocity corpse nearby you can butcher before starting a fight, and even then its questionable. This rebalance should make them have an actual usecase, that being either getting somewhere quickly or starting off a fight at higher speed (especially useful against hierophant and bubblegum). Being able to apply them to your mounts should also make them useful for those who ride raptors or, for some reason, goliaths or goldgrubs.
## Changelog
:cl:
balance: Brimdust sacks no longer hit user's mount or allied mobs within lavaland pressure.
balance: Rush glands have had their speed boost reduced, but got a massive increase in duration. Non-implanted glands also only protect from damage slowdowns as opposed to all slowdowns in general.
balance: Goliaths, raptors and goldgrubs are now affected by movespeed modifiers, such as rush glands, when mounted.
image: Brimdust sacks' effect have received a visual upgrade.
/:cl:
