### PR TITLE
Fixes holodeck ready button

### DIFF
--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -129,9 +129,12 @@
 	if(numbuttons == numready)
 		begin_event()
 
-/obj/machinery/readybutton/update_icon_state()
-	icon_state = "auth_[ready ? "on" : "off"]"
-	return ..()
+/obj/machinery/readybutton/update_overlays()
+	. = ..()
+	if(ready && is_operational)
+		. += mutable_appearance(icon, "auth_on")
+		. += emissive_appearance(icon, "auth_on", src, alpha = src.alpha)
+
 
 /obj/machinery/readybutton/proc/begin_event()
 


### PR DESCRIPTION
## About The Pull Request

Only been, hey, 4+years?

`auth_on` is an overlay not a state anymore

## Changelog

:cl: Melbert
fix: Holodeck ready buttons no longer vanish 
/:cl:

