### PR TITLE
Fix error icons on loadout item GAGS reskins

### DIFF
--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -390,7 +390,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 		UNTYPED_LIST_ADD(reskins, list(
 			"name" = skin,
 			"tooltip" = skin,
-			"skin_icon_state" = cached_reskin_options[skin],
+			"skin_icon_state" = ((loadout_flags & LOADOUT_FLAG_GREYSCALING_ALLOWED) && !(loadout_flags & LOADOUT_FLAG_JOB_GREYSCALING)) ? item_path::icon_state : cached_reskin_options[skin],
 		))
 
 	return reskins


### PR DESCRIPTION
## About The Pull Request

Specifically for items that use GAGS. I'm not sure if TG has any of these in the loadout but we do and they look messed up. It's because GAGS items need to use map_icons for the loadout menu assets.

It still will only show the main icon (to show the actual reskins, that would require map icons to be generated for all reskins which currently does not happen, as well as adding more complicated logic) so I opted for this simple approach for now. Still better than error icons though.

<details><summary>before</summary>

<img width="402" height="598" alt="image" src="https://github.com/user-attachments/assets/ae57101c-87db-4128-b328-fcac5296bfd5" />

</details>

<details><summary>after</summary>

<img width="463" height="475" alt="QHo6HOnpwH" src="https://github.com/user-attachments/assets/d85f7027-b6d9-44dc-a76a-cd29f11d1c4e" />

</details>

## Why It's Good For The Game

Error icons dont look good

## Changelog

:cl:
fix: loadout item styles will no longer have broken icons in their selection menu
/:cl: