### PR TITLE
Prevents you from putting yourself in the DNA vault multiple times

### DIFF
--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -54,32 +54,23 @@
 
 /obj/item/dna_probe/proc/try_upload_dna(obj/machinery/dna_vault/target, mob/user)
 	var/uploaded = 0
+	stored_dna_plants -= target.plant_dna
+	stored_dna_human -= target.human_dna
+	stored_dna_animal -= target.animal_dna
 	var/plant_dna_length = length(stored_dna_plants)
 	var/human_dna_length = length(stored_dna_human)
 	var/animal_dna_length = length(stored_dna_animal)
 	if(plant_dna_length)
-		for(var/plant_type in stored_dna_plants)
-			if(target.plant_dna[plant_type])
-				stored_dna_plants -= plant_type
-				plant_dna_length--
 		uploaded += plant_dna_length
-		target.plant_dna += stored_dna_plants
+		target.plant_dna |= stored_dna_plants
 		stored_dna_plants.Cut()
 	if(human_dna_length)
-		for(var/human_type in stored_dna_human)
-			if(target.human_dna[human_type])
-				stored_dna_human -= human_type
-				human_dna_length--
 		uploaded += human_dna_length
-		target.human_dna += stored_dna_human
+		target.human_dna |= stored_dna_human
 		stored_dna_human.Cut()
 	if(animal_dna_length)
-		for(var/animal_type in stored_dna_animal)
-			if(target.animal_dna[animal_type])
-				stored_dna_animal -= animal_type
-				human_dna_length--
 		uploaded += animal_dna_length
-		target.animal_dna += stored_dna_animal
+		target.animal_dna |= stored_dna_animal
 		stored_dna_animal.Cut()
 	target.check_goal()
 	playsound(target, 'sound/machines/compiler/compiler-stage1.ogg', 50)

--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -62,15 +62,15 @@
 	var/animal_dna_length = length(stored_dna_animal)
 	if(plant_dna_length)
 		uploaded += plant_dna_length
-		target.plant_dna |= stored_dna_plants
+		target.plant_dna += stored_dna_plants
 		stored_dna_plants.Cut()
 	if(human_dna_length)
 		uploaded += human_dna_length
-		target.human_dna |= stored_dna_human
+		target.human_dna += stored_dna_human
 		stored_dna_human.Cut()
 	if(animal_dna_length)
 		uploaded += animal_dna_length
-		target.animal_dna |= stored_dna_animal
+		target.animal_dna += stored_dna_animal
 		stored_dna_animal.Cut()
 	target.check_goal()
 	playsound(target, 'sound/machines/compiler/compiler-stage1.ogg', 50)

--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -58,14 +58,26 @@
 	var/human_dna_length = length(stored_dna_human)
 	var/animal_dna_length = length(stored_dna_animal)
 	if(plant_dna_length)
+		for(var/plant_type in stored_dna_plants)
+			if(target.plant_dna[plant_type])
+				stored_dna_plants -= plant_type
+				plant_dna_length--
 		uploaded += plant_dna_length
 		target.plant_dna += stored_dna_plants
 		stored_dna_plants.Cut()
 	if(human_dna_length)
+		for(var/human_type in stored_dna_human)
+			if(target.human_dna[human_type])
+				stored_dna_human -= human_type
+				human_dna_length--
 		uploaded += human_dna_length
 		target.human_dna += stored_dna_human
 		stored_dna_human.Cut()
 	if(animal_dna_length)
+		for(var/animal_type in stored_dna_animal)
+			if(target.animal_dna[animal_type])
+				stored_dna_animal -= animal_type
+				human_dna_length--
 		uploaded += animal_dna_length
 		target.animal_dna += stored_dna_animal
 		stored_dna_animal.Cut()


### PR DESCRIPTION
## About The Pull Request

You can't put more than one of the same dna in the vault, because the probe checks when it scans you that your dna isn't in the probe's storage or the vault's storage. But it doesn't check other probes, so multiple probes can have the same dna, and can all upload the same dna to the vault for duplicate DNA. 

This PR adds a check when you upload to a vault that throws out dna already in the vault before it's counted.

## Why It's Good For The Game

Duplicate DNA is clearly not intentional

## Changelog
:cl:

fix: You can no longer duplicate DNA for the DNA vault objective by scanning yourself on several probes at once.

/:cl:
