### PR TITLE
fixes runtime in plumbing iv add_context()

### DIFF
--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/iv_drip/plumbing/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()
-	if(held_item.tool_behaviour != TOOL_WRENCH)
+	if(isnull(held_item) || held_item.tool_behaviour != TOOL_WRENCH)
 		return
 	context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Una" : "A"]nchor"
 	return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION

## About The Pull Request

nullchecks `held_item` in `iv_drip/plumbing/add_context()` to prevent runtimes when attempting to check null.tool_behaviour

## Why It's Good For The Game

fixes #93815

## Changelog
:cl:

fix: prevents runtime when hovering over plumbing iv drip

/:cl:
