### PR TITLE
Updates two corporation names

### DIFF
--- a/code/datums/stock_market_events.dm
+++ b/code/datums/stock_market_events.dm
@@ -8,7 +8,7 @@
 		"MODular Solutions",
 		"SolGov",
 		"Australicus Industrial Mining",
-		"Vey-Medical",
+		"Nanotrasen-DeForest Corporation",
 		"Aussec Armory",
 		"Dreamland Robotics"
 	)
@@ -147,5 +147,3 @@
 	SSstock_market.materials_quantity[mat] = initial(mat.tradable_base_quantity) //Force the material to be available again.
 	SSstock_market.materials_prices[mat] = initial(mat.value_per_unit) * SHEET_MATERIAL_AMOUNT //Force the price to be reset once the lockdown is over.
 	create_news()
-
-

--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -1,5 +1,5 @@
 /obj/vehicle/sealed/mecha/odysseus
-	desc = "These exosuits are developed and produced by Vey-Med. (&copy; All rights reserved)."
+	desc = "A nimble DeForest Odysseus exosuit, designed and outfitted for frontline medical support and rapid response."
 	name = "\improper Odysseus"
 	icon_state = "odysseus"
 	base_icon_state = "odysseus"


### PR DESCRIPTION
## About The Pull Request

Replaces (the only two uses of) "Vey-Medical" with "Deforest Corporation" 

## Why It's Good For The Game

While a funny reference (which apparently dates back 14+ years according to the blame on the Ody), DeForest has kinda been established as the leading medical equipment producer, so I think it's more appropriate to use them instead.

I know we can allow one-off corporations to exist for "worldbuilding :tm:", but this is just a joke name. So I don't feel like replacing it is much of a loss.

If you (the maintainer reading this) think outright removal is too 1984 I can leave the reference in somewhere, that's fine by me

## Changelog

:cl: Melbert
spellcheck: Replaced mentions of "Vey-Medical" with "DeForest Corporation" 
/:cl:


