### PR TITLE
Drone chat recolor

### DIFF
--- a/code/modules/mob/living/basic/drone/drone_say.dm
+++ b/code/modules/mob/living/basic/drone/drone_say.dm
@@ -48,4 +48,4 @@
 /mob/living/basic/drone/proc/drone_chat(message, list/spans = list(), list/message_mods = list())
 	log_sayverb_talk(message, message_mods, tag = "drone chat")
 	var/message_part = generate_messagepart(message, spans, message_mods)
-	alert_drones("<i>Drone Chat: [span_name("[name]")] <span class='message'>[message_part]</span></i>", TRUE)
+	alert_drones("<i class='drone'> Drone Chat: [span_name("[name]")] <span class='message'>[message_part]</span></i>", TRUE)

--- a/code/modules/mob/living/basic/drone/drone_say.dm
+++ b/code/modules/mob/living/basic/drone/drone_say.dm
@@ -48,4 +48,4 @@
 /mob/living/basic/drone/proc/drone_chat(message, list/spans = list(), list/message_mods = list())
 	log_sayverb_talk(message, message_mods, tag = "drone chat")
 	var/message_part = generate_messagepart(message, spans, message_mods)
-	alert_drones(span_drone("<i> Drone Chat: [span_name("[name]")] [span_message(message_part)]</i>"), TRUE)
+	alert_drones(span_drone("Drone Chat: [span_name("[name]")] [span_message(message_part)]"), TRUE)

--- a/code/modules/mob/living/basic/drone/drone_say.dm
+++ b/code/modules/mob/living/basic/drone/drone_say.dm
@@ -48,4 +48,4 @@
 /mob/living/basic/drone/proc/drone_chat(message, list/spans = list(), list/message_mods = list())
 	log_sayverb_talk(message, message_mods, tag = "drone chat")
 	var/message_part = generate_messagepart(message, spans, message_mods)
-	alert_drones("<i class='drone'> Drone Chat: [span_name("[name]")] <span class='message'>[message_part]</span></i>", TRUE)
+	alert_drones(span_drone("<i> Drone Chat: [span_name("[name]")] [span_message(message_part)]</i>"), TRUE)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -159,7 +159,7 @@ h1.alert, h2.alert		{color: #000000;}
 .abductor				{color: #800080;	font-style: italic;}
 .mind_control			{color: #A00D6F;	font-size: 3;	font-weight: bold;	font-style: italic;}
 .slime					{color: #00CED1;}
-.drone					{color: #848482;}
+.drone					{color: #ffff00;	background-color: #7c2395;}
 .monkey					{color: #975032;}
 .swarmer				{color: #2C75FF;}
 .resonate				{color: #298F85;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -159,7 +159,7 @@ h1.alert, h2.alert		{color: #000000;}
 .abductor				{color: #800080;	font-style: italic;}
 .mind_control			{color: #A00D6F;	font-size: 3;	font-weight: bold;	font-style: italic;}
 .slime					{color: #00CED1;}
-.drone					{color: #ffff00;	background-color: #7c2395;}
+.drone					{color: #ffff00;	background-color: #7c2395;	font-style: italic;}
 .monkey					{color: #975032;}
 .swarmer				{color: #2C75FF;}
 .resonate				{color: #298F85;}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -925,7 +925,8 @@ em {
 }
 
 .drone {
-  color: hsl(60, 0.8%, 51.4%);
+  color: hsl(60, 100%, 50%);
+  background-color: hsl(287 62% 36%);
 }
 
 .monkey {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -927,6 +927,7 @@ em {
 .drone {
   color: hsl(60, 100%, 50%);
   background-color: hsl(287 62% 36%);
+  font-style: italic;
 }
 
 .monkey {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -929,7 +929,8 @@ h2.alert {
 }
 
 .drone {
-  color: hsl(60, 0.8%, 51.4%);
+  color: hsl(60 100% 50%);
+  background-color: hsl(287 62% 36%);
 }
 
 .monkey {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -931,6 +931,7 @@ h2.alert {
 .drone {
   color: hsl(60 100% 50%);
   background-color: hsl(287 62% 36%);
+  font-style: italic;
 }
 
 .monkey {


### PR DESCRIPTION
## About The Pull Request

Recolors the appearance of drone chat.
<img width="491" height="123" alt="image" src="https://github.com/user-attachments/assets/97d30174-5d4d-47f5-b0d6-915863d0ec65" />
<img width="481" height="70" alt="image" src="https://github.com/user-attachments/assets/b5bd0fcf-91dc-436d-8d44-5526c5a98f83" />


## Why It's Good For The Game

Drones have access to their very own unique comms, however the messages within it are extremely difficult to notice within the chat window and barely distinguishable from every other message being spammed all the time. This gives drone chat a cool background color similar to the cyborgs' binary chat, except this one is a warm shade of purple/violet and the text encased in it is a very light yellow.

## Changelog
:cl:

qol: Messages in drone comms appear with their own color in chat

/:cl:
