### PR TITLE
Clowns don't get standard death moodlets

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -574,7 +574,7 @@
 	if(isnull(dead_mob))
 		return
 	if(HAS_TRAIT(owner, TRAIT_NAIVE) && naive_immune)
-		description = "Have a good nap, [get_descriptor(dead_mob)]."
+		description = "Have a good nap, [dead_mob.name]."
 		mood_change = 0
 		timeout *= 0.2
 		return

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -565,12 +565,15 @@
 	var/pet_message = "%DEAD_MOB% just died!!"
 	/// Message variant for desensitized people (security, medical, cult with halo, etc)
 	var/desensitized_message = "I saw %DEAD_MOB% die."
+	/// Standard message variant
 	var/normal_message = "I just saw %DEAD_MOB% die. How horrible..."
+	/// Naive mobs are immune to the effect
+	var/naive_immune = TRUE
 
 /datum/mood_event/see_death/add_effects(mob/dead_mob)
 	if(isnull(dead_mob))
 		return
-	if(HAS_TRAIT(owner, TRAIT_NAIVE))
+	if(HAS_TRAIT(owner, TRAIT_NAIVE) && naive_immune)
 		description = "Have a good nap, [get_descriptor(dead_mob)]."
 		mood_change = 0
 		timeout *= 0.2
@@ -642,6 +645,7 @@
 	pet_message = "%DEAD_MOB% just exploded!!"
 	desensitized_message = "I saw %DEAD_MOB% explode."
 	normal_message = "%DEAD_MOB% just exploded in front of me!!"
+	naive_immune = FALSE
 
 /datum/mood_event/see_death/dusted
 	description = "Someone was just vaporized in front of me!! I don't feel so good..."
@@ -651,6 +655,7 @@
 	pet_message = "%DEAD_MOB% just vaporized!!"
 	desensitized_message = "I saw %DEAD_MOB% get vaporized."
 	normal_message = "%DEAD_MOB% was just vaporized in front of me!!"
+	naive_immune = FALSE
 
 /datum/mood_event/slots/loss
 	description = "Aww dang it!"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -570,6 +570,11 @@
 /datum/mood_event/see_death/add_effects(mob/dead_mob)
 	if(isnull(dead_mob))
 		return
+	if(HAS_TRAIT(owner, TRAIT_NAIVE))
+		description = "Have a good nap, [get_descriptor(dead_mob)]."
+		mood_change = 0
+		timeout *= 0.2
+		return
 	if(HAS_TRAIT(dead_mob, TRAIT_SPAWNED_MOB))
 		mood_change *= 0.25
 		timeout *= 0.2


### PR DESCRIPTION
## About The Pull Request

`TRAIT_NAIVE` mobs are immune to the effect of the standard death moodlet

Dusting and gibbing still apply though

## Why It's Good For The Game

They see all deaths as people falling asleep so they shouldn't get sad

## Changelog

:cl: Melbert
fix: Clowns have regained their innocence towards death
/:cl:

