### PR TITLE
adds a qdeleted check to ammo transfers from one box to another

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -187,7 +187,8 @@
 		for(var/obj/item/ammo_casing/casing in other_box.ammo_list())
 			var/did_load = give_round(casing, replace_spent)
 			if(did_load)
-				other_box.stored_ammo -= casing
+				if(!QDELETED(other_box))
+					other_box.stored_ammo -= casing
 				num_loaded++
 			// failed to load (full already? ran out of ammo?)
 			if(!did_load)


### PR DESCRIPTION
## About The Pull Request

Makes it so that, when reloading an ammo box from another ammo box, if the other ammo box is marked for deletion, it doesn't try removing ammo casings from its `stored_ammo` variable.

This... shouldn't be particularly applicable to anything, since I don't think any magazines as of now delete themselves when emptied, but you never know.

(I was asked to move this up from https://github.com/NovaSector/NovaSector/pull/6155. For what it's worth, it works for the ammo handful case downstream...)

<details><summary>Okay but why</summary>

Downstream has ammo handfuls (implemented as a magazine subtype,`/obj/item/ammo_box/magazine/ammo_stack`) which are coded to delete themselves when emptied.

Unfortunately, when they're deleting themselves when emptied during reloading another magazine (e.g. loading the last shell in a handful into an ammo box), they runtime, as they're trying to remove from a list that's in a deleted object.
<img width="582" height="136" alt="image" src="https://github.com/user-attachments/assets/8c09fbda-c4de-4255-bca5-b06504924bd4" />

The QDELETED() check here prevents us from trying to remove the moved casing from the relevant ammo handful (which at that point in time has been deleted), preventing the runtime.
</details>

## Why It's Good For The Game

Runtime prevention in case something's been deleted.

## Changelog

Nothing player-facing.
