### PR TITLE
Makes aux base builder failure message say the name not the path

### DIFF
--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -35,7 +35,7 @@
 		to_chat(owner, span_warning("You can only build within [area_constraint::name]!"))
 		return FALSE
 	if(only_station_z && !is_station_level(build_target.z))
-		to_chat(owner, span_warning("[area_constraint.name] has launched and can no longer be modified."))
+		to_chat(owner, span_warning("[area_constraint::name] has launched and can no longer be modified."))
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -32,7 +32,7 @@
 	if (!area_constraint)
 		return TRUE
 	if(!istype(build_area, area_constraint))
-		to_chat(owner, span_warning("You can only build within [area_constraint]!"))
+		to_chat(owner, span_warning("You can only build within [area_constraint.name]!"))
 		return FALSE
 	if(only_station_z && !is_station_level(build_target.z))
 		to_chat(owner, span_warning("[area_constraint] has launched and can no longer be modified."))

--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -32,7 +32,7 @@
 	if (!area_constraint)
 		return TRUE
 	if(!istype(build_area, area_constraint))
-		to_chat(owner, span_warning("You can only build within [area_constraint.name]!"))
+		to_chat(owner, span_warning("You can only build within [area_constraint::name]!"))
 		return FALSE
 	if(only_station_z && !is_station_level(build_target.z))
 		to_chat(owner, span_warning("[area_constraint.name] has launched and can no longer be modified."))

--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -35,7 +35,7 @@
 		to_chat(owner, span_warning("You can only build within [area_constraint.name]!"))
 		return FALSE
 	if(only_station_z && !is_station_level(build_target.z))
-		to_chat(owner, span_warning("[area_constraint] has launched and can no longer be modified."))
+		to_chat(owner, span_warning("[area_constraint.name] has launched and can no longer be modified."))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Makes the base builder console "you can't build here" response thing say the name of the area, rather than the path

## Why It's Good For The Game

You can't build within area/shuttle/auxillary_base

## Changelog
:cl:

spellcheck: Auxbase construction console says the name of the area rather than the path in failure messages

/:cl:
