### PR TITLE
[NO GBP] fixes turret controls changing its icon

### DIFF
--- a/code/game/machinery/porta_turret/turret_control.dm
+++ b/code/game/machinery/porta_turret/turret_control.dm
@@ -203,16 +203,6 @@
 		turret.setState(enabled, lethal, shoot_cyborgs)
 	update_appearance()
 
-/obj/machinery/turretid/update_icon_state()
-	if(machine_stat & NOPOWER)
-		icon_state = "[base_icon_state]_off"
-		return ..()
-	if (enabled)
-		icon_state = "[base_icon_state]_[lethal ? "kill" : "stun"]"
-		return ..()
-	icon_state = "[base_icon_state]_standby"
-	return ..()
-
 /obj/item/wallframe/turret_control
 	name = "turret control frame"
 	desc = "Used for building turret control panels."


### PR DESCRIPTION

## About The Pull Request
Removed redundant icon state update logic from turret control that was accidentally copied over when splitting files

## Why It's Good For The Game
The icon states previously mentioned in the code don't exist anymore and the appearance is handled by overlays

## Changelog
:cl:
fix: Turret controls should have a carcass again
/:cl:
