### PR TITLE
Enable limited auto staling for issue reports

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,11 +19,15 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 7 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
+          stale-issue-message: "This issue has been marked for cleanup and will be automatically closed in ~ 14 days. If there is evidence that the issue still occurs, leave a comment with it attached and contact a maintainer to have the label removed."
           days-before-stale: 7
           days-before-close: 7
+          days-before-issue-stale: 14
+          days-before-issue-close: 14
           stale-pr-label: "Stale"
-          days-before-issue-stale: -1
-          stale-issue-label: "Cleanup Flagged"
+          stale-issue-label: "Stale"
+          any-of-issue-labels: "Cleanup Flagged,🤖 Flaky Test Report"
           remove-issue-stale-when-updated: false
+          exempt-issue-labels: "RED LABEL"
           exempt-pr-labels: "RED LABEL,Good First PR"
           operations-per-run: 300


### PR DESCRIPTION

## About The Pull Request

Change stale action settings so issues with the cleanup flagged or flaky test report labels will auto close after 28 days. I picked that number and the specific stale message pretty arbitrarily, so if maints have better suggestions feel free

## Why It's Good For The Game

Cleanup flagged is supposed to enable auto-staling on an issue but it was using the wrong setting (stale-issue-label is the setting for what label to apply to a stale issue, not which issues to stale). As for flaky bot, there are a ton of these issues built up from years ago that most likely no longer occur, but nobody knows that so they never get closed, the old issues are near-useless because GitHub has since deleted the workflow logs that they occurred in, and if the issue still occurs then the bot will just open a new report for it

## Changelog

N/A
