### PR TITLE
Lets you make Trick Trick Cigarettes

### DIFF
--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -422,6 +422,18 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	damtype = BURN
 	force = 4
 
+	if(reagents && reagents.has_reagent(/datum/reagent/toxin/mindbreaker))
+		if(isliving(loc))
+			var/mob/living/user = loc
+			loc.visible_message(span_hear("[user]'s [src] burns up as [p_they(user)] fall to the ground!"), span_danger("The solution violently explodes!"))
+			user.flash_act(INFINITY, override_blindness_check = TRUE , visual = TRUE, length = 5 SECONDS)
+			user.playsound_local(get_turf(user), pick('sound/effects/explosion/explosion1.ogg', 'sound/effects/explosion/explosion2.ogg'), 50, TRUE)
+			user.cause_hallucination(/datum/hallucination/death, "trick trick [name]")
+		else
+			loc.visible_message(span_hear("\The [src] burns up!"))
+		qdel(src)
+		return
+
 	if(reagents && reagents.has_reagent(/datum/reagent/drug/methamphetamine))
 		reagents.flags |= NO_REACT
 

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -422,28 +422,29 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	damtype = BURN
 	force = 4
 
-	if(reagents && reagents.has_reagent(/datum/reagent/flash_powder))
-		if(isliving(loc))
-			var/mob/living/user = loc
-			loc.visible_message(span_hear("[user]'s [src] burns up as [p_they(user)] fall to the ground!"), span_danger("The solution violently explodes!"))
-			user.flash_act(INFINITY, visual = TRUE, length = 5 SECONDS)
-			user.playsound_local(get_turf(user), SFX_EXPLOSION, 50, TRUE)
-			user.cause_hallucination(/datum/hallucination/death, "trick trick [name]")
-		else
+	if(reagents?.has_reagent(/datum/reagent/flash_powder))
+		if(!isliving(loc))
 			loc.visible_message(span_hear("\The [src] burns up!"))
+			qdel(src)
+			return
+		var/mob/living/user = loc
+		loc.visible_message(span_hear("[user]'s [name] burns up as [p_they(user)] fall to the ground!"), span_danger("The solution violently explodes!"))
+		user.flash_act(INFINITY, visual = TRUE, length = 5 SECONDS)
+		user.playsound_local(get_turf(user), SFX_EXPLOSION, 50, TRUE)
+		user.cause_hallucination(/datum/hallucination/death, "trick trick [name]")
 		qdel(src)
 		return
 
-	if(reagents && reagents.has_reagent(/datum/reagent/drug/methamphetamine))
+	if(reagents?.has_reagent(/datum/reagent/drug/methamphetamine))
 		reagents.flags |= NO_REACT
 
-	if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire
+	if(reagents?.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(round(reagents.get_reagent_amount(/datum/reagent/toxin/plasma) / 2.5, 1), get_turf(src), 0, 0)
 		e.start(src)
 		qdel(src)
 		return
-	if(reagents.get_reagent_amount(/datum/reagent/fuel)) // the fuel explodes, too, but much less violently
+	if(reagents?.get_reagent_amount(/datum/reagent/fuel)) // the fuel explodes, too, but much less violently
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(round(reagents.get_reagent_amount(/datum/reagent/fuel) / 5, 1), get_turf(src), 0, 0)
 		e.start(src)

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -427,7 +427,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/mob/living/user = loc
 			loc.visible_message(span_hear("[user]'s [src] burns up as [p_they(user)] fall to the ground!"), span_danger("The solution violently explodes!"))
 			user.flash_act(INFINITY, override_blindness_check = TRUE , visual = TRUE, length = 5 SECONDS)
-			user.playsound_local(get_turf(user), pick('sound/effects/explosion/explosion1.ogg', 'sound/effects/explosion/explosion2.ogg'), 50, TRUE)
+			user.playsound_local(get_turf(user), SFX_EXPLOSION, 50, TRUE)
 			user.cause_hallucination(/datum/hallucination/death, "trick trick [name]")
 		else
 			loc.visible_message(span_hear("\The [src] burns up!"))

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -422,7 +422,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	damtype = BURN
 	force = 4
 
-	if(reagents && reagents.has_reagent(/datum/reagent/toxin/mindbreaker))
+	if(reagents && reagents.has_reagent(/datum/reagent/flash_powder))
 		if(isliving(loc))
 			var/mob/living/user = loc
 			loc.visible_message(span_hear("[user]'s [src] burns up as [p_they(user)] fall to the ground!"), span_danger("The solution violently explodes!"))

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -722,6 +722,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	lung_harm = 2
 	list_reagents = list (/datum/reagent/drug/nicotine = 20, /datum/reagent/medicine/regen_jelly = 15, /datum/reagent/drug/krokodil = 4)
 
+/obj/item/cigarette/flash_powder
+	desc = "A Space brand cigarette that can be smoked anywhere."
+	list_reagents = list (/datum/reagent/drug/nicotine = 9, /datum/reagent/flash_powder = 5)
+
 // Rollies.
 
 /obj/item/cigarette/rollie

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -426,7 +426,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(isliving(loc))
 			var/mob/living/user = loc
 			loc.visible_message(span_hear("[user]'s [src] burns up as [p_they(user)] fall to the ground!"), span_danger("The solution violently explodes!"))
-			user.flash_act(INFINITY, override_blindness_check = TRUE , visual = TRUE, length = 5 SECONDS)
+			user.flash_act(INFINITY, visual = TRUE, length = 5 SECONDS)
 			user.playsound_local(get_turf(user), SFX_EXPLOSION, 50, TRUE)
 			user.cause_hallucination(/datum/hallucination/death, "trick trick [name]")
 		else

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -723,7 +723,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	list_reagents = list (/datum/reagent/drug/nicotine = 20, /datum/reagent/medicine/regen_jelly = 15, /datum/reagent/drug/krokodil = 4)
 
 /obj/item/cigarette/flash_powder
-	desc = "A Space brand cigarette that can be smoked anywhere."
+	desc = /obj/item/cigarette/space_cigarette::desc
 	list_reagents = list (/datum/reagent/drug/nicotine = 9, /datum/reagent/flash_powder = 5)
 
 // Rollies.

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -465,6 +465,9 @@
 	spawn_coupon = FALSE
 	open_status = FANCY_CONTAINER_OPEN
 
+/obj/item/storage/fancy/cigarettes/flash_powder
+	spawn_type = /obj/item/cigarette/flash_powder
+
 /obj/item/storage/fancy/rollingpapers
 	name = "rolling paper pack"
 	desc = "A pack of Nanotrasen brand rolling papers."

--- a/code/modules/cargo/markets/market_items/misc.dm
+++ b/code/modules/cargo/markets/market_items/misc.dm
@@ -221,3 +221,12 @@
 	. = ..()
 	if(.)
 		availability_prob *= 0.5
+
+/datum/market_item/misc/tricktrickcigarettes
+	name = "Trick Trick Cigarettes"
+	desc = "Cigarettes filled with flash powder. Makes for a fun prank!"
+	item = /obj/item/storage/fancy/cigarettes/flash_powder
+	price_min = PAYCHECK_CREW
+	price_max = PAYCHECK_CREW * 3
+	stock_max = 3
+	availability_prob = 25


### PR DESCRIPTION
## About The Pull Request

<img width="827" height="85" alt="image" src="https://github.com/user-attachments/assets/91749cb4-9a94-4295-afbe-8a993ddc5b38" />
It's just this. Add flash powder and it acts like you got a trick plasma cigarette, but not real.

They are also purchasable from the black market.

## Why It's Good For The Game

Something to fill a cigarette with other than drugs or explosives
Silly little prank

## Changelog
:cl:
add: Adds fake explosive cigarettes. Add flash powder to cigarettes to create.

/:cl:
