### PR TITLE
Adds a rewards bonus for nohitting combat bitrunning domains

### DIFF
--- a/code/__DEFINES/bitrunning.dm
+++ b/code/__DEFINES/bitrunning.dm
@@ -27,13 +27,14 @@
 /// Camera network bitrunner bodycams are on
 #define BITRUNNER_CAMERA_NET "bitrunner"
 
-/**
- * Bitrunner Domain External Load Restriction Bitflags
- */
 /// Domain forbids external sources from loading items onto avatars
 #define DOMAIN_FORBIDS_ITEMS (1<<0)
 /// Domain forbids external sources from loading abilities onto avatars
 #define DOMAIN_FORBIDS_ABILITIES (1<<1)
+/// Block nohit bonus from applying
+#define DOMAIN_NO_NOHIT_BONUS (1<<2)
+/// Test domain, don't let it be loaded normally
+#define DOMAIN_TEST_ONLY (1<<3)
 
 /// Combination flag for blocking anything from being loaded onto avatars by external sources
 #define DOMAIN_FORBIDS_ALL ALL

--- a/code/__DEFINES/dcs/signals/signals_bitrunning.dm
+++ b/code/__DEFINES/dcs/signals/signals_bitrunning.dm
@@ -41,7 +41,7 @@
 /// from /obj/machienry/quantum_server/station_spawn()
 #define COMSIG_BITRUNNER_STATION_SPAWN "bitrunner_station_spawn"
 
-/// from /obj/machinery/quantum_server/stock_gear(): (mob/living/carbon/human/avatar, external_load_flags)
+/// from /obj/machinery/quantum_server/stock_gear(): (mob/living/carbon/human/avatar, domain_flags)
 #define COMSIG_BITRUNNER_STOCKING_GEAR "bitrunner_stocking_gear"
 
 // Ladder

--- a/code/controllers/subsystem/networks/bitrunning.dm
+++ b/code/controllers/subsystem/networks/bitrunning.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(bitrunning)
 	var/list/levels = list()
 
 	for(var/datum/lazy_template/virtual_domain/domain as anything in all_domains)
-		if(domain.test_only)
+		if(domain.domain_flags & DOMAIN_TEST_ONLY)
 			continue
 		var/can_view = domain.difficulty < scanner_tier && domain.cost <= points + 5
 		var/can_view_reward = domain.difficulty < (scanner_tier + 1) && domain.cost <= points + 3

--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -56,8 +56,8 @@
 	)
 
 // Give our owner shock touch when entering the digital realm
-/obj/item/stock_parts/power_store/cell/lead/proc/shockingly_improve_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
-	if(external_load_flags & DOMAIN_FORBIDS_ABILITIES)
+/obj/item/stock_parts/power_store/cell/lead/proc/shockingly_improve_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
+	if(domain_flags & DOMAIN_FORBIDS_ABILITIES)
 		return BITRUNNER_GEAR_LOAD_BLOCKED
 
 	if(!avatar.can_mutate())

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -11,6 +11,8 @@
 	var/datum/weakref/server_ref
 	/// The netpod the avatar is in
 	var/datum/weakref/netpod_ref
+	/// If we've taken any damage, is set to FALSE - for tracking nohit bonus
+	var/nohit = TRUE
 
 /datum/component/avatar_connection/Initialize(
 	datum/mind/old_mind,
@@ -179,6 +181,7 @@
 	if(old_body.stat > SOFT_CRIT) // KO!
 		full_avatar_disconnect(cause_damage = TRUE)
 
+	nohit = FALSE
 
 /// Handles minds being swapped around in subsequent avatars
 /datum/component/avatar_connection/proc/on_mind_transfer(datum/mind/source, mob/living/previous_body)

--- a/code/modules/bitrunning/components/avatar_gear.dm
+++ b/code/modules/bitrunning/components/avatar_gear.dm
@@ -64,6 +64,6 @@
 	tracked_human_ref = WEAKREF(to_track)
 	RegisterSignal(to_track, COMSIG_BITRUNNER_STOCKING_GEAR, PROC_REF(load_onto_avatar))
 
-/datum/component/loads_avatar_gear/proc/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
+/datum/component/loads_avatar_gear/proc/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
 	SIGNAL_HANDLER
-	return load_callback?.Invoke(neo, avatar, external_load_flags)
+	return load_callback?.Invoke(neo, avatar, domain_flags)

--- a/code/modules/bitrunning/objects/disks.dm
+++ b/code/modules/bitrunning/objects/disks.dm
@@ -35,7 +35,7 @@
 	. += span_notice("It cannot make another selection.")
 
 /// Handles loading our stuff onto avatars
-/obj/item/bitrunning_disk/proc/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
+/obj/item/bitrunning_disk/proc/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
 	return NONE
 
 
@@ -46,8 +46,8 @@
 	/// The list of actions that this can grant
 	var/list/datum/action/selectable_actions = list()
 
-/obj/item/bitrunning_disk/ability/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
-	if(external_load_flags & DOMAIN_FORBIDS_ABILITIES)
+/obj/item/bitrunning_disk/ability/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
+	if(domain_flags & DOMAIN_FORBIDS_ABILITIES)
 		return BITRUNNER_GEAR_LOAD_BLOCKED
 
 	if(isnull(granted_action))
@@ -118,8 +118,8 @@
 	/// The list of actions that this can grant
 	var/list/obj/selectable_items = list()
 
-/obj/item/bitrunning_disk/item/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
-	if(external_load_flags & DOMAIN_FORBIDS_ITEMS)
+/obj/item/bitrunning_disk/item/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
+	if(domain_flags & DOMAIN_FORBIDS_ITEMS)
 		return BITRUNNER_GEAR_LOAD_BLOCKED
 
 	if(isnull(granted_item))

--- a/code/modules/bitrunning/objects/gimmick_disks/_gimmick_disk.dm
+++ b/code/modules/bitrunning/objects/gimmick_disks/_gimmick_disk.dm
@@ -13,10 +13,10 @@
 	QDEL_NULL(granted_loadout)
 	return ..()
 
-/obj/item/bitrunning_disk/gimmick/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
+/obj/item/bitrunning_disk/gimmick/load_onto_avatar(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
 	if(isnull(granted_loadout))
 		return BITRUNNER_GEAR_LOAD_FAILED
-	return granted_loadout.grant_loadout(neo, avatar, external_load_flags)
+	return granted_loadout.grant_loadout(neo, avatar, domain_flags)
 
 /obj/item/bitrunning_disk/gimmick/attack_self(mob/user, modifiers)
 	. = ..()
@@ -57,17 +57,17 @@
 	var/prefix_container_name = TRUE
 
 /// Grants out loadout.
-/datum/bitrunning_gimmick/proc/grant_loadout(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
+/datum/bitrunning_gimmick/proc/grant_loadout(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
 	var/return_flags = NONE
-	return_flags |= grant_items(neo, avatar, external_load_flags)
-	return_flags |= grant_abilities(neo, avatar, external_load_flags)
+	return_flags |= grant_items(neo, avatar, domain_flags)
+	return_flags |= grant_abilities(neo, avatar, domain_flags)
 	return return_flags
 
-/datum/bitrunning_gimmick/proc/grant_items(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
+/datum/bitrunning_gimmick/proc/grant_items(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
 	if(!length(granted_items))
 		return NONE
 
-	if(external_load_flags & DOMAIN_FORBIDS_ITEMS)
+	if(domain_flags & DOMAIN_FORBIDS_ITEMS)
 		return BITRUNNER_GEAR_LOAD_BLOCKED
 
 	var/obj/item/container_item = new container_item_type()
@@ -81,11 +81,11 @@
 
 	return NONE
 
-/datum/bitrunning_gimmick/proc/grant_abilities(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, external_load_flags)
+/datum/bitrunning_gimmick/proc/grant_abilities(mob/living/carbon/human/neo, mob/living/carbon/human/avatar, domain_flags)
 	if(!length(granted_actions))
 		return NONE
 
-	if(external_load_flags & DOMAIN_FORBIDS_ABILITIES)
+	if(domain_flags & DOMAIN_FORBIDS_ABILITIES)
 		return BITRUNNER_GEAR_LOAD_BLOCKED
 
 	var/return_flags = NONE
@@ -99,4 +99,3 @@
 		our_action.Grant(avatar)
 
 	return return_flags
-

--- a/code/modules/bitrunning/server/_parent.dm
+++ b/code/modules/bitrunning/server/_parent.dm
@@ -28,6 +28,8 @@
 	var/list/datum/weakref/spawned_threat_refs = list()
 	/// Scales loot with extra players
 	var/multiplayer_bonus = 1.1
+	/// Extra bonus for every player that nohits the run
+	var/nohit_bonus = 0.8
 	/// The amount of points in the system, used to purchase maps
 	var/points = 0
 	/// Keeps track of the number of times someone has built a hololadder

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -26,7 +26,7 @@
 /obj/machinery/quantum_server/proc/get_multiplayer_bonus()
 	var/total = 0
 	var/multiplayer = FALSE
-	for(var/datum/weakref/connection_ref in avatar_connection_refs)
+	for(var/datum/weakref/connection_ref as anything in avatar_connection_refs)
 		var/datum/component/avatar_connection/connection = connection_ref.resolve()
 		if(isnull(connection))
 			continue
@@ -41,11 +41,9 @@
 		return 0
 
 	var/total = 0
-	for(var/datum/weakref/connection_ref in avatar_connection_refs)
+	for(var/datum/weakref/connection_ref as anything in avatar_connection_refs)
 		var/datum/component/avatar_connection/connection = connection_ref.resolve()
-		if(isnull(connection))
-			continue
-		if(connection.nohit)
+		if(connection?.nohit)
 			total += nohit_bonus
 	return total
 

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -22,6 +22,7 @@
 
 	return rewards_base
 
+/// Calculates total bonus from completing the domain in multiplayer
 /obj/machinery/quantum_server/proc/get_multiplayer_bonus()
 	var/total = 0
 	var/multiplayer = FALSE
@@ -32,9 +33,9 @@
 		if(multiplayer)
 			total += multiplayer_bonus
 		multiplayer = TRUE
-
 	return total
 
+/// Calculates total bonus from completing the domain without taking damage
 /obj/machinery/quantum_server/proc/get_nohit_bouns()
 	var/total = 0
 	for(var/datum/weakref/connection_ref in avatar_connection_refs)
@@ -44,7 +45,6 @@
 		if(connection.nohit && !(generated_domain.domain_flags & DOMAIN_NO_NOHIT_BONUS))
 			total += nohit_bonus
 	return total
-
 
 /// Handles spawning the (new) crate and deleting the former
 /obj/machinery/quantum_server/proc/generate_loot(obj/cache, obj/machinery/byteforge/chosen_forge)

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -16,8 +16,16 @@
 
 	rewards_base += (length(spawned_threat_refs) * 2)
 
-	for(var/index in 2 to length(avatar_connection_refs))
-		rewards_base += multiplayer_bonus
+	var/multiplayer = FALSE
+	for(var/i in 1 to length(avatar_connection_refs))
+		var/datum/component/avatar_connection/connection = avatar_connection_refs[i]?.resolve()
+		if(isnull(connection))
+			continue
+		if(multiplayer)
+			rewards_base += multiplayer_bonus
+		if(connection.nohit && !(generated_domain.domain_flags & DOMAIN_NO_NOHIT_BONUS))
+			rewards_base += nohit_bonus
+		multiplayer = TRUE
 
 	return rewards_base
 

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -37,12 +37,15 @@
 
 /// Calculates total bonus from completing the domain without taking damage
 /obj/machinery/quantum_server/proc/get_nohit_bouns()
+	if(generated_domain.domain_flags & DOMAIN_NO_NOHIT_BONUS)
+		return 0
+
 	var/total = 0
 	for(var/datum/weakref/connection_ref in avatar_connection_refs)
 		var/datum/component/avatar_connection/connection = connection_ref.resolve()
 		if(isnull(connection))
 			continue
-		if(connection.nohit && !(generated_domain.domain_flags & DOMAIN_NO_NOHIT_BONUS))
+		if(connection.nohit)
 			total += nohit_bonus
 	return total
 

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -129,7 +129,7 @@
 
 /// Scans over neo's contents for bitrunning tech disks. Loads the items or abilities onto the avatar.
 /obj/machinery/quantum_server/proc/stock_gear(mob/living/carbon/human/avatar, mob/living/carbon/human/neo, datum/lazy_template/virtual_domain/generated_domain)
-	var/domain_forbids_flags = generated_domain.external_load_flags
+	var/domain_forbids_flags = generated_domain.domain_flags
 
 	var/import_ban = list()
 	var/disk_ban = list()

--- a/code/modules/bitrunning/server/util.dm
+++ b/code/modules/bitrunning/server/util.dm
@@ -96,7 +96,7 @@
 	for(var/datum/lazy_template/virtual_domain/available as anything in subtypesof(/datum/lazy_template/virtual_domain))
 		var/init_cost = initial(available.cost)
 
-		if(!initial(available.test_only) && \
+		if(!(initial(available.domain_flags) & DOMAIN_TEST_ONLY) && \
 			init_cost <= points && \
 			init_cost > BITRUNNER_COST_NONE && \
 			init_cost < BITRUNNER_COST_EXTREME \

--- a/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
@@ -6,6 +6,7 @@
 	Maybe a few drinks of liquid charm will get the spirits up. As the saying goes, if you can't beat 'em, join 'em."
 	key = "beach_bar"
 	map_name = "beach_bar"
+	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 /datum/lazy_template/virtual_domain/beach_bar/setup_domain(list/created_atoms)
 	. = ..()

--- a/code/modules/bitrunning/virtual_domain/domains/breeze_bay.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/breeze_bay.dm
@@ -5,6 +5,7 @@
 	key = "breeze_bay"
 	map_name = "breeze_bay"
 	reward_points = BITRUNNER_REWARD_LOW
+	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 /datum/lazy_template/virtual_domain/breeze_bay/setup_domain(list/created_atoms)
 	. = ..()

--- a/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
@@ -6,6 +6,7 @@
 	I bet there's a way to move it myself."
 	key = "gondola_asteroid"
 	map_name = "gondola_asteroid"
+	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 /// Very pushy gondolas, great for moving loot crates.
 /obj/structure/closet/crate/secure/bitrunning/encrypted/gondola

--- a/code/modules/bitrunning/virtual_domain/domains/grassland_hunt.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/grassland_hunt.dm
@@ -6,6 +6,7 @@
 	key = "grasslands_hunt"
 	map_name = "grasslands_hunt"
 	mob_modules = list(/datum/modular_mob_segment/deer)
+	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 
 /datum/lazy_template/virtual_domain/grasslands_hunt/setup_domain(list/created_atoms)

--- a/code/modules/bitrunning/virtual_domain/domains/pipedream.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/pipedream.dm
@@ -15,7 +15,6 @@
 		/datum/modular_mob_segment/hivebots_strong
 	)
 	reward_points = BITRUNNER_REWARD_LOW
-	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 // ID Trims
 /datum/id_trim/factory

--- a/code/modules/bitrunning/virtual_domain/domains/pipedream.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/pipedream.dm
@@ -15,6 +15,7 @@
 		/datum/modular_mob_segment/hivebots_strong
 	)
 	reward_points = BITRUNNER_REWARD_LOW
+	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 // ID Trims
 /datum/id_trim/factory
@@ -102,4 +103,3 @@
 	name = "Factory Quartermaster"
 	outfit = /datum/outfit/factory/qm
 	icon_state = "corpsecargotech"
-

--- a/code/modules/bitrunning/virtual_domain/domains/psyker_shuffle.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/psyker_shuffle.dm
@@ -9,4 +9,3 @@
 	key = "psyker_shuffle"
 	map_name = "psyker_shuffle"
 	reward_points = BITRUNNER_REWARD_HIGH
-	domain_flags = DOMAIN_NO_NOHIT_BONUS

--- a/code/modules/bitrunning/virtual_domain/domains/psyker_shuffle.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/psyker_shuffle.dm
@@ -9,3 +9,4 @@
 	key = "psyker_shuffle"
 	map_name = "psyker_shuffle"
 	reward_points = BITRUNNER_REWARD_HIGH
+	domain_flags = DOMAIN_NO_NOHIT_BONUS

--- a/code/modules/bitrunning/virtual_domain/domains/stairs_and_cliffs.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/stairs_and_cliffs.dm
@@ -12,6 +12,7 @@
 	key = "stairs_and_cliffs"
 	map_name = "stairs_and_cliffs"
 	reward_points = BITRUNNER_REWARD_MEDIUM
+	domain_flags = DOMAIN_NO_NOHIT_BONUS
 
 /turf/open/cliff/snowrock/virtual_domain
 	name = "icy cliff"

--- a/code/modules/bitrunning/virtual_domain/domains/test_only.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/test_only.dm
@@ -3,7 +3,7 @@
 	name = "Test Only"
 	key = "test_only"
 	map_name = "test_only"
-	test_only = TRUE
+	domain_flags = DOMAIN_TEST_ONLY
 
 /datum/lazy_template/virtual_domain/test_only/expensive
 	key = "test_only_expensive"

--- a/code/modules/bitrunning/virtual_domain/domains/vaporwave.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/vaporwave.dm
@@ -7,3 +7,4 @@
 	key = "vaporwave"
 	map_name = "vaporwave"
 	reward_points = BITRUNNER_REWARD_EXTREME
+	domain_flags = DOMAIN_NO_NOHIT_BONUS

--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -30,13 +30,13 @@
 	var/name = "Virtual Domain"
 	/// Points to reward for completion. Used to purchase new domains and calculate ore rewards.
 	var/reward_points = BITRUNNER_REWARD_MIN
+	/// Any additional flags for this domain
+	var/domain_flags = NONE
 
 	/**
 	 * Player customization
 	 */
 
-	/// Any restrictions this domain has on what external sources can load in
-	var/domain_flags = NONE
 	/// Any outfit that you wish to force on avatars. Overrides preferences
 	var/datum/outfit/forced_outfit
 

--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -13,8 +13,6 @@
 	var/filename = "virtual_domain.dmm"
 	/// The start time of the map. Used to calculate time taken
 	var/start_time
-	/// This map is specifically for unit tests. Shouldn't display in game
-	var/test_only = FALSE
 
 	/**
 	 * Generic settings / UI
@@ -38,7 +36,7 @@
 	 */
 
 	/// Any restrictions this domain has on what external sources can load in
-	var/external_load_flags = NONE
+	var/domain_flags = NONE
 	/// Any outfit that you wish to force on avatars. Overrides preferences
 	var/datum/outfit/forced_outfit
 


### PR DESCRIPTION
## About The Pull Request

Completing a combat bitrunning domain grants 0.8 score bonus per player that escaped without being hit

## Why It's Good For The Game

I figured it be a fun challenge to try to nohit these things, especially the megafauna ones. For a bonus.

## Changelog

:cl: Melbert
add: Nohitting a combat bitrunning domain rewards a higher score.
/:cl:
