### PR TITLE
Ties security level looping sounds to ambience volume

### DIFF
--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(security_level)
 	if(!current_security_level.looping_sound) // No sound? No play.
 		can_fire = FALSE
 		return
-	sound_to_playing_players(current_security_level.looping_sound)
+	sound_to_playing_players(current_security_level.looping_sound, volume_preference = /datum/preference/numeric/volume/sound_ambience_volume)
 
 
 /**

--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -179,13 +179,13 @@
 
 	SEND_SOUND(src, sound_to_use)
 
-/proc/sound_to_playing_players(soundin, volume = 100, vary = FALSE, frequency = 0, channel = 0, pressure_affected = FALSE, sound/S)
+/proc/sound_to_playing_players(soundin, volume = 100, vary = FALSE, frequency = 0, channel = 0, pressure_affected = FALSE, sound/S, datum/preference/numeric/volume/volume_preference = null)
 	if(!S)
 		S = sound(get_sfx(soundin))
 	for(var/m in GLOB.player_list)
 		if(ismob(m) && !isnewplayer(m))
 			var/mob/M = m
-			M.playsound_local(M, null, volume, vary, frequency, null, channel, pressure_affected, S)
+			M.playsound_local(M, null, volume, vary, frequency, null, channel, pressure_affected, S, volume_preference = volume_preference)
 
 /mob/proc/stop_sound_channel(chan)
 	SEND_SOUND(src, sound(null, repeat = 0, wait = 0, channel = chan))


### PR DESCRIPTION
## About The Pull Request
Adds `volume_preference` to `sound_to_playing_players` and uses it to tie security level looping sounds to the ambience volume

Maybe this needs a new preference or to be tied to a different one?
## Why It's Good For The Game
TG doesn't have any security level datums that play looping sounds but some downstreams do. If we ever do get looping sounds for an existing/new security level, this will probably be helpful.
## Changelog
:cl:
code: `sound_to_playing_players` now has an argument for taking a volume preference, and it's applied to security level looping sounds in case any are added.
/:cl:
