### PR TITLE
Fixes SS_KEEP_TIMING causing RUNLEVEL_LOBBY subsystems to fire with 75% their set wait

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -620,8 +620,9 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 			var/delay = SS.wait
 			if(SS.flags & SS_TICKER)
 				delay = TICKS2DS(delay)
-			SS.next_fire = world.time + rand(0, min(delay, 2 SECONDS))
-			
+			// Gotta convert to ticks cause rand needs integers
+			SS.next_fire = world.time + TICKS2DS(rand(0, DS2TICKS(min(delay, 2 SECONDS))))
+
 		var/ss_runlevels = SS.runlevels
 		var/added_to_any = FALSE
 		for(var/I in 1 to GLOB.bitflags.len)
@@ -721,7 +722,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 					var/delay = SS.wait
 					if(SS.flags & SS_TICKER)
 						delay = TICKS2DS(delay)
-					SS.next_fire = world.time + rand(0, min(delay, 2 SECONDS))
+					SS.next_fire = world.time + TICKS2DS(rand(0, DS2TICKS(min(delay, 2 SECONDS))))
 
 			subsystems_to_check = current_runlevel_subsystems
 		else

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -390,11 +390,11 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 	// Topological sorting algorithm end
 
 	if(length(subsystems) != length(sorted_subsystems))
-		var/list/circular_dependency = subsystems.Copy() - sorted_subsystems
+		var/list/circular_dependency = subsystems - sorted_subsystems
 		var/list/debug_msg = list()
 		var/list/usr_msg = list()
 		for(var/datum/controller/subsystem/subsystem as anything in circular_dependency)
-			usr_msg += "[subsystem.name]"
+			usr_msg += subsystem.name
 
 		var/list/datum/controller/subsystem/nodes = list(circular_dependency[1])
 		var/list/loop = list()
@@ -610,10 +610,18 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 		if ((SS.flags & (SS_TICKER|SS_BACKGROUND)) == SS_TICKER)
 			tickersubsystems += SS
 			// Timer subsystems aren't allowed to bunch up, so we offset them a bit
-			timer += world.tick_lag * rand(0, 1)
+			timer += TICKS2DS(rand(0, 1))
 			SS.next_fire = timer
 			continue
 
+		// Now, we have to set starting next_fires for all our new non ticker kids
+		if(SS.init_stage == init_stage - 1 && (SS.runlevels & current_runlevel))
+			// Give em a random offset so things don't clump up too bad
+			var/delay = SS.wait
+			if(SS.flags & SS_TICKER)
+				delay = TICKS2DS(delay)
+			SS.next_fire = world.time + rand(0, min(delay, 2 SECONDS))
+			
 		var/ss_runlevels = SS.runlevels
 		var/added_to_any = FALSE
 		for(var/I in 1 to GLOB.bitflags.len)
@@ -709,7 +717,11 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 					//we only want to offset it if it's new and also behind
 					if(SS.next_fire > world.time || (SS in old_subsystems))
 						continue
-					SS.next_fire = world.time + world.tick_lag * rand(0, DS2TICKS(min(SS.wait, 2 SECONDS)))
+					// If they're new, give em a random offset so things don't clump up too bad
+					var/delay = SS.wait
+					if(SS.flags & SS_TICKER)
+						delay = TICKS2DS(delay)
+					SS.next_fire = world.time + rand(0, min(delay, 2 SECONDS))
 
 			subsystems_to_check = current_runlevel_subsystems
 		else
@@ -804,6 +816,8 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 		if (SS_flags & SS_NO_FIRE)
 			subsystemstocheck -= SS
 			continue
+		// If we're keeping timing and running behind,
+		// fire at most 25% faster then normal to try and make up the gap without spamming
 		if ((SS_flags & (SS_TICKER|SS_KEEP_TIMING)) == SS_KEEP_TIMING && SS.last_fire + (SS.wait * 0.75) > world.time)
 			continue
 		if (SS.postponed_fires >= 1)


### PR DESCRIPTION
## About The Pull Request

Ok so this explanation is gonna suck a bit I'm sorry. I was sittin in coderbus and @flleeppyy mentioned this problem where SSticker counted down to roundstart significantly faster then it should.

I poked on tg, and saw the same behavior. I did further poking, and realized that despite wait being 20ds, the actual delay between fires was 15ds.

I'll spare you the rest of the story, it turned out that SSticker's next_fire was set to 0 at the start instead of world.time, so when we did the KEEP_TIMING thing of incrementing next_fire by wait, we were pretty much always going to be trying to fire on the very next tick.

This was prevented by the existing sanity check which limits how fast KEEP_TIMING subsystems are allowed to try and recover their tick locked nature, reducing it to 15ds instead of 1ds delay.

The actual problem here was next_fire not being set properly, which is normally handled by a block in the while(1) block that checks to see if the run level has changed. Unfortunately if you have the starting run level, this never happens.

This impacts EXACTLY SSticker, and nothing else. For now at least.

Solution is to write similar code in Loop's setup block, which brings SSticker's roundstart timer back into parity with real life. This has the nice side effect of achieving the randomized starting delays we want for subsystems, to prevent clumping. See discussion on #71730 for more on that. 

I'm going straight off the dome on this one. Didn't wanna bug mto about it if I feel comfortable and all.

Please note, this does mean the roundstart lobby time is slower now, it's accurate but it's slower. Might need config changes idk. 

I also added some code that checks to see if the subsystem we're randomizing is a ticker or not, I'm kind of dubious on the "wait is actually TICKS for ONLY TICKER" thing but I'm not comfortable enough to change that yet.

## Why It's Good For The Game

When we say the round starts in 5 minutes, it should actually do that.

## Changelog
:cl:
fix: Fixed a timing issue with SS_KEEP_TIMING subsystems, which impacts exactly SSticker. TLDR is roundstart will now actually take the time it says it does, instead of 75% of it.
config: The roundstart delay config is now accurate, so you may want to decrease it to not overlengthen lobby time. IDK you decide.
/:cl:
