### PR TITLE
Bodybags don't have a door animation

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -19,6 +19,7 @@
 	can_install_electronics = FALSE
 	paint_jobs = null
 	can_weld_shut = FALSE
+	door_anim_time = 0
 
 	var/foldedbag_path = /obj/item/bodybag
 	var/obj/item/bodybag/foldedbag_instance = null


### PR DESCRIPTION
## About The Pull Request

Sets door_anim_time = 0 so bodybags don't try to animate a door that doesn't exist

## Changelog

:cl: Melbert
fix: Things disappear instantly when going into bodybags
/:cl:

