### PR TITLE
Adds an option to hide your ckey from the roundend report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -691,7 +691,11 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	var/jobtext = ""
 	if(!is_unassigned_job(ply.assigned_role))
 		jobtext = " the <b>[ply.assigned_role.title]</b>"
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
+	var/text
+	if(GLOB.roundend_hidden_ckeys[ckey(ply.key)])
+		text = "<b>[ply.name]</b>[jobtext] "
+	else
+		text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " [span_redtext("died")]"

--- a/code/modules/client/preferences/hide_roundend_ckey.dm
+++ b/code/modules/client/preferences/hide_roundend_ckey.dm
@@ -1,0 +1,10 @@
+GLOBAL_DATUM_INIT(roundend_hidden_ckeys, /alist, alist())
+
+/datum/preference/toggle/hide_roundend_ckey
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "hide_roundend_ckey"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE
+
+/datum/preference/toggle/hide_roundend_ckey/apply_to_client(client/client, value)
+	GLOB.roundend_hidden_ckeys[client.ckey] = value

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3957,6 +3957,7 @@
 #include "code\modules\client\preferences\glasses.dm"
 #include "code\modules\client\preferences\hemiplegic.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
+#include "code\modules\client\preferences\hide_roundend_ckey.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
 #include "code\modules\client\preferences\item_outlines.dm"
 #include "code\modules\client\preferences\jobless_role.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/hide_roundend_ckey.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/hide_roundend_ckey.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, type FeatureToggle } from '../base';
+
+export const hide_roundend_ckey: FeatureToggle = {
+  name: 'Hide roundend report ckey',
+  category: 'GAMEPLAY',
+  description: 'When enabled, your ckey will be hidden in the roundend report.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Piggybacking [this PR](https://github.com/Monkestation/Monkestation2.0/pull/7873)

Adds an ingame setting to hide your ckey from roundend report
Admins can still get your ckey 
Off by default

## Why It's Good For The Game

- Less metaknowledge
- Makes admin life easier
- Preference - Character of yours to not be public knowledge/linked

## Changelog

:cl: ArchBTW
add: Added an option to hide your ckey from the roundend report (off by default)
/:cl:
