### PR TITLE
Makes soda cans explode when exposed at low pressure.

### DIFF
--- a/code/game/objects/effects/decals/cleanable/mess.dm
+++ b/code/game/objects/effects/decals/cleanable/mess.dm
@@ -382,3 +382,7 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 	flick("rubble_bounce", src)
 	icon_state = "rubble"
 	update_appearance(UPDATE_ICON_STATE)
+
+/obj/effect/decal/cleanable/can_bits
+	name = "shredded can"
+	desc = "This story doesn't hold water anymore."

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -179,7 +179,7 @@
 		return TRUE
 
 /obj/item/reagent_containers/cup/soda_cans/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	if(reagents.total_volume)
+	if(reagents.total_volume && !(reagents.flags & OPENCONTAINER))
 		burst_soda(loc)
 
 #undef SODA_FIZZINESS_THROWN

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -174,7 +174,7 @@
 		. += "\t[span_warning("You get a menacing aura of fizziness from it...")]"
 
 /obj/item/reagent_containers/cup/soda_cans/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return (air.return_pressure() <= SODA_EXPLOSION_PRESSURE) && !(reagents.flags & OPENCONTAINER))
+	return ((air.return_pressure() <= SODA_EXPLOSION_PRESSURE) && !(reagents.flags & OPENCONTAINER))
 
 /obj/item/reagent_containers/cup/soda_cans/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	if(reagents.total_volume && !(reagents.flags & OPENCONTAINER))

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -174,9 +174,7 @@
 		. += "\t[span_warning("You get a menacing aura of fizziness from it...")]"
 
 /obj/item/reagent_containers/cup/soda_cans/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	. = ..()
-	if(air.return_pressure() <=  SODA_EXPLOSION_PRESSURE)
-		return TRUE
+	return air.return_pressure() <= SODA_EXPLOSION_PRESSURE
 
 /obj/item/reagent_containers/cup/soda_cans/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	if(reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -5,6 +5,8 @@
 #define SODA_FIZZINESS_THROWN 15
 /// How much fizziness is added to the can of soda by shaking it, in percentage points
 #define SODA_FIZZINESS_SHAKE 5
+/// At what atmospheric pressure do we burst a soda can? Empirical evidance (one googled experiment video) states that ~67.458 kPa is where a can bursts.
+#define SODA_EXPLOSION_PRESSURE 67.458
 
 /obj/item/reagent_containers/cup/soda_cans
 	name = "soda can"
@@ -24,6 +26,7 @@
 /obj/item/reagent_containers/cup/soda_cans/Initialize(mapload, vol)
 	. = ..()
 	AddElement(/datum/element/slapcrafting, string_list(list(/datum/crafting_recipe/improv_explosive)))
+	AddElement(/datum/element/atmos_sensitive, mapload) //Enables soda cans to explode in vaccuum.
 
 /obj/item/reagent_containers/cup/soda_cans/random/Initialize(mapload)
 	..()
@@ -170,8 +173,18 @@
 		. += span_notice("<i>You examine [src] closer, and note the following...</i>")
 		. += "\t[span_warning("You get a menacing aura of fizziness from it...")]"
 
+/obj/item/reagent_containers/cup/soda_cans/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
+	. = ..()
+	if(air.return_pressure() <=  SODA_EXPLOSION_PRESSURE)
+		return TRUE
+
+/obj/item/reagent_containers/cup/soda_cans/atmos_expose(datum/gas_mixture/air, exposed_temperature)
+	if(reagents.total_volume)
+		burst_soda(loc)
+
 #undef SODA_FIZZINESS_THROWN
 #undef SODA_FIZZINESS_SHAKE
+#undef SODA_EXPLOSION_PRESSURE
 
 /obj/item/reagent_containers/cup/soda_cans/cola
 	name = "Space Cola"

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -174,7 +174,7 @@
 		. += "\t[span_warning("You get a menacing aura of fizziness from it...")]"
 
 /obj/item/reagent_containers/cup/soda_cans/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return air.return_pressure() <= SODA_EXPLOSION_PRESSURE
+	return (air.return_pressure() <= SODA_EXPLOSION_PRESSURE) && !(reagents.flags & OPENCONTAINER))
 
 /obj/item/reagent_containers/cup/soda_cans/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	if(reagents.total_volume && !(reagents.flags & OPENCONTAINER))


### PR DESCRIPTION
## About The Pull Request

Fun idea discussed on the discord.
At low pressure, cans of soda will burst at 67.458 kPa, which is WAY higher than I would have expected, but that may just say something about the construction of the average can of soda.

## Why It's Good For The Game

Fun little realism feature, which I found amusing enough for a quick 15 minute project. Only applies to cans that are actually exposed to atmos, so a held can while in space or in the bag won't trigger this reaction.

## Changelog

:cl:
add: Leaving a can of soda exposed to the elements at low pressure will now burst.
/:cl:
