### PR TITLE
CQC block buff (Not RNG anymore)

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -12,8 +12,8 @@
 	display_combos = TRUE
 	/// Weakref to a mob we're currently restraining (with grab-grab combo)
 	VAR_PRIVATE/datum/weakref/restraining_mob
-	/// Probability of successfully blocking attacks while on throw mode
-	var/block_chance = 75
+	/// Stamina cost for blocking when in throw mode
+	var/block_stamina = 30
 
 /datum/martial_art/cqc/activate_style(mob/living/new_holder)
 	. = ..()
@@ -50,7 +50,7 @@
 		return NONE
 	if(attack_type == PROJECTILE_ATTACK)
 		return NONE
-	if(!prob(block_chance))
+	if(100 - cqc_user.getStaminaLoss() <= block_stamina)
 		return NONE
 
 	var/mob/living/attacker = GET_ASSAILANT(hitby)
@@ -59,6 +59,7 @@
 			span_danger("[cqc_user] blocks [attack_text] and twists [attacker]'s arm behind [attacker.p_their()] back!"),
 			span_userdanger("You block [attack_text]!"),
 		)
+		cqc_user.adjustStaminaLoss(30)
 		attacker.Stun(4 SECONDS)
 	else
 		cqc_user.visible_message(
@@ -375,7 +376,7 @@
 	to_chat(usr, "[span_notice("Pressure")]: Shove Grab. Decent stamina damage.")
 	to_chat(usr, "[span_notice("Consecutive CQC")]: Shove Shove Punch. Mainly offensive move, huge damage and decent stamina damage.")
 
-	to_chat(usr, "<b><i>In addition, by having your throw mode on when being attacked, you enter an active defense mode where you have a chance to block and sometimes even counter attacks done to you.</i></b>")
+	to_chat(usr, "<b><i>In addition, by having your throw mode on when being attacked, you enter an active defense mode where you block and sometimes even counter attacks done to you at the cost of stamina.</i></b>")
 
 ///Subtype of CQC. Only used for the chef.
 /datum/martial_art/cqc/under_siege


### PR DESCRIPTION
## About The Pull Request

More new player friendly version of https://github.com/tgstation/tgstation/pull/88695

This is a buff

When you have **THROW MODE ON** and you're hit by anything that isn't a projectile you will block it and take 30 stamina damage. If you don't have enough stamina to block without going into stamcrit you won't block and **WON'T GO INTO STAMCRIT**

Updated the Remember the Basics text to tell you how it works 

## Why It's Good For The Game

> If you try to attack a CQC user in melee combat, alone, you should be totally and completely fucked. But, we don't want CQC users to be immune to stun batons or something equally ridiculous, so adding a stamina cost to a successful block seems like a fair trade. If a nukie wants to get stimmed to the tits and remember the basics of close quarters combat, that sounds fucking sick actually. They would still need to account for projectile weapons in this hypothetical power fantasy. This would also be the case for the chef inside their kitchen; if I leap the counter and try to baton the chef, I shouldn't have a 25% chance to succeed at a close quarters attack against a close quarters combat master. I'll just chuck a CLF3 foam in there or something because fuck that.

Also rng in combat suggs

## Changelog
:cl:
balance: CQC blocks are guaranteed but cost 30 stamina damage, can't block with less than 30 stamina
/:cl:
