### PR TITLE
[no gpb] fixes EVERYTHING wrong with golf carts

### DIFF
--- a/code/modules/vehicles/cars/golfcart/golfcart.dm
+++ b/code/modules/vehicles/cars/golfcart/golfcart.dm
@@ -151,6 +151,8 @@
 	if(!isliving(bumped_atom))
 		return
 	var/mob/living/mob = bumped_atom
+	if (mob in child.buckled_mobs)
+		return
 	mob.throw_at(get_edge_target_turf(mob, dir), 2, 3)
 	RegisterSignal(mob, COMSIG_MOVABLE_THROW_LANDED, PROC_REF(thrown_mob_landed))
 	mob.visible_message(
@@ -199,7 +201,8 @@
 	if (!is_hotrod())
 		return
 	for(var/mob/living/future_pancake in loc)
-		run_over(future_pancake)
+		if (!(future_pancake in child.buckled_mobs))
+			run_over(future_pancake)
 
 /obj/vehicle/ridden/golfcart/mouse_drop_receive(atom/dropped, mob/user, params)
 	if (child.can_load(dropped))


### PR DESCRIPTION
## About The Pull Request
Fixes #93589, fixes #93594, fixes (probably) #93663 by BANNING mobs that have things buckled on them from getting on. also if you try to buckle to something that is already in the cart you CANT do that anymore

## Why It's Good For The Game
It fixes golf cart bugs which are NOT good.. :(

## Changelog

:cl:
fix: fixes permanent soul binding between golf carts and riders
/:cl: