### PR TITLE
Adds a missing fire alarm sanity ignore landmark to icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -59876,6 +59876,7 @@
 	codes_txt = "delivery;dir=4";
 	location = "Atmospherics"
 	},
+/obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "qNn" = (


### PR DESCRIPTION

## About The Pull Request

While testing locally, I have noticed a flaky test on icebox. The central medical maintenance sometimes failed the firelock sanity unity test, caused by an airlock on the atmospherics mulebot dropoff point. Couldn't found if this was caused by the Grille/Trash spawner, or the abandoned airlock spawner (that has a chance to replace the airlock with a wall), but either way, there is a lot of precedent for excluding a chunk of maintenance from this unit test, if it is adjacent to a firelock.

The marker has been placed in the following location:
<img width="611" height="287" alt="image" src="https://github.com/user-attachments/assets/1e263299-b5b2-4a65-a75f-cb665f633dd5" />


## Why It's Good For The Game

Flaky unit tests are not good.

## Changelog

Nothing player facing.
