### PR TITLE
Fixes living food / creature hybrids not grabbing ghosts or storing brains.

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_bread.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_bread.dm
@@ -165,6 +165,10 @@
 		/datum/reagent/blood = 30,
 		/datum/reagent/teslium = 1 //To shock the whole thing into life
 	)
+	parts = list(
+		/obj/item/organ/brain,
+		/obj/item/organ/heart
+	)
 	result = /mob/living/basic/pet/dog/breaddog
 	category = CAT_BREAD
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -234,6 +234,10 @@
 		/datum/reagent/consumable/sprinkles = 5,
 		/datum/reagent/teslium = 1 //To shock the whole thing into life
 	)
+	parts = list(
+		/obj/item/organ/brain,
+		/obj/item/organ/heart
+	)
 	result = /mob/living/basic/pet/cat/cak
 	category = CAT_CAKE //Cat! Haha, get it? CAT? GET IT? We get it - Love Felines
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -170,6 +170,10 @@
 		/datum/reagent/blood = 50,
 		/datum/reagent/teslium = 1 //To shock the whole thing into life
 	)
+	parts = list(
+		/obj/item/organ/brain,
+		/obj/item/organ/heart
+	)
 	result = /mob/living/basic/bear/butter
 	category = CAT_MISCFOOD
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes a long standing issue where food creatures created with player brains did not work correctly, due to their code checking for the brain within their contents, where it was absent. 

It also stores the heart used in contents for consistency. 

## Why It's Good For The Game

It lets people enjoy playing as these wonderous creatures, and lets these strange beasts be revived when destroyed with proper veterinary or culinary intervention. 

## Changelog

:cl:
fix: food / animal hybrids like the butterbear and cak now once again correctly grab ghosts and store brains.
/:cl:

