### PR TITLE
DRAFT: The Body Keeps The Score: Metabolic stress for livers or: Liver Fatigue

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -17,6 +17,11 @@
 /// Called when an organ finishes inserting into a bodypart (obj/item/bodypart/limb, movement_flags)
 #define COMSIG_ORGAN_BODYPART_INSERTED "organ_bodypart_inserted"
 
+/// Called when a liver metabolizes some of a reagent that isn't part of homeostatic body functions
+/// From /obj/item/organ/liver/proc/stressed_by_metabolization(datum/reagent/chem, units_metabolized)
+#define COMSIG_LIVER_METABOLIC_STRESS "liver_metabolic_stress"
+	#define COMPONENT_CANCEL_METABOLIC_STRESS (1<<0)
+
 ///Called when movement intent is toggled.
 #define COMSIG_MOVE_INTENT_TOGGLED "move_intent_toggled"
 

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -125,6 +125,9 @@
 /// If present, this reagent will not be affected by the mob's metabolism at all, meaning it exits at a fixed rate for all mobs.
 /// Supercedes [REAGENT_REVERSE_METABOLISM].
 #define REAGENT_UNAFFECTED_BY_METABOLISM (1<<10)
+/// Indicates that the body is able to metabolize this reagent without effort
+/// Primarily: food, water, magical bullshit, things we use as reagents we probably shouldn't
+#define REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS (1<<11)
 
 //Chemical reaction flags, for determining reaction specialties
 ///Convert into impure/pure on reaction completion

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -3,7 +3,7 @@
 /// but bear in mind it will(should) have other reagents along side it.
 /datum/reagent/consumable/nutriment/soup
 	name = "Soup"
-	chemical_flags = NONE
+	chemical_flags = REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	nutriment_factor = 12 // Slightly less to that of nutriment as soups will come with nutriments in tow
 	burning_temperature = 520
 	default_container = /obj/item/reagent_containers/cup/bowl

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -181,7 +181,9 @@
 			metabolizing_out /= affected_mob.metabolism_efficiency
 		else
 			metabolizing_out *= affected_mob.metabolism_efficiency
-
+	if(!(chemical_flags & REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS))
+		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
+		liver?.stressed_by_metabolization(src, metabolizing_out)
 	holder.remove_reagent(type, metabolizing_out)
 
 

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -4,7 +4,7 @@
 	color = "#E78108" // rgb: 231, 129, 8
 	taste_description = "oranges"
 	ph = 3.3
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice
 
 /datum/reagent/consumable/orangejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -18,7 +18,7 @@
 	description = "Tomatoes made into juice. What a waste of big, juicy tomatoes, huh?"
 	color = "#731008" // rgb: 115, 16, 8
 	taste_description = "tomatoes"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/tomatojuice
 
 /datum/reagent/consumable/tomatojuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -33,7 +33,7 @@
 	color = "#a6f19a" // rgb: 166, 241, 154
 	taste_description = "unbearable sourness"
 	ph = 2.2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/limejuice
 
 /datum/reagent/consumable/limejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -47,7 +47,7 @@
 	description = "It is just like a carrot but without crunching."
 	color = "#973800" // rgb: 151, 56, 0
 	taste_description = "carrots"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/carrotjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -68,7 +68,7 @@
 	description = "A delicious blend of several different kinds of berries."
 	color = "#863333" // rgb: 134, 51, 51
 	taste_description = "berries"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/applejuice
 	name = "Apple Juice"
@@ -82,7 +82,7 @@
 	description = "A tasty juice blended from various kinds of very deadly and toxic berries."
 	color = "#792b49" // rgb: 121, 43, 73
 	taste_description = "berries"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/poisonberryjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -94,7 +94,7 @@
 	description = "Delicious juice made from watermelon."
 	color = "#af5e5e" // rgb: 175, 94, 94
 	taste_description = "juicy watermelon"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/lemonjuice
 	name = "Lemon Juice"
@@ -102,14 +102,14 @@
 	color = "#ebeb9e" // rgb: 235, 235, 158
 	taste_description = "sourness"
 	ph = 2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/banana
 	name = "Banana Juice"
 	description = "The raw essence of a banana. HONK"
 	color = "#FFFCB9" // rgb: 255, 252, 185
 	taste_description = "banana"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/banana/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -122,7 +122,7 @@
 	name = "Nothing"
 	description = "Absolutely nothing."
 	taste_description = "nothing"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/glass_style/shot_glass/nothing
 	required_drink_type = /datum/reagent/consumable/nothing
@@ -141,7 +141,7 @@
 	metabolization_rate = INFINITY
 	color = "#FF4DD2"
 	taste_description = "laughter"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -154,7 +154,7 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	color = "#FF4DD2"
 	taste_description = "laughter"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/superlaughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -169,7 +169,7 @@
 	nutriment_factor = 2
 	color = "#E8A856" // rgb: 234, 157, 58
 	taste_description = "irish sadness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/pickle
 	name = "Pickle Juice"
@@ -177,7 +177,7 @@
 	nutriment_factor = 2
 	color = "#cde65e" // rgb: 205, 230, 94
 	taste_description = "vinegar brine"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/pickle/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -191,14 +191,14 @@
 	description = "The juice of a bunch of grapes. Guaranteed non-alcoholic."
 	color = "#290029" // dark purple
 	taste_description = "grape soda"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/plumjuice
 	name = "Plum Juice"
 	description = "Refreshing and slightly acidic beverage."
 	color = "#b6062c"
 	taste_description = "plums"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/milk
 	name = "Milk"
@@ -206,7 +206,7 @@
 	color = "#DFDFDF" // rgb: 223, 223, 223
 	taste_description = "milk"
 	ph = 6.5
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/milk
 
 // Milk is good for humans, but bad for plants.
@@ -237,7 +237,7 @@
 	description = "An opaque white liquid made from soybeans."
 	color = "#DFDFC7" // rgb: 223, 223, 199
 	taste_description = "soy milk"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/soymilk
 
 /datum/reagent/consumable/soymilk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -251,7 +251,7 @@
 	description = "The fatty, still liquid part of milk. Why don't you mix this with sum scotch, eh?"
 	color = "#DFD7AF" // rgb: 223, 215, 175
 	taste_description = "creamy milk"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/cream
 
 /datum/reagent/consumable/cream/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -266,7 +266,7 @@
 	nutriment_factor = 0
 	overdose_threshold = 80
 	taste_description = "bitterness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_STOCK
 	metabolized_traits = list(TRAIT_STIMULATED)
 
@@ -290,7 +290,7 @@
 	color = "#101000" // rgb: 16, 16, 0
 	nutriment_factor = 0
 	taste_description = "tart black tea"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_STOCK
 	default_container = /obj/item/reagent_containers/cup/glass/mug/tea
 	metabolized_traits = list(TRAIT_STIMULATED)
@@ -342,7 +342,7 @@
 	color = "#FFE978"
 	quality = DRINK_NICE
 	taste_description = "sunshine and summertime"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_EASY
 
 /datum/reagent/consumable/tea/arnold_palmer
@@ -352,7 +352,7 @@
 	quality = DRINK_NICE
 	nutriment_factor = 10
 	taste_description = "bitter tea"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/tea/arnold_palmer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -366,7 +366,7 @@
 	nutriment_factor = 0
 	overdose_threshold = 80
 	taste_description = "bitter coldness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/icecoffee/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
@@ -387,7 +387,7 @@
 	nutriment_factor = 0
 	overdose_threshold = 80
 	taste_description = "bitter coldness and a hint of smoke"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/hot_ice_coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
@@ -409,7 +409,7 @@
 	color = "#104038" // rgb: 16, 64, 56
 	nutriment_factor = 0
 	taste_description = "sweet tea"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/icetea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -427,7 +427,7 @@
 	description = "A refreshing beverage."
 	color = "#100800" // rgb: 16, 8, 0
 	taste_description = "cola"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/space_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -440,7 +440,7 @@
 	color = "#53090B"
 	quality = DRINK_GOOD
 	taste_description = "fruity overlysweet cola"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/roy_rogers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.set_jitter_if_lower(12 SECONDS * REM * seconds_per_tick)
@@ -454,7 +454,7 @@
 	color = "#100800" // rgb: 16, 8, 0
 	quality = DRINK_VERYGOOD
 	taste_description = "the future"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/nuka_cola/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -483,7 +483,7 @@
 	nutriment_factor = 10
 	metabolization_rate = 2 * REAGENTS_METABOLISM
 	taste_description = "a monstrous sugar rush"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	/// If we activated the effect
 	var/effect_enabled = FALSE
 
@@ -514,7 +514,7 @@
 	color = "#EEFF00" // rgb: 238, 255, 0
 	quality = DRINK_VERYGOOD
 	taste_description = "carbonated oil"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_SHOCKIMMUNE)
 
 /datum/reagent/consumable/grey_bull/on_mob_metabolize(mob/living/carbon/affected_atom)
@@ -537,7 +537,7 @@
 	description = "Blows right through you like a space wind."
 	color = "#102000" // rgb: 16, 32, 0
 	taste_description = "sweet citrus soda"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/spacemountainwind/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -552,7 +552,7 @@
 	description = "A delicious blend of 42 different flavours."
 	color = "#102000" // rgb: 16, 32, 0
 	taste_description = "cherry soda" // FALSE ADVERTISING
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/dr_gibb/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -564,7 +564,7 @@
 	description = "Tastes like a hull breach in your mouth."
 	color = COLOR_VIBRANT_LIME // rgb: 0, 255, 0
 	taste_description = "cherry soda"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/space_up/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -575,7 +575,7 @@
 	description = "A tangy substance made of 0.5% natural citrus!"
 	color = "#8CFF00" // rgb: 135, 255, 0
 	taste_description = "tangy lime and lemon soda"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/lemon_lime/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -586,7 +586,7 @@
 	description = "The only drink with the PWR that true gamers crave."
 	color = "#9385bf" // rgb: 58, 52, 75
 	taste_description = "sweet and salty tang"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/pwr_game/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -606,7 +606,7 @@
 	description = "~Shake me up some of that Shambler's Juice!~"
 	color = "#f00060" // rgb: 94, 0, 38
 	taste_description = "carbonated metallic soda"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/shamblers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -617,7 +617,7 @@
 	description = "A can of club soda. Why not make a scotch and soda?"
 	color = "#619494" // rgb: 97, 148, 148
 	taste_description = "carbonated water"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 // A variety of nutrients are dissolved in club soda, without sugar.
 // These nutrients include carbon, oxygen, hydrogen, phosphorous, potassium, sulfur and sodium, all of which are needed for healthy plant growth.
@@ -636,7 +636,7 @@
 	description = "It tastes strange but at least the quinine keeps the Space Malaria at bay."
 	color = "#0064C8" // rgb: 0, 100, 200
 	taste_description = "tart and fresh"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/tonic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -650,7 +650,7 @@
 	description = "A strange purple drink, smelling of saltwater. Somewhere in the distance, you hear seagulls."
 	color = "#762399" // rgb: 118, 35, 153
 	taste_description = "grapes and the fresh open sea"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/wellcheers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -672,7 +672,7 @@
 	color = "#f39b03" // rgb: 243, 155, 3
 	overdose_threshold = 60
 	taste_description = "barbecue and nostalgia"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/monkey_energy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -702,7 +702,7 @@
 	description = "Frozen water, your dentist wouldn't like you chewing this."
 	color = "#619494" // rgb: 97, 148, 148
 	taste_description = "ice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/ice
 
 /datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -717,7 +717,7 @@
 	overdose_threshold = 80
 	quality = DRINK_NICE
 	taste_description = "creamy coffee"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_EASY
 	metabolized_traits = list(TRAIT_STIMULATED)
 
@@ -744,7 +744,7 @@
 	overdose_threshold = 80
 	quality = DRINK_NICE
 	taste_description = "bitter cream"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_EASY
 	metabolized_traits = list(TRAIT_STIMULATED)
 
@@ -770,7 +770,7 @@
 	color = "#FF8CFF" // rgb: 255, 140, 255
 	quality = DRINK_VERYGOOD
 	taste_description = "homely fruit"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/doctor_delight/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -793,7 +793,7 @@
 	color = "#FF6A50"
 	quality = DRINK_VERYGOOD
 	taste_description = "sweet tangy fruit"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/cinderella/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -806,7 +806,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 8
 	taste_description = "creamy tart cherry"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_MEDIUM
 
 /datum/reagent/consumable/bluecherryshake
@@ -816,7 +816,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 8
 	taste_description = "creamy blue cherry"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/vanillashake
 	name = "Vanilla Shake"
@@ -825,7 +825,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 8
 	taste_description = "sweet creamy vanilla"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_MEDIUM
 
 /datum/reagent/consumable/caramelshake
@@ -835,7 +835,7 @@
 	quality = DRINK_GOOD
 	nutriment_factor = 10
 	taste_description = "sweet rich creamy caramel"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_MEDIUM
 
 /datum/reagent/consumable/choccyshake
@@ -845,7 +845,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 8
 	taste_description = "sweet creamy chocolate"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_MEDIUM
 
 /datum/reagent/consumable/strawberryshake
@@ -855,7 +855,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 8
 	taste_description = "sweet strawberries and milk"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_MEDIUM
 
 /datum/reagent/consumable/bananashake
@@ -865,7 +865,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 8
 	taste_description = "thick banana"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_MEDIUM
 
 /datum/reagent/consumable/pumpkin_latte
@@ -876,7 +876,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 3
 	taste_description = "creamy pumpkin"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/pumpkin_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
@@ -902,21 +902,21 @@
 	quality = DRINK_NICE
 	nutriment_factor = 3
 	taste_description = "creamy cherry"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/pumpkinjuice
 	name = "Pumpkin Juice"
 	description = "Juiced from real pumpkin."
 	color = "#FFA500"
 	taste_description = "pumpkin"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/blumpkinjuice
 	name = "Blumpkin Juice"
 	description = "Juiced from real blumpkin."
 	color = "#00BFFF"
 	taste_description = "a mouthful of pool water"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/triple_citrus
 	name = "Triple Citrus"
@@ -924,14 +924,14 @@
 	color = "#EEFF00"
 	quality = DRINK_NICE
 	taste_description = "extreme bitterness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/grape_soda
 	name = "Grape Soda"
 	description = "Beloved by children and teetotalers."
 	color = "#E6CDFF"
 	taste_description = "grape soda"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/grape_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -943,7 +943,7 @@
 	color = "#7D4E29"
 	quality = DRINK_NICE
 	taste_description = "chocolate milk"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/hot_coco
 	name = "Hot Coco"
@@ -951,7 +951,7 @@
 	nutriment_factor = 4
 	color = "#3b240e" // rgb: 59, 36, 14
 	taste_description = "creamy chocolate"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/hot_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
@@ -969,7 +969,7 @@
 	color = "#57372A"
 	quality = DRINK_VERYGOOD
 	taste_description = "thick creamy chocolate"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/italian_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -980,7 +980,7 @@
 	description = "Alleviates coughing symptoms one might have."
 	color = "#80AF9C"
 	taste_description = "mint"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/menthol
 
 /datum/reagent/consumable/menthol/on_mob_life(mob/living/affected_mob, seconds_per_tick, times_fired)
@@ -992,7 +992,7 @@
 	description = "Not cherry flavored!"
 	color = "#EA1D26"
 	taste_description = "sweet pomegranates"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/grenadine/on_mob_metabolize(mob/living/drinker)
 	. = ..()
@@ -1011,14 +1011,14 @@
 	description = "Why..."
 	color = "#FFA500"
 	taste_description = "parsnip"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/pineapplejuice
 	name = "Pineapple Juice"
 	description = "Tart, tropical, and hotly debated."
 	color = "#F7D435"
 	taste_description = "pineapple"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/pineapplejuice
 
 /datum/reagent/consumable/peachjuice //Intended to be extremely rare due to being the limiting ingredients in the blazaam drink
@@ -1026,7 +1026,7 @@
 	description = "Just peachy."
 	color = "#E78108"
 	taste_description = "peaches"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/cream_soda
 	name = "Cream Soda"
@@ -1034,7 +1034,7 @@
 	color = "#dcb137"
 	quality = DRINK_VERYGOOD
 	taste_description = "fizzy vanilla"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/cream_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1046,7 +1046,7 @@
 	color = "#f7d26a"
 	quality = DRINK_NICE
 	taste_description = "sweet ginger spice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1058,7 +1058,7 @@
 	color = "#F43724"
 	quality = DRINK_GOOD
 	taste_description = "sweet cherry syrup and ginger spice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/shirley_temple/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjust_disgust(-3 * REM * seconds_per_tick)
@@ -1070,7 +1070,7 @@
 	color = "#e6ddc3"
 	quality = DRINK_GOOD
 	taste_description = "wonder"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	var/current_size = RESIZE_DEFAULT_SIZE
 
 /datum/reagent/consumable/red_queen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -1095,21 +1095,21 @@
 	color = "#F9E43D"
 	description = "Exotic! You feel like you are on vacation already."
 	taste_description = "succulent bungo"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/prunomix
 	name = "Pruno Mixture"
 	color = "#E78108"
 	description = "Fruit, sugar, yeast, and water pulped together into a pungent slurry."
 	taste_description = "garbage"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/aloejuice
 	name = "Aloe Juice"
 	color = "#b3c5a7" // rgb: 179, 197, 167
 	description = "A healthy and refreshing juice."
 	taste_description = "vegetable"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/aloejuice/on_mob_life(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1123,7 +1123,7 @@
 	color = "#D25B66"
 	quality = DRINK_VERYGOOD
 	taste_description = "cool refreshing watermelon"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/agua_fresca/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1138,7 +1138,7 @@
 	color = "#674945" // rgb: 16, 16, 0
 	nutriment_factor = 0
 	taste_description = "mushrooms"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1153,7 +1153,7 @@
 	color = "#554862" // rgb: 85, 72, 98
 	nutriment_factor = 0
 	taste_description = "fiery itchy pain"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/toechtauese_syrup
 	name = "Töchtaüse Syrup"
@@ -1161,7 +1161,7 @@
 	color = "#554862" // rgb: 85, 72, 98
 	nutriment_factor = 0
 	taste_description = "sugar, spice, and nothing nice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/strawberry_banana
 	name = "strawberry banana smoothie"
@@ -1169,7 +1169,7 @@
 	color = "#FF9999"
 	nutriment_factor = 0
 	taste_description = "strawberry and banana"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/berry_blast
 	name = "berry blast smoothie"
@@ -1177,7 +1177,7 @@
 	color = "#A76DC5"
 	nutriment_factor = 0
 	taste_description = "mixed berry"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/funky_monkey
 	name = "funky monkey smoothie"
@@ -1185,7 +1185,7 @@
 	color = COLOR_BROWNER_BROWN
 	nutriment_factor = 0
 	taste_description = "chocolate and banana"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/green_giant
 	name = "green giant smoothie"
@@ -1193,7 +1193,7 @@
 	color = COLOR_VERY_DARK_LIME_GREEN
 	nutriment_factor = 0
 	taste_description = "green, just green"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/melon_baller
 	name = "melon baller smoothie"
@@ -1201,7 +1201,7 @@
 	color = "#D22F55"
 	nutriment_factor = 0
 	taste_description = "fresh melon"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/vanilla_dream
 	name = "vanilla dream smoothie"
@@ -1209,14 +1209,14 @@
 	color = "#FFF3DD"
 	nutriment_factor = 0
 	taste_description = "creamy vanilla"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/cucumberjuice
 	name = "Cucumber Juice"
 	description = "Ordinary cucumber juice, nothing from the fantasy world."
 	color = "#B1D861" // rgb: 177, 216, 97
 	taste_description = "light cucumber"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/cucumberlemonade
 	name = "Cucumber Lemonade"
@@ -1224,7 +1224,7 @@
 	color = "#cbe248" // rgb: 203, 226, 72
 	quality = DRINK_GOOD
 	taste_description = "citrus soda with cucumber"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_HIGH
 
 /datum/reagent/consumable/cucumberlemonade/on_mob_life(mob/living/carbon/doll, seconds_per_tick, times_fired)
@@ -1239,7 +1239,7 @@
 	description = "If you think you're so hot, how about a victory drink?"
 	color = "#d4422f" // rgb: 212,66,47
 	taste_description = "sludge seeping down your throat"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/mississippi_queen/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
@@ -1257,7 +1257,7 @@
 	description = "You expected to find this in a soup, but this is fine too."
 	color = "#583d09" // rgb: 88, 61, 9
 	taste_description = "one of your 26 favorite letters"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/t_letter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -1276,28 +1276,28 @@
 	description = "A Martian-made yerba mate soda, dragged straight out of the pits of a hacking convention."
 	color = "#c4b000"
 	taste_description = "bubbly yerba mate"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/coconut_milk
 	name = "Coconut Milk"
 	description = "A versatile milk substitute that's perfect for everything from cooking to making cocktails."
 	color = "#DFDFDF"
 	taste_description = "milky coconut"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/melon_soda
 	name = "Melon Soda"
 	description = "A neon green hit of nostalgia."
 	color = "#6FEB48"
 	taste_description = "fizzy melon"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/volt_energy
 	name = "24-Volt Energy"
 	description = "An artificially coloured and flavoured electric energy drink, in lanternfruit flavour. Made for ethereals, by ethereals."
 	color = "#99E550"
 	taste_description = "sour pear"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolized_traits = list(TRAIT_STIMULATED)
 
 /datum/reagent/consumable/volt_energy/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
@@ -1316,7 +1316,7 @@
 		It's unique recipe heals and rejuvinates the drinker, but is unsafe to consume without the support of a nearby watercooler."
 	color = "#f7b2e3"
 	taste_description = "dangerously sweet fruit"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	quality = DRINK_VERYGOOD
 
 /datum/reagent/consumable/fruit_punch/on_mob_life(mob/living/affected_mob, seconds_per_tick)
@@ -1375,7 +1375,7 @@
 	quality = DRINK_NICE
 	taste_description = "mild aromatics"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	
+
 /datum/reagent/consumable/ethanol/bitters_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -63,7 +63,7 @@
 	description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
 	nutriment_factor = 15
 	color = "#664330" // rgb: 102, 67, 48
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 	/// Whether this reagent should get the tastes of food it's in applied onto it
 	var/carry_food_tastes = TRUE
@@ -127,7 +127,7 @@
 	name = "Vitamin"
 	description = "All the best vitamins, minerals, and carbohydrates the body needs in pure form."
 	taste_description = "bitterness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	brute_heal = 1
 	burn_heal = 1
 
@@ -143,7 +143,7 @@
 	taste_description = "chalk"
 	brute_heal = 0.8 //Rewards the player for eating a balanced diet.
 	nutriment_factor = 9 //45% as calorie dense as oil.
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/protein
 
 /datum/reagent/consumable/nutriment/fat
@@ -154,7 +154,7 @@
 	brute_heal = 0
 	burn_heal = 1
 	nutriment_factor = 18 // Twice as nutritious compared to protein and carbohydrates
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	var/fry_temperature = 450 //Around ~350 F (117 C) which deep fryers operate around in the real world
 
 /datum/reagent/consumable/nutriment/fat/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
@@ -218,7 +218,7 @@
 	nutriment_factor = 7 //Not very healthy on its own
 	metabolization_rate = 10 * REAGENTS_METABOLISM
 	penetrates_skin = NONE
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/vegetable_oil
 
 /datum/reagent/consumable/nutriment/fat/oil/olive
@@ -240,7 +240,7 @@
 	name = "Organ Tissue"
 	description = "Natural tissues that make up the bulk of organs, providing many vitamins and minerals."
 	taste_description = "rich earthy pungent"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/nutriment/organ_tissue/stomach_lining
 	name = "Stomach Lining"
@@ -252,7 +252,7 @@
 	description = "It's not actually a form of nutriment but it does keep Mothpeople going for a short while..."
 	taste_description = "cloth"
 	nutriment_factor = 30
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	brute_heal = 0
 	burn_heal = 0
 	///Amount of satiety that will be drained when the cloth_fibers is fully metabolized
@@ -298,7 +298,7 @@
 	creation_purity = 1 // impure base reagents are a big no-no
 	overdose_threshold = 120 // Hyperglycaemic shock
 	taste_description = "sweetness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/sugar
 
 // Plants should not have sugar, they can't use it and it prevents them getting water/ nutients, it is good for mold though...
@@ -326,7 +326,7 @@
 	nutriment_factor = 2
 	color = "#899613" // rgb: 137, 150, 19
 	taste_description = "watery milk"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 // Compost for EVERYTHING
 /datum/reagent/consumable/virus_food/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
@@ -338,7 +338,7 @@
 	nutriment_factor = 2
 	color = "#792300" // rgb: 121, 35, 0
 	taste_description = "umami"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/soysauce
 
 /datum/reagent/consumable/ketchup
@@ -347,7 +347,7 @@
 	nutriment_factor = 5
 	color = "#731008" // rgb: 115, 16, 8
 	taste_description = "ketchup"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/ketchup
 
 /datum/reagent/consumable/capsaicin
@@ -356,7 +356,7 @@
 	color = "#B31008" // rgb: 179, 16, 8
 	taste_description = "hot peppers"
 	taste_mult = 1.5
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/capsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -380,7 +380,7 @@
 	color = "#8BA6E9" // rgb: 139, 166, 233
 	taste_description = "mint"
 	ph = 13 //HMM! I wonder
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	///40 joules per unit.
 	specific_heat = 40
 	default_container = /obj/item/reagent_containers/cup/bottle/frostoil
@@ -427,7 +427,7 @@
 	taste_description = "scorching agony"
 	penetrates_skin = NONE
 	ph = 7.4
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/bottle/capsaicin
 
 /datum/reagent/consumable/condensedcapsaicin/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
@@ -473,7 +473,7 @@
 	color = COLOR_WHITE // rgb: 255,255,255
 	taste_description = "salt"
 	penetrates_skin = NONE
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/saltshaker
 
 /datum/reagent/consumable/salt/expose_turf(turf/exposed_turf, reac_volume) //Creates an umbra-blocking salt pile
@@ -522,7 +522,7 @@
 	description = "A powder ground from peppercorns. *AAAACHOOO*"
 	// no color (ie, black)
 	taste_description = "pepper"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/peppermill
 
 /datum/reagent/consumable/coco
@@ -531,7 +531,7 @@
 	nutriment_factor = 5
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "bitterness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/garlic //NOTE: having garlic in your blood stops vampires from biting you.
 	name = "Garlic Juice"
@@ -539,7 +539,7 @@
 	color = "#FEFEFE"
 	taste_description = "garlic"
 	metabolization_rate = 0.15 * REAGENTS_METABOLISM
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	added_traits = list(TRAIT_GARLIC_BREATH)
 
 /datum/reagent/consumable/garlic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
@@ -584,7 +584,7 @@
 	description = "Multi-colored little bits of sugar, commonly found on donuts. Loved by cops."
 	color = COLOR_MAGENTA // rgb: 255, 0, 255
 	taste_description = "childhood whimsy"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -598,7 +598,7 @@
 	description = "A universal enzyme used in the preparation of certain chemicals and foods."
 	color = "#365E30" // rgb: 54, 94, 48
 	taste_description = "sweetness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/enzyme
 
 /datum/reagent/consumable/dry_ramen
@@ -606,7 +606,7 @@
 	description = "Space age food, since August 25, 1958. Contains dried noodles, vegetables, and chemicals that boil in contact with water."
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "dry and cheap noodles"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/dry_ramen
 
 /datum/reagent/consumable/hot_ramen
@@ -615,7 +615,7 @@
 	nutriment_factor = 5
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "wet and cheap noodles"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/dry_ramen
 
 /datum/reagent/consumable/nutraslop
@@ -624,7 +624,7 @@
 	nutriment_factor = 5
 	color = "#3E4A00" // rgb: 62, 74, 0
 	taste_description = "your imprisonment"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/hot_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -636,7 +636,7 @@
 	nutriment_factor = 5
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "wet and cheap noodles on fire"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -696,7 +696,7 @@
 	nutriment_factor = 10
 	color = "#801E28" // rgb: 128, 30, 40
 	taste_description = "cherry"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/cherryjelly
 
 /datum/reagent/consumable/bluecherryjelly
@@ -711,7 +711,7 @@
 	nutriment_factor = 3
 	color = COLOR_WHITE // rgb: 0, 0, 0
 	taste_description = "rice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/rice
 
 /datum/reagent/consumable/rice_flour
@@ -719,7 +719,7 @@
 	description = "Flour mixed with Rice"
 	color = COLOR_WHITE // rgb: 0, 0, 0
 	taste_description = "chalky wheat with rice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/vanilla
 	name = "Vanilla Powder"
@@ -728,7 +728,7 @@
 	nutriment_factor = 5
 	color = "#FFFACD"
 	taste_description = "vanilla"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/eggyolk
 	name = "Egg Yolk"
@@ -736,7 +736,7 @@
 	nutriment_factor = 8
 	color = "#FFB500"
 	taste_description = "egg"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/eggwhite
 	name = "Egg White"
@@ -744,7 +744,7 @@
 	nutriment_factor = 4
 	color = "#fffdf7"
 	taste_description = "bland egg"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/corn_starch
 	name = "Corn Starch"
@@ -791,7 +791,7 @@
 	color = "#DBCE95"
 	metabolization_rate = 3 * REAGENTS_METABOLISM
 	taste_description = "sweet slime"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -804,7 +804,7 @@
 	nutriment_factor = 15
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "sweetness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/honey
 
 // On the other hand, honey has been known to carry pollen with it rarely. Can be used to take in a lot of plant qualities all at once, or harm the plant.
@@ -842,7 +842,7 @@
 	description = "A white and oily mixture of mixed egg yolks."
 	color = "#DFDFDF"
 	taste_description = "mayonnaise"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/mayonnaise
 
 /datum/reagent/consumable/mold // yeah, ok, togopal, I guess you could call that a condiment
@@ -850,7 +850,7 @@
 	description = "This condiment will make any food break the mold. Or your stomach."
 	color ="#708a88"
 	taste_description = "rancid fungus"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/moltobeso
 	name = "Molt'Obeso" //pardon my Italian
@@ -861,7 +861,7 @@
 	nutriment_factor = 0 //the essence of this sauce is to stimulate hunger and improve the absorption of calories from food eaten
 	metabolization_rate = 0.025 * REAGENTS_METABOLISM
 	metabolized_traits = list(TRAIT_GLUTTON)
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/moltobeso/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -878,14 +878,14 @@
 	description = "It smells absolutely dreadful."
 	color ="#708a88"
 	taste_description = "rotten eggs"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/nutriment/stabilized
 	name = "Stabilized Nutriment"
 	description = "A bioengineered protein-nutrient structure designed to decompose in high saturation. In layman's terms, it won't get you fat."
 	nutriment_factor = 15
 	color = "#664330" // rgb: 102, 67, 48
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/nutriment/stabilized/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -901,7 +901,7 @@
 	color = "#1d043d"
 	taste_description = "bitter mushroom"
 	ph = 12
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/entpoly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -950,7 +950,7 @@
 	nutriment_factor = 3
 	taste_description = "fruity mushroom"
 	ph = 10.4
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/vitfro/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -967,7 +967,7 @@
 	nutriment_factor = 5
 	color = "#97ee63"
 	taste_description = "pure electricity"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/liquidelectricity/enriched
 	name = "Enriched Liquid Electricity"
@@ -999,7 +999,7 @@
 	taste_mult = 8
 	taste_description = "sweetness"
 	overdose_threshold = 17
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/astrotame/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1026,7 +1026,7 @@
 	burn_heal = 1
 	inverse_chem = /datum/reagent/peptides_failed//should be impossible, but it's so it appears in the chemical lookup gui
 	inverse_chem_val = 0.2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/caramel
 	name = "Caramel"
@@ -1035,7 +1035,7 @@
 	color = "#D98736"
 	taste_mult = 2
 	taste_description = "caramel"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/caramel/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -1050,7 +1050,7 @@
 	taste_mult = 6
 	taste_description = "smoke"
 	overdose_threshold = 15
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/char/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1064,7 +1064,7 @@
 	color = "#78280A" // rgb: 120 40, 10
 	taste_mult = 2.5 //sugar's 1.5, capsacin's 1.5, so a good middle ground.
 	taste_description = "smokey sweetness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/bbqsauce
 
 /datum/reagent/consumable/chocolatepudding
@@ -1074,7 +1074,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 4
 	taste_description = "sweet chocolate"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	glass_price = DRINK_PRICE_EASY
 
 /datum/glass_style/drinking_glass/chocolatepudding
@@ -1091,7 +1091,7 @@
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 4
 	taste_description = "sweet vanilla"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/glass_style/drinking_glass/vanillapudding
 	required_drink_type = /datum/reagent/consumable/vanillapudding
@@ -1107,7 +1107,7 @@
 	nutriment_factor = 5
 	taste_mult = 2
 	taste_description = "fizzy sweetness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/gravy
 	name = "Gravy"
@@ -1115,28 +1115,28 @@
 	taste_description = "gravy"
 	color = "#623301"
 	taste_mult = 1.2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/pancakebatter
 	name = "Pancake Batter"
 	description = "A very milky batter. 5 units of this on the griddle makes a mean pancake."
 	taste_description = "milky batter"
 	color = "#fccc98"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/korta_flour
 	name = "Korta Flour"
 	description = "A coarsely-ground, peppery flour made from korta nut shells."
 	taste_description = "earthy heat"
 	color = "#EEC39A"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/korta_milk
 	name = "Korta Milk"
 	description = "A milky liquid made by crushing the centre of a korta nut."
 	taste_description = "sugary milk"
 	color = COLOR_WHITE
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/korta_nectar
 	name = "Korta Nectar"
@@ -1145,7 +1145,7 @@
 	nutriment_factor = 5
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "peppery sweetness"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/whipped_cream
 	name = "Whipped Cream"
@@ -1153,7 +1153,7 @@
 	color = "#efeff0"
 	nutriment_factor = 4
 	taste_description = "fluffy sweet cream"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/peanut_butter
 	name = "Peanut Butter"
@@ -1161,7 +1161,7 @@
 	taste_description = "peanuts"
 	color = "#D9A066"
 	nutriment_factor = 15
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/peanut_butter
 
 /datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired) //ET loves peanut butter
@@ -1175,7 +1175,7 @@
 	description = "Useful for pickling, or putting on chips."
 	taste_description = "acid"
 	color = "#661F1E"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/vinegar
 
 /datum/reagent/consumable/cornmeal
@@ -1183,7 +1183,7 @@
 	description = "Ground cornmeal, for making corn related things."
 	taste_description = "raw cornmeal"
 	color = "#ebca85"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/cornmeal
 
 /datum/reagent/consumable/yoghurt
@@ -1192,7 +1192,7 @@
 	taste_description = "yoghurt"
 	color = "#efeff0"
 	nutriment_factor = 2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/yoghurt
 
 /datum/reagent/consumable/cornmeal_batter
@@ -1200,14 +1200,14 @@
 	description = "An eggy, milky, corny mixture that's not very good raw."
 	taste_description = "raw batter"
 	color = "#ebca85"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/olivepaste
 	name = "Olive Paste"
 	description = "A mushy pile of finely ground olives."
 	taste_description = "mushy olives"
 	color = "#adcf77"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/creamer
 	name = "Coffee Creamer"
@@ -1215,7 +1215,7 @@
 	taste_description = "milk"
 	color = "#efeff0"
 	nutriment_factor = 1.5
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/creamer
 
 /datum/reagent/consumable/mintextract
@@ -1223,7 +1223,7 @@
 	description = "Useful for dealing with undesirable customers."
 	color = "#CF3600" // rgb: 207, 54, 0
 	taste_description = "mint"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/mintextract/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1237,7 +1237,7 @@
 	nutriment_factor = 2 * REAGENTS_METABOLISM
 	color = "#572b26"
 	taste_description = "sweet fish"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/worcestershire
 
 /datum/reagent/consumable/red_bay
@@ -1245,7 +1245,7 @@
 	description = "A secret blend of herbs and spices that goes well with anything- according to Martians, at least."
 	color = "#8E4C00"
 	taste_description = "spice"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/red_bay
 
 /datum/reagent/consumable/curry_powder
@@ -1253,7 +1253,7 @@
 	description = "One of humanity's most common spices. Typically used to make curry."
 	color = "#F6C800"
 	taste_description = "dry curry"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/curry_powder
 
 /datum/reagent/consumable/dashi_concentrate
@@ -1261,7 +1261,7 @@
 	description = "A concentrated form of dashi. Simmer with water in a 1:8 ratio to produce a tasty dashi broth."
 	color = "#372926"
 	taste_description = "extreme umami"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/condiment/dashi_concentrate
 
 /datum/reagent/consumable/martian_batter
@@ -1269,11 +1269,11 @@
 	description = "A thick batter made with dashi and flour, used for making dishes such as okonomiyaki and takoyaki."
 	color = "#D49D26"
 	taste_description = "umami dough"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/consumable/grounding_solution
 	name = "Grounding Solution"
 	description = "A food-safe ionic solution designed to neutralise the enigmatic \"liquid electricity\" that is common to food from Sprout, forming harmless salt on contact."
 	color = "#efeff0"
 	taste_description = "metallic salt"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2852,7 +2852,7 @@
 	description = "For when you need to push on a little more. Do NOT allow near plants."
 	color = "#D2FFFA"
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM // 5u (WOUND_DETERMINATION_CRITICAL) will last for ~34 seconds
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	self_consuming = TRUE
 	metabolized_traits = list(TRAIT_ANALGESIA)
 	/// Whether we've had at least WOUND_DETERMINATION_SEVERE (2.5u) of determination at any given time. No damage slowdown immunity or indication we're having a second wind if it's just a single moderate wound

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2,6 +2,7 @@
 	name = "Blood"
 	description  = "Blood cells suspended in plasma, the most abundant of which being the hemoglobin-containing red blood cells."
 	color = "#C80000" // rgb: 200, 0, 0
+	chemical_flags = REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	metabolization_rate = 12.5 * REAGENTS_METABOLISM //fast rate so it disappears fast.
 	taste_description = "iron"
 	taste_mult = 1.3
@@ -109,7 +110,7 @@
 	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha)
 	taste_description = "water"
 	var/cooling_temperature = 2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	default_container = /obj/item/reagent_containers/cup/glass/waterbottle
 
 /datum/glass_style/shot_glass/water
@@ -293,7 +294,7 @@
 	color = "#E0E8EF" // rgb: 224, 232, 239
 	self_consuming = TRUE //divine intervention won't be limited by the lack of a liver
 	ph = 7.5 //God is alkaline
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_UNAFFECTED_BY_METABOLISM // Operates at fixed metabolism for balancing memes.
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS|REAGENT_UNAFFECTED_BY_METABOLISM // Operates at fixed metabolism for balancing memes.
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/holywater
 	metabolized_traits = list(TRAIT_HOLY)
 
@@ -439,7 +440,7 @@
 	metabolization_rate = 2.5 * REAGENTS_METABOLISM  //0.5u/second
 	penetrates_skin = TOUCH|VAPOR
 	ph = 6.5
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE/REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/fuel/unholywater/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -1105,7 +1106,7 @@
 	description = "Pure iron is a metal."
 	taste_description = "iron"
 	material = /datum/material/iron
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 	color = "#606060" //pure iron? let's make it violet of course
 	ph = 6
 
@@ -2896,7 +2897,7 @@
 	self_consuming = TRUE //eldritch intervention won't be limited by the lack of a liver
 	color = "#1f8016"
 	metabolization_rate = 2.5 * REAGENTS_METABOLISM  //0.5u/second
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE|REAGENT_METABOLIZED_WITHOUT_LIVER_STRESS
 
 /datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -36,7 +36,16 @@
 	LAZYSET(victim_mind.active_addictions, type, 1) //Start at first cycle.
 	SEND_SIGNAL(victim_mind.current, COMSIG_CARBON_GAIN_ADDICTION, victim_mind)
 	victim_mind.current.log_message("has become addicted to [name].", LOG_GAME)
+	RegisterSignal(victim_mind.current, COMSIG_LIVER_METABOLIC_STRESS, PROC_REF(minimize_liver_stress))
 
+/// A victim's current body adapts to the stress of this drug, but if their addicted mind ends up in a
+/// different body, it won't carry the same tolerance that would minimize the liver stress, and honestly
+/// they can keep it if someone systematically becomes addicted to everything they can to minimize liver
+/// stress, rounds don't last long enough for this to be worth worrying about
+/datum/addiction/proc/minimize_liver_stress(mob/living/carbon/affected_mob, datum/reagent/chem, list/stress_amount)
+	SIGNAL_HANDLER
+	if(chem.addiction_types[type])
+		stress_amount[1] = 0.1
 
 ///Called when you lose addiction poitns somehow. Takes a mind as argument and sees if you lost the addiction
 /datum/addiction/proc/on_lose_addiction_points(datum/mind/victim_mind)

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -32,7 +32,7 @@
 	var/operated = FALSE //whether the liver's been repaired with surgery and can be fixed again or not
 	VAR_PROTECTED/metabolic_stress = 0
 	VAR_PROTECTED/max_metabolic_stress = 100
-	VAR_PROTECTED/metabolic_stress_recovery_rate = 1
+	VAR_PROTECTED/metabolic_stress_recovery_rate = 0.5
 	COOLDOWN_DECLARE(last_metabolic_stress_time)
 
 /obj/item/organ/liver/Initialize(mapload)
@@ -140,7 +140,7 @@
 
 	owner.reagents?.metabolize(owner, seconds_per_tick, times_fired, can_overdose = TRUE)
 	if(COOLDOWN_FINISHED(src, last_metabolic_stress_time))
-		metabolic_stress &&= max(metabolic_stress - metabolic_stress_recovery_rate, 0)
+		metabolic_stress &&= max(metabolic_stress - (seconds_per_tick * metabolic_stress_recovery_rate), 0)
 
 /obj/item/organ/liver/handle_failing_organs(seconds_per_tick)
 	if(HAS_TRAIT(owner, TRAIT_STABLELIVER) || HAS_TRAIT(owner, TRAIT_LIVERLESS_METABOLISM))
@@ -232,12 +232,13 @@
 	return owner_species.mutantliver
 
 /obj/item/organ/liver/feel_for_damage(self_aware)
-	switch(metabolic_stress ? max_metabolic_stress / metabolic_stress : 0)
+	var/stress_ratio = metabolic_stress / max_metabolic_stress
+	switch(stress_ratio)
 		if(0 to 0.2)
-			if(!prob(10))
+			if(!prob(1))
 				. += span_green("You feel healthy from your dedication to clean living.")
 			else
-				. += span_green("You feel healthy from your dedication to clean living." + span_notice("No wonder you don't get invited to any parties..."))
+				. += span_green("You feel healthy from your dedication to clean living." + span_notice(" No wonder you don't get invited to any parties..."))
 		if(0.21 to 0.4)
 			. += span_notice("You feel a little worn out; a hangover from chems of various kinds, no doubt.")
 		if(0.41 to 0.6)


### PR DESCRIPTION
## About The Pull Request
This is a pull request to address microdosing chems (and chem patches invalidating medbay) as being the end all win button for any encounter. It introduces the foundations of a system for metabolic stress for livers.

### How it works

- ~~If you metabolize a reagent, you incur some liver stress if it's not flagged~~
- ~~All food reagents are flagged to NOT cause liver stress~~
- Any reagents you are addicted to cause 1/5 the amount of liver stress
- If you have cryoxadone in you, and are below its effective temperature, reagents do not cause liver stress
- After a 30 second cooldown from your last chem-induced stress, you heal 1 metabolic stress per life tick
- If you incur liver stress while at max liver stress (100, currently), you suffer the overflow as liver damage
- Current liver stress rate: The amount metabolized or, minimum, 0.5
- Addiction liver stress rate( for chems you're addicted to): 0.1

### To reiterate: the following reagents do not cause liver stress:
- Food of any type
- Regen jelly
- Iron
- Blood
- Water (normal, holy, unholy)
- Eldritch essence
- Any chems + cryoxadone, below its effective temperature

### Ethanol reagents (various drinks):
- You won't take liver stress from each type of booze, there's snowflake handling for booze to treat them all as one reagent for the purposes of liver stress. So, big win for alcoholism

https://github.com/user-attachments/assets/a5490949-c587-4c1b-bc7f-5d7d79d42fc5


### Also, cryoxadone works when you're conscious now 👍 


## Why It's Good For The Game
There are numbers I want to fiddle with for this, such as cybernetic livers, or eating really healthily increasing your stress recovery rate, but as it is now, I would like to get a feel for how it plays in the game in a state of not-fucked-with-too-much-yet.

Chemistry microdosing and heal-all patches invalidate huge swathes of the game in an oppressive fashion that is not fun to play against, and is only fun for the autistically specially interested among us oriented towards spreadsheets and chem factory blueprints.

This system introduces a mechanism to push people towards NOT constantly microdosing chems of some kind, while also nudging them towards doing things like pestering the chef for particularly healthy foods or, if they need the super ultimate mega healing from chemistry bullshit, they can do so with cryo and not incur any of the liver stress.

It is, currently, a bare framework meant to work as the foundation for the concept; I have not made any modifications for things like cybernetic livers or biomods. There are signal hooks for other things to also make you immune to the metabolic stress of chem processing, or to reduce/increase the rate of stress for certain chems in certain scenarios (though none besides cryoxadone are implemented for this modified/cancelled stress scenario).

## Changelog
:cl: Bisar
add: Metabolic stress for livers: Most reagents that are not food or specially designated now cause metabolic stress.
add: Metabolic stress will cause liver damage if you push your liver past its maximum threshold for tolerating metabolic stress.
add: You recover from metabolic stress after a 30 second cooldown of not using any stress-inducing chems.
add: You can roughly judge your current metabolic stress by examining your health state.
add: Chems, besides food, specially designated to not cause metabolic stress: Heretic Eldritch Essence, Water, Holy Water, Unholy Water, Slime Regen Jelly, Iron, Blood
add: The various alcohols won't cause stacking reagent stress; booze is handled specially to broadly act like all the booze types in you are the same reagent for the purposes of stress.
add: Cryoxadone, when the patient is below its effective temperature threshold, now prevents metabolic stress from reagents.
add: If you become addicted to a reagent, your body develops a tolerance: You will take 1/5 of the metabolic stress from reagents that satisfy your addiction(s).
balance: Cryoxadone no longer requires you to be unconscious to work.
/:cl:
