### PR TITLE
Takes away soil's gender

### DIFF
--- a/code/modules/hydroponics/soil.dm
+++ b/code/modules/hydroponics/soil.dm
@@ -5,7 +5,6 @@
 	desc = "A patch of dirt."
 	icon = 'icons/obj/service/hydroponics/equipment.dmi'
 	icon_state = "soil"
-	gender = PLURAL
 	circuit = null
 	density = FALSE
 	use_power = NO_POWER_USE

--- a/code/modules/hydroponics/soil.dm
+++ b/code/modules/hydroponics/soil.dm
@@ -73,6 +73,7 @@
 	name = "hydrogel beads"
 	desc = "A plant bed made of superabsorbent polymer beads.\n\nThese types of water gel beads can hold onto an incredible amount of water and reduces evaporative losses to almost nothing."
 	icon_state = "soil_gel"
+	gender = PLURAL
 	maxwater = 300
 	tray_flags = SOIL | HYDROPONIC | SUPERWATER
 	plant_offset_y = 2


### PR DESCRIPTION

## About The Pull Request

Takes away soil's plural gender, reverting it back to neuter.

## Why It's Good For The Game

closes #93718

## Changelog
:cl:

spellcheck: Examine text for soil no longer refers to it as "They"

/:cl:
