### PR TITLE
Charlie Station ghostroles notify ghosts when taken

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2291,8 +2291,8 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldsec,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sec,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "ks" = (
@@ -2393,18 +2393,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
 /obj/item/clothing/neck/link_scryer/loaded/charlie,
-/turf/open/floor/iron,
-/area/ruin/space/ancientstation/charlie/dorms)
-"kO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldsci,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "kP" = (
@@ -2545,7 +2533,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldeng,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sci,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "lq" = (
@@ -2563,7 +2551,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldsci,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/eng,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "lw" = (
@@ -12496,9 +12484,9 @@ jJ
 cq
 Qg
 bN
-ln
+lr
 bN
-kO
+ln
 bN
 lr
 uX

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -1,23 +1,40 @@
 
 //Ancient cryogenic sleepers. Players become NT crewmen from a hundred year old space station, now on the verge of collapse.
-/obj/effect/mob_spawn/ghost_role/human/oldsec
+/obj/effect/mob_spawn/ghost_role/human/oldstation
 	name = "old cryogenics pod"
-	desc = "A humming cryo pod. You can barely recognise a security uniform underneath the built up ice. The machine is attempting to wake up its occupant."
-	prompt_name = "a security officer"
+	desc = "A humming cryo pod. You can barely recognise a uniform underneath the built up ice. The machine is attempting to wake up its occupant."
+	prompt_name = "an ancient crewman"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	mob_species = /datum/species/human
-	you_are_text = "You are a security officer working for Nanotrasen, stationed onboard a state of the art research station."
+	you_are_text = "You are a crewman working for Nanotrasen, stationed onboard a state of the art research station."
 	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. \
 	The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
 	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
 	important_text = "Work as a team with your fellow survivors and do not abandon them."
-	outfit = /datum/outfit/oldsec
+	outfit = /datum/outfit/oldeng
 	spawner_job_path = /datum/job/ancient_crew
 
-/obj/effect/mob_spawn/ghost_role/human/oldsec/Destroy()
-	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
+/obj/effect/mob_spawn/ghost_role/human/oldstation/create_from_ghost(mob/dead/user)
+	. = ..()
+	notify_ghosts(
+		"Someone just woke up on Charlie Station! Why not join them and help out?",
+		source = ., //the spawned mob
+		header = "Join in, help out!",
+		click_interact = TRUE,
+		notify_flags = NOTIFY_CATEGORY_NOFLASH,
+	)
+
+/obj/effect/mob_spawn/ghost_role/human/oldstation/Destroy()
+	new /obj/structure/showcase/machinery/oldpod/used(drop_location())
 	return ..()
+
+
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sec
+	desc = "A humming cryo pod. You can barely recognise a security uniform underneath the built up ice. The machine is attempting to wake up its occupant."
+	prompt_name = "a security officer"
+	you_are_text = "You are a security officer working for Nanotrasen, stationed onboard a state of the art research station."
+	outfit = /datum/outfit/oldsec
 
 /datum/outfit/oldsec
 	name = "Ancient Security"
@@ -27,24 +44,11 @@
 	l_pocket = /obj/item/assembly/flash/handheld
 	r_pocket = /obj/item/restraints/handcuffs
 
-/obj/effect/mob_spawn/ghost_role/human/oldeng
-	name = "old cryogenics pod"
+/obj/effect/mob_spawn/ghost_role/human/oldstation/eng
 	desc = "A humming cryo pod. You can barely recognise an engineering uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	prompt_name = "an engineer"
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper"
-	mob_species = /datum/species/human
 	you_are_text = "You are an engineer working for Nanotrasen, stationed onboard a state of the art research station."
-	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. The last thing \
-	you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
-	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	important_text = "Work as a team with your fellow survivors and do not abandon them."
 	outfit = /datum/outfit/oldeng
-	spawner_job_path = /datum/job/ancient_crew
-
-/obj/effect/mob_spawn/ghost_role/human/oldeng/Destroy()
-	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
 
 /datum/outfit/oldeng
 	name = "Ancient Engineer"
@@ -61,24 +65,11 @@
 	mask = /obj/item/clothing/mask/breath
 	internals_slot = ITEM_SLOT_SUITSTORE
 
-/obj/effect/mob_spawn/ghost_role/human/oldsci
-	name = "old cryogenics pod"
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sci
 	desc = "A humming cryo pod. You can barely recognise a science uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	prompt_name = "a scientist"
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper"
-	mob_species = /datum/species/human
 	you_are_text = "You are a scientist working for Nanotrasen, stationed onboard a state of the art research station."
-	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. \
-	The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
-	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	important_text = "Work as a team with your fellow survivors and do not abandon them."
 	outfit = /datum/outfit/oldsci
-	spawner_job_path = /datum/job/ancient_crew
-
-/obj/effect/mob_spawn/ghost_role/human/oldsci/Destroy()
-	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
 
 /datum/outfit/oldsci
 	name = "Ancient Scientist"


### PR DESCRIPTION

OOPS i forgot about this branch for like a month
## About The Pull Request

When someone takes one of those cryopod ghostroles a notification goes out to observers advertising the ability to join up.
What better way to convince salty observers to commit to the bit than to show them you've already done so?

## Why It's Good For The Game
Charlie station is great with friends, and as one of our better ghost roles the game would benefit from turning heads when someone joins a session.
## Changelog

:cl:
qol: Charlie station ghostroles call on other observers to join in the fun when taken.
/:cl:
