### PR TITLE
Fixes admin spawn panel search not updating on search mode toggle

### DIFF
--- a/tgui/packages/tgui/interfaces/SpawnPanel/CreateObject.tsx
+++ b/tgui/packages/tgui/interfaces/SpawnPanel/CreateObject.tsx
@@ -1,5 +1,5 @@
 import { storage } from 'common/storage';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Button,
   DmIcon,
@@ -55,10 +55,15 @@ export function CreateObject(props: CreateObjectProps) {
   const currentList = objList;
   const currentType = allObjects[data.copied_type ?? '']?.type || 'Objects';
 
+  const getSearchString = useCallback(
+    (key: string) => (searchBy ? key : allObjects[key]?.name || ''),
+    [searchBy, allObjects],
+  );
+
   const { query, setQuery, results } = useFuzzySearch({
     searchArray: Object.keys(allObjects),
     matchStrategy: 'smart',
-    getSearchString: (key) => (searchBy ? key : allObjects[key]?.name || ''),
+    getSearchString,
   });
 
   const filteredResults = results.filter((obj) => {


### PR DESCRIPTION

## About The Pull Request
Fixes search results not updating immediately when toggling between 'By name' and 'By type' modes in the admin spawn panel.

The issue was that the getSearchString function wasn't properly memoized, so the fuzzy search hook didn't rebuild its index when searchBy state changed.

Fixed by using useCallback to memoize getSearchString with proper dependencies.
## Why It's Good For The Game
Better UX.
## Changelog
:cl:
fix: Admin spawn panel toggle "By name"/"By type" updates search results without having to update the search string.
/:cl:
