### PR TITLE
fixes taking pizza slices having a swapped self message and visible message

### DIFF
--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -73,7 +73,7 @@
 	. = ..()
 	if(!sliced)
 		return
-	user.visible_message(span_notice("You take a slice of [src]."), span_notice("[user] takes a slice of [src]."))
+	user.visible_message(span_notice("[user] takes a slice of [src]."), span_notice("You take a slice of [src]."))
 	produce_slice(user)
 
 /obj/item/food/pizza/proc/get_slices_filter() //to not repeat code


### PR DESCRIPTION

## About The Pull Request

when taking a pizza slice, the message displayed to other plays says "You take a slice of...", this is because the messages were backwards in the visible message proc
## Why It's Good For The Game

Immersion broken that's not me taking the pizza slice
## Changelog
:cl:
fix: fixes pizza slices displaying the wrong message when taken
/:cl:
