### PR TITLE
Panicier Syphon!

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
@@ -166,7 +166,8 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 
 /datum/air_alarm_mode/panic_siphon/apply(area/applied)
 	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
-		vent.on = FALSE
+		vent.on = TRUE
+		vent.pump_direction = ATMOS_DIRECTION_SIPHONING
 		vent.update_appearance(UPDATE_ICON)
 
 	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
@@ -168,6 +168,7 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
 		vent.on = TRUE
 		vent.pump_direction = ATMOS_DIRECTION_SIPHONING
+		vent.pressure_checks = NO_BOUND
 		vent.update_appearance(UPDATE_ICON)
 
 	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_modes.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(air_alarm_modes, init_air_alarm_modes())
 	for (var/obj/machinery/atmospherics/components/unary/vent_pump/vent as anything in applied.air_vents)
 		vent.on = TRUE
 		vent.pump_direction = ATMOS_DIRECTION_SIPHONING
-		vent.pressure_checks = NO_BOUND
+		vent.pressure_checks = NONE
 		vent.update_appearance(UPDATE_ICON)
 
 	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber as anything in applied.air_scrubbers)


### PR DESCRIPTION

## About The Pull Request

The Panic Syphon mode on air alarms now makes vents syphon too

## Why It's Good For The Game

If you're pressing panic syphon you want the atmos in the room gone asap and this way there's less buttons to press. There's plenty of other options for removing bad stuff into the scrubber pipes without contaminating distro.

## Changelog
:cl:
qol: Panic Syphon makes the vents in the room syphon too
/:cl:
