### PR TITLE
Turns the chaplain's energy swords into...energy swords.

### DIFF
--- a/_maps/templates/lazy_templates/ninja_den.dmm
+++ b/_maps/templates/lazy_templates/ninja_den.dmm
@@ -532,9 +532,9 @@
 /area/centcom/central_command_areas/holding)
 "ni" = (
 /obj/structure/rack,
-/obj/item/nullrod/claymore/saber/red{
+/obj/item/melee/energy/sword/nullrod/red{
 	damtype = "stamina";
-	force = 30
+	active_force = 30
 	},
 /obj/item/nullrod/claymore/katana{
 	damtype = "stamina";
@@ -898,9 +898,9 @@
 /area/centcom/central_command_areas/holding)
 "vr" = (
 /obj/structure/rack,
-/obj/item/nullrod/claymore/saber{
+/obj/item/melee/energy/sword/nullrod{
 	damtype = "stamina";
-	force = 30;
+	active_force = 30;
 	pixel_x = 5;
 	pixel_y = -3
 	},

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -289,6 +289,8 @@ GLOBAL_LIST_INIT(chaplain_suit_allowed, list(
 	/obj/item/tank/internals/plasmaman,
 	/obj/item/gun/ballistic/bow/divine,
 	/obj/item/gun/ballistic/revolver/chaplain,
+	/obj/item/toy/plush/carpplushie/nullrod,
+	/obj/item/melee/energy/sword/nullrod,
 ))
 
 //Allowed list for all mining suits

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -519,3 +519,51 @@
 	playsound(src, 'sound/items/baton/telescopic_baton_folded_pickup.ogg', 40, TRUE)
 	COOLDOWN_START(src, jiggle_cooldown, 1 SECONDS)
 	return TRUE
+
+// Null rod variants
+
+/obj/item/melee/energy/sword/nullrod
+	name = "light energy sword"
+	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
+	throw_speed = 3
+	throw_range = 4
+	block_chance = 30
+	armour_penetration = 0
+	wound_bonus = -10
+	embed_type = /datum/embedding/holy_esword
+	sword_color_icon = "blue"
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+	active_force = 18
+	active_throwforce = 10
+	alt_force_mod = -3
+
+/obj/item/melee/energy/sword/nullrod/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/nullrod_core)
+
+/datum/embedding/holy_esword
+	embed_chance = 0
+
+/obj/item/melee/energy/sword/nullrod/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
+	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
+		return FALSE
+
+	if(attack_type == (PROJECTILE_ATTACK || LEAP_ATTACK || OVERWHELMING_ATTACK))
+		final_block_chance = 0 //Don't bring a sword to a gunfight, and also you aren't going to really block someone full body tackling you with a sword. Or a road roller, if one happened to hit you.
+
+	return ..()
+
+/obj/item/melee/energy/sword/nullrod/red
+	name = "dark energy sword"
+	desc = "Woefully ineffective when used on steep terrain."
+	sword_color_icon = "red"
+	light_color = COLOR_SOFT_RED
+
+/obj/item/melee/energy/sword/nullrod/pirate
+	name = "nautical energy cutlass"
+	desc = "Convincing HR that your religion involved piracy was no mean feat."
+	icon_state = "e_cutlass"
+	inhand_icon_state = "e_cutlass"
+	base_icon_state = "e_cutlass"
+	sword_color_icon = null
+	light_color = COLOR_RED

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -530,6 +530,7 @@
 	block_chance = 30
 	armour_penetration = 0
 	wound_bonus = -10
+	demolition_mod = 1
 	embed_type = /datum/embedding/holy_esword
 	sword_color_icon = "blue"
 	light_color = LIGHT_COLOR_LIGHT_CYAN

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -549,7 +549,7 @@
 	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
 		return FALSE
 
-	if(attack_type == (PROJECTILE_ATTACK || LEAP_ATTACK || OVERWHELMING_ATTACK))
+	if(attack_type == PROJECTILE_ATTACK || attack_type == LEAP_ATTACK || attack_type == OVERWHELMING_ATTACK)
 		final_block_chance = 0 //Don't bring a sword to a gunfight, and also you aren't going to really block someone full body tackling you with a sword. Or a road roller, if one happened to hit you.
 
 	return ..()

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -63,8 +63,12 @@
 /obj/item/fake_e_cutlass
 	name = "fake energy cutlass"
 	desc = "Damn, son, where'd you find this? (Tell a coder if you do)"
+	icon = 'icons/obj/weapons/transforming_energy.dmi'
 	icon_state = "e_cutlass_on"
 	inhand_icon_state = "e_cutlass_on"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	item_flag = ABSTRACT
 
 /datum/outfit/pirate/silverscale
 	name = "Silver Scale Member"

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -58,7 +58,13 @@
 
 /datum/outfit/pirate/space/captain/cardboard
 	name = "Space Pirate Captain (EVA)"
-	l_hand = /obj/item/nullrod/claymore/saber/pirate
+	l_hand = /obj/item/fake_e_cutlass
+
+/obj/item/fake_e_cutlass
+	name = "fake energy cutlass"
+	desc = "Damn, son, where'd you find this? (Tell a coder if you do)"
+	icon_state = "e_cutlass_on"
+	inhand_icon_state = "e_cutlass_on"
 
 /datum/outfit/pirate/silverscale
 	name = "Silver Scale Member"

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -68,7 +68,7 @@
 	inhand_icon_state = "e_cutlass_on"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	item_flag = ABSTRACT
+	item_flags = ABSTRACT
 
 /datum/outfit/pirate/silverscale
 	name = "Silver Scale Member"

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -20,6 +20,10 @@ GLOBAL_LIST_INIT(nullrod_variants, init_nullrod_variants())
 		The shard also causes you to become Morbid, shifting your interests towards the macabre."
 	rods[/obj/item/melee/skateboard/holyboard] = "A skateboard that grants you flight and anti-magic abilities while ridden. Fits in your bag."
 
+	for(var/obj/item/melee/energy/sword/nullrod/energy_nullrod_type as anything in typesof(/obj/item/melee/energy/sword/nullrod))
+		rods[energy_nullrod_type] = "An energy sword, but with a lower force, no armour penetration and a low chance of blocking. Can be switched on and off. \
+			Can be stored away easily while off, but impossible while on."
+
 	return rods
 
 /obj/item/nullrod
@@ -186,33 +190,6 @@ GLOBAL_LIST_INIT(nullrod_variants, init_nullrod_variants())
 /obj/item/nullrod/claymore/multiverse/pre_attack(atom/target, mob/living/user, list/modifiers, list/attack_modifiers)
 	SET_ATTACK_FORCE(attack_modifiers, rand(max(force - 15, 1), force + 15))
 	return ..()
-
-/obj/item/nullrod/claymore/saber
-	name = "light energy sword"
-	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
-	icon = 'icons/obj/weapons/transforming_energy.dmi'
-	icon_state = "e_sword_on_blue"
-	inhand_icon_state = "e_sword_on_blue"
-	worn_icon_state = "swordblue"
-	icon_angle = -45
-	slot_flags = ITEM_SLOT_BELT
-	hitsound = 'sound/items/weapons/blade1.ogg'
-	block_sound = 'sound/items/weapons/block_blade.ogg'
-	menu_description = "A sharp energy sword which provides a low chance of blocking incoming melee attacks. Can be worn on the belt."
-
-/obj/item/nullrod/claymore/saber/red
-	name = "dark energy sword"
-	desc = "Woefully ineffective when used on steep terrain."
-	icon_state = "e_sword_on_red"
-	inhand_icon_state = "e_sword_on_red"
-	worn_icon_state = "swordred"
-
-/obj/item/nullrod/claymore/saber/pirate
-	name = "nautical energy sword"
-	desc = "Convincing HR that your religion involved piracy was no mean feat."
-	icon_state = "e_cutlass_on"
-	inhand_icon_state = "e_cutlass_on"
-	worn_icon_state = "swordred"
 
 /// Vibro Variant
 /// This subtype possesses armor penetration and is sharp.


### PR DESCRIPTION

## About The Pull Request

The chaplain's energy swords were weird fake energy swords that couldn't be turned on or off. This is largely because, in the past, we couldn't easily convert other objects into null rods conveniently. Though we did get the transforming component, it never was added to the chaplain weapons. Maybe because there would be a lot of copypasted code.

Now, with the ``nullrod_core`` element, we can easily turn an object into a null rod. So I did that. It's now an energy sword AND a null rod. The future is now.

For clarity, the stats on the null rods are identical to before. The only difference being that it has the ability to switch on and off, and it now emits light. That's it really. If there are any extra stats I missed, let me know.

Also adds the carp'sie plushie to the list of wearable objects for chaplain suit storage. 

## Why It's Good For The Game

This has bugged me like, for a really, really long time. And we now have a lot of the bits and pieces to make more of the null rods actually closer to the objects they're ripping off.

## Changelog
:cl:
qol: The chaplain energy swords now work like energy swords. Turn them on and off! Light your way with the blade. Light a cigarette with your blade like a badass. Feel bad that it isn't a REAL energy sword.
fix: The carp'sie plushie now fits in chaplain suit storage.
/:cl:
