### PR TITLE
syndicate modsuit visor pseudo-toggle (tied to combat mode)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -20,6 +20,9 @@
 ///Called when movement intent is toggled.
 #define COMSIG_MOVE_INTENT_TOGGLED "move_intent_toggled"
 
+/// Called when combat mode is toggled.
+#define COMSIG_COMBAT_MODE_TOGGLED "combat_mode_toggled"
+
 ///from base of mob/update_transform()
 #define COMSIG_LIVING_POST_UPDATE_TRANSFORM "living_post_update_transform"
 

--- a/code/__HELPERS/dynamic_human_icon_gen.dm
+++ b/code/__HELPERS/dynamic_human_icon_gen.dm
@@ -2,13 +2,13 @@
 GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 
 /// Creates a human with the given parameters and returns an appearance of it
-/proc/get_dynamic_human_appearance(outfit_path, species_path = /datum/species/human, mob_spawn_path, r_hand, l_hand, bloody_slots = NONE, animated = TRUE)
+/proc/get_dynamic_human_appearance(outfit_path, species_path = /datum/species/human, mob_spawn_path, r_hand, l_hand, bloody_slots = NONE, animated = TRUE, combat_mode = TRUE)
 	if(!species_path)
 		return FALSE
 	if(!ispath(species_path))
 		stack_trace("Attempted to call get_dynamic_human_appearance() with an instantiated species_path. Pass the species datum typepath instead.")
 		return FALSE
-	var/arg_string = "[outfit_path]_[species_path]_[mob_spawn_path]_[l_hand]_[r_hand]_[bloody_slots]"
+	var/arg_string = "[outfit_path]_[species_path]_[mob_spawn_path]_[l_hand]_[r_hand]_[bloody_slots]_[combat_mode]"
 	if(GLOB.dynamic_human_appearances[arg_string]) //if already exists in our cache, just return that
 		return GLOB.dynamic_human_appearances[arg_string]
 	var/mob/living/carbon/human/dummy/consistent/dummy = new()
@@ -17,6 +17,7 @@ GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 	dummy.underwear = "Nude"
 	dummy.undershirt = "Nude"
 	dummy.socks = "Nude"
+	dummy.set_combat_mode(combat_mode)
 	if(outfit_path)
 		var/datum/outfit/outfit = new outfit_path()
 		if(r_hand != NO_REPLACE) //we can still override to be null, no replace means just use outfit's

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -471,6 +471,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	dummy = dummy || new /mob/living/carbon/human/dummy/consistent
 	dummy.equipOutfit(outfit, visuals_only = TRUE)
 	dummy.wear_suit?.update_greyscale()
+	dummy.set_combat_mode(TRUE)
 	var/icon = getFlatIcon(dummy)
 
 	// We don't want to qdel the dummy right away, since its items haven't initialized yet.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -201,6 +201,7 @@
 		SEND_SOUND(src, sound('sound/misc/ui_togglecombat.ogg', volume = 25)) //Sound from interbay!
 	else
 		SEND_SOUND(src, sound('sound/misc/ui_toggleoffcombat.ogg', volume = 25)) //Slightly modified version of the above
+	SEND_SIGNAL(src, COMSIG_COMBAT_MODE_TOGGLED)
 
 /mob/living/hitby(atom/movable/AM, skipcatch, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)
 	if(!isitem(AM))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -193,6 +193,7 @@
 		return
 	. = combat_mode
 	combat_mode = new_mode
+	SEND_SIGNAL(src, COMSIG_COMBAT_MODE_TOGGLED)
 	if(hud_used?.action_intent)
 		hud_used.action_intent.update_appearance()
 	if(silent || !client?.prefs.read_preference(/datum/preference/toggle/sound_combatmode))
@@ -201,7 +202,6 @@
 		SEND_SOUND(src, sound('sound/misc/ui_togglecombat.ogg', volume = 25)) //Sound from interbay!
 	else
 		SEND_SOUND(src, sound('sound/misc/ui_toggleoffcombat.ogg', volume = 25)) //Slightly modified version of the above
-	SEND_SIGNAL(src, COMSIG_COMBAT_MODE_TOGGLED)
 
 /mob/living/hitby(atom/movable/AM, skipcatch, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)
 	if(!isitem(AM))

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -26,7 +26,7 @@
 		head_cover.flash_protect = initial(head_cover.flash_protect)
 
 /obj/item/mod/module/welding/syndicate
-	name = "MODsuit flash protection suite"
+	name = "MODsuit flash-protected optical suite"
 	complexity = 0
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/welding, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/stealth/wraith)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -26,6 +26,7 @@
 		head_cover.flash_protect = initial(head_cover.flash_protect)
 
 /obj/item/mod/module/welding/syndicate
+	name = "MODsuit flash protection suite"
 	complexity = 0
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/welding, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/stealth/wraith)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -35,13 +35,10 @@
 	mask_worn_overlay = TRUE
 
 /obj/item/mod/module/welding/syndicate/generate_worn_overlay(obj/item/source, mutable_appearance/standing)
-	if(!mod.wearer)
+	if(!mod.wearer || !mod.wearer.combat_mode)
 		overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
 	else
-		if(mod.wearer.combat_mode)
-			overlay_state_inactive = "module_armorbooster_on-[mod.skin]"
-		else
-			overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
+		overlay_state_inactive = "module_armorbooster_on-[mod.skin]"
 	return ..()
 
 
@@ -55,6 +52,7 @@
 
 /// Changes which overlay state we're using depending on combat mode status.
 /obj/item/mod/module/welding/syndicate/proc/on_combat_mode_toggle(mob/living/carbon/human/toggler)
+	SIGNAL_HANDLER
 	playsound(src, 'sound/vehicles/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	update_clothing_slots()
 

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -29,13 +29,33 @@
 	complexity = 0
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/welding, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/stealth/wraith)
-	overlay_state_inactive = "module_armorbooster_on"
+	overlay_state_inactive = "module_armorbooster_off"
 	use_mod_colors = TRUE
 	mask_worn_overlay = TRUE
 
 /obj/item/mod/module/welding/syndicate/generate_worn_overlay(obj/item/source, mutable_appearance/standing)
-	overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
+	if(!mod.wearer)
+		overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
+	else
+		if(mod.wearer.combat_mode)
+			overlay_state_inactive = "module_armorbooster_on-[mod.skin]"
+		else
+			overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
 	return ..()
+
+
+/obj/item/mod/module/welding/syndicate/on_part_activation()
+	. = ..()
+	RegisterSignal(mod.wearer, COMSIG_COMBAT_MODE_TOGGLED, PROC_REF(on_combat_mode_toggle))
+
+/obj/item/mod/module/welding/syndicate/on_part_deactivation(deleting = FALSE)
+	. = ..()
+	UnregisterSignal(mod.wearer, COMSIG_COMBAT_MODE_TOGGLED)
+
+/// Changes which overlay state we're using depending on combat mode status.
+/obj/item/mod/module/welding/syndicate/proc/on_combat_mode_toggle(mob/living/carbon/human/toggler)
+	playsound(src, 'sound/vehicles/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	update_clothing_slots()
 
 ///T-Ray Scan - Scans the terrain for undertile objects.
 /obj/item/mod/module/t_ray


### PR DESCRIPTION
## About The Pull Request

The visors on MODsuits using the Syndicate welding visor (now renamed the "flash-protected optical suite") now toggle their armor booster overlay depending on whether the user has combat mode on or off.

## Why It's Good For The Game

Style. Listen, man, I just thought it'd be a shame if the cool visor sprites never got used again.

https://github.com/user-attachments/assets/d5103168-7a1e-4405-adb3-53420c8601d7

## Changelog

:cl:
add: The visors on MODsuits that used to have armor boosters now visibly toggle based on whether the wearer is in combat mode or not.
/:cl: