### PR TITLE
Buffs holodeck claymore to 30 force again

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -404,8 +404,8 @@
 
 /obj/item/claymore/weak
 	desc = "This one is rusted."
-	force = 24
-	armour_penetration = 10
+	force = 30
+	armour_penetration = 15
 
 /obj/item/claymore/weak/make_stabby()
 	AddComponent(/datum/component/alternative_sharpness, SHARP_POINTY, alt_continuous, alt_simple, -9)


### PR DESCRIPTION
## About The Pull Request

Reverts the changes in https://github.com/tgstation/tgstation/pull/83334 weak claymore to its former glory so its no longer so bad.

## Why It's Good For The Game

This will let people use melee more often against threats and this person nerfed the claymore thats used in the holodeck when said claymore is used elsewhere- and in my opinion the holodeck claymore was not deserving of this nerf anyhow as it allows crew or antagonists to have a fairly good melee in a pinch with some extremely hefty downsides such as the fact that it will disappear from your hand mid fight is non zero.

The other places this claymore can be found is from A: Templar skeletons, so literally only from the end of snowdin and B: Fishing? if this becomes a problem ill make a subtype of the claymore that deals 24 brute and 10 pen like how it used to and just give that to the fishing corpse instead

and also fallowing the format that mothblocks gave me

for a revert to merge, a rule of thumb is it must prove **one** of the following things:

1| that the problem it was solving was redundantly solved by something else: The claymores obtainable from the holodeck can be removed from the holodeck by a law 2 or by one bomb, the holodeck is a massive area and its very hard to fortify the holodeck against attack and if somebody does try to make an r-wall around the entire holodeck your going to have a long notice for that, alternatively you can use x-ray eyes+telepathy to just turn it off remotely even if its been fortified.

2| that it did not solve the problem, and has either made it worse or provides an extra loss: It did solve the problem by making this weapon with already huge downsides completely unviable for any purpose other than being a shield.

3| that the problem it was solving is illegitimate (the absolute hardest one): This was an ided PR, its admitted to be such https://github.com/tgstation/tgstation/pull/83334#issuecomment-2120321699 and they say this which corroborates with the comment that the comment im linking to is replying to. "Hey AI, I need my free 4-hit weapon. I'm totally not a changeling or anything." And the issue that they were "solving" also in-advertently nerfed the one other location where you could actually get this claymore from. In my opinion these claymores are not a problem for the reasons as stated above and the reason why it was ever even merged has a good chance of just being oranges going "haha this funny"

## Changelog
:cl:
balance: restored the weak claymore to its former glory
/:cl:
