### PR TITLE
Stops trying to update slot icons for qdeleted mobs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -975,7 +975,7 @@
 
 /obj/item/proc/update_slot_icon()
 	SIGNAL_HANDLER
-	if(!ismob(loc))
+	if(!ismob(loc) || QDELETED(loc))
 		return
 	var/mob/owner = loc
 	owner.update_clothing(slot_flags | owner.get_slot_by_item(src))


### PR DESCRIPTION
## About The Pull Request

Another found runtime

<img width="1012" height="30" alt="image" src="https://github.com/user-attachments/assets/b9cc4e6f-b962-4f44-a158-1077ee449716" />

<img width="958" height="511" alt="avsfvHfCR5" src="https://github.com/user-attachments/assets/4b0746eb-b074-4a8d-bcb8-5b215babffa6" />

When a decal element is detached, it asynchronously invokes update_slot_icon. Including when it gets deleted.

<img width="742" height="163" alt="image" src="https://github.com/user-attachments/assets/b8c26d92-0699-4638-aebe-0dc5a26ad12d" />

Which leads to a chain of unnecessary proccalls until eventually one runtimes.

## Why It's Good For The Game

Removes a lot of needless proc calls from the stack.

## Changelog

Not player facing