### PR TITLE
fixes spraycans left-click

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -215,8 +215,10 @@
 	drawtype = pick(all_drawables)
 
 	AddElement(/datum/element/venue_price, FOOD_PRICE_EXOTIC)
-	AddElement(/datum/element/tool_renaming)
-	if(can_change_colour)
+	//This makes sure that spraycans do not rename stuff instead of painting
+	if(!can_change_colour)
+		AddElement(/datum/element/tool_renaming)
+	else
 		AddComponent(/datum/component/palette, AVAILABLE_SPRAYCAN_SPACE, paint_color)
 
 	refill()


### PR DESCRIPTION

## About The Pull Request
The spraycans were rendered unable to paint some items via left-click, it forced the use of right-click which paints all over the object instead of primary parts.
## Why It's Good For The Game
Crayons are available everywhere to rename stuff, the spraycan left-click recoloring shouldn't have vanished so soon

Here's an example:

The regular det's revolver:
<img width="67" height="66" alt="image" src="https://github.com/user-attachments/assets/6b6c422b-ecbd-4ed5-adf0-0b5c524204db" />

Spraycan left-click:
<img width="65" height="68" alt="image" src="https://github.com/user-attachments/assets/b3b952f2-ac8d-42a5-8805-d41b9ef42125" />

Spraycan right-click:
<img width="65" height="63" alt="image" src="https://github.com/user-attachments/assets/c5c6f7d6-da91-48c9-a920-278939ff2f0a" />

And crayons/pen can still be used to change description and name.
## Changelog
:cl:
fix: fixed the spraycan left-click
/:cl:
