### PR TITLE
[NO GBP] Un-reverts some core crafting changes (with better fix)

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -372,21 +372,21 @@
 	if(recipe.structures)
 		requirements += recipe.structures
 
-	var/list/surroundings
+	var/list/surroundings = get_environment(atom, recipe.blacklist)
 	for(var/path_key in requirements)
 		var/amount = recipe.reqs?[path_key] || recipe.machinery?[path_key] || recipe.structures?[path_key]
 		if(!amount)//since machinery & structures can have 0 aka CRAFTING_MACHINERY_USE - i.e. use it, don't consume it!
 			continue
-		surroundings = get_environment(atom, recipe.blacklist)
-		surroundings -= return_list
 		if(ispath(path_key, /datum/reagent))
 			if(!holder)
 				holder = new(INFINITY, NO_REACT) //an infinite volume holder than can store reagents without reacting
 				return_list += holder
+			var/list/checked = list()
 			while(amount > 0)
-				var/obj/item/reagent_containers/container = locate() in surroundings
+				var/obj/item/reagent_containers/container = locate() in ((surroundings | return_list) - checked)
 				if(isnull(container)) //This would only happen if the previous checks for contents and tools were flawed.
 					stack_trace("couldn't fulfill the required amount for [path_key]. Dangit")
+					break
 				if(QDELING(container)) //it's deleting...
 					surroundings -= container
 					continue
@@ -394,7 +394,7 @@
 				if(reagent_volume)
 					container.reagents.trans_to(holder, min(amount, reagent_volume), target_id = path_key, no_react = TRUE)
 					amount -= reagent_volume
-				surroundings -= container
+				checked += container
 				container.update_appearance(UPDATE_ICON)
 		else if(ispath(path_key, /obj/item/stack))
 			var/obj/item/stack/tally_stack
@@ -402,6 +402,7 @@
 				var/obj/item/stack/origin_stack = locate(path_key) in surroundings
 				if(isnull(origin_stack)) //This would only happen if the previous checks for contents and tools were flawed.
 					stack_trace("couldn't fulfill the required amount for [path_key]. Dangit")
+					break
 				if(QDELING(origin_stack))
 					continue
 				var/amount_to_give = min(origin_stack.amount, amount)
@@ -420,6 +421,7 @@
 				var/atom/movable/item = locate(path_key) in surroundings
 				if(isnull(item)) //This would only happen if the previous checks for contents and tools were flawed.
 					stack_trace("couldn't fulfill the required amount for [path_key]. Dangit")
+					break
 				if(QDELING(item))
 					continue
 				return_list += item

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -208,6 +208,20 @@
 	)
 	result = /obj/item/food/rootdough/egg
 	removed_foodtypes = RAW
+	/**
+	 * So, at some point, we've had some mean issues with crafting with empty containers.
+	 * Bugs happen and we fix them all the time, so let's make sure stuff like this won't happen again.
+	 * Let's make his recipe spawn a bunch of unneeded containers and something else as well.
+	 * If this breaks the CI, then something is wrong with crafting.
+	 */
+	unit_test_spawn_extras = list(
+		/obj/item/food/rootdough/egg,
+		/obj/item/food/grown/potato,
+		/obj/item/reagent_containers/condiment,
+		/obj/item/reagent_containers/cup/bottle,
+		/obj/item/reagent_containers/cup/beaker/slime,
+		/obj/item/reagent_containers/applicator/patch/synthflesh,
+	)
 	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/snail_nizaya

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -215,12 +215,12 @@
 	 * If this breaks the CI, then something is wrong with crafting.
 	 */
 	unit_test_spawn_extras = list(
-		/obj/item/food/rootdough/egg,
-		/obj/item/food/grown/potato,
-		/obj/item/reagent_containers/condiment,
-		/obj/item/reagent_containers/cup/bottle,
-		/obj/item/reagent_containers/cup/beaker/slime,
-		/obj/item/reagent_containers/applicator/patch/synthflesh,
+		/obj/item/food/rootdough/egg = 1,
+		/obj/item/food/grown/potato = 1,
+		/obj/item/reagent_containers/condiment = 1,
+		/obj/item/reagent_containers/cup/bottle = 2,
+		/obj/item/reagent_containers/cup/beaker/slime = 1,
+		/obj/item/reagent_containers/applicator/patch/synthflesh = 1,
 	)
 	crafting_flags = CRAFT_CLEARS_REAGENTS
 


### PR DESCRIPTION
## About The Pull Request
The soft-revert was merged since it targeted an issue that could crash the server with infinite loops. However, the solution was kinda shoddy, which brought the `get_environment` inside the main loop, which I'm once again trying to move outside it. This way it only has to be called once.

The NO GBP tag is here because the issue was my fault. This PR includes some small changes done to test and ensure that this won't happen in the future.

## Why It's Good For The Game
Fewer unnecessary calls. The performance of the crafting unit test is roughly the same (10 seconds circa), because the bulk of it is spawning the required objects anyway.

## Changelog
N/A