### PR TITLE
Fixes shears not allowed surgery tray

### DIFF
--- a/code/datums/storage/subtypes/others/misc.dm
+++ b/code/datums/storage/subtypes/others/misc.dm
@@ -32,6 +32,7 @@
 		/obj/item/reagent_containers/medigel/sterilizine,
 		/obj/item/retractor,
 		/obj/item/scalpel,
+		/obj/item/shears,
 		/obj/item/stack/medical/bone_gel,
 		/obj/item/stack/sticky_tape/surgical,
 		/obj/item/surgical_drapes,

--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -218,6 +218,7 @@
 		/obj/item/reagent_containers/medigel/sterilizine,
 		/obj/item/bonesetter,
 		/obj/item/blood_filter,
+		/obj/item/shears,
 		/obj/item/stack/medical/bone_gel,
 		/obj/item/stack/sticky_tape/surgical,
 		/obj/item/clothing/mask/surgical,


### PR DESCRIPTION
## About The Pull Request

- Fixes shears being unable to be stored in the surgery tray
- Adds shears to the debug surgery tray on runtimestation

## Why It's Good For The Game

- Shears can be consistently stored like other surgery tools
- Saves time debugging bodyparts with runtimestation

## Changelog

:cl: LT3
fix: Shears now able to be stored in the surgery tray
/:cl: