### PR TITLE
Mech equipment buttons DLC

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -451,10 +451,9 @@
  * Creates a new action, sets up the chassis and equipment references, and grants it to the mob.
  */
 /obj/vehicle/sealed/mecha/proc/grant_equipment_action(mob/occupant, obj/item/mecha_parts/mecha_equipment/equipment)
-	var/action_type = call(equipment, "get_action_type")()
-	var/datum/action/vehicle/sealed/mecha/equipment/action = new action_type // We cannot use grant_action_type_to_mob() because:
-	action.set_chassis(src) 									  			// 1. grant_action_type_to_mob() works with a single predefined action type
-	action.set_equipment(equipment) 							 		   // 2. We create unique action instances for each equipment with specific equipment references
+	var/datum/action/vehicle/sealed/mecha/equipment/action = new equipment.action_type // We cannot use grant_action_type_to_mob() because:
+	action.set_chassis(src) 									  					  // 1. grant_action_type_to_mob() works with a single predefined action type
+	action.set_equipment(equipment) 							 					 // 2. We create unique action instances for each equipment with specific equipment references
 
 	action.Grant(occupant)
 	LAZYINITLIST(occupant_actions[occupant])

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -451,9 +451,10 @@
  * Creates a new action, sets up the chassis and equipment references, and grants it to the mob.
  */
 /obj/vehicle/sealed/mecha/proc/grant_equipment_action(mob/occupant, obj/item/mecha_parts/mecha_equipment/equipment)
-	var/datum/action/vehicle/sealed/mecha/equipment/action = new  // We cannot use grant_action_type_to_mob() because:
-	action.set_chassis(src) 									  // 1. grant_action_type_to_mob() works with a single predefined action type
-	action.set_equipment(equipment) 							 // 2. We create unique action instances for each equipment with specific equipment references
+	var/action_type = call(equipment, "get_action_type")()
+	var/datum/action/vehicle/sealed/mecha/equipment/action = new action_type // We cannot use grant_action_type_to_mob() because:
+	action.set_chassis(src) 									  			// 1. grant_action_type_to_mob() works with a single predefined action type
+	action.set_equipment(equipment) 							 		   // 2. We create unique action instances for each equipment with specific equipment references
 
 	action.Grant(occupant)
 	LAZYINITLIST(occupant_actions[occupant])

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -37,6 +37,8 @@
 	var/harmful = FALSE
 	///Sound file: Sound to play when this equipment is destroyed while still attached to the mech
 	var/destroy_sound = 'sound/vehicles/mecha/critdestr.ogg'
+	///The action type to use for this equipment. Override for custom action buttons.
+	var/action_type = /datum/action/vehicle/sealed/mecha/equipment
 
 /obj/item/mecha_parts/mecha_equipment/Destroy()
 	if(chassis)
@@ -271,5 +273,3 @@
 /obj/item/mecha_parts/mecha_equipment/proc/needs_rearm()
 	return FALSE
 
-/// the action type to use for this equipment. Override for custom action buttons.
-/obj/item/mecha_parts/mecha_equipment/var/action_type = /datum/action/vehicle/sealed/mecha/equipment

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -270,3 +270,7 @@
 /// AI mech pilot: returns TRUE if the Ai should try to reload the mecha
 /obj/item/mecha_parts/mecha_equipment/proc/needs_rearm()
 	return FALSE
+
+/// Returns the action type to use for this equipment. Override for custom action buttons.
+/obj/item/mecha_parts/mecha_equipment/proc/get_action_type()
+	return /datum/action/vehicle/sealed/mecha/equipment

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -271,6 +271,5 @@
 /obj/item/mecha_parts/mecha_equipment/proc/needs_rearm()
 	return FALSE
 
-/// Returns the action type to use for this equipment. Override for custom action buttons.
-/obj/item/mecha_parts/mecha_equipment/proc/get_action_type()
-	return /datum/action/vehicle/sealed/mecha/equipment
+/// the action type to use for this equipment. Override for custom action buttons.
+/obj/item/mecha_parts/mecha_equipment/var/action_type = /datum/action/vehicle/sealed/mecha/equipment

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -162,6 +162,7 @@
 	range = MECHA_MELEE|MECHA_RANGED
 	mech_flags = ALL
 	can_be_triggered = TRUE
+	action_type = /datum/action/vehicle/sealed/mecha/equipment/extinguisher_action
 	///Minimum amount of reagent needed to activate.
 	var/required_amount = 80
 
@@ -222,9 +223,6 @@
 		if("refill")
 			attempt_refill(usr)
 			return TRUE
-
-/obj/item/mecha_parts/mecha_equipment/extinguisher/get_action_type()
-	return /datum/action/vehicle/sealed/mecha/equipment/extinguisher_action
 
 ///Maximum range the RCD can construct at.
 #define RCD_RANGE 3

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -160,7 +160,8 @@
 	energy_drain = 0
 	equipment_slot = MECHA_UTILITY
 	range = MECHA_MELEE|MECHA_RANGED
-	mech_flags = EXOSUIT_MODULE_WORKING
+	mech_flags = ALL
+	can_be_triggered = TRUE
 	///Minimum amount of reagent needed to activate.
 	var/required_amount = 80
 
@@ -221,6 +222,9 @@
 		if("refill")
 			attempt_refill(usr)
 			return TRUE
+
+/obj/item/mecha_parts/mecha_equipment/extinguisher/get_action_type()
+	return /datum/action/vehicle/sealed/mecha/equipment/extinguisher_action
 
 ///Maximum range the RCD can construct at.
 #define RCD_RANGE 3

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -207,23 +207,23 @@
 		return
 	if(!istype(equipment, /obj/item/mecha_parts/mecha_equipment/ejector))
 		return
-	
+
 	var/obj/item/mecha_parts/mecha_equipment/ejector/cargo_hold = equipment
-	
+
 	// Right click - show radial menu
 	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
 		var/list/cargo_radial = list()
 		for(var/atom/movable/cargo_item in cargo_hold.contents)
 			cargo_radial[cargo_item] = cargo_item.appearance
-		
+
 		if(!length(cargo_radial))
 			chassis.balloon_alert(owner, "cargo hold empty!")
 			return
-		
+
 		var/atom/movable/picked_item = show_radial_menu(owner, chassis, cargo_radial, require_near = TRUE)
 		if(!picked_item || !(picked_item in cargo_hold.contents))
 			return
-		
+
 		to_chat(chassis.occupants, "[icon2html(cargo_hold, chassis.occupants)][span_notice("You unload [picked_item].")]")
 		picked_item.forceMove(cargo_hold.drop_location())
 		if(picked_item == chassis.ore_box)
@@ -231,7 +231,7 @@
 		playsound(chassis, 'sound/items/weapons/tap.ogg', 50, TRUE)
 		cargo_hold.log_message("Unloaded [picked_item]. Cargo compartment capacity: [cargo_hold.cargo_capacity - cargo_hold.contents.len]", LOG_MECHA)
 		return
-	
+
 	// Left click - dispose first item
 	if(cargo_hold.contents.len)
 		var/atom/movable/first_item = cargo_hold.contents[1]
@@ -248,7 +248,7 @@
 	name = "Extinguisher"
 
 /datum/action/vehicle/sealed/mecha/equipment/extinguisher_action/set_equipment(passed_equipment)
-	..()
+	. = ..()
 	name = "[equipment.name]"
 
 /datum/action/vehicle/sealed/mecha/equipment/extinguisher_action/Trigger(mob/clicker, trigger_flags)
@@ -256,17 +256,17 @@
 		return
 	if(!istype(equipment, /obj/item/mecha_parts/mecha_equipment/extinguisher))
 		return
-	
+
 	var/obj/item/mecha_parts/mecha_equipment/extinguisher/extinguisher = equipment
-	
+
 	// Right click - refill
 	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
 		extinguisher.attempt_refill(owner)
 		return
-	
+
 	// Left click - spray
 	if(extinguisher.reagents.total_volume < extinguisher.required_amount)
 		chassis.balloon_alert(owner, "not enough water!")
 		return
-	
+
 	extinguisher.spray_extinguisher(owner)

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -194,3 +194,79 @@
 		AddComponent(/datum/component/action_item_overlay, equipment)
 
 	build_button_icon()
+
+/datum/action/vehicle/sealed/mecha/equipment/cargo_module
+	name = "Cargo Module"
+
+/datum/action/vehicle/sealed/mecha/equipment/cargo_module/set_equipment(passed_equipment)
+	..()
+	name = "[equipment.name]"
+
+/datum/action/vehicle/sealed/mecha/equipment/cargo_module/Trigger(mob/clicker, trigger_flags)
+	if(!chassis || !(owner in chassis.occupants) || !equipment)
+		return
+	if(!istype(equipment, /obj/item/mecha_parts/mecha_equipment/ejector))
+		return
+	
+	var/obj/item/mecha_parts/mecha_equipment/ejector/cargo_hold = equipment
+	
+	// Right click - show radial menu
+	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
+		var/list/cargo_radial = list()
+		for(var/atom/movable/cargo_item in cargo_hold.contents)
+			cargo_radial[cargo_item] = cargo_item.appearance
+		
+		if(!length(cargo_radial))
+			chassis.balloon_alert(owner, "cargo hold empty!")
+			return
+		
+		var/atom/movable/picked_item = show_radial_menu(owner, chassis, cargo_radial, require_near = TRUE)
+		if(!picked_item || !(picked_item in cargo_hold.contents))
+			return
+		
+		to_chat(chassis.occupants, "[icon2html(cargo_hold, chassis.occupants)][span_notice("You unload [picked_item].")]")
+		picked_item.forceMove(cargo_hold.drop_location())
+		if(picked_item == chassis.ore_box)
+			chassis.ore_box = null
+		playsound(chassis, 'sound/items/weapons/tap.ogg', 50, TRUE)
+		cargo_hold.log_message("Unloaded [picked_item]. Cargo compartment capacity: [cargo_hold.cargo_capacity - cargo_hold.contents.len]", LOG_MECHA)
+		return
+	
+	// Left click - dispose first item
+	if(cargo_hold.contents.len)
+		var/atom/movable/first_item = cargo_hold.contents[1]
+		to_chat(chassis.occupants, "[icon2html(cargo_hold, chassis.occupants)][span_notice("You unload [first_item].")]")
+		first_item.forceMove(cargo_hold.drop_location())
+		if(first_item == chassis.ore_box)
+			chassis.ore_box = null
+		playsound(chassis, 'sound/items/weapons/tap.ogg', 50, TRUE)
+		cargo_hold.log_message("Unloaded [first_item]. Cargo compartment capacity: [cargo_hold.cargo_capacity - cargo_hold.contents.len]", LOG_MECHA)
+	else
+		chassis.balloon_alert(owner, "cargo hold empty!")
+
+/datum/action/vehicle/sealed/mecha/equipment/extinguisher_action
+	name = "Extinguisher"
+
+/datum/action/vehicle/sealed/mecha/equipment/extinguisher_action/set_equipment(passed_equipment)
+	..()
+	name = "[equipment.name]"
+
+/datum/action/vehicle/sealed/mecha/equipment/extinguisher_action/Trigger(mob/clicker, trigger_flags)
+	if(!chassis || !(owner in chassis.occupants) || !equipment)
+		return
+	if(!istype(equipment, /obj/item/mecha_parts/mecha_equipment/extinguisher))
+		return
+	
+	var/obj/item/mecha_parts/mecha_equipment/extinguisher/extinguisher = equipment
+	
+	// Right click - refill
+	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
+		extinguisher.attempt_refill(owner)
+		return
+	
+	// Left click - spray
+	if(extinguisher.reagents.total_volume < extinguisher.required_amount)
+		chassis.balloon_alert(owner, "not enough water!")
+		return
+	
+	extinguisher.spray_extinguisher(owner)

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -199,7 +199,7 @@
 	name = "Cargo Module"
 
 /datum/action/vehicle/sealed/mecha/equipment/cargo_module/set_equipment(passed_equipment)
-	..()
+	. = ..()
 	name = "[equipment.name]"
 
 /datum/action/vehicle/sealed/mecha/equipment/cargo_module/Trigger(mob/clicker, trigger_flags)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -301,11 +301,9 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	equipment_slot = MECHA_UTILITY
 	detachable = FALSE
 	can_be_triggered = TRUE
+	action_type = /datum/action/vehicle/sealed/mecha/equipment/cargo_module
 	///Number of atoms we can store
 	var/cargo_capacity = 15
-
-/obj/item/mecha_parts/mecha_equipment/ejector/get_action_type()
-	return /datum/action/vehicle/sealed/mecha/equipment/cargo_module
 
 /obj/item/mecha_parts/mecha_equipment/ejector/attach()
 	. = ..()

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -300,8 +300,12 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	icon_state = "mecha_bin"
 	equipment_slot = MECHA_UTILITY
 	detachable = FALSE
+	can_be_triggered = TRUE
 	///Number of atoms we can store
 	var/cargo_capacity = 15
+
+/obj/item/mecha_parts/mecha_equipment/ejector/get_action_type()
+	return /datum/action/vehicle/sealed/mecha/equipment/cargo_module
 
 /obj/item/mecha_parts/mecha_equipment/ejector/attach()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Adds equipment action buttons for cargo module and fire extinguisher

YOU can access YOUR mech cargo module without using mech UI screen

simply press left click to unload first item OR right click to select item to unload(comes in dat radial menu thing)
<img width="300" height="259" alt="riplaey" src="https://github.com/user-attachments/assets/4469bfb9-ec64-4e71-b774-4b5e8aa964ce" />
also works for fatty if ANYONE cares about him
<img width="272" height="234" alt="fatty" src="https://github.com/user-attachments/assets/ff6cf41a-ab7a-48fa-b490-8ce98448b647" />

My baby boy fire extinguisher mech module was untouched by original mech action buttons PR so i had to do him right

left click to spluff, right click to refill

Also made so fire extinguisher now goes on all mechs because its more usefull in combat scenario than for firefighting (3x3 slips??? yes please!!!)

## Why It's Good For The Game

more action buttons bloat on screen less use of clanky UI

## Changelog
:cl:
add: Added UI buttons for mech cargo module, left click to dispose first item in the list and right click to select an item to drop.
add: Added UI button for mech fire extinguisher, left click to splash and right click to refill.
balance: Mech fire extinguisher module now goes on any mech, combat slips with a press of a button!
/:cl:
