### PR TITLE
[NO GBP] Fixes ear protection equipment doing nothing. Flashbangs don't work well in vacuums

### DIFF
--- a/code/datums/components/earprotection.dm
+++ b/code/datums/components/earprotection.dm
@@ -9,8 +9,7 @@
 
 /datum/component/wearertargeting/earprotection/Initialize(protection_amount = EAR_PROTECTION_NORMAL)
 	. = ..()
-	if(protection_amount)
-		src.protection_amount = protection_amount
+	src.protection_amount = protection_amount
 
 /datum/component/wearertargeting/earprotection/proc/reducebang(datum/source, list/reflist)
 	SIGNAL_HANDLER

--- a/code/datums/components/earprotection.dm
+++ b/code/datums/components/earprotection.dm
@@ -1,14 +1,17 @@
+///Whenever get_ear_protection() is called, this proc adds 'protection_value' to the wearer's natural ear protection.
 /datum/component/wearertargeting/earprotection
 	signals = list(COMSIG_LIVING_GET_EAR_PROTECTION)
 	mobtype = /mob/living/carbon
 	proctype = PROC_REF(reducebang)
-	var/reduce_amount = 1
+	//positive amount indicating how much protection this gives
+	var/protection_amount = 1
 	valid_slots = ITEM_SLOT_EARS | ITEM_SLOT_HEAD
 
-/datum/component/wearertargeting/earprotection/Initialize(reduce_amount = 1)
+/datum/component/wearertargeting/earprotection/Initialize(protection_amount = 1)
 	. = ..()
-	if(reduce_amount)
-		src.reduce_amount = reduce_amount
+	if(protection_amount)
+		src.protection_amount = protection_amount
 
 /datum/component/wearertargeting/earprotection/proc/reducebang(datum/source, list/reflist)
-	reflist[EAR_PROTECTION_ARG] -= reduce_amount
+	SIGNAL_HANDLER
+	reflist[EAR_PROTECTION_ARG] += protection_amount

--- a/code/datums/components/earprotection.dm
+++ b/code/datums/components/earprotection.dm
@@ -7,7 +7,7 @@
 	var/protection_amount = 1
 	valid_slots = ITEM_SLOT_EARS | ITEM_SLOT_HEAD
 
-/datum/component/wearertargeting/earprotection/Initialize(protection_amount = 1)
+/datum/component/wearertargeting/earprotection/Initialize(protection_amount = EAR_PROTECTION_NORMAL)
 	. = ..()
 	if(protection_amount)
 		src.protection_amount = protection_amount

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -37,7 +37,7 @@
 		return
 
 	//Check that there's enough pressure on the detonation turf for the 'bang' part of the flashbang to work.
-	var/datum/gas_mixture/environment = current_turf.return_air()
+	var/datum/gas_mixture/environment = flashbang_turf.return_air()
 	var/pressure = environment?.return_pressure()
 	var/soundbang = pressure >= SOUND_MINIMUM_PRESSURE
 

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -35,21 +35,27 @@
 	var/flashbang_turf = get_turf(src)
 	if(!flashbang_turf)
 		return
+
+	//Check that there's enough pressure on the detonation turf for the 'bang' part of the flashbang to work.
+	var/datum/gas_mixture/environment = current_turf.return_air()
+	var/pressure = environment?.return_pressure()
+	var/soundbang = pressure >= SOUND_MINIMUM_PRESSURE
+
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/items/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, flashbang_range + 2, 4, COLOR_WHITE, 2)
 	for(var/mob/living/living_mob in get_hearers_in_view(flashbang_range, flashbang_turf))
-		bang(get_turf(living_mob), living_mob)
+		bang(get_turf(living_mob), living_mob, soundbang)
 	qdel(src)
 
-/obj/item/grenade/flashbang/proc/bang(turf/turf, mob/living/living_mob)
+/obj/item/grenade/flashbang/proc/bang(turf/turf, mob/living/living_mob, soundbang = TRUE)
 	if(living_mob.stat == DEAD) //They're dead!
 		return
 	living_mob.show_message(span_warning("BANG"), MSG_AUDIBLE)
 	var/distance = get_dist(get_turf(src), turf)
 	var/sweetspot_range = clamp(CEILING(flashbang_range/sweetspot_divider, 1), 0, flashbang_range)
 
-//Flash
+	//Flash
 	var/attempt_flash = living_mob.flash_act(affect_silicon = 1)
 	if(attempt_flash == FLASH_COMPLETED)
 		if(distance <= sweetspot_range || issilicon(living_mob))
@@ -60,7 +66,10 @@
 		living_mob.dropItemToGround(living_mob.get_active_held_item())
 		living_mob.dropItemToGround(living_mob.get_inactive_held_item())
 
-//Bang
+	//Bang
+	if(!soundbang && distance)
+		return
+
 	if(!distance)
 		living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 20 SECONDS, 10, 15)
 		return

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -32,7 +32,7 @@
 		return
 
 	update_mob()
-	var/flashbang_turf = get_turf(src)
+	var/turf/flashbang_turf = get_turf(src)
 	if(!flashbang_turf)
 		return
 

--- a/code/modules/clothing/head/perceptomatrix.dm
+++ b/code/modules/clothing/head/perceptomatrix.dm
@@ -102,7 +102,7 @@
 
 	// When someone makes TRAIT_DEAF an element, or status effect, or whatever, give this item a way to bypass said deafness.
 	// just blocking future instances of deafness isn't what the item is meant to do but there's no proper way to do it otherwise at the moment.
-	active_components += AddComponent(/datum/component/wearertargeting/earprotection, reduce_amount = 2) // should be same as highest value
+	active_components += AddComponent(/datum/component/wearertargeting/earprotection, EAR_PROTECTION_HEAVY) // should be same as highest value
 	active_components += AddComponent(
 		/datum/component/anti_magic, \
 		antimagic_flags = MAGIC_RESISTANCE_MIND, \

--- a/code/modules/unit_tests/combat.dm
+++ b/code/modules/unit_tests/combat.dm
@@ -150,3 +150,6 @@
 	var/obj/item/organ/ears/ears = victim.get_organ_slot(ORGAN_SLOT_EARS)
 	ears.adjust_temporary_deafness(-20 SECONDS)
 	TEST_ASSERT(!HAS_TRAIT_FROM(victim, TRAIT_DEAF, EAR_DAMAGE), "victim hasn't recovered from temprorary deafness")
+	victim.equip_to_slot_if_possible(new /obj/item/clothing/ears/earmuffs, ITEM_SLOT_EARS)
+	victim.soundbang_act(intensity = SOUNDBANG_NORMAL, deafen_pwr = 20 SECONDS)
+	TEST_ASSERT(!HAS_TRAIT_FROM(victim, TRAIT_DEAF, EAR_DAMAGE), "victim has been deafened despite wearing earmuffs")


### PR DESCRIPTION
## About The Pull Request
Turns out ear protection was subtracting the values rather than adding them to the protection, and I didn't notice that much until later (now). Also flashbangs don't have much of a bang (flashbangs without the bang basically) when there's no air.

## Why It's Good For The Game
Also everyone should know that IRL sounds don't work well in vacuums cuz there are no molecules to carry sound waves around. Unfortunately we are not so refined about it in game, which is a fucking shame. This is a very simplistic implementation than anything. The fact that I'm adding it to this PR as well is because being in a vacuum gives you plenty of sound protection now. It's about *some* consistency.

## Changelog

:cl:
fix: Fixes ear protection equipment doing nothing. 
balance: Detonating a flashbang in space or any environment with little to no air no longer stuns anyone NOT on the same tile as the flashbang with loud bangs. Flashing still works as intended though.
/:cl:
