### PR TITLE
Big slappy buff

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -305,7 +305,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = NONE
 	toolspeed = 0.1
-	force = 30
+	force = 35
 	throwforce = 20
 	block_chance = 30
 	throw_range = 2


### PR DESCRIPTION

## About The Pull Request

Buffs the big slappy by 5 damage

## Why It's Good For The Game

The big slappy is a pain to make/get however you can get it reliably and its quite- okay against just naked people with no armor but quickly falls off if your opponent is wearing any armor which makes sense because it shouldnt be able to pen, this simply buffs its damage by five bringing it up to 35 meaning that it will hit harder, however with this melee are some major downsides such as its slowdown and its huge sprite (actually a big dis-advantage in melee) and the fact that it cant be stored anywhere easily, with these comedically huge downsides I was tempted to buff its damage to 40.

## Changelog

buffs the big slappy by 5 damage

:cl:
balance: buffs the big slappy by 5 brute
/:cl:
