### PR TITLE
Laser tag refactor to use components instead of checking for the vest

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_lasertag.dm
+++ b/code/__DEFINES/dcs/signals/signals_lasertag.dm
@@ -1,6 +1,13 @@
 ///Sending this signal will return either BLOCK_FIRE bitflag or ALLOW_FIRE bitflag
 #define COMSIG_LIVING_FIRING_PIN_CHECK "lasertag_firing_pin_check"
-///blocks the lasertag firing pin from authorizing the shot
-#define BLOCK_FIRE (1 << 0)
-///allows the lasertag firing pin to authorize the shot
-#define ALLOW_FIRE (1 << 1)
+	///blocks the lasertag firing pin from authorizing the shot
+	#define BLOCK_FIRE (1 << 0)
+	///allows the lasertag firing pin to authorize the shot
+	#define ALLOW_FIRE (1 << 1)
+
+///Neutral Lasertag team
+#define LASERTAG_TEAM_NEUTRAL "neutral"
+///Red Lasertag team
+#define LASERTAG_TEAM_RED "red"
+///Blue Lasertag team
+#define LASERTAG_TEAM_BLUE "blue"

--- a/code/__DEFINES/dcs/signals/signals_lasertag.dm
+++ b/code/__DEFINES/dcs/signals/signals_lasertag.dm
@@ -1,0 +1,6 @@
+///Sending this signal will return either BLOCK_FIRE bitflag or ALLOW_FIRE bitflag
+#define COMSIG_LIVING_FIRING_PIN_CHECK "lasertag_firing_pin_check"
+///blocks the lasertag firing pin from authorizing the shot
+#define BLOCK_FIRE (1 << 0)
+///allows the lasertag firing pin to authorize the shot
+#define ALLOW_FIRE (1 << 1)

--- a/code/modules/clothing/suits/_lasertag_components.dm
+++ b/code/modules/clothing/suits/_lasertag_components.dm
@@ -1,10 +1,10 @@
 ///lasertag team tracking component
 /datum/component/lasertag
 	dupe_mode = COMPONENT_DUPE_SOURCES
-	///What team the mob that this component is attached to is part of. This should be all lowercase and either a color or "neutral"
-	var/team_color = "neutral"
+	///What team the mob that this component is attached to is part of.
+	var/team_color = LASERTAG_TEAM_NEUTRAL
 
-/datum/component/lasertag/Initialize(datum/source, datum/source_item, team_color)
+/datum/component/lasertag/Initialize(team_color)
 	if (!ishuman(parent))
 		return COMPONENT_INCOMPATIBLE
 	register_lasertag_signals()
@@ -18,6 +18,7 @@
 
 /datum/component/lasertag/proc/team_color_match(datum/source, color)
 	SIGNAL_HANDLER
+	to_chat(parent, span_yell("DEBUG: testing if [color] is the same as [team_color]")) //FIX: team_color is null for some reason
 	if (color == team_color)
 		return ALLOW_FIRE
 	return BLOCK_FIRE

--- a/code/modules/clothing/suits/_lasertag_components.dm
+++ b/code/modules/clothing/suits/_lasertag_components.dm
@@ -1,0 +1,18 @@
+/datum/component/lasertag
+	///What team the mob that this component is attached to is part of. This should be all lowercase and either a color or "neutral"
+	var/team_color = "neutral"
+	///Anything that makes a human a valid lasertag target should be added to this
+	var/list/lasertag_granters = list()
+
+/datum/component/lasertag/Initialize(...)
+	. = ..()
+	var/mob/living/carbon/human/H = parent
+	if (!H)
+		return COMPONENT_INCOMPATIBLE
+
+///call this proc before removing the component.
+/datum/component/lasertag/proc/should_delete(var/source)
+	lasertag_granters -= source
+	if(LAZYLEN(lasertag_granters))
+		return FALSE
+	return TRUE

--- a/code/modules/clothing/suits/_lasertag_components.dm
+++ b/code/modules/clothing/suits/_lasertag_components.dm
@@ -16,9 +16,10 @@
 	RegisterSignal(parent, COMSIG_ATOM_BULLET_ACT, PROC_REF(on_laser_hit))
 
 
-/datum/component/lasertag/proc/team_color_match(datum/source, color)
+/datum/component/lasertag/proc/team_color_match(datum/source, firing_pin)
 	SIGNAL_HANDLER
-	if (color == team_color)
+	var/obj/item/firing_pin/tag/pin = firing_pin
+	if (pin.tagcolor == team_color)
 		return ALLOW_FIRE
 	return BLOCK_FIRE
 

--- a/code/modules/clothing/suits/_lasertag_components.dm
+++ b/code/modules/clothing/suits/_lasertag_components.dm
@@ -4,7 +4,7 @@
 	///What team the mob that this component is attached to is part of. This should be all lowercase and either a color or "neutral"
 	var/team_color = "neutral"
 
-/datum/component/lasertag/Initialize(datum/source, team_color)
+/datum/component/lasertag/Initialize(datum/source, datum/source_item, team_color)
 	if (!ishuman(parent))
 		return COMPONENT_INCOMPATIBLE
 	register_lasertag_signals()
@@ -17,11 +17,13 @@
 
 
 /datum/component/lasertag/proc/team_color_match(datum/source, color)
+	SIGNAL_HANDLER
 	if (color == team_color)
 		return ALLOW_FIRE
 	return BLOCK_FIRE
 
 /datum/component/lasertag/proc/on_laser_hit(datum/source, projectile)
+	SIGNAL_HANDLER
 	if(!istype(projectile, /obj/projectile/beam/lasertag))
 		return
 	var/obj/projectile/beam/lasertag/laser = projectile

--- a/code/modules/clothing/suits/_lasertag_components.dm
+++ b/code/modules/clothing/suits/_lasertag_components.dm
@@ -11,7 +11,7 @@
 		return COMPONENT_INCOMPATIBLE
 
 ///call this proc before removing the component.
-/datum/component/lasertag/proc/should_delete(var/source)
+/datum/component/lasertag/proc/should_delete(source)
 	lasertag_granters -= source
 	if(LAZYLEN(lasertag_granters))
 		return FALSE

--- a/code/modules/clothing/suits/_lasertag_components.dm
+++ b/code/modules/clothing/suits/_lasertag_components.dm
@@ -18,7 +18,6 @@
 
 /datum/component/lasertag/proc/team_color_match(datum/source, color)
 	SIGNAL_HANDLER
-	to_chat(parent, span_yell("DEBUG: testing if [color] is the same as [team_color]")) //FIX: team_color is null for some reason
 	if (color == team_color)
 		return ALLOW_FIRE
 	return BLOCK_FIRE

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -10,21 +10,16 @@
 	allowed = list (/obj/item/gun/energy/laser/bluetag)
 	resistance_flags = NONE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	var/last_slot
 
 /obj/item/clothing/suit/bluetag/equipped(mob/equipper, slot)
 	. = ..()
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
-	last_slot = slot
 	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, LASERTAG_TEAM_BLUE)
 
 
 /obj/item/clothing/suit/bluetag/dropped(mob/living/user)
 	. = ..()
-	if(last_slot != ITEM_SLOT_OCLOTHING)
-		return
-	last_slot = null
 	user.RemoveComponentSource(REF(src), /datum/component/lasertag)
 
 /obj/item/clothing/suit/redtag
@@ -39,20 +34,15 @@
 	allowed = list (/obj/item/gun/energy/laser/redtag)
 	resistance_flags = NONE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	var/last_slot
 
 
 /obj/item/clothing/suit/redtag/equipped(mob/equipper, slot)
 	. = ..()
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
-	last_slot = slot
 	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, LASERTAG_TEAM_RED)
 
 
 /obj/item/clothing/suit/redtag/dropped(mob/living/user)
 	. = ..()
-	if(last_slot != ITEM_SLOT_OCLOTHING)
-		return
-	last_slot = null
 	user.RemoveComponentSource(REF(src), /datum/component/lasertag)

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -17,7 +17,6 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	to_chat(equipper, span_yell("Team color is [LASERTAG_TEAM_BLUE]"))
 	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, LASERTAG_TEAM_BLUE)
 
 
@@ -48,7 +47,6 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	to_chat(equipper, span_yell("Team color is [LASERTAG_TEAM_RED]"))
 	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, LASERTAG_TEAM_RED)
 
 

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -17,13 +17,7 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	var/mob/living/carbon/human/wearer = equipper
-	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
-	if (!comp)
-		wearer.AddComponent(/datum/component/lasertag)
-		comp = wearer.GetComponent(/datum/component/lasertag)
-		comp.team_color = "blue"
-	comp.lasertag_granters += src
+	AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
 
 
 /obj/item/clothing/suit/bluetag/dropped(mob/living/user)
@@ -31,10 +25,7 @@
 	if(last_slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = null
-	var/mob/living/carbon/human/wearer = user
-	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
-	if (comp.should_delete(src))
-		qdel(comp)
+	RemoveComponentSource(REF(src), /datum/component/lasertag)
 
 /obj/item/clothing/suit/redtag
 	name = "red laser tag armor"
@@ -56,13 +47,7 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	var/mob/living/carbon/human/wearer = equipper
-	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
-	if (!comp)
-		wearer.AddComponent(/datum/component/lasertag)
-		comp = wearer.GetComponent(/datum/component/lasertag)
-		comp.team_color = "red"
-	comp.lasertag_granters += src
+	AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
 
 
 /obj/item/clothing/suit/redtag/dropped(mob/living/user)
@@ -70,7 +55,4 @@
 	if(last_slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = null
-	var/mob/living/carbon/human/wearer = user
-	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
-	if (comp.should_delete(src))
-		qdel(comp)
+	RemoveComponentSource(REF(src), /datum/component/lasertag)

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -9,6 +9,32 @@
 	body_parts_covered = CHEST
 	allowed = list (/obj/item/gun/energy/laser/bluetag)
 	resistance_flags = NONE
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	var/last_slot
+
+/obj/item/clothing/suit/bluetag/equipped(mob/equipper, slot)
+	. = ..()
+	if (slot != ITEM_SLOT_OCLOTHING)
+		return
+	last_slot = slot
+	var/mob/living/carbon/human/wearer = equipper
+	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
+	if (!comp)
+		wearer.AddComponent(/datum/component/lasertag)
+		comp = wearer.GetComponent(/datum/component/lasertag)
+	comp.team_color = "blue"
+	comp.lasertag_granters += src
+
+
+/obj/item/clothing/suit/bluetag/dropped(mob/living/user)
+	. = ..()
+	if(last_slot != ITEM_SLOT_OCLOTHING)
+		return
+	last_slot = null
+	var/mob/living/carbon/human/wearer = user
+	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
+	if (comp.should_delete(src))
+		qdel(comp)
 
 /obj/item/clothing/suit/redtag
 	name = "red laser tag armor"
@@ -21,3 +47,30 @@
 	body_parts_covered = CHEST
 	allowed = list (/obj/item/gun/energy/laser/redtag)
 	resistance_flags = NONE
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	var/last_slot
+
+
+/obj/item/clothing/suit/redtag/equipped(mob/equipper, slot)
+	. = ..()
+	if (slot != ITEM_SLOT_OCLOTHING)
+		return
+	last_slot = slot
+	var/mob/living/carbon/human/wearer = equipper
+	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
+	if (!comp)
+		wearer.AddComponent(/datum/component/lasertag)
+		comp = wearer.GetComponent(/datum/component/lasertag)
+	comp.team_color = "red"
+	comp.lasertag_granters += src
+
+
+/obj/item/clothing/suit/redtag/dropped(mob/living/user)
+	. = ..()
+	if(last_slot != ITEM_SLOT_OCLOTHING)
+		return
+	last_slot = null
+	var/mob/living/carbon/human/wearer = user
+	var/datum/component/lasertag/comp = wearer.GetComponent(/datum/component/lasertag)
+	if (comp.should_delete(src))
+		qdel(comp)

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -17,7 +17,8 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, "blue")
+	to_chat(equipper, span_yell("Team color is [LASERTAG_TEAM_BLUE]"))
+	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, LASERTAG_TEAM_BLUE)
 
 
 /obj/item/clothing/suit/bluetag/dropped(mob/living/user)
@@ -47,7 +48,8 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, "blue")
+	to_chat(equipper, span_yell("Team color is [LASERTAG_TEAM_RED]"))
+	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, LASERTAG_TEAM_RED)
 
 
 /obj/item/clothing/suit/redtag/dropped(mob/living/user)

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -17,7 +17,7 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
+	equipper.AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
 
 
 /obj/item/clothing/suit/bluetag/dropped(mob/living/user)
@@ -25,7 +25,7 @@
 	if(last_slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = null
-	RemoveComponentSource(REF(src), /datum/component/lasertag)
+	user.RemoveComponentSource(REF(src), /datum/component/lasertag)
 
 /obj/item/clothing/suit/redtag
 	name = "red laser tag armor"
@@ -47,7 +47,7 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
+	equipper.AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
 
 
 /obj/item/clothing/suit/redtag/dropped(mob/living/user)
@@ -55,4 +55,4 @@
 	if(last_slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = null
-	RemoveComponentSource(REF(src), /datum/component/lasertag)
+	user.RemoveComponentSource(REF(src), /datum/component/lasertag)

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -17,7 +17,7 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	equipper.AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
+	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, "blue")
 
 
 /obj/item/clothing/suit/bluetag/dropped(mob/living/user)
@@ -47,7 +47,7 @@
 	if (slot != ITEM_SLOT_OCLOTHING)
 		return
 	last_slot = slot
-	equipper.AddComponentFrom(/datum/component/lasertag, REF(src), "blue")
+	equipper.AddComponentFrom(REF(src), /datum/component/lasertag, "blue")
 
 
 /obj/item/clothing/suit/redtag/dropped(mob/living/user)

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -22,7 +22,7 @@
 	if (!comp)
 		wearer.AddComponent(/datum/component/lasertag)
 		comp = wearer.GetComponent(/datum/component/lasertag)
-	comp.team_color = "blue"
+		comp.team_color = "blue"
 	comp.lasertag_granters += src
 
 
@@ -61,7 +61,7 @@
 	if (!comp)
 		wearer.AddComponent(/datum/component/lasertag)
 		comp = wearer.GetComponent(/datum/component/lasertag)
-	comp.team_color = "red"
+		comp.team_color = "red"
 	comp.lasertag_granters += src
 
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -354,12 +354,13 @@
 	name = "laser tag firing pin"
 	desc = "A recreational firing pin, used in laser tag units to ensure users have their vests on."
 	fail_message = "suit check failed!"
-	var/tagcolor = "neutral"
+	var/tagcolor = LASERTAG_TEAM_NEUTRAL
 
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
 		var/result = SEND_SIGNAL(user, COMSIG_LIVING_FIRING_PIN_CHECK, tagcolor)
-		if(result & ALLOW_FIRE) //FIX: always returns false
+		to_chat(user, span_yell("DEBUG: result of SEND_SIGNAL is [result] and needs [ALLOW_FIRE]. tagcolor is [tagcolor]"))
+		if(result == ALLOW_FIRE) //FIX: always returns false
 			return TRUE
 	to_chat(user, span_warning("You need to be wearing [tagcolor] laser tag armor!"))
 	return FALSE
@@ -367,12 +368,12 @@
 /obj/item/firing_pin/tag/red
 	name = "red laser tag firing pin"
 	icon_state = "firing_pin_red"
-	tagcolor = "red"
+	tagcolor = LASERTAG_TEAM_RED
 
 /obj/item/firing_pin/tag/blue
 	name = "blue laser tag firing pin"
 	icon_state = "firing_pin_blue"
-	tagcolor = "blue"
+	tagcolor = LASERTAG_TEAM_BLUE
 
 /obj/item/firing_pin/monkey
 	name = "monkeylock firing pin"

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -358,9 +358,8 @@
 
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
-		var/mob/living/carbon/human/M = user
-		var/datum/component/lasertag/comp = M.GetComponent(/datum/component/lasertag)
-		if(comp?.team_color == tagcolor)
+		var/result = SEND_SIGNAL(user, COMSIG_LIVING_FIRING_PIN_CHECK, tagcolor)
+		if(result & ALLOW_FIRE)
 			return TRUE
 	to_chat(user, span_warning("You need to be wearing [tagcolor] laser tag armor!"))
 	return FALSE

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -19,6 +19,7 @@
 	///Can be removed from the gun using tools or replaced by a pin with force_replace
 	var/pin_removable = TRUE
 	var/obj/item/gun/gun
+	var/default_pin_auth = TRUE
 
 /obj/item/firing_pin/Destroy()
 	if(gun)
@@ -72,7 +73,12 @@
 	return
 
 /obj/item/firing_pin/proc/pin_auth(mob/living/user)
-	return TRUE
+	var/result = SEND_SIGNAL(user, COMSIG_LIVING_FIRING_PIN_CHECK, src)
+	if(result & ALLOW_FIRE)
+		return TRUE
+	if(result & BLOCK_FIRE)
+		return FALSE
+	return default_pin_auth
 
 /obj/item/firing_pin/proc/auth_fail(mob/living/user)
 	if(user)
@@ -354,15 +360,12 @@
 	name = "laser tag firing pin"
 	desc = "A recreational firing pin, used in laser tag units to ensure users have their vests on."
 	fail_message = "suit check failed!"
+	default_pin_auth = FALSE
 	var/tagcolor = LASERTAG_TEAM_NEUTRAL
 
-/obj/item/firing_pin/tag/pin_auth(mob/living/user)
-	if(ishuman(user))
-		var/result = SEND_SIGNAL(user, COMSIG_LIVING_FIRING_PIN_CHECK, tagcolor)
-		if(result == ALLOW_FIRE)
-			return TRUE
+/obj/item/firing_pin/tag/auth_fail(mob/living/user)
+	. = ..()
 	to_chat(user, span_warning("You need to be wearing [tagcolor] laser tag armor!"))
-	return FALSE
 
 /obj/item/firing_pin/tag/red
 	name = "red laser tag firing pin"

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -359,7 +359,7 @@
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
 		var/result = SEND_SIGNAL(user, COMSIG_LIVING_FIRING_PIN_CHECK, tagcolor)
-		if(result & ALLOW_FIRE)
+		if(result & ALLOW_FIRE) //FIX: always returns false
 			return TRUE
 	to_chat(user, span_warning("You need to be wearing [tagcolor] laser tag armor!"))
 	return FALSE

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -359,8 +359,7 @@
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
 		var/result = SEND_SIGNAL(user, COMSIG_LIVING_FIRING_PIN_CHECK, tagcolor)
-		to_chat(user, span_yell("DEBUG: result of SEND_SIGNAL is [result] and needs [ALLOW_FIRE]. tagcolor is [tagcolor]"))
-		if(result == ALLOW_FIRE) //FIX: always returns false
+		if(result == ALLOW_FIRE)
 			return TRUE
 	to_chat(user, span_warning("You need to be wearing [tagcolor] laser tag armor!"))
 	return FALSE

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -354,13 +354,13 @@
 	name = "laser tag firing pin"
 	desc = "A recreational firing pin, used in laser tag units to ensure users have their vests on."
 	fail_message = "suit check failed!"
-	var/obj/item/clothing/suit/suit_requirement = null
-	var/tagcolor = ""
+	var/tagcolor = "neutral"
 
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/M = user
-		if(istype(M.wear_suit, suit_requirement))
+		var/datum/component/lasertag/comp = M.GetComponent(/datum/component/lasertag)
+		if(comp?.team_color == tagcolor)
 			return TRUE
 	to_chat(user, span_warning("You need to be wearing [tagcolor] laser tag armor!"))
 	return FALSE
@@ -368,13 +368,11 @@
 /obj/item/firing_pin/tag/red
 	name = "red laser tag firing pin"
 	icon_state = "firing_pin_red"
-	suit_requirement = /obj/item/clothing/suit/redtag
 	tagcolor = "red"
 
 /obj/item/firing_pin/tag/blue
 	name = "blue laser tag firing pin"
 	icon_state = "firing_pin_blue"
-	suit_requirement = /obj/item/clothing/suit/bluetag
 	tagcolor = "blue"
 
 /obj/item/firing_pin/monkey

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -368,21 +368,22 @@
 	hitsound = null
 	damage = 0
 	damage_type = STAMINA
-	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
+	var/lasertag_team = "neutral"
 
 /obj/projectile/beam/lasertag/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
-		if(istype(M.wear_suit))
-			if(M.wear_suit.type in suit_types)
+		var/datum/component/lasertag/comp = M?.GetComponent(/datum/component/lasertag)
+		if(comp)
+			if(lasertag_team != comp.team_color)
 				M.adjustStaminaLoss(34)
 
 /obj/projectile/beam/lasertag/redtag
 	icon_state = "laser"
-	suit_types = list(/obj/item/clothing/suit/bluetag)
+	lasertag_team = "red"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = COLOR_SOFT_RED
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -395,7 +396,7 @@
 
 /obj/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
-	suit_types = list(/obj/item/clothing/suit/redtag)
+	lasertag_team = "blue"
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	impact_type = /obj/effect/projectile/impact/laser/blue

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -370,12 +370,12 @@
 	damage_type = STAMINA
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
-	var/lasertag_team = "neutral"
+	var/lasertag_team = LASERTAG_TEAM_NEUTRAL
 	var/lasertag_damage = 34
 
 /obj/projectile/beam/lasertag/redtag
 	icon_state = "laser"
-	lasertag_team = "red"
+	lasertag_team = LASERTAG_TEAM_RED
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = COLOR_SOFT_RED
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -388,7 +388,7 @@
 
 /obj/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
-	lasertag_team = "blue"
+	lasertag_team = LASERTAG_TEAM_BLUE
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	impact_type = /obj/effect/projectile/impact/laser/blue

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -371,15 +371,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 	var/lasertag_team = "neutral"
-
-/obj/projectile/beam/lasertag/on_hit(atom/target, blocked = 0, pierce_hit)
-	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/M = target
-		var/datum/component/lasertag/comp = M?.GetComponent(/datum/component/lasertag)
-		if(comp)
-			if(lasertag_team != comp.team_color)
-				M.adjustStaminaLoss(34)
+	var/lasertag_damage = 34
 
 /obj/projectile/beam/lasertag/redtag
 	icon_state = "laser"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -339,6 +339,7 @@
 #include "code\__DEFINES\dcs\signals\signals_janitor.dm"
 #include "code\__DEFINES\dcs\signals\signals_key.dm"
 #include "code\__DEFINES\dcs\signals\signals_ladder.dm"
+#include "code\__DEFINES\dcs\signals\signals_lasertag.dm"
 #include "code\__DEFINES\dcs\signals\signals_lattice.dm"
 #include "code\__DEFINES\dcs\signals\signals_lazy_templates.dm"
 #include "code\__DEFINES\dcs\signals\signals_leash.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4136,6 +4136,7 @@
 #include "code\modules\clothing\spacesuits\softsuit.dm"
 #include "code\modules\clothing\spacesuits\specialops.dm"
 #include "code\modules\clothing\spacesuits\syndi.dm"
+#include "code\modules\clothing\suits\_lasertag_components.dm"
 #include "code\modules\clothing\suits\_suits.dm"
 #include "code\modules\clothing\suits\ablativecoat.dm"
 #include "code\modules\clothing\suits\armor.dm"


### PR DESCRIPTION

## About The Pull Request
Baby's first refactor!
Originally meant for a downstream, I was told to PR it here instead. Please do tell me if I did something wrong.
Previously the Lasertag guns would directly check if you were wearing a vest before dealing stamina damage. Now they instead check for a component and it's team, which is added by the vest.

## Why It's Good For The Game
This should make it easier to add new lasertag equipment.
It compiles and lasertag functionality seems to remain unchanged from the player side.

## Changelog
:cl:
refactor: refactored Lasertag equipment to use components, therefore making it scalable. Please report any issues.
/:cl:
