### PR TITLE
N2O not N20

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -5708,10 +5708,10 @@
 	dir = 1
 	},
 /obj/machinery/meter{
-	name = "N20 meter"
+	name = "N2O meter"
 	},
 /obj/machinery/atmospherics/pipe/multiz/yellow/visible{
-	name = "N20 Multideck Adapter";
+	name = "N2O Multideck Adapter";
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -31251,11 +31251,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/multiz/yellow/visible{
-	name = "N20 Multideck Adapter";
+	name = "N2O Multideck Adapter";
 	dir = 4
 	},
 /obj/machinery/meter{
-	name = "N20 meter"
+	name = "N2O meter"
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/upper)


### PR DESCRIPTION

## About The Pull Request

Four things that were labeled N Twenty rather than N2 O

## Why It's Good For The Game

Correct

## Changelog
:cl:

spellcheck: Four pipes labeled N20 are now labeled N2O

/:cl:
