### PR TITLE
WHEN_MAP() and WHEN_COMPILE()

### DIFF
--- a/code/__DEFINES/map_switch.dm
+++ b/code/__DEFINES/map_switch.dm
@@ -3,6 +3,10 @@
 // or if map tools ever agree on a standard, this should switch to use that.
 #ifdef CBT
 #define MAP_SWITCH(compile_time, map_time) ##compile_time
+#define WHEN_MAP(map_time) // Not mapping, nothing here
+#define WHEN_COMPILE(compile_time) ##compile_time
 #else
 #define MAP_SWITCH(compile_time, map_time) ##map_time
+#define WHEN_MAP(map_time) ##map_time
+#define WHEN_COMPILE(compile_time) // Not compiling, nothing here
 #endif

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -44,15 +44,14 @@
 
 /turf/closed/wall/rust
 	//SDMM supports colors, this is simply for easier mapping
-	//and should be removed on initialize
-	color = MAP_SWITCH(null, COLOR_ORANGE_BROWN)
+	WHEN_MAP(color = COLOR_ORANGE_BROWN)
 
 /turf/closed/wall/rust/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/rust)
 
 /turf/closed/wall/heretic_rust
-	color = MAP_SWITCH(null, COLOR_GREEN_GRAY)
+	WHEN_MAP(color = COLOR_GREEN_GRAY)
 
 /turf/closed/wall/heretic_rust/Initialize(mapload)
 	. = ..()
@@ -60,8 +59,7 @@
 
 /turf/closed/wall/r_wall/rust
 	//SDMM supports colors, this is simply for easier mapping
-	//and should be removed on initialize
-	color = MAP_SWITCH(null, COLOR_ORANGE_BROWN)
+	WHEN_MAP(color = COLOR_ORANGE_BROWN)
 	base_decon_state = "rusty_r_wall"
 
 /turf/closed/wall/r_wall/rust/Initialize(mapload)
@@ -69,7 +67,7 @@
 	AddElement(/datum/element/rust)
 
 /turf/closed/wall/r_wall/heretic_rust
-	color = MAP_SWITCH(null, COLOR_GREEN_GRAY)
+	WHEN_MAP(color = COLOR_GREEN_GRAY)
 
 /turf/closed/wall/r_wall/heretic_rust/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(starlight)
 
 /turf/open/space
 	icon = 'icons/turf/space.dmi'
-	MAP_SWITCH(icon_state = "space", icon_state = "space_map")
+	icon_state = MAP_SWITCH("space", "space_map")
 	name = "\proper space"
 	overfloor_placed = FALSE
 	underfloor_accessibility = UNDERFLOOR_INTERACTABLE
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(starlight)
 	force_no_gravity = TRUE
 
 /turf/open/space/basic
-	MAP_SWITCH(icon_state = "space", icon_state = "space_basic_map")
+	icon_state = MAP_SWITCH("space", "space_basic_map")
 
 /turf/open/space/basic/New() //Do not convert to Initialize
 	SHOULD_CALL_PARENT(FALSE)


### PR DESCRIPTION
## About The Pull Request
Alternatives for MAP_SWITCH when you dont have an "alternative" you want, e.g if you want to override the icon file for mapping but want the type to inherit its parents icon file otherwise

Also tweaks the syntax on the space turf map switches because I didnt realize that was the standard here.

Minor bonus of it being a bit clearer for people who dont know the arg order of mapswitch

Partial upstreaming of https://github.com/DarkPack13/SecondCity/pull/89

## Why It's Good For The Game
More convenient to write.
## Changelog
N/A
