### PR TITLE
[NO GBP] Fixing the fish scanner UI

### DIFF
--- a/code/modules/fishing/aquarium/fish_analyzer.dm
+++ b/code/modules/fishing/aquarium/fish_analyzer.dm
@@ -72,30 +72,22 @@
 	if(target != scanned_object)
 		unregister_scanned()
 		register_scanned(target)
-	update_static_data_for_all_viewers()
 	ui_interact(user)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/fish_analyzer/proc/register_scanned(atom/target)
 	scanned_object = target
 	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(on_target_deleted))
-	if(HAS_TRAIT(target, TRAIT_IS_AQUARIUM))
-		RegisterSignals(target, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, COMSIG_ATOM_EXITED), PROC_REF(aquarium_update))
 
 /obj/item/fish_analyzer/proc/unregister_scanned()
 	if(!scanned_object)
 		return
-	UnregisterSignal(scanned_object, list(COMSIG_QDELETING, COMSIG_ATOM_ENTERED, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, COMSIG_ATOM_EXITED))
+	UnregisterSignal(scanned_object, COMSIG_QDELETING)
 	scanned_object = null
 
 /obj/item/fish_analyzer/proc/on_target_deleted()
 	SIGNAL_HANDLER
 	unregister_scanned()
-
-/obj/item/fish_analyzer/proc/aquarium_update()
-	SIGNAL_HANDLER
-	//update static data on the next tick. to give time to offsprings to properly inherit the parents' traits and all.
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, update_static_data_for_all_viewers)), 0)
 
 /obj/item/fish_analyzer/ui_interact(mob/user, datum/tgui/ui)
 	if(isnull(scanned_object))
@@ -103,6 +95,7 @@
 		return TRUE
 	if(!(scanned_object in view(7, get_turf(src))))
 		balloon_alert(user, "specimen data lost!")
+		unregister_scanned()
 		return TRUE
 
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -117,25 +110,13 @@
 		return UI_CLOSE
 	return ..()
 
-/obj/item/fish_analyzer/ui_static_data(mob/user)
+/obj/item/fish_analyzer/ui_data(mob/user)
 	var/list/data = list()
 	data["fish_list"] = list()
 	data["fish_scanned"] = FALSE
 
 	if(isfish(scanned_object))
 		data["fish_scanned"] = TRUE
-		return extract_static_fish_info(data, scanned_object)
-
-	for(var/obj/item/fish/fishie in scanned_object)
-		extract_static_fish_info(data, fishie)
-
-	return data
-
-/obj/item/fish_analyzer/ui_data(mob/user)
-	var/list/data = list()
-	data["fish_list"] = list()
-
-	if(isfish(scanned_object))
 		return extract_fish_info(data, scanned_object)
 
 	for(var/obj/item/fish/fishie in scanned_object)
@@ -143,7 +124,7 @@
 
 	return data
 
-/obj/item/fish_analyzer/proc/extract_static_fish_info(list/data, obj/item/fish/fishie)
+/obj/item/fish_analyzer/proc/extract_fish_info(list/data, obj/item/fish/fishie)
 	var/list/fish_traits = list()
 	var/list/fish_evolutions = list()
 
@@ -175,12 +156,6 @@
 		"fish_traits" = fish_traits,
 		"fish_evolutions" = fish_evolutions,
 		"fish_suitable_temp" = fishie.fish_flags & FISH_FLAG_SAFE_TEMPERATURE,
-	))
-
-	return data
-
-/obj/item/fish_analyzer/proc/extract_fish_info(list/data, obj/item/fish/fishie)
-	data["fish_list"] += list(list(
 		"fish_health" = fishie.status == FISH_DEAD ? 0 : PERCENT(fishie.get_health_percentage()),
 		"fish_size" = fishie.size,
 		"fish_weight" = fishie.weight,


### PR DESCRIPTION
## About The Pull Request
Ok, I'm going to be real honest, somehow I've ended up thinking building two separate data lists for the same fish without associating them to a key or something when building tgui data would've worked, when in fact it doesn't.

The ideal solution could've been to use refs, change the tsx code a fair bit and keep both static and non-static ui data procs, but it's also past AM here, I made a mistake, I don't have the mental capacity to do it right now and it's honestly just a insignificant micro-optimization, considering aquariums are (hard)coded to hold at most 20 fishes. Not a huge impact.

TL;DR It's all ui_data now.

## Why It's Good For The Game
Fixing the fish scanner UI.

## Changelog
N/A until an issue report is (if) made.