### PR TITLE
Rename feature_human_ears and feature_human_tail

### DIFF
--- a/code/modules/client/preferences/migrations/human_tail_ears_migration.dm
+++ b/code/modules/client/preferences/migrations/human_tail_ears_migration.dm
@@ -1,0 +1,4 @@
+/// Rename feature_human_tail and feature_human_ears to something not stupid
+/datum/preferences/proc/migrate_felinid_feature_keys(list/save_data)
+	save_data["feature_cat_ears"] = save_data["feature_human_ears"]
+	save_data["feature_cat_tail"] = save_data["feature_human_tail"]

--- a/code/modules/client/preferences/species_features/felinid.dm
+++ b/code/modules/client/preferences/species_features/felinid.dm
@@ -1,12 +1,12 @@
 /datum/preference/choiced/species_feature/tail_felinid
-	savefile_key = "feature_human_tail" //savefile keys cannot be changed, blame whoever named them this way.
+	savefile_key = "feature_cat_tail"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	can_randomize = FALSE
 	relevant_organ = /obj/item/organ/tail/cat
 
 /datum/preference/choiced/species_feature/felinid_ears
-	savefile_key = "feature_human_ears" //savefile keys cannot be changed, blame whoever named them this way.
+	savefile_key = "feature_cat_ears"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	can_randomize = FALSE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -13,7 +13,7 @@
 /// You do not need to raise this if you are adding new values that have sane defaults.
 /// Only raise this value when changing the meaning/format/name/layout of an existing value
 /// where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 50
+#define SAVEFILE_VERSION_MAX 51
 
 #define IS_DATA_OBSOLETE(version) (version == SAVE_DATA_OBSOLETE)
 #define SHOULD_UPDATE_DATA(version) (version >= SAVE_DATA_NO_ERROR && version < SAVEFILE_VERSION_MAX)
@@ -162,6 +162,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			quirk_to_migrate = "Spiritual",
 			new_typepath = /datum/personality/spiritual,
 		)
+	if(current_version < 51)
+		migrate_felinid_feature_keys(save_data)
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4016,6 +4016,7 @@
 #include "code\modules\client\preferences\middleware\tts.dm"
 #include "code\modules\client\preferences\migrations\body_type_migration.dm"
 #include "code\modules\client\preferences\migrations\convert_to_json_savefile.dm"
+#include "code\modules\client\preferences\migrations\human_tail_ears_migration.dm"
 #include "code\modules\client\preferences\migrations\legacy_sound_toggles_migration.dm"
 #include "code\modules\client\preferences\migrations\quirk_loadout_migration.dm"
 #include "code\modules\client\preferences\migrations\quirk_personality_migration.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
@@ -50,7 +50,7 @@ export const hair_gradient_color: Feature<string> = {
   component: FeatureColorInput,
 };
 
-export const feature_human_ears: FeatureChoiced = {
+export const feature_cat_ears: FeatureChoiced = {
   name: 'Ears',
   component: (
     props: FeatureValueProps<string, string, FeatureChoicedServerData>,
@@ -59,7 +59,7 @@ export const feature_human_ears: FeatureChoiced = {
   },
 };
 
-export const feature_human_tail: FeatureChoiced = {
+export const feature_cat_tail: FeatureChoiced = {
   name: 'Tail',
   component: (
     props: FeatureValueProps<string, string, FeatureChoicedServerData>,


### PR DESCRIPTION

## About The Pull Request

Despite what the code comments said we can rename them and we should because they make no sense

## Why It's Good For The Game

The save file keys for cat features should have cat in the name and not human

## Changelog
:cl:
server: renamed feature_human_ears and feature_human_tail to feature_cat_ears and feature_cat_tail respectively
/:cl:
