### PR TITLE
Adds Super Duper Lube recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -11,7 +11,7 @@
 
 /datum/chemical_reaction/lube/superlube
 	results = list(/datum/reagent/lube/superlube = 3)
-	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/banana = 1)
+	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/laughter = 3)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/spraytan

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -9,6 +9,11 @@
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
 
+/datum/chemical_reaction/lube/superlube
+	results = list(/datum/reagent/lube/superlube = 3)
+	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/silicon = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+
 /datum/chemical_reaction/spraytan
 	results = list(/datum/reagent/spraytan = 2)
 	required_reagents = list(/datum/reagent/consumable/orangejuice = 1, /datum/reagent/fuel/oil = 1)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -11,7 +11,7 @@
 
 /datum/chemical_reaction/lube/superlube
 	results = list(/datum/reagent/lube/superlube = 3)
-	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/wittel = 1)
+	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/banana = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/spraytan

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -11,7 +11,7 @@
 
 /datum/chemical_reaction/lube/superlube
 	results = list(/datum/reagent/lube/superlube = 3)
-	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/silicon = 1)
+	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/wittel = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/spraytan

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -11,7 +11,7 @@
 
 /datum/chemical_reaction/lube/superlube
 	results = list(/datum/reagent/lube/superlube = 3)
-	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/laughter = 3)
+	required_reagents = list(/datum/reagent/lube = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/banana = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/spraytan


### PR DESCRIPTION
## About The Pull Request

<img width="1247" height="793" alt="image" src="https://github.com/user-attachments/assets/89312358-3169-4694-bb30-5bf01b3dd174" />
<img width="1236" height="755" alt="image" src="https://github.com/user-attachments/assets/e03d2a57-cc6d-414b-aa8c-f2397e32b9b9" />


Adds super duper lube recipe
1 lube, 1 strange reagent, 1 banana juice

Super Lube recipe requires Strange Reagent, alongside banana juice.
Not 'simple' to make. Takes a lot of running around to make. Potentially limited due to Omnizine/Holy Water (/Bananas).

## Why It's Good For The Game

Funny
Sandbox synergy
Well-thought-out pranks
Opportunities for funny gimmicks
Incentivizes creativity - Healthy for a sandbox game
Recipe not 'easily' obtainable (shouldn't be overused)
Gliding after being slipped already exists through Cryostylane 

## Changelog

:cl: ArchBTW
add: adds super duper lube recipe (1 lube, 1 strange reagent, 1 banana juice)
/:cl:
