### PR TITLE
bridge assistant and veteran advisor PDAs (inside backpack) are now imprinted automatically

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -413,18 +413,25 @@
 
 		equipped.update_ID_card()
 
+	if(!pda_slot) //This job outfit doesn't have a PDA.
+		return
+
 	var/obj/item/modular_computer/pda/pda = equipped.get_item_by_slot(pda_slot)
+	if(pda && !istype(pda)) //we found something but it isn't a PDA, check if it's inside it instead.
+		pda = locate() in pda
 
-	if(istype(pda))
-		pda.imprint_id(equipped.real_name, equipped_job.title)
-		pda.update_ringtone(equipped_job.job_tone)
-		pda.UpdateDisplay()
+	if(!istype(pda)) //We couldn't find a PDA at all.
+		stack_trace("pda_slot was set but we couldn't find a PDA!")
+		return
 
-		var/client/equipped_client = GLOB.directory[ckey(equipped.mind?.key)]
+	pda.imprint_id(equipped.real_name, equipped_job.title)
+	pda.update_ringtone(equipped_job.job_tone)
+	pda.UpdateDisplay()
 
-		if(equipped_client)
-			pda.update_pda_prefs(equipped_client)
+	var/client/equipped_client = GLOB.directory[ckey(equipped.mind?.key)]
 
+	if(equipped_client)
+		pda.update_pda_prefs(equipped_client)
 
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -60,6 +60,7 @@
 	ears = null
 	shoes = /obj/item/clothing/shoes/sneakers/orange
 	box = /obj/item/storage/box/survival/prisoner
+	pda_slot = null
 
 /datum/outfit/job/prisoner/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/station_trait/bridge_assistant.dm
+++ b/code/modules/jobs/job_types/station_trait/bridge_assistant.dm
@@ -80,3 +80,4 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	l_pocket = /obj/item/gun/energy/e_gun/mini
 	r_pocket = /obj/item/assembly/flash/handheld
+	pda_slot = ITEM_SLOT_BACK

--- a/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
+++ b/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
@@ -83,3 +83,4 @@
 	r_hand = /obj/item/cane
 
 	implants = list(/obj/item/implant/mindshield)
+	pda_slot = ITEM_SLOT_BACK


### PR DESCRIPTION
## About The Pull Request
job outfits with a set pda_slot variable are now expected to have a pda on that slot, or inside whatever item is on that slot. An error will be thrown if none is found.

## Why It's Good For The Game
Making sure bridge assistants and other jobs won't have to do it manually in the future.

## Changelog


:cl:
fix: bridge assistant and veteran advisor PDAs (inside backpack) are now imprinted automatically
/:cl:
