### PR TITLE
Prevents double-dipping when making fake walls

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -134,7 +134,7 @@
 			qdel(src)
 		return
 
-	if(istype(stack, /obj/item/stack/sheet/iron))
+	else if(istype(stack, /obj/item/stack/sheet/iron))
 		var/amount = construction_cost[/obj/item/stack/sheet/iron]
 		if(state == GIRDER_DISPLACED)
 			if(stack.get_amount() < amount)
@@ -180,7 +180,7 @@
 				qdel(src)
 			return
 
-	if(istype(stack, /obj/item/stack/sheet/titaniumglass) && state == GIRDER_TRAM)
+	else if(istype(stack, /obj/item/stack/sheet/titaniumglass) && state == GIRDER_TRAM)
 		var/amount = construction_cost[/obj/item/stack/sheet/titaniumglass]
 		if(stack.get_amount() < amount)
 			balloon_alert(user, "need [amount] sheets!")
@@ -195,7 +195,7 @@
 			qdel(src)
 		return
 
-	if(istype(stack, /obj/item/stack/sheet/plasteel))
+	else if(istype(stack, /obj/item/stack/sheet/plasteel))
 		var/amount = construction_cost[/obj/item/stack/sheet/plasteel]
 		if(state == GIRDER_DISPLACED)
 			if(stack.get_amount() < amount)
@@ -238,7 +238,7 @@
 				qdel(src)
 			return
 
-	if(istype(stack, /obj/item/stack/sheet/mineral/plastitanium))
+	else if(istype(stack, /obj/item/stack/sheet/mineral/plastitanium))
 		if(state == GIRDER_REINF)
 			if(stack.get_amount() < 1)
 				return
@@ -254,7 +254,7 @@
 			return
 		// No return here because generic material construction handles making normal plastitanium walls
 
-	if(!stack.has_unique_girder && stack.material_type)
+	else if(!stack.has_unique_girder && stack.material_type)
 		if(istype(src, /obj/structure/girder/reinforced))
 			balloon_alert(user, "need plasteel or plastitanium!")
 			return


### PR DESCRIPTION

## About The Pull Request

Makes each "if stack is this material type" an "else if" in the fake wall making code, preventing trying a second time after failing a `do_after()`

## Why It's Good For The Game

You can currently do this:


https://github.com/user-attachments/assets/b4fa2ecc-84e8-48fb-9bf9-7ba8388de9a7

You should not be able to do that, for two reasons.

## Changelog
:cl:

fix: prevents retrying making a fake wall from range

/:cl:
