### PR TITLE
Adds the Crusher Retool Kit to the Crusher voucher

### DIFF
--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -46,6 +46,7 @@
 	set_items = list(
 		/obj/item/kinetic_crusher,
 		/obj/item/extinguisher/mini,
+		/obj/item/crusher_trophy/retool_kit,
 	)
 
 /datum/voucher_set/mining/extraction_kit


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

The Crusher Retool Kit is dirt cheap already, 150 points. This just means if someone wants to LARP as a swordminer they can do it roundstart.

## Changelog
:cl:
add: The Crusher now comes with a free Retool kit!
/:cl:
