### PR TITLE
Increases spider tox vuln, increase bugkiller damage and lets flyswatter bane all basic bugs.  (The author was deadened by spiders.) 

### DIFF
--- a/code/datums/elements/bugkiller_reagent.dm
+++ b/code/datums/elements/bugkiller_reagent.dm
@@ -30,7 +30,7 @@
 		return
 
 	// capping damage so splashing a beaker on a moth is not an instant crit
-	var/damage = min(round(0.4 * reac_volume * (1 - touch_protection), 0.1), 12)
+	var/damage = min(round(reac_volume * (1 - touch_protection), 0.1), 20)
 	if(damage < 1)
 		return
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1023,10 +1023,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	w_class = WEIGHT_CLASS_SMALL
 	/// Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
 	var/static/list/splattable
-	/// Things in this list which take a lot more damage from the fly swatter, but not be necessarily killed by it.
-	var/static/list/strong_against
-	/// How much extra damage the fly swatter does against mobs it is strong against
-	var/extra_strength_damage = 24
 
 /obj/item/melee/flyswatter/Initialize(mapload)
 	. = ..()
@@ -1041,11 +1037,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			/obj/effect/decal/cleanable/ants,
 			/obj/item/queen_bee,
 		))
-	if (isnull(strong_against))
-		strong_against = typecacheof(list(
-			/mob/living/basic/spider,
-		))
-
+	AddElement(/datum/element/bane, mob_biotypes = MOB_BUG,  target_type = /mob/living/basic, damage_multiplier = 0, added_damage = 24, requires_combat_mode = FALSE)
 
 /obj/item/melee/flyswatter/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	if(is_type_in_typecache(target, splattable))
@@ -1057,10 +1049,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			bug.gib(DROP_ALL_REMAINS)
 		else
 			qdel(target)
-		return
-	if(is_type_in_typecache(target, strong_against) && isliving(target))
-		var/mob/living/living_target = target
-		living_target.adjustBruteLoss(extra_strength_damage)
 
 /obj/item/proc/can_trigger_gun(mob/living/user, akimbo_usage)
 	if(!user.can_use_guns(src))

--- a/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
@@ -16,7 +16,7 @@
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
-	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 1, STAMINA = 1, OXY = 1)
+	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 3, STAMINA = 1, OXY = 1)
 	basic_mob_flags = FLAMMABLE_MOB
 	status_flags = NONE
 	speed = -0.1

--- a/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
@@ -16,7 +16,7 @@
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
-	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 3, STAMINA = 1, OXY = 1)
+	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 4, STAMINA = 1, OXY = 1)
 	basic_mob_flags = FLAMMABLE_MOB
 	status_flags = NONE
 	speed = -0.1

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -14,7 +14,7 @@
 	response_disarm_simple = "gently push aside"
 	initial_language_holder = /datum/language_holder/spider
 	melee_attack_cooldown = CLICK_CD_MELEE
-	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 1, STAMINA = 1, OXY = 1)
+	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 3, STAMINA = 1, OXY = 1)
 	basic_mob_flags = FLAMMABLE_MOB
 	status_flags = NONE
 	unsuitable_cold_damage = 4


### PR DESCRIPTION

## About The Pull Request

This PR makes the flyswatter a bonus damage a bug bane restricted to basic mobs(Since moths and fly people have their own snowflake handling.) 

The result of this is that the 24 extra damage flyswatters cause against giant spiders now applies to more mobs like:

* flesh spiders
* mega arachnids

It also buffs the damage per unit caused by bugkillers from 0.4 to 1 and the max damage per application is also increased.

Giant spiders now have a tox mod of 3 and flesh spiders have a tox mod of 4. 

## Why It's Good For The Game

I hate flesh spiders, the main thing I dislike about them, other than them being incredibly OP and stacked statwise, is that they are not spiders at all and none of the anti-spider tech even works on them, not even a little bit!

They killed me recently, chasing me into the janitors closet while is was desperately swatting it with a flyswatter, to no effect 

If they are going to have such a heavy spider themeing, you'd at least except the flyswatter to work on them. intuitively it should, and it is such a niche interaction, most players probably thinks, like me, the bonus damage applies to bugs in genereral. 

I also decided to check out pest spray and see if that does something. 

Currently a pest spray blast does 2(!) damage per application to any bug. 

A total joke even against a normal giant spider, let alone a 90 health rapidly regenerating flesh spider. 

I suspect it has been heavily hugboxed to prevent players from using the sandbox to kill moths with pest killer foam, so I opted to mainly increase the tox mod of the basics in question rather than increasing the main bugkiller damage. 

A normal little pest killer blast will still be pretty bad, but if you can find ways to apply a lot of reagent, pest killer can now maybe be effective against giant spider and flesh spiders. 

## Changelog

:cl:
balance: fly swatter now has bonus damage against all basic bugs.
balance: bug killer reagents now do slightly more damage. 
balance: spiders and flesh spiders have greatly increased tox vulnerability.
/:cl:

