### PR TITLE
Deletes every 'political' holiday ever

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -130,50 +130,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 
 // FEBRUARY
 
-/datum/holiday/groundhog
-	name = "Groundhog Day"
-	begin_day = 2
-	begin_month = FEBRUARY
-
-/datum/holiday/groundhog/getStationPrefix()
-	return pick("Deja Vu") //I have been to this place before
-
-/datum/holiday/nz
-	name = "Waitangi Day"
-	timezones = list(TIMEZONE_NZDT, TIMEZONE_CHADT)
-	begin_day = 6
-	begin_month = FEBRUARY
-	holiday_colors = list(
-		COLOR_UNION_JACK_BLUE,
-		COLOR_WHITE,
-		COLOR_UNION_JACK_RED,
-		COLOR_WHITE,
-	)
-
-/datum/holiday/nz/getStationPrefix()
-	return pick("Aotearoa","Kiwi","Fish 'n' Chips","Kākāpō","Southern Cross")
-
-/datum/holiday/nz/greet()
-	var/nz_age = text2num(time2text(world.timeofday, "YYYY", TIMEZONE_NZST)) - 1840
-	return "On this day [nz_age] years ago, New Zealand's Treaty of Waitangi, the founding document of the nation, was signed!"
-
-/datum/holiday/valentines
-	name = VALENTINES
-	begin_day = 13
-	end_day = 15
-	begin_month = FEBRUARY
-	poster_name = "lovey poster"
-	poster_desc = "A poster celebrating all the relationships built today. Of course, you probably don't have one."
-	poster_icon = "holiday_love"
-	holiday_mail = list(
-		/obj/item/food/bonbon/chocolate_truffle,
-		/obj/item/food/candyheart,
-		/obj/item/food/grown/rose,
-		)
-
-/datum/holiday/valentines/getStationPrefix()
-	return pick("Love","Amore","Single","Smootch","Hug")
-
 /datum/holiday/birthday
 	name = "Birthday of Space Station 13"
 	begin_day = 16
@@ -258,29 +214,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/pi/getStationPrefix()
 	return pick("Sine","Cosine","Tangent","Secant", "Cosecant", "Cotangent")
 
-/datum/holiday/no_this_is_patrick
-	name = "St. Patrick's Day"
-	begin_day = 17
-	begin_month = MARCH
-	holiday_hat = /obj/item/clothing/head/soft/green
-	holiday_colors = list(
-		COLOR_IRISH_GREEN,
-		COLOR_WHITE,
-		COLOR_IRISH_ORANGE,
-	)
-	holiday_pattern = PATTERN_VERTICAL_STRIPE
-	/// Could we settle this over a pint?
-	holiday_mail = list(
-		/obj/item/reagent_containers/cup/glass/bottle/ale,
-		/obj/item/reagent_containers/cup/glass/drinkingglass/filled/irish_cream,
-	)
-
-/datum/holiday/no_this_is_patrick/getStationPrefix()
-	return pick("Blarney","Green","Leprechaun","Booze")
-
-/datum/holiday/no_this_is_patrick/greet()
-	return "Happy National Inebriation Day!"
-
 // APRIL
 
 /datum/holiday/april_fools
@@ -315,21 +248,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/spess/greet()
 	return "On this day over 600 years ago, Comrade Yuri Gagarin first ventured into space!"
 
-/datum/holiday/fourtwenty
-	name = "Four-Twenty"
-	begin_day = 20
-	begin_month = APRIL
-	holiday_hat = /obj/item/clothing/head/rasta
-	holiday_colors = list(
-		COLOR_ETHIOPIA_GREEN,
-		COLOR_ETHIOPIA_YELLOW,
-		COLOR_ETHIOPIA_RED,
-	)
-	holiday_mail = list(/obj/item/cigarette/rollie/cannabis)
-
-/datum/holiday/fourtwenty/getStationPrefix()
-	return pick("Snoop","Blunt","Toke","Dank","Cheech","Chong")
-
 /datum/holiday/tea
 	name = "National Tea Day"
 	begin_day = 21
@@ -339,29 +257,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/tea/getStationPrefix()
 	return pick("Crumpet","Assam","Oolong","Pu-erh","Sweet Tea","Green","Black")
 
-/datum/holiday/earth
-	name = "Earth Day"
-	begin_day = 22
-	begin_month = APRIL
-
-/datum/holiday/anz
-	name = "ANZAC Day"
-	timezones = list(TIMEZONE_TKT, TIMEZONE_TOT, TIMEZONE_NZST, TIMEZONE_NFT, TIMEZONE_LHST, TIMEZONE_AEST, TIMEZONE_ACST, TIMEZONE_ACWST, TIMEZONE_AWST, TIMEZONE_CXT, TIMEZONE_CCT, TIMEZONE_CKT, TIMEZONE_NUT)
-	begin_day = 25
-	begin_month = APRIL
-	holiday_hat = /obj/item/food/grown/poppy
-
-/datum/holiday/anz/getStationPrefix()
-	return pick("Australian","New Zealand","Poppy", "Southern Cross")
-
 // MAY
-
-/datum/holiday/labor
-	name = "Labor Day"
-	begin_day = 1
-	begin_month = MAY
-	holiday_hat = /obj/item/clothing/head/utility/hardhat
-	no_mail_holiday = TRUE
 
 //Draconic Day is celebrated on May 3rd, the date on which the Draconic language was merged (#26780)
 /datum/holiday/draconic_day
@@ -384,20 +280,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 
 /datum/holiday/firefighter/getStationPrefix()
 	return pick("Burning","Blazing","Plasma","Fire")
-
-/datum/holiday/bee
-	name = "Bee Day"
-	begin_day = 20
-	begin_month = MAY
-	holiday_mail = list(
-		/obj/item/clothing/suit/hooded/bee_costume,
-		/obj/item/food/honeycomb,
-		/obj/item/food/monkeycube/bee,
-		/obj/item/toy/plush/beeplushie,
-	)
-
-/datum/holiday/bee/getStationPrefix()
-	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")
 
 /datum/holiday/goth
 	name = "Goth Day"
@@ -450,48 +332,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_month = JUNE
 	holiday_hat = /obj/item/clothing/head/costume/garland
 
-/datum/holiday/pride_week
-	name = PRIDE_WEEK
-	begin_month = JUNE
-	// Stonewall was June 28th, this captures its week.
-	begin_day = 23
-	end_day = 29
-	holiday_colors = list(
-		COLOR_PRIDE_PURPLE,
-		COLOR_PRIDE_BLUE,
-		COLOR_PRIDE_GREEN,
-		COLOR_PRIDE_YELLOW,
-		COLOR_PRIDE_ORANGE,
-		COLOR_PRIDE_RED,
-	)
-	holiday_mail = list(
-		/obj/item/bedsheet/rainbow,
-		/obj/item/clothing/accessory/pride,
-		/obj/item/clothing/gloves/color/rainbow,
-		/obj/item/clothing/head/costume/garland/rainbowbunch,
-		/obj/item/clothing/head/soft/rainbow,
-		/obj/item/clothing/shoes/sneakers/rainbow,
-		/obj/item/clothing/under/color/jumpskirt/rainbow,
-		/obj/item/clothing/under/color/rainbow,
-		/obj/item/food/egg/rainbow,
-		/obj/item/food/grown/rainbow_flower,
-		/obj/item/food/snowcones/rainbow,
-		/obj/item/toy/crayon/rainbow,
-	)
-
-// JULY
-
-/datum/holiday/doctor
-	name = "Doctor's Day"
-	begin_day = 1
-	begin_month = JULY
-	holiday_hat = /obj/item/clothing/head/costume/nursehat
-	holiday_mail = list(
-		/obj/item/stack/medical/gauze,
-		/obj/item/stack/medical/ointment,
-		/obj/item/storage/box/bandages,
-	)
-
 /datum/holiday/ufo
 	name = "UFO Day"
 	begin_day = 2
@@ -507,50 +347,11 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/ufo/getStationPrefix() //Is such a thing even possible?
 	return pick("Ayy","Truth","Tsoukalos","Mulder","Scully") //Yes it is!
 
-/datum/holiday/usa
-	name = "US Independence Day"
-	timezones = list(TIMEZONE_EDT, TIMEZONE_CDT, TIMEZONE_MDT, TIMEZONE_MST, TIMEZONE_PDT, TIMEZONE_AKDT, TIMEZONE_HDT, TIMEZONE_HST)
-	begin_day = 4
-	begin_month = JULY
-	no_mail_holiday = TRUE
-	holiday_hat = /obj/item/clothing/head/cowboy/brown
-	holiday_colors = list(
-		COLOR_OLD_GLORY_BLUE,
-		COLOR_OLD_GLORY_RED,
-		COLOR_WHITE,
-		COLOR_OLD_GLORY_RED,
-		COLOR_WHITE,
-	)
-
-
-/datum/holiday/usa/getStationPrefix()
-	return pick("Independent","American","Burger","Bald Eagle","Star-Spangled", "Fireworks")
-
 /datum/holiday/writer
 	name = "Writer's Day"
 	begin_day = 8
 	begin_month = JULY
 	holiday_mail = list(/obj/item/pen/fountain)
-
-/datum/holiday/france
-	name = "Bastille Day"
-	timezones = list(TIMEZONE_CEST)
-	begin_day = 14
-	begin_month = JULY
-	holiday_hat = /obj/item/clothing/head/beret
-	no_mail_holiday = TRUE
-	holiday_colors = list(
-		COLOR_FRENCH_BLUE,
-		COLOR_WHITE,
-		COLOR_FRENCH_RED
-	)
-	holiday_pattern = PATTERN_VERTICAL_STRIPE
-
-/datum/holiday/france/getStationPrefix()
-	return pick("Francais", "Fromage", "Zut", "Merde", "Sacrebleu")
-
-/datum/holiday/france/greet()
-	return "Do you hear the people sing?"
 
 /datum/holiday/hotdogday
 	name = HOTDOG_DAY
@@ -579,27 +380,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 
 /datum/holiday/friendship/greet()
 	return "Have a magical [name]!"
-
-// AUGUST
-
-/datum/holiday/indigenous //Indigenous Peoples' Day from Earth!
-	name = "International Day of the World's Indigenous Peoples"
-	begin_month = AUGUST
-	begin_day = 9
-
-/datum/holiday/indigenous/getStationPrefix()
-	return pick("Endangered language", "Word", "Language", "Language revitalization", "Potato", "Corn")
-
-// AUGUST
-
-/datum/holiday/ukraine
-	name = "Independence Day of Ukraine"
-	begin_month = AUGUST
-	begin_day = 24
-	holiday_colors = list(COLOR_TRUE_BLUE, COLOR_TANGERINE_YELLOW)
-
-/datum/holiday/ukraine/getStationPrefix()
-	return pick("Kyiv", "Ukraine")
 
 // SEPTEMBER
 
@@ -639,19 +419,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/ianbirthday/getStationPrefix()
 	return pick("Ian", "Corgi", "Erro")
 
-/datum/holiday/pirate
-	name = "Talk-Like-a-Pirate Day"
-	begin_day = 19
-	begin_month = SEPTEMBER
-	holiday_hat = /obj/item/clothing/head/costume/pirate
-	holiday_mail = list(/obj/item/clothing/head/costume/pirate)
-
-/datum/holiday/pirate/greet()
-	return "Ye be talkin' like a pirate today or else ye'r walkin' tha plank, matey!"
-
-/datum/holiday/pirate/getStationPrefix()
-	return pick("Yarr","Scurvy","Yo-ho-ho")
-
 /datum/holiday/questions
 	name = "Stupid-Questions Day"
 	begin_day = 28
@@ -662,14 +429,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 
 // OCTOBER
 
-/datum/holiday/animal
-	name = "Animal's Day"
-	begin_day = 4
-	begin_month = OCTOBER
-
-/datum/holiday/animal/getStationPrefix()
-	return pick("Parrot","Corgi","Cat","Pug","Goat","Fox")
-
 /datum/holiday/smile
 	name = "Smiling Day"
 	begin_day = 7
@@ -677,82 +436,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	holiday_hat = /obj/item/clothing/head/costume/papersack/smiley
 	holiday_mail = list(/obj/item/sticker/smile)
 
-/datum/holiday/boss
-	name = "Boss' Day"
-	begin_day = 16
-	begin_month = OCTOBER
-	holiday_hat = /obj/item/clothing/head/hats/tophat
-
-/datum/holiday/un_day
-	name = "Anniversary of the Foundation of the United Nations"
-	begin_month = OCTOBER
-	begin_day = 24
-
-/datum/holiday/un_day/greet()
-	return "On this day in 1945, the United Nations was founded, laying the foundation for humanity's united government!"
-
-/datum/holiday/un_day/getStationPrefix()
-	return pick("United", "Cooperation", "Humanitarian")
-
-/datum/holiday/halloween
-	name = HALLOWEEN
-	begin_day = 29
-	begin_month = OCTOBER
-	end_day = 2
-	end_month = NOVEMBER
-	holiday_colors = list(COLOR_MOSTLY_PURE_ORANGE, COLOR_PRISONER_BLACK)
-	holiday_mail = list(
-		/obj/item/food/cookie/sugar/spookycoffin,
-		/obj/item/food/cookie/sugar/spookyskull,
-		)
-
-/datum/holiday/halloween/greet()
-	return "Have a spooky Halloween!"
-
-/datum/holiday/halloween/getStationPrefix()
-	return pick("Bone-Rattling","Mr. Bones' Own","2SPOOKY","Spooky","Scary","Skeletons")
-
 // NOVEMBER
-
-/datum/holiday/vegan
-	name = "Vegan Day"
-	begin_day = 1
-	begin_month = NOVEMBER
-	holiday_mail = list(/obj/item/food/tofu)
-
-/datum/holiday/vegan/getStationPrefix()
-	return pick("Tofu", "Tempeh", "Seitan", "Tofurkey")
-
-/datum/holiday/october_revolution
-	name = "October Revolution"
-	begin_day = 6
-	begin_month = NOVEMBER
-	end_day = 7
-	holiday_colors = list(
-		COLOR_MEDIUM_DARK_RED,
-		COLOR_GOLD,
-		COLOR_MEDIUM_DARK_RED,
-	)
-
-/datum/holiday/october_revolution/getStationPrefix()
-	return pick("Communist", "Soviet", "Bolshevik", "Socialist", "Red", "Workers'")
-
-/datum/holiday/remembrance_day
-	name = "Remembrance Day"
-	begin_month = NOVEMBER
-	begin_day = 11
-	holiday_hat = /obj/item/food/grown/poppy
-	holiday_mail = list(
-		/obj/item/food/grown/harebell,
-		/obj/item/food/grown/poppy,
-		/obj/item/storage/fancy/candle_box,
-	)
-
-/datum/holiday/remembrance_day/greet()
-	return "Lest we forget."
-
-/datum/holiday/remembrance_day/getStationPrefix()
-	return pick("Peace", "Armistice", "Poppy")
 
 /datum/holiday/lifeday
 	name = "Life Day"
@@ -812,21 +496,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 
 // DECEMBER
 
-/datum/holiday/festive_season
-	name = FESTIVE_SEASON
-	begin_day = 1
-	begin_month = DECEMBER
-	end_day = 31
-	holiday_hat = /obj/item/clothing/head/costume/santa
-
-/datum/holiday/festive_season/greet()
-	return "Have a nice festive season!"
-
-/datum/holiday/human_rights
-	name = "Human-Rights Day"
-	begin_day = 10
-	begin_month = DECEMBER
-
 /datum/holiday/monkey
 	name = MONKEYDAY
 	begin_day = 14
@@ -840,53 +509,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	name = "Mayan Doomsday Anniversary"
 	begin_day = 21
 	begin_month = DECEMBER
-
-/datum/holiday/xmas
-	name = CHRISTMAS
-	begin_day = 18
-	begin_month = DECEMBER
-	end_day = 27
-	holiday_hat = /obj/item/clothing/head/costume/santa
-	no_mail_holiday = TRUE
-	holiday_colors = list(
-		COLOR_CHRISTMAS_GREEN,
-		COLOR_CHRISTMAS_RED,
-	)
-
-/datum/holiday/xmas/getStationPrefix()
-	return pick(
-		"Bible",
-		"Birthday",
-		"Chimney",
-		"Claus",
-		"Crucifixion",
-		"Elf",
-		"Fir",
-		"Ho Ho Ho",
-		"Jesus",
-		"Jolly",
-		"Merry",
-		"Present",
-		"Sack",
-		"Santa",
-		"Sleigh",
-		"Yule",
-	)
-
-/datum/holiday/xmas/greet()
-	return "Have a merry Christmas!"
-
-/datum/holiday/boxing
-	name = "Boxing Day"
-	begin_day = 26
-	begin_month = DECEMBER
-	holiday_mail = list(
-		/obj/item/clothing/gloves/boxing,
-		/obj/item/clothing/gloves/boxing/blue,
-		/obj/item/clothing/gloves/boxing/green,
-		/obj/item/clothing/gloves/boxing/yellow,
-	)
-
 /datum/holiday/new_year
 	name = NEW_YEAR
 	begin_day = 31
@@ -928,142 +550,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 
 /datum/holiday/programmers/getStationPrefix()
 	return pick("span>","DEBUG: ","null","/list","EVENT PREFIX NOT FOUND") //Portability
-
-// ISLAMIC
-
-/datum/holiday/islamic
-	name = "Islamic calendar code broken"
-
-/datum/holiday/islamic/shouldCelebrate(dd, mm, yyyy, ddd)
-	var/datum/foreign_calendar/islamic/cal = new(yyyy, mm, dd)
-	return ..(cal.dd, cal.mm, cal.yyyy, ddd)
-
-/datum/holiday/islamic/ramadan
-	name = "Start of Ramadan"
-	begin_month = 9
-	begin_day = 1
-	end_day = 3
-
-/datum/holiday/islamic/ramadan/getStationPrefix()
-	return pick("Haram","Halaal","Jihad","Muslim", "Al", "Mohammad", "Rashidun", "Umayyad", "Abbasid", "Abdul", "Fatimid", "Ayyubid", "Almohad", "Abu")
-
-/datum/holiday/islamic/ramadan/end
-	name = "End of Ramadan"
-	end_month = 10
-	begin_day = 28
-	end_day = 1
-
-// HEBREW
-
-/datum/holiday/hebrew
-	name = "If you see this the Hebrew holiday calendar code is broken"
-
-/datum/holiday/hebrew/shouldCelebrate(dd, mm, yyyy, ddd)
-	var/datum/foreign_calendar/hebrew/cal = new(yyyy, mm, dd)
-	return ..(cal.dd, cal.mm, cal.yyyy, ddd)
-
-/datum/holiday/hebrew/hanukkah
-	name = "Hanukkah"
-	begin_day = 25
-	begin_month = 9
-	end_day = 2
-	end_month = 10
-
-/datum/holiday/hebrew/hanukkah/greet()
-	return "Happy [pick("Hanukkah", "Chanukah")]!"
-
-/datum/holiday/hebrew/hanukkah/getStationPrefix()
-	return pick("Dreidel", "Menorah", "Latkes", "Gelt")
-
-/datum/holiday/hebrew/passover
-	name = "Passover"
-	begin_day = 15
-	begin_month = 1
-	end_day = 22
-
-/datum/holiday/hebrew/passover/getStationPrefix()
-	return pick("Matzah", "Moses", "Red Sea")
-
-// HOLIDAY ADDONS
-
-/datum/holiday/xmas/celebrate()
-	. = ..()
-	SSticker.OnRoundstart(CALLBACK(src, PROC_REF(roundstart_celebrate)))
-	GLOB.maintenance_loot += list(
-		list(
-			/obj/item/clothing/head/costume/santa = 1,
-			/obj/item/gift/anything = 1,
-			/obj/item/toy/xmas_cracker = 3,
-		) = maint_holiday_weight,
-	)
-
-/datum/holiday/xmas/proc/roundstart_celebrate()
-	for(var/obj/machinery/computer/security/telescreen/entertainment/Monitor as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		Monitor.icon_state_on = "entertainment_xmas"
-
-	for(var/mob/living/basic/pet/dog/corgi/ian/Ian in GLOB.mob_living_list)
-		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
-
-
-// EASTER (this having its own spot should be understandable)
-
-/datum/holiday/easter
-	name = EASTER
-	holiday_hat = /obj/item/clothing/head/costume/rabbitears
-	holiday_mail = list(
-		/obj/item/clothing/head/costume/rabbitears,
-		/obj/item/food/chocolatebunny,
-		/obj/item/food/chocolateegg,
-		/obj/item/food/egg/blue,
-		/obj/item/food/egg/green,
-		/obj/item/food/egg/orange,
-		/obj/item/food/egg/purple,
-		/obj/item/food/egg/rainbow,
-		/obj/item/food/egg/red,
-		/obj/item/food/egg/yellow,
-	)
-	var/const/days_early = 1 //to make editing the holiday easier
-	var/const/days_extra = 1
-
-/datum/holiday/easter/shouldCelebrate(dd, mm, yyyy, ddd)
-	if(!begin_month)
-		current_year = text2num(time2text(world.timeofday, "YYYY", world.timezone))
-		var/list/easterResults = EasterDate(current_year+year_offset)
-
-		begin_day = easterResults["day"]
-		begin_month = easterResults["month"]
-
-		end_day = begin_day + days_extra
-		end_month = begin_month
-		if(end_day >= 32 && end_month == MARCH) //begins in march, ends in april
-			end_day -= 31
-			end_month++
-		if(end_day >= 31 && end_month == APRIL) //begins in april, ends in june
-			end_day -= 30
-			end_month++
-
-		begin_day -= days_early
-		if(begin_day <= 0)
-			if(begin_month == APRIL)
-				begin_day += 31
-				begin_month-- //begins in march, ends in april
-
-	return ..()
-
-/datum/holiday/easter/celebrate()
-	. = ..()
-	GLOB.maintenance_loot += list(
-		list(
-			/obj/item/surprise_egg = 15,
-			/obj/item/storage/basket/easter = 15
-		) = maint_holiday_weight,
-	)
-
-/datum/holiday/easter/greet()
-	return "Greetings! Have a Happy Easter and keep an eye out for Easter Bunnies!"
-
-/datum/holiday/easter/getStationPrefix()
-	return pick("Fluffy","Bunny","Easter","Egg")
 
 /// Takes a holiday datum, a starting month, ending month, max amount of days to test in, and min/max year as input
 /// Returns a list in the form list("yyyy/m/d", ...) representing all days the holiday runs on in the tested range


### PR DESCRIPTION

## About The Pull Request

As https://github.com/tgstation/tgstation/pull/93806 has brought up an excellent point that we shouldn't celebrate things like alternatives to capitalism, hope for a better world or anything, really, I've decided to follow their lead and remove as many political holidays as I can.

Sadly the Gregorian Calander (made by a Pope) has to stay. 

## Why It's Good For The Game
politic bad actually


-St. Patrick's Day. Catholic event, promotes catholicism and Irish Republicanism (colours used are the Irish Tricolour.)

-Four-Twenty. Promotes drug use.

-Earth Day. Promotes a green/environmentalist ideology.

-ANZAC Day. Promotes all Australians and New Zealanders "who served and died in all wars, conflicts, and peacekeeping operations" which by definition would include those who fought in Vietnam against the liberation forces, and all colonial police.

-Pride. Promotes the idea that LGBT people should be allowed to exist. I agree with that, as well as most of the ones I'm listing but it's still promoting a political message so we should get that going too.

-US Independence Day. As you mentioned. The death toll of the American Empire, which, as your comment on the Soviet Union mentioned, includes "tragedies, genocides, etc.", American Independence led to the deaths of millions, mass famine, repressions and other political BS.

-Bastille Day. Same story. The French Revolution led to the deaths of millions, mass famine, repressions and other political BS.

-Independence Day of Ukraine. Promotes the idea that Ukraine should exist. Gotta go. It's Ukraine Republicanism, an ideology.

-Talk-Like-a-Pirate Day. Pirates killed and raped a lot of people, we shouldn't celebrate that by this PR's logic.

-Animal's Day. Animal rights, going.

-Boss' Day. Pro-Capitalist ideology.

-Anniversary of the Foundation of the United Nations. Political, pro-UN ideology.

-HALLOWEEN. Promotes paganism.

-Vegan Day. Animal rights, again.

-Remembrance Day. Celebrates all British troops, including those who murdered innocent irish citizens during Bloody Sunday and other activities. This is the one here I genuinely, unironically support removing.

-Christmas. Supports Christian ideology, the idea that Jesus Christ was a God.

-Human-Rights Day. Human rights, a political issue.

-Boxing Day/Saint Stephen's Day. Both promote Christan Ideology.

-The entire Islamic calendar. Promotes Islamic traditions.

-The entire Hebrew calender. Promotes Jewish traditions.

-Easter. Promotes Rabbits, and also the idea that Jesus came back to life (necromancy, black magic.).

## Changelog
:cl:
del: No more politics ever.
/:cl:
