### PR TITLE
Gives the bartender a service plumbing constructor.

### DIFF
--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -312,6 +312,8 @@
 	name = "service plumbing constructor"
 	desc = "A type of plumbing constructor designed to rapidly deploy the machines needed to make a brewery."
 	icon_state = "plumberer_service"
+	///EXtra price because it appears in bartender's vendor
+	custom_premium_price = PAYCHECK_CREW * 6
 	///Design types for plumbing service constructor
 	var/static/list/service_design_types = list(
 		//Category 1 synthesizers

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -55,6 +55,7 @@
 			/obj/machinery/plumbing/filter = 5,
 			/obj/machinery/plumbing/splitter = 5,
 			/obj/machinery/plumbing/sender = 20,
+			/obj/machinery/plumbing/receiver = 20
 			/obj/machinery/plumbing/output = 5,
 		),
 
@@ -336,6 +337,7 @@
 			/obj/machinery/plumbing/splitter = 5,
 			/obj/machinery/plumbing/output/tap = 5,
 			/obj/machinery/plumbing/sender = 20,
+			/obj/machinery/plumbing/receiver = 20
 		),
 
 		//category 3 storage

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -55,7 +55,6 @@
 			/obj/machinery/plumbing/filter = 5,
 			/obj/machinery/plumbing/splitter = 5,
 			/obj/machinery/plumbing/sender = 20,
-			/obj/machinery/plumbing/receiver = 20
 			/obj/machinery/plumbing/output = 5,
 		),
 
@@ -337,7 +336,6 @@
 			/obj/machinery/plumbing/splitter = 5,
 			/obj/machinery/plumbing/output/tap = 5,
 			/obj/machinery/plumbing/sender = 20,
-			/obj/machinery/plumbing/receiver = 20
 		),
 
 		//category 3 storage

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -313,7 +313,7 @@
 	name = "service plumbing constructor"
 	desc = "A type of plumbing constructor designed to rapidly deploy the machines needed to make a brewery."
 	icon_state = "plumberer_service"
-	///EXtra price because it appears in bartender's vendor
+	///Extra price because it appears in bartender's vendor
 	custom_premium_price = PAYCHECK_CREW * 6
 	///Design types for plumbing service constructor
 	var/static/list/service_design_types = list(

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -422,6 +422,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	premium = list(
 		/obj/item/storage/box/dishdrive = 1,
+		/obj/item/construction/plumbing/service = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/bar_wardrobe
 	payment_department = ACCOUNT_MED


### PR DESCRIPTION
## About The Pull Request

Puts one service plumbing constructor in bartender's wardrobe vendor
Lets plumbing constructors actually build the chemical teleporters (before this only the sender could be made)

## Why It's Good For The Game

An alcohol factory isn't anything game changing. Not forcing the bartender to wait for very niche research nobody will ever do to play with it is a good thing

## Changelog
:cl: Cat
balance: Bartender's wardrobe vendor starts with a service plumbing constructor
/:cl:
