### PR TITLE
Fix: Allergies not initialising correctly

### DIFF
--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -37,15 +37,13 @@
 	allergy_string = allergy_chem_names.Join(", ")
 	name = "Extreme [allergy_string] Allergies"
 	medical_record_text = "Patient's immune system responds violently to [allergy_string]"
+	RegisterSignal(quirk_holder, COMSIG_MOB_REAGENT_TICK, PROC_REF(block_metab))
 
 /datum/quirk/item_quirk/allergic/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/clothing/accessory/dogtag/allergy/dogtag = new(get_turf(human_holder), allergy_string)
 
 	give_item_to_holder(dogtag, list(LOCATION_BACKPACK, LOCATION_HANDS), flavour_text = "Make sure medical staff can see this...", notify_player = TRUE)
-
-/datum/quirk/item_quirk/allergic/add()
-	RegisterSignal(quirk_holder, COMSIG_MOB_REAGENT_TICK, PROC_REF(block_metab))
 
 /datum/quirk/item_quirk/allergic/remove()
 	UnregisterSignal(quirk_holder, COMSIG_MOB_REAGENT_TICK)


### PR DESCRIPTION
## About The Pull Request

During a big refactor the allergies quirk wasn't quite modified correctly and its usual add proc got overwritten by an add proc with vital functionality. However it clobbered the logic that actually gave the quirk recipient any chemicals to be allergic to.

## Why It's Good For The Game

Extreme Medicine Allergy should not be a free quirk points source I think

## Changelog

:cl:
fix: Extreme Medicine Allergy quirk will no longer lead to you being allergic to nothing
/:cl: