### PR TITLE
Fixes Sterilizine not applying its surgical speed modifier

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1089,7 +1089,7 @@
 		return
 
 	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(0.2, surgery.speed_modifier)
+		surgery.speed_modifier = min(0.8, surgery.speed_modifier)
 
 /datum/reagent/space_cleaner/sterilizine/on_burn_wound_processing(datum/wound/burn/flesh/burn_wound)
 	burn_wound.sanitization += 0.9


### PR DESCRIPTION
## About The Pull Request

Sterilizine is supposed to provide a 20% surgery speed bonus in surgeries, but that part of the reagent's effects don't work due to it using max( instead of min( like the other surgery modifying reagents. This PR fixes that so Sterilizine can once again make surgeries faster.

## Why It's Good For The Game

Bugfix, the reagent has made surgeries faster before and should still do it now.

## Changelog
:cl:
fix: Sterilizine will now correctly apply its 20% surgery speed bonus.
/:cl: