### PR TITLE
Optimized vine spawning

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -546,7 +546,7 @@
 * e.g. pick_n(list_of_stuff, 10) would return a list of 10 items from the list, chosen randomly.
 */
 /proc/pick_n(list/list_to_pick, n)
-	var/list_to_pick_length = list_to_pick.len
+	var/list_to_pick_length = length(list_to_pick)
 	if(!islist(list_to_pick) || !list_to_pick_length || n <= 0)
 		return list()
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -556,7 +556,7 @@
 	n = min(n, list_to_pick_length)
 
 	// Shuffle and slice the first n indices
-	var/list/copy_to_shuffle = copy_to_shuffle = list_to_pick.Copy()
+	var/list/copy_to_shuffle = list_to_pick.Copy()
 	shuffle(copy_to_shuffle)
 	result = copy_to_shuffle.Copy(1, n + 1)
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -542,6 +542,39 @@
 	list_to_pick[.]--
 
 /**
+* Picks n items from a list
+* e.g. pick_n(list_of_stuff, 10) would return a list of 10 items from the list, chosen randomly.
+*/
+proc/pick_n(list/list_to_pick, n)
+	if(!islist(list_to_pick) || !list_to_pick.len || n <= 0)
+		return list()
+
+	/// The final list that gets returned
+	var/list/result
+	/// Shuffling the list and picking the first n indices is faster in some cases
+	var/list/copy_to_shuffle
+	var/len = list_to_pick.len
+	n = min(n, len)
+
+	// If we're picking more than 25% of the list, shuffle once (faster)
+	if(n >= len / 4)
+		copy_to_shuffle = list_to_pick.Copy()
+		shuffle(copy_to_shuffle)
+		result = copy_to_shuffle.Copy(1, n + 1)
+	else
+		// For small samples, select random indices (no full copy or shuffle)
+		result = list()
+		var/list/used = list()
+		while(result.len < n)
+			var/i = rand(1, len)
+			if(used[i])
+				continue
+			used[i] = TRUE
+			result += list_to_pick[i]
+
+	return result
+
+/**
  * Given a list, return a copy where values without defined weights are given weight 1.
  * For example, fill_with_ones(list(A, B=2, C)) = list(A=1, B=2, C=1)
  * Useful for weighted random choices (loot tables, syllables in languages, etc.)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -546,7 +546,8 @@
 * e.g. pick_n(list_of_stuff, 10) would return a list of 10 items from the list, chosen randomly.
 */
 /proc/pick_n(list/list_to_pick, n)
-	if(!islist(list_to_pick) || !list_to_pick.len || n <= 0)
+	var/list_to_pick_length = list_to_pick.len
+	if(!islist(list_to_pick) || !list_to_pick_length || n <= 0)
 		return list()
 
 	/// The final list that gets returned
@@ -554,7 +555,6 @@
 	/// Shuffling the list and picking the first n indices is faster in some cases
 	var/list/copy_to_shuffle
 	/// length of our list_to_pick
-	var/list_to_pick_length = list_to_pick.len
 	n = min(n, list_to_pick_length)
 
 	// Shuffle and slice the first n indices

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -552,13 +552,11 @@
 
 	/// The final list that gets returned
 	var/list/result
-	/// Shuffling the list and picking the first n indices is faster in some cases
-	var/list/copy_to_shuffle
 	/// length of our list_to_pick
 	n = min(n, list_to_pick_length)
 
 	// Shuffle and slice the first n indices
-	copy_to_shuffle = list_to_pick.Copy()
+	var/list/copy_to_shuffle = copy_to_shuffle = list_to_pick.Copy()
 	shuffle(copy_to_shuffle)
 	result = copy_to_shuffle.Copy(1, n + 1)
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -542,39 +542,6 @@
 	list_to_pick[.]--
 
 /**
-* Picks n items from a list
-* e.g. pick_n(list_of_stuff, 10) would return a list of 10 items from the list, chosen randomly.
-*/
-proc/pick_n(list/list_to_pick, n)
-	if(!islist(list_to_pick) || !list_to_pick.len || n <= 0)
-		return list()
-
-	/// The final list that gets returned
-	var/list/result
-	/// Shuffling the list and picking the first n indices is faster in some cases
-	var/list/copy_to_shuffle
-	var/len = list_to_pick.len
-	n = min(n, len)
-
-	// If we're picking more than 25% of the list, shuffle once (faster)
-	if(n >= len / 4)
-		copy_to_shuffle = list_to_pick.Copy()
-		shuffle(copy_to_shuffle)
-		result = copy_to_shuffle.Copy(1, n + 1)
-	else
-		// For small samples, select random indices (no full copy or shuffle)
-		result = list()
-		var/list/used = list()
-		while(result.len < n)
-			var/i = rand(1, len)
-			if(used[i])
-				continue
-			used[i] = TRUE
-			result += list_to_pick[i]
-
-	return result
-
-/**
  * Given a list, return a copy where values without defined weights are given weight 1.
  * For example, fill_with_ones(list(A, B=2, C)) = list(A=1, B=2, C=1)
  * Useful for weighted random choices (loot tables, syllables in languages, etc.)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -542,6 +542,29 @@
 	list_to_pick[.]--
 
 /**
+* Picks n items from a list. The same index will not be chosen more than once.
+* e.g. pick_n(list_of_stuff, 10) would return a list of 10 items from the list, chosen randomly.
+*/
+/proc/pick_n(list/list_to_pick, n)
+	if(!islist(list_to_pick) || !list_to_pick.len || n <= 0)
+		return list()
+
+	/// The final list that gets returned
+	var/list/result
+	/// Shuffling the list and picking the first n indices is faster in some cases
+	var/list/copy_to_shuffle
+	/// length of our list_to_pick
+	var/list_to_pick_length = list_to_pick.len
+	n = min(n, list_to_pick_length)
+
+	// Shuffle and slice the first n indices
+	copy_to_shuffle = list_to_pick.Copy()
+	shuffle(copy_to_shuffle)
+	result = copy_to_shuffle.Copy(1, n + 1)
+
+	return result
+
+/**
  * Given a list, return a copy where values without defined weights are given weight 1.
  * For example, fill_with_ones(list(A, B=2, C)) = list(A=1, B=2, C=1)
  * Useful for weighted random choices (loot tables, syllables in languages, etc.)

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -36,11 +36,18 @@
 		turfs += override_turf
 	else
 		var/obj/structure/spacevine/vine = new()
-
 		for(var/area/station/hallway/area in GLOB.areas)
+			var/list/floor_candidates = list()
 			for(var/turf/open/floor in area.get_turfs_from_all_zlevels())
-				if(!isopenspaceturf(floor) && floor.Enter(vine))
-					turfs += floor
+				if(isopenspaceturf(floor))
+					continue
+				floor_candidates += floor
+
+			// Enter() is expensive to call on potentially hundreds-thousands of turfs at once and can even lead to server crashes. We can pick() a subset instead and get close enough results at a fraction of the cost.
+			for(var/turf/open/floor as anything in pick(floor_candidates, min(25, length(floor_candidates))))
+				if(!floor.Enter())
+					continue
+				turfs += floor
 
 		qdel(vine)
 

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -44,7 +44,7 @@
 				floor_candidates += floor
 
 			// Enter() is expensive to call on potentially hundreds to thousands of turfs at once and can even lead to server crashes. We can pick() a subset instead and get close enough results at a fraction of the cost.
-			for(var/turf/open/floor as anything in pick(floor_candidates, min(25, length(floor_candidates)))) // pick up to 25 turfs per area to sample
+			for(var/turf/open/floor as anything in pick_n(floor_candidates, min(25, length(floor_candidates)))) // pick up to 25 turfs per area to sample
 				if(!floor.Enter(vine))
 					continue
 				turfs += floor

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -44,7 +44,7 @@
 				floor_candidates += floor
 
 			// Enter() is expensive to call on potentially hundreds to thousands of turfs at once and can even lead to server crashes. We can pick() a subset instead and get close enough results at a fraction of the cost.
-			for(var/turf/open/floor as anything in pick(floor_candidates, min(25, length(floor_candidates))))
+			for(var/turf/open/floor as anything in pick(floor_candidates, min(25, length(floor_candidates)))) // pick up to 25 turfs per area to sample
 				if(!floor.Enter(vine))
 					continue
 				turfs += floor

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -45,7 +45,7 @@
 
 			// Enter() is expensive to call on potentially hundreds-thousands of turfs at once and can even lead to server crashes. We can pick() a subset instead and get close enough results at a fraction of the cost.
 			for(var/turf/open/floor as anything in pick(floor_candidates, min(25, length(floor_candidates))))
-				if(!floor.Enter())
+				if(!floor.Enter(vine))
 					continue
 				turfs += floor
 

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -48,7 +48,7 @@
 		var/attempts = 0
 
 		// Pick extra candidates to compensate for potential Enter() failures
-		var/list/chosen = pick_n(floor_candidates, min(max_attempts * 2, length(floor_candidates)))
+		var/list/chosen = pick_n(floor_candidates, min(max_attempts * 2, length(floor_candidates))) // results in at most 50 calls of Enter(), a reasonable amount while still feeling random.
 
 		for(var/turf/open/floor as anything in chosen)
 			if(attempts >= max_attempts)

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -44,8 +44,8 @@
 
 		// Enter() is expensive to call on potentially hundreds to thousands of turfs at once and can even lead to server crashes.
 		// We can pick() a subset instead and get close enough results at a fraction of the cost.
-		var/turfs_to_test = 50
-		var/list/chosen = pick_n(floor_candidates, min(turfs_to_test, length(floor_candidates))) // results in at most 50 calls of Enter(), a reasonable amount while still feeling random.
+		var/turfs_to_test = 100
+		var/list/chosen = pick_n(floor_candidates, min(turfs_to_test, length(floor_candidates))) // results in at most 100 calls of Enter(), a reasonable amount while still feeling random.
 
 		for(var/turf/open/floor as anything in chosen)
 			if(floor.Enter(vine))

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -43,7 +43,7 @@
 					continue
 				floor_candidates += floor
 
-			// Enter() is expensive to call on potentially hundreds-thousands of turfs at once and can even lead to server crashes. We can pick() a subset instead and get close enough results at a fraction of the cost.
+			// Enter() is expensive to call on potentially hundreds to thousands of turfs at once and can even lead to server crashes. We can pick() a subset instead and get close enough results at a fraction of the cost.
 			for(var/turf/open/floor as anything in pick(floor_candidates, min(25, length(floor_candidates))))
 				if(!floor.Enter(vine))
 					continue

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -44,18 +44,12 @@
 
 		// Enter() is expensive to call on potentially hundreds to thousands of turfs at once and can even lead to server crashes.
 		// We can pick() a subset instead and get close enough results at a fraction of the cost.
-		var/max_attempts = 25
-		var/attempts = 0
-
-		// Pick extra candidates to compensate for potential Enter() failures
-		var/list/chosen = pick_n(floor_candidates, min(max_attempts * 2, length(floor_candidates))) // results in at most 50 calls of Enter(), a reasonable amount while still feeling random.
+		var/turfs_to_test = 50
+		var/list/chosen = pick_n(floor_candidates, min(turfs_to_test, length(floor_candidates))) // results in at most 50 calls of Enter(), a reasonable amount while still feeling random.
 
 		for(var/turf/open/floor as anything in chosen)
-			if(attempts >= max_attempts)
-				break
 			if(floor.Enter(vine))
 				turfs += floor
-				attempts++
 		qdel(vine)
 
 	if(length(turfs)) //Pick a turf to spawn at if we can

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -29,10 +29,10 @@
 	var/production
 
 /datum/round_event/spacevine/start()
-	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas
+	var/list/final_turf_candidates = list() // final list of eligible empty floor turfs in the hallway areas that can be chosen
 
 	if(override_turf)
-		turfs += override_turf
+		final_turf_candidates += override_turf
 	else
 		var/obj/structure/spacevine/vine = new()
 		var/list/floor_candidates = list()
@@ -45,15 +45,15 @@
 		// Enter() is expensive to call on potentially hundreds to thousands of turfs at once and can even lead to server crashes.
 		// We can pick() a subset instead and get close enough results at a fraction of the cost.
 		var/turfs_to_test = 100
-		var/list/chosen = pick_n(floor_candidates, min(turfs_to_test, length(floor_candidates))) // results in at most 100 calls of Enter(), a reasonable amount while still feeling random.
+		var/list/sampled_floor_candidates = pick_n(floor_candidates, min(turfs_to_test, length(floor_candidates))) // results in at most 100 calls of Enter(), a reasonable amount while still feeling random.
 
-		for(var/turf/open/floor as anything in chosen)
+		for(var/turf/open/floor as anything in sampled_floor_candidates)
 			if(floor.Enter(vine))
-				turfs += floor
+				final_turf_candidates += floor
 		qdel(vine)
 
-	if(length(turfs)) //Pick a turf to spawn at if we can
-		var/turf/floor = pick(turfs)
+	if(length(final_turf_candidates)) //Pick a turf to spawn at if we can
+		var/turf/floor = pick(final_turf_candidates)
 		var/list/selected_mutations = list()
 
 		if(mutations_overridden == FALSE)


### PR DESCRIPTION
## About The Pull Request

Tin, the current algorithm is very greedy and can call Enter() on thousands of turfs potentially depending on how your map is set up. This really isn't necessary and leads to spess lag and sometimes spess crashes.

Instead of doing that we can test a smaller random subset of tiles with Enter() and achieve basically the same results.

This basically just puts a safe bound on how many Enter() calls we can do.

<img width="1307" height="739" alt="dreamseeker_6nE6Hjad7B" src="https://github.com/user-attachments/assets/3405ee8f-1af8-4dce-b253-1fcbf47412ea" />

## Why It's Good For The Game

Less spess lag

## Changelog

:cl:
code: optimizes space vine spawning to create less lag.
/:cl: