### PR TITLE
Fixes annoying flaky runtimes with water elements

### DIFF
--- a/code/datums/elements/swimming_tile.dm
+++ b/code/datums/elements/swimming_tile.dm
@@ -41,6 +41,10 @@
 	SIGNAL_HANDLER
 	if (!istype(swimmer))
 		return
+	if(QDELETED(swimmer))
+		return
+	if(HAS_TRAIT(swimmer, TRAIT_IMMERSED))
+		return
 	RegisterSignal(swimmer, SIGNAL_ADDTRAIT(TRAIT_IMMERSED), PROC_REF(dip_in))
 	if(HAS_TRAIT(swimmer, TRAIT_IMMERSED))
 		dip_in(swimmer)

--- a/code/datums/elements/watery_tile.dm
+++ b/code/datums/elements/watery_tile.dm
@@ -24,7 +24,7 @@
 
 	if(QDELETED(entered))
 		return
-	if(HAS_TRAIT(entered, TRAIT_IMMERSED || HAS_TRAIT(entered, TRAIT_WALLMOUNTED)))
+	if(HAS_TRAIT(entered, TRAIT_IMMERSED) || HAS_TRAIT(entered, TRAIT_WALLMOUNTED))
 		return
 	RegisterSignal(entered, SIGNAL_ADDTRAIT(TRAIT_IMMERSED), PROC_REF(dip_in))
 	if(isliving(entered))

--- a/code/datums/elements/watery_tile.dm
+++ b/code/datums/elements/watery_tile.dm
@@ -22,6 +22,10 @@
 /datum/element/watery_tile/proc/enter_water(atom/source, atom/movable/entered)
 	SIGNAL_HANDLER
 
+	if(QDELETED(entered))
+		return
+	if(HAS_TRAIT(entered, TRAIT_IMMERSED || HAS_TRAIT(entered, TRAIT_WALLMOUNTED)))
+		return
 	RegisterSignal(entered, SIGNAL_ADDTRAIT(TRAIT_IMMERSED), PROC_REF(dip_in))
 	if(isliving(entered))
 		RegisterSignal(entered, SIGNAL_REMOVETRAIT(TRAIT_IMMERSED), PROC_REF(dip_out))


### PR DESCRIPTION
## About The Pull Request

Like the immerse element, these register the entered() procs to both `COMSIG_ATOM_ENTERED` and `COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON`.

This is fine, but when you are creating an atom on a turf with this element, both signals will be sent and it will double up on the proc call. Additionally there is a possibility for qdeleted items to end up in these tiles and create hard dels. This should fix all that.

<img width="1700" height="405" alt="firefox_rxIsE9ZKN9" src="https://github.com/user-attachments/assets/c8fb11df-9d17-4d81-9eee-920a03bb40e8" />

## Why It's Good For The Game

Bugfix

## Changelog

Nothing players will notice