### PR TITLE
Gets rid of lie in contractor kit uplink purchase description

### DIFF
--- a/code/modules/antagonists/traitor/contractor/contractor_items.dm
+++ b/code/modules/antagonists/traitor/contractor/contractor_items.dm
@@ -11,23 +11,23 @@
 	name = "Contractor Guide"
 	default_raw_text = {"Welcome agent, congratulations on your new position as contractor. On top of your already assigned objectives,\
 		this kit will provide you contracts to take on for TC payments.\
-		<p>Provided within, we give your specialist contractor space suit. It's even more compact, being able to fit into a pocket, and faster than the\
-		Syndicate space suit available to you on the uplink. We also provide your chameleon jumpsuit and mask, both of which can be changed\
+		<p>Provided within, we give your specialist contractor space suit. It's even more compact, being able to fit into a pocket, and faster than the \
+		Syndicate space suit available to you on the uplink. We also provide your chameleon jumpsuit and mask, both of which can be changed \
 		to any form you need for the moment. The cigarettes are a special blend - it'll heal your injuries slowly overtime.</p>\
-		<p>Your standard issue contractor baton hits harder than the ones you might be used to, and likely be your go to weapon for kidnapping your\
-		targets. The three additional items have been randomly selected from what we had available. We hope they're useful to you for your mission.</p>\
-		<p>The contractor hub, available at the top right of the uplink, will provide you unique items and abilities. These are bought using Contractor Rep,\
+		<p>Your standard issue contractor baton hits harder than the ones you might be used to, and likely be your go to weapon for kidnapping your \
+		targets.</p>\
+		<p>The contractor hub, available at the top right of the uplink, will provide you unique items and abilities. These are bought using Contractor Rep, \
 		with two Rep being provided each time you complete a contract.</p>\
 		<h3>Using the tablet</h3>\
 		<ol>\
 			<li>Open the Syndicate Contract Uplink program.</li>\
 			<li>Here, you can accept a contract, and redeem your TC payments from completed contracts.</li>\
-			<li>The payment number shown in brackets is the bonus you'll receive when bringing your target <b>alive</b>. You receive the\
+			<li>The payment number shown in brackets is the bonus you'll receive when bringing your target <b>alive</b>. You receive the \
 			other number regardless of if they were alive or dead.</li>\
-			<li>Contracts are completed by bringing the target to designated dropoff, calling for extraction, and putting them\
+			<li>Contracts are completed by bringing the target to designated dropoff, calling for extraction, and putting them \
 			inside the pod.</li>\
 		</ol>\
-		<p>Be careful when accepting a contract. While you'll be able to see the location of the dropoff point, cancelling will make it\
+		<p>Be careful when accepting a contract. While you'll be able to see the location of the dropoff point, cancelling will make it \
 		unavailable to take on again.</p>\
 		<p>The tablet can also be recharged at any cell charger.</p>\
 		<h3>Extracting</h3>\
@@ -38,7 +38,7 @@
 			<li>Grab your target, and drag them into the pod.</li>\
 		</ol>\
 		<h3>Ransoms</h3>\
-		<p>We need your target for our own reasons, but we ransom them back to your mission area once their use is served. They will return back\
-		from where you sent them off from in several minutes time. Don't worry, we give you a cut of what we get paid. We pay this into whatever\
+		<p>We need your target for our own reasons, but we ransom them back to your mission area once their use is served. They will return back
+		from where you sent them off from in several minutes time. Don't worry, we give you a cut of what we get paid. We pay this into whatever \
 		ID card you have equipped, on top of the TC payment we give.</p>\
 		<p>Good luck agent. You can burn this document with the supplied lighter.</p>"}

--- a/code/modules/uplink/uplink_items/contractor.dm
+++ b/code/modules/uplink/uplink_items/contractor.dm
@@ -8,8 +8,7 @@
 		and cash payouts. Upon purchase, you'll be granted your own contract uplink embedded within the supplied \
 		tablet computer. Additionally, you'll be granted standard contractor gear to help with your mission - \
 		comes supplied with the tablet, specialised space suit, chameleon jumpsuit and mask, agent card, \
-		specialised contractor baton, and three randomly selected low cost items. \
-		Can include otherwise unobtainable items."
+		and a specialised contractor baton."
 	item = /obj/item/storage/box/syndicate/contract_kit
 	category = /datum/uplink_category/contractor
 	cost = 20


### PR DESCRIPTION
## About The Pull Request

It says there's three random items, but that isn't true anymore.
Also, some messed-up spacing.

## Why It's Good For The Game

The syndicate's evil and all, but lying might be a bit too much

## Changelog
:cl:

spellcheck: Removed lie about free stuff from contractor kit uplink description

/:cl:
