### PR TITLE
Fixes some theme CSS

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1215,9 +1215,13 @@
 			if("operative")
 				outline_color = COLOR_THEME_OPERATIVE
 			if("clockwork")
-				outline_color = COLOR_THEME_CLOCKWORK //if you want free gbp go fix the fact that clockwork's tooltip css is glass'
+				outline_color = COLOR_THEME_CLOCKWORK
 			if("glass")
 				outline_color = COLOR_THEME_GLASS
+			if("trasen-knox")
+				outline_color = COLOR_THEME_TRASENKNOX
+			if("detective")
+				outline_color = COLOR_THEME_DETECTIVE
 			else //this should never happen, hopefully
 				outline_color = COLOR_WHITE
 	if(color)

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -160,6 +160,24 @@
         background-color: #282831;
       }
 
+      .clockwork .wrap {
+        border-color: #cfbc47;
+      }
+      .clockwork .content {
+        color: #b18e25;
+        border-color: #cfbc47;
+        background-color: #523c15;
+      }
+
+      .glass .wrap {
+        border-color: #344b58;
+      }
+      .glass .content {
+        color: #75a4c4;
+        border-color: #344b58;
+        background-color: #1f252b;
+      }
+
       .trasen-knox .wrap {
         border-color: #998e81;
       }
@@ -172,7 +190,7 @@
       .detective .wrap {
         border-color: #2c0f0c;
       }
-      .detective .wrap {
+      .detective .content {
         color: #c7b08b;
         border-color: #2c0f0c;
         background-color: #221c1a;


### PR DESCRIPTION
## About The Pull Request

I came across a 5 year old comment to fix some theme CSS, so I did.

- Adds themes missing UI outlines
- Adds themes missing tooltip CSS
- Fixes Detective theme CSS

## Why It's Good For The Game

Fix bug

## Changelog

:cl: LT3
fix: Fixed Clockwork, Glass, and Detective tooltip styling
fix: Fixed Trasen-Knox and Detective UI highlighting
/:cl: