### PR TITLE
[NO GBP] Fixes temporary deafness

### DIFF
--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -73,7 +73,7 @@
 ///Adjust the temporary deafness of the person, up or down
 /obj/item/organ/ears/proc/adjust_temporary_deafness(amount)
 	// organ failure makes us permanently deafened. Also, doesn't do anything if not in someone or during godmode
-	if(amount <= 0 || (owner && HAS_TRAIT(owner, TRAIT_GODMODE)))
+	if(amount > 0 && owner && HAS_TRAIT(owner, TRAIT_GODMODE))
 		return
 
 	temporary_deafness = max(temporary_deafness + amount * damage_multiplier, 0)

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -76,7 +76,7 @@
 	if(amount <= 0 || (owner && HAS_TRAIT(owner, TRAIT_GODMODE)))
 		return
 
-	temporary_deafness += max(amount * damage_multiplier, 0)
+	temporary_deafness = max(temporary_deafness + amount * damage_multiplier, 0)
 
 	if(!owner)
 		return


### PR DESCRIPTION
## About The Pull Request
Yeah, if we just use the `+=` operator, the temporary deafness will never decrease since the addendum will never be below zero. This PR fixes that.

## Why It's Good For The Game
This will fix #93579 

## Changelog

:cl:
fix: Fixed temporary deafness never going away.
/:cl:
