### PR TITLE
Fires the roboticist who installs your shiftstart skillchip and replaces them with a neurosurgeon. (also suspends mannitol medication)

### DIFF
--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -34,9 +34,9 @@
 
 	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
 	installed_chip = new installed_chip()
-
-	RegisterSignals(installed_chip, list(COMSIG_QDELETING, COMSIG_SKILLCHIP_REMOVED), PROC_REF(remove_effect))
-	RegisterSignal(installed_chip, COMSIG_SKILLCHIP_IMPLANTED, PROC_REF(apply_effect))
-
 	quirk_holder_carbon.implant_skillchip(installed_chip, force = TRUE)
 	installed_chip.try_activate_skillchip(silent = FALSE, force = TRUE)
+
+/datum/quirk/chipped/remove()
+	QDEL_NULL(installed_chip)
+	return ..()

--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -3,7 +3,7 @@
 	desc = "You got caught up in the skillchip craze a few years back, and had one of the commercially available chips implanted into yourself."
 	icon = FA_ICON_MICROCHIP
 	value = 2
-	gain_text = span_notice("Your suddenly feels chipped.")
+	gain_text = span_notice("You suddenly feels chipped.")
 	lose_text = span_danger("You don't feel so chipped anymore.")
 	medical_record_text = "Patient explained how they got caught up in 'the skillchip chase' recently, and now they have some useless chip in their head. Dumbass."
 	mail_goodies = list(

--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -10,12 +10,9 @@
 		/obj/item/skillchip/matrix_taunt,
 		/obj/item/skillchip/big_pointer,
 		/obj/item/skillchip/acrobatics,
-		/obj/item/storage/pill_bottle/mannitol/braintumor,
 	)
 	/// Variable that holds the chip, used on removal.
 	var/obj/item/skillchip/installed_chip
-	///itchy status effect we give our owner
-	var/datum/itchy_effect
 
 /datum/quirk_constant_data/chipped
 	associated_typepath = /datum/quirk/chipped
@@ -43,42 +40,3 @@
 
 	quirk_holder_carbon.implant_skillchip(installed_chip, force = TRUE)
 	installed_chip.try_activate_skillchip(silent = FALSE, force = TRUE)
-
-/datum/quirk/chipped/proc/apply_effect(datum/source, obj/item/brain_applied)
-	SIGNAL_HANDLER
-	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
-	if(brain_applied == quirk_holder_carbon.get_organ_slot(ORGAN_SLOT_BRAIN))
-		itchy_effect = quirk_holder.apply_status_effect(/datum/status_effect/itchy_skillchip_quirk)
-
-/datum/quirk/chipped/proc/remove_effect(datum/source, obj/item/brain_removed)
-	SIGNAL_HANDLER
-	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
-	if(QDELING(source) || brain_removed == quirk_holder_carbon.get_organ_slot(ORGAN_SLOT_BRAIN))
-		quirk_holder.remove_status_effect(itchy_effect)
-		itchy_effect = null
-
-/datum/quirk/chipped/remove()
-	QDEL_NULL(installed_chip)
-	if(itchy_effect)
-		quirk_holder.remove_status_effect(itchy_effect)
-		itchy_effect = null
-	return ..()
-
-/datum/status_effect/itchy_skillchip_quirk
-	id = "itchy skillchip"
-	tick_interval_lowerbound = 5 SECONDS
-	tick_interval_upperbound = 10 MINUTES
-	alert_type = null
-	///lower damage we apply to our itchy owner
-	var/minimum_damage = 1
-	///upper damage we apply to our itchy owner
-	var/maximum_damage = 5
-
-/datum/status_effect/itchy_skillchip_quirk/tick(seconds_between_ticks)
-	var/mob/living/carbon/carbon_owner = owner
-	var/obj/item/organ/brain/itchy_brain = carbon_owner.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(isnull(itchy_brain))
-		return
-	itchy_brain.apply_organ_damage(rand(minimum_damage, maximum_damage), maximum = itchy_brain.maxHealth * 0.3)
-	if(owner.stat == CONSCIOUS && !owner.incapacitated && owner.get_empty_held_indexes())
-		to_chat(owner, span_warning("You scratch the itch in your head."))

--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -3,9 +3,9 @@
 	desc = "You got caught up in the skillchip craze a few years back, and had one of the commercially available chips implanted into yourself."
 	icon = FA_ICON_MICROCHIP
 	value = 2
-	gain_text = span_notice("The chip in your head itches a bit.")
-	lose_text = span_danger("You don't feel so chipped anymore..")
-	medical_record_text = "Patient explained how they got caught up in 'the skillchip chase' recently, and now the chip in their head itches every so often. Dumbass."
+	gain_text = span_notice("Your suddenly feels chipped.")
+	lose_text = span_danger("You don't feel so chipped anymore.")
+	medical_record_text = "Patient explained how they got caught up in 'the skillchip chase' recently, and now they have some useless chip in their head. Dumbass."
 	mail_goodies = list(
 		/obj/item/skillchip/matrix_taunt,
 		/obj/item/skillchip/big_pointer,
@@ -24,8 +24,8 @@
 	if(isnull(chip_pref))
 		return ..()
 	installed_chip = GLOB.quirk_chipped_choice[chip_pref] || GLOB.quirk_chipped_choice[pick(GLOB.quirk_chipped_choice)]
-	gain_text = span_notice("The [installed_chip::name] in your head itches a bit.")
-	lose_text = span_notice("Your head stops itching so much.")
+	gain_text = span_notice("The [installed_chip::name] in your head buzzes with knowledge.")
+	lose_text = span_notice("You stop feeling the chip inside your head.")
 	return ..()
 
 /datum/quirk/chipped/add_unique(client/client_source)


### PR DESCRIPTION
## About The Pull Request
Removes the brain itch damage from the chipped quirk, as well as its var, datums, and procs, and flavor text that refers to it. (give me an 👀 if you didn't know about this)
Also removes mannitol as a mail item for chipped crew given that its unnecessary now.
## Why It's Good For The Game
A good quirk should not give you an unadvertised brain damaging status effect when you can just go get chipped on the station without any of the downsides. Also the downside should be taking a negative quirk (and even then we gave everyone two free points).

I'm also accepting suggestions on reworking the flavor text.
## Changelog
:cl:
del: Removes chipped's brain damage status effect and flavor text
del: Removes mannitol from the mail list for chipped crew
/:cl:
