### PR TITLE
Everyone can use bow now

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/_bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/_bow.dm
@@ -22,6 +22,7 @@
 	bolt_type = BOLT_TYPE_NO_BOLT
 	click_on_low_ammo = FALSE
 	must_hold_to_load = TRUE
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 	/// whether the bow is drawn back
 	var/drawn = FALSE
 


### PR DESCRIPTION
## About The Pull Request

adds TRIGGER_GUARD_ALLOW_ALL for bows so hulks, golems and other nonstandard carbons can use them.

## Why It's Good For The Game

why wouldnt you be able to use bow with big fingers like thousands of years ago
<img width="498" height="399" alt="image" src="https://github.com/user-attachments/assets/25706bc6-64b0-45c6-a0f5-50bdea79cc76" />


## Changelog

:cl:
qol: You can now use bow with big fingers.
/:cl: