### PR TITLE
Fix /datum/dna_block/feature/accessory abstract type

### DIFF
--- a/code/datums/dna/blocks/dna_features_block.dm
+++ b/code/datums/dna/blocks/dna_features_block.dm
@@ -20,6 +20,7 @@
 
 /// Features tied to a sprite accessory
 /datum/dna_block/feature/accessory
+	abstract_type = /datum/dna_block/feature/accessory
 
 /datum/dna_block/feature/accessory/create_unique_block(mob/living/carbon/human/target)
 	var/block_value = SSaccessories.feature_list[feature_key].Find(target.dna.features[feature_key])
@@ -33,7 +34,6 @@
 	target.dna.features[feature_key] = SSaccessories.feature_list[feature_key][deconstructed]
 
 /datum/dna_block/feature/accessory/ears
-	abstract_type = /datum/dna_block/feature/accessory
 	feature_key = FEATURE_EARS
 
 // One day, someone should consider merging all tails into one, this is stupid


### PR DESCRIPTION

## About The Pull Request

This was only set on the cat ears subtype but I think it should probably be set on the parent type

## Why It's Good For The Game

Child types should all have correct abstract type