### PR TITLE
Scientist armor consistency change thingy

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -450,7 +450,7 @@
 	species_exception = list(/datum/species/golem)
 
 /datum/armor/wintercoat_science
-	bomb = 10
+	bio = 10
 	fire = 20
 
 /obj/item/clothing/head/hooded/winterhood/science
@@ -460,7 +460,7 @@
 
 // Research Director
 /datum/armor/winterhood_science
-	bomb = 10
+	bio = 10
 	fire = 20
 
 /obj/item/clothing/suit/hooded/wintercoat/science/rd

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -2,10 +2,10 @@
 	icon = 'icons/obj/clothing/under/rnd.dmi'
 	worn_icon = 'icons/mob/clothing/under/rnd.dmi'
 	abstract_type = /obj/item/clothing/under/rank/rnd
-	armor_type = /datum/armor/clothing_under/science
 
 /datum/armor/clothing_under/science
-	bio = 50
+	bomb = 10
+	bio = 40
 
 /obj/item/clothing/under/rank/rnd/research_director
 	desc = "It's a suit worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."


### PR DESCRIPTION
## About The Pull Request

So basically, the description of the scientist jumpsuit/jumpskirt says that it provides minor protection against explosives. This is actually a complete lie because it doesn't do that. Instead, the scientist _winter jacket_ has a minor protection against explosives. Why? I have no idea, it's probably a bug. 

This pr swaps out the bomb 1 and fire 2 on the winter jacket for bio 1 and fire 2, because every other winter jacket (that I know of) has at least bio 1, and adds the bomb 1 to the scientist jumpsuit and jumpskirt. Also, the jumpsuit and jumpskirt went from bio 5 to bio 4, for game balance reasons I guess. If they're better off staying at bio 5 I can change that.

## Why It's Good For The Game

Bugfix... I think? Consistency improvement at the very least.

## Changelog

:cl:
fix: Scientist jumpsuits have minor bomb protection and less biohazard protection
fix: Scientist winter jackets no longer have bomb protection
/:cl: