### PR TITLE
TRAIT_NODISMEMBER protects your limbs from bioscramblers and abductor heal glands

### DIFF
--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -55,7 +55,7 @@
 		if(!limb)
 			replace_limb(zone)
 			return
-		if((limb.get_damage() >= (limb.max_damage / 2)) || (!IS_ORGANIC_LIMB(limb)))
+		if((limb.get_damage() >= (limb.max_damage / 2)) || (!IS_ORGANIC_LIMB(limb)) && !HAS_TRAIT(owner, TRAIT_NODISMEMBER))
 			replace_limb(zone, limb)
 			return
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -718,14 +718,15 @@
 		new_organ.replace_into(src)
 		new_organ.organ_flags |= ORGAN_MUTANT
 
-	var/obj/item/bodypart/new_part = pick(GLOB.bioscrambler_valid_parts)
-	var/obj/item/bodypart/picked_user_part = get_bodypart(initial(new_part.body_zone))
-	if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part.bodytype))
-		changed_something = TRUE
-		new_part = new new_part()
-		new_part.replace_limb(src, special = TRUE)
-		if (picked_user_part)
-			qdel(picked_user_part)
+	if (!HAS_TRAIT(src, TRAIT_NODISMEMBER))
+		var/obj/item/bodypart/new_part = pick(GLOB.bioscrambler_valid_parts)
+		var/obj/item/bodypart/picked_user_part = get_bodypart(initial(new_part.body_zone))
+		if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part.bodytype))
+			changed_something = TRUE
+			new_part = new new_part()
+			new_part.replace_limb(src, special = TRUE)
+			if (picked_user_part)
+				qdel(picked_user_part)
 
 	if (!changed_something)
 		to_chat(src, span_notice("Your augmented body protects you from [scramble_source]!"))


### PR DESCRIPTION
## About The Pull Request

(My first salt pr 😁)
This PR makes it so that bioscramble effects skip replacing limbs and the abductor heal gland won't eject limbs if the carbon in question has TRAIT_NODISMEMBER. You can still have your organs affected of course. 

## Why It's Good For The Game

The plasma lake in ice box and that one bitrunning domain won't replace a carbon's body parts with plasma parts if it has nodismember. This is because unlike bioscramblers, plasma lakes recognize that changing your limbs back is _literally impossible_ unless you get an augmentation, and once you get an augmentation it's permanent. I can't say this for sure, but I don't think the design intention behind nodismember is that you become a lot more vulnerable to bioscramblers in exchange for not losing limbs.

As for the heal glands, they literally remove your limbs. Removing your limbs shouldn't be possible if you have the no-removing-your-limbs trait.

## Changelog

:cl:
fix: Bioscramble effects no longer swap body parts of that can't lose limbs
fix: Abductor heal gland no longer ejects limbs of carbons that can't lose limbs
/:cl: