### PR TITLE
Prevents cold lighters from welding doors & fixes mime lighter runtime

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1157,7 +1157,7 @@
 			return
 
 		if(atom_integrity < max_integrity)
-			if(!W.tool_start_check(user, amount=1))
+			if(!W.tool_start_check(user, amount=1, heat_required = HIGH_TEMPERATURE_REQUIRED))
 				return
 			user.visible_message(span_notice("[user] begins welding the airlock."), \
 							span_notice("You begin repairing the airlock..."), \
@@ -1172,7 +1172,7 @@
 			to_chat(user, span_notice("The airlock doesn't need repairing."))
 
 /obj/machinery/door/airlock/try_to_weld_secondary(obj/item/weldingtool/tool, mob/user)
-	if(!tool.tool_start_check(user, amount=1))
+	if(!tool.tool_start_check(user, amount=1, heat_required = HIGH_TEMPERATURE_REQUIRED))
 		return
 	user.visible_message(span_notice("[user] begins [welded ? "unwelding":"welding"] the airlock."), \
 		span_notice("You begin [welded ? "unwelding":"welding"] the airlock..."), \

--- a/code/game/objects/items/lighter.dm
+++ b/code/game/objects/items/lighter.dm
@@ -327,7 +327,7 @@
 	desc = "In lieu of fuel, performative spirit can be used to light cigarettes."
 	icon_state = "mlighter" //These ones don't show a flame.
 	light_color = LIGHT_COLOR_HALOGEN
-	heat_while_on = 0 //I swear it's a real lighter dude you just can't see the flame dude I promise
+	heat_while_on = TCMB //I swear it's a real lighter dude you just can't see the flame dude I promise
 	overlay_state = "mime"
 	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/toxin/mutetoxin = 5, /datum/reagent/consumable/nothing = 10)
 	light_range = 0


### PR DESCRIPTION

## About The Pull Request

in #85941, lighters were intentionally given the ability to weld doors via just not adding the `heat_required` check on them. This pr adds the standard `heat_required = HIGH_TEMPERATURE_REQUIRED` to the tool checks for welding and repairing airlocks, which prevents most lighters from being able to weld them. The hot lighter(slime lighter) can still weld doors, as it already has the heat to. 
Also ups the mime lighter's "flame" temp from absolute zero up to cosmic microwave background, preventing runtimes within `hotspot_expose()`

## Why It's Good For The Game

This is such a huge inconsistency that I initially thought it was a bug. Lighters are too cold to:

- heat up safety screws on windows
- cut the iron rods of a kitchen meatspike apart
- fix cracks on air tanks
- fix dents on borgs
- fix segways
- Weld or unweld disposals tubes
- Weld or unweld other disposals apparatuses

but are somehow hot enough to melt and weld together a meter-thick wad of solid iron? 
This makes what a lighter can act like a welder on seem random and unclear, when it should be as simple as "Could a lighter actually do this?".

Also, lighters are almost a straight upgrade from welders if you don't have eye protection. 

## Changelog
:cl:

fix: Mime lighters no longer constantly runtime when lit
balance: Cold lighters can't weld doors together

/:cl:
