### PR TITLE
A new type of cybernetic ear, volume-adjusting ears. Also changes the stats of the basic and regular cybernetic ears for consistency

### DIFF
--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -38,6 +38,7 @@
 		/obj/item/organ/ears/cybernetic/upgraded = TRUE,
 		/obj/item/organ/ears/cybernetic/whisper = TRUE,
 		/obj/item/organ/ears/cybernetic/xray = TRUE,
+		/obj/item/organ/ears/cybernetic/volume = TRUE,
 	)
 
 /datum/bounty/item/medical/liver

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -1019,6 +1019,23 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
+/datum/design/cybernetic_ears_volume
+	name = "Volume-adjusting Cybernetic Ears"
+	desc = "A pair of volume-adjusting cybernetic ears"
+	id = "cybernetic_ears_volume"
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	construction_time = 4 SECONDS
+	materials = list(
+			/datum/material/iron = SMALL_MATERIAL_AMOUNT*5,
+			/datum/material/glass = SMALL_MATERIAL_AMOUNT*5,
+			/datum/material/silver = SMALL_MATERIAL_AMOUNT*5,
+	)
+	build_path = /obj/item/organ/ears/cybernetic/volume
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_3
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
 /datum/design/cybernetic_ears_xray
 	name = "Wall-penetrating Cybernetic Ears"
 	desc = "A pair of wall-penetrating cybernetic ears."

--- a/code/modules/research/techweb/nodes/cyborg_nodes.dm
+++ b/code/modules/research/techweb/nodes/cyborg_nodes.dm
@@ -226,6 +226,7 @@
 		"ci-gloweyes-moth",
 		"ci-welding-moth",
 		"cybernetic_ears_whisper",
+		"cybernetic_ears_volume",
 		"cybernetic_lungs_tier3",
 		"cybernetic_stomach_tier3",
 		"cybernetic_liver_tier3",

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -230,15 +230,15 @@
 	name = "basic cybernetic ears"
 	icon_state = "ears-c"
 	desc = "A basic cybernetic organ designed to mimic the operation of ears."
-	damage_multiplier = 0.9
+	damage_multiplier = 1.2
 	organ_flags = ORGAN_ROBOTIC
 	failing_desc = "seems to be broken."
 
 /obj/item/organ/ears/cybernetic/upgraded
 	name = "cybernetic ears"
 	icon_state = "ears-c-u"
-	desc =  "An advanced cybernetic ear, surpassing the performance of organic ears."
-	damage_multiplier = 0.5
+	desc =  "A cybernetic ear, surpassing the performance of organic ears."
+	damage_multiplier = 0.75
 
 /obj/item/organ/ears/cybernetic/whisper
 	name = "whisper-sensitive cybernetic ears"
@@ -256,6 +256,13 @@
 /obj/item/organ/ears/cybernetic/whisper/on_mob_remove(mob/living/carbon/ear_owner)
 	. = ..()
 	REMOVE_TRAIT(ear_owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
+
+/obj/item/organ/ears/cybernetic/volume
+	name = "volume-adjusting cybernetic ears"
+	icon_state = "ears-c-u"
+	desc = "Advanced cybernetic ears capable of dampening loud noises to protect their user."
+	bang_protect = 1
+	damage_multiplier = 0.5
 
 // "X-ray ears" that let you hear through walls
 /obj/item/organ/ears/cybernetic/xray


### PR DESCRIPTION
## About The Pull Request

Currently, basic cybernetic ears take 10% less damage and cybernetic ears take 50% less damage. That's kinda weird since most basic organs are slightly weaker while regular cybernetic organs are slightly stronger. This PR changes the basic one to take 1.2x damage and the regular one to take 0.75x damage.

In place of the old durable ears is a new t3 ear, the volume-adjusting ears. They are the equivalent of welding shielded eyes for hearing protection, and take 0.5x damage like the old cybernetic ears did.

This isn't new behavior but I feel like it should be said that getting flashbanged with two sources of hearing protection keeps you safe from even the very center of the "explosion". Thus, someone with volume-adjusting ears, flash protection and bowmans is completely unaffected by flashbangs

## Why It's Good For The Game

The basic and regular cybernetic organs were changed for consistency. The addition of the volume-adjusting ears is because unlike flash protection there are so few sources of hearing protection and tier 3 organs should do more than just take reduced damage. 

Additionallyt, the whisper-sensitive and wall-penetrating cybernetic ears both take twice the damage that normal ears do (equal to cat ears) so if you don't like becoming deaf your choices as far as t3 organs go are pretty limited. 

## Changelog

:cl:
add: New T3 cybernetic ears, the volume-adjusted ears.
balance: The T1 and T2 ears are now slightly worse than and slightly better than normal ears, respectively.
/:cl: