### PR TITLE
Fix a flaky ci runtime

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -739,6 +739,8 @@ Behavior that's still missing from this component that original food items had t
 ///Ability to feed food to puppers
 /datum/component/edible/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
+	if(QDELETED(parent))
+		return
 	SEND_SIGNAL(parent, COMSIG_FOOD_CROSSED, arrived, bitecount)
 
 ///Response to being used to customize something


### PR DESCRIPTION
## About The Pull Request

<img width="2026" height="403" alt="firefox_F5RtIpll8a" src="https://github.com/user-attachments/assets/75615f48-f6de-4ca5-8eac-8b6812335e42" />

Enter signals are always a little iffy when it comes to things being deleted. Adds a guard against this race condition.

## Why It's Good For The Game

less CI failures

## Changelog

Not player-facing

