### PR TITLE
Nerf Cyborg Hypospray

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -112,13 +112,13 @@
 	 * In most places we add + 1 because we're secretly keeping [max_volume_per_reagent + 1]
 	 * units, so that when this reagent runs out it's not wholesale removed from the reagents
 	 */
-	var/max_volume_per_reagent = 30
+	var/max_volume_per_reagent = 25
 	/// Cell cost for charging a reagent
-	var/charge_cost = 0.05 * STANDARD_CELL_CHARGE
+	var/charge_cost = 0.75 * STANDARD_CELL_CHARGE
 	/// Counts up to the next time we charge
 	var/charge_timer = 0
 	/// Time it takes for shots to recharge (in seconds)
-	var/recharge_time = 10
+	var/recharge_time = 12
 	///Optional variable to override the temperature add_reagent() will use
 	var/dispensed_temperature = DEFAULT_REAGENT_TEMPERATURE
 	/// If the hypospray can go through armor or thick material

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -114,7 +114,7 @@
 	 */
 	var/max_volume_per_reagent = 25
 	/// Cell cost for charging a reagent
-	var/charge_cost = 0.75 * STANDARD_CELL_CHARGE
+	var/charge_cost = 0.075 * STANDARD_CELL_CHARGE
 	/// Counts up to the next time we charge
 	var/charge_timer = 0
 	/// Time it takes for shots to recharge (in seconds)


### PR DESCRIPTION
## About The Pull Request
Nerfs Cyborg hypospray:
 - +20% recharge time (from 10s to 12s)
 - +50% charge cost (from 0.5 Joules to 0.75 Joules)
 - -17% reagent volume (from 30u to 25u)

## Why It's Good For The Game

I love mediborg, but the hypospray needs to be nerfed. It overshadows MD like crazy and allows you to stabilize upwards of three people by yourself at once. In my opinion, one of two things needs to happen:
 - Reagents recharge slower and have a lower max capacity
 - The charge cost of reagents is increased substantially to be *closer* (note: Not nearly at the same level) to a tool like the borg RCD, where a great deal of spam will have a noticable impact on your battery.

Either of these, if not overzealous, would reduce mediborg's ability to heal multiple critical people at once without majorly impacting their ability to heal slightly injured people or a single critical patient.

This PR mostly leans to the first solution. I don't expect this PR to majorly impact the viability, but it should be a good "jumping off point" to test the waters.

## Changelog

:cl:
balance: Nerfed cyborg hypospray across the board, notably refilling chems 20% slower.
/:cl:
