### PR TITLE
Fix typo for cuffable component

### DIFF
--- a/code/datums/elements/cuffable_item.dm
+++ b/code/datums/elements/cuffable_item.dm
@@ -20,7 +20,7 @@
 
 	if(length(user.held_items) < 0 || iscyborg(user) || source.anchored)
 		return
-	examine_list += span_smallnotice("You could bind [source.p_they()] to your wrist with a pair of handcuffs...")
+	examine_list += span_smallnotice("You could bind [source.p_them()] to your wrist with a pair of handcuffs...")
 
 ///Give context to players holding a pair of handcuffs when hovering the item
 /datum/element/cuffable_item/proc/on_requesting_context_from_item(datum/source, list/context, obj/item/held_item, mob/user)


### PR DESCRIPTION
## About The Pull Request

The examine more text uses p_they instead of p_them, so you'd get text like "You could bind he to your wrist".
I've just changed the proc.

## Why It's Good For The Game

while I am amused by things like "bind he to your wrist" that's probably something best said by players and not in system text

## Changelog

:cl: Cirrial
spellcheck: Examining something you can cuff now uses the correct pronoun.
/:cl:
