### PR TITLE
Non-admin spawned atlas gravitronic spinal implants now use their intentional(?) sprite

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -335,6 +335,7 @@
 	added_throw_speed = /obj/item/organ/cyberimp/chest/spine/atlas::added_throw_speed
 	strength_bonus = /obj/item/organ/cyberimp/chest/spine/atlas::strength_bonus
 	core_applied = TRUE
+	icon_state = "herculean_implant_core"
 	update_appearance()
 	qdel(tool)
 	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION
## About The Pull Request

so apparently there are two sprites for herculean gravitronics, one with the core in and one without, but the code for adding a core to the gravitronic doesn't actually change the sprite so it's unused unless an admin spawns in an atlas with a core already in it which in that case it'll have the sprite.

This single line of code makes the sprite change when a new core is put in.

yes I tested it no it's not a web edit

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: Atlas gravitronic spinal implants now use their intended sprite
/:cl: