### PR TITLE
[NO GBP] Fixes raptor eggs runtiming when spawned by non-raptors

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
@@ -33,7 +33,7 @@
 	if (!isturf(loc) || length(GLOB.raptor_population) >= MAX_RAPTOR_POP)
 		return
 
-	var/growth_value = rand(min_growth_rate, max_growth_rate) * seconds_per_tick * (1 + inherited_stats.growth_modifier)
+	var/growth_value = rand(min_growth_rate, max_growth_rate) * seconds_per_tick * (1 + inherited_stats?.growth_modifier)
 	// Slower growth off hot lavaland
 	if (!SSmapping.level_trait(z, ZTRAIT_ASHSTORM))
 		growth_value *= 0.75


### PR DESCRIPTION

## About The Pull Request

No idea how this passed C&D in the original PR's CI, but eggs that don't get stats assigned immediately would start throwing runtimes from trying to access their growth modifier.

## Changelog
:cl:
fix: Fixed raptor eggs runtiming when spawned by non-raptors
/:cl:
