### PR TITLE
A new neutral quirk - Carbon Based - Stops you from being borged

### DIFF
--- a/code/datums/quirks/neutral_quirks/carbon_based.dm
+++ b/code/datums/quirks/neutral_quirks/carbon_based.dm
@@ -1,0 +1,23 @@
+/datum/quirk/item_quirk/carbon_based
+	name = "Carbon Based"
+	desc = "Something about the way you think makes you completely incompatible with Man-Machine Interfaces."
+	icon = FA_ICON_SEEDLING
+	value = 0
+	medical_record_text = "Patient's brain posesses a rare incompatibility with Man-Machine Interfaces."
+	hardcore_value = 0
+	quirk_flags = QUIRK_HUMAN_ONLY
+	mail_goodies = list(/obj/item/toy/braintoy)
+
+/datum/quirk/item_quirk/carbon_based/add(client/client_source)
+	var/mob/living/carbon/carbon_holder = quirk_holder
+	var/obj/item/organ/brain/quirk_holder_brain = carbon_holder.get_organ_slot(ORGAN_SLOT_BRAIN)
+	quirk_holder_brain.no_mmi = TRUE
+
+/datum/quirk/item_quirk/carbon_based/add_unique(client/client_source)
+	var/obj/item/clothing/accessory/dogtag/borg_not_ready/dogtag = new(quirk_holder)
+	give_item_to_holder(dogtag, list(LOCATION_BACKPACK, LOCATION_HANDS), notify_player = TRUE)
+
+/datum/quirk/item_quirk/carbon_based/remove()
+	var/mob/living/carbon/carbon_holder = quirk_holder
+	var/obj/item/organ/brain/quirk_holder_brain = carbon_holder.get_organ_slot(ORGAN_SLOT_BRAIN)
+	quirk_holder_brain.no_mmi = null

--- a/code/datums/quirks/neutral_quirks/carbon_based.dm
+++ b/code/datums/quirks/neutral_quirks/carbon_based.dm
@@ -11,7 +11,8 @@
 /datum/quirk/item_quirk/carbon_based/add(client/client_source)
 	var/mob/living/carbon/carbon_holder = quirk_holder
 	var/obj/item/organ/brain/quirk_holder_brain = carbon_holder.get_organ_slot(ORGAN_SLOT_BRAIN)
-	quirk_holder_brain.no_mmi = TRUE
+	if(quirk_holder_brain)
+		quirk_holder_brain.no_mmi = TRUE
 
 /datum/quirk/item_quirk/carbon_based/add_unique(client/client_source)
 	var/obj/item/clothing/accessory/dogtag/borg_not_ready/dogtag = new(quirk_holder)
@@ -20,4 +21,5 @@
 /datum/quirk/item_quirk/carbon_based/remove()
 	var/mob/living/carbon/carbon_holder = quirk_holder
 	var/obj/item/organ/brain/quirk_holder_brain = carbon_holder.get_organ_slot(ORGAN_SLOT_BRAIN)
-	quirk_holder_brain.no_mmi = null
+	if(quirk_holder_brain)
+		quirk_holder_brain.no_mmi = null

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -177,6 +177,10 @@
 	name = "Pre-Approved Cyborg Candidate dogtag"
 	display = "This employee has been screened for negative mental traits to an acceptable level of accuracy, and is approved for the NT Cyborg program as an alternative to medical resuscitation."
 
+/obj/item/clothing/accessory/dogtag/borg_not_ready
+	name = "Silicon incompatibility dogtag"
+	display = "This employee is incompatible with man-machine interfaces, and cannot be made into a cyborg as an alternative to medical resuscitation."
+
 /obj/item/clothing/accessory/pride
 	name = "pride pin"
 	desc = "A Nanotrasen Diversity & Inclusion Center-sponsored holographic pin to show off your pride, reminding the crew of their unwavering commitment to equity, diversity, and inclusion!"

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -56,6 +56,9 @@
 		if(brain)
 			to_chat(user, span_warning("There's already a brain in the MMI!"))
 			return
+		if(newbrain.no_mmi)
+			to_chat(user, span_warning("[src]'s indicator light turns red and it refuses to connect to [newbrain]."))
+			return
 		if(newbrain.suicided)
 			to_chat(user, span_warning("[newbrain] is completely useless."))
 			return

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -48,6 +48,8 @@
 	var/variant_traits_added
 	/// Variance in brain traits removed by subtypes
 	var/variant_traits_removed
+	// Can this brain fit in an MMI?
+	var/no_mmi = null
 
 /obj/item/organ/brain/Initialize(mapload)
 	. = ..()
@@ -235,6 +237,8 @@
 	. = ..()
 	if(length(skillchips))
 		. += span_info("It has a skillchip embedded in it.")
+	if(no_mmi)
+		. += span_info("Something aobut it looks a little off.")
 	. += brain_damage_examine()
 	if (smooth_brain)
 		. += span_notice("All the pesky wrinkles are gone. Now it just needs a good drying...")

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -238,7 +238,7 @@
 	if(length(skillchips))
 		. += span_info("It has a skillchip embedded in it.")
 	if(no_mmi)
-		. += span_info("Something aobut it looks a little off.")
+		. += span_info("Something about it looks a little off...")
 	. += brain_damage_examine()
 	if (smooth_brain)
 		. += span_notice("All the pesky wrinkles are gone. Now it just needs a good drying...")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1890,6 +1890,7 @@
 #include "code\datums\quirks\negative_quirks\unstable.dm"
 #include "code\datums\quirks\negative_quirks\unusual.dm"
 #include "code\datums\quirks\neutral_quirks\bald.dm"
+#include "code\datums\quirks\neutral_quirks\carbon_based.dm"
 #include "code\datums\quirks\neutral_quirks\deviant_tastes.dm"
 #include "code\datums\quirks\neutral_quirks\evil.dm"
 #include "code\datums\quirks\neutral_quirks\foreigner.dm"


### PR DESCRIPTION
## About The Pull Request

A new quirk worth 0 points (and 0 hardcore points) that just stops your brain from being able to be put in an MMI. This means you can't become a borg or an AI. (malf robo factories unaffected)

## Why It's Good For The Game

Being silicon requires you to adhere to laws, and while (I think) most people are up for that, some people might not appreciate being restricted by laws and would rather DNR. This quirk just lets medical staff and roboticists know not to borg them.

It comes with a dogtag, and yeah you can grab the cyborg candidate dogtag too but I don't really know why you would do that. Also anyone can check medical records or examine your brain to tell if it can't be borged.

As a side thing, the no_mmi property can be assigned to any brain in the future if someone wants it to be unborgable. That's about it.

## Changelog

:cl:
add: Added a new quirk that stops you from becoming a silicon
/:cl: