### PR TITLE
Makes 2 turrets on interdyne pirate ship have regular integrity instead of varedited 10k

### DIFF
--- a/_maps/shuttles/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate_ex_interdyne.dmm
@@ -802,13 +802,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
-"Tr" = (
-/obj/machinery/porta_turret/syndicate/energy/heavy{
-	faction = list("pirate","Syndicate");
-	max_integrity = 10000
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
 "Ur" = (
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 8
@@ -967,7 +960,7 @@ aj
 aj
 aa
 aj
-Tr
+aO
 "}
 (8,1,1) = {"
 vz
@@ -1039,7 +1032,7 @@ aj
 aj
 DD
 aj
-Tr
+aO
 "}
 (12,1,1) = {"
 af


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

consistency

## Changelog

:cl:
map: Removed two over-strong turrets on interdyne pirate ship.
/:cl:
