### PR TITLE
Reverse beartrap message fix

### DIFF
--- a/code/game/objects/items/devices/reverse_bear_trap.dm
+++ b/code/game/objects/items/devices/reverse_bear_trap.dm
@@ -101,7 +101,7 @@
 	if(!do_after(user, 3 SECONDS, target = target) || target.get_item_by_slot(ITEM_SLOT_HEAD))
 		return
 	target.visible_message(span_warning("[user] forces and locks [src] onto [target]'s head!"), \
-		span_userdanger("[target] locks [src] onto your head!"), "<i>You hear a click, and then a timer ticking down.</i>")
+		span_userdanger("[user] locks [src] onto your head!"), "<i>You hear a click, and then a timer ticking down.</i>")
 	to_chat(user, span_danger("You force [src] onto [target]'s head and click the padlock shut."))
 
 	user.dropItemToGround(src)


### PR DESCRIPTION
## About The Pull Request

fixed wrong mob in span message

## Changelog

:cl:
fix: Reversed bear trap now correctly displays name of person who put it on you.
/:cl:
