### PR TITLE
deer eat "real" grass as well

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/deer/deer_ai.dm
+++ b/code/modules/mob/living/basic/farm_animals/deer/deer_ai.dm
@@ -44,7 +44,7 @@
 	target_key = BB_DEER_GRASS_TARGET
 	finding_behavior = /datum/ai_behavior/find_and_set/in_list/turf_types
 	hunting_behavior = /datum/ai_behavior/hunt_target/eat_grass
-	hunt_targets = list(/turf/open/floor/grass)
+	hunt_targets = list(/turf/open/floor/grass, /turf/open/misc/grass)
 	hunt_range = 7
 	hunt_chance = 45
 


### PR DESCRIPTION

## About The Pull Request
Right now they only eat the grass that goes ontop of plating, adds it to the "real" grass
## Why It's Good For The Game
immersion or something
## Changelog
:cl:
fix: deer now eat* real grass
/:cl:
