### PR TITLE
Adds a new admin verb, Mass Modify Traits

### DIFF
--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -30,6 +30,8 @@
 #define PERSONALITY_TRAIT "personality_trait"
 /// (B)admins only.
 #define ADMIN_TRAIT "admin"
+/// Traits that were granted via modify_traits in vv or the mass_modify_traits verb
+#define TRAIT_ADMIN_GRANTED "adminabuse"
 /// Any traits given through a smite.
 #define SMITE_TRAIT "smite"
 #define CHANGELING_TRAIT "changeling"

--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -125,7 +125,7 @@ ADMIN_VERB(cmd_admin_check_player_exp, R_ADMIN, "Player Playtime", "View player 
 		return
 	chosen_trait = available_traits[chosen_trait]
 
-	var/source = "adminabuse"
+	var/source = TRAIT_ADMIN_GRANTED
 	switch(add_or_remove)
 		if("Add") //Not doing source choosing here intentionally to make this bit faster to use, you can always vv it.
 			if(GLOB.movement_type_trait_to_flag[chosen_trait]) //include the required element.

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -169,10 +169,10 @@ ADMIN_VERB(polymorph_all, R_ADMIN, "Polymorph All", "Applies the effects of the 
 ADMIN_VERB(mass_modify_traits, R_ADMIN, "Mass Modify Traits", "Adds or removes a trait from every mob.", ADMIN_CATEGORY_FUN)
 
 	var/choice = tgui_alert(user, "Add or Remove Trait?", "Mass Add/Remove Trait", list("Add", "Remove"))
-	if(!choice)
+	if(isnull(choice))
 		return
 	var/is_add = (choice == "Add")
-	var/lower_choice = lowertext(choice)
+	var/lower_choice = LOWER_TEXT(choice)
 
 	// Build list of valid traits that can be applied to mobs
 	var/list/available_traits = list()

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -169,7 +169,8 @@ ADMIN_VERB(polymorph_all, R_ADMIN, "Polymorph All", "Applies the effects of the 
 ADMIN_VERB(mass_modify_traits, R_ADMIN, "Mass Modify Traits", "Adds or removes a trait from every mob.", ADMIN_CATEGORY_FUN)
 
 	var/choice = tgui_alert(user, "Add or Remove Trait?", "Mass Add/Remove Trait", list("Add", "Remove"))
-	if(!choice) return
+	if(!choice)
+		return
 	var/is_add = (choice == "Add")
 	var/lower_choice = lowertext(choice)
 

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -235,9 +235,8 @@ ADMIN_VERB(mass_modify_traits, R_ADMIN, "Mass Modify Traits", "Adds or removes a
 				applied_successfully = TRUE
 
 	if(applied_successfully)
-		var/msg_string = "[key_name_admin(user)] mass [lowertext(add_or_remove)][add_or_remove == "Add" ? "ed" : "d" [GLOB.admin_trait_name_map[chosen_trait] || chosen_trait] \
+		var/msg_string = "[key_name_admin(user)] mass [lowertext(add_or_remove)][add_or_remove == "Add" ? "ed" : "d"] [GLOB.admin_trait_name_map[chosen_trait] || chosen_trait] \
 			[add_or_remove == "Add" ? "to" : "from"] every [cliented_only ? "cliented" : ""] mob."
-
 		message_admins(msg_string)
 		log_admin(msg_string )
 

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -231,7 +231,7 @@ ADMIN_VERB(mass_modify_traits, R_ADMIN, "Mass Modify Traits", "Adds or removes a
 		switch(remove_mode)
 			if("Admin-Granted Traits") source = TRAIT_ADMIN_GRANTED
 			if("Specific")
-				source = lowertext(tgui_input_text(user, "Enter source", "Mass Remove Trait", max_length = MAX_NAME_LEN))
+				source = LOWER_TEXT(tgui_input_text(user, "Enter source", "Mass Remove Trait", max_length = MAX_NAME_LEN))
 				if(isnull(source))
 					return
 

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -166,7 +166,7 @@ ADMIN_VERB(polymorph_all, R_ADMIN, "Polymorph All", "Applies the effects of the 
 	message_admins("Mass polymorph started by [who_did_it] is complete.")
 
 /// Allow admin to mass add or remove a trait across all mobs
-ADMIN_VERB(mass_modify_traits, R_ADMIN, "Mass Modify Traits", "Adds or removes a trait from every mob.", ADMIN_CATEGORY_FUN)
+ADMIN_VERB(mass_modify_traits, R_FUN, "Mass Modify Traits", "Adds or removes a trait from every mob.", ADMIN_CATEGORY_FUN)
 
 	var/choice = tgui_alert(user, "Add or Remove Trait?", "Mass Add/Remove Trait", list("Add", "Remove"))
 	if(isnull(choice))


### PR DESCRIPTION
## About The Pull Request

Adds a verb, Mass Modify Traits, which allows an admin to apply or remove a specific trait from all living mobs.

This lets you do things like give all mobs the `TRAIT_NOBREATHING`, or making all mobs able to fly.

<img width="345" height="138" alt="JvkEnGMkQI" src="https://github.com/user-attachments/assets/fad89db3-a1a5-42d7-ae54-67ca7ba92301" />

You can specify only cliented mobs, as well as the trait source for removals.

<details><summary>results</summary>

![dreamseeker_K4w1Mmt73N](https://github.com/user-attachments/assets/62025b6a-1c16-4eb5-81ac-e2f5387877dd)

</details>

## Why It's Good For The Game

More tools for admins to get creative with is always a good thing, I think! The trait system uses macros so it's difficult to use SQL to mass-apply, so here's an easy verb for it instead.

## Changelog

:cl:
admin: added new admin verb, 'Mass Modify Traits', which can be used to add or remove a trait to/from every living mob.
/:cl:
