### PR TITLE
Jaws of Recovery QOL's

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -118,3 +118,14 @@
 	)
 	category = CAT_TOOLS
 
+/datum/crafting_recipe/jaws_of_recovery
+	name = "Modified Jaws of Life"
+	time = 10 SECONDS
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER)
+	result = /obj/item/crowbar/power/paramedic/silent
+	reqs = list(
+		/obj/item/crowbar/power = 1,
+		/obj/item/bonesetter = 1,
+	)
+	category = CAT_TOOLS
+

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -326,6 +326,12 @@
 		"TOOL" = "replaced with the tool used",
 	)
 
+/obj/item/crowbar/power/paramedic/silent
+	name = "modified jaws of recovery"
+	desc = "Modified version for jaws of life, made to act like jaws of recovery. This one doesn't announce doors you're prying open and lets you pry any door, acting like regular jaws of life"
+	limit_jaws_access = FALSE
+	radio_alert = FALSE
+
 /obj/item/crowbar/cyborg
 	name = "hydraulic crowbar"
 	desc = "A hydraulic prying tool, simple but powerful."

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -416,6 +416,11 @@
 	inhand_icon_state = null
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/paramedic
 
+/obj/item/clothing/suit/hooded/wintercoat/medical/paramedic/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/adjust_fishing_difficulty, -3) //mirrored from jacket
+	allowed += /obj/item/crowbar/power/paramedic
+
 /obj/item/clothing/head/hooded/winterhood/medical/paramedic
 	desc = "A white winter coat hood with blue markings."
 	icon_state = "hood_paramed"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -641,6 +641,7 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/storage/bag/chemistry,
 		/obj/item/storage/bag/bio,
+		/obj/item/crowbar/power/paramedic,
 	)
 	variants = list(
 		"medical" = list(


### PR DESCRIPTION
## About The Pull Request

changelog should say pretty much enough, dont want to double it here.

## Why It's Good For The Game

as paramedic later into the game you'll prefer jaws of life over jaws of recovery because theyre both silent AND have no area restrictions, but heres the thing: you cant wear it in suit storage, nor it can act as bonesetter additionally (why would paramed need wirecutter?) this PR is aimed to combie both of those jaws into one modified, that would be useful for paramedic.

also you really should be able to wear them in mod suit storage, trust me, it sucks to carry paramedic jacket/coat in inventory everytime and waste time on swapping

## Changelog
:cl:
qol: Jaws of Recovery can be worn on medical MODSuit suit storage now.
add: Added modified Jaws of Recovery and recipe for them. Made from regular Jaws of Life they act like one, without area restrictions and radio announcements.
/:cl:
