### PR TITLE
Doubles low pressure damage

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -103,7 +103,7 @@
 #define PRESSURE_DAMAGE_COEFFICIENT 2
 #define MAX_HIGH_PRESSURE_DAMAGE 2
 /// The amount of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
-#define LOW_PRESSURE_DAMAGE 2
+#define LOW_PRESSURE_DAMAGE 4
 
 /// Humans are slowed by the difference between bodytemp and BODYTEMP_COLD_DAMAGE_LIMIT divided by this
 #define COLD_SLOWDOWN_FACTOR 20


### PR DESCRIPTION

## About The Pull Request

Doubles low pressure damage(black pressure warning)
crit in 22 seconds without internals, 25 seconds with()
I was able to spacewalk from perma on meta station
testmerge probably maybe

## Why It's Good For The Game
57 seconds with internals is how long you have before crit on live, that's WILD
I've found myself saddened at the distance I am able to entirely forgo any preparation for a spacewalk to the shuttle and still be in fighting condition.
Low temp damage isn't changed because that's tied to slowdown and that's its own consideration, same with O2 damage, we wouldn't want spacemen losing consciousness too fast.
## Changelog
:cl:
balance: Low pressure damage has been doubled
/:cl:
