### PR TITLE
remove buy powersink on lowpop

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -275,6 +275,7 @@
 	item = /obj/item/powersink
 	cost = 11
 	limited_stock = 1
+	population_minimum = TRAITOR_POPULATION_LOWPOP
 
 /datum/uplink_item/device_tools/syndicate_contacts
 	name = "Polarized Contact Lenses"


### PR DESCRIPTION
## About The Pull Request

you can't buy powersink on low pop from traitor uplink

## Why It's Good For The Game

it kills lowpop
protect lowpop

## Changelog

:cl: ArchBTW
del: remove buy powersink on lowpop
/:cl:
