### PR TITLE
Minor grammar edits for EMP_PROTECT flags

### DIFF
--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -26,18 +26,18 @@
 	if(flags & EMP_NO_EXAMINE)
 		return
 
-	if(flags & EMP_PROTECT_ALL == EMP_PROTECT_ALL)
+	if((flags & EMP_PROTECT_ALL) == EMP_PROTECT_ALL)
 		examine_list["EMP proof"] = "[source.p_They()] [source.p_are()] unaffected by electromagnetic pulses, and shields [source.p_their()] contents and wiring from them."
 		return
 
 	if(flags & EMP_PROTECT_SELF)
 		examine_list["EMP resilient"] = "[source.p_They()] [source.p_are()] unaffected by electromagnetic pulses."
 
-	if(flags & (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRES) == (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRES))
-		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring and contents from electromagnetic pulses."
+	if((flags & (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRES)) == (EMP_PROTECT_CONTENTS|EMP_PROTECT_WIRES))
+		examine_list["partially EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring and contents from electromagnetic pulses."
 
 	else if(flags & EMP_PROTECT_CONTENTS)
-		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] contents from electromagnetic pulses."
+		examine_list["partially EMP blocking"] = "[source.p_They()] protects [source.p_their()] contents from electromagnetic pulses."
 
 	else if(flags & EMP_PROTECT_WIRES)
-		examine_list["EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring from electromagnetic pulses."
+		examine_list["partially EMP blocking"] = "[source.p_They()] protects [source.p_their()] wiring from electromagnetic pulses."


### PR DESCRIPTION
## About The Pull Request

title (unrelated to grammar but pr also adds wrapping brackets in code!!!)

## Why It's Good For The Game

i think we should say that something is only PARTIALLY blocks emps, like borgs - their wires are protected from EMPs, but examine says "EMP blocking" and at first glance i'd assume they fully block EMPs.

## Changelog

:cl:
spellcheck: Items that block contents/wires from EMPs now showed up as only "partially EMP blocking" objects in examine menu.
/:cl:
