### PR TITLE
Moves "adv. parts" and "adv. surgery" from required to discount experiments.

### DIFF
--- a/code/modules/research/techweb/nodes/engi_nodes.dm
+++ b/code/modules/research/techweb/nodes/engi_nodes.dm
@@ -59,7 +59,7 @@
 		"hyper_cell",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
-	required_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier2_any)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier2_any = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(RADIO_CHANNEL_ENGINEERING)
 
 

--- a/code/modules/research/techweb/nodes/surgery_nodes.dm
+++ b/code/modules/research/techweb/nodes/surgery_nodes.dm
@@ -37,7 +37,7 @@
 		"surgery_wing_reconstruction",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
-	required_experiments = list(/datum/experiment/autopsy/human)
+	discount_experiments = list(/datum/experiment/autopsy/human = TECHWEB_TIER_2_POINTS)
 	announce_channels = list(RADIO_CHANNEL_MEDICAL)
 
 /datum/techweb_node/surgery_exp


### PR DESCRIPTION
## About The Pull Request

title says pretty much all

## Why It's Good For The Game

To begin with i'll say, that we should gatekeep advanced and more powerful nodes from being researched, rather than we do with those 2 nodes. While having medbay/engineering/other jobs like bitrunning to rely on science might sound like an interesting idea - it just doesnt really work well. I faced quite a lot of rounds, where station stuck with t2/basic surgeries, only because coroner/sci are too lazy to do the basics, resulting in completely unrelated to sci crewmembers doing experiments instead. 

Yes, i've seen also a lot of highpop rounds with staffed science department just fucking off for the next 50 minutes, rather than doing something, that takes you like 30-60 seconds of your round and benefits whole station, and honestly? I can understand them, not many people want to do the same job routine from round to round, even if its quite easy. 

Attempts to bring player intearctions with code are usually not ending well, with these features becoming a nuisance rather than something interesting. (see: removed Vend Shortages station trait). This PR is aimed to turn experiments to a nice bonuses for faster researches instead of keeping them as another required everyround routine.

## Changelog

:cl:
balance: Adv. parts and adv. surgery experiments are now discounts, instead of requirements.
/:cl:
