### PR TITLE
[NO GBP] Fixes dimensional anomalies duplicating airlocks

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -157,8 +157,8 @@
 			var/obj/machinery/door/airlock/airlock = object
 			var/obj/machinery/door/new_airlock = new_object
 			new_airlock.unres_sides = airlock.unres_sides
-			new_airlock.req_access = airlock.req_access.Copy()
-			new_airlock.req_one_access = airlock.req_one_access.Copy()
+			new_airlock.req_access = airlock.req_access?.Copy()
+			new_airlock.req_one_access = airlock.req_one_access?.Copy()
 			new_airlock.locked = airlock.locked
 			new_airlock.emergency = airlock.emergency
 			new_airlock.update_appearance()


### PR DESCRIPTION
## About The Pull Request
The code assumed that req_access and req_one_access weren't null. A mistake that led to runtime errors, preventing the old airlock from being deleted among other things.

## Why It's Good For The Game
This will fix https://github.com/tgstation/tgstation/issues/93355.

## Changelog

:cl:
fix: Fixed dimensional anomalies duplicating airlocks
/:cl:
