### PR TITLE
Add observer and latejoin landmarks to minimal centcom

### DIFF
--- a/_maps/map_files/generic/CentCom_minimal.dmm
+++ b/_maps/map_files/generic/CentCom_minimal.dmm
@@ -11,6 +11,8 @@
 /area/centcom/central_command_areas/control)
 "x" = (
 /obj/effect/landmark/error,
+/obj/effect/landmark/observer_start,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "A" = (


### PR DESCRIPTION

## About The Pull Request

Missing these two causes a runtime whenever you spawn in, and certain verbs won't work without them (spawn debug full crew won't work without an observer landmark)

## Why It's Good For The Game

Make absolute minimum define more usable

## Changelog

N/A
