### PR TITLE
saftey checks for play_ambience

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -54,12 +54,17 @@ SUBSYSTEM_DEF(ambience)
 ///Attempts to play an ambient sound to a mob, returning the cooldown in deciseconds
 /area/proc/play_ambience(mob/M, sound/override_sound, volume = 27)
 	var/sound/new_sound = override_sound || pick(ambientsounds)
+	if(!new_sound) // Dont try to play a sound if we dont have any.
+		return 1 MINUTES
 	/// volume modifier for ambience as set by the player in preferences.
 	var/volume_modifier = (M.client?.prefs.read_preference(/datum/preference/numeric/volume/sound_ambience_volume))/100
 	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume*volume_modifier, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)
 
 	var/sound_length = SSsounds.get_sound_length(new_sound.file)
+	if(!sound_length)
+		// This will cause sounds to cut into eachother if the sound is longer then the min_ambience_cooldown
+		stack_trace("play_ambience failed to get soundlength from [new_sound] with a file of [new_sound.file].")
 	return sound_length + rand(min_ambience_cooldown, max_ambience_cooldown)
 
 /datum/controller/subsystem/ambience/proc/remove_ambience_client(client/to_remove)


### PR DESCRIPTION

## About The Pull Request
first part with the 1 minute return is so you can have a area without an ambience without insane runtimes

second part: In the course of making https://github.com/DarkPack13/SecondCity/pull/246 I experienced some weird bugs where it was playing the sound but failing to get the length.
This notifies you why the fuck its happening cause its otherwise really confusing
## Why It's Good For The Game
I spent a while debugging it, still REALLY confused why the bug is actually happening in the first place, its somehow referencing a file that's both gone, and no longer being referenced anywhere in the repo. Either way this shit annoyed me lol.
