### PR TITLE
ghost basic mobs use natural hair colors

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/ghost.dm
+++ b/code/modules/mob/living/basic/space_fauna/ghost.dm
@@ -65,7 +65,7 @@
 /mob/living/basic/ghost/proc/give_identity()
 	if(random_identity)
 		ghost_hairstyle = random_hairstyle() //This only gives us the hairstyle name, not the icon_state (which we need).
-		ghost_hair_color = "#[random_color()]"
+		ghost_hair_color = random_hair_color()
 
 		if(prob(50)) //Only a chance at also getting facial hair
 			ghost_facial_hairstyle = random_facial_hairstyle()


### PR DESCRIPTION
## About The Pull Request
<img width="1142" height="956" alt="image" src="https://github.com/user-attachments/assets/6395e71d-cecd-42f1-a0b7-ebf322a3cb65" />

## Why It's Good For The Game
I have no whimsy and am repulsed by the funny colors (standardization for how the rest of human hair color selections is done.)
## Changelog
:cl:
fix: ghost basic mobs use natural hair colors
/:cl:
