### PR TITLE
Agent IDs autofill their user's age and display custom jobs upon inspection

### DIFF
--- a/code/datums/quirks/negative_quirks/addict.dm
+++ b/code/datums/quirks/negative_quirks/addict.dm
@@ -16,7 +16,7 @@
 	var/process_interval = 30 SECONDS //! how frequently the quirk processes
 	COOLDOWN_DECLARE(next_process) //! ticker for processing
 
-/datum/quirk/item_quirk/addict/add_unique(client/client_source)
+/datum/quirk/item_quirk/addict/add(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 
 	if(!reagent_type)
@@ -27,6 +27,7 @@
 	for(var/addiction in reagent_instance.addiction_types)
 		human_holder.last_mind?.add_addiction_points(addiction, 1000)
 
+/datum/quirk/item_quirk/addict/add_unique(client/client_source)
 	var/current_turf = get_turf(quirk_holder)
 
 	if(!drug_container_type)

--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -39,7 +39,6 @@
 	medical_record_text = "Patient's immune system responds violently to [allergy_string]"
 
 /datum/quirk/item_quirk/allergic/add_unique(client/client_source)
-
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/clothing/accessory/dogtag/allergy/dogtag = new(get_turf(human_holder), allergy_string)
 

--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -26,7 +26,7 @@
 		)
 	var/allergy_string
 
-/datum/quirk/item_quirk/allergic/add_unique(client/client_source)
+/datum/quirk/item_quirk/allergic/add(client/client_source)
 	var/list/chem_list = subtypesof(/datum/reagent/medicine) - blacklist
 	var/list/allergy_chem_names = list()
 	for(var/i in 0 to 5)
@@ -37,6 +37,8 @@
 	allergy_string = allergy_chem_names.Join(", ")
 	name = "Extreme [allergy_string] Allergies"
 	medical_record_text = "Patient's immune system responds violently to [allergy_string]"
+
+/datum/quirk/item_quirk/allergic/add_unique(client/client_source)
 
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/clothing/accessory/dogtag/allergy/dogtag = new(get_turf(human_holder), allergy_string)

--- a/code/datums/quirks/negative_quirks/asthma.dm
+++ b/code/datums/quirks/negative_quirks/asthma.dm
@@ -60,17 +60,18 @@
 		/datum/disease/asthma_attack/critical = 1, // this can quickly kill you, so its rarity is justified
 	)
 
-/datum/quirk/item_quirk/asthma/add_unique(client/client_source)
-	. = ..()
-
-	var/obj/item/inhaler/albuterol/asthma/rescue_inhaler = new(get_turf(quirk_holder))
-	give_item_to_holder(rescue_inhaler, list(LOCATION_BACKPACK, LOCATION_HANDS), flavour_text = "You can use this to quickly relieve the symptoms of your asthma.")
-
+/datum/quirk/item_quirk/asthma/add(client/client_source)
 	RegisterSignal(quirk_holder, COMSIG_CARBON_EXPOSED_TO_SMOKE, PROC_REF(holder_exposed_to_smoke))
 	RegisterSignal(quirk_holder, COMSIG_CARBON_LOSE_ORGAN, PROC_REF(organ_removed))
 	RegisterSignal(quirk_holder, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(exposed_to_reagents))
 	RegisterSignal(quirk_holder, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(on_full_heal))
 	RegisterSignal(quirk_holder, COMSIG_LIVING_LIFE, PROC_REF(on_life))
+
+/datum/quirk/item_quirk/asthma/add_unique(client/client_source)
+	. = ..()
+
+	var/obj/item/inhaler/albuterol/asthma/rescue_inhaler = new(get_turf(quirk_holder))
+	give_item_to_holder(rescue_inhaler, list(LOCATION_BACKPACK, LOCATION_HANDS), flavour_text = "You can use this to quickly relieve the symptoms of your asthma.")
 
 	COOLDOWN_START(src, next_attack_cooldown, time_first_attack_can_happen)
 

--- a/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -11,9 +11,11 @@
 		/obj/item/storage/pill_bottle/prescription_stimulant,
 	)
 
-/datum/quirk/item_quirk/narcolepsy/add_unique(client/client_source)
+/datum/quirk/item_quirk/narcolepsy/add(client/client_source)
 	var/mob/living/carbon/carbon_user = quirk_holder
 	carbon_user.gain_trauma(/datum/brain_trauma/severe/narcolepsy/permanent, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/item_quirk/narcolepsy/add_unique(client/client_source)
 
 	give_item_to_holder(
 		/obj/item/storage/pill_bottle/prescription_stimulant,

--- a/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -16,7 +16,6 @@
 	carbon_user.gain_trauma(/datum/brain_trauma/severe/narcolepsy/permanent, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/item_quirk/narcolepsy/add_unique(client/client_source)
-
 	give_item_to_holder(
 		/obj/item/storage/pill_bottle/prescription_stimulant,
 		list(

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1932,8 +1932,11 @@
 	var/target_occupation = tgui_input_text(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels.", "Agent card job assignment", assignment ? assignment : "Assistant", max_length = MAX_NAME_LEN)
 	if(!after_input_check(user))
 		return TRUE
-
-	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", AGE_MIN, AGE_MAX, AGE_MIN)
+	var/default_age = AGE_MIN
+	if ishuman(user)
+		var/mob/living/carbon/human/H = user
+		default_age = H.age
+	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", default_age, AGE_MAX, AGE_MIN)
 	if(!after_input_check(user))
 		return TRUE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -127,7 +127,7 @@
 			id_species ||= dna.species.name
 			id_blood_type ||= get_bloodtype()
 
-		if(istype(id, /obj/item/card/id/advanced))
+		else if(istype(id, /obj/item/card/id/advanced))
 			var/obj/item/card/id/advanced/advancedID = id
 			id_job = advancedID.trim_assignment_override || id_job
 

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -751,11 +751,17 @@
 	var/typepath = owner.type
 	clone = new typepath(owner.drop_location())
 	if(iscarbon(owner) && iscarbon(clone))
-		var/mob/living/carbon/carbon_owner = owner
-		var/mob/living/carbon/carbon_clone = clone
-		carbon_clone.real_name = carbon_owner.real_name
-		carbon_owner.dna.copy_dna(carbon_clone.dna, COPY_DNA_SE|COPY_DNA_SPECIES)
-		carbon_clone.updateappearance(mutcolor_update = TRUE)
+		var/mob/living/carbon/human/human_owner = owner
+		var/mob/living/carbon/human/human_clone = clone
+		human_clone.physique = human_owner.physique
+		human_clone.real_name = human_owner.real_name
+		human_clone.age = human_owner.age
+		human_clone.voice = human_owner.voice
+		human_clone.voice_filter = human_owner.voice_filter
+		for(var/datum/quirk/original_quirks as anything in human_owner.quirks)
+			human_clone.add_quirk(original_quirks.type, add_unique = FALSE, announce = FALSE)
+		human_owner.dna.copy_dna(human_clone.dna, COPY_DNA_SE|COPY_DNA_SPECIES)
+		human_clone.updateappearance(mutcolor_update = TRUE)
 	return ..()
 
 /datum/status_effect/stabilized/cerulean/tick(seconds_between_ticks)


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. When you're forging an Agent ID if you're a human your age will autofill. If you aren't a human (tested as a gorilla) it will autofill the minimum age, which is what it currently always does. This just makes forging quicker, you probably aren't using an Agent ID to pass off as someone way older than yourself.

Also, when you inspect someone and check their displayed ID it'll show you the job they entered while forging it and not the job that their trim is associated with. I'm assuming this fixes an oversight because you can already rename the ID to display a custom job, the inspection on examine feature just lets you ignore this for some reason.

<img width="488" height="146" alt="Screenshot 2025-10-20 002248" src="https://github.com/user-attachments/assets/46a2fc00-f77d-4ce7-93df-fb0f982be0d3" />

This lets you display jobs that don't exist

## Why It's Good For The Game

Qol, also enables funny gimmicks.

## Changelog

:cl:
qol: Agent IDs autofill the user's current age if they have one
fix: Agent IDs can display custom jobs upon close examination
/:cl:
