### PR TITLE
Fix screen alert click

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -155,9 +155,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	..()
-	if(!usr || !usr.client)
-		return FALSE
-	if(usr != owner)
+	if(!usr || !GET_CLIENT(usr) || usr != owner)
 		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
@@ -168,6 +166,8 @@
 	var/datum/our_master = master_ref?.resolve()
 	if(our_master)
 		return usr.client.Click(our_master, location, control, params)
+
+	return TRUE
 
 /atom/movable/screen/alert/Destroy()
 	. = ..()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -90,6 +90,7 @@
 #include "abductor_baton_spell.dm"
 #include "ablative_hud.dm"
 #include "achievements.dm"
+#include "alerts.dm"
 #include "anchored_mobs.dm"
 #include "anonymous_themes.dm"
 #include "antag_conversion.dm"

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -9,9 +9,9 @@
 	var/old_usr = usr // Click still relies on usr so let's not mess this up
 	usr = dummy
 
-	var/atom/movable/screen/alert/test_alert = dummy.throw_alert(TRAIT_SOURCE_UNIT_TESTS, /atom/movable/screen/alert/test_alert)
-	test_alert.linked = src
-	test_alert.Click()
+	var/atom/movable/screen/alert/test_alert/clickme = dummy.throw_alert(TRAIT_SOURCE_UNIT_TESTS, /atom/movable/screen/alert/test_alert)
+	clickme.linked = src
+	clickme.Click()
 	if(!was_clicked)
 		TEST_FAIL("Screen alert was not clickable.")
 

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -18,7 +18,7 @@
 	usr = old_usr
 
 /atom/movable/screen/alert/test_alert
-	var/datum/unit_test/linked
+	var/datum/unit_test/alerts/linked
 
 /atom/movable/screen/alert/test_alert/Click(location, control, params)
 	. = ..()

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -1,0 +1,32 @@
+/// Tests screen alerts are clickable
+/datum/unit_test/alerts
+	var/was_clicked = FALSE
+
+/datum/unit_test/alerts/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+	dummy.mock_client = new /datum/client_interface()
+
+	var/old_usr = usr // Click still relies on usr so let's not mess this up
+	usr = dummy
+
+	var/atom/movable/screen/alert/test_alert = dummy.throw_alert(TRAIT_SOURCE_UNIT_TESTS, /atom/movable/screen/alert/test_alert)
+	test_alert.linked = src
+	test_alert.Click(dummy)
+	if(!was_clicked)
+		TEST_FAIL(was_clicked, "Screen alert was not clickable.")
+
+	usr = old_usr
+
+/atom/movable/screen/alert/test_alert
+	var/datum/unit_test/linked
+
+/atom/movable/screen/alert/test_alert/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return
+
+	linked.was_clicked = TRUE
+
+/atom/movable/screen/alert/test_alert/Destroy()
+	linked = null
+	return ..()

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -13,7 +13,7 @@
 	test_alert.linked = src
 	test_alert.Click(dummy)
 	if(!was_clicked)
-		TEST_FAIL(was_clicked, "Screen alert was not clickable.")
+		TEST_FAIL("Screen alert was not clickable.")
 
 	usr = old_usr
 

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -11,7 +11,7 @@
 
 	var/atom/movable/screen/alert/test_alert = dummy.throw_alert(TRAIT_SOURCE_UNIT_TESTS, /atom/movable/screen/alert/test_alert)
 	test_alert.linked = src
-	test_alert.Click(dummy)
+	test_alert.Click()
 	if(!was_clicked)
 		TEST_FAIL("Screen alert was not clickable.")
 


### PR DESCRIPTION
## About The Pull Request

#93305 rearranged the logic for `alert/Click` but deleted `return TRUE` at the end which all subtypes rely on

## Changelog

:cl: Melbert
fix: Screen alerts are clickable again
/:cl:
