### PR TITLE
Items no longer randomly fall out of bags when changing their size

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1165,8 +1165,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/contents_changed_w_class(datum/source, obj/item/changed, old_w_class, new_w_class)
 	SIGNAL_HANDLER
 
-	if(new_w_class <= max_specific_storage && new_w_class + get_total_weight() <= max_total_storage)
+	// If old weight already overloaded the storage, don't drop the item out just in case we're inside of a premade box
+	if(new_w_class <= max_specific_storage && (get_total_weight() <= max_total_storage || get_total_weight() - new_w_class + old_w_class > max_total_storage))
 		return
+
 	if(!attempt_remove(changed, parent.drop_location()))
 		return
 


### PR DESCRIPTION
## About The Pull Request
Not sure what this code was meant to achieve, but just checking total weight is enough. Also added a safeguard to not drop the item if the storage container was already overloaded just in case we're in a premade box (this should never happen in-game otherwise)

Fixes #85658

## Changelog
:cl:
fix: Items no longer randomly fall out of bags when changing their size
/:cl:
