### PR TITLE
[Fix] Corrects exploit that allowed to use departamental budget to buy goodie items

### DIFF
--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -259,7 +259,7 @@
 				if(isnull(reason) || ..())
 					return
 
-			if(id_card_customer?.registered_account?.account_job) //Find a budget to pull from
+			if(id_card_customer?.registered_account?.account_job && !self_paid) //Find a budget to pull from
 				var/datum/bank_account/personal_department = SSeconomy.get_dep_account(id_card_customer.registered_account.account_job.paycheck_department)
 				if(!(personal_department.account_holder == "Cargo Budget"))
 					var/choice = tgui_alert(usr, "Which department are you requesting this for?", "Choose request department", list("Cargo Budget", "[personal_department.account_holder]"))


### PR DESCRIPTION

## About The Pull Request
Adds a check on wherever its self paid or not when buying stuff as self paid on the budgetering pda program, so it works like a regular cargo console

## Why It's Good For The Game
Well, behaviors should be consistent, and this looks more like an oversight. Its also the only way to order goodies with departamental budgets atm, and the comments on the goodies flag seem to heavily imply the intent is for this not to happen.

## Proof of work

### Before

<img width="800" height="506" alt="image" src="https://github.com/user-attachments/assets/6305531c-0b0e-4a25-bff8-7c20c8a72472" />


<img width="901" height="551" alt="image" src="https://github.com/user-attachments/assets/c45e70a1-be6c-4513-b00a-87f2c098c577" />

### After

<img width="924" height="734" alt="image" src="https://github.com/user-attachments/assets/e9862bf9-5ae7-4945-912c-08c509e18058" />

<img width="831" height="616" alt="image" src="https://github.com/user-attachments/assets/4b66aa64-03cd-4724-913f-2fee5489d09f" />


## Changelog
:cl:
fix: solves an exploit that allowed users to buy goodie packs with the pda budget program
/:cl:
