### PR TITLE
Caps custom AAS message length to a more reasonable value

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -118,7 +118,7 @@
 #define MAX_PLAQUE_LEN 144
 #define MAX_LABEL_LEN 64
 #define MAX_DESC_LEN 280
-#define MAX_AAS_LENGTH 101
+#define MAX_AAS_LENGTH 168
 
 // Audio/Visual Flags. Used to determine what sense are required to notice a message.
 #define MSG_VISUAL (1<<0)

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -118,6 +118,7 @@
 #define MAX_PLAQUE_LEN 144
 #define MAX_LABEL_LEN 64
 #define MAX_DESC_LEN 280
+#define MAX_AAS_LENGTH 101
 
 // Audio/Visual Flags. Used to determine what sense are required to notice a message.
 #define MSG_VISUAL (1<<0)

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -122,6 +122,13 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 		))
 	return list("config_entries" = configs)
 
+/obj/machinery/announcement_system/ui_static_data(mob/user)
+	var/list/data = list()
+
+	data["max_announcement_len"] = MAX_AAS_LENGTH
+
+	return data
+
 /obj/machinery/announcement_system/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
@@ -148,7 +155,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 				message_admins("[ADMIN_LOOKUPFLW(usr)] tried to set announcement line for nonexisting line in the [config.name] for AAS. Probably href injection. Received line: [html_encode(params["lineKey"])]")
 				log_game("[key_name(usr)] tried to mess with AAS. For [config.name] he tried to edit nonexistend [params["lineKey"]]")
 				return
-			var/new_message = trim(html_encode(params["newText"]), MAX_MESSAGE_LEN)
+			var/new_message = trim(html_encode(params["newText"]), MAX_PLAQUE_LEN)
 			if(new_message)
 				config.announcement_lines_map[params["lineKey"]] = new_message
 				usr.log_message("updated [params["lineKey"]] line in the [config.name] to: [new_message]", LOG_GAME)

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -155,7 +155,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 				message_admins("[ADMIN_LOOKUPFLW(usr)] tried to set announcement line for nonexisting line in the [config.name] for AAS. Probably href injection. Received line: [html_encode(params["lineKey"])]")
 				log_game("[key_name(usr)] tried to mess with AAS. For [config.name] he tried to edit nonexistend [params["lineKey"]]")
 				return
-			var/new_message = trim(html_encode(params["newText"]), MAX_PLAQUE_LEN)
+			var/new_message = trim(html_encode(params["newText"]), MAX_AAS_LENGTH)
 			if(new_message)
 				config.announcement_lines_map[params["lineKey"]] = new_message
 				usr.log_message("updated [params["lineKey"]] line in the [config.name] to: [new_message]", LOG_GAME)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -87,6 +87,7 @@
 #define EASY_ALLOCATE(arguments...) allocate(__IMPLIED_TYPE__, run_loc_floor_bottom_left, ##arguments)
 
 // BEGIN_INCLUDE
+#include "aas_configs.dm"
 #include "abductor_baton_spell.dm"
 #include "ablative_hud.dm"
 #include "achievements.dm"

--- a/code/modules/unit_tests/aas_configs.dm
+++ b/code/modules/unit_tests/aas_configs.dm
@@ -1,0 +1,10 @@
+/datum/unit_test/aas_configs
+
+/datum/unit_test/aas_configs/Run()
+	var/expected_max_length = MAX_AAS_LENGTH
+
+	for(var/config_type in valid_subtypesof(/datum/aas_config_entry))
+		var/datum/aas_config_entry/entry = allocate(config_type)
+		for(var/key, line in entry.announcement_lines_map)
+			if(length(line) > expected_max_length)
+				TEST_FAIL("Announcement line '[key]' in config '[config_type]' exceeds max length of [expected_max_length] characters (actual length: [length(line)])")

--- a/code/modules/unit_tests/aas_configs.dm
+++ b/code/modules/unit_tests/aas_configs.dm
@@ -6,5 +6,5 @@
 	for(var/config_type in valid_subtypesof(/datum/aas_config_entry))
 		var/datum/aas_config_entry/entry = allocate(config_type)
 		for(var/key, line in entry.announcement_lines_map)
-			if(length(line) > expected_max_length)
+			if(length_char(line) > expected_max_length)
 				TEST_FAIL("Announcement line '[key]' in config '[config_type]' exceeds max length of [expected_max_length] characters (actual length: [length(line)])")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6478,7 +6478,6 @@
 #include "code\modules\tutorials\tutorials\drop.dm"
 #include "code\modules\tutorials\tutorials\switch_hands.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"
-#include "code\modules\unit_tests\aas_configs.dm"
 #include "code\modules\uplink\uplink_devices.dm"
 #include "code\modules\uplink\uplink_items.dm"
 #include "code\modules\uplink\uplink_purchase_log.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6478,6 +6478,7 @@
 #include "code\modules\tutorials\tutorials\drop.dm"
 #include "code\modules\tutorials\tutorials\switch_hands.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"
+#include "code\modules\unit_tests\aas_configs.dm"
 #include "code\modules\uplink\uplink_devices.dm"
 #include "code\modules\uplink\uplink_items.dm"
 #include "code\modules\uplink\uplink_purchase_log.dm"

--- a/tgui/packages/tgui/interfaces/AutomatedAnnouncement.tsx
+++ b/tgui/packages/tgui/interfaces/AutomatedAnnouncement.tsx
@@ -27,11 +27,12 @@ type AASConfigEntry = {
 
 type Data = {
   config_entries: AASConfigEntry[];
+  max_announcement_len: number;
 };
 
 export const AutomatedAnnouncement = (props) => {
   const { act, data } = useBackend<Data>();
-  const { config_entries = [] } = data;
+  const { config_entries = [], max_announcement_len } = data;
 
   const [search, setSearch] = useState('');
 
@@ -130,6 +131,7 @@ export const AutomatedAnnouncement = (props) => {
                                 fluid
                                 value={announcementLine}
                                 disabled={!entry.modifiable}
+                                maxLength={max_announcement_len}
                                 onBlur={(value) =>
                                   act('Text', {
                                     entryRef: entry.entryRef,


### PR DESCRIPTION
## About The Pull Request

Reduces the max length you can set an AAS message by 83% (1024 characters -> 168 characters)

## Why It's Good For The Game

I think most people would agree it's fairly annoying when someone edits the AAS messages to be full paragraphs, filling common up with nonsense

Ostensibly this can be handled by admins but I think allowing someone to enter 1000 characters here is a bit excessive in the first place - The longest default message we have is 144 characters

Alternatively I can cap message length on a per-message-type basis so the most common messages (arrivals, weather) have a far shorter limit than the uncommon messages (security alerts) 

## Changelog

:cl: Melbert
del: Caps "Automated Announcement System" messages to 168 characters (was: 1024 characters)  
/:cl:
