### PR TITLE
Stops animals from humping dirt

### DIFF
--- a/code/datums/components/breeding.dm
+++ b/code/datums/components/breeding.dm
@@ -51,7 +51,10 @@
 	if(source.combat_mode)
 		return
 
-	if(source.client || (ismob(target) && target.client))
+	if(!ismob(target)
+		return
+
+	if(source.client || target.client)
 		return
 
 	if(!is_type_in_typecache(target, can_breed_with))

--- a/code/datums/components/breeding.dm
+++ b/code/datums/components/breeding.dm
@@ -51,7 +51,7 @@
 	if(source.combat_mode)
 		return
 
-	if(source.client || target.client)
+	if(source.client || (ismob(target) && target.client))
 		return
 
 	if(!is_type_in_typecache(target, can_breed_with))

--- a/code/datums/components/breeding.dm
+++ b/code/datums/components/breeding.dm
@@ -51,7 +51,7 @@
 	if(source.combat_mode)
 		return
 
-	if(!ismob(target)
+	if(!ismob(target))
 		return
 
 	if(source.client || target.client)


### PR DESCRIPTION
## About The Pull Request

Yeah so the animals were trying to mate with geology, they probably shouldn't be doing that.

<details><summary> runtime here, with details about bug </summary>

<img width="1948" height="523" alt="image" src="https://github.com/user-attachments/assets/89abe9d7-eacd-445b-b686-cb5419df2e24" />

Runtime occurs because `client` is a mob var. A lot of mobs make use of that `early_melee_attack()` to do things like eat so we shouldn't expect them to only be targeting mobs here.
Adds an `ismob()` check to guard against that var/client runtime which is basically free due to being a special native byond op and should not affect performance in any meaningful way.

</details>

## Why It's Good For The Game

Think about the miners...

## Changelog

:cl:
fix: animal AI no longer mistakes rocks for a valid breeding partner
/:cl: