### PR TITLE
Water helps heal liver slowly

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -222,7 +222,7 @@
 
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && !IS_ROBOTIC_ORGAN(liver) && liver.damage && !(liver.organ_flags & ORGAN_FAILING))
-		var/healing_bonus = liver.healing_factor * liver.maxHealth // doubles your natural organ healing rate
+		var/healing_bonus = liver.healing_factor * liver.maxHealth
 		liver.apply_organ_damage(-healing_bonus * REM * seconds_per_tick)
 
 	var/water_adaptation = HAS_TRAIT(affected_mob, TRAIT_WATER_ADAPTATION)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -222,7 +222,7 @@
 
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && !IS_ROBOTIC_ORGAN(liver) && liver.damage && !(liver.organ_flags & ORGAN_FAILING))
-		var/healing_bonus = liver.healing_factor * liver.maxHealth * 3
+		var/healing_bonus = liver.healing_factor * liver.maxHealth // doubles your natural organ healing rate
 		liver.apply_organ_damage(-healing_bonus * REM * seconds_per_tick)
 
 	var/water_adaptation = HAS_TRAIT(affected_mob, TRAIT_WATER_ADAPTATION)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -221,7 +221,7 @@
 	. = ..()
 
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
-	if(liver && !IS_ROBOTIC_ORGAN(liver) && liver.damage && !(liver.organ_flags & ORGAN_FAILING))
+	if(liver?.damage && !IS_ROBOTIC_ORGAN(liver) && !(liver.organ_flags & ORGAN_FAILING))
 		var/healing_bonus = liver.healing_factor * liver.maxHealth
 		liver.apply_organ_damage(-healing_bonus * REM * seconds_per_tick)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -219,6 +219,12 @@
 
 /datum/reagent/water/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
+
+	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
+	if(liver && !IS_ROBOTIC_ORGAN(liver) && liver.damage && !(liver.organ_flags & ORGAN_FAILING))
+		var/healing_bonus = liver.healing_factor * liver.maxHealth * 3
+		liver.apply_organ_damage(-healing_bonus * REM * seconds_per_tick)
+
 	var/water_adaptation = HAS_TRAIT(affected_mob, TRAIT_WATER_ADAPTATION)
 	if(affected_mob.blood_volume)
 		var/blood_restored = water_adaptation ? 0.3 : 0.1

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -166,7 +166,7 @@ As the AI, you can use CTRL + 1-9 to set a location hotkey for your camera, allo
 As the Bartender, the drinks you start with only give you the basics. If you want more advanced mixtures, look into working with chemistry, hydroponics, or even mining for things to grind up and throw in!
 As the Bartender, you can use a circular saw on your shotgun to make it easier to store.
 As the Bartender, remember to set up the bar sign by walking up to it and clicking it!
-As the Bartender, a glass of water between drinks is your best friend. It slows alcohol absorption and provides hydration to support liver recovery.
+As the Bartender, serving a glass of water between drinks is your best friend. It slows alcohol absorption and provides hydration to support liver recovery.
 As the Blob, don't neglect the creation of factories. These create spores that carry your reagent and can chase crew members far further than you. Spores can also be rallied to swarm the crew and cause panic, and can even take over corpses to create much more dangerous blob zombies!
 As the Blob, keep your core some distance from space, as it is both expensive to expand onto space, easy to be attacked from, and does not count towards your win condition. Emitter platforms built in space are especially dangerous.
 As the Blob, removing strong blobs, resource nodes, factories, and nodes will give you 4, 15, 25, and 25 resources back, respectively.

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -166,6 +166,7 @@ As the AI, you can use CTRL + 1-9 to set a location hotkey for your camera, allo
 As the Bartender, the drinks you start with only give you the basics. If you want more advanced mixtures, look into working with chemistry, hydroponics, or even mining for things to grind up and throw in!
 As the Bartender, you can use a circular saw on your shotgun to make it easier to store.
 As the Bartender, remember to set up the bar sign by walking up to it and clicking it!
+As the Bartender, a glass of water between drinks is your best friend. It slows alcohol absorption and provides hydration to support liver recovery.
 As the Blob, don't neglect the creation of factories. These create spores that carry your reagent and can chase crew members far further than you. Spores can also be rallied to swarm the crew and cause panic, and can even take over corpses to create much more dangerous blob zombies!
 As the Blob, keep your core some distance from space, as it is both expensive to expand onto space, easy to be attacked from, and does not count towards your win condition. Emitter platforms built in space are especially dangerous.
 As the Blob, removing strong blobs, resource nodes, factories, and nodes will give you 4, 15, 25, and 25 resources back, respectively.


### PR DESCRIPTION

## About The Pull Request
Water now helps heal livers by doubling their natural organ healing rate.

The default organ healing is `~0.05` dmg per tick, so water healing is another `~0.05` dmg per tick. It's a small boost that won't stop your liver from dying from hazardous chemicals or a massive alcoholic binge, but if you combine it with sleep, it can help heal your liver over time.

## Why It's Good For The Game
Water should have positive effects on livers, but since it is so plentiful across the station, the positive effect should be minimal. Aiming to boost the natural healing rate is a good way to give a positive effect without it becoming too overpowered.

## Changelog
:cl:
add: Central Command has finally realized that old fashioned water is actually good for you. It now provides a minor buff to the natural healing of liver damage.
/:cl:
