### PR TITLE
Replace Antinoblium with Halon in the Crystallizer Zaukerite Recipe

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	min_temp = 5
 	max_temp = 20
 	energy_release = 2900000
-	requirements = list(/datum/gas/antinoblium = 5, /datum/gas/zauker = 20, /datum/gas/bz = 7.5)
+	requirements = list(/datum/gas/halon = 5, /datum/gas/zauker = 20, /datum/gas/bz = 7.5)
 	products = list(/obj/item/stack/sheet/mineral/zaukerite = 2)
 
 /datum/gas_recipe/crystallizer/fuel_pellet


### PR DESCRIPTION
## About The Pull Request
I’ve been sitting on the change made in #91048 for a while, letting it simmer and gauge reactions, talking with other atmos mains and even an initiate, about the knock-on effect that this has caused to other aspects of atmos.
This PR targets the newer atmos player experience and their journey through learning reactions, hammering out machines that make the gasses they want and being able to put all that experience together, focused into a single goal when they think they're ready.

It seems like what's agreed to be the capstone project of new techs to prove they’ve mastered fundamental gas synthesis and make the Elder Atmosian Statue has been put behind a wall that requires snowflake attention and has nothing to do with the fundamentals through either taking over engineering to run a non-standard and dangerous supermatter, or running a high tier HFR. Both of which would I think be considered outside of the scope of a new atmos tech just cutting their teeth.

This PR aims to rectify that by replacing Antinoblium with Halon, a regular electrolysis product just like Antinoblium was and is a gas with similarly few uses. This change will return making Zaukerite to the old difficulty. You already make both Hypernoblium and BZ over the course of making Zaukerite normally, so changing the requirement to Halon is in effect equivalent to the old system.
## Why It's Good For The Game
It's good to have a reasonably attainable goal for newer atmos players to shoot towards, giving purpose and direction, and a desire to improve rather than making gasses for making's sake, or being quite reasonably too afraid of blowing something up when they're still learning.
One gas requiring such a departure from everything else someone has been learning has almost completely killed an initiate’s desire to learn atmos because the “fundamentals capstone project” is now all but beyond reach because of a single gas with special and unique rules not seen elsewhere.
## Changelog
:cl:
balance: Replaces Antinoblium in the Crystallizer Zaukerite recipe with Halon, restoring the old difficulty.
/:cl:
