### PR TITLE
Fixes another spammy elevation runtime

### DIFF
--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -57,8 +57,8 @@
 	if(!isturf(location))
 		return
 	if(!HAS_TRAIT(location, TRAIT_TURF_HAS_ELEVATED_OBJ(pixel_shift)))
-		reset_elevation(location)
 		RegisterSignal(location, COMSIG_TURF_RESET_ELEVATION, PROC_REF(check_elevation))
+		reset_elevation(location) // This needs to go in the before COMSIG_TURF_CHANGE, or we can end up bouncing back into this and getting a runtime
 		RegisterSignal(location, COMSIG_TURF_CHANGE, PROC_REF(pre_change_turf))
 	ADD_TRAIT(location, TRAIT_TURF_HAS_ELEVATED_OBJ(pixel_shift), ref(source))
 

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -57,9 +57,9 @@
 	if(!isturf(location))
 		return
 	if(!HAS_TRAIT(location, TRAIT_TURF_HAS_ELEVATED_OBJ(pixel_shift)))
+		reset_elevation(location)
 		RegisterSignal(location, COMSIG_TURF_RESET_ELEVATION, PROC_REF(check_elevation))
 		RegisterSignal(location, COMSIG_TURF_CHANGE, PROC_REF(pre_change_turf))
-		reset_elevation(location)
 	ADD_TRAIT(location, TRAIT_TURF_HAS_ELEVATED_OBJ(pixel_shift), ref(source))
 
 /datum/element/elevation/proc/unregister_turf(atom/movable/source, atom/location)


### PR DESCRIPTION
## About The Pull Request

An even more spammy signal override runtime that's been annoying me.

<img width="1933" height="479" alt="image" src="https://github.com/user-attachments/assets/9d73a01b-858e-46a8-9449-7bb60680c977" />

This bug most frequently appears near cargo, triggered by mail crates moving around on conveyors.
Seems to be caused by another elevation element being mid-attach and also trying to register on the same turf simultaneously, which results in a recursive register_turf() call essentially.

## Why It's Good For The Game

Fixes a spammy runtime, and improves performance a bit.

<details><summary>still works</summary>

![dreamseeker_Nz6BUoU11X](https://github.com/user-attachments/assets/446b6ba8-510e-4a5c-b02f-db5781a8e296)

</details>

## Changelog

Not player-facing