### PR TITLE
Adds fake emagged apc hallucination

### DIFF
--- a/code/modules/hallucination/malf_apc.dm
+++ b/code/modules/hallucination/malf_apc.dm
@@ -1,0 +1,49 @@
+/datum/hallucination/malf_apc
+	random_hallucination_weight = 5
+	hallucination_tier = HALLUCINATION_TIER_COMMON
+
+	/// APC icon to use for the hallucination
+	var/apc_icon = 'icons/obj/machines/wallmounts.dmi'
+	/// APC icon state to use for the hallucination
+	var/apc_icon_state = "apcemag"
+
+	/// The hacked APC image shown to the hallucinating mob
+	VAR_PRIVATE/image/hacked_image
+
+/datum/hallucination/malf_apc/start()
+	if(!hallucinator.client)
+		return FALSE
+
+	var/num_ais = 0
+	for(var/mob/living/silicon/ai/ai in GLOB.silicon_mobs)
+		if(is_valid_z_level(get_turf(hallucinator), get_turf(ai)))
+			num_ais += 1
+
+	// less likely to see apcs if there are few to no ais around, but no guarantees.
+	if(!prob(clamp(45 * num_ais, 10, 90)))
+		return FALSE
+
+	var/list/nearby_apcs = list()
+	for(var/obj/machinery/power/apc/apc in view(hallucinator))
+		if(!apc.is_operational || !apc.area || !apc.area.requires_power || apc.opened != APC_COVER_CLOSED)
+			continue
+		nearby_apcs += apc
+
+	if(!length(nearby_apcs))
+		return FALSE
+
+	var/obj/machinery/power/apc/selected_apc = pick(nearby_apcs)
+	hacked_image = image(
+		icon = apc_icon,
+		icon_state = apc_icon_state,
+		layer = FLOAT_LAYER,
+		loc = selected_apc,
+	)
+	hallucinator.client.images |= hacked_image
+	QDEL_IN(src, 1 SECONDS)
+	return TRUE
+
+/datum/hallucination/malf_apc/Destroy()
+	hallucinator.client?.images -= hacked_image
+	hacked_image = null
+	return ..()

--- a/code/modules/unit_tests/hallucination_icons.dm
+++ b/code/modules/unit_tests/hallucination_icons.dm
@@ -68,6 +68,12 @@
 	var/ice_hallucination_icon_state = initial(ice_hallucination.ice_icon_state)
 	check_hallucination_icon(ice_hallucination, ice_hallucination_icon, ice_hallucination_icon_state)
 
+	// Test malf_apc hallucination for if the hacked apc icon state exists
+	var/datum/hallucination/malf_apc/malf_apc_hallucination = /datum/hallucination/malf_apc
+	var/malf_apc_icon = initial(malf_apc_hallucination.apc_icon)
+	var/malf_apc_icon_state = initial(malf_apc_hallucination.apc_icon_state)
+	check_hallucination_icon(malf_apc_hallucination, malf_apc_icon, malf_apc_icon_state)
+
 /datum/unit_test/hallucination_icons/proc/check_hallucination_icon(hallucination, icon, icon_state)
 	if(!icon)
 		TEST_FAIL("Hallucination [hallucination] forgot to set its icon file.")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4469,6 +4469,7 @@
 #include "code\modules\hallucination\hud_screw.dm"
 #include "code\modules\hallucination\ice_cube.dm"
 #include "code\modules\hallucination\inhand_fake_item.dm"
+#include "code\modules\hallucination\malf_apc.dm"
 #include "code\modules\hallucination\mother.dm"
 #include "code\modules\hallucination\nearby_fake_item.dm"
 #include "code\modules\hallucination\on_fire.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a common tier hallucination which makes an active apc near you flash blue. 
The hallucination itself has a low weight (and it has a random chance to skip if there are 0-1 ais)

## Why It's Good For The Game

Someone gave me this idea after the change that made hacked APCs no longer consistently blue and I think it's pretty good

## Changelog

:cl: Melbert
add: Adds emagged apc hallucination
/:cl:

