### PR TITLE
Regal Rats can target zombies, skeletons, and ghouls

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -197,7 +197,7 @@
 		return TRUE // it might be possible to attack this? we'll find out soon enough
 
 	var/mob/living/living_target = the_target
-	if (HAS_TRAIT(living_target, TRAIT_FAKEDEATH) || living_target.stat == DEAD)
+	if(HAS_TRAIT_NOT_FROM(living_target, TRAIT_FAKEDEATH, SPECIES_TRAIT) || living_target.stat == DEAD)
 		balloon_alert(src, "already dead!")
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Regal rats can now attack zombies, ghouls, skeletons, and other "fake undead" species.

This is done by changing the "already dead" check to ignore the FAKEDEATH trait if it's applied as a species trait. This means that regal rats still won't be able to tell if someone's faking it with zombie powder or changeling stasis.
## Why It's Good For The Game

Rats should be able to kill zombies I guess.

Closes #93770.
## Changelog
:cl: Rhials
fix: Regal rats can now attack FAKEDEATH species mobs, like zombies and skeletons.
/:cl:
