### PR TITLE
Moves computer frame's anchored check to frame finalization

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -106,9 +106,6 @@
 	if(state != FRAME_COMPUTER_STATE_EMPTY)
 		balloon_alert(user, "circuit already installed!")
 		return FALSE
-	if(!anchored && istype(board))
-		balloon_alert(user, "frame must be anchored!")
-		return FALSE
 	. = ..()
 	if(. && !by_hand) // Installing via RPED auto-secures it
 		state = FRAME_COMPUTER_STATE_BOARD_SECURED
@@ -194,8 +191,6 @@
 		if(FRAME_COMPUTER_STATE_GLASSED)
 			if(finalize_construction(user, tool))
 				return ITEM_INTERACT_SUCCESS
-
-			balloon_alert(user, "missing components!")
 			return ITEM_INTERACT_BLOCKING
 
 /obj/structure/frame/computer/crowbar_act(mob/living/user, obj/item/tool)
@@ -295,6 +290,10 @@
 	return TRUE
 
 /obj/structure/frame/computer/finalize_construction(mob/living/user, obj/item/tool)
+	if(!anchored)
+		balloon_alert(user, "frame must be anchored!")
+		return FALSE
+
 	tool.play_tool_sound(src)
 	var/obj/machinery/new_machine = new circuit.build_path(loc)
 	new_machine.balloon_alert(user, "monitor connected")


### PR DESCRIPTION
## About The Pull Request

- Moves the anchored check to when construction is being finalized
- Removes unnecessary "missing components" balloon alert when failing finalization

## Why It's Good For The Game

Fixes a bug where you could have unanchored functional PCs which can be pretty powerful depending on the PC. It's fun so I hate it and it needs to die instantly.

## Changelog

:cl:
fix: moves the computer frame's anchor requirement from circuit step to finalization step, fixing an issue where you could construct unanchored and FUNCTIONAL computers
qol: as a side effect, you only need to wrench the PC down when construction is being finished
/:cl:
