### PR TITLE
Revert "Doubles low pressure damage"

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -103,7 +103,7 @@
 #define PRESSURE_DAMAGE_COEFFICIENT 2
 #define MAX_HIGH_PRESSURE_DAMAGE 2
 /// The amount of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
-#define LOW_PRESSURE_DAMAGE 4
+#define LOW_PRESSURE_DAMAGE 2
 
 /// Humans are slowed by the difference between bodytemp and BODYTEMP_COLD_DAMAGE_LIMIT divided by this
 #define COLD_SLOWDOWN_FACTOR 20


### PR DESCRIPTION
### About The Pull Request
Reverts tgstation/tgstation#93647
### Why It's Good For The Game

- Been playing this since the merge & it feels abhorrent to play.
- It feels like there is little to no counterplay (you get half health in little under 10 seconds, with slowdown).
- On a server like Terry, where there are a lot of bombings being the norm, we have to deal with:
Hullbreaches, stub toe calling, firelock hell, no crowbar, no coffee, z-level breaches, now double damage.
It feels extremely unfair and unfun to play.
- The double damage is instantaneous acting - Echoing what MrMelbert said in the PR - "(though my preferred solution would probably be starting lower and ramping up, so it's not excessively punishing on people who are exposed for a short time)".
- Isn't a test merge - it was suggested but echoing what Ghommie said in the PR - "One line change that can be easily reverted or changed again if the results are unsatisfying.".
- The PR author lied/was incorrect about timings on how long it takes to die, and didn't address any concerns on what impact it'll have on hull breaches, (hull breaches already feel absolutely horrible to play against, on top of ss13 being a frustration simulator) but rather their concern was space walking. I think this viewpoint is silly and doesn't look at the bigger picture. Bit of a nothingburger point, but putting it here anyhow.

## Changelog

:cl: ArchBTW
del: Revert "Doubles low pressure damage"
/:cl: