### PR TITLE
Fixes chatmessage runtime

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -207,7 +207,7 @@
 	var/starting_height = target.maptext_height
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = isturf(target) ? target : get_atom_on_turf(target)
-	if (owned_by.seen_messages)
+	if (owned_by && owned_by.seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines
 		for(var/datum/chatmessage/m as anything in owned_by.seen_messages[message_loc])
@@ -280,8 +280,9 @@
 	animate_lifespan = lifespan
 
 	// View the message
-	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
-	owned_by.images |= message
+	if(owned_by)
+		LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
+		owned_by.images |= message
 
 	// Fade in
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)


### PR DESCRIPTION
## About The Pull Request

`Runtime in code/datums/chatmessage.dm,210: Cannot read null.seen_messages`

The client can become null at any time due to logouts, and runtiming here can prevent the chatmessage from cleaning up properly, which isn't great.

## Why It's Good For The Game

Fixes bug/runtime log spam.

## Changelog

