### PR TITLE
Fix the swapped "display who played this song" anonymity buttons for Play Internet Sound

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -119,17 +119,17 @@ GLOBAL_VAR_INIT(web_sound_cooldown, 0)
 				music_extra_data["album"] = "Default"
 			if("Cancel", null)
 				return
-		var/stay_anonimous = tgui_alert(user, "Display who played the song?", "Credit Yourself", list("Yes", "No", "Cancel"))
+		var/credit_yourself = tgui_alert(user, "Display who played the song?", "Credit Yourself", list("Yes", "No", "Cancel"))
 
 		var/list/to_chat_message = list()
 
-		switch(stay_anonimous)
-			if("No")
+		switch(credit_yourself)
+			if("Yes")
 				if(include_song_data == "Yes")
 					to_chat_message += span_notice("[user.ckey] played: [span_linkify(webpage_url)]")
 				else
 					to_chat_message += span_notice("[user.ckey] played a sound.")
-			if("Yes")
+			if("No")
 				if(include_song_data == "Yes")
 					to_chat_message += span_notice("An admin played: [span_linkify(webpage_url)]")
 				else


### PR DESCRIPTION
## About The Pull Request

Hi I'm on a downstream server and this is driving me actually insane

## Why It's Good For The Game

I can't speak for tgstation admins but I like it when the buttons in a panel are not lies

## Changelog
:cl:
admin: Made the buttons asking you for anonymity when you select/approve a Play Internet Sound request actually do what they say, instead of the opposite.
/:cl: