### PR TITLE
Louder drone pings

### DIFF
--- a/code/modules/mob/living/basic/drone/verbs.dm
+++ b/code/modules/mob/living/basic/drone/verbs.dm
@@ -30,5 +30,5 @@
 	var/area/A = get_area(loc)
 
 	if(alert_s && A && stat != DEAD)
-		var/msg = span_boldnotice("DRONE PING: [name]: [alert_s] priority alert in [A.name]!")
+		var/msg = span_big("DRONE PING: [name]: [alert_s] priority alert in [A.name]!")
 		alert_drones(msg)


### PR DESCRIPTION
## About The Pull Request

Makes the drone ping alert appear larger in chat

## Why It's Good For The Game

Drones have this nifty ping system to call each other to areas in need of droning, but the ping alert is extremely difficult to notice in chat. This makes it larger and louder.
## Changelog
:cl:

qol: Drone pings are now louder
/:cl:
