### PR TITLE
Fixes the icon state for the ashen bow

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
@@ -42,6 +42,7 @@
 /obj/item/gun/ballistic/bow/ashenbow
 	name = "ashen bow"
 	desc = "A bow made from watcher sinew and bone. Seems to possess an almost eerie radiance about it."
+	icon_state = "ashenbow"
 	inhand_icon_state = "ashenbow"
 	base_icon_state = "ashenbow"
 	worn_icon_state = "ashenbow"


### PR DESCRIPTION

## About The Pull Request

What it says on the tin.

## Why It's Good For The Game

This is obviously the incorrect icon state.

## Changelog
:cl:
fix: Ashen bows look like they are actually made from bone.
/:cl:
