### PR TITLE
Fix eye organ runtimes in on_mob_remove

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -155,9 +155,9 @@
 	organ_owner.remove_status_effect(/datum/status_effect/temporary_blindness)
 
 	if (scarring)
-		owner.cure_nearsighted(TRAIT_RIGHT_EYE_SCAR)
-		owner.cure_nearsighted(TRAIT_LEFT_EYE_SCAR)
-		owner.cure_blind(EYE_SCARRING_TRAIT)
+		organ_owner.cure_nearsighted(TRAIT_RIGHT_EYE_SCAR)
+		organ_owner.cure_nearsighted(TRAIT_LEFT_EYE_SCAR)
+		organ_owner.cure_blind(EYE_SCARRING_TRAIT)
 
 	organ_owner.update_tint()
 	organ_owner.update_sight()


### PR DESCRIPTION

## About The Pull Request

By the time `on_mob_remove` is called `owner` is null, you have to use the mob it passes

## Why It's Good For The Game

The code runtimes

## Changelog

N/A
