### PR TITLE
[NO GBP] Fixes 2 more wall mounts

### DIFF
--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -252,6 +252,7 @@
 
 	flick("poster_being_set", placed_poster)
 	placed_poster.forceMove(src) //deletion of the poster is handled in poster/Exited(), so don't have to worry about P anymore.
+	placed_poster.find_and_hang_on_wall()
 	playsound(src, 'sound/items/poster/poster_being_created.ogg', 100, TRUE)
 
 	var/turf/user_drop_location = get_turf(user) //cache this so it just falls to the ground if they move. also no tk memes allowed.

--- a/code/modules/transport/_transport_machinery.dm
+++ b/code/modules/transport/_transport_machinery.dm
@@ -150,12 +150,3 @@
 	set_machine_stat(machine_stat & ~BROKEN)
 	update_appearance()
 	return TRUE
-
-/obj/item/wallframe/tram/try_build(obj/structure/tram/on_tram, mob/user)
-	var/turf/tram_turf = get_turf(user)
-	var/obj/structure/thermoplastic/tram_floor = locate() in tram_turf
-	if(!istype(tram_floor))
-		balloon_alert(user, "needs tram!")
-		return FALSE
-
-	return ..()

--- a/code/modules/transport/_transport_machinery.dm
+++ b/code/modules/transport/_transport_machinery.dm
@@ -152,48 +152,10 @@
 	return TRUE
 
 /obj/item/wallframe/tram/try_build(obj/structure/tram/on_tram, mob/user)
-	if(get_dist(on_tram,user) > 1)
-		balloon_alert(user, "you are too far!")
-		return
-
-	var/floor_to_tram = get_dir(user, on_tram)
-	if(!(floor_to_tram in GLOB.cardinals))
-		balloon_alert(user, "stand in line with tram wall!")
-		return
-
 	var/turf/tram_turf = get_turf(user)
 	var/obj/structure/thermoplastic/tram_floor = locate() in tram_turf
 	if(!istype(tram_floor))
 		balloon_alert(user, "needs tram!")
-		return
+		return FALSE
 
-	if(check_wall_item(tram_turf, floor_to_tram, wall_external))
-		balloon_alert(user, "already something here!")
-		return
-
-	return TRUE
-
-/obj/item/wallframe/tram/attach(obj/structure/tram/on_tram, mob/user)
-	if(result_path)
-		playsound(src.loc, 'sound/machines/click.ogg', 75, TRUE)
-		user.visible_message(span_notice("[user.name] installs [src] on the tram."),
-			span_notice("You install [src] on the tram."),
-			span_hear("You hear clicking."))
-		var/floor_to_tram = get_dir(user, on_tram)
-
-		var/obj/cabinet = new result_path(get_turf(user), floor_to_tram, TRUE)
-		cabinet.setDir(floor_to_tram)
-
-		if(pixel_shift)
-			switch(floor_to_tram)
-				if(NORTH)
-					cabinet.pixel_y = pixel_shift
-				if(SOUTH)
-					cabinet.pixel_y = -pixel_shift
-				if(EAST)
-					cabinet.pixel_x = pixel_shift
-				if(WEST)
-					cabinet.pixel_x = -pixel_shift
-		after_attach(cabinet)
-
-	qdel(src)
+	return ..()

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -1198,3 +1198,12 @@
 	custom_materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 4, /datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 2)
 	result_path = /obj/machinery/transport/tram_controller
 	pixel_shift = 32
+
+/obj/item/wallframe/tram/try_build(obj/structure/tram/on_tram, mob/user)
+	var/turf/tram_turf = get_turf(user)
+	var/obj/structure/thermoplastic/tram_floor = locate() in tram_turf
+	if(!istype(tram_floor))
+		balloon_alert(user, "needs tram!")
+		return FALSE
+
+	return ..()


### PR DESCRIPTION
## About The Pull Request
- Fixes #93603. posters now apply the wall mount component
- Fixes tram wall frame doing a lot of extra checks & not applying the wall mount component

## Changelog
:cl:
fix: posters applied on walls fall off when the wall is destroyed
fix: player mounted tram wall frame controller falls off when the wall is destroyed
/:cl:
