### PR TITLE
Changes cat tail define from FEATURE_TAIL to FEATURE_TAIL_CAT so it matches the rest

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -57,7 +57,7 @@
 #define FEATURE_MUTANT_COLOR "mcolor"
 #define FEATURE_ETHEREAL_COLOR "ethcolor"
 #define FEATURE_EARS "ears"
-#define FEATURE_TAIL "tail_cat"
+#define FEATURE_TAIL_CAT "tail_cat"
 #define FEATURE_TAIL_LIZARD "tail_lizard"
 #define FEATURE_TAIL_FISH "fish_tail"
 #define FEATURE_SNOUT "snout"

--- a/code/datums/dna/blocks/dna_features_block.dm
+++ b/code/datums/dna/blocks/dna_features_block.dm
@@ -30,7 +30,7 @@
 // One day, someone should consider merging all tails into one, this is stupid
 // No I don't care that it will "Create situations where a felinid grows a lizard tail" that makes it more fun
 /datum/dna_block/feature/tail
-	feature_key = FEATURE_TAIL
+	feature_key = FEATURE_TAIL_CAT
 
 /datum/dna_block/feature/tail/create_unique_block(mob/living/carbon/human/target)
 	return construct_block(SSaccessories.tails_list_felinid.Find(target.dna.features[feature_key]), length(SSaccessories.tails_list_felinid))

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -231,9 +231,8 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				log_admin("[key_name(holder)] turned all humans into [result]")
 				message_admins("\blue [key_name_admin(holder)] turned all humans into [result]")
 				var/newtype = GLOB.species_list[result]
-				for(var/i in GLOB.human_list)
-					var/mob/living/carbon/human/H = i
-					H.set_species(newtype)
+				for(var/mob/living/carbon/human/human_mob as anything in GLOB.human_list)
+					human_mob.set_species(newtype)
 		if("power")
 			if(!is_funmin)
 				return
@@ -518,9 +517,8 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Monkeyize All Humans"))
 			message_admins("[key_name_admin(holder)] made everyone into monkeys.")
 			log_admin("[key_name_admin(holder)] made everyone into monkeys.")
-			for(var/i in GLOB.human_list)
-				var/mob/living/carbon/human/H = i
-				INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon, monkeyize))
+			for(var/mob/living/carbon/human/human_mob as anything in GLOB.human_list)
+				INVOKE_ASYNC(human_mob, TYPE_PROC_REF(/mob/living/carbon, monkeyize))
 		if("antag_all")
 			if(!is_funmin)
 				return
@@ -554,9 +552,9 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			if(!is_funmin)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Mass Braindamage"))
-			for(var/mob/living/carbon/human/H in GLOB.player_list)
-				to_chat(H, span_bolddanger("You suddenly feel stupid."), confidential = TRUE)
-				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 60, 80)
+			for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
+				to_chat(human_mob, span_bolddanger("You suddenly feel stupid."), confidential = TRUE)
+				human_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 60, 80)
 			message_admins("[key_name_admin(holder)] made everybody brain damaged")
 		if("floorlava")
 			SSweather.run_weather(/datum/weather/floor_is_lava)
@@ -573,33 +571,32 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Chinese Cartoons"))
 			message_admins("[key_name_admin(holder)] made everything kawaii.")
-			for(var/i in GLOB.human_list)
-				var/mob/living/carbon/human/H = i
-				SEND_SOUND(H, sound(SSstation.announcer.event_sounds[ANNOUNCER_ANIMES]))
+			for(var/mob/living/carbon/human/human_mob as anything in GLOB.human_list)
+				SEND_SOUND(human_mob, sound(SSstation.announcer.event_sounds[ANNOUNCER_ANIMES]))
 
-				if(H.dna.species.id == SPECIES_HUMAN)
-					if(H.dna.features[FEATURE_TAIL_CAT] == "None" || H.dna.features[FEATURE_EARS] == "None")
+				if(human_mob.dna.species.id == SPECIES_HUMAN)
+					if(human_mob.dna.features[FEATURE_TAIL_CAT] == "None" || human_mob.dna.features[FEATURE_EARS] == "None")
 						var/obj/item/organ/ears/cat/ears = new
 						var/obj/item/organ/tail/cat/tail = new
-						ears.Insert(H, movement_flags = DELETE_IF_REPLACED)
-						tail.Insert(H, movement_flags = DELETE_IF_REPLACED)
+						ears.Insert(human_mob, movement_flags = DELETE_IF_REPLACED)
+						tail.Insert(human_mob, movement_flags = DELETE_IF_REPLACED)
 					var/list/honorifics = list("[MALE]" = list("kun"), "[FEMALE]" = list("chan","tan"), "[NEUTER]" = list("san"), "[PLURAL]" = list("san")) //John Robust -> Robust-kun
-					var/list/names = splittext(H.real_name," ")
+					var/list/names = splittext(human_mob.real_name," ")
 					var/forename = names.len > 1 ? names[2] : names[1]
-					var/newname = "[forename]-[pick(honorifics["[H.gender]"])]"
-					H.fully_replace_character_name(H.real_name,newname)
-					H.update_body_parts()
+					var/newname = "[forename]-[pick(honorifics["[human_mob.gender]"])]"
+					human_mob.fully_replace_character_name(human_mob.real_name,newname)
+					human_mob.update_body_parts()
 					if(animetype == "Yes")
 						var/seifuku = pick(typesof(/obj/item/clothing/under/costume/seifuku))
-						var/obj/item/clothing/under/costume/seifuku/I = new seifuku
-						var/olduniform = H.w_uniform
-						H.temporarilyRemoveItemFromInventory(H.w_uniform, TRUE, FALSE)
-						H.equip_to_slot_or_del(I, ITEM_SLOT_ICLOTHING)
+						var/obj/item/clothing/under/costume/seifuku/anime_uniform = new seifuku
+						var/olduniform = human_mob.w_uniform
+						human_mob.temporarilyRemoveItemFromInventory(human_mob.w_uniform, TRUE, FALSE)
+						human_mob.equip_to_slot_or_del(anime_uniform, ITEM_SLOT_ICLOTHING)
 						qdel(olduniform)
 						if(droptype == "Yes")
-							ADD_TRAIT(I, TRAIT_NODROP, ADMIN_TRAIT)
+							ADD_TRAIT(anime_uniform, TRAIT_NODROP, ADMIN_TRAIT)
 				else
-					to_chat(H, span_warning("You're not kawaii enough for this!"), confidential = TRUE)
+					to_chat(human_mob, span_warning("You're not kawaii enough for this!"), confidential = TRUE)
 		if("masspurrbation")
 			if(!is_funmin)
 				return
@@ -709,16 +706,16 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 /// portal_appearance is a list in the form (turf's plane offset + 1) -> appearance to use
 /proc/do_portal_spawn(turf/loc, mobtype, numtospawn, list/portal_appearance, players, humanoutfit)
 	for (var/i in 1 to numtospawn)
-		var/mob/spawnedMob = new mobtype(loc)
+		var/mob/spawned_mob = new mobtype(loc)
 		if (length(players))
 			var/mob/chosen = players[1]
 			if (chosen.client)
-				chosen.client.prefs.safe_transfer_prefs_to(spawnedMob, is_antag = TRUE)
-				spawnedMob.PossessByPlayer(chosen.key)
+				chosen.client.prefs.safe_transfer_prefs_to(spawned_mob, is_antag = TRUE)
+				spawned_mob.PossessByPlayer(chosen.key)
 			players -= chosen
-		if (ishuman(spawnedMob) && ispath(humanoutfit, /datum/outfit))
-			var/mob/living/carbon/human/H = spawnedMob
-			H.equipOutfit(humanoutfit)
+		if (ishuman(spawned_mob) && ispath(humanoutfit, /datum/outfit))
+			var/mob/living/carbon/human/human_mob = spawned_mob
+			human_mob.equipOutfit(humanoutfit)
 	var/turf/T = get_step(loc, SOUTHWEST)
 	T.flick_overlay_static(portal_appearance[GET_TURF_PLANE_OFFSET(T) + 1], 15)
 	playsound(T, 'sound/effects/magic/lightningbolt.ogg', rand(80, 100), TRUE)

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -578,7 +578,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				SEND_SOUND(H, sound(SSstation.announcer.event_sounds[ANNOUNCER_ANIMES]))
 
 				if(H.dna.species.id == SPECIES_HUMAN)
-					if(H.dna.features[FEATURE_TAIL] == "None" || H.dna.features[FEATURE_EARS] == "None")
+					if(H.dna.features[FEATURE_TAIL_CAT] == "None" || H.dna.features[FEATURE_EARS] == "None")
 						var/obj/item/organ/ears/cat/ears = new
 						var/obj/item/organ/tail/cat/tail = new
 						ears.Insert(H, movement_flags = DELETE_IF_REPLACED)

--- a/code/modules/client/preferences/species_features/felinid.dm
+++ b/code/modules/client/preferences/species_features/felinid.dm
@@ -9,7 +9,7 @@
 	return assoc_to_keys_features(SSaccessories.tails_list_felinid)
 
 /datum/preference/choiced/tail_felinid/apply_to_human(mob/living/carbon/human/target, value)
-	target.dna.features[FEATURE_TAIL] = value
+	target.dna.features[FEATURE_TAIL_CAT] = value
 
 /datum/preference/choiced/tail_felinid/create_default_value()
 	var/datum/sprite_accessory/tails/felinid/cat/tail = /datum/sprite_accessory/tails/felinid/cat

--- a/code/modules/mining/lavaland/mining_loot/megafauna/ash_drake.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/ash_drake.dm
@@ -173,7 +173,7 @@
 			consumer.dna.features = list(
 				FEATURE_MUTANT_COLOR = "#A02720",
 				FEATURE_TAIL_LIZARD = "Dark Tiger",
-				FEATURE_TAIL = "None",
+				FEATURE_TAIL_CAT = "None",
 				FEATURE_SNOUT = "Sharp",
 				FEATURE_HORNS = "Curled",
 				FEATURE_EARS = "None",

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -121,7 +121,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	target.dna.features[FEATURE_MOTH_WINGS] = get_consistent_feature_entry(SSaccessories.moth_wings_list)
 	target.dna.features[FEATURE_SNOUT] = get_consistent_feature_entry(SSaccessories.snouts_list)
 	target.dna.features[FEATURE_SPINES] = get_consistent_feature_entry(SSaccessories.spines_list)
-	target.dna.features[FEATURE_TAIL] = get_consistent_feature_entry(SSaccessories.tails_list_felinid) // it's a lie
+	target.dna.features[FEATURE_TAIL_CAT] = get_consistent_feature_entry(SSaccessories.tails_list_felinid) // it's a lie
 	target.dna.features[FEATURE_TAIL_LIZARD] = get_consistent_feature_entry(SSaccessories.tails_list_lizard)
 	target.dna.features[FEATURE_TAIL_MONKEY] = get_consistent_feature_entry(SSaccessories.tails_list_monkey)
 	target.dna.features[FEATURE_TAIL_FISH] = get_consistent_feature_entry(SSaccessories.tails_list_fish)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -26,8 +26,8 @@
 
 /datum/species/human/felinid/on_species_gain(mob/living/carbon/human/human_who_gained_species, datum/species/old_species, pref_load, regenerate_icons = TRUE, replace_missing = TRUE)
 	if(!pref_load) //Hah! They got forcefully purrbation'd. Force default felinid parts on them if they have no mutant parts in those areas!
-		if(human_who_gained_species.dna.features[FEATURE_TAIL] == SPRITE_ACCESSORY_NONE)
-			human_who_gained_species.dna.features[FEATURE_TAIL] = get_consistent_feature_entry(SSaccessories.tails_list_felinid)
+		if(human_who_gained_species.dna.features[FEATURE_TAIL_CAT] == SPRITE_ACCESSORY_NONE)
+			human_who_gained_species.dna.features[FEATURE_TAIL_CAT] = get_consistent_feature_entry(SSaccessories.tails_list_felinid)
 		if(human_who_gained_species.dna.features[FEATURE_EARS] == SPRITE_ACCESSORY_NONE)
 			human_who_gained_species.dna.features[FEATURE_EARS] = get_consistent_feature_entry(SSaccessories.ears_list)
 

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -163,7 +163,7 @@
 
 ///Cat tail bodypart overlay
 /datum/bodypart_overlay/mutant/tail/cat
-	feature_key = FEATURE_TAIL
+	feature_key = FEATURE_TAIL_CAT
 	color_source = ORGAN_COLOR_HAIR
 
 /datum/bodypart_overlay/mutant/tail/cat/get_global_feature_list()


### PR DESCRIPTION
## About The Pull Request

Just a simple find + replace PR. All the other tail defines match their text strings, but for some reason cat tails are just `FEATURE_TAIL` which is inconsistent.

## Why It's Good For The Game

Consistency, + a lot of downstreams have a generic "tail" feature key which is distinct from cat tails, so not taking up that define is better.

## Changelog

Nothing any players would notice