### PR TITLE
Add Insert Button to Chemistry Machines

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -2103,4 +2103,4 @@
 
 /// Checks if this container is valid for use with chemistry machinery.
 /obj/item/proc/is_chem_container()
-	return is_reagent_container(src) && is_open_container() && !(item_flags & ABSTRACT) && !(flags_1 & HOLOGRAM_1)
+	return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -2096,3 +2096,11 @@
 		target_limb = victim.get_bodypart(target_limb) || victim.bodyparts[1]
 
 	return get_embed()?.embed_into(victim, target_limb)
+
+/// Checks if user can insert a valid container into the chemistry machine.
+/obj/item/proc/can_insert_container(mob/living/user, obj/machinery/chem_machine)
+	return is_chem_container() && chem_machine.can_interact(user) && user.can_perform_action(chem_machine, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
+
+/// Checks if this container is valid for use with chemistry machinery.
+/obj/item/proc/is_chem_container()
+	return is_reagent_container(src) && is_open_container() && !(item_flags & ABSTRACT) && !(flags_1 & HOLOGRAM_1)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -214,7 +214,8 @@
 	.["displayedUnits"] = cell.charge ? (cell.charge / power_cost) : 0
 	.["displayedMaxUnits"] = cell.maxcharge / power_cost
 	.["showpH"] = isnull(recording_recipe) ? show_ph : FALSE //virtual beakers have no ph to compute & display
-	.["hasBeakerInHand"] = is_valid_container(user.get_active_held_item())
+	var/obj/item/held_item = user.get_active_held_item()
+	.["hasBeakerInHand"] = held_item?.is_chem_container() || FALSE
 
 	var/list/chemicals = list()
 	var/is_hallucinating = FALSE
@@ -309,7 +310,7 @@
 
 		if("insert")
 			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
+			if(container?.can_insert_container(ui.user, src))
 				replace_beaker(ui.user, container)
 
 			return TRUE
@@ -408,7 +409,7 @@
 	return ITEM_INTERACT_BLOCKING
 
 /obj/machinery/chem_dispenser/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(!can_insert_beaker(user, tool))
+	if(!tool.can_insert_container(user, src))
 		return NONE
 	if(!replace_beaker(user, tool))
 		return ITEM_INTERACT_BLOCKING
@@ -480,14 +481,6 @@
 	update_appearance(UPDATE_OVERLAYS)
 
 	return TRUE
-
-/// Checks if user can interact with beaker slot and container is valid
-/obj/machinery/chem_dispenser/proc/can_insert_beaker(mob/living/user, obj/item/reagent_containers/container)
-	return is_valid_container(container) && can_interact(user) && user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
-
-/// Checks if container can be used with this machine
-/obj/machinery/chem_dispenser/proc/is_valid_container(obj/item/reagent_containers/container)
-	return is_reagent_container(container) && container.is_open_container() && !(container.item_flags & ABSTRACT) && !(container.flags_1 & HOLOGRAM_1)
 
 /obj/machinery/chem_dispenser/on_deconstruction(disassembled)
 	cell = null

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -306,6 +306,12 @@
 			replace_beaker(ui.user)
 			return TRUE
 
+		if("insert")
+			var/obj/item/reagent_containers/container = usr.get_active_held_item()
+			if(container)
+				item_interaction(user = usr, tool = container)
+			return TRUE
+
 		if("dispense_recipe")
 			if(!is_operational || QDELETED(cell))
 				return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -308,9 +308,12 @@
 			return TRUE
 
 		if("insert")
-			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
-				replace_beaker(ui.user, container)
+			var/mob/ui_user = ui.user
+			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
+
+			if(can_insert_beaker(ui_user, container))
+				replace_beaker(ui_user, container)
+
 			return TRUE
 
 		if("dispense_recipe")

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -308,11 +308,9 @@
 			return TRUE
 
 		if("insert")
-			var/mob/ui_user = ui.user
-			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
-
-			if(can_insert_beaker(ui_user, container))
-				replace_beaker(ui_user, container)
+			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, container)
 
 			return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -160,12 +160,12 @@
 
 	if(!QDELETED(new_beaker))
 		if(!user.transferItemToLoc(new_beaker, src))
-			update_appearance(UPDATE_OVERLAYS)
+			update_appearance()
 			return FALSE
 		beaker = new_beaker
 		RegisterSignal(beaker.reagents, COMSIG_REAGENTS_REACTION_STEP, PROC_REF(on_reaction_step))
 
-	update_appearance(UPDATE_OVERLAYS)
+	update_appearance()
 
 	return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -332,11 +332,9 @@
 			return replace_beaker(ui.user)
 
 		if("insert")
-			var/mob/ui_user = ui.user
-			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
-
-			if(can_insert_beaker(ui_user, container))
-				replace_beaker(ui_user, container)
+			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, container)
 
 			return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -46,10 +46,10 @@
 		if(istype(held_item, /obj/item/reagent_containers/dropper) || istype(held_item, /obj/item/reagent_containers/syringe))
 			context[SCREENTIP_CONTEXT_LMB] = "Inject"
 			return CONTEXTUAL_SCREENTIP_SET
-		if(is_valid_container(held_item))
+		if(held_item.is_chem_container())
 			context[SCREENTIP_CONTEXT_LMB] = "Replace beaker"
 			return CONTEXTUAL_SCREENTIP_SET
-	else if(is_valid_container(held_item))
+	else if(held_item.is_chem_container())
 		context[SCREENTIP_CONTEXT_LMB] = "Insert beaker"
 		return CONTEXTUAL_SCREENTIP_SET
 
@@ -90,7 +90,7 @@
 		heater_coefficient *= micro_laser.tier
 
 /obj/machinery/chem_heater/item_interaction(mob/living/user, obj/item/held_item, list/modifiers)
-	if(!can_insert_beaker(user, held_item))
+	if(!held_item.can_insert_container(user, src))
 		return NONE
 
 	if(!QDELETED(beaker))
@@ -169,14 +169,6 @@
 
 	return TRUE
 
-/// Checks if user can interact with beaker slot and container is valid
-/obj/machinery/chem_heater/proc/can_insert_beaker(mob/living/user, obj/item/reagent_containers/container)
-	return is_valid_container(container) && can_interact(user) && user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
-
-/// Checks if container can be used with this machine
-/obj/machinery/chem_heater/proc/is_valid_container(obj/item/reagent_containers/container)
-	return is_reagent_container(container) && container.is_open_container() && !(container.item_flags & ABSTRACT) && !(container.flags_1 & HOLOGRAM_1)
-
 /**
  * Heats the reagents of the currently inserted beaker only if machine is on & beaker has some reagents inside
  * Arguments
@@ -229,7 +221,8 @@
 	.["targetTemp"] = target_temperature
 	.["isActive"] = on
 	.["upgradeLevel"] = heater_coefficient * 10
-	.["hasBeakerInHand"] = is_valid_container(user.get_active_held_item())
+	var/obj/item/held_item = user.get_active_held_item()
+	.["hasBeakerInHand"] = held_item?.is_chem_container() || FALSE
 
 	var/list/beaker_data = null
 	var/chem_temp = 0
@@ -333,7 +326,7 @@
 
 		if("insert")
 			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
+			if(container?.can_insert_container(ui.user, src))
 				replace_beaker(ui.user, container)
 
 			return TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -160,12 +160,12 @@
 
 	if(!QDELETED(new_beaker))
 		if(!user.transferItemToLoc(new_beaker, src))
-			update_appearance()
+			update_appearance(UPDATE_ICON_STATE)
 			return FALSE
 		beaker = new_beaker
 		RegisterSignal(beaker.reagents, COMSIG_REAGENTS_REACTION_STEP, PROC_REF(on_reaction_step))
 
-	update_appearance()
+	update_appearance(UPDATE_ICON_STATE)
 
 	return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -322,6 +322,12 @@
 			//Eject doesn't turn it off, so you can preheat for beaker swapping
 			return replace_beaker(ui.user)
 
+		if("insert")
+			var/obj/item/reagent_containers/container = usr.get_active_held_item()
+			if(container)
+				item_interaction(user = usr, held_item = container)
+			return TRUE
+
 		if("acidBuffer")
 			var/target = params["target"]
 			if(!target)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -160,12 +160,12 @@
 
 	if(!QDELETED(new_beaker))
 		if(!user.transferItemToLoc(new_beaker, src))
-			update_appearance()
+			update_appearance(UPDATE_OVERLAYS)
 			return FALSE
 		beaker = new_beaker
 		RegisterSignal(beaker.reagents, COMSIG_REAGENTS_REACTION_STEP, PROC_REF(on_reaction_step))
 
-	update_appearance()
+	update_appearance(UPDATE_OVERLAYS)
 
 	return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -90,14 +90,14 @@
 		heater_coefficient *= micro_laser.tier
 
 /obj/machinery/chem_heater/item_interaction(mob/living/user, obj/item/held_item, list/modifiers)
-	if(!held_item.can_insert_container(user, src))
-		return NONE
-
 	if(!QDELETED(beaker))
 		if(istype(held_item, /obj/item/reagent_containers/dropper) || istype(held_item, /obj/item/reagent_containers/syringe))
 			var/obj/item/reagent_containers/injector = held_item
 			injector.interact_with_atom(beaker, user, modifiers)
 			return ITEM_INTERACT_SUCCESS
+
+	if(!held_item.can_insert_container(user, src))
+		return NONE
 
 	if(!replace_beaker(user, held_item))
 		return ITEM_INTERACT_BLOCKING

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -332,9 +332,12 @@
 			return replace_beaker(ui.user)
 
 		if("insert")
-			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
-				replace_beaker(ui.user, container)
+			var/mob/ui_user = ui.user
+			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
+
+			if(can_insert_beaker(ui_user, container))
+				replace_beaker(ui_user, container)
+
 			return TRUE
 
 		if("acidBuffer")

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -444,15 +444,21 @@
 			return TRUE
 
 		if("insert1")
-			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
-				replace_beaker(ui.user, TRUE, container)
+			var/mob/ui_user = ui.user
+			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
+
+			if(can_insert_beaker(ui_user, container))
+				replace_beaker(ui_user, TRUE, container)
+
 			return TRUE
 
 		if("insert2")
-			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
-				replace_beaker(ui.user, FALSE, container)
+			var/mob/ui_user = ui.user
+			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
+
+			if(can_insert_beaker(ui_user, container))
+				replace_beaker(ui_user, FALSE, container)
+
 			return TRUE
 
 /obj/machinery/chem_mass_spec/click_alt(mob/living/user)

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -444,20 +444,16 @@
 			return TRUE
 
 		if("insert1")
-			var/mob/ui_user = ui.user
-			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
-
-			if(can_insert_beaker(ui_user, container))
-				replace_beaker(ui_user, TRUE, container)
+			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, TRUE, container)
 
 			return TRUE
 
 		if("insert2")
-			var/mob/ui_user = ui.user
-			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
-
-			if(can_insert_beaker(ui_user, container))
-				replace_beaker(ui_user, FALSE, container)
+			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, FALSE, container)
 
 			return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -61,7 +61,7 @@
 	if(isnull(held_item) || (held_item.item_flags & ABSTRACT) || (held_item.flags_1 & HOLOGRAM_1))
 		return
 
-	if(is_valid_container(held_item))
+	if(held_item.is_chem_container())
 		if(QDELETED(beaker1))
 			context[SCREENTIP_CONTEXT_LMB] = "Insert input beaker"
 		else
@@ -146,7 +146,7 @@
 		cms_coefficient /= laser.tier
 
 /obj/machinery/chem_mass_spec/item_interaction(mob/living/user, obj/item/item, list/modifiers)
-	if(!can_insert_beaker(user, item))
+	if(!item.can_insert_container(user, src))
 		return NONE
 
 	if(processing_reagents)
@@ -255,14 +255,6 @@
 
 	return TRUE
 
-/// Checks if user can interact with beaker slot and container is valid
-/obj/machinery/chem_mass_spec/proc/can_insert_beaker(mob/living/user, obj/item/reagent_containers/container)
-	return is_valid_container(container) && can_interact(user) && user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
-
-/// Checks if container can be used with this machine
-/obj/machinery/chem_mass_spec/proc/is_valid_container(obj/item/reagent_containers/container)
-	return is_reagent_container(container) && container.is_open_container() && !(container.item_flags & ABSTRACT) && !(container.flags_1 & HOLOGRAM_1)
-
 ///Computes time to purity reagents
 /obj/machinery/chem_mass_spec/proc/estimate_time()
 	PRIVATE_PROC(TRUE)
@@ -303,7 +295,8 @@
 	.["processing"] = processing_reagents
 	.["eta"] = delay_time - progress_time
 	.["peakHeight"] = 0
-	.["hasBeakerInHand"] = is_valid_container(user.get_active_held_item())
+	var/obj/item/held_item = user.get_active_held_item()
+	.["hasBeakerInHand"] = held_item?.is_chem_container() || FALSE
 
 	//input reagents
 	var/list/beaker1Data = null
@@ -445,14 +438,14 @@
 
 		if("insert1")
 			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
+			if(container?.can_insert_container(ui.user, src))
 				replace_beaker(ui.user, TRUE, container)
 
 			return TRUE
 
 		if("insert2")
 			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
+			if(container?.can_insert_container(ui.user, src))
 				replace_beaker(ui.user, FALSE, container)
 
 			return TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -61,7 +61,7 @@
 	if(isnull(held_item) || (held_item.item_flags & ABSTRACT) || (held_item.flags_1 & HOLOGRAM_1))
 		return
 
-	if(is_reagent_container(held_item))
+	if(is_valid_container(held_item))
 		if(QDELETED(beaker1))
 			context[SCREENTIP_CONTEXT_LMB] = "Insert input beaker"
 		else
@@ -146,26 +146,22 @@
 		cms_coefficient /= laser.tier
 
 /obj/machinery/chem_mass_spec/item_interaction(mob/living/user, obj/item/item, list/modifiers)
-	if((item.item_flags & ABSTRACT) || (item.flags_1 & HOLOGRAM_1) || !can_interact(user) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+	if(!can_insert_beaker(user, item))
 		return NONE
 
-	if(is_reagent_container(item) && item.is_open_container())
-		if(processing_reagents)
-			balloon_alert(user, "still processing!")
-			return ITEM_INTERACT_BLOCKING
+	if(processing_reagents)
+		balloon_alert(user, "still processing!")
+		return ITEM_INTERACT_BLOCKING
 
-		var/obj/item/reagent_containers/beaker = item
-		if(!user.transferItemToLoc(beaker, src))
-			return ITEM_INTERACT_BLOCKING
+	var/is_right_clicking = LAZYACCESS(modifiers, RIGHT_CLICK)
+	if(!replace_beaker(user, !is_right_clicking, item))
+		return ITEM_INTERACT_BLOCKING
 
-		var/is_right_clicking = LAZYACCESS(modifiers, RIGHT_CLICK)
-		replace_beaker(user, !is_right_clicking, beaker)
-		to_chat(user, span_notice("You add [beaker] to [is_right_clicking ? "output" : "input"] slot."))
-		update_appearance()
-		ui_interact(user)
-		return ITEM_INTERACT_SUCCESS
+	to_chat(user, span_notice("You add [item] to [is_right_clicking ? "output" : "input"] slot."))
+	update_appearance()
+	ui_interact(user)
 
-	return NONE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/chem_mass_spec/wrench_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_BLOCKING
@@ -222,7 +218,7 @@
 	return smallest ? FLOOR(result, 50) : CEILING(result, 50)
 
 /*
- * Replaces a beaker in the machine, either input or output
+ * Replaces a beaker in the machine, either input or output. Returns TRUE on success.
  * Arguments
  *
  * * user - The one bonking the machine
@@ -235,17 +231,37 @@
 	if(is_input) //replace input beaker
 		if(!QDELETED(beaker1))
 			try_put_in_hand(beaker1, user)
-		beaker1 = new_beaker
-		lower_mass_range = calculate_mass(smallest = TRUE)
-		upper_mass_range = calculate_mass(smallest = FALSE)
-		estimate_time()
+		if(!QDELETED(new_beaker))
+			if(!user.transferItemToLoc(new_beaker, src))
+				update_appearance(UPDATE_OVERLAYS)
+				return FALSE
+
+			beaker1 = new_beaker
+			lower_mass_range = calculate_mass(smallest = TRUE)
+			upper_mass_range = calculate_mass(smallest = FALSE)
+			estimate_time()
 	else //replace output beaker
 		if(!QDELETED(beaker2))
 			try_put_in_hand(beaker2, user)
-		beaker2 = new_beaker
-		log.Cut()
+		if(!QDELETED(new_beaker))
+			if(!user.transferItemToLoc(new_beaker, src))
+				update_appearance(UPDATE_OVERLAYS)
+				return FALSE
+
+			beaker2 = new_beaker
+			log.Cut()
 
 	update_appearance()
+
+	return TRUE
+
+/// Checks if user can interact with beaker slot and container is valid
+/obj/machinery/chem_mass_spec/proc/can_insert_beaker(mob/living/user, obj/item/reagent_containers/container)
+	return is_valid_container(container) && can_interact(user) && user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
+
+/// Checks if container can be used with this machine
+/obj/machinery/chem_mass_spec/proc/is_valid_container(obj/item/reagent_containers/container)
+	return is_reagent_container(container) && container.is_open_container() && !(container.item_flags & ABSTRACT) && !(container.flags_1 & HOLOGRAM_1)
 
 ///Computes time to purity reagents
 /obj/machinery/chem_mass_spec/proc/estimate_time()
@@ -287,6 +303,7 @@
 	.["processing"] = processing_reagents
 	.["eta"] = delay_time - progress_time
 	.["peakHeight"] = 0
+	.["hasBeakerInHand"] = is_valid_container(user.get_active_held_item())
 
 	//input reagents
 	var/list/beaker1Data = null
@@ -428,14 +445,14 @@
 
 		if("insert1")
 			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(container)
-				item_interaction(user = ui.user, item = container)
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, TRUE, container)
 			return TRUE
 
 		if("insert2")
 			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(container)
-				item_interaction(user = usr, item = container, modifiers = list(RIGHT_CLICK = TRUE))
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, FALSE, container)
 			return TRUE
 
 /obj/machinery/chem_mass_spec/click_alt(mob/living/user)

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -426,6 +426,18 @@
 			replace_beaker(ui.user, FALSE)
 			return TRUE
 
+		if("insert1")
+			var/obj/item/reagent_containers/container = usr.get_active_held_item()
+			if(container)
+				item_interaction(user = ui.user, item = container)
+			return TRUE
+
+		if("insert2")
+			var/obj/item/reagent_containers/container = usr.get_active_held_item()
+			if(container)
+				item_interaction(user = usr, item = container, modifiers = list(RIGHT_CLICK = TRUE))
+			return TRUE
+
 /obj/machinery/chem_mass_spec/click_alt(mob/living/user)
 	if(processing_reagents)
 		balloon_alert(user, "still processing!")

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -146,12 +146,12 @@
 		cms_coefficient /= laser.tier
 
 /obj/machinery/chem_mass_spec/item_interaction(mob/living/user, obj/item/item, list/modifiers)
-	if(!item.can_insert_container(user, src))
-		return NONE
-
 	if(processing_reagents)
 		balloon_alert(user, "still processing!")
 		return ITEM_INTERACT_BLOCKING
+
+	if(!item.can_insert_container(user, src))
+		return NONE
 
 	var/is_right_clicking = LAZYACCESS(modifiers, RIGHT_CLICK)
 	if(!replace_beaker(user, !is_right_clicking, item))

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -251,7 +251,7 @@
 			beaker2 = new_beaker
 			log.Cut()
 
-	update_appearance()
+	update_appearance(UPDATE_OVERLAYS)
 
 	return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -429,11 +429,9 @@
 			return TRUE
 
 		if("insert")
-			var/mob/ui_user = ui.user
-			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
-
-			if(can_insert_beaker(ui_user, container))
-				replace_beaker(ui_user, container)
+			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, container)
 
 			return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -61,7 +61,7 @@
 			. = CONTEXTUAL_SCREENTIP_SET
 		return .
 
-	if(is_valid_container(held_item))
+	if(held_item.is_chem_container())
 		if(!QDELETED(beaker))
 			context[SCREENTIP_CONTEXT_LMB] = "Replace beaker"
 		else
@@ -169,7 +169,7 @@
 	return containers
 
 /obj/machinery/chem_master/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(!can_insert_beaker(user, tool))
+	if(!tool.can_insert_container(user, src))
 		return NONE
 	if(!replace_beaker(user, tool))
 		return ITEM_INTERACT_BLOCKING
@@ -236,14 +236,6 @@
 
 	return TRUE
 
-/// Checks if user can interact with beaker slot and container is valid
-/obj/machinery/chem_master/proc/can_insert_beaker(mob/living/user, obj/item/reagent_containers/container)
-	return is_valid_container(container) && can_interact(user) && user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
-
-/// Checks if container can be used with this machine
-/obj/machinery/chem_master/proc/is_valid_container(obj/item/reagent_containers/container)
-	return is_reagent_container(container) && container.is_open_container() && !(container.item_flags & ABSTRACT) && !(container.flags_1 & HOLOGRAM_1)
-
 /obj/machinery/chem_master/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
@@ -301,7 +293,8 @@
 	.["printingProgress"] = printing_progress
 	.["printingTotal"] = printing_total
 	.["selectedPillDuration"] = pill_layers
-	.["hasBeakerInHand"] = is_valid_container(user.get_active_held_item())
+	var/obj/item/held_item = user.get_active_held_item()
+	.["hasBeakerInHand"] = held_item?.is_chem_container() || FALSE
 
 	//contents of source beaker
 	var/list/beaker_data = null
@@ -430,7 +423,7 @@
 
 		if("insert")
 			var/obj/item/reagent_containers/container = ui.user.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
+			if(container?.can_insert_container(ui.user, src))
 				replace_beaker(ui.user, container)
 
 			return TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -418,6 +418,12 @@
 			replace_beaker(ui.user)
 			return TRUE
 
+		if("insert")
+			var/obj/item/reagent_containers/container = usr.get_active_held_item()
+			if(container)
+				item_interaction(user = usr, tool = container)
+			return TRUE
+
 		if("transfer")
 			if(is_printing)
 				say("The buffer is locked while printing.")

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -429,9 +429,12 @@
 			return TRUE
 
 		if("insert")
-			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(can_insert_beaker(ui.user, container))
-				replace_beaker(ui.user, container)
+			var/mob/ui_user = ui.user
+			var/obj/item/reagent_containers/container = ui_user.get_active_held_item()
+
+			if(can_insert_beaker(ui_user, container))
+				replace_beaker(ui_user, container)
+
 			return TRUE
 
 		if("transfer")

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -61,7 +61,7 @@
 			. = CONTEXTUAL_SCREENTIP_SET
 		return .
 
-	if(is_reagent_container(held_item) && held_item.is_open_container())
+	if(is_valid_container(held_item))
 		if(!QDELETED(beaker))
 			context[SCREENTIP_CONTEXT_LMB] = "Replace beaker"
 		else
@@ -169,18 +169,13 @@
 	return containers
 
 /obj/machinery/chem_master/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(user.combat_mode && !is_reagent_container(tool) && !tool.is_open_container() || (tool.item_flags & ABSTRACT) || (tool.flags_1 & HOLOGRAM_1) || !can_interact(user) || !user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH))
+	if(!can_insert_beaker(user, tool))
 		return NONE
+	if(!replace_beaker(user, tool))
+		return ITEM_INTERACT_BLOCKING
 
-	if(is_reagent_container(tool) && tool.is_open_container())
-		replace_beaker(user, tool)
-		if(!panel_open)
-			ui_interact(user)
-			return ITEM_INTERACT_SUCCESS
-		else
-			return ITEM_INTERACT_BLOCKING
-
-	return NONE
+	ui_interact(user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/chem_master/wrench_act(mob/living/user, obj/item/tool)
 	if(user.combat_mode)
@@ -220,7 +215,7 @@
 		return ITEM_INTERACT_SUCCESS
 
 /**
- * Insert, remove, replace the existig beaker
+ * Insert, remove, replace the existig beaker. Returns TRUE on success.
  * Arguments
  *
  * * mob/living/user - the player trying to replace the beaker
@@ -231,9 +226,23 @@
 
 	if(!QDELETED(beaker))
 		try_put_in_hand(beaker, user)
-	if(!QDELETED(new_beaker) && user.transferItemToLoc(new_beaker, src))
+	if(!QDELETED(new_beaker))
+		if(!user.transferItemToLoc(new_beaker, src))
+			update_appearance(UPDATE_OVERLAYS)
+			return FALSE
 		beaker = new_beaker
+
 	update_appearance(UPDATE_OVERLAYS)
+
+	return TRUE
+
+/// Checks if user can interact with beaker slot and container is valid
+/obj/machinery/chem_master/proc/can_insert_beaker(mob/living/user, obj/item/reagent_containers/container)
+	return is_valid_container(container) && can_interact(user) && user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH)
+
+/// Checks if container can be used with this machine
+/obj/machinery/chem_master/proc/is_valid_container(obj/item/reagent_containers/container)
+	return is_reagent_container(container) && container.is_open_container() && !(container.item_flags & ABSTRACT) && !(container.flags_1 & HOLOGRAM_1)
 
 /obj/machinery/chem_master/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
@@ -292,6 +301,7 @@
 	.["printingProgress"] = printing_progress
 	.["printingTotal"] = printing_total
 	.["selectedPillDuration"] = pill_layers
+	.["hasBeakerInHand"] = is_valid_container(user.get_active_held_item())
 
 	//contents of source beaker
 	var/list/beaker_data = null
@@ -420,8 +430,8 @@
 
 		if("insert")
 			var/obj/item/reagent_containers/container = usr.get_active_held_item()
-			if(container)
-				item_interaction(user = usr, tool = container)
+			if(can_insert_beaker(ui.user, container))
+				replace_beaker(ui.user, container)
 			return TRUE
 
 		if("transfer")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -424,3 +424,6 @@
 	SEND_SIGNAL(src, COMSIG_REAGENTS_CUP_TRANSFER_FROM, target)
 	target.update_appearance()
 	return ITEM_INTERACT_SUCCESS
+
+/obj/item/reagent_containers/is_chem_container()
+	return is_open_container() && !(item_flags & ABSTRACT) && !(flags_1 & HOLOGRAM_1)

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -218,25 +218,16 @@ export const ChemDispenser = (props) => {
         </Section>
         <Section
           title="Beaker"
-          buttons={
-            beaker && (
-              <>
-                <Box inline color="label" mr={1}>
-                  {beaker.currentVolume}/{beaker.maxVolume}u
-                </Box>
-                {beakerTransferAmounts.map((amount) => (
-                  <Button
-                    key={amount}
-                    icon="minus"
-                    disabled={recording}
-                    onClick={() => act('remove', { amount })}
-                  >
-                    {amount}
-                  </Button>
-                ))}
-              </>
-            )
-          }
+          buttons={beakerTransferAmounts.map((amount) => (
+            <Button
+              key={amount}
+              icon="minus"
+              disabled={recording}
+              onClick={() => act('remove', { amount })}
+            >
+              {amount}
+            </Button>
+          ))}
         >
           {beaker ? (
             <BeakerDisplay

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -38,12 +38,13 @@ type Data = {
   recordingRecipe: string[];
   recipeReagents: string[];
   beaker: TransferableBeaker;
+  hasBeakerInHand: BooleanLike;
 };
 
 export const ChemDispenser = (props) => {
   const { act, data } = useBackend<Data>();
   const recording = !!data.recordingRecipe;
-  const { recipeReagents = [], recipes = [], beaker } = data;
+  const { recipeReagents = [], recipes = [], beaker, hasBeakerInHand } = data;
   const [showPhCol, setShowPhCol] = useState(false);
 
   const beakerTransferAmounts = beaker ? beaker.transferAmounts : [];
@@ -230,7 +231,19 @@ export const ChemDispenser = (props) => {
                 </Button>
               ))
             ) : (
-              <Button icon="eject" onClick={() => act('insert')}>
+              <Button
+                icon="eject"
+                onClick={() => act('insert')}
+                style={{
+                  opacity: hasBeakerInHand ? 1 : 0.5,
+                }}
+                tooltip={
+                  hasBeakerInHand
+                    ? 'Insert container from your hand'
+                    : 'You need to hold a container in your hand'
+                }
+                tooltipPosition="bottom-start"
+              >
                 Insert
               </Button>
             )

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -217,23 +217,35 @@ export const ChemDispenser = (props) => {
         </Section>
         <Section
           title="Beaker"
-          buttons={beakerTransferAmounts.map((amount) => (
-            <Button
-              key={amount}
-              icon="minus"
-              disabled={recording}
-              onClick={() => act('remove', { amount })}
-            >
-              {amount}
-            </Button>
-          ))}
+          buttons={
+            beaker ? (
+              beakerTransferAmounts.map((amount) => (
+                <Button
+                  key={amount}
+                  icon="minus"
+                  disabled={recording}
+                  onClick={() => act('remove', { amount })}
+                >
+                  {amount}
+                </Button>
+              ))
+            ) : (
+              <Button icon="eject" onClick={() => act('insert')}>
+                Insert
+              </Button>
+            )
+          }
         >
-          <BeakerDisplay
-            beaker={beaker}
-            title_label={recording && 'Virtual beaker'}
-            replace_contents={recordedContents}
-            showpH={data.showpH}
-          />
+          {beaker ? (
+            <BeakerDisplay
+              beaker={beaker}
+              title_label={recording && 'Virtual beaker'}
+              replace_contents={recordedContents}
+              showpH={data.showpH}
+            />
+          ) : (
+            <Box color="label">No beaker loaded.</Box>
+          )}
         </Section>
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -219,33 +219,22 @@ export const ChemDispenser = (props) => {
         <Section
           title="Beaker"
           buttons={
-            beaker ? (
-              beakerTransferAmounts.map((amount) => (
-                <Button
-                  key={amount}
-                  icon="minus"
-                  disabled={recording}
-                  onClick={() => act('remove', { amount })}
-                >
-                  {amount}
-                </Button>
-              ))
-            ) : (
-              <Button
-                icon="eject"
-                onClick={() => act('insert')}
-                style={{
-                  opacity: hasBeakerInHand ? 1 : 0.5,
-                }}
-                tooltip={
-                  hasBeakerInHand
-                    ? 'Insert container from your hand'
-                    : 'You need to hold a container in your hand'
-                }
-                tooltipPosition="bottom-start"
-              >
-                Insert
-              </Button>
+            beaker && (
+              <>
+                <Box inline color="label" mr={1}>
+                  {beaker.currentVolume}/{beaker.maxVolume}u
+                </Box>
+                {beakerTransferAmounts.map((amount) => (
+                  <Button
+                    key={amount}
+                    icon="minus"
+                    disabled={recording}
+                    onClick={() => act('remove', { amount })}
+                  >
+                    {amount}
+                  </Button>
+                ))}
+              </>
             )
           }
         >
@@ -257,7 +246,29 @@ export const ChemDispenser = (props) => {
               showpH={data.showpH}
             />
           ) : (
-            <Box color="label">No beaker loaded.</Box>
+            <Box
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Box color="label">No beaker loaded.</Box>
+              <Button
+                icon="eject"
+                onClick={() => act('insert')}
+                style={{
+                  opacity: data.hasBeakerInHand ? 1 : 0.5,
+                }}
+                tooltip={
+                  data.hasBeakerInHand &&
+                  'You need to hold a container in your hand'
+                }
+                tooltipPosition="left-start"
+              >
+                Insert
+              </Button>
+            </Box>
           )}
         </Section>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -261,7 +261,7 @@ export const ChemDispenser = (props) => {
                   opacity: data.hasBeakerInHand ? 1 : 0.5,
                 }}
                 tooltip={
-                  data.hasBeakerInHand &&
+                  !data.hasBeakerInHand &&
                   'You need to hold a container in your hand'
                 }
                 tooltipPosition="left-start"

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -229,7 +229,7 @@ export const ChemDispenser = (props) => {
             </Button>
           ))}
         >
-          {beaker ? (
+          {beaker || recording ? (
             <BeakerDisplay
               beaker={beaker}
               title_label={recording && 'Virtual beaker'}

--- a/tgui/packages/tgui/interfaces/ChemHeater.tsx
+++ b/tgui/packages/tgui/interfaces/ChemHeater.tsx
@@ -41,6 +41,7 @@ type Data = {
   acidicBufferVol: number;
   basicBufferVol: number;
   dispenseVolume: number;
+  hasBeakerInHand: BooleanLike;
 };
 
 type ReactionDisplayProps = {
@@ -192,6 +193,7 @@ export const ChemHeater = (props) => {
     dispenseVolume,
     upgradeLevel,
     activeReactions = [],
+    hasBeakerInHand,
   } = data;
   const isBeakerLoaded = beaker !== null;
 
@@ -359,6 +361,7 @@ export const ChemHeater = (props) => {
           beaker={beaker}
           showpH={false}
           showInsertButton={true}
+          hasBeakerInHand={hasBeakerInHand}
         />
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/ChemHeater.tsx
+++ b/tgui/packages/tgui/interfaces/ChemHeater.tsx
@@ -355,7 +355,11 @@ export const ChemHeater = (props) => {
             highDangerDisplay={upgradeLevel >= 2}
           />
         )}
-        <BeakerSectionDisplay beaker={beaker} showpH={false} />
+        <BeakerSectionDisplay
+          beaker={beaker}
+          showpH={false}
+          showInsertButton={true}
+        />
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -139,9 +139,7 @@ const ChemMasterContent = (props: {
                 opacity: hasBeakerInHand ? 1 : 0.5,
               }}
               tooltip={
-                hasBeakerInHand
-                  ? 'Insert container from your hand'
-                  : 'You need to hold a container in your hand'
+                !hasBeakerInHand && 'You need to hold a container in your hand'
               }
               tooltipPosition="bottom-start"
             >

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -119,7 +119,7 @@ const ChemMasterContent = (props: {
       <Section
         title="Beaker"
         buttons={
-          beaker && (
+          beaker ? (
             <Box>
               <Box inline color="label" mr={2}>
                 <AnimatedNumber value={beaker.currentVolume} initial={0} />
@@ -129,6 +129,10 @@ const ChemMasterContent = (props: {
                 Eject
               </Button>
             </Box>
+          ) : (
+            <Button icon="eject" onClick={() => act('insert')}>
+              Insert
+            </Button>
           )
         }
       >

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -65,6 +65,7 @@ type Data = {
   selectedContainerRef: string;
   selectedContainerVolume: number;
   selectedContainerCategory?: string;
+  hasBeakerInHand: BooleanLike;
 };
 
 export const ChemMaster = (props) => {
@@ -107,6 +108,7 @@ const ChemMasterContent = (props: {
     categories,
     selectedContainerVolume,
     selectedContainerCategory,
+    hasBeakerInHand,
   } = data;
 
   const [itemCount, setItemCount] = useState<number>(1);
@@ -130,7 +132,19 @@ const ChemMasterContent = (props: {
               </Button>
             </Box>
           ) : (
-            <Button icon="eject" onClick={() => act('insert')}>
+            <Button
+              icon="eject"
+              onClick={() => act('insert')}
+              style={{
+                opacity: hasBeakerInHand ? 1 : 0.5,
+              }}
+              tooltip={
+                hasBeakerInHand
+                  ? 'Insert container from your hand'
+                  : 'You need to hold a container in your hand'
+              }
+              tooltipPosition="bottom-start"
+            >
               Insert
             </Button>
           )

--- a/tgui/packages/tgui/interfaces/MassSpec.tsx
+++ b/tgui/packages/tgui/interfaces/MassSpec.tsx
@@ -125,9 +125,8 @@ export const MassSpec = (props) => {
                   opacity: hasBeakerInHand ? 1 : 0.5,
                 }}
                 tooltip={
-                  hasBeakerInHand
-                    ? 'Insert container from your hand'
-                    : 'You need to hold a container in your hand'
+                  !hasBeakerInHand &&
+                  'You need to hold a container in your hand'
                 }
                 tooltipPosition="bottom-start"
               >
@@ -165,9 +164,8 @@ export const MassSpec = (props) => {
                   opacity: hasBeakerInHand ? 1 : 0.5,
                 }}
                 tooltip={
-                  hasBeakerInHand
-                    ? 'Insert container from your hand'
-                    : 'You need to hold a container in your hand'
+                  !hasBeakerInHand &&
+                  'You need to hold a container in your hand'
                 }
                 tooltipPosition="bottom-start"
               >

--- a/tgui/packages/tgui/interfaces/MassSpec.tsx
+++ b/tgui/packages/tgui/interfaces/MassSpec.tsx
@@ -37,6 +37,7 @@ type Data = {
   peakHeight: number;
   beaker1: Beaker;
   beaker2: Beaker;
+  hasBeakerInHand: BooleanLike;
 };
 
 const GRAPH_MAX_WIDTH = 1060;
@@ -53,6 +54,7 @@ export const MassSpec = (props) => {
     peakHeight,
     beaker1,
     beaker2,
+    hasBeakerInHand,
   } = data;
 
   const centerValue = (lowerRange + upperRange) / 2;
@@ -116,7 +118,19 @@ export const MassSpec = (props) => {
                 </Button>
               </>
             ) : (
-              <Button icon="eject" onClick={() => act('insert1')}>
+              <Button
+                icon="eject"
+                onClick={() => act('insert1')}
+                style={{
+                  opacity: hasBeakerInHand ? 1 : 0.5,
+                }}
+                tooltip={
+                  hasBeakerInHand
+                    ? 'Insert container from your hand'
+                    : 'You need to hold a container in your hand'
+                }
+                tooltipPosition="bottom-start"
+              >
                 Insert
               </Button>
             )
@@ -144,7 +158,19 @@ export const MassSpec = (props) => {
                 </Button>
               </>
             ) : (
-              <Button icon="eject" onClick={() => act('insert2')}>
+              <Button
+                icon="eject"
+                onClick={() => act('insert2')}
+                style={{
+                  opacity: hasBeakerInHand ? 1 : 0.5,
+                }}
+                tooltip={
+                  hasBeakerInHand
+                    ? 'Insert container from your hand'
+                    : 'You need to hold a container in your hand'
+                }
+                tooltipPosition="bottom-start"
+              >
                 Insert
               </Button>
             )

--- a/tgui/packages/tgui/interfaces/MassSpec.tsx
+++ b/tgui/packages/tgui/interfaces/MassSpec.tsx
@@ -106,17 +106,19 @@ export const MassSpec = (props) => {
         <Section
           title="Input beaker"
           buttons={
-            !!beaker1 && (
+            beaker1 ? (
               <>
-                {
-                  <Box inline color="label" mr={2}>
-                    {beaker1.currentVolume} / {beaker1.maxVolume} units
-                  </Box>
-                }
+                <Box inline color="label" mr={2}>
+                  {beaker1.currentVolume} / {beaker1.maxVolume} units
+                </Box>
                 <Button icon="eject" onClick={() => act('eject1')}>
                   Eject
                 </Button>
               </>
+            ) : (
+              <Button icon="eject" onClick={() => act('insert1')}>
+                Insert
+              </Button>
             )
           }
         >
@@ -132,17 +134,19 @@ export const MassSpec = (props) => {
         <Section
           title="Output beaker"
           buttons={
-            !!beaker2 && (
+            beaker2 ? (
               <>
-                {
-                  <Box inline color="label" mr={2}>
-                    {beaker2.currentVolume} / {beaker2.maxVolume} units
-                  </Box>
-                }
+                <Box inline color="label" mr={2}>
+                  {beaker2.currentVolume} / {beaker2.maxVolume} units
+                </Box>
                 <Button icon="eject" onClick={() => act('eject2')}>
                   Eject
                 </Button>
               </>
+            ) : (
+              <Button icon="eject" onClick={() => act('insert2')}>
+                Insert
+              </Button>
             )
           }
         >

--- a/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
@@ -115,7 +115,8 @@ export const BeakerSectionDisplay = (props: BeakerProps) => {
       }
     >
       <Box color="label">
-        {(!beaker && 'N/A') || (beakerContents.length === 0 && 'Nothing')}
+        {(!beaker && 'No beaker loaded') ||
+          (beakerContents.length === 0 && 'Nothing')}
       </Box>
       {beakerContents.map((chemical) => (
         <Box key={chemical.name} color="label">

--- a/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
@@ -114,9 +114,7 @@ export const BeakerSectionDisplay = (props: BeakerProps) => {
                 opacity: hasBeakerInHand ? 1 : 0.5,
               }}
               tooltip={
-                hasBeakerInHand
-                  ? 'Insert container from your hand'
-                  : 'You need to hold a container in your hand'
+                !hasBeakerInHand && 'You need to hold a container in your hand'
               }
               tooltipPosition="bottom-start"
             >

--- a/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
@@ -28,6 +28,7 @@ type BeakerProps = {
   showpH?: BooleanLike;
   insertAction?: string;
   showInsertButton?: boolean;
+  hasBeakerInHand?: BooleanLike;
 };
 
 export const BeakerDisplay = (props: BeakerProps) => {
@@ -87,6 +88,7 @@ export const BeakerSectionDisplay = (props: BeakerProps) => {
     showpH,
     insertAction = 'insert',
     showInsertButton = false,
+    hasBeakerInHand,
   } = props;
 
   const beakerContents = replace_contents || beaker?.contents || [];
@@ -107,7 +109,19 @@ export const BeakerSectionDisplay = (props: BeakerProps) => {
           </>
         ) : (
           showInsertButton && (
-            <Button icon="eject" onClick={() => act(insertAction)}>
+            <Button
+              icon="eject"
+              onClick={() => act('insert')}
+              style={{
+                opacity: hasBeakerInHand ? 1 : 0.5,
+              }}
+              tooltip={
+                hasBeakerInHand
+                  ? 'Insert container from your hand'
+                  : 'You need to hold a container in your hand'
+              }
+              tooltipPosition="bottom-start"
+            >
               Insert
             </Button>
           )

--- a/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
@@ -26,6 +26,8 @@ type BeakerProps = {
   replace_contents?: BeakerReagent[];
   title_label?: string;
   showpH?: BooleanLike;
+  insertAction?: string;
+  showInsertButton?: boolean;
 };
 
 export const BeakerDisplay = (props: BeakerProps) => {
@@ -78,14 +80,23 @@ export const BeakerDisplay = (props: BeakerProps) => {
 
 export const BeakerSectionDisplay = (props: BeakerProps) => {
   const { act } = useBackend();
-  const { beaker, replace_contents, title_label, showpH } = props;
+  const {
+    beaker,
+    replace_contents,
+    title_label,
+    showpH,
+    insertAction = 'insert',
+    showInsertButton = false,
+  } = props;
+
   const beakerContents = replace_contents || beaker?.contents || [];
+  const isBeakerLoaded = !!beaker;
 
   return (
     <Section
       title={title_label || 'Beaker'}
       buttons={
-        !!beaker && (
+        isBeakerLoaded ? (
           <>
             <Box inline color="label" mr={2}>
               {beaker.currentVolume} / {beaker.maxVolume} units
@@ -94,6 +105,12 @@ export const BeakerSectionDisplay = (props: BeakerProps) => {
               Eject
             </Button>
           </>
+        ) : (
+          showInsertButton && (
+            <Button icon="eject" onClick={() => act(insertAction)}>
+              Insert
+            </Button>
+          )
         )
       }
     >

--- a/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/common/BeakerDisplay.tsx
@@ -26,7 +26,6 @@ type BeakerProps = {
   replace_contents?: BeakerReagent[];
   title_label?: string;
   showpH?: BooleanLike;
-  insertAction?: string;
   showInsertButton?: boolean;
   hasBeakerInHand?: BooleanLike;
 };
@@ -86,7 +85,6 @@ export const BeakerSectionDisplay = (props: BeakerProps) => {
     replace_contents,
     title_label,
     showpH,
-    insertAction = 'insert',
     showInsertButton = false,
     hasBeakerInHand,
   } = props;


### PR DESCRIPTION
## About The Pull Request
Adds an "Insert" button to chemistry machine UIs so you don't have to click on the physical machine behind the interface window. 

<img width="1615" height="723" alt="Screenshot 2025-11-01 193237" src="https://github.com/user-attachments/assets/184c02b1-5ee3-4426-af8e-4adae79d8703" />

## Why It's Good For The Game

- No more moving or closing UI windows just to insert containers
- Much easier to move beakers between different chemistry machines
## Changelog
:cl:
qol:  Added Insert beaker buttons to chemistry machines.
code: Minor code update for interacting with chemical machines
/:cl:
