### PR TITLE
Fixes luxury paywall laserguns dropping their pins when spawned, refactors them to item_interaction

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -377,7 +377,7 @@
 	#define COMPONENT_CANCEL_SAWING_OFF (1<<0)
 #define COMSIG_GUN_SAWN_OFF "gun_sawn_off"
 
-///called in /obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/new_gun): (obj/item/firing_pin/pin, mob/living/user)
+///called in /obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/new_gun, starting): (obj/item/firing_pin/pin, mob/living/user, starting)
 #define COMSIG_GUN_PIN_INSERTED "gun_pin_inserted"
 
 ///called in /obj/item/firing_pin/proc/gun_remove(mob/living/user): (obj/item/firing_pin/pin, mob/living/user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -95,7 +95,7 @@
 	. = ..()
 	if(ispath(pin))
 		pin = new pin
-		pin.gun_insert(new_gun = src)
+		pin.gun_insert(new_gun = src, starting = TRUE)
 
 	add_seclight_point()
 	add_bayonet_point()
@@ -645,7 +645,7 @@
 	if(pin)
 		qdel(pin)
 	var/obj/item/firing_pin/new_pin = new
-	new_pin.gun_insert(new_gun = src)
+	new_pin.gun_insert(new_gun = src, starting = TRUE)
 
 //Happens before the actual projectile creation
 /obj/item/gun/proc/before_firing(atom/target,mob/user)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -212,7 +212,6 @@
 // luxury shuttle funnies
 /obj/item/firing_pin/paywall/luxury
 	multi_payment = TRUE
-	owned = TRUE
 	payment_amount = 20
 
 /obj/item/gun/energy/laser/luxurypaywall

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -59,11 +59,11 @@
 	balloon_alert(user, "authentication checks overridden")
 	return TRUE
 
-/obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/new_gun)
+/obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/new_gun, starting = FALSE)
 	gun = new_gun
 	forceMove(gun)
 	gun.pin = src
-	SEND_SIGNAL(gun, COMSIG_GUN_PIN_INSERTED, src, user)
+	SEND_SIGNAL(gun, COMSIG_GUN_PIN_INSERTED, src, user, starting)
 	return TRUE
 
 /obj/item/firing_pin/proc/gun_remove(mob/living/user)
@@ -173,7 +173,7 @@
 			return TRUE //The clown op leader antag datum isn't a subtype of the normal clown op antag datum.
 	return FALSE
 
-/obj/item/firing_pin/clown/ultra/gun_insert(mob/living/user, obj/item/gun/new_gun)
+/obj/item/firing_pin/clown/ultra/gun_insert(mob/living/user, obj/item/gun/new_gun, starting = FALSE)
 	..()
 	new_gun.clumsy_check = FALSE
 
@@ -232,69 +232,66 @@
 	desc = "A firing pin with a built-in configurable paywall."
 	color = COLOR_GOLD
 	fail_message = ""
-	///list of account IDs which have accepted the license prompt. If this is the multi-payment pin, then this means they accepted the waiver that each shot will cost them money
+	/// List of account IDs which have accepted the license prompt. If this is the multi-payment pin, then this means they accepted the waiver that each shot will cost them money
 	var/list/gun_owners = list()
-	///how much gets paid out to license yourself to the gun
+	/// How much gets paid out to license yourself to the gun
 	var/payment_amount
+	/// Owner of the gun
 	var/datum/bank_account/pin_owner
-	///if true, user has to pay everytime they fire the gun
+	/// If true, user has to pay everytime they fire the gun
 	var/multi_payment = FALSE
-	var/owned = FALSE
-	///purchase prompt to prevent spamming it, set to the user who opens to prompt to prevent locking the gun up for other users.
+	/// Purchase prompt to prevent spamming it, set to the user who opens to prompt to prevent locking the gun up for other users.
 	var/active_prompt_user
 
 /obj/item/firing_pin/paywall/attack_self(mob/user)
 	multi_payment = !multi_payment
-	to_chat(user, span_notice("You set the pin to [( multi_payment ) ? "process payment for every shot" : "one-time license payment"]."))
+	to_chat(user, span_notice("You set the pin to [multi_payment ? "process payment for every shot" : "one-time license payment"]."))
 
 /obj/item/firing_pin/paywall/examine(mob/user)
 	. = ..()
 	if(pin_owner)
 		. += span_notice("This firing pin is currently authorized to pay into the account of [pin_owner.account_holder].")
 
-/obj/item/firing_pin/paywall/gun_insert(mob/living/user, obj/item/gun/new_gun)
-	if(!pin_owner)
-		if(isnull(user))
-			forceMove(new_gun.drop_location())
-		else
-			to_chat(user, span_warning("ERROR: Please swipe valid identification card before installing firing pin!"))
-			user.put_in_hands(src)
-		return FALSE
-	..()
-	if(multi_payment)
-		gun.desc += span_notice(" This [gun.name] has a per-shot cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].")
-		return TRUE
-	gun.desc += span_notice(" This [gun.name] has a license permit cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].")
-	return TRUE
+/obj/item/firing_pin/paywall/gun_insert(mob/living/user, obj/item/gun/new_gun, starting = FALSE)
+	if(pin_owner || starting)
+		. = ..()
+		gun.desc += span_notice("This [gun.name] has a [multi_payment ? "per-shot" : "license permit"] cost of [payment_amount] credit[payment_amount > 1 ? "s" : ""].")
+		return
 
+	if(isnull(user))
+		forceMove(new_gun.drop_location())
+	else
+		to_chat(user, span_warning("ERROR: Please swipe valid identification card before installing firing pin!"))
+		user.put_in_hands(src)
+	return FALSE
 
 /obj/item/firing_pin/paywall/gun_remove(mob/living/user)
 	gun.desc = gun::desc
-	..()
+	. = ..()
 
-/obj/item/firing_pin/paywall/attackby(obj/item/M, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(isidcard(M))
-		var/obj/item/card/id/id = M
-		if(!id.registered_account)
-			to_chat(user, span_warning("ERROR: Identification card lacks registered bank account!"))
-			return
-		if(id.registered_account != pin_owner && owned)
-			to_chat(user, span_warning("ERROR: This firing pin has already been authorized!"))
-			return
-		if(id.registered_account == pin_owner)
-			to_chat(user, span_notice("You unlink the card from the firing pin."))
-			gun_owners -= user.get_bank_account()
-			pin_owner = null
-			owned = FALSE
-			return
-		var/transaction_amount = tgui_input_number(user, "Insert valid deposit amount for gun purchase", "Money Deposit")
-		if(!transaction_amount || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
-			return
-		pin_owner = id.registered_account
-		owned = TRUE
-		payment_amount = transaction_amount
-		gun_owners += user.get_bank_account()
-		to_chat(user, span_notice("You link the card to the firing pin."))
+/obj/item/firing_pin/paywall/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!isidcard(tool))
+		return NONE
+	var/obj/item/card/id/id = tool
+	if(!id.registered_account)
+		to_chat(user, span_warning("ERROR: Identification card lacks registered bank account!"))
+		return ITEM_INTERACT_BLOCKING
+	if(id.registered_account != pin_owner)
+		to_chat(user, span_warning("ERROR: This firing pin has already been authorized!"))
+		return ITEM_INTERACT_BLOCKING
+	if(id.registered_account == pin_owner)
+		to_chat(user, span_notice("You unlink the card from the firing pin."))
+		gun_owners -= user.get_bank_account()
+		pin_owner = NUTRITION_LEVEL_START_MIN
+		return ITEM_INTERACT_SUCCESS
+	var/transaction_amount = tgui_input_number(user, "Insert valid deposit amount for gun purchase", "Money Deposit")
+	if(!transaction_amount || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+		return ITEM_INTERACT_BLOCKING
+	pin_owner = id.registered_account
+	payment_amount = transaction_amount
+	gun_owners += user.get_bank_account()
+	to_chat(user, span_notice("You link the card to the firing pin."))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/firing_pin/paywall/pin_auth(mob/living/user)
 	if(!istype(user))//nice try commie
@@ -332,12 +329,12 @@
 					pin_owner.adjust_money(payment_amount, "Firing Pin: Gun License Bought")
 				gun_owners += credit_card_details
 				to_chat(user, span_notice("Gun license purchased, have a secure day!"))
-
 			else
 				to_chat(user, span_warning("ERROR: User balance insufficent for successful transaction!"))
 
 		if("No", null)
 			to_chat(user, span_warning("ERROR: User has declined to purchase gun license!"))
+
 	active_prompt_user = null
 	return FALSE //we return false here so you don't click initially to fire, get the prompt, accept the prompt, and THEN the gun
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -209,7 +209,7 @@
 
 	QDEL_NULL(gun_reward.pin)
 	var/obj/item/firing_pin/pin = new
-	pin.gun_insert(new_gun = gun_reward)
+	pin.gun_insert(new_gun = gun_reward, starting = TRUE)
 
 ///For special overrides if an item can be bought or not.
 /datum/uplink_item/proc/can_be_bought(datum/uplink_handler/source)


### PR DESCRIPTION

## About The Pull Request

Closes #93839
Also made them use item_interaction while I'm at it

## Changelog
:cl:
fix: Luxury paywall lasers no longer drop their pins when spawned
/:cl:
