### PR TITLE
Add active RETA to airlock examine

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -515,10 +515,10 @@
  */
 /obj/machinery/door/airlock/proc/has_active_reta_access()
 	if(!CONFIG_GET(flag/reta_enabled))
-		return null
+		return FALSE
 
 	if(!length(req_access) && !length(req_one_access))
-		return null
+		return FALSE
 
 	// Check if this door belongs to a department providing access via RETA
 	for(var/target_dept in GLOB.reta_active_grants)
@@ -536,7 +536,7 @@
 				if(required_access in origin_dept_access)
 					return target_dept
 
-	return null
+	return FALSE
 
 /**
  * Set the airlock state to a new value, change the icon state

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -509,13 +509,16 @@
 /obj/machinery/door/airlock/proc/is_secure()
 	return (security_level > 0)
 
-/// Checks if this door would be affected by any currently active RETA grants
+/**
+ * Checks if this door would be affected by any currently active RETA grants
+ * If a grant is active, return the authorized department
+ */
 /obj/machinery/door/airlock/proc/has_active_reta_access()
 	if(!CONFIG_GET(flag/reta_enabled))
-		return FALSE
+		return null
 
 	if(!length(req_access) && !length(req_one_access))
-		return FALSE
+		return null
 
 	// Check if this door belongs to a department providing access via RETA
 	for(var/target_dept in GLOB.reta_active_grants)
@@ -527,13 +530,13 @@
 
 			for(var/required_access in req_access)
 				if(required_access in origin_dept_access)
-					return TRUE
+					return target_dept
 
 			for(var/required_access in req_one_access)
 				if(required_access in origin_dept_access)
-					return TRUE
+					return target_dept
 
-	return FALSE
+	return null
 
 /**
  * Set the airlock state to a new value, change the icon state
@@ -741,6 +744,10 @@
 			. += "It looks a bit stronger."
 		else
 			. += "It looks very robust."
+
+	var/active_reta = has_active_reta_access()
+	if(active_reta)
+		. += span_nicegreen("Emergency Temporary Access is enabled for [EXAMINE_HINT(active_reta)].")
 
 	if(issilicon(user) && !(machine_stat & BROKEN))
 		. += span_notice("Shift-click [src] to [ density ? "open" : "close"] it.")


### PR DESCRIPTION
## About The Pull Request

Adds the active RETA grant to examine on airlocks.

## Why It's Good For The Game

Lets you know what RETA door access is enabled without having to guess by trying to open it. In the future this could be expanded to different icon states based on active department.

## Changelog

:cl: LT3
qol: Airlock RETA status is now shown on examine
/:cl: