### PR TITLE
The items in the throwing box in the armoury's contraband locker have a chance to have the boomerang component.

### DIFF
--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -53,7 +53,7 @@
 	loot = list(
 		/obj/item/gun/ballistic/automatic/pistol/contraband = 80,
 		/obj/item/gun/ballistic/shotgun/automatic/combat = 50,
-		/obj/item/storage/box/syndie_kit/throwing_weapons = 30,
+		/obj/item/storage/box/syndie_kit/throwing_weapons/contraband = 30,
 		/obj/item/grenade/clusterbuster/teargas = 20,
 		/obj/item/grenade/clusterbuster = 20,
 		/obj/item/gun/ballistic/automatic/pistol/deagle/contraband,

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -546,12 +546,23 @@
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
 /obj/item/storage/box/syndie_kit/throwing_weapons/PopulateContents()
+	var/list/items = list()
 	for(var/i in 1 to 5)
-		new /obj/item/throwing_star(src)
+		items += new /obj/item/throwing_star(src)
 	for(var/i in 1 to 2)
-		new /obj/item/paperplane/syndicate(src)
-	new /obj/item/restraints/legcuffs/bola/tactical(src)
-	new /obj/item/restraints/legcuffs/bola/tactical(src)
+		items += new /obj/item/paperplane/syndicate(src)
+	for(var/i in 1 to 2)
+		items += new /obj/item/restraints/legcuffs/bola/tactical(src)
+	return items
+
+/obj/item/storage/box/syndie_kit/throwing_weapons/contraband/PopulateContents()
+	. = ..()
+	for(var/obj/item/item in src)
+		if(prob(20))
+			item.throw_range = 2
+			item.AddComponent(/datum/component/boomerang, boomerang_throw_range = 7)
+			ADD_TRAIT(item, TRAIT_UNCATCHABLE, TRAIT_GENERIC)
+
 
 /obj/item/storage/box/syndie_kit/cutouts/PopulateContents()
 	for(var/i in 1 to 3)


### PR DESCRIPTION

## About The Pull Request
They have a 20% chance to have the boomerang component, be uncatchable (ideally only uncatchable for the user but I didn't want to make 3 subtypes for this) and have a throw range of 2. This doesn't apply to the throwing weapon kits that are not from the armoury.

## Why It's Good For The Game
Sometimes the syndicate leave sabotaged weapons around to hinder Nanotrasen's research and intelligence on them.

## Changelog

:cl:
balance: The syndicate throwing weapons found in the contraband locker sometimes have unusual aerodynamics.
/:cl:

