### PR TITLE
[NO GBP] Fixes high export value of seeds

### DIFF
--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -8,7 +8,7 @@
 	/// Plants sold on the market
 	var/static/list/discovered_plants = list()
 	/// Highest rarity of the most valuable seed
-	var/highest_rarity = 0
+	var/highest_rarity
 
 /datum/export/seed/New()
 	. = ..()

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -8,7 +8,7 @@
 	/// Plants sold on the market
 	var/static/list/discovered_plants = list()
 	/// Highest rarity of the most valuable seed
-	var/highest_rarity
+	var/highest_rarity = 0
 
 /datum/export/seed/New()
 	. = ..()

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -3,17 +3,27 @@
 	k_elasticity = 0 //price inelastic/quantity elastic, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)
-	// Only for undiscovered species
+	/// Only for undiscovered species
 	var/needs_discovery = FALSE
-	// Plants sold on the market
+	/// Plants sold on the market
 	var/static/list/discovered_plants = list()
+	/// Highest rarity of the most valuable seed
+	var/static/highest_rarity = 0
+
+/datum/export/seed/New()
+	. = ..()
+	if(!highest_rarity)
+		for(var/obj/item/seeds/seed as anything in subtypesof(/obj/item/seeds))
+			if(seed::rarity > highest_rarity)
+				highest_rarity = seed::rarity
 
 /datum/export/seed/get_base_cost(obj/item/seeds/S)
-	if(!needs_discovery && (S.type in discovered_plants))
+	var/discovered = discovered_plants[S.type]
+	if(!needs_discovery && discovered)
 		return 0
-	if(needs_discovery && !(S.type in discovered_plants))
+	if(needs_discovery && !discovered)
 		return 0
-	return ..() * S.rarity // That's right, no bonus for potency. Send a crappy sample first to "show improvement" later.
+	return ..() * (S.rarity /  highest_rarity) // That's right, no bonus for potency. Send a crappy sample first to "show improvement" later.
 
 /datum/export/seed/sell_object(obj/item/seeds/S, datum/export_report/report, dry_run, apply_elastic)
 	. = ..()
@@ -23,7 +33,6 @@
 /datum/export/seed/potency
 	cost = CARGO_CRATE_VALUE * 0.0125 // Gets multiplied by potency and rarity.
 	unit_name = "improved plant sample"
-	export_types = list(/obj/item/seeds)
 	needs_discovery = TRUE // Only for already discovered species
 
 /datum/export/seed/potency/get_base_cost(obj/item/seeds/S)

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -8,14 +8,13 @@
 	/// Plants sold on the market
 	var/static/list/discovered_plants = list()
 	/// Highest rarity of the most valuable seed
-	var/static/highest_rarity = 0
+	var/highest_rarity = 0
 
 /datum/export/seed/New()
 	. = ..()
-	if(!highest_rarity)
-		for(var/obj/item/seeds/seed as anything in subtypesof(/obj/item/seeds))
-			if(seed::rarity > highest_rarity)
-				highest_rarity = seed::rarity
+	for(var/obj/item/seeds/seed as anything in subtypesof(/obj/item/seeds))
+		if(seed::rarity > highest_rarity)
+			highest_rarity = seed::rarity
 
 /datum/export/seed/get_base_cost(obj/item/seeds/S)
 	var/discovered = discovered_plants[S.type]


### PR DESCRIPTION
## About The Pull Request
- Fixes https://github.com/tgstation/tgstation/pull/93235#discussion_r2467112106

Seeds export value now scales with this formulae

`(0.1'ish most common seed -> 1 most rarest seed) * base cost(CRATE_VALUE * 0.025). `

so you get the same uniform scale before the elasticity rework.

## Changelog
:cl:
fix: exporting seeds won't yield ridiculously large profits
/:cl:
