### PR TITLE
Subsystem status effect fix (stun shoving/stuns fix)

### DIFF
--- a/code/controllers/subsystem/processing/priority_effects.dm
+++ b/code/controllers/subsystem/processing/priority_effects.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(priority_effects)
 	name = "Priority Status Effects"
-	flags = SS_TICKER | SS_KEEP_TIMING | SS_NO_INIT
+	flags = SS_KEEP_TIMING | SS_NO_INIT
 	wait = 2 // Not seconds - we're running on SS_TICKER, so this is ticks.
 	priority = FIRE_PRIORITY_PRIORITY_EFFECTS
 	stat_tag = "PEFF"

--- a/code/controllers/subsystem/processing/priority_effects.dm
+++ b/code/controllers/subsystem/processing/priority_effects.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(priority_effects)
 	name = "Priority Status Effects"
 	flags = SS_KEEP_TIMING | SS_NO_INIT
-	wait = 2 SECONDS
+	wait = 1 SECONDS
 	priority = FIRE_PRIORITY_PRIORITY_EFFECTS
 	stat_tag = "PEFF"

--- a/code/controllers/subsystem/processing/priority_effects.dm
+++ b/code/controllers/subsystem/processing/priority_effects.dm
@@ -1,6 +1,5 @@
 PROCESSING_SUBSYSTEM_DEF(priority_effects)
 	name = "Priority Status Effects"
 	flags = SS_KEEP_TIMING | SS_NO_INIT
-	wait = 2 // Not seconds - we're running on SS_TICKER, so this is ticks.
 	priority = FIRE_PRIORITY_PRIORITY_EFFECTS
 	stat_tag = "PEFF"

--- a/code/controllers/subsystem/processing/priority_effects.dm
+++ b/code/controllers/subsystem/processing/priority_effects.dm
@@ -1,5 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(priority_effects)
 	name = "Priority Status Effects"
 	flags = SS_KEEP_TIMING | SS_NO_INIT
+	wait = 2 SECONDS
 	priority = FIRE_PRIORITY_PRIORITY_EFFECTS
 	stat_tag = "PEFF"


### PR DESCRIPTION
## About The Pull Request
@RikuTheKiller 

Closes #93875

Remove obsolete SS_TICKER flag due to refactor (#93694)

## Why It's Good For The Game

#93694 Oversight
Bug - Status effects (stun shoving, etc) are too short (things such as shove combat are broken at the moment).

## Changelog

:cl: ArchBTW
fix: Subsystem status effect fix (stun shoves, stuns in general)
/:cl:
