### PR TITLE
Fixes 2 order console bugs

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -98,7 +98,7 @@
 	var/cost = pack.get_cost()
 	if(applied_coupon) //apply discount price
 		cost *= (1 - applied_coupon.discount_pct_off)
-	if(paying_account && !pack.goody) //privately purchased and not a goody means 1.1x the cost
+	if(paying_account?.add_to_accounts && !pack.goody) //privately purchased and not a goody means 1.1x the cost
 		cost *= 1.1
 	return round(cost)
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -124,8 +124,8 @@
 			"id" = order.id,
 			"amount" = 1,
 			"orderer" = order.orderer,
-			"paid" = order.paying_account?.add_to_accounts ? TRUE : FALSE, //number of orders purchased privatly
-			"dep_order" = order.department_destination ? TRUE : FALSE, //number of orders purchased by a department
+			"paid" = !!order.paying_account?.add_to_accounts, //number of orders purchased privatly
+			"dep_order" = !!order.department_destination, //number of orders purchased by a department
 			"can_be_cancelled" = order.can_be_cancelled,
 		))
 	data["cart"] = list()

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -124,8 +124,8 @@
 			"id" = order.id,
 			"amount" = 1,
 			"orderer" = order.orderer,
-			"paid" = order.paying_account?.add_to_accounts ? 1 : 0, //number of orders purchased privatly
-			"dep_order" = order.department_destination ? 1 : 0, //number of orders purchased by a department
+			"paid" = order.paying_account?.add_to_accounts ? TRUE : FALSE, //number of orders purchased privatly
+			"dep_order" = order.department_destination ? TRUE : FALSE, //number of orders purchased by a department
 			"can_be_cancelled" = order.can_be_cancelled,
 		))
 	data["cart"] = list()

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -103,11 +103,9 @@
 		message = blockade_warning
 	data["message"] = message
 
-	var/list/amount_by_name = list()
 	var/cart_list = list()
 	for(var/datum/supply_order/order in SSshuttle.shopping_list)
 		if(cart_list[order.pack.name])
-			amount_by_name[order.pack.name] += 1
 			cart_list[order.pack.name][1]["amount"]++
 			cart_list[order.pack.name][1]["cost"] += order.get_final_cost()
 			if(order.department_destination)
@@ -116,7 +114,6 @@
 				cart_list[order.pack.name][1]["paid"]++
 			continue
 
-		amount_by_name[order.pack.name] += 1
 		cart_list[order.pack.name] = list(list(
 			"cost_type" = order.cost_type,
 			"object" = order.pack.name,
@@ -136,7 +133,6 @@
 	data["requests"] = list()
 	for(var/datum/supply_order/order in SSshuttle.request_list)
 		var/datum/supply_pack/pack = order.pack
-		amount_by_name[pack.name] += 1
 		data["requests"] += list(list(
 			"object" = pack.name,
 			"cost" = pack.get_cost(),
@@ -145,7 +141,6 @@
 			"id" = order.id,
 			"account" = order.paying_account ? order.paying_account.account_holder : "Cargo Department"
 		))
-	data["amount_by_name"] = amount_by_name
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCart.tsx
@@ -57,7 +57,7 @@ export function CargoCart(props) {
 
 function CheckoutItems(props) {
   const { act, data } = useBackend<CargoData>();
-  const { amount_by_name = {}, can_send, cart = [], max_order } = data;
+  const { can_send, cart = [], max_order } = data;
 
   const [isValid, setIsValid] = useState(true);
 
@@ -107,7 +107,7 @@ function CheckoutItems(props) {
                 />
                 <Button
                   icon="plus"
-                  disabled={amount_by_name[entry.object] >= max_order}
+                  disabled={entry.amount >= max_order}
                   onClick={() =>
                     act('add_by_name', { order_name: entry.object })
                   }
@@ -119,8 +119,8 @@ function CheckoutItems(props) {
           </Table.Cell>
 
           <Table.Cell collapsing color="average">
-            {!!entry.paid && <b>[Private x {entry.paid}]</b>}
-            {!!entry.dep_order && <b>[Department x {entry.dep_order}]</b>}
+            {!!entry.paid && <b>[Private x {entry.amount}]</b>}
+            {!!entry.dep_order && <b>[Department x {entry.amount}]</b>}
           </Table.Cell>
 
           <Table.Cell collapsing color="gold" textAlign="right">

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -181,7 +181,7 @@ type CatalogListProps = {
 
 function CatalogList(props: CatalogListProps) {
   const { act, data } = useBackend<CargoData>();
-  const { amount_by_name = {}, max_order, self_paid, app_cost } = data;
+  const { cart = [], max_order, self_paid, app_cost } = data;
   const { packs = [], openContents } = props;
 
   return (
@@ -206,6 +206,14 @@ function CatalogList(props: CatalogListProps) {
           </Stack.Item>
         );
 
+        let amount = 0;
+        if (cart) {
+          const entry = cart.find((entry) => entry.object === pack.name);
+          if (entry) {
+            amount = entry.amount;
+          }
+        }
+
         return (
           <ImageButton
             key={pack.id}
@@ -214,7 +222,7 @@ function CatalogList(props: CatalogListProps) {
             dmIconState={pack.first_item_icon_state}
             imageSize={32}
             color={color}
-            disabled={(amount_by_name[pack.name] || 0) >= max_order}
+            disabled={amount >= max_order}
             buttonsAlt={
               <Button
                 color="transparent"

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -1,7 +1,6 @@
 import type { BooleanLike } from 'tgui-core/react';
 
 export type CargoData = {
-  amount_by_name: Record<string, number> | undefined;
   app_cost?: number;
   away: BooleanLike;
   can_approve_requests: BooleanLike;


### PR DESCRIPTION
## About The Pull Request
- Fixes #93416
- Order console displays correct Private/Department order text amounts

## Changelog
:cl:
fix: order console correctly differentiates between private & department orders
fix: order console checkout cart displays correct Private/Department order text amounts
/:cl:

