### PR TITLE
Adds a popup for logging in with an unrecommended byond version

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -13,7 +13,7 @@
 #if (DM_VERSION == 516 && DM_BUILD == 1660)
 #error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. If possible, update your BYOND version. Otherwise, visit www.byond.com/download/build to download an older release.
 #endif
-#if (DM_VERSION == 516 && DM_BUILD == 1671)
+#if (DM_VERSION == 516 && (DM_BUILD == 1670 || DM_BUILD == 1671))
 #error This version of BYOND (516.1671) has a bug which prevents this codebase from compiling. If possible, update your BYOND version. Otherwise, visit www.byond.com/download/build to download an older release.
 #endif
 

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -13,6 +13,9 @@
 #if (DM_VERSION == 516 && DM_BUILD == 1660)
 #error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. If possible, update your BYOND version. Otherwise, visit www.byond.com/download/build to download an older release.
 #endif
+#if (DM_VERSION == 516 && DM_BUILD == 1671)
+#error This version of BYOND (516.1671) has a bug which prevents this codebase from compiling. If possible, update your BYOND version. Otherwise, visit www.byond.com/download/build to download an older release.
+#endif
 
 // Keep savefile compatibilty at minimum supported level
 /savefile/byond_version = MIN_COMPILER_VERSION

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1622" = "Bug breaking rendering can lead to wallhacks.",
 ))
 GLOBAL_LIST_INIT(unrecommended_builds, list(
+	"1670" = "Bug breaking in-world text rendering.",
 	"1671" = "Bug breaking in-world text rendering.",
 ))
 #define LIMITER_SIZE 5

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -4,8 +4,10 @@
 
 GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1622" = "Bug breaking rendering can lead to wallhacks.",
-	))
-
+))
+GLOBAL_LIST_INIT(unrecommended_builds, list(
+	"1671" = "Bug breaking in-world text rendering.",
+))
 #define LIMITER_SIZE 5
 #define CURRENT_SECOND 1
 #define SECOND_COUNT 2

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -56,4 +56,11 @@
 		var/tl = SSticker.GetTimeLeft()
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [tl > 0 ? "in about [DisplayTimeText(tl)]" : "soon"].")
 
+	if(GLOB.unrecommended_builds[num2text(client.byond_build)])
+		INVOKE_ASYNC(src, PROC_REF(unrcommended_build_alert))
 
+/mob/dead/new_player/proc/unrcommended_build_alert()
+	var/warning = "Hey! The build of byond you are running ([client.byond_build]) has one or more potential issues that may cause major gameplay disruptions.\n\n\
+		You may continue to play, but be aware you may encounter the following issue while playing:\n\"[GLOB.unrecommended_builds[num2text(client.byond_build)]]\"\n\n\
+		If possible, we recommend updating your BYOND version.\nIf you are on the latest version, download an earlier release instead from www.byond.com/download/build."
+	alert(src, warning, "Bad BYOND Build", "OK")


### PR DESCRIPTION
## About The Pull Request

Adds `GLOB.unrecommended_builds`, for byond build which are broken for the end user in some way, but not in a way that warrants outright blacklisting players from connecting with them

Looks like this (Ignore the number I changed it for testing purposes) 

<img width="493" height="267" alt="image" src="https://github.com/user-attachments/assets/d31636e8-a106-4d13-a8fa-aee6a50c6d27" />

Uses this system for the new byond build, 1670+, which breaks text rendering

Also adds 1670+ to the list of builds to warn on compile

## Why It's Good For The Game

1670 broke the compilation step, probably permanently

Whether we will fix this or flip a pragma or w/e remains to be seen, but until then we can tell people to compile an earlier version

1670 also broke the user experience, causing map text to show up as really big. This will be fixed in an upcoming version 
<https://www.byond.com/forum/post/2983385>

## Changelog

:cl: Melbert
qol: If you are on Byond 516.1670+, you will get an alert on login that your build is less than functional
/:cl:
