### PR TITLE
Fixes circuit airlock shells being unusable

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -941,6 +941,9 @@
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 
+/obj/machinery/door/airlock/screwdriver_act_secondary(mob/living/user, obj/item/tool)
+	return screwdriver_act(user, tool)
+
 /obj/machinery/door/airlock/wirecutter_act(mob/living/user, obj/item/tool)
 	if(panel_open && security_level == AIRLOCK_SECURITY_PLASTEEL)
 		. = ITEM_INTERACT_SUCCESS  // everything after this shouldn't result in attackby


### PR DESCRIPTION
## About The Pull Request

The shell component now listens for `COMSIG_ATOM_ITEM_INTERACTION` instead of `COMSIG_ATOM_ATTACKBY`, allowing it to take precedence over opening airlocks when trying to insert or modify a circuit. The wires and maintenance panel can still be interacted with by right-clicking if a circuit is installed.

## Why It's Good For The Game

Makes a feature actually work for the first time since it was added four years ago.

## Changelog
:cl:
fix: Integrated circuits can now correctly be inserted into circuit-compatible airlocks.
qol: Airlock maintenance panels can now be opened/closed with right click as well, to avoid removing an integrated circuit instead.
/:cl:
