### PR TITLE
Blob minion mobs spawned from a non-blob source can no longer traverse blob tiles

### DIFF
--- a/code/datums/components/blob_minion.dm
+++ b/code/datums/components/blob_minion.dm
@@ -49,6 +49,8 @@
 	RegisterSignal(overmind, COMSIG_QDELETING, PROC_REF(overmind_deleted))
 	RegisterSignal(overmind, COMSIG_BLOB_SELECTED_STRAIN, PROC_REF(strain_properties_changed))
 	strain_properties_changed(overmind, overmind.blobstrain)
+	var/mob/living_parent = parent
+	living_parent.pass_flags |= PASSBLOB
 
 /// Our overmind is gone, uh oh!
 /datum/component/blob_minion/proc/overmind_deleted()
@@ -70,7 +72,6 @@
 
 /datum/component/blob_minion/RegisterWithParent()
 	var/mob/living/living_parent = parent
-	living_parent.pass_flags |= PASSBLOB
 	living_parent.faction |= ROLE_BLOB
 	ADD_TRAIT(parent, TRAIT_BLOB_ALLY, REF(src))
 	remove_verb(parent, /mob/living/verb/pulled) // No dragging people into the blob
@@ -113,6 +114,7 @@
 		COMSIG_HOSTILE_PRE_ATTACKINGTARGET,
 	))
 	GLOB.blob_telepathy_mobs -= parent
+	living_parent.pass_flags &= ~PASSBLOB
 
 /// Become blobpilled when we gain a mind
 /datum/component/blob_minion/proc/on_mind_init(mob/living/minion, datum/mind/new_mind)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -198,7 +198,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /// Create a blob spore and link it to us
 /mob/eye/blob/proc/create_spore(turf/spore_turf, spore_type = /mob/living/basic/blob_minion/spore/minion)
-	var/mob/living/basic/blob_minion/spore/spore = new spore_type(spore_turf)
+	var/mob/living/basic/blob_minion/spore/spore = new spore_type(spore_turf, blob_borne = TRUE)
 	spore.AddComponent(/datum/component/blob_minion, src)
 	return spore
 

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -216,7 +216,8 @@
 		factory.assign_blobbernaut(null)
 		return FALSE
 
-	var/mob/living/basic/blob_minion/blobbernaut/minion/blobber = new(get_turf(factory))
+	var/mob_type = /mob/living/basic/blob_minion/spore/minion
+	var/mob/living/basic/blob_minion/blobbernaut/minion/blobber = new mob_type(get_turf(factory), blob_borne = TRUE)
 	blobber.AddComponent(/datum/component/blob_minion, new_overmind = src, new_death_cloud_size = blobber.death_cloud_size)
 	factory.assign_blobbernaut(blobber)
 	blobber.assign_key(ghost.key, blobstrain)

--- a/code/modules/mob/living/basic/blob_minions/blob_mob.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_mob.dm
@@ -7,7 +7,6 @@
 	base_icon_state = "blob_head"
 	unique_name = TRUE
 	status_flags = CANPUSH
-	pass_flags = PASSBLOB
 	faction = list(ROLE_BLOB)
 	combat_mode = TRUE
 	bubble_icon = "blob"
@@ -24,6 +23,11 @@
 	/// Size of cloud produced from a dying spore
 	var/death_cloud_size = BLOBMOB_CLOUD_NONE
 	var/loot = /obj/item/food/spore_sack
+
+/mob/living/basic/blob_minion/New(loc, blob_borne)
+	. = ..()
+	if(blob_borne)
+		pass_flags = PASSBLOB
 
 /mob/living/basic/blob_minion/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/blob_minions/blob_spore.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_spore.dm
@@ -52,6 +52,7 @@
 /mob/living/basic/blob_minion/spore/proc/zombify(mob/living/carbon/human/target)
 	visible_message(span_warning("The corpse of [target.name] suddenly rises!"))
 	var/mob/living/basic/blob_minion/zombie/blombie = change_mob_type(zombie_type, loc, new_name = initial(zombie_type.name))
+	blombie.pass_flags |= PASSBLOB //No way to pass the blob_borne info through change_mob_type() to Initilize(), so we just circumvent it here.
 	blombie.faction |= faction //inherit the spore's faction in case it was spawned with a different one (eg gold core)
 	blombie.set_name()
 	if (istype(blombie)) // In case of badmin


### PR DESCRIPTION

## About The Pull Request

See title.
## Why It's Good For The Game

Closes #84270. Blob minions can no longer attack blob tiles, but this takes care of them getting free healing from the blob while fighting its minions.
## Changelog
:cl: Rhials
fix: Non-blob-spawned blob minion mobs can no longer traverse blob tiles.
/:cl:
