### PR TITLE
Fixes a runtime in mob_only_listeners

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -219,8 +219,8 @@
 /proc/mob_only_listeners(list/atom/movable/hearers)
 	RETURN_TYPE(/list/mob)
 
-	var/hearers_length = hearers.len
-	if(isnull(hearers) || !hearers_length)
+	var/hearers_length
+	if(isnull(hearers) || !(hearers_length = hearers.len))
 		return list()
 
 	for(var/hearer_index in 1 to hearers_length)

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -218,9 +218,15 @@
 /// Modifies input list.
 /proc/mob_only_listeners(list/atom/movable/hearers)
 	RETURN_TYPE(/list/mob)
-	for(var/hearer_index in 1 to hearers.len)
+
+	if(isnull(hearers) || !hearers.len)
+		return list()
+
+	var/hearers_length = hearers.len
+	for(var/hearer_index in 1 to hearers_length)
 		var/atom/movable/hearer = hearers[hearer_index]
 		hearers[hearer_index] = hearer.get_listening_mob()
+
 	list_clear_nulls(hearers)
 	return hearers
 

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -220,7 +220,7 @@
 	RETURN_TYPE(/list/mob)
 
 	var/hearers_length
-	if(isnull(hearers) || !(hearers_length = hearers.len))
+	if(isnull(hearers) || !(hearers_length = hearers.len)) // note onvar assignment in the conditional: this is a micro op so we do not have to do a length() check before assigning hearers.len and so we only have to isnull() once.
 		return list()
 
 	for(var/hearer_index in 1 to hearers_length)

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -220,7 +220,7 @@
 	RETURN_TYPE(/list/mob)
 
 	var/hearers_length = hearers.len
-	if(isnull(hearers) || !(hearers_length))
+	if(isnull(hearers) || !hearers_length)
 		return list()
 
 	for(var/hearer_index in 1 to hearers_length)

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -219,10 +219,10 @@
 /proc/mob_only_listeners(list/atom/movable/hearers)
 	RETURN_TYPE(/list/mob)
 
-	if(isnull(hearers) || !hearers.len)
+	var/hearers_length
+	if(isnull(hearers) || !(hearers_length = hearers.len))
 		return list()
 
-	var/hearers_length = hearers.len
 	for(var/hearer_index in 1 to hearers_length)
 		var/atom/movable/hearer = hearers[hearer_index]
 		hearers[hearer_index] = hearer.get_listening_mob()

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -219,8 +219,8 @@
 /proc/mob_only_listeners(list/atom/movable/hearers)
 	RETURN_TYPE(/list/mob)
 
-	var/hearers_length
-	if(isnull(hearers) || !(hearers_length = hearers.len))
+	var/hearers_length = hearers.len
+	if(isnull(hearers) || !(hearers_length))
 		return list()
 
 	for(var/hearer_index in 1 to hearers_length)

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -220,7 +220,7 @@
 	RETURN_TYPE(/list/mob)
 
 	var/hearers_length
-	if(isnull(hearers) || !(hearers_length = hearers.len)) // note onvar assignment in the conditional: this is a micro op so we do not have to do a length() check before assigning hearers.len and so we only have to isnull() once.
+	if(isnull(hearers) || !(hearers_length = hearers.len)) // note on var assignment in the conditional: this is a micro op so we do not have to do a length() check before assigning hearers.len and so we only have to isnull() once.
 		return list()
 
 	for(var/hearer_index in 1 to hearers_length)

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -237,7 +237,7 @@
 	var/list/mix_message = list()
 	for(var/datum/equilibrium/equilibrium as anything in reaction_list)
 		mix_message += end_reaction(equilibrium)
-	if(my_atom && length(mix_message))
+	if(!QDELETED(my_atom) && length(mix_message))
 		my_atom.audible_message(span_notice("[icon2html(my_atom, viewers(DEFAULT_MESSAGE_RANGE, src))] [mix_message.Join()]"))
 	finish_reacting()
 


### PR DESCRIPTION
## About The Pull Request

<img width="911" height="633" alt="firefox_JwrWjsNY7Y" src="https://github.com/user-attachments/assets/39712708-59e3-4c27-92cf-382a809048b4" />

If a holy cow udders its last words and no one is around to hear it, does it make a runtime?

(Yes it does) It turns out that `get_hearers_in_view()` can early return null as a micro optimization so it needs to be guarded against in here.

Also does a couple micro optimizations since this is fairly hot code.

## Why It's Good For The Game

Fixes a runtime.

## Changelog

Nothing