### PR TITLE
allow admins to allow AA

### DIFF
--- a/code/datums/components/simple_access.dm
+++ b/code/datums/components/simple_access.dm
@@ -3,6 +3,8 @@
 	dupe_mode = COMPONENT_DUPE_ALLOWED
 	///list of accesses we are allowed to access via this component
 	var/list/access
+	///Admin Access
+	var/aa_access
 
 /datum/component/simple_access/Initialize(list/new_access, atom/donor_atom)
 	. = ..()
@@ -21,6 +23,8 @@
 
 /datum/component/simple_access/proc/on_tried_access(datum/source, atom/locked_thing)
 	SIGNAL_HANDLER
+	if(aa_access)
+		return ACCESS_ALLOWED
 	if(!isobj(locked_thing))
 		return LOCKED_ATOM_INCOMPATIBLE
 	var/obj/locked_object = locked_thing


### PR DESCRIPTION

## About The Pull Request

Allow Admins to enforce AA

:cl:
admin: NT has increased the permission of admirals, allowing them to allow All Access easily.
/:cl:

Its obviously good for the game.
