### PR TITLE
Delta funny pipe connection removal

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -81194,7 +81194,7 @@
 	},
 /area/station/science/research)
 "uaY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
 	dir = 4
@@ -81459,7 +81459,7 @@
 /area/station/medical/abandoned)
 "udG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
 	dir = 4
 	},
@@ -82245,7 +82245,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "unO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
 	dir = 4
 	},


### PR DESCRIPTION
## About The Pull Request
This PR replaces regular cyan pipe under the layer adaptors in atmos to bridge one, because sometimes this pipe can connect like this:
<img width="380" height="247" alt="image" src="https://github.com/user-attachments/assets/08a47cff-d4c6-45a7-bd31-5db213b3f654" />

## Why It's Good For The Game
It just replaces one pipe to another but here's the thing - it's just stupid then pipe connects through layer adaptor. it just stupid.
## Changelog
:cl:
map: No more regular pipes in atmos under layer adaptors on DeltaStation
/:cl:

