### PR TITLE
Fix elevator music

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -82,7 +82,8 @@
 	set_parent(_parent)
 	direct = _direct
 	skip_starting_sounds = _skip_starting_sounds
-	src.sound_channel = sound_channel
+	if(sound_channel)
+		src.sound_channel = sound_channel
 
 	if(start_immediately)
 		start()

--- a/code/modules/transport/elevator/elev_music_zone.dm
+++ b/code/modules/transport/elevator/elev_music_zone.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_EMPTY(elevator_music)
 
 /obj/effect/abstract/elevator_music_zone/Destroy(force)
 	GLOB.elevator_music -= src
+	QDEL_NULL(sound_player)
 	return ..()
 
 /obj/effect/abstract/elevator_music_zone/proc/link_to_panel(atom/elevator_panel)

--- a/code/modules/transport/elevator/elev_music_zone.dm
+++ b/code/modules/transport/elevator/elev_music_zone.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(elevator_music)
 	/// Sound loop type to use
 	var/soundloop_type = /datum/looping_sound/local_forecast
 	/// Proximity monitor which handles playing sounds to clients
-	var/datum/proximity_monitor/advanced/elevator_music_area/sound_player
+	var/datum/proximity_monitor/elevator_music_area/sound_player
 
 /obj/effect/abstract/elevator_music_zone/Initialize(mapload)
 	. = ..()
@@ -51,8 +51,7 @@ GLOBAL_LIST_EMPTY(elevator_music)
 	qdel(src)
 
 /// Load or unload a looping sound when mobs enter or exit the area
-/datum/proximity_monitor/advanced/elevator_music_area
-	edge_is_a_field = TRUE
+/datum/proximity_monitor/elevator_music_area
 	/// Are we currently playing sounds?
 	var/enabled = TRUE
 	/// Looping sound datum type to play
@@ -60,15 +59,16 @@ GLOBAL_LIST_EMPTY(elevator_music)
 	/// Assoc list of mobs to sound loops currently playing
 	var/list/tracked_mobs = list()
 
-/datum/proximity_monitor/advanced/elevator_music_area/New(atom/_host, range, _ignore_if_not_on_turf, soundloop_type)
+/datum/proximity_monitor/elevator_music_area/New(atom/_host, range, _ignore_if_not_on_turf, soundloop_type)
 	. = ..()
 	src.soundloop_type = soundloop_type
 
-/datum/proximity_monitor/advanced/elevator_music_area/Destroy()
+/datum/proximity_monitor/elevator_music_area/Destroy()
 	QDEL_LIST_ASSOC_VAL(tracked_mobs)
 	return ..()
 
-/datum/proximity_monitor/advanced/elevator_music_area/field_turf_crossed(mob/entered, turf/old_location, turf/new_location)
+/datum/proximity_monitor/elevator_music_area/on_entered(turf/new_location, mob/entered, turf/old_location)
+	. = ..()
 	if (!istype(entered) || !entered.mind)
 		return
 
@@ -83,31 +83,32 @@ GLOBAL_LIST_EMPTY(elevator_music)
 		tracked_mobs[entered] = null // Still add it to the list so we don't keep making this check
 	RegisterSignal(entered, COMSIG_QDELETING, PROC_REF(mob_destroyed))
 
-/datum/proximity_monitor/advanced/elevator_music_area/field_turf_uncrossed(mob/exited, turf/old_location, turf/new_location)
+/datum/proximity_monitor/elevator_music_area/on_uncrossed(turf/old_location, mob/exited, direction)
+	. = ..()
 	if (!(exited in tracked_mobs))
 		return
-	if ((new_location in field_turfs) || (new_location in edge_turfs))
+	if(get_dist(host, exited) <= current_range)
 		return
 	qdel(tracked_mobs[exited])
 	tracked_mobs -= exited
 	UnregisterSignal(exited, COMSIG_QDELETING)
 
 /// Remove references on mob deletion
-/datum/proximity_monitor/advanced/elevator_music_area/proc/mob_destroyed(mob/former_mob)
+/datum/proximity_monitor/elevator_music_area/proc/mob_destroyed(mob/former_mob)
 	SIGNAL_HANDLER
 	if (former_mob in tracked_mobs)
 		qdel(tracked_mobs[former_mob])
 		tracked_mobs -= former_mob
 
 /// Start sound loops playing
-/datum/proximity_monitor/advanced/elevator_music_area/proc/turn_on()
+/datum/proximity_monitor/elevator_music_area/proc/turn_on()
 	enabled = TRUE
 	for (var/mob in tracked_mobs)
 		var/datum/looping_sound/loop = tracked_mobs[mob]
 		loop.start()
 
 /// Stop active sound loops
-/datum/proximity_monitor/advanced/elevator_music_area/proc/turn_off()
+/datum/proximity_monitor/elevator_music_area/proc/turn_off()
 	enabled = FALSE
 	for (var/mob in tracked_mobs)
 		var/datum/looping_sound/loop = tracked_mobs[mob]


### PR DESCRIPTION
## About The Pull Request

There was a few things going on here
- The prox monitor for elevators didn't need to be the advanced subtype, and that was actually breaking it because for some reason with a range of 1 `field_turfs` only includes the center turf and there are no `edge_turfs`, meaning the check to not overlap music if you're already in range wouldn't work and music would start every step except the middle
- The looping_sound subtype for elevator music had `sound_channel` already set but the `New` code for looping_sound also has a sound_channel arg and didn't check if one has actually been passed before setting it, so sound_channel was being overwritten with null and thus the music would not stop when you exited the elevator zone

## Why It's Good For The Game

Fixes #92623
Fixes #88261 

https://github.com/user-attachments/assets/e5a2f736-bf68-430a-a3bc-070482e9b68e

## Changelog
:cl:
fix: fixed elevator music starting every time you took a step
fix: fixed elevator music not stopping when you left the elevator
/:cl:
