### PR TITLE
The Temperature Gun, Cryokinesis and .38 Iceblox now apply a status effect that briefly prevents temperature regulation.

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1108,7 +1108,7 @@
 /atom/movable/screen/alert/status_effect/no_temp_reg
 	name = "Ineffective Thermoregulation"
 	desc = "You can't regulate your temperature! You can't heat up or cool down normally!"
-	icon_state = "frozen" //temporary
+	icon_state = "stasis"
 //effects handled in _species
 
 // Desginated Target - Applied typically by Flare lasers

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1102,7 +1102,7 @@
 /datum/status_effect/ineffective_thermoregulation
 	id = "no_temp_reg"
 	alert_type = /atom/movable/screen/alert/status_effect/no_temp_reg
-	duration = 2 SECONDS
+	duration = 5 SECONDS
 	status_type = STATUS_EFFECT_REPLACE
 
 /atom/movable/screen/alert/status_effect/no_temp_reg

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1099,6 +1099,18 @@
 	UnregisterSignal(owner, COMSIG_ATOM_UPDATE_OVERLAYS)
 	owner.update_icon()
 
+/datum/status_effect/ineffective_thermoregulation
+	id = "no_temp_reg"
+	alert_type = /atom/movable/screen/alert/status_effect/no_temp_reg
+	duration = 2 SECONDS
+	status_type = STATUS_EFFECT_REPLACE
+
+/atom/movable/screen/alert/status_effect/no_temp_reg
+	name = "Ineffective Thermoregulation"
+	desc = "You can't regulate your temperature! You can't heat up or cool down normally!"
+	icon_state = "frozen" //temporary
+//effects handled in _species
+
 // Desginated Target - Applied typically by Flare lasers
 
 /atom/movable/screen/alert/status_effect/designated_target

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1097,6 +1097,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	humi.adjust_coretemperature(skin_core_change)
 
+	if(humi.has_status_effect(/datum/status_effect/ineffective_thermoregulation))
+		return
+
 	// get the enviroment details of where the mob is standing
 	var/datum/gas_mixture/environment = humi.loc?.return_air()
 	if(!environment) // if there is no environment (nullspace) drop out here.

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -122,7 +122,7 @@
 /obj/projectile/bullet/c38/iceblox //see /obj/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
 	damage = 20
-	var/temperature = 100
+	var/temperature = 50 //its better than a laser
 	ricochets_max = 0
 
 /obj/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = 0, pierce_hit)
@@ -130,6 +130,7 @@
 	if(isliving(target))
 		var/mob/living/criminal_scum = target
 		criminal_scum.adjust_bodytemperature(((100-blocked)/100)*(temperature - criminal_scum.bodytemperature))
+		criminal_scum.apply_status_effect(/datum/status_effect/ineffective_thermoregulation)
 
 // .357 (Syndie Revolver)
 

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -48,13 +48,7 @@
 	name = "cryo beam"
 	range = 9
 	temperature = -350 // Single slow shot reduces temp greatly
-
-/obj/projectile/temp/cryo/on_hit(atom/target, blocked = 0, pierce_hit)
-	. = ..()
-
-	if(isliving(target))
-		var/mob/living/living_target = target
-		living_target.apply_status_effect(/datum/status_effect/freezing_blast) //its traitor only so i dont care
+	//removed watchers gaze because this shits already incredibly strong for genetics
 
 /obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	armor_flag = ENERGY
-	var/temperature = -50 // reduce the body temperature by 50 points
+	var/temperature = -30 // reduce the body temperature by 50 points
 
 /obj/projectile/temp/is_hostile_projectile()
 	return temperature != 0 // our damage is done by cooling or heating (casting to boolean here)
@@ -18,6 +18,7 @@
 		// The new body temperature is adjusted by the bullet's effect temperature
 		// Reduce the amount of the effect temperature change based on the amount of insulation the mob is wearing
 		hit_mob.adjust_bodytemperature((thermal_protection * temperature) + temperature)
+		hit_mob.apply_status_effect(/datum/status_effect/ineffective_thermoregulation)
 
 	else if(isliving(target))
 		var/mob/living/L = target
@@ -34,7 +35,7 @@
 /obj/projectile/temp/hot
 	name = "heat beam"
 	icon_state = "lava"
-	temperature = 100 // Raise the body temp by 100 points
+	temperature = 50 // Raise the body temp by 50 points
 
 /obj/projectile/temp/hot/on_hit(atom/target, blocked = FALSE, pierce_hit)
 	. = ..()
@@ -53,7 +54,7 @@
 
 	if(isliving(target))
 		var/mob/living/living_target = target
-		living_target.apply_status_effect(/datum/status_effect/freezing_blast)
+		living_target.apply_status_effect(/datum/status_effect/freezing_blast) //its traitor only so i dont care
 
 /obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	armor_flag = ENERGY
-	var/temperature = -30 // reduce the body temperature by 50 points
+	var/temperature = -30 // reduce the body temperature by 30 points
 
 /obj/projectile/temp/is_hostile_projectile()
 	return temperature != 0 // our damage is done by cooling or heating (casting to boolean here)

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -48,7 +48,13 @@
 	name = "cryo beam"
 	range = 9
 	temperature = -350 // Single slow shot reduces temp greatly
-	//removed watchers gaze because this shits already incredibly strong for genetics
+
+/obj/projectile/temp/cryo/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+
+	if(isliving(target))
+		var/mob/living/living_target = target
+		living_target.apply_status_effect(/datum/status_effect/freezing_blast)
 
 /obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## About The Pull Request

The Temperature Gun (and Cryokinesis and .38 Iceblox) now apply a status effect that briefly prevents temperature regulation. You won't naturally heat or cool (unless I fucked up somewhere) as long as it's active. The temp gun should be more effective at slowing people down. Insulated clothing affects this greatly, which is interesting compared to armor or stun resist. It's intended to reward good aim by making subsequent shots a little easier until they're stopped in their tracks.

The heat mode still sucks idk why you'd use it anyway

## Why It's Good For The Game

The Temp Gun is really, really bad cuz of how fast carbons thermoregulate. This tries to bring it in line with other armory weapons, suitably specialized for making criminals FREEZE when commanded to. 

Adds new avenues for security to nonlethally incapacitate targets without relying on stamina damage. Adds new avenues for antagonists to combat this by wearing (thermally) insulated clothing.

Scuffed demo: (NOT ACCURATE)
https://www.youtube.com/watch?v=IVElh0lKLBk

## Changelog

:cl:
balance: The Temperature Gun, Cryokinesis and .38 Iceblox now apply a status effect that briefly prevents temperature regulation. However, the Temperature Gun and .38 Iceblox adjust temperature less.
/:cl: