### PR TITLE
Improvement for trash food unit test

### DIFF
--- a/code/modules/unit_tests/trash_food.dm
+++ b/code/modules/unit_tests/trash_food.dm
@@ -30,5 +30,5 @@
 			continue
 		if(trash in food_trash_blacklist)
 			continue
-
-		TEST_ASSERT(food_trash[trash], "[food] must include its trash_type for loot table /obj/effect/spawner/random/trash/food_packaging or be added to this unit tests food_trash_blacklist")
+		if(!food_trash[trash])
+			TEST_FAIL("[food] must include its trash_type for loot table /obj/effect/spawner/random/trash/food_packaging or be added to this unit tests food_trash_blacklist")


### PR DESCRIPTION

## About The Pull Request

`TEST_ASSERT` returns on failure, in a loop like this test that means if you encounter a single failure the whole test fails immediately. We want every failure listed, `TEST_FAIL` fails without returning.

## Why It's Good For The Game

I thought my code base had one failure but it didn't it had 60+
