### PR TITLE
Moves the Metastation Security Locker Room APC

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6805,7 +6805,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -37079,9 +37078,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "mMl" = (
@@ -44709,6 +44706,8 @@
 "pti" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "pts" = (


### PR DESCRIPTION

## About The Pull Request
Moves the sec locker room apc on Meta
<img width="346" height="272" alt="Screenshot 2025-11-10 113932" src="https://github.com/user-attachments/assets/b4143da4-8527-4cfe-aa23-687f83fca4ee" />
<img width="373" height="454" alt="Screenshot 2025-11-10 122716" src="https://github.com/user-attachments/assets/2939bac4-e690-41fb-991a-cbaf9b8b346a" />


## Why It's Good For The Game
the lightswitch for the locker room is under the apc, moving the apc made the most sense
## Changelog
:cl:
map: moved metastation security locker room apc
/:cl:
