### PR TITLE
Charger items fix

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -354,7 +354,7 @@
 	to_chat(eater, span_notice("You feel energized as you bite into [our_plant]."))
 	var/batteries_recharged = FALSE
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	for(var/obj/item/stock_parts/power_store/found_cell in eater.get_all_cells())
+	for(var/obj/item/stock_parts/power_store/found_cell in assoc_to_values(eater.get_all_cells()))
 		var/newcharge = min(our_seed.potency * 0.01 * found_cell.maxcharge, found_cell.maxcharge)
 		if(found_cell.charge < newcharge)
 			found_cell.charge = newcharge

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -598,7 +598,7 @@
 		return ..()
 	cooldown = max_cooldown
 	var/list/batteries = list()
-	for(var/obj/item/stock_parts/power_store/C in owner.get_all_cells())
+	for(var/obj/item/stock_parts/power_store/C in assoc_to_values(owner.get_all_cells()))
 		if(C.charge < C.maxcharge)
 			batteries += C
 	if(batteries.len)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -87,9 +87,9 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/yellow/core_effect(mob/living/target, mob/user)
 	var/list/batteries = list()
-	for(var/obj/item/stock_parts/power_store/C in target.get_all_cells())
-		if(C.charge < C.maxcharge)
-			batteries += C
+	for(var/obj/item/stock_parts/power_store/cell in assoc_to_values(target.get_all_cells()))
+		if(cell.charge < cell.maxcharge)
+			batteries += cell
 	if(batteries.len)
 		var/obj/item/stock_parts/power_store/ToCharge = pick(batteries)
 		ToCharge.charge = ToCharge.maxcharge

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -108,7 +108,7 @@
 		return
 
 	var/list/batteries = list()
-	for(var/obj/item/stock_parts/power_store/cell in owner.get_all_cells())
+	for(var/obj/item/stock_parts/power_store/cell in assoc_to_values(owner.get_all_cells()))
 		if(cell.used_charge())
 			batteries += cell
 


### PR DESCRIPTION

## About The Pull Request
Items(i.e yellow stabilized/regenerative extract, glowshroom cap, voltaic cybernetic heart) now recharges cells of mob equipment as they are supposed.

## Why It's Good For The Game
After [(this)](https://github.com/tgstation/tgstation/pull/92987) PR was merged items, that were supposed to recharge cells in items, stopped functioning due to change in code of how batteries inside items recharge. This PR supposed to fix the issue.

## Changelog
:cl: Vishenka0704
fix: yellow stabilized/regenerative extract, glowshroom cap, voltaic cybernetic heart now recharges cells of mob equipment
/:cl:
