### PR TITLE
Agent IDs autofill their user's age and display custom jobs upon inspection

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1933,7 +1933,7 @@
 	if(!after_input_check(user))
 		return TRUE
 	var/default_age = AGE_MIN
-	if ishuman(user)
+	if(ishuman(user))
 		var/mob/living/carbon/human/human_user = user
 		default_age = human_user.age ? clamp(human_user.age, AGE_MIN, AGE_MAX) : AGE_MIN
 	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", default_age, AGE_MAX, AGE_MIN)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1934,8 +1934,8 @@
 		return TRUE
 	var/default_age = AGE_MIN
 	if ishuman(user)
-		var/mob/living/carbon/human/H = user
-		default_age = H.age
+		var/mob/living/carbon/human/human_user = user
+		default_age = human_user.age ? clamp(human_user.age, AGE_MIN, AGE_MAX) : AGE_MIN
 	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", default_age, AGE_MAX, AGE_MIN)
 	if(!after_input_check(user))
 		return TRUE

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1932,8 +1932,11 @@
 	var/target_occupation = tgui_input_text(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels.", "Agent card job assignment", assignment ? assignment : "Assistant", max_length = MAX_NAME_LEN)
 	if(!after_input_check(user))
 		return TRUE
-
-	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", AGE_MIN, AGE_MAX, AGE_MIN)
+	var/default_age = AGE_MIN
+	if ishuman(user)
+		var/mob/living/carbon/human/H = user
+		default_age = H.age
+	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", default_age, AGE_MAX, AGE_MIN)
 	if(!after_input_check(user))
 		return TRUE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -127,7 +127,7 @@
 			id_species ||= dna.species.name
 			id_blood_type ||= get_bloodtype()
 
-		if(istype(id, /obj/item/card/id/advanced))
+		else if(istype(id, /obj/item/card/id/advanced))
 			var/obj/item/card/id/advanced/advancedID = id
 			id_job = advancedID.trim_assignment_override || id_job
 


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. When you're forging an Agent ID if you're a human your age will autofill. If you aren't a human (tested as a gorilla) it will autofill the minimum age, which is what it currently always does. This just makes forging quicker, you probably aren't using an Agent ID to pass off as someone way older than yourself.

Also, when you inspect someone and check their displayed ID it'll show you the job they entered while forging it and not the job that their trim is associated with. I'm assuming this fixes an oversight because you can already rename the ID to display a custom job, the inspection on examine feature just lets you ignore this for some reason.

<img width="373" height="238" alt="Screenshot 2025-10-20 005151" src="https://github.com/user-attachments/assets/38345d4b-65cf-4d01-bd88-015321687810" />

This lets you display jobs that don't exist. If I tried this on live servers the job would be listed as "Admiral" while the ID's name would still be "Nyaria Luma (Nuclear Disk Inspector), making it a dead giveaway that the ID is fake.

## Why It's Good For The Game

Qol, also enables funny gimmicks.

## Changelog

:cl:
qol: Agent IDs autofill the user's current age if they have one
fix: Agent IDs can display custom jobs upon close examination
/:cl:
