### PR TITLE
Prevents welding moving cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(!tool.use_tool(src, user, delay = 5 SECONDS, amount = 1, volume = 50))
 			return ITEM_INTERACT_BLOCKING
 	else
-		if(!tool.use_tool(src, user, delay = 0 SECONDS, amount = 1, volume = 50))
+		if(!tool.use_tool(src, user, delay = 0.5 SECONDS, amount = 1, volume = 50))
 			return ITEM_INTERACT_BLOCKING
 
 	adjustBruteLoss(-30)


### PR DESCRIPTION

## About The Pull Request

Adds a delay of 0.5 seconds to the `use_tool()` that is used for welding cyborgs. This prevents welding cyborgs while they or you are moving, but does not slow down how quickly you repair them if both of you are still.

A quick note is that this is effected by tool speed as any other `use_tool()` is, so alien welding tools remain able to weld while moving because they're just that quick.

## Why It's Good For The Game

I've always thought that the instant healing for moving cyborgs was weird, but in a recent round I've found that it's also extremely powerful in combat, to the point that the cyborg's opponent is basically incapable of making any headway because the cyborg gets the sustainability of both being eternally fast-dodging and healing very quickly. This nerf doesn't actually slow down cyborg healing, it just makes them sit still, as they should have always had to.

## Changelog
:cl:

balance: Cyborgs can no longer be healed while moving

/:cl:
