### PR TITLE
Fixes planet_allergy effect not going away

### DIFF
--- a/code/datums/components/space_allergy.dm
+++ b/code/datums/components/space_allergy.dm
@@ -18,6 +18,8 @@
 	SIGNAL_HANDLER
 
 	if(is_on_a_planet(parent) && parent.has_gravity())
-		allergy = parent.apply_status_effect(/datum/status_effect/planet_allergy) //your gamer body cant stand real gravity < Soul
+		var/status_effect = parent.apply_status_effect(/datum/status_effect/planet_allergy) //your gamer body cant stand real gravity < Soul
+		if(status_effect)
+			allergy = status_effect
 	else
 		QDEL_NULL(allergy)


### PR DESCRIPTION
closes #93444

It's the component that voidwalkers have and that you get when you get kidnapped. The punishment for being in planetary gravity never went away
## Changelog
:cl:
fix: Voidwalker's 'planet allergy' effect goes away again when you leave a planet
/:cl:
