### PR TITLE
fix moon robes runtime + make adjustDamageType be handled by moon robes

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -415,6 +415,8 @@
 /datum/status_effect/heretic_passive/moon/on_apply()
 	. = ..()
 	var/obj/item/organ/brain/our_brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return
 	ADD_TRAIT(our_brain, TRAIT_BRAIN_TRAUMA_IMMUNITY, REF(src))
 	owner.AddElement(/datum/element/relay_attackers)
 	RegisterSignal(owner, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(on_attacked))
@@ -450,6 +452,8 @@
 
 /datum/status_effect/heretic_passive/moon/on_remove()
 	var/obj/item/organ/brain/our_brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return ..()
 	REMOVE_TRAIT(our_brain, TRAIT_BRAIN_TRAUMA_IMMUNITY, REF(src))
 	REMOVE_TRAIT(owner, TRAIT_SLEEPIMMUNE, REF(src))
 	UnregisterSignal(owner, COMSIG_ATOM_WAS_ATTACKED)


### PR DESCRIPTION

## About The Pull Request
small followup to fix adjustBruteLoss and etc not being handled by moon robes, as i had refactored it heavily to make the code better, this was a thing i missed
## Why It's Good For The Game
moon robes not blocking damage good, probably
## Changelog
:cl:
fix: moon robes now again will protect you from full body damage like low pressure or high pressure or fire
/:cl:
