### PR TITLE
Maybe makes stuff like zombie powder more consistent / less buggy with status effects

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -57,7 +57,6 @@
 // Grouped effect sources, see also code/__DEFINES/traits.dm
 
 #define STASIS_MACHINE_EFFECT "stasis_machine"
-#define STASIS_CHEMICAL_EFFECT "stasis_chemical"
 #define STASIS_SHAPECHANGE_EFFECT "stasis_shapechange"
 #define STASIS_ADMIN "stasis_admin"
 #define STASIS_LEGION_EATEN "stasis_eaten"

--- a/code/datums/status_effects/reagent_effect.dm
+++ b/code/datums/status_effects/reagent_effect.dm
@@ -1,5 +1,7 @@
 /// Status effect that is tied to the existence of a reagent in a mob's system
 /datum/status_effect/reagent_effect
+	abstract_type = /datum/status_effect/reagent_effect
+	id = STATUS_EFFECT_ID_ABSTRACT
 	alert_type = null
 	tick_interval = STATUS_EFFECT_NO_TICK
 	/// We need this reagent type

--- a/code/datums/status_effects/reagent_effect.dm
+++ b/code/datums/status_effects/reagent_effect.dm
@@ -1,0 +1,82 @@
+/// Status effect that is tied to the existence of a reagent in a mob's system
+/datum/status_effect/reagent_effect
+	alert_type = null
+	tick_interval = STATUS_EFFECT_NO_TICK
+	/// We need this reagent type
+	var/reagent_typepath
+	/// Whether subtypes of the reagent are allowed to keep the effect active
+	var/subtypes_allowed
+
+/datum/status_effect/reagent_effect/on_creation(mob/living/new_owner, reagent_typepath, subtypes_allowed = TRUE)
+	if(isnull(src.reagent_typepath))
+		if(isnull(reagent_typepath))
+			stack_trace("Reagent effect [src] created without a reagent typepath!")
+		src.reagent_typepath = reagent_typepath
+	if(isnull(src.subtypes_allowed))
+		src.subtypes_allowed = subtypes_allowed
+	return ..()
+
+/datum/status_effect/reagent_effect/on_apply()
+	if(isnull(owner.reagents) || isnull(reagent_typepath) || !can_effect())
+		return FALSE
+
+	RegisterSignal(owner.reagents, COMSIG_REAGENTS_HOLDER_UPDATED, PROC_REF(check_reagents))
+	add_effect()
+	return TRUE
+
+/datum/status_effect/reagent_effect/on_remove()
+	remove_effect()
+	UnregisterSignal(owner.reagents, COMSIG_REAGENTS_HOLDER_UPDATED)
+
+/datum/status_effect/reagent_effect/proc/check_reagents(datum/reagents/updated_reagents)
+	SIGNAL_HANDLER
+
+	if(owner.reagents?.has_reagent(reagent_typepath, check_subtypes = subtypes_allowed))
+		return
+	qdel(src)
+
+/// Can we add this effect to the owner?
+/datum/status_effect/reagent_effect/proc/can_effect()
+	return TRUE
+
+/// Add the side effect to the owner
+/datum/status_effect/reagent_effect/proc/add_effect()
+	return
+
+/// Remove the side effect from the owner
+/datum/status_effect/reagent_effect/proc/remove_effect()
+	return
+
+/datum/status_effect/reagent_effect/fakedeath
+	id = "reagent_fake_death"
+
+/datum/status_effect/reagent_effect/fakedeath/add_effect()
+	owner.fakedeath(type)
+
+/datum/status_effect/reagent_effect/fakedeath/remove_effect()
+	owner.cure_fakedeath(type)
+
+/datum/status_effect/reagent_effect/freeze
+	id = "reagent_freeze"
+
+/datum/status_effect/reagent_effect/freeze/can_effect()
+	return !HAS_TRAIT(owner, TRAIT_RESISTCOLD)
+
+/datum/status_effect/reagent_effect/freeze/add_effect()
+	owner.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
+	owner.apply_status_effect(/datum/status_effect/grouped/stasis, type)
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(escape_prison))
+
+/datum/status_effect/reagent_effect/freeze/remove_effect()
+	owner.remove_status_effect(/datum/status_effect/frozenstasis/irresistable)
+	owner.remove_status_effect(/datum/status_effect/grouped/stasis, type)
+	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+
+/datum/status_effect/reagent_effect/freeze/proc/escape_prison(...)
+	SIGNAL_HANDLER
+
+	if(isturf(owner.loc)) // we escaped ice prison
+		owner.reagents?.del_reagent(reagent_typepath)
+	if(!QDELETED(src))
+		stack_trace("Despite nuking the reagent from the mob, [owner] still has [type]")
+		qdel(src)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -118,3 +118,7 @@
 		return
 
 	return ..()
+
+/datum/reagent/inverse/cryostylane/on_mob_end_metabolize(mob/living/affected_mob)
+	. = ..()
+	affected_mob.remove_status_effect(/datum/status_effect/reagent_effect/freeze)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -106,30 +106,15 @@
 		holder.del_reagent(type)
 		return
 
-	human_thing.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
-	if(!human_thing.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT))
-		human_thing.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
+	human_thing.apply_status_effect(/datum/status_effect/reagent_effect/freeze, type)
 
 /datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	if(!affected_mob.has_status_effect(/datum/status_effect/frozenstasis/irresistable))
-		holder.remove_reagent(type, volume) // remove it all if we were broken out
-		return
 	metabolization_rate += 0.01 //speed up our metabolism over time. Chop chop.
 
 /datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	if(current_cycle >= 60)
 		holder.remove_reagent(type, volume) // remove it all if we're past 60 cycles
 		return
+
 	return ..()
-
-/datum/reagent/inverse/cryostylane/on_mob_end_metabolize(mob/living/affected_mob)
-	. = ..()
-	affected_mob.remove_status_effect(/datum/status_effect/frozenstasis/irresistable)
-	affected_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
-
-/datum/reagent/inverse/cryostylane/on_mob_delete(mob/living/affected_mob, amount)
-	. = ..()
-	affected_mob.remove_status_effect(/datum/status_effect/frozenstasis/irresistable)
-	affected_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CHEMICAL_EFFECT)
-

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -282,15 +282,11 @@
 
 	holder_mob.adjustOxyLoss(0.5*REM, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if((data?["method"] & (INGEST|INHALE)) && holder_mob.stat != DEAD)
-		holder_mob.fakedeath(type)
+		holder_mob.apply_status_effect(/datum/status_effect/reagent_effect/fakedeath, type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/holder_mob)
 	. = ..()
 	zombify(holder_mob)
-
-/datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/affected_mob)
-	. = ..()
-	affected_mob.cure_fakedeath(type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -288,6 +288,10 @@
 	. = ..()
 	zombify(holder_mob)
 
+/datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/affected_mob)
+	. = ..()
+	affected_mob.remove_status_effect(/datum/status_effect/reagent_effect/fakedeath)
+
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_FAKEDEATH) && HAS_TRAIT(affected_mob, TRAIT_DEATHCOMA))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1984,6 +1984,7 @@
 #include "code\datums\status_effects\grouped_effect.dm"
 #include "code\datums\status_effects\limited_effect.dm"
 #include "code\datums\status_effects\neutral.dm"
+#include "code\datums\status_effects\reagent_effect.dm"
 #include "code\datums\status_effects\song_effects.dm"
 #include "code\datums\status_effects\stacking_effect.dm"
 #include "code\datums\status_effects\wound_effects.dm"


### PR DESCRIPTION
## About The Pull Request

I don't know WHY some reagents are failing to call on_mob_delete and friends when exiting the system

However I have one idea to circumvent it: Status effects

Instead of relying on on mob metabolize / on mob delete to add or remove the effect, we apply a status effect which handles all relevant persistent effects

That status effect hooks `on_reagent_update` which checks every time the mob's reagent changes to see if the mob still has the reagent. It it no longer has the reagent, it deletes the effect and thus removes all the effects

## Changelog

:cl: Melbert
refactor: Refactored how zombie powder and inverse cryogeldia apply their effects to maybe have them get stuck less
/:cl:


