### PR TITLE
Fixes 'bricking' of ballistic laser rifles

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -329,6 +329,7 @@
 	inhand_icon_state = "arg"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge
 	empty_indicator = TRUE
+	bolt_type = BOLT_TYPE_OPEN
 	fire_delay = 2
 	can_suppress = FALSE
 	burst_size = 0


### PR DESCRIPTION
## About The Pull Request
I don't think these are obtainable through normal gameplay, these guns are ballistic weapons designed to emulate laser guns, except with a swappable "battery".

It had the wrong bolt type, which caused problems. It chambered rounds so it could fire a shot without a battery in it, and worse when it emptied its chamber and didn't have a new round to load in, the gun would unrack itself. There is no way to re-rack this gun so at that point it is made permanantly useless. Now it fires directly from the clip without chambering anything or caring about whether or not it is racked. This stops it getting stuck, stops you being able to fire the gun when there's no power pack loaded, and simplifies ammo management which makes it feel more like an energy weapon. Even if it isn't really one.
## Why It's Good For The Game
Fixes some bugs that made using this thing needlessly difficult.
## Changelog
:cl:
fix: Ballistic laser guns will no longer brick themselves when out of ammo.
fix: Ballistic laser guns now fire ammo directly from their loaded clip, without chambering.
/:cl:
