### PR TITLE
Wings fix fix

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -73,7 +73,7 @@
 
 // Other
 #define FEATURE_WINGS "wings"
-#define FEATURE_WINGS_OPEN "[FEATURE_WINGS]open"
+#define FEATURE_WINGS_OPEN "wingsopen"
 #define FEATURE_TAIL_MONKEY "tail_monkey"
 #define FEATURE_TAIL_XENO "tail_xeno"
 #define FEATURE_TAILSPINES "tailspines" // Different from regular spines, these appear on tails


### PR DESCRIPTION
## About The Pull Request

The wings fix from the previous PR made it "[FEATURE_WINGS]open" which works technically but if you use the macro to do something like 
`feature_key = FEATURE_WINGS_OPEN` outside of a proc the compiler will yell at you that it's not a constant expression. 

## Why It's Good For The Game

Bugfix

## Changelog

Nothing anyone will notice