### PR TITLE
Angry monkeys are violent again

### DIFF
--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -31,7 +31,11 @@ have ways of interacting with a specific mob and control it.
 /datum/targeting_strategy/basic/monkey
 
 /datum/targeting_strategy/basic/monkey/faction_check(datum/ai_controller/controller, mob/living/living_mob, mob/living/the_target)
+	// if they wronged us, all bets are off
 	if(controller.blackboard[BB_MONKEY_ENEMIES][the_target])
+		return FALSE
+	// target was forcibly set, all bets are off again
+	if(controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET] == the_target)
 		return FALSE
 	return ..()
 

--- a/code/datums/ai/monkey/monkey_subtrees.dm
+++ b/code/datums/ai/monkey/monkey_subtrees.dm
@@ -55,7 +55,8 @@
 			controller.queue_behavior(/datum/ai_behavior/recruit_monkeys, BB_MONKEY_CURRENT_ATTACK_TARGET)
 			return
 
-		controller.queue_behavior(/datum/ai_behavior/battle_screech/monkey)
+		if(SPT_PROB(ismonkey(living_pawn) ? 25 : 10, seconds_per_tick))
+			controller.queue_behavior(/datum/ai_behavior/battle_screech/monkey)
 		controller.queue_behavior(/datum/ai_behavior/monkey_attack_mob, BB_MONKEY_CURRENT_ATTACK_TARGET)
 		return SUBTREE_RETURN_FINISH_PLANNING
 


### PR DESCRIPTION
## About The Pull Request

### Fix

If a monkey has no enemies, it will not attack anything.

For normal monkeys, this just caused nothing to happen. 

For angry monkeys, this allowed them to run `monkey_set_combat_target` and pick a target from view rather than enemies list.

However, when determining "am I allowed to attack this guy", it checked the enemies list. Which is still empty. Meaning angry monkeys would not attack the target they just selected. 

I fixed this by adding a check for target in addition to a check for enemies.

### Other

I also reduced the chance of screeching from 100% to 25% (or 10% for humans).

## Why It's Good For The Game

- Bugfix

- In testing this bugfix, monkeys screeching literally every attack is a bit excessive and spammy, especially if you're not a monkey. Bumping the odds down keeps the "rabid monkey" effect without overdoing it. 

## Changelog

:cl: Melbert
fix: Angry monkeys (and the primal instincts trauma) are VIOLENT again
qol: Monkeys no longer screech every tick they are attacking someone (now ~1 in 4 ticks, or ~1 in 10 for primal instincts) 
/:cl:
