### PR TITLE
Makes ore refineries drop materials below them when not linked to a silo

### DIFF
--- a/code/__HELPERS/construction.dm
+++ b/code/__HELPERS/construction.dm
@@ -1,5 +1,5 @@
 /// Makes sure only integer values are used when consuming, removing & checking for mats
-#define OPTIMAL_COST(cost)(max(1, round(cost)))
+#define OPTIMAL_COST(cost)(max(1, floor(cost)))
 
 /// Wrapper for fetching material references. Exists exclusively so that people don't need to wrap everything in a list every time.
 #define GET_MATERIAL_REF(arguments...) SSmaterials._GetMaterialRef(list(##arguments))
@@ -31,7 +31,7 @@
  */
 /proc/amount2sheet(amt)
 	if(amt >= SHEET_MATERIAL_AMOUNT)
-		return round(amt / SHEET_MATERIAL_AMOUNT)
+		return floor(amt / SHEET_MATERIAL_AMOUNT)
 	return 0
 
 /**

--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -245,7 +245,7 @@
 		if(!space_left)
 			return MATERIAL_INSERT_ITEM_NO_SPACE
 		var/material_per_sheet = material_amount / item_stack.amount
-		var/sheets_to_insert = round(space_left / material_per_sheet)
+		var/sheets_to_insert = floor(space_left / material_per_sheet)
 		if(!sheets_to_insert)
 			return MATERIAL_INSERT_ITEM_NO_SPACE
 		target = fast_split_stack(item_stack, sheets_to_insert)
@@ -690,7 +690,7 @@
 		return 0
 
 	//requested amount greater than available amount or just an invalid value
-	stack_amt = min(round(materials[material] / SHEET_MATERIAL_AMOUNT), stack_amt)
+	stack_amt = min(floor(materials[material] / SHEET_MATERIAL_AMOUNT), stack_amt)
 	if(stack_amt <= 0)
 		return 0
 	//auto drop location

--- a/code/modules/mining/boulder_processing/_boulder_processing.dm
+++ b/code/modules/mining/boulder_processing/_boulder_processing.dm
@@ -103,6 +103,8 @@
 /obj/machinery/bouldertech/CanAllowThrough(atom/movable/mover, border_dir)
 	if(!anchored)
 		return FALSE
+	if(istype(mover, /obj/item/stack/sheet))
+		return TRUE
 	if(istype(mover, /obj/item/boulder))
 		return can_process_boulder(mover)
 	if(isgolem(mover))
@@ -350,8 +352,8 @@
 				rejected_mats[possible_mat] = quantity
 				continue
 			points_held = round(points_held + (quantity * possible_mat.points_per_unit * MINING_POINT_MACHINE_MULTIPLIER)) // put point total here into machine
-			if(!silo_materials.mat_container.insert_amount_mat(quantity, possible_mat))
-				rejected_mats[possible_mat] = quantity
+			if(isnull(silo_materials.silo) || !silo_materials.mat_container.insert_amount_mat(quantity, possible_mat))
+				new possible_mat.sheet_type(drop_location(), floor(quantity / SHEET_MATERIAL_AMOUNT))
 
 		//puts back materials that couldn't be processed
 		chosen_boulder.set_custom_materials(rejected_mats, refining_efficiency)


### PR DESCRIPTION

## About The Pull Request

- What it says above, makes them drop materials instead of sending them to the shadow realm
- Replaces some 1 argument `round()'s` with `floor()'s` in material logic, someone should regex all of them sometime for a giant conflict merge PR

## Why It's Good For The Game

> What it says above, makes them drop materials instead of sending them to the shadow realm
- Makes custom-made refinery setups a bit more viable, alongside recovering from the ore silo being bombed/eaten by a hungry boi
> Replaces some 1 argument `round()'s` with `floor()'s` in material logic
- Round() using 1 argument is deprecated, should slowly start switching over

## Changelog

:cl:
fix: the ore refineries now drop stacks of materials below them if they are not linked to a silo instead of being sent to the shadow realm
/:cl:
