### PR TITLE
Moves the HFR from process() to process_atmos()

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -325,7 +325,7 @@ SUBSYSTEM_DEF(air)
 		currentrun.len--
 		if(!M)
 			atmos_machinery -= M
-		if(M.process_atmos() == PROCESS_KILL)
+		if(M.process_atmos(wait * 0.1) == PROCESS_KILL)
 			stop_processing_machine(M)
 		if(MC_TICK_CHECK)
 			return

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -309,7 +309,11 @@
 	set waitfor = FALSE
 	return PROCESS_KILL
 
-/obj/machinery/proc/process_atmos()//If you dont use process why are you here
+/**
+ * Process but for machines interacting with atmospherics.
+ * Like process, anything sensitive to changes in the wait time between process ticks should account for seconds_per_tick.
+**/
+/obj/machinery/proc/process_atmos(seconds_per_tick)//If you dont touch atmos why are you here
 	set waitfor = FALSE
 	return PROCESS_KILL
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -4,7 +4,7 @@
  * fusion_process() handles all the main fusion reaction logic and consequences (lightning, radiation, particles) from an active fusion reaction.
  */
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/process(seconds_per_tick)
+/obj/machinery/atmospherics/components/unary/hypertorus/core/process_atmos(seconds_per_tick)
 	/*
 	 *Pre-checks
 	 */
@@ -21,11 +21,11 @@
 
 	// Run the reaction if it is either live or being started
 	if (start_power || power_level)
-		play_ambience()
+		play_ambience(seconds_per_tick)
 		fusion_process(seconds_per_tick)
 		// Note that we process damage/healing even if the fusion process aborts.
 		// Running out of fuel won't save you if your moderator and coolant are exploding on their own.
-		process_moderator_overflow()
+		process_moderator_overflow(seconds_per_tick)
 		process_damageheal(seconds_per_tick)
 		check_alert()
 	if (start_power)
@@ -33,6 +33,10 @@
 	update_pipenets()
 
 	check_deconstructable()
+
+	if(linked_interface)
+		// The interface MUST be updated after every atmos tick to show accurate information.
+		SStgui.update_uis(linked_interface)
 
 /**
  * Called by process()
@@ -202,11 +206,11 @@
 	radiation = max(-(PLANCK_LIGHT_CONSTANT / 5e-18) * radiation_modifier * delta_temperature, 0)
 	power_output = efficiency * (internal_power - conduction - radiation)
 	//Hotter air is easier to heat up and cool down
-	heat_limiter_modifier = 10 * (10 ** power_level) * (heating_conductor / 100)
+	heat_limiter_modifier = 5 * (10 ** power_level) * (heating_conductor / 100)
 	//The amount of heat that is finally emitted, based on the power output. Min and max are variables that depends of the modifier
 	heat_output_min = - heat_limiter_modifier * 0.01 * negative_temperature_multiplier
 	heat_output_max = heat_limiter_modifier * positive_temperature_multiplier
-	heat_output = clamp(internal_instability * power_output * heat_modifier / 100, heat_output_min, heat_output_max)
+	heat_output = clamp(internal_instability * power_output * heat_modifier / 200, heat_output_min, heat_output_max)
 
 	// Is the fusion process actually going to run?
 	// Note we have to always perform the above calculations to keep the UI updated, so we can't use this to early return.
@@ -219,9 +223,9 @@
 	var/production_amount
 	switch(power_level)
 		if(3,4)
-			production_amount = clamp(heat_output * 5e-4, 0, fuel_consumption_rate) * seconds_per_tick
+			production_amount = clamp(heat_output * 1e-3, 0, fuel_consumption_rate) * seconds_per_tick
 		else
-			production_amount = clamp(heat_output / 10 ** (power_level+1), 0, fuel_consumption_rate) * seconds_per_tick
+			production_amount = clamp(heat_output * 2 / 10 ** (power_level+1), 0, fuel_consumption_rate) * seconds_per_tick
 
 	// antinob production is special, and uses its own calculations from how stale the fusion mix is (via byproduct ratio and fresh fuel rate)
 	var/dirty_production_rate = scaled_fuel_list[scaled_fuel_list[3]] / fuel_injection_rate
@@ -379,7 +383,11 @@
 	//Modifies the internal_fusion temperature with the amount of heat output
 	var/temperature_modifier = selected_fuel.temperature_change_multiplier
 	if(internal_fusion.temperature <= FUSION_MAXIMUM_TEMPERATURE * temperature_modifier)
-		internal_fusion.temperature = clamp(internal_fusion.temperature + heat_output,TCMB,FUSION_MAXIMUM_TEMPERATURE * temperature_modifier)
+		internal_fusion.temperature = clamp(
+			internal_fusion.temperature + heat_output * seconds_per_tick,
+			TCMB,
+			FUSION_MAXIMUM_TEMPERATURE * temperature_modifier,
+		)
 	else
 		internal_fusion.temperature -= heat_limiter_modifier * 0.01 * seconds_per_tick
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -223,7 +223,7 @@
 	var/production_amount
 	switch(power_level)
 		if(3,4)
-			production_amount = clamp(heat_output * 1e-3, 0, fuel_consumption_rate) * seconds_per_tick
+			production_amount = clamp(heat_output / 1000, 0, fuel_consumption_rate) * seconds_per_tick
 		else
 			production_amount = clamp(heat_output * 2 / 10 ** (power_level+1), 0, fuel_consumption_rate) * seconds_per_tick
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -214,9 +214,9 @@
 /**
  * Infrequently plays accent sounds, and adjusts main loop parameters
  */
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/play_ambience()
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/play_ambience(seconds_per_tick)
 	// We play delam/neutral sounds at a rate determined by power and critical_threshold_proximity
-	if(last_accent_sound < world.time && prob(20))
+	if(last_accent_sound < world.time && SPT_PROB(10, seconds_per_tick))
 		var/aggression = min(((critical_threshold_proximity / 800) * ((power_level) / 5)), 1.0) * 100
 		if(critical_threshold_proximity >= 300)
 			playsound(src, SFX_HYPERTORUS_MELTING, max(50, aggression), FALSE, 40, 30, falloff_distance = 10)


### PR DESCRIPTION
## About The Pull Request

This pull request makes the HFR process at the same rate as other atmospheric components. Because its temperature changes previously didn't take `seconds_per_tick` into account, heat output and a few things related to it had to be adjusted to compensate. This also fixes a bug preventing the moderator from being able to leak its gases from cracked parts.

## Why It's Good For The Game

The HFR not processing with the rest of atmospheric machinery can occasionally cause odd behavior such as pressure spikes in the waste output every 1 in 4 atmos ticks, which this PR corrects.

## Changelog
:cl:
fix: Fixed cracked HFR parts not being able to leak moderator gases.
code: The HFR now processes at the same rate as other atmos machinery.
/:cl:
