### PR TITLE
Removes october revolution holiday

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -723,20 +723,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/vegan/getStationPrefix()
 	return pick("Tofu", "Tempeh", "Seitan", "Tofurkey")
 
-/datum/holiday/october_revolution
-	name = "October Revolution"
-	begin_day = 6
-	begin_month = NOVEMBER
-	end_day = 7
-	holiday_colors = list(
-		COLOR_MEDIUM_DARK_RED,
-		COLOR_GOLD,
-		COLOR_MEDIUM_DARK_RED,
-	)
-
-/datum/holiday/october_revolution/getStationPrefix()
-	return pick("Communist", "Soviet", "Bolshevik", "Socialist", "Red", "Workers'")
-
 /datum/holiday/remembrance_day
 	name = "Remembrance Day"
 	begin_month = NOVEMBER


### PR DESCRIPTION
## About The Pull Request

removes october revolution holiday

## Why It's Good For The Game

**firstly and mainly**: we SHOULDNT bring ideological holidays in this game. at all. nothing left/right, its a silly space game.
**secondly:** we shouldnt make holidays from tragedies, genocides, etc. october revolution led to deaths of millions, mass famine, repressions and other political BS, that we shouldnt have in-game holiday, that glorifies events leading to all of this.
**thirdly**: yes, we do have a bastille or US independence days and they were revolutions with many deaths too indeed, im not a big fan of keeping those aswell, but theyre different from october revolution and serve more of a national/country holiday purpose. feel free to remove them, but my points is october day.

we already have a labor/worker day as holiday and thats what we should actually keep, if initial purpose of october revolution PR was to be a holiday about workers.


## Changelog

:cl:
del: October Revolution day was removed.
/:cl:
