### PR TITLE
Fixes missing Chemistry items/objects in Catwalk/Delta/Meta/Tram

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -16420,6 +16420,10 @@
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/item/folder/white{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /obj/item/assembly/timer{
 	pixel_x = -2;
 	pixel_y = 3
@@ -31491,6 +31495,7 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/multitool,
 /obj/item/stack/cable_coil{
 	pixel_x = -12
 	},
@@ -60806,12 +60811,9 @@
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
-/obj/item/folder/white{
-	pixel_x = -1;
-	pixel_y = 3
-	},
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "rxH" = (
@@ -64663,12 +64665,13 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/item/clothing/head/utility/welding,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "sFU" = (

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -16420,10 +16420,6 @@
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
-/obj/item/folder/white{
-	pixel_x = -1;
-	pixel_y = 3
-	},
 /obj/item/assembly/timer{
 	pixel_x = -2;
 	pixel_y = 3
@@ -31495,7 +31491,6 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/multitool,
 /obj/item/stack/cable_coil{
 	pixel_x = -12
 	},
@@ -60811,9 +60806,12 @@
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/item/folder/white{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "rxH" = (
@@ -64665,13 +64663,12 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/item/clothing/head/utility/welding,
-/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "sFU" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -86183,6 +86183,7 @@
 "vmK" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/table,
+/obj/item/multitool,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/utility/welding,
 /obj/effect/turf_decal/tile/neutral/fourcorners,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -66769,6 +66769,7 @@
 "wPH" = (
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/structure/table,
+/obj/item/multitool,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/utility/welding,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6616,6 +6616,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/item/multitool,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/utility/welding,
 /obj/machinery/light/directional/north,
@@ -10039,6 +10040,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
 	},
+/obj/item/assembly/igniter,
 /obj/item/clothing/glasses/science,
 /obj/machinery/requests_console/directional/west{
 	name = "Pharmacy Requests Console";


### PR DESCRIPTION
## About The Pull Request

Gives Plumbing a Multitool in Catwalk/Delta/Meta/Tram (Wawa, Nebula, Icebox already have a Multitool) - This item is essential for chemists to link Chemical Beacons
Adds missing Welding Mask in Catwalk Chemistry
Adds missing Igniter in Tram Chemistry
Gives Chemistry another all-in-one-grinder in Catwalk Chemistry (All other maps have 2, but on catwalk for some reason you have to climb a ladder to use the single All-In-One-Grinder - there are none downstairs)

i put it balance tag because its technically giving stuff to maps otherwise missing, even if it is an oversight (correct me if i'm wrong).

## Why It's Good For The Game

Adds essential/missing things for Chemists certain maps forgot
Makes a Chemists' life less inconsistent/tedious across different maps

## Changelog

:cl: ArchBTW
balance: Fixes missing Chemistry items/objects in Catwalk/Delta/Meta/Tram
/:cl: