### PR TITLE
True Strike is now also an armour piercing munition

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -58,7 +58,7 @@
 
 /obj/item/ammo_box/magazine/m38/true
 	name = "battle rifle magazine (.38 True Strike)"
-	desc = parent_type::desc + " Bullets bounce towards new targets with surprising accuracy."
+	desc = parent_type::desc + " Bullets bounce towards new targets with surprising accuracy and can strike through armored target"
 	ammo_type = /obj/item/ammo_casing/c38/match/true
 	ammo_band_color = COLOR_AMMO_TRUESTRIKE
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -65,6 +65,7 @@
 	ricochet_shoots_firer = FALSE
 	shrapnel_type = null
 	embed_type = null
+	armour_penetration = 30
 
 // premium .38 ammo from cargo, weak against armor, lower base damage, but excellent at embedding and causing slice wounds at close range
 /obj/projectile/bullet/c38/dumdum

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -71,7 +71,7 @@
 
 /datum/design/c38_true
 	name = "Speedloader (.38 True Strike) (Lethal)"
-	desc = "Designed to quickly reload revolvers. Bullets bounce towards new targets with surprising accuracy."
+	desc = "Designed to quickly reload revolvers. Bullets bounce towards new targets with surprising accuracy and can strike through armored target"
 	id = "c38_true_strike"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(
@@ -183,7 +183,7 @@
 
 /datum/design/c38_true_mag
 	name = "Magazine (.38 True Strike) (Lethal)"
-	desc = "Designed to tactically reload a NT BR-38 Battle Rifle. Bullets bounce towards new targets with surprising accuracy."
+	desc = "Designed to tactically reload a NT BR-38 Battle Rifle. Bullets bounce towards new targets with surprising accuracy and can strike through armored target"
 	id = "c38_true_strike_mag"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(


### PR DESCRIPTION

## About The Pull Request
So it dawned on me for awhile, we did get true strike and I got to use it way more, not necessarily after it is available as speedloader but I've used it for atleast a bit, realized just buying the match mag was better anyway.

so, true strike sucks for actually bouncing and killing people. and while 15 damage is nothing to scoff at because any damage is better than doing no damage at all. It's already well outclassed by it's actual roundstart counterpart. This fix that, the truestrike ammo is researched fairly late into the round. Giving it AP make it more useful
## Why It's Good For The Game

I think it make senses we'd want a researched ammo type more effective than something you can just. Buy? It's not like we don't have tech laser that are more effective than buckshot for raw damage. This is similar to that idea
## Changelog
:cl:
add: True Strike is also now AP, making detective more scary and BR-38 much more effective against highly armoured target
/:cl:
