### PR TITLE
Granibitaluri now offers painkilling

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1779,6 +1779,7 @@
 	overdose_threshold = 50
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM //same as C2s
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	metabolized_traits = list(TRAIT_ANALGESIA)
 
 /datum/reagent/medicine/granibitaluri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Tweaks Granibitaluri to offer painkilling as well as its normal effects.

## Why It's Good For The Game

This reagent is meant to be a filler chem for premade Medbay chems as well as a minor healer overall. However, it is barely worth making by itself since the effects are minimal. Making it a painkiller should give it the edge it needs to reduce pain during surgeries, as well as offering Medbay doctors alternate painkillers!

(credit to Sonnzer for being the ideasguy :tm:)

## Changelog
:cl:
qol: Granibitaluri now offers painkilling as well as its normal effects.
/:cl: