### PR TITLE
Repairing brains will turn them a more accurate brighter color

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -119,6 +119,7 @@
 	greyscale_config = /datum/greyscale_config/mutant_organ
 	greyscale_colors = CARP_COLORS
 	can_smoothen_out = FALSE
+	shade_color = "blue"
 
 	///Timer counting down. When finished, the owner gets a bad moodlet.
 	var/cooldown_timer

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -63,6 +63,7 @@
 	greyscale_config = /datum/greyscale_config/mutant_organ
 	greyscale_colors = GOLIATH_COLORS
 	can_smoothen_out = FALSE
+	shade_color = "garnet"
 
 	var/obj/item/goliath_infuser_hammer/hammer
 

--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -8,6 +8,7 @@
 	desc = "A fleshy growth that was dug out of the skull of a Nightmare."
 	icon = 'icons/obj/medical/organs/organs.dmi'
 	icon_state = "brain-x-d"
+	shade_color = "black, somehow"
 
 	///Our associated shadow jaunt spell, for all nightmares
 	var/datum/action/cooldown/spell/jaunt/shadow_walk/our_jaunt

--- a/code/modules/mob/living/brain/brain_cybernetic.dm
+++ b/code/modules/mob/living/brain/brain_cybernetic.dm
@@ -4,6 +4,7 @@
 	icon_state = "brain-c"
 	organ_flags = ORGAN_ROBOTIC | ORGAN_VITAL
 	failing_desc = "seems to be broken, and will not work without repairs."
+	shade_color = null
 
 /obj/item/organ/brain/cybernetic/brain_damage_examine()
 	if(suicided)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -46,6 +46,8 @@
 	var/variant_traits_added
 	/// Variance in brain traits removed by subtypes
 	var/variant_traits_removed
+	/// The color of this brain. Fluff, only used when repairing (shade of...).
+	var/shade_color = "pink"
 
 /obj/item/organ/brain/Initialize(mapload)
 	. = ..()
@@ -220,8 +222,8 @@
 		if(!do_after(user, 3 SECONDS, src))
 			to_chat(user, span_warning("You failed to pour the contents of [item] onto [src]!"))
 			return TRUE
-
-		user.visible_message(span_notice("[user] pours the contents of [item] onto [src], causing it to reform its original shape and turn a slightly brighter shade of pink."), span_notice("You pour the contents of [item] onto [src], causing it to reform its original shape and turn a slightly brighter shade of pink."))
+		var/and_bright_shade = !shade_color ? "" : " and turn a slightly brighter shade of [shade_color]"
+		user.visible_message(span_notice("[user] pours the contents of [item] onto [src], causing it to reform its original shape[and_bright_shade]."), span_notice("You pour the contents of [item] onto [src], causing it to reform its original shape[and_bright_shade]."))
 		var/amount = item.reagents.get_reagent_amount(/datum/reagent/medicine/mannitol)
 		var/healto = max(0, damage - amount * 2)
 		item.reagents.remove_all(ROUND_UP(item.reagents.total_volume / amount * (damage - healto) * 0.5)) //only removes however much solution is needed while also taking into account how much of the solution is mannitol
@@ -450,12 +452,14 @@
 	icon_state = "brain-x"
 	variant_traits_added = list(TRAIT_PRIMITIVE)
 	variant_traits_removed = list(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
+	shade_color = "green"
 
 /obj/item/organ/brain/alien
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
 	variant_traits_removed = list(TRAIT_LITERATE, TRAIT_ADVANCEDTOOLUSER)
+	shade_color = "green"
 
 /obj/item/organ/brain/primitive //No like books and stompy metal men
 	name = "primitive brain"
@@ -476,6 +480,7 @@
 	icon_state = "adamantine_resonator"
 	can_smoothen_out = FALSE
 	color = COLOR_GOLEM_GRAY
+	shade_color = "teal"
 	organ_flags = ORGAN_MINERAL
 	variant_traits_added = list(TRAIT_ROCK_METAMORPHIC)
 
@@ -484,6 +489,7 @@
 	desc = "This is your brain on bluespace dust. Not even once."
 	icon_state = "random_fly_4"
 	can_smoothen_out = FALSE
+	shade_color = null
 
 // This fixes an edge case from species/regenerate_organs that would transfer the brain trauma before organ/on_mob_remove can remove it
 // Prevents wizards from using the magic mirror to gain bluespace_prophet trauma and then switching to another race
@@ -525,6 +531,7 @@
 	icon_state = "brain-ghost"
 	movement_type = PHASING
 	organ_flags = parent_type::organ_flags | ORGAN_GHOST
+	shade_color = "ectoplasmic white"
 
 /obj/item/organ/brain/abductor
 	name = "grey brain"
@@ -532,6 +539,7 @@
 	icon_state = "brain-x"
 	brain_size = 1.3
 	variant_traits_added = list(TRAIT_REMOTE_TASTING)
+	shade_color = "grey"
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 
@@ -696,3 +704,4 @@
 	desc = "The brain of a pod person, it's a bit more plant-like than a human brain."
 	foodtype_flags = PODPERSON_ORGAN_FOODTYPES
 	color = COLOR_LIME
+	shade_color = "lime"

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -111,6 +111,7 @@
 	name = "shadowling tumor"
 	desc = "Something that was once a brain, before being remolded by a shadowling. It has adapted to the dark, irreversibly."
 	icon = 'icons/obj/medical/organs/shadow_organs.dmi'
+	shade_color = "something" // Look at that sprite and tell me what color that is
 
 /datum/species/shadow/get_scream_sound(mob/living/carbon/human/moth)
 	return 'sound/mobs/humanoids/shadow/shadow_wail.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -111,7 +111,7 @@
 	name = "shadowling tumor"
 	desc = "Something that was once a brain, before being remolded by a shadowling. It has adapted to the dark, irreversibly."
 	icon = 'icons/obj/medical/organs/shadow_organs.dmi'
-	shade_color = "something" // Look at that sprite and tell me what color that is
+	shade_color = "grey-ish"
 
 /datum/species/shadow/get_scream_sound(mob/living/carbon/human/moth)
 	return 'sound/mobs/humanoids/shadow/shadow_wail.ogg'

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -8,6 +8,7 @@
 		/datum/action/cooldown/spell/forcewall/psychic_wall,
 	)
 	w_class = WEIGHT_CLASS_NORMAL
+	shade_color = "blue"
 	var/does_it_blind = FALSE
 	variant_traits_added = list(TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 


### PR DESCRIPTION
## About The Pull Request

Brains getting mannitol'd that aren't pink or shouldn't be changing color at all still displayed turning a brighter color of pink. This PR fixes that. 

Fixes #93455

## Changelog
:cl:
spellcheck: Repairing a brain will now have it turn a brighter shade of a more accurate color.
/:cl:
