### PR TITLE
Fixes every single high-priority status effect in the game running twice as fast

### DIFF
--- a/code/controllers/subsystem/processing/priority_effects.dm
+++ b/code/controllers/subsystem/processing/priority_effects.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(priority_effects)
 	name = "Priority Status Effects"
-	flags = SS_TICKER | SS_KEEP_TIMING | SS_NO_INIT
-	wait = 2 // Not seconds - we're running on SS_TICKER, so this is ticks.
+	flags = SS_KEEP_TIMING | SS_NO_INIT
+	wait = 0.2 SECONDS // Same as SSfastprocess, but can be anything, assuming you refactor all high-priority status effect intervals and durations to be a multiple of it.
 	priority = FIRE_PRIORITY_PRIORITY_EFFECTS
 	stat_tag = "PEFF"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #93875

Removes an obsolete SS_TICKER flag from SSpriority_effects, which was originally put there by Absolucy for a priority bump. The original issue with status effects pausing for long periods of time was very likely caused by the SS_BACKGROUND flag on both SSprocessing and SSfast_process, which SSpriority_effects doesn't have.

The reason why this issue surfaced is because of #93694, which caused the inconsistency between the real wait time of 0.1s and passed seconds_per_tick of 0.2s to become apparent in the duration of status effects. Previously, duration was based on world.time, which was unaffected by this inconsistency, even though it existed before my PR as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing all stun times being halved for no raisin is pretty good for the game.

It's also better for the SSpriority_effects subsystem to respect the subsystem priority order. If we need it to be higher in the order, then make it that way, instead of using SS_TICKER to bypass it entirely.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: High-priority status effects like stuns no longer process (and thus expire) twice as quickly as they should.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
