### PR TITLE
Fixes internals/externals not protecting humans from inhaling reagents

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -727,4 +727,6 @@
 /mob/living/carbon/human/expose_reagents(list/reagents, datum/reagents/source, methods, volume_modifier, show_message)
 	if(external || internal)
 		methods &= ~INHALE
+		if(methods == NONE)
+			return
 	return ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -723,3 +723,8 @@
 	if (HAS_TRAIT(src, TRAIT_IGNORE_FIRE_PROTECTION))
 		no_protection = TRUE
 	fire_handler.harm_human(seconds_per_tick, no_protection)
+
+/mob/living/carbon/human/expose_reagents(list/reagents, datum/reagents/source, methods, volume_modifier, show_message)
+	if(external || internal)
+		methods &= ~INHALE
+	return ..()


### PR DESCRIPTION
## About The Pull Request
- Fixes #93719

Be it zombie powder or any reagent that is exposed to humans (not general carbon mobs) via `INHALE` method it is now nullified if they have their internals/externals on

## Changelog
:cl:
fix: internals/externals in humans now protect against all inhalation effects of reagents
/:cl:
