### PR TITLE
Fix theoretical hard delete with redirect_attack_hand_from_turf component

### DIFF
--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -28,13 +28,20 @@
 	src.screentip_texts = screentip_texts
 	src.interact_check = interact_check
 
-	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	connect_to_new_turf()
+
+/datum/component/redirect_attack_hand_from_turf/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 
 /datum/component/redirect_attack_hand_from_turf/Destroy(force)
 	interact_check = null
 	disconnect_from_old_turf()
 	return ..()
+
+/datum/component/redirect_attack_hand_from_turf/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
 
 /datum/component/redirect_attack_hand_from_turf/proc/find_turf()
 	PRIVATE_PROC(TRUE)

--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -32,6 +32,7 @@
 	connect_to_new_turf()
 
 /datum/component/redirect_attack_hand_from_turf/Destroy(force)
+	interact_check = null
 	disconnect_from_old_turf()
 	return ..()
 
@@ -101,7 +102,7 @@
 	var/atom/movable/movable_parent = parent
 	if (!movable_parent.can_interact(user))
 		return NONE
-	
+
 	if (!isnull(interact_check) && !interact_check.Invoke(user))
 		return NONE
 
@@ -123,7 +124,7 @@
 
 	if (!isnull(held_item))
 		return NONE
-	
+
 	if (!isnull(interact_check) && !interact_check.Invoke(user))
 		return NONE
 


### PR DESCRIPTION

## About The Pull Request

- Nulls the ref to the interact callback in `/datum/component/redirect_attack_hand_from_turf/Destroy()`
- Move parent signal registration from `Initialize()` to `RegisterWithParent()`
- Add parent signal un-registration in `UnregisterFromParent()`

## Why It's Good For The Game

Moving signal registration was just a "while I'm here" type thing because it should go in those procs, the ref null is because it's causing flaky hard deletes [but only on a downstream](https://github.com/effigy-se/effigy/actions/runs/18415754211/attempts/1) for some reason, I have no idea why I haven't seen it here but it should be nulled regardless so

## Changelog

N/A
