### PR TITLE
Adds the normal stabilizers to catwalk engineering

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -16708,11 +16708,14 @@
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
+/obj/machinery/camera/autoname/directional/west,
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/item/tank/jetpack{
+	pixel_y = 4
+	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -69504,9 +69507,8 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/tank/jetpack{
-	pixel_y = 4
-	},
+/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/plasma_stabilizer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "twz" = (


### PR DESCRIPTION

## About The Pull Request

Adds plasma and thermal stabilizer MODules to catwalk engineering

## Why It's Good For The Game

Every other map's got them. And they're useful.

## Changelog
:cl:

qol: Added thermal and plasma stabilizer MODules to catwalk engineering

/:cl:
