### PR TITLE
Adds a plasma stabilizers and thermal regulator to the Operative equipment locker.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -31,6 +31,7 @@
 	new /obj/item/mod/module/plasma_stabilizer(src)
 	new /obj/item/climbing_hook/syndicate(src)
 	new /obj/item/mod/module/thermal_regulator(src)
+	new /obj/item/mod/module/plasma_stabilizer(src)
 
 /obj/structure/closet/syndicate/nuclear
 	desc = "It's a storage unit for a Syndicate boarding party."

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -30,6 +30,7 @@
 	new /obj/item/clothing/shoes/sneakers/black(src)
 	new /obj/item/mod/module/plasma_stabilizer(src)
 	new /obj/item/climbing_hook/syndicate(src)
+	new /obj/item/mod/module/thermal_regulator(src)
 
 /obj/structure/closet/syndicate/nuclear
 	desc = "It's a storage unit for a Syndicate boarding party."


### PR DESCRIPTION

## About The Pull Request

What it says on the tin

## Why It's Good For The Game

These modules are often found mapped in roundstart, and are also printable extremely early in the round. They're not exactly high power modules, and they are largely important quality of life tools for non-humans species.

Which, now, operatives can be. So if the op cares to get it, they can shove it in their suit. The complexity limits of their suit will more than likely require them to be picky about what they put in anyway. That's why the complexity system exists in the first place.

They're best placed here so we can assume by default the operative doesn't need them, since most species don't need, for example, plasma stabilization. It might be important for icemoon in case an operative has a nasty fall! ~~Or experiences that weird bug where plasmification spreads to people~~

## Changelog
:cl:
qol: Operative lockers come with thermal regulator and plasma stabilizer modules.
/:cl:
