### PR TITLE
Removes throwing box from sec sontraband locker

### DIFF
--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -60,7 +60,6 @@
 	loot = list(
 		/obj/item/gun/ballistic/automatic/pistol/contraband = 80,
 		/obj/item/gun/ballistic/shotgun/automatic/combat = 50,
-		/obj/item/storage/box/syndie_kit/throwing_weapons = 30,
 		/obj/item/grenade/clusterbuster/teargas = 20,
 		/obj/item/grenade/clusterbuster = 20,
 		/obj/item/gun/ballistic/automatic/pistol/deagle/contraband,


### PR DESCRIPTION
## About The Pull Request

Removes throwing items box from sec contraband locker, found in armory

## Why It's Good For The Game

### Gear Checks 
The items found in the throwing box (reinforced bola in particular, and usually taken shiftstart) require gear checks for antagonists to acquire pre-emptively (teleports upon being surprise thrown at), or numbers advantage (for quite a few antagonists/gimmicks, friends may not be feasible/can necessarily be done). Energy Bolas on the other hand are bearable (despite not being catchable through throw mode), but reinforced bolas in particular are a particular problem item. Same goes with the throwing stars (embedded blood wounds), although isn't as bad as RBolas in particular.

### Non-interactive/unfun for antagonists to play against
Being hit by r-bolas essentially signs a death sentance for the antagonist unless they have some sort of teleportation, due to the long knockdown, long time to unequip, and extreme slowness. It encourages antag gear checks and powergaming. 

### Antag fight between the antagonist and the crew, gets wasted
The awesome potential between the antagonist and crew/sec could be such an epic fight, and could end up as an interesting story. But instead, Sec using RBolas essentially signs a death sentence for the antagonist, unless the antagonist has planned for this specific circumstance pre-emptively. 

### Ordinary bolas/energy bolas
I don't think they're an issue.
- Energy Bola: 2s breakout time, no knockdown, can't be caught, bearable walkspeed
- Ordinary Bola: 3.5s breakout time, no knockdown
- Reinforced Bola: 7s breakout time, 3.5s knockdown, heavier walkspeed

### Just hold throw mode
Personally I don't take this thing seriously just simply because no one is omniscient to know that sec will be using reinforced bolas that shift, or juggling throw mode 24/7 every single shift, including during mid fight.

### Why not nerf throwing box
I don't think antagonists having overpowered toys is a bad thing, and this is specifically targeting sec.
If sec still want RBolas/contraband they can still go through an unlocked traitor PDA.

### Sec contraband overuse
I don't have stats for this, so this is anecdotal evidence (LRP Terry. I was told MRP does this, too). I can ask for stats.

### Why not remove contraband locker
I don't want to get rid of the contraband locker altogether because it opens up sandbox opportunities - R bolas on the other hand I don't believe encourage really any sandbox opportunities at all, and I don't think they're healthy in that aspect due to sec using them to stop the potential awesomeness of an antag fight altogether.

## Changelog

:cl: ArchBTW
balance: Removes throwing items box from sec contraband locker
/:cl:
