### PR TITLE
Unregister qdeleting signal in /datum/thrownthing/Destroy

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -114,6 +114,7 @@ SUBSYSTEM_DEF(throwing)
 /datum/thrownthing/Destroy()
 	SSthrowing.processing -= thrownthing
 	SSthrowing.currentrun -= thrownthing
+	UnregisterSignal(thrownthing, COMSIG_QDELETING)
 	thrownthing.throwing = null
 	thrownthing = null
 	thrower = null


### PR DESCRIPTION

## About The Pull Request

Unregisters the signal registered in `/datum/thrownthing/New` that tracks when the thrown thing gets qdeled

## Why It's Good For The Game

<img width="1217" height="737" alt="image" src="https://github.com/user-attachments/assets/6fe77084-ea80-4229-90d4-aa94ddde1bf3" />
