### PR TITLE
ORM now displays your mining point balance instead of your bank account balance

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -290,7 +290,7 @@
 		if(card?.registered_account)
 			data["user"] = list(
 				"name" = card.registered_account.account_holder,
-				"cash" = card.registered_account.account_balance,
+				"cash" = card.registered_account.mining_points,
 			)
 
 		else if(issilicon(user))

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.tsx
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.tsx
@@ -157,7 +157,7 @@ function IDSection(props: IDSectionProps) {
             <LabeledList.Item label="Name">
               {user?.name || 'No Name Detected'}
             </LabeledList.Item>
-            <LabeledList.Item label="Balance">
+            <LabeledList.Item label="Point Balance">
               {user?.cash || 'No Balance Detected'}
             </LabeledList.Item>
           </LabeledList>


### PR DESCRIPTION

## About The Pull Request
I don't think that the payout is in credits, chief.

## Why It's Good For The Game
This is pretty clearly an oversight, as it only makes sense if its meant to display the balance to which your payout will be added

## Changelog
:cl:
fix: ORM now displays your mining point balance instead of your bank account balance
/:cl:
