### PR TITLE
feat: any melee item can now be used to bash shields

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -1,4 +1,4 @@
-#define BATON_BASH_COOLDOWN (3 SECONDS)
+#define WEAPON_BASH_COOLDOWN (3 SECONDS)
 
 /obj/item/shield
 	name = "shield"
@@ -26,7 +26,7 @@
 	/// sound the shield makes when it breaks
 	var/shield_break_sound = 'sound/effects/bang.ogg'
 	/// baton bash cooldown
-	COOLDOWN_DECLARE(baton_bash)
+	COOLDOWN_DECLARE(weapon_bash)
 	/// is shield bashable?
 	var/is_bashable = TRUE
 	/// sound when a shield is bashed
@@ -74,13 +74,14 @@
 	. = ..()
 	if(. & ITEM_INTERACT_ANY_BLOCKER)
 		return .
-	if(!istype(tool, /obj/item/melee/baton) || !is_bashable)
+	if(!istype(tool, /obj/item/melee) || !is_bashable)
 		return .
-	if(!COOLDOWN_FINISHED(src, baton_bash))
+	if(!COOLDOWN_FINISHED(src, weapon_bash))
 		return ITEM_INTERACT_BLOCKING
-	user.visible_message(span_warning("[user] bashes [src] with [tool]!"))
 	playsound(src, shield_bash_sound, 50, TRUE)
-	COOLDOWN_START(src, baton_bash, BATON_BASH_COOLDOWN)
+	user.manual_emote("bashes [src] with [tool]!")
+	COOLDOWN_START(src, weapon_bash, WEAPON_BASH_COOLDOWN)
+	user.Shake(3, 3, 0.5 SECONDS)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/shield/proc/on_shield_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
@@ -483,4 +484,4 @@
 	armor_type = /datum/armor/item_shield/improvised
 	block_sound = 'sound/items/trayhit/trayhit2.ogg'
 
-#undef BATON_BASH_COOLDOWN
+#undef WEAPON_BASH_COOLDOWN


### PR DESCRIPTION
## About The Pull Request

You can now use any melee weapon to bash shields with

<img width="312" height="216" alt="{013D1FE3-ED14-4743-AF45-857740F702C0}" src="https://github.com/user-attachments/assets/6214eea5-91e8-49f5-8956-f0b235a305bf" />

## Why It's Good For The Game

![oypwozqu7vze1](https://github.com/user-attachments/assets/32acce24-126d-454c-a353-36bbd177ad2d)

more *menacing* moments

## Changelog

:cl:
add: You can now bash shields with any melee weapon
/:cl:
