### PR TITLE
Readds voidwalker victim stabilization

### DIFF
--- a/code/modules/antagonists/voidwalker/voidwalker_mob.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_mob.dm
@@ -146,6 +146,9 @@
 
 		var/should_attack = try_kidnap(hewmon)
 
+		// Marks the victim with nodeath
+		hewmon.apply_status_effect(/datum/status_effect/void_chomped)
+
 		if(!should_attack)
 			return FALSE
 

--- a/code/modules/antagonists/voidwalker/voidwalker_status_effects.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_status_effects.dm
@@ -16,16 +16,17 @@
 	use_user_hud_icon = TRUE
 	overlay_state = "paralysis"
 
-/datum/status_effect/void_eatered
-	id = "void_eatered"
-	duration = 10 SECONDS
+/datum/status_effect/void_chomped
+	id = "void_chomped"
+	duration = 15 SECONDS
+	status_type = STATUS_EFFECT_REFRESH
 	remove_on_fullheal = TRUE
 	alert_type = null
 
-/datum/status_effect/void_eatered/on_apply()
+/datum/status_effect/void_chomped/on_apply()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_NODEATH, TRAIT_STATUS_EFFECT(id))
 
-/datum/status_effect/void_eatered/on_remove()
+/datum/status_effect/void_chomped/on_remove()
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_NODEATH, TRAIT_STATUS_EFFECT(id))


### PR DESCRIPTION

## About The Pull Request
Gives anyone hit by the voidwalker 15s of NODEATH. Aside from blocking accidental deaths, it also blocks succumbing

Voidwalker already got this in https://github.com/tgstation/tgstation/pull/85045, it just got lost somewhere in [the rework. ](https://github.com/tgstation/tgstation/pull/91646)

## Why It's Good For The Game

It gives voidwalkers some more leeway with moving people to safer spaces to kidnap them. It also helps now that the pressure damage has been doubled, and victims can slip into death more easily

People also like to succumb to prevent voidwalkers from getting the wall recharge and nebula vomits. It's just really spiteful, and is a surefire way to get themselves roundremoved, but the whole interaction need not even exist! Admins have been dealing with it, but it's pretty easy to just patch the whole thing out. 
## Changelog
:cl:
qol: Readds nodeath and succumb-blocking for voidwalker victims
/:cl:
