### PR TITLE
Makes plumbing synthesizers default to 5u

### DIFF
--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -5,8 +5,8 @@
 	icon_state = "synthesizer"
 	icon = 'icons/obj/pipes_n_cables/hydrochem/plumbers.dmi'
 
-	///Amount we produce for every process. Ideally keep under 5 since thats currently the standard duct capacity
-	var/amount = 1
+	///Amount we produce for every process by default.
+	var/amount = 5
 	///I track them here because I have no idea how I'd make tgui loop like that
 	var/static/list/possible_amounts = list(0, 1, 2, 3, 4, 5)
 	///The reagent we are producing. We are a typepath, but are also typecast because there's several occations where we need to use initial.


### PR DESCRIPTION
## About The Pull Request

As Chemists, when make our massive plumbing factories we always use 5u because anything under is pointless, and only makes our plumbing factories slower, and takes up extra tedious/unnecessary time to setup.

This is simply a QoL change so that we don't have to keep pressing the 5u button when we make our synthesizers (its very tedious when working on huge factories).

## Why It's Good For The Game

Less tediousness, notably when making huge factories

## Changelog

:cl: ArchBTW
qol: Makes plumbing synthesizers default to 5u
/:cl:
