### PR TITLE
Makes fire_act respect damage_deflection (prevents smoking out the cap's ID)

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -125,7 +125,7 @@
 /obj/fire_act(exposed_temperature, exposed_volume)
 	if(HAS_TRAIT(src, TRAIT_UNDERFLOOR))
 		return
-	if(exposed_temperature && !(resistance_flags & FIRE_PROOF))
+	if(exposed_temperature && !(resistance_flags & FIRE_PROOF) && (((0.02 * exposed_temperature) - damage_deflection) > 0))
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, FIRE, 0)
 	if(QDELETED(src)) // take_damage() can send our obj to an early grave, let's stop here if that happens
 		return

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -125,8 +125,9 @@
 /obj/fire_act(exposed_temperature, exposed_volume)
 	if(HAS_TRAIT(src, TRAIT_UNDERFLOOR))
 		return
-	if(exposed_temperature && !(resistance_flags & FIRE_PROOF) && ((0.02 * exposed_temperature) > damage_deflection))
-		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, FIRE, 0)
+	var/potential_damage = 0.02 * exposed_temperature
+	if(exposed_temperature && !(resistance_flags & FIRE_PROOF) && (potential_damage > damage_deflection))
+		take_damage(clamp(potential_damage, 0, 20), BURN, FIRE, 0)
 	if(QDELETED(src)) // take_damage() can send our obj to an early grave, let's stop here if that happens
 		return
 	if(!(resistance_flags & ON_FIRE) && (resistance_flags & FLAMMABLE) && !(resistance_flags & FIRE_PROOF))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -125,7 +125,7 @@
 /obj/fire_act(exposed_temperature, exposed_volume)
 	if(HAS_TRAIT(src, TRAIT_UNDERFLOOR))
 		return
-	if(exposed_temperature && !(resistance_flags & FIRE_PROOF) && (((0.02 * exposed_temperature) - damage_deflection) > 0))
+	if(exposed_temperature && !(resistance_flags & FIRE_PROOF) && ((0.02 * exposed_temperature) > damage_deflection))
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, FIRE, 0)
 	if(QDELETED(src)) // take_damage() can send our obj to an early grave, let's stop here if that happens
 		return


### PR DESCRIPTION

## About The Pull Request

Prevents destroying the cap's ID safe with a normal bonfire by making `fire_act` respect `damage_reflection` and not do damage if it's higher than the potential damage. The bonfire does 20 damage, so the only objects that have a `damage_reflection` high enough to benefit definitely shouldn't be taking damage from a wood fire.

## Why It's Good For The Game

Fixes #80592

## Changelog
:cl:

fix: Prevents woodfires from melting the captain's Spare ID Safe

/:cl:
