### PR TITLE
Fix flaky fish mount CI runtimes

### DIFF
--- a/code/modules/fishing/fish_mount.dm
+++ b/code/modules/fishing/fish_mount.dm
@@ -69,7 +69,8 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/fish_mount/proc/add_first_fish()
-	var/obj/item/fish/fish_path = pick(subtypesof(/obj/item/fish) - list(typesof(/obj/item/fish/holo) + list(/obj/item/fish/starfish/chrystarfish))) // chrystarfish immediately shatters when placed
+	var/list/valid_picks = subtypesof(/obj/item/fish) - typesof(/obj/item/fish/holo) - /obj/item/fish/starfish/chrystarfish // chrystarfish immediately shatters when placed
+	var/obj/item/fish/fish_path = pick(valid_picks)
 	if(fish_path.fish_id_redirect_path)
 		fish_path = fish_path.fish_id_redirect_path
 	var/fluff_name = pick("John Trasen III", "a nameless intern", "Pun Pun", AQUARIUM_COMPANY, "Unknown", "Central Command")


### PR DESCRIPTION

## About The Pull Request

Holo fish were being selected as starting fish for fish mounts when they were coded not to be, I have no idea how this only started runtiming now but it did, I tested this fix and it produces a list without holo fish or the chrystarfish

## Why It's Good For The Game

https://github.com/tgstation/tgstation/actions/runs/18764652594/attempts/1

## Changelog

N/A
