### PR TITLE
Prevents SSwardrobe from messing with modsuit parts

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -30,7 +30,7 @@
 #define NO_MAT_REDEMPTION (1<<5) // Stops you from putting things like an RCD or other items into an ORM or protolathe for materials.
 #define DROPDEL (1<<6) // When dropped, it calls qdel on itself
 #define NOBLUDGEON (1<<7) // when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
-#define MODSUIT_PART (1<<8) // Used to denote anything that is part of a mod suit.
+#define DO_NOT_WARDROBE (1<<8) // Used to denote anything that should not be stashed by SSwardrobe
 /**
  * for all things that are technically items but don't want to be treated as such, given on a case-by-case basis
  * examples of use are hand items, omni-toolsets, non-limb limbs (hand eater, mounted chainsaw, many null rods), borg modules, bodyparts, organs, etc.

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -30,6 +30,7 @@
 #define NO_MAT_REDEMPTION (1<<5) // Stops you from putting things like an RCD or other items into an ORM or protolathe for materials.
 #define DROPDEL (1<<6) // When dropped, it calls qdel on itself
 #define NOBLUDGEON (1<<7) // when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
+#define MODSUIT_PART (1<<8) // Used to denote anything that is part of a mod suit.
 /**
  * for all things that are technically items but don't want to be treated as such, given on a case-by-case basis
  * examples of use are hand items, omni-toolsets, non-limb limbs (hand eater, mounted chainsaw, many null rods), borg modules, bodyparts, organs, etc.

--- a/code/controllers/subsystem/wardrobe.dm
+++ b/code/controllers/subsystem/wardrobe.dm
@@ -210,6 +210,8 @@ SUBSYSTEM_DEF(wardrobe)
 /// Take an existing object, and insert it into our storage
 /// If we can't or won't take it, it's deleted. You do not own this object after passing it in
 /datum/controller/subsystem/wardrobe/proc/stash_object(atom/movable/object)
+	if(object.item_flags & DO_NOT_WARDROBE)
+		return
 	var/object_type = object.type
 	var/list/master_info = canon_minimum[object_type]
 	// I will not permit objects you didn't reserve ahead of time

--- a/code/controllers/subsystem/wardrobe.dm
+++ b/code/controllers/subsystem/wardrobe.dm
@@ -209,7 +209,7 @@ SUBSYSTEM_DEF(wardrobe)
 
 /// Take an existing object, and insert it into our storage
 /// If we can't or won't take it, it's deleted. You do not own this object after passing it in
-/datum/controller/subsystem/wardrobe/proc/stash_object(obj/object)
+/datum/controller/subsystem/wardrobe/proc/stash_object(obj/item/object)
 	if(object.item_flags & DO_NOT_WARDROBE)
 		return
 	var/object_type = object.type

--- a/code/controllers/subsystem/wardrobe.dm
+++ b/code/controllers/subsystem/wardrobe.dm
@@ -209,7 +209,7 @@ SUBSYSTEM_DEF(wardrobe)
 
 /// Take an existing object, and insert it into our storage
 /// If we can't or won't take it, it's deleted. You do not own this object after passing it in
-/datum/controller/subsystem/wardrobe/proc/stash_object(atom/movable/object)
+/datum/controller/subsystem/wardrobe/proc/stash_object(obj/object)
 	if(object.item_flags & DO_NOT_WARDROBE)
 		return
 	var/object_type = object.type

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -52,16 +52,14 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		var/obj/item/checking = items_to_check[i]
 		if(QDELETED(checking)) //Nulls in the list, depressing
 			continue
-		if(istype(checking) && checking.item_flags & DO_NOT_WARDROBE)
-			continue
 		if(!isitem(checking)) //What the fuck are you on
 			to_nuke += checking
+			continue
+		if(checking.item_flags & DO_NOT_WARDROBE) // Skip any items like MOD parts, which are created in the contents of a stashed item and should not be destroyed
 			continue
 
 		var/list/contents = checking.contents
 		if(length(contents))
-			if(istype(checking) && checking.item_flags & DO_NOT_WARDROBE) // Skip any items like MOD parts, which are created in the contents of a stashed item and should not be destroyed, as well as non-items
-				continue
 			items_to_check |= contents //Please don't make an infinite loop somehow thx
 			to_nuke += checking //Goodbye
 			continue

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -52,7 +52,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		var/obj/item/checking = items_to_check[i]
 		if(QDELETED(checking)) //Nulls in the list, depressing
 			continue
-		if(checking.item_flags & DO_NOT_WARDROBE)
+		if(istype(checking) && checking.item_flags & DO_NOT_WARDROBE)
 			continue
 		if(!isitem(checking)) //What the fuck are you on
 			to_nuke += checking

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -58,6 +58,8 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 
 		var/list/contents = checking.contents
 		if(length(contents))
+			if(checking.item_flags & MODSUIT_PART) // Skip any MOD parts, which are created indirectly + reside in the suit's contents, and should be managed by the suit itself
+				continue
 			items_to_check |= contents //Please don't make an infinite loop somehow thx
 			to_nuke += checking //Goodbye
 			continue

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -52,13 +52,15 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		var/obj/item/checking = items_to_check[i]
 		if(QDELETED(checking)) //Nulls in the list, depressing
 			continue
+		if(checking.item_flags & DO_NOT_WARDROBE)
+			continue
 		if(!isitem(checking)) //What the fuck are you on
 			to_nuke += checking
 			continue
 
 		var/list/contents = checking.contents
 		if(length(contents))
-			if(checking.item_flags & MODSUIT_PART) // Skip any MOD parts, which are created indirectly + reside in the suit's contents, and should be managed by the suit itself
+			if(checking.item_flags & DO_NOT_WARDROBE) // Skip any items like MOD parts, which are created in the contents of a stashed item and should not be destroyed
 				continue
 			items_to_check |= contents //Please don't make an infinite loop somehow thx
 			to_nuke += checking //Goodbye

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -60,7 +60,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 
 		var/list/contents = checking.contents
 		if(length(contents))
-			if(checking.item_flags & DO_NOT_WARDROBE) // Skip any items like MOD parts, which are created in the contents of a stashed item and should not be destroyed
+			if(istype(checking) && checking.item_flags & DO_NOT_WARDROBE) // Skip any items like MOD parts, which are created in the contents of a stashed item and should not be destroyed, as well as non-items
 				continue
 			items_to_check |= contents //Please don't make an infinite loop somehow thx
 			to_nuke += checking //Goodbye

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -126,7 +126,7 @@
 		part.set_armor(armor_type)
 		part.resistance_flags = resistance_flags
 		part.flags_1 |= atom_flags //flags like initialization or admin spawning are here, so we cant set, have to add
-		part.item_flags |= MODSUIT_PART
+		part.item_flags |= DO_NOT_WARDROBE
 		part.heat_protection = NONE
 		part.cold_protection = NONE
 		part.max_heat_protection_temperature = max_heat_protection_temperature

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -126,6 +126,7 @@
 		part.set_armor(armor_type)
 		part.resistance_flags = resistance_flags
 		part.flags_1 |= atom_flags //flags like initialization or admin spawning are here, so we cant set, have to add
+		part.item_flags |= MODSUIT_PART
 		part.heat_protection = NONE
 		part.cold_protection = NONE
 		part.max_heat_protection_temperature = max_heat_protection_temperature


### PR DESCRIPTION
## About The Pull Request

If you have an outfit with a modsuit control, and are equipping it to a dummy for previews, when you unequip it SSwardrobe tries to delete the individual parts when stashing the mod control since they are in the suit's `contents`.

The control is then stashed, and the parts all cause hard deletes after a while since the suit itself is still holding a ref to all of them.

Since there is currently no good fast way of checking all the modsuit parts outside of a nest of istypes I added an item flag for it.

## Why It's Good For The Game

Fixes an oversight, should not have any performance impact.

## Changelog

:cl:
fix: fixes an oversight where the wardrobe system tries to delete modsuit parts when stashing the modsuit
/:cl: