### PR TITLE
[NO GBP] Fix locked secure safes not showing correct UI

### DIFF
--- a/code/game/objects/structures/secure_safe.dm
+++ b/code/game/objects/structures/secure_safe.dm
@@ -104,7 +104,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
 /obj/structure/secure_safe/Initialize(mapload)
 	. = ..()
 	//this will create the storage for us.
-	AddComponent(/datum/component/lockable_storage, , stored_lock_code)
+	AddComponent(/datum/component/lockable_storage, stored_lock_code)
 	if(mapload)
 		PopulateContents()
 		find_and_hang_on_wall()


### PR DESCRIPTION

## About The Pull Request
Caused by: 
- #93085

I messed up the formatting for arguments accidentally so the 2nd argument was moved to the 3rd position due to the extra `,`.

## Why It's Good For The Game
Fixes the UI.

## Changelog
:cl:
fix: Fix locked secure safes not showing correct UI
/:cl:
