### PR TITLE
Fix strip menu

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -380,7 +380,8 @@
 
 		result["icon"] = icon2base64(icon(item.icon, item.icon_state))
 		result["name"] = item.name
-		result["alternate"] = item_data.get_alternate_actions(owner, user, item) - null
+		result["alternate"] = item_data.get_alternate_actions(owner, user, item)
+		list_clear_nulls(result["alternate"])
 		var/static/list/already_cried = list()
 		if(length(result["alternate"]) > 3 && !(type in already_cried))
 			stack_trace("Too many alternate actions for [type]! Only three are supported at the moment! This will look bad!")

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -380,8 +380,7 @@
 
 		result["icon"] = icon2base64(icon(item.icon, item.icon_state))
 		result["name"] = item.name
-		var/list/alt_actions = item_data.get_alternate_actions(owner, user, item)
-		result["alternate"] = length(alt_actions) ? alt_actions : null
+		result["alternate"] = item_data.get_alternate_actions(owner, user, item) - null
 		var/static/list/already_cried = list()
 		if(length(result["alternate"]) > 3 && !(type in already_cried))
 			stack_trace("Too many alternate actions for [type]! Only three are supported at the moment! This will look bad!")

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -63,7 +63,7 @@ const ALTERNATE_ACTIONS: Record<string, AlternateAction> = {
     icon: 'handcuffs',
     text: 'Remove Handcuffs',
   },
- 
+
   enable_internals: {
     icon: 'tg-air-tank',
     text: 'Enable internals',
@@ -322,7 +322,7 @@ export const StripMenu = (props) => {
                     );
 
                     tooltip = item.name;
-                    if (item.alternate) {
+                    if (item.alternate?.length) {
                       alternateActions = item.alternate.map(
                         (alternateKey, idx) => {
                           const alternateAction =


### PR DESCRIPTION
## About The Pull Request

#93305 changed some of the logic of how strip menu buttons are shown

However when moving `get_strippable_alternate_action_internals`, it changed the logic from `return list() or null` to `return list() or list(null)`

`null` elements in the strip list would break the ui

I changed the logic every so lightly so we just clear nulls on the list first. Then I also changed the ui to support empty lists.

## Changelog

:cl: Melbert
fix: Fixed strip menu
/:cl:

