### PR TITLE
Mech Equipment Action Buttons

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -429,7 +429,7 @@
 	if(!(occupant in occupants) || !(occupants[occupant] & VEHICLE_CONTROL_SETTINGS))
 		return
 	for(var/obj/item/mecha_parts/mecha_equipment/equipment in flat_equipment)
-		if(!is_equipment_eligible_for_action(equipment))
+		if(!is_equipment_valid_for_action(equipment))
 			continue
 
 		grant_equipment_action(occupant, equipment)
@@ -462,13 +462,15 @@
 
 /**
  * Called when equipment is attached to the mecha.
- * Grants equipment actions to all current occupants.
+ * Grants equipment actions to current occupants with VEHICLE_CONTROL_SETTINGS flag.
  */
 /obj/vehicle/sealed/mecha/proc/on_equipment_attach(obj/item/mecha_parts/mecha_equipment/equipment)
-	if(!is_equipment_eligible_for_action(equipment))
+	if(!is_equipment_valid_for_action(equipment))
 		return
 
 	for(var/mob/occupant in occupants)
+		if(!(occupants[occupant] & VEHICLE_CONTROL_SETTINGS))
+			continue
 		grant_equipment_action(occupant, equipment)
 
 /**
@@ -480,7 +482,7 @@
 		remove_action_type_from_mob(equipment.type, occupant)
 
 /// Create actions only for equipment that can be toggled or triggered, excluding air tanks.
-/obj/vehicle/sealed/mecha/proc/is_equipment_eligible_for_action(obj/item/mecha_parts/mecha_equipment/equipment)
+/obj/vehicle/sealed/mecha/proc/is_equipment_valid_for_action(obj/item/mecha_parts/mecha_equipment/equipment)
 	if(!(equipment.can_be_toggled || equipment.can_be_triggered))
 		return FALSE
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -451,14 +451,9 @@
  * Creates a new action, sets up the chassis and equipment references, and grants it to the mob.
  */
 /obj/vehicle/sealed/mecha/proc/grant_equipment_action(mob/occupant, obj/item/mecha_parts/mecha_equipment/equipment)
-	/**
- 	* We cannot use grant_action_type_to_mob() because:
- 	* 1. grant_action_type_to_mob() works with a single predefined action type
- 	* 2. We create unique action instances for each equipment with specific equipment references
- 	*/
-	var/datum/action/vehicle/sealed/mecha/equipment/action = new
-	action.set_chassis(src)
-	action.set_equipment(equipment)
+	var/datum/action/vehicle/sealed/mecha/equipment/action = new  // We cannot use grant_action_type_to_mob() because:
+	action.set_chassis(src) 									  // 1. grant_action_type_to_mob() works with a single predefined action type
+	action.set_equipment(equipment) 							 // 2. We create unique action instances for each equipment with specific equipment references
 
 	action.Grant(occupant)
 	LAZYINITLIST(occupant_actions[occupant])

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -416,6 +416,84 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/mech_view_stats, VEHICLE_CONTROL_SETTINGS)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/strafe, VEHICLE_CONTROL_DRIVE)
 
+/obj/vehicle/sealed/mecha/add_occupant(mob/M, control_flags, forced)
+	if(..())
+		generate_equipment_actions(M)
+
+/obj/vehicle/sealed/mecha/remove_occupant(mob/M)
+	remove_all_equipment_actions(M)
+	return ..()
+
+///Generates action buttons for all eligible equipment and grants them to the occupant with VEHICLE_CONTROL_SETTINGS flag.
+/obj/vehicle/sealed/mecha/proc/generate_equipment_actions(mob/occupant)
+	if(!(occupant in occupants) || !(occupants[occupant] & VEHICLE_CONTROL_SETTINGS))
+		return
+	for(var/obj/item/mecha_parts/mecha_equipment/equipment in flat_equipment)
+		if(!is_equipment_eligible_for_action(equipment))
+			continue
+
+		grant_equipment_action(occupant, equipment)
+
+///Removes all equipment actions from a specific occupant.
+/obj/vehicle/sealed/mecha/proc/remove_all_equipment_actions(mob/occupant)
+	var/list/actions = LAZYACCESS(occupant_actions, occupant)
+	if(!actions)
+		return
+
+	for(var/equipment_type in actions)
+		if(!ispath(equipment_type, /obj/item/mecha_parts/mecha_equipment))
+			continue
+
+		remove_action_type_from_mob(equipment_type, occupant)
+
+/**
+ * Grants a specific equipment action to an occupant.
+ * Creates a new action, sets up the chassis and equipment references, and grants it to the mob.
+ */
+/obj/vehicle/sealed/mecha/proc/grant_equipment_action(mob/occupant, obj/item/mecha_parts/mecha_equipment/equipment)
+	/**
+ 	* We cannot use grant_action_type_to_mob() because:
+ 	* 1. grant_action_type_to_mob() works with a single predefined action type
+ 	* 2. We create unique action instances for each equipment with specific equipment references
+ 	*/
+	var/datum/action/vehicle/sealed/mecha/equipment/action = new
+	action.set_chassis(src)
+	action.set_equipment(equipment)
+
+	action.Grant(occupant)
+	LAZYINITLIST(occupant_actions[occupant])
+	// Use equipment type as actiontype for remove_action_type_from_mob() compatibility
+	occupant_actions[occupant][equipment.type] = action
+
+/**
+ * Called when equipment is attached to the mecha.
+ * Grants equipment actions to all current occupants.
+ */
+/obj/vehicle/sealed/mecha/proc/on_equipment_attach(obj/item/mecha_parts/mecha_equipment/equipment)
+	if(!is_equipment_eligible_for_action(equipment))
+		return
+
+	for(var/mob/occupant in occupants)
+		grant_equipment_action(occupant, equipment)
+
+/**
+ * Called when equipment is detached from the mecha.
+ * Removes equipment actions from all current occupants.
+ */
+/obj/vehicle/sealed/mecha/proc/on_equipment_detach(obj/item/mecha_parts/mecha_equipment/equipment)
+	for(var/mob/occupant in occupants)
+		remove_action_type_from_mob(equipment.type, occupant)
+
+/// Create actions only for equipment that can be toggled or triggered, excluding air tanks.
+/obj/vehicle/sealed/mecha/proc/is_equipment_eligible_for_action(obj/item/mecha_parts/mecha_equipment/equipment)
+	if(!(equipment.can_be_toggled || equipment.can_be_triggered))
+		return FALSE
+
+	if(istype(equipment, /obj/item/mecha_parts/mecha_equipment/air_tank)) // this thing has its own button
+		return FALSE
+
+	return TRUE
+
 /obj/vehicle/sealed/mecha/proc/get_mecha_occupancy_state()
 	if((mecha_flags & SILICON_PILOT) && silicon_icon_state)
 		return silicon_icon_state

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -214,6 +214,7 @@
 	SEND_SIGNAL(src, COMSIG_MECHA_EQUIPMENT_ATTACHED)
 	forceMove(new_mecha)
 	log_message("[src] initialized.", LOG_MECHA)
+	chassis.on_equipment_attach(src)
 
 /**
  * called to detach this equipment
@@ -221,6 +222,7 @@
  * * moveto: optional target to move this equipment to
  */
 /obj/item/mecha_parts/mecha_equipment/proc/detach(atom/moveto)
+	chassis.on_equipment_detach(src)
 	moveto = moveto || get_turf(chassis)
 	forceMove(moveto)
 	playsound(chassis, 'sound/items/weapons/tap.ogg', 50, TRUE)

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -144,10 +144,14 @@
 		chassis.balloon_alert(owner, "controlling gunner seat")
 		chassis.remove_control_flags(owner, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 		chassis.add_control_flags(owner, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT)
+		chassis.remove_all_equipment_actions(owner)
+		chassis.generate_equipment_actions(owner)
 	else
 		chassis.balloon_alert(owner, "controlling pilot seat")
 		chassis.remove_control_flags(owner, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT)
 		chassis.add_control_flags(owner, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
+		chassis.remove_all_equipment_actions(owner)
+		chassis.generate_equipment_actions(owner)
 	chassis.update_icon_state()
 
 /datum/action/vehicle/sealed/mecha/mech_overclock
@@ -162,3 +166,33 @@
 	chassis.toggle_overclock(forced_state)
 	button_icon_state = "mech_overload_[chassis.overclock_mode ? "on" : "off"]"
 	build_all_button_icons()
+
+/datum/action/vehicle/sealed/mecha/equipment
+	name = "Mech Equipment"
+	button_icon_state = null
+	background_icon_state = "bg_tech"
+	var/obj/item/mecha_parts/mecha_equipment/equipment
+
+/datum/action/vehicle/sealed/mecha/equipment/Destroy()
+	equipment = null
+	return ..()
+
+/datum/action/vehicle/sealed/mecha/equipment/Trigger(mob/clicker, trigger_flags)
+	if(!..())
+		return
+	if(!chassis || !(owner in chassis.occupants) || !equipment)
+		return
+
+	equipment.set_active(!equipment.active)
+	equipment.handle_ui_act(action = "toggle")
+	chassis.balloon_alert(owner, "[equipment.name] [equipment.active ? "on" : "off"]!")
+
+/datum/action/vehicle/sealed/mecha/equipment/proc/set_equipment(passed_equipment)
+	equipment = passed_equipment
+	name = "Toggle [equipment.name]"
+	desc = equipment.desc
+	target = equipment
+	if(target)
+		AddComponent(/datum/component/action_item_overlay, equipment)
+
+	build_button_icon()

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -145,12 +145,10 @@
 		chassis.remove_control_flags(owner, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
 		chassis.add_control_flags(owner, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT)
 		chassis.remove_all_equipment_actions(owner)
-		chassis.generate_equipment_actions(owner)
 	else
 		chassis.balloon_alert(owner, "controlling pilot seat")
 		chassis.remove_control_flags(owner, VEHICLE_CONTROL_MELEE|VEHICLE_CONTROL_EQUIPMENT)
 		chassis.add_control_flags(owner, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_SETTINGS)
-		chassis.remove_all_equipment_actions(owner)
 		chassis.generate_equipment_actions(owner)
 	chassis.update_icon_state()
 


### PR DESCRIPTION
## About The Pull Request
Adds action buttons for toggling mech equipment without opening the UI

<img width="971" height="140" alt="butt" src="https://github.com/user-attachments/assets/be2b38ba-6526-4271-9b54-d946ee6fa7e3" />

## Why It's Good For The Game
Quick equipment access
Less UI navigation needed

## Changelog
:cl:
qol:  Added action buttons for toggling mech equipment
/:cl:
