### PR TITLE
Cuffsnapping doesn't spam runtimes in context

### DIFF
--- a/code/datums/elements/cuffsnapping.dm
+++ b/code/datums/elements/cuffsnapping.dm
@@ -51,13 +51,15 @@
 
 /datum/element/cuffsnapping/proc/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	SIGNAL_HANDLER
-	if(!iscarbon(target)) //Removing restraints takes precedence
+	if(!isliving(target)) //Removing restraints takes precedence
 		return NONE
-	var/mob/living/carbon/carbon_target = target
-	if(carbon_target.handcuffed)
-		context[SCREENTIP_CONTEXT_RMB] = "Cut Restraints"
-		return CONTEXTUAL_SCREENTIP_SET
-	if(carbon_target.has_status_effect(/datum/status_effect/cuffed_item))
+	var/mob/living/living_target = target
+	if(iscarbon(living_target))
+		var/mob/living/carbon/carbon_target = living_target
+		if(carbon_target.handcuffed)
+			context[SCREENTIP_CONTEXT_RMB] = "Cut Restraints"
+			return CONTEXTUAL_SCREENTIP_SET
+	if(living_target.has_status_effect(/datum/status_effect/cuffed_item))
 		context[SCREENTIP_CONTEXT_RMB] = "Remove Binds From Item"
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE

--- a/code/datums/elements/cuffsnapping.dm
+++ b/code/datums/elements/cuffsnapping.dm
@@ -49,16 +49,18 @@
 	UnregisterSignal(target, list(COMSIG_ITEM_ATTACK_SECONDARY, COMSIG_ATOM_EXAMINE, COMSIG_ITEM_REQUESTING_CONTEXT_FOR_TARGET))
 	return ..()
 
-/datum/element/cuffsnapping/proc/add_item_context(obj/item/source, list/context, mob/living/target, mob/living/user)
+/datum/element/cuffsnapping/proc/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	SIGNAL_HANDLER
-	if(iscarbon(target)) //Removing restraints takes precedence
-		var/mob/living/carbon/carbon_target = target
-		if(carbon_target.handcuffed)
-			context[SCREENTIP_CONTEXT_RMB] = "Cut Restraints"
-			return CONTEXTUAL_SCREENTIP_SET
-	if(target.has_status_effect(/datum/status_effect/cuffed_item))
+	if(!iscarbon(target)) //Removing restraints takes precedence
+		return NONE
+	var/mob/living/carbon/carbon_target = target
+	if(carbon_target.handcuffed)
+		context[SCREENTIP_CONTEXT_RMB] = "Cut Restraints"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(carbon_target.has_status_effect(/datum/status_effect/cuffed_item))
 		context[SCREENTIP_CONTEXT_RMB] = "Remove Binds From Item"
 		return CONTEXTUAL_SCREENTIP_SET
+	return NONE
 
 ///signal called on parent being examined
 /datum/element/cuffsnapping/proc/on_examine(datum/target, mob/user, list/examine_list)


### PR DESCRIPTION
## About The Pull Request

Asserts that target is a mob when target is definitely not always a mob

<img width="673" height="200" alt="image" src="https://github.com/user-attachments/assets/f47c2464-0eb1-4bdf-b39f-a35ec53fff2b" />

