### PR TITLE
Stops monkey ai from trying to path to themselves when using an object

### DIFF
--- a/code/datums/ai/generic/generic_behaviors.dm
+++ b/code/datums/ai/generic/generic_behaviors.dm
@@ -86,6 +86,8 @@
 	var/atom/target = controller.blackboard[target_key]
 	if(QDELETED(target))
 		return FALSE
+	if(target == controller.pawn) // this can sometimes end up as ourselves, in which case there is no reason to move
+		return FALSE
 	set_movement_target(controller, target)
 
 /datum/ai_behavior/use_on_object/perform(seconds_per_tick, datum/ai_controller/controller, target_key)


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/91973

## About The Pull Request

Monke is smarter than this.

If they try to move to themselves, it will result in a signal override that we don't want or need. I'm not sure if this is something we'd wanna guard against globally so I just left it locally in the behavior

## Why It's Good For The Game

Less runtime spam

<img width="556" height="153" alt="rwPanV9e5S" src="https://github.com/user-attachments/assets/cf2a759a-9b2d-449d-a8ec-ab1d1c4a4fda" />

## Changelog

Not-player-facing