### PR TITLE
Viscerator PASS flags

### DIFF
--- a/code/modules/mob/living/basic/trooper/syndicate.dm
+++ b/code/modules/mob/living/basic/trooper/syndicate.dm
@@ -219,7 +219,7 @@
 	icon_state = "viscerator_attack"
 	icon_living = "viscerator_attack"
 	density = FALSE
-	pass_flags = PASSTABLE | PASSMOB | PASSMACHINE | PASSFLAP
+	pass_flags = PASSTABLE | PASSMOB | PASSMACHINE | PASSFLAPS
 	combat_mode = TRUE
 	mob_biotypes = MOB_ROBOTIC
 	basic_mob_flags = DEL_ON_DEATH

--- a/code/modules/mob/living/basic/trooper/syndicate.dm
+++ b/code/modules/mob/living/basic/trooper/syndicate.dm
@@ -218,7 +218,8 @@
 	desc = "A small, twin-bladed machine capable of inflicting very deadly lacerations."
 	icon_state = "viscerator_attack"
 	icon_living = "viscerator_attack"
-	pass_flags = PASSTABLE | PASSMOB
+	density = FALSE
+	pass_flags = PASSTABLE | PASSMOB | PASSMACHINE | PASSFLAP
 	combat_mode = TRUE
 	mob_biotypes = MOB_ROBOTIC
 	basic_mob_flags = DEL_ON_DEATH


### PR DESCRIPTION
## About The Pull Request

Viscerator has PASSMOB, but doesn't respect the flag. Fixes possible oversight.
Adds flags PASSMACHINE && PASSFLAP.

## Why It's Good For The Game

PASSMOB:
- Possible oversight - Supposed to be respecting the PASSMOB flag

PASSMACHINE && PASSFLAP:
- Realistically manhacks would be able to fly over machines, and fly through flaps

## Changelog

:cl: ArchBTW
balance: viscerators get PASSMACHINE && PASSFLAP
fix: viscerators respect the PASSMOB flag
/:cl:
