### PR TITLE
Unsorts the ruins in the Spawn Ruin verb

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -615,7 +615,7 @@ ADMIN_VERB(place_ruin, R_DEBUG, "Spawn Ruin", "Attempt to randomly place a speci
 			themed_names[name] = list(ruin, theme, list(ruin.default_area))
 		names += sort_list(themed_names)
 
-	var/ruinname = tgui_input_list(user, "Select ruin", "Spawn Ruin", sort_list(names))
+	var/ruinname = tgui_input_list(user, "Select ruin", "Spawn Ruin", names)
 	var/data = names[ruinname]
 	if (!data)
 		return


### PR DESCRIPTION

## About The Pull Request

why

<img width="325" height="329" alt="image" src="https://github.com/user-attachments/assets/8a9aa05a-b85b-415e-977c-9d43d35297e3" />

Now they're only sorted within their own categories instead of being sorted twice

## Changelog
:cl:
fix: Spawn Ruin verb no longer "sorts" its ruins alphabetically, instead sorting them within their categories
/:cl:
