### PR TITLE
Add qdel for mook bard guitar

### DIFF
--- a/code/modules/mob/living/basic/lavaland/mook/mook.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook.dm
@@ -257,6 +257,10 @@
 	ai_controller.set_blackboard_key(BB_SONG_INSTRUMENT, held_guitar)
 	update_appearance()
 
+/mob/living/basic/mining/mook/worker/bard/Destroy(force)
+	QDEL_NULL(held_guitar)
+	. = ..()
+
 /mob/living/basic/mining/mook/worker/tribal_chief
 	name = "tribal chief"
 	desc = "Acknowledge him!"


### PR DESCRIPTION

## About The Pull Request

QDEL_NULL for the mook bard's `held_guitar`

## Why It's Good For The Game

Some kind of hard delete waiting to happen

## Changelog

N/A
