### PR TITLE
Fixes ``"Return Value of Proccall"`` breaking on list returns

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -159,7 +159,10 @@ ADMIN_VERB(advanced_proc_call, R_DEBUG, "Advanced ProcCall", "Call a proc on any
 		returnval = WrapAdminProcCall(GLOBAL_PROC, procname, lst) // Pass the lst as an argument list to the proc
 	BLACKBOX_LOG_ADMIN_VERB("Advanced ProcCall")
 	if(get_retval)
-		get_retval += returnval
+		if (islist(returnval))
+			get_retval += list(returnval) // Wrap to stop BYOND from concat-ing the lists
+		else
+			get_retval += returnval
 	. = get_callproc_returnval(returnval, procname)
 	if(.)
 		to_chat(usr, ., confidential = TRUE)


### PR DESCRIPTION

## About The Pull Request

Closes #93693

## Changelog
:cl:
fix: Fixed ``"Return Value of Proccall"`` breaking on list returns when an admin calls a proc
/:cl:
