### PR TITLE
Adds Visitation Shutters Control button to Icebox Security

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -55603,7 +55603,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/button/flasher{
 	id = "visitorflash";
-	pixel_y = -26
+	pixel_y = -26;
+	pixel_x = -7
+	},
+/obj/machinery/button/door/directional/south{
+	pixel_x = 7;
+	pixel_y = -26;
+	name = "Visitation Shutters Control";
+	id = "visitation";
+	req_access = list("brig")
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)


### PR DESCRIPTION

## About The Pull Request

Adds a control button for visitation shutters
## Why It's Good For The Game

For whatever reason Icebox perma has been missing a shutter control button for a while, now it has one.

https://github.com/user-attachments/assets/78f544c7-6e85-4bae-9e33-ae064cad510d
## Changelog
:cl:
map: adds visitation shutter control button to icebox perma
/:cl:
