### PR TITLE
Fix hard del/race condition in reflections

### DIFF
--- a/code/datums/components/reflection.dm
+++ b/code/datums/components/reflection.dm
@@ -148,9 +148,9 @@
 	SIGNAL_HANDLER
 
 	var/atom/movable/reflection = LAZYACCESS(reflected_movables, target)
+	LAZYREMOVE(reflected_movables, target)
 	if(reflection)
 		qdel(reflection)
-	LAZYREMOVE(reflected_movables, target)
 	UnregisterSignal(target, check_reflect_signals)
 	UnregisterSignal(target, COMSIG_QDELETING)
 

--- a/code/datums/components/reflection.dm
+++ b/code/datums/components/reflection.dm
@@ -149,7 +149,7 @@
 
 	var/atom/movable/reflection = LAZYACCESS(reflected_movables, target)
 	LAZYREMOVE(reflected_movables, target)
-	if(reflection)
+	if(!QDELETED(reflection))
 		qdel(reflection)
 	UnregisterSignal(target, check_reflect_signals)
 	UnregisterSignal(target, COMSIG_QDELETING)


### PR DESCRIPTION
## About The Pull Request

Tin, the proc that's managing references should remove the thing from the list before calling qdel on it. Also, it should not be calling qdel on something that's already being qdeleted (which could happen before if `nuke_reflection()` was reached via the `COMSIG_QDELING` signal).

<img width="1675" height="480" alt="firefox_xIIRCIbgdU" src="https://github.com/user-attachments/assets/246be9de-6ff0-46a5-bf5e-1d0895fd9f55" />


## Why It's Good For The Game

Less hard deletes

## Changelog

Not player facing/should get the hard deletes tag