### PR TITLE
Fixes examines sometimes running on qdeleted atoms

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -531,6 +531,8 @@
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(run_examinate), examinify))
 
 /mob/proc/run_examinate(atom/examinify, force_examinate_more = FALSE)
+	if(QDELETED(examinify)) // since this can run async we might have had the atom get qdeleted already
+		return
 
 	if(isturf(examinify) && !(sight & SEE_TURFS) && !(examinify in view(client ? client.view : world.view, src)))
 		// shift-click catcher may issue examinate() calls for out-of-sight turfs


### PR DESCRIPTION
## About The Pull Request

<img width="573" height="77" alt="HAuAh8ioY0" src="https://github.com/user-attachments/assets/33eb5b66-330b-42c1-b395-841561ef2bb0" />

Because run_examinify can get queued to run async we need to consider the possibility that the item does not exist when the callback is finally invoked.

## Why It's Good For The Game

Less runtime spam

## Changelog

Not player-facing
