### PR TITLE
Non-tiled floor dont have tiled water overlays

### DIFF
--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -64,7 +64,7 @@
 		return
 
 	var/intended
-	if(!isfloorturf(parent))
+	if(!parent.tiled_turf)
 		intended = generic_turf_overlay
 	else
 		switch(highest_strength)

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -54,17 +54,17 @@
 	return ..()
 
 /datum/component/wet_floor/proc/update_overlay()
+	var/turf/parent_turf = parent
 	if(!should_display_overlay)
 		if(!current_overlay)
 			return
 
-		var/turf/parent_turf = parent
 		parent_turf.cut_overlay(current_overlay)
 		current_overlay = null
 		return
 
 	var/intended
-	if(!parent.tiled_turf)
+	if(!parent_turf.tiled_turf)
 		intended = generic_turf_overlay
 	else
 		switch(highest_strength)
@@ -75,7 +75,6 @@
 			else
 				intended = water_overlay
 	if(current_overlay != intended)
-		var/turf/parent_turf = parent
 		parent_turf.cut_overlay(current_overlay)
 		parent_turf.add_overlay(intended)
 		current_overlay = intended

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -64,16 +64,14 @@
 		return
 
 	var/intended
-	if(!parent_turf.tiled_turf)
-		intended = generic_turf_overlay
-	else
-		switch(highest_strength)
-			if(TURF_WET_PERMAFROST)
-				intended = permafrost_overlay
-			if(TURF_WET_ICE)
-				intended = ice_overlay
-			else
-				intended = water_overlay
+	switch(highest_strength)
+		if(TURF_WET_PERMAFROST)
+			intended = permafrost_overlay
+		if(TURF_WET_ICE)
+			// Should really get someone to make a generic_ice_overlay.
+			intended = parent_turf.tiled_turf ? ice_overlay : generic_turf_overlay
+		else
+			intended = parent_turf.tiled_turf ? water_overlay : generic_turf_overlay
 	if(current_overlay != intended)
 		parent_turf.cut_overlay(current_overlay)
 		parent_turf.add_overlay(intended)

--- a/code/game/objects/effects/decals/cleanable/mess.dm
+++ b/code/game/objects/effects/decals/cleanable/mess.dm
@@ -82,7 +82,7 @@
 	if(!isnull(broken_flooring))
 		return
 	var/turf/T = get_turf(src)
-	if(T.tiled_dirt && is_tileable)
+	if(T.tiled_turf && is_tileable)
 		icon = 'icons/effects/dirt.dmi'
 		icon_state = "dirt-0"
 		smoothing_flags = SMOOTH_BITMASK

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -188,7 +188,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = TRUE
+	tiled_turf = TRUE
 
 /turf/open/indestructible/Melt()
 	to_be_destroyed = FALSE
@@ -264,7 +264,7 @@
 	barefootstep = FOOTSTEP_LAVA
 	clawfootstep = FOOTSTEP_LAVA
 	heavyfootstep = FOOTSTEP_LAVA
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/indestructible/necropolis/Initialize(mapload)
 	. = ..()
@@ -327,7 +327,7 @@
 	barefootstep = null
 	clawfootstep = null
 	heavyfootstep = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/indestructible/binary
 	name = "tear in the fabric of reality"

--- a/code/game/turfs/open/ashplanet.dm
+++ b/code/game/turfs/open/ashplanet.dm
@@ -14,7 +14,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 	var/smooth_icon = 'icons/turf/floors/ash.dmi'
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -16,7 +16,7 @@
 
 	thermal_conductivity = 0.02
 	heat_capacity = 20000
-	tiled_dirt = TRUE
+	tiled_turf = TRUE
 
 
 	overfloor_placed = TRUE

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -16,7 +16,7 @@
 	barefootstep = FOOTSTEP_WOOD_BAREFOOT
 	clawfootstep = FOOTSTEP_WOOD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_BASIC
 
 /turf/open/floor/wood/broken_states()
@@ -148,7 +148,7 @@
 	barefootstep = FOOTSTEP_GRASS
 	clawfootstep = FOOTSTEP_GRASS
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/grass/broken_states()
@@ -202,7 +202,7 @@
 	barefootstep = FOOTSTEP_GRASS
 	clawfootstep = FOOTSTEP_GRASS
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/fake_snow
@@ -216,7 +216,7 @@
 	floor_tile = null
 	initial_gas_mix = FROZEN_ATMOS
 	bullet_bounce_sound = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 	slowdown = 1.5
 	bullet_sizzle = TRUE
@@ -251,7 +251,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/fakebasalt/Initialize(mapload)
 	. = ..()
@@ -280,7 +280,7 @@
 	barefootstep = FOOTSTEP_CARPET_BAREFOOT
 	clawfootstep = FOOTSTEP_CARPET_BAREFOOT
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_BASIC
 
 /turf/open/floor/carpet/examine(mob/user)
@@ -867,7 +867,7 @@
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_TURF_CHASM
 	canSmoothWith = SMOOTH_GROUP_TURF_CHASM
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/fakepit/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.icon = 'icons/turf/floors.dmi'
@@ -893,7 +893,7 @@
 	floor_tile = /obj/item/stack/tile/fakespace
 	layer = SPACE_LAYER
 	plane = PLANE_SPACE
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	damaged_dmi = 'icons/turf/space.dmi'
 
 /turf/open/floor/fakespace/broken_states()

--- a/code/game/turfs/open/floor/iron_floor.dm
+++ b/code/game/turfs/open/floor/iron_floor.dm
@@ -472,7 +472,7 @@
 /turf/open/floor/iron/grimy
 	icon_state = "grimy"
 	base_icon_state = "grimy"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	floor_tile = /obj/item/stack/tile/iron/grimy
 
 /turf/open/floor/iron/vaporwave
@@ -485,13 +485,13 @@
 	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding."
 	icon_state = "plaque"
 	base_icon_state = "plaque"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	floor_tile = /obj/item/stack/tile/iron/goonplaque
 
 /turf/open/floor/iron/stairs
 	icon_state = "stairs"
 	base_icon_state = "stairs"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/iron/stairs/airless
 	initial_gas_mix = AIRLESS_ATMOS

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -19,7 +19,7 @@
 	var/currentcolor = LIGHT_COLOR_CYAN
 	///var to prevent changing color on certain admin spawn only tiles
 	var/can_modify_colour = TRUE
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	///icons for radial menu
 	var/static/list/lighttile_designs
 	///used for light floors that cycle colours

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -15,7 +15,7 @@
 	material_flags = MATERIAL_EFFECTS
 	rust_resistance = RUST_RESISTANCE_BASIC
 	var/list/icons
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 
 

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -18,7 +18,7 @@
 	name = "alien floor"
 	icon_state = "alienpod1"
 	base_icon_state = "alienpod1"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 	// Not actually broken, just should never break...yeah.
 	broken = TRUE
@@ -32,7 +32,7 @@
 	name = "alien plating"
 	icon_state = "alienplating"
 	base_icon_state = "alienplating"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 	damaged_dmi = null
 

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -10,7 +10,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rcd_proof = TRUE
 	rust_resistance = RUST_RESISTANCE_REINFORCED
 	floor_tile = /obj/item/stack/rods

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -19,7 +19,7 @@
 
 	thermal_conductivity = 0.02
 	heat_capacity = 20000
-	tiled_dirt = TRUE
+	tiled_turf = TRUE
 
 /turf/open/misc/attackby(obj/item/attacking_item, mob/user, list/modifiers)
 	. = ..()

--- a/code/game/turfs/open/planet.dm
+++ b/code/game/turfs/open/planet.dm
@@ -12,7 +12,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/misc/dirt/station

--- a/code/game/turfs/open/sand.dm
+++ b/code/game/turfs/open/sand.dm
@@ -72,7 +72,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/misc/sandy_dirt/break_tile()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/bullet_sizzle = FALSE //used by ammo_casing/bounce_away() to determine if the shell casing should make a sizzle sound when it's ejected over the turf
 							//IE if the turf is supposed to be water, set TRUE.
 
-	var/tiled_dirt = FALSE // use smooth tiled dirt decal
+	var/tiled_turf = FALSE // use smooth tiled dirt decal
 
 	///Icon-smoothing variable to map a diagonal wall corner with a fixed underlay.
 	var/list/fixed_underlay = null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/bullet_sizzle = FALSE //used by ammo_casing/bounce_away() to determine if the shell casing should make a sizzle sound when it's ejected over the turf
 							//IE if the turf is supposed to be water, set TRUE.
 
-	var/tiled_turf = FALSE // use smooth tiled dirt decal
+	var/tiled_turf = FALSE // use tiled water and dirt decals
 
 	///Icon-smoothing variable to map a diagonal wall corner with a fixed underlay.
 	var/list/fixed_underlay = null

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -63,7 +63,7 @@
 	desc = "Looking at the luscious field, you suddenly feel homesick."
 	icon_state = "grass0"
 	bullet_bounce_sound = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/grass/Initialize(mapload)
 	. = ..()
@@ -76,7 +76,7 @@
 	icon = 'icons/turf/sand.dmi'
 	icon_state = "sand"
 	bullet_bounce_sound = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/beach/coast
 	gender = NEUTER
@@ -103,7 +103,7 @@
 	name = "asteroid sand"
 	desc = "The sand crunches beneath your feet, though it feels soft to the touch."
 	icon_state = "asteroid"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/asteroid/Initialize(mapload)
 	icon_state = "asteroid[rand(0, 12)]"
@@ -114,7 +114,7 @@
 	name = "basalt"
 	desc = "You still feel hot, despite the cool walls of the holodeck."
 	icon_state = "basalt0"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/basalt/Initialize(mapload)
 	. = ..()
@@ -140,7 +140,7 @@
 	icon = 'icons/turf/space.dmi'
 	icon_state = "speedspace_ns_1"
 	bullet_bounce_sound = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/hyperspace/Initialize(mapload)
 	icon_state = "speedspace_ns_[(x + 5*y + (y%2+1)*7)%15+1]"
@@ -161,7 +161,7 @@
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET
 	canSmoothWith = SMOOTH_GROUP_CARPET
 	bullet_bounce_sound = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/carpet/Initialize(mapload)
 	. = ..()
@@ -175,7 +175,7 @@
 /turf/open/floor/holofloor/wood
 	icon_state = "wood"
 	desc = "Makes you feel at home."
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/snow
 	gender = PLURAL
@@ -186,7 +186,7 @@
 	slowdown = 2
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/dark
 	icon_state = "darkfull"
@@ -195,7 +195,7 @@
 /turf/open/floor/holofloor/stairs
 	name = "stairs"
 	icon_state = "stairs"
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/floor/holofloor/stairs/left
 	icon_state = "stairs-l"

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -266,13 +266,13 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	desc = "Stylish dark wood with extra reinforcement. Secured firmly to the floor to prevent tampering."
 	icon_state = "wood"
 	footstep = FOOTSTEP_WOOD
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/indestructible/hoteltile
 	desc = "Smooth tile with extra reinforcement. Secured firmly to the floor to prevent tampering."
 	icon_state = "showroomfloor"
 	footstep = FOOTSTEP_FLOOR
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 
 /turf/open/space/bluespace
 	name = "\proper bluespace hyperzone"

--- a/code/modules/transport/tram/tram_floors.dm
+++ b/code/modules/transport/tram/tram_floors.dm
@@ -15,7 +15,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	tiled_dirt = FALSE
+	tiled_turf = FALSE
 	rcd_proof = TRUE
 
 /turf/open/floor/tram/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request
changes tiled_dirt to just tiled_turf and expands its use slightly to be the "i have a 2x2 tile sprite"
<img width="864" height="691" alt="image" src="https://github.com/user-attachments/assets/78a7ba96-fffe-42e1-9eef-35b96b22481b" />

https://github.com/user-attachments/assets/7a273302-a331-48b2-a06f-d65bddf13bfd

## Why It's Good For The Game
its silly for things that arent visually tiled to use the tiled water sprite
## Changelog
:cl:
fix: stuff like carpet and wood tiles dont use the 2x2 tiled sprite
fix: similarly, floors that dont use the tiled sprite now can have permafrost sprites (as they are not tiled)
/:cl:
