### PR TITLE
Small spear change: slightly better stats but they fall apart

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -98,7 +98,7 @@
 			throwforce = 21
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plasmaglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
 			icon_prefix = "spearplasma"
-			max_integrity = 220
+			modify_max_integrity(220)
 			wound_bonus = -10
 			force_unwielded = 11
 			force_wielded = 19
@@ -116,7 +116,7 @@
 			throw_range = 8
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/titaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			max_integrity = 230
+			modify_max_integrity(230)
 			wound_bonus = -5
 			force_unwielded = 12
 			force_wielded = 20
@@ -136,7 +136,7 @@
 			throw_range = 9
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plastitaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			max_integrity = 240
+			modify_max_integrity(240)
 			wound_bonus = 0
 			exposed_wound_bonus = 20
 			force_unwielded = 13

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -157,7 +157,7 @@
 /obj/item/spear/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	if(improvised_construction)
 		return
-	take_damage(force, sound_effect = FALSE)
+	take_damage(force/2, sound_effect = FALSE)
 
 /obj/item/spear/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
@@ -165,7 +165,7 @@
 		return
 	if(!improvised_construction)
 		return
-	take_damage(throwforce, sound_effect = FALSE)
+	take_damage(throwforce/2, sound_effect = FALSE)
 
 /obj/item/spear/atom_destruction(damage_flag)
 	playsound(src, 'sound/effects/grillehit.ogg', 50)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -157,7 +157,7 @@
 /obj/item/spear/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	if(improvised_construction)
 		return
-	take_damage(force)
+	take_damage(force, sound_effect = FALSE)
 
 /obj/item/spear/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
@@ -165,7 +165,7 @@
 		return
 	if(!improvised_construction)
 		return
-	take_damage(throwforce)
+	take_damage(throwforce, sound_effect = FALSE)
 
 /obj/item/spear/atom_destruction(damage_flag)
 	playsound(src, 'sound/effects/grillehit.ogg', 50)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -313,7 +313,6 @@
 	custom_materials = list(/datum/material/bone = HALF_SHEET_MATERIAL_AMOUNT * 7)
 	force_unwielded = 12
 	force_wielded = 20
-	improvised_construction = FALSE
 	spear_leftovers = /obj/item/stack/sheet/bone
 
 /obj/item/spear/bonespear/add_headpike_component()

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -302,12 +302,11 @@
  * Bone Spear
  */
 /obj/item/spear/bonespear //Blatant imitation of spear, but made out of bone. Not valid for explosive modification.
+	name = "bone spear"
+	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
 	icon_state = "bone_spear0"
 	base_icon_state = "bone_spear0"
 	icon_prefix = "bone_spear"
-	name = "bone spear"
-	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
-
 	throwforce = 22
 	armour_penetration = 20 //Enhanced armor piercing
 	custom_materials = list(/datum/material/bone = HALF_SHEET_MATERIAL_AMOUNT * 7)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -8,11 +8,12 @@
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	icon_angle = -45
 	force = 10
+	reach = 2
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 20
 	throw_speed = 4
-	demolition_mod = 0.75
+	demolition_mod = 0.75 // Note: This is significant, as this needs to be low enough that any possible force adjustments from better spears does not go over airlock deflection. See AIRLOCK_DAMAGE_DEFLECTION_N.
 	embed_type = /datum/embedding/spear
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass= HALF_SHEET_MATERIAL_AMOUNT * 2)
@@ -32,6 +33,10 @@
 	var/force_unwielded = 10
 	/// How much damage to do wielded
 	var/force_wielded = 18
+	/// Whether or not hitting with this spear causes damage to the spear itself
+	var/improvised_construction = TRUE
+	/// What is left over when a spear breaks
+	var/spear_leftovers = /obj/item/stack/rods
 
 /datum/embedding/spear
 	impact_pain_mult = 2
@@ -59,6 +64,8 @@
 		force_unwielded = force_unwielded, \
 		force_wielded = force_wielded, \
 		icon_wielded = "[icon_prefix]1", \
+		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
 	)
 	add_headpike_component()
 	update_appearance()
@@ -91,35 +98,88 @@
 			throwforce = 21
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plasmaglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
 			icon_prefix = "spearplasma"
+			max_integrity = 220
+			wound_bonus = -10
 			force_unwielded = 11
 			force_wielded = 19
-			AddComponent(/datum/component/two_handed, force_unwielded=force_unwielded, force_wielded=force_wielded, icon_wielded="[icon_prefix]1")
+			armour_penetration = 15
+			AddComponent(/datum/component/two_handed, \
+				force_unwielded = force_unwielded, \
+				force_wielded = force_wielded, \
+				icon_wielded = "[icon_prefix]1", \
+				wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+				unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
+			)
+
 		if(/obj/item/shard/titanium)
-			force = 13
-			throwforce = 21
+			force = 12
+			throwforce = 22
 			throw_range = 8
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/titaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			wound_bonus = -10
-			force_unwielded = 13
-			force_wielded = 18
+			max_integrity = 230
+			wound_bonus = -5
+			force_unwielded = 12
+			force_wielded = 20
+			armour_penetration = 20
 			icon_prefix = "speartitanium"
-			AddComponent(/datum/component/two_handed, force_unwielded=force_unwielded, force_wielded=force_wielded, icon_wielded="[icon_prefix]1")
+			AddComponent(/datum/component/two_handed, \
+				force_unwielded = force_unwielded, \
+				force_wielded = force_wielded, \
+				icon_wielded = "[icon_prefix]1", \
+				wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+				unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
+			)
+
 		if(/obj/item/shard/plastitanium)
 			force = 13
-			throwforce = 22
+			throwforce = 23
 			throw_range = 9
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plastitaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			wound_bonus = -10
+			max_integrity = 240
+			wound_bonus = 0
 			exposed_wound_bonus = 20
 			force_unwielded = 13
-			force_wielded = 20
+			force_wielded = 21
+			armour_penetration = 25
 			icon_prefix = "spearplastitanium"
-			AddComponent(/datum/component/two_handed, force_unwielded=force_unwielded, force_wielded=force_wielded, icon_wielded="[icon_prefix]1")
+			AddComponent(/datum/component/two_handed, \
+				force_unwielded = force_unwielded, \
+				force_wielded = force_wielded, \
+				icon_wielded = "[icon_prefix]1", \
+				wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+				unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
+			)
 
 	update_appearance()
 	return ..()
+
+/obj/item/spear/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	if(improvised_construction)
+		return
+	take_damage(force)
+
+/obj/item/spear/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	if (.) //spear was caught
+		return
+	if(!improvised_construction)
+		return
+	take_damage(throwforce)
+
+/obj/item/spear/atom_destruction(damage_flag)
+	playsound(src, 'sound/effects/grillehit.ogg', 50)
+	new spear_leftovers(get_turf(src))
+	if(isliving(loc))
+		loc.balloon_alert(loc, "spear broken!")
+	return ..()
+
+/obj/item/spear/proc/on_wield(obj/item/source, mob/living/carbon/user)
+	reach = 1
+
+/obj/item/spear/proc/on_unwield(obj/item/source, mob/living/carbon/user)
+	reach = 2
 
 /obj/item/spear/explosive
 	name = "explosive lance"
@@ -196,6 +256,7 @@
 	attack_verb_simple = list("gore")
 	force_unwielded = 15
 	force_wielded = 25
+	improvised_construction = FALSE
 
 /obj/item/spear/grey_tide/afterattack(atom/movable/target, mob/living/user, list/modifiers, list/attack_modifiers)
 	user.faction |= "greytide([REF(user)])"
@@ -226,6 +287,7 @@
 	throw_range = 9
 	throw_speed = 5
 	sharpness = NONE // we break bones instead of cutting flesh
+	improvised_construction = FALSE
 
 /obj/item/spear/military/add_headpike_component()
 	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpikemilitary)
@@ -246,10 +308,12 @@
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
 
 	throwforce = 22
-	armour_penetration = 15 //Enhanced armor piercing
+	armour_penetration = 20 //Enhanced armor piercing
 	custom_materials = list(/datum/material/bone = HALF_SHEET_MATERIAL_AMOUNT * 7)
 	force_unwielded = 12
 	force_wielded = 20
+	improvised_construction = FALSE
+	spear_leftovers = /obj/item/stack/sheet/bone
 
 /obj/item/spear/bonespear/add_headpike_component()
 	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpikebone)
@@ -269,11 +333,9 @@
 	name = "bamboo spear"
 	desc = "A haphazardly-constructed bamboo stick with a sharpened tip, ready to poke holes into unsuspecting people."
 
-	throwforce = 22	//Better to throw
+	throwforce = 23	//Better to throw
 	custom_materials = list(/datum/material/bamboo = SHEET_MATERIAL_AMOUNT * 20)
-	force_unwielded = 10
-	force_wielded = 18
-
+	spear_leftovers = /obj/item/stack/sheet/mineral/bamboo
 
 /obj/item/spear/bamboospear/add_headpike_component()
 	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpikebamboo)
@@ -305,6 +367,7 @@
 	)
 	action_slots = ITEM_SLOT_HANDS
 	actions_types = list(/datum/action/item_action/skybulge)
+	improvised_construction = FALSE
 
 ///The action button the spear gives, usable once a minute.
 /datum/action/item_action/skybulge

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -15,7 +15,7 @@
 	throw_speed = 4
 	demolition_mod = 0.75 // Note: This is significant, as this needs to be low enough that any possible force adjustments from better spears does not go over airlock deflection. See AIRLOCK_DAMAGE_DEFLECTION_N.
 	embed_type = /datum/embedding/spear
-	armour_penetration = 10
+	armour_penetration = 5
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass= HALF_SHEET_MATERIAL_AMOUNT * 2)
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
@@ -102,7 +102,6 @@
 			wound_bonus = -10
 			force_unwielded = 11
 			force_wielded = 19
-			armour_penetration = 15
 			AddComponent(/datum/component/two_handed, \
 				force_unwielded = force_unwielded, \
 				force_wielded = force_wielded, \
@@ -121,7 +120,7 @@
 			wound_bonus = -5
 			force_unwielded = 12
 			force_wielded = 20
-			armour_penetration = 20
+			armour_penetration = 10
 			icon_prefix = "speartitanium"
 			AddComponent(/datum/component/two_handed, \
 				force_unwielded = force_unwielded, \
@@ -142,7 +141,7 @@
 			exposed_wound_bonus = 20
 			force_unwielded = 13
 			force_wielded = 21
-			armour_penetration = 25
+			armour_penetration = 15
 			icon_prefix = "spearplastitanium"
 			AddComponent(/datum/component/two_handed, \
 				force_unwielded = force_unwielded, \
@@ -177,9 +176,11 @@
 
 /obj/item/spear/proc/on_wield(obj/item/source, mob/living/carbon/user)
 	reach = 1
+	armour_penetration *= 2
 
 /obj/item/spear/proc/on_unwield(obj/item/source, mob/living/carbon/user)
 	reach = 2
+	armour_penetration /= 2
 
 /obj/item/spear/explosive
 	name = "explosive lance"


### PR DESCRIPTION

## About The Pull Request

Better material spears have more consistent stats and additional improvements as the material improves.

Better material spears have better AP, wounding power and base force. These are also direct increases as the material improves from glass > plasma glass > titanium glass > planetarium glass

Spears also have 2 range while not wielded, but wielding the spear doubles the AP (at just the glass and plasma glass level, this is still only 10 AP)

Hitting something with the spear causes the spear to start to break. Once it reaches 0 integrity, it falls apart.

This doesn't affect the Grey Tide or the Sky Bulge.

## Why It's Good For The Game

### Stats

Largely, these can be just a smidge better with the understanding that the spear itself is perishable, requiring you to make more or use duct tape to keep them functional.

That, and the demolition mod now actually meaningfully keeps spears from smashing up airlocks if their force gets too high now, so they can have a bit more leeway against other players for a perishable two-handed weapon.

### Reach

I kind of like the idea of weapons with reach, and spears...are known for their reach. The actual force of the weapon is relatively low enough that it isn't suicide to approach someone with a spear, but more like how well the spear user can keep an attacker at arms length. Also, the classic spear and shield combo actually has functionality.

### Breaking

This was something I encountered in SS14 and I thought...actually, this is a neat mechanic and makes sense if the spears meaningfully improved in power with better material. That was only sorta true in SS14, but could be true here with our more varied levers to toy with.

With the introduction of duct tape, repairing objects is now also a lot more simple. So if you have a spear you want to keep, you can restore it with duct tape pretty easily. Really sells the 'improvised' feeling.

## Changelog
:cl:
balance: Spear materials are somewhat more consistent as you use better materials. More statistics improve with material used.
balance: Spears, when not wielded, have 2 tiles of reach. When wielded, they also gain twice as much AP than their material type allows.
balance: Spears start to break as they're used until they fall apart. Some types of spears are not affected.
/:cl:
