### PR TITLE
Adds time defines to a couple of shooting related delay vars

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -84,7 +84,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	/// World.time the turret last fired
 	var/last_fired = 0
 	/// Ticks until next shot (1.5 ?)
-	var/shot_delay = 15
+	var/shot_delay = 1.5 SECONDS
 	/// Turret flags about who is turret allowed to shoot
 	var/turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS
 	/// Determines if the turret is on
@@ -830,7 +830,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 /obj/machinery/porta_turret/syndicate/shuttle
 	scan_range = 9
-	shot_delay = 3
+	shot_delay = 3 DECISECONDS
 	stun_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile_sound = 'sound/items/weapons/gun/smg/shot.ogg'
@@ -969,7 +969,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	.["stun_projectile"] = /obj/projectile/beam/lasertag/bluetag
 	.["lethal_projectile"] = /obj/projectile/beam/lasertag/bluetag
 	.["base_icon_state"] = "blue"
-	.["shot_delay"] = 30
+	.["shot_delay"] = 3 SECONDS
 	.["team_color"] = "blue"
 
 /obj/item/gun/energy/laser/redtag/get_turret_properties()
@@ -977,7 +977,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	.["stun_projectile"] = /obj/projectile/beam/lasertag/redtag
 	.["lethal_projectile"] = /obj/projectile/beam/lasertag/redtag
 	.["base_icon_state"] = "red"
-	.["shot_delay"] = 30
+	.["shot_delay"] = 3 SECONDS
 	.["team_color"] = "red"
 
 /obj/item/gun/energy/e_gun/turret/get_turret_properties()

--- a/code/game/objects/structures/cannons/cannon.dm
+++ b/code/game/objects/structures/cannons/cannon.dm
@@ -15,7 +15,7 @@
 	var/anchorable_cannon = TRUE
 	var/obj/item/stack/cannonball/loaded_cannonball = null
 	var/charge_ignited = FALSE
-	var/fire_delay = 15
+	var/fire_delay = 1.5 SECONDS
 	var/charge_size = 15
 	var/fire_sound = 'sound/items/weapons/gun/general/cannon.ogg'
 

--- a/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
+++ b/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
@@ -28,9 +28,9 @@
 	///If the gun is currently loaded with its maximum capacity.
 	var/fully_loaded_gun = TRUE
 	///delay in firing the gun after lighting
-	var/fire_delay = 5
+	var/fire_delay = 5 DECISECONDS
 	///Delay between shots
-	var/shot_delay = 3
+	var/shot_delay = 3 DECISECONDS
 	///If the gun shakes the camera when firing
 	var/firing_shakes_camera = TRUE
 	///sound of firing for all but last shot
@@ -111,8 +111,8 @@
 	projectile_type = /obj/projectile/bullet/junk
 	loaded_gun = TRUE
 	fully_loaded_gun = TRUE
-	fire_delay = 3
-	shot_delay = 2
+	fire_delay = 3 DECISECONDS
+	shot_delay = 2 DECISECONDS
 	firing_shakes_camera = FALSE
 
 /obj/structure/mounted_gun/pipe/examine_more(mob/user)
@@ -174,8 +174,8 @@
 	projectile_type = /obj/projectile/bullet/shrapnel
 	loaded_gun = TRUE
 	fully_loaded_gun = TRUE
-	fire_delay = 3
-	shot_delay = 1
+	fire_delay = 3 DECISECONDS
+	shot_delay = 1 DECISECONDS
 	firing_shakes_camera = FALSE
 
 /obj/item/ammo_casing/canister_shot

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -262,7 +262,7 @@
 	inhand_icon_state = "shrink_ray"
 	icon_state = "shrink_ray"
 	automatic_charge_overlays = FALSE
-	fire_delay = 30
+	fire_delay = 3 SECONDS
 	selfcharge = 1//shot costs 200 energy, has a max capacity of 1000 for 5 shots. self charge returns 25 energy every couple ticks, so about 1 shot charged every 12~ seconds
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL// variable-size trigger, get it? (abductors need this to be set so the gun is usable for them)
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -297,7 +297,7 @@
 	fire_sound = 'sound/effects/splat.ogg'
 	force = 0
 	max_charges = 1
-	fire_delay = 1
+	fire_delay = 1 DECISECONDS
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0

--- a/code/modules/mapfluff/ruins/spaceruin_code/hauntedtradingpost.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hauntedtradingpost.dm
@@ -325,7 +325,7 @@
 	desc = "A ballistic machine gun auto-turret with Donk Co. branding. It uses 9mm rounds."
 	armor_type = /datum/armor/donk_turret
 	scan_range = 6
-	shot_delay = 10
+	shot_delay = 1 SECONDS
 
 /datum/armor/donk_turret
 	melee = 20
@@ -352,7 +352,7 @@
 	desc = "An energy gun auto-turret with Cybersun branding. It fires high-energy plasma beams that do a lot of damage, but it can be fairly slow."
 	armor_type = /datum/armor/syndicate_shuttle
 	scan_range = 6
-	shot_delay = 50
+	shot_delay = 5 SECONDS
 	always_up = FALSE
 	has_cover = TRUE
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -16,7 +16,7 @@
 	automated_announcements = list(ED209_VOICED_DOWN_WEAPONS = 'sound/mobs/non-humanoids/ed209/ed209_20sec.ogg')
 
 	var/lastfired = 0
-	var/shot_delay = 15
+	var/shot_delay = 1.5 SECONDS
 	var/shoot_sound = 'sound/items/weapons/laser.ogg'
 	var/projectile = /obj/projectile/beam/disabler
 	var/fair_market_projectile = /obj/projectile/bullet/c38 // For shooting the worst scumbags of all: the poor

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -11,7 +11,7 @@
 	///How many shots per volley.
 	var/rapid = 0
 	///Time between rapid fire shots
-	var/rapid_fire_delay = 2
+	var/rapid_fire_delay = 2 DECISECONDS
 
 	///Are we dodging?
 	var/dodging = FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -47,7 +47,7 @@
 	/// Delay between shots in a burst.
 	var/burst_delay = 2
 	/// Delay between bursts (if burst-firing) or individual shots (if weapon is single-fire).
-	var/fire_delay = 0
+	var/fire_delay = 0 SECONDS
 	var/firing_burst = 0 //Prevent the weapon from firing again while already firing
 	/// firing cooldown, true if this gun shouldn't be allowed to manually fire
 	var/fire_cd = 0

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -286,7 +286,7 @@
 	burst_fire_selection = !burst_fire_selection
 	if(!burst_fire_selection)
 		burst_size = 1
-		fire_delay = 0
+		fire_delay = 0 SECONDS
 		balloon_alert(user, "switched to semi-automatic")
 	else
 		burst_size = initial(burst_size)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -330,7 +330,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge
 	empty_indicator = TRUE
 	bolt_type = BOLT_TYPE_OPEN
-	fire_delay = 2
+	fire_delay = 2 DECISECONDS
 	can_suppress = FALSE
 	burst_size = 0
 	actions_types = list()
@@ -359,7 +359,7 @@
 	mag_display = TRUE
 	projectile_damage_multiplier = 1.2
 	projectile_speed_multiplier = 1.2
-	fire_delay = 2
+	fire_delay = 2 DECISECONDS
 	burst_size = 1
 	actions_types = list()
 	fire_sound = 'sound/items/weapons/thermalpistol.ogg'

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -60,7 +60,7 @@
 	fire_sound = 'sound/items/weapons/gun/general/grenade_launch.ogg'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m75
 	burst_size = 1
-	fire_delay = 0
+	fire_delay = 0 SECONDS
 	actions_types = list()
 	casing_ejector = FALSE
 
@@ -82,7 +82,7 @@
 	can_suppress = FALSE
 	pin = /obj/item/firing_pin/implant/pindicate
 	burst_size = 1
-	fire_delay = 0
+	fire_delay = 0 SECONDS
 	casing_ejector = FALSE
 	weapon_weight = WEAPON_HEAVY
 	bolt_type = BOLT_TYPE_NO_BOLT

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -6,7 +6,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m9mm
 	can_suppress = TRUE
 	burst_size = 1
-	fire_delay = 0
+	fire_delay = 0 SECONDS
 	actions_types = list()
 	bolt_type = BOLT_TYPE_LOCKING
 	fire_sound = 'sound/items/weapons/gun/pistol/shot.ogg'

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -46,7 +46,7 @@
 	desc = "A sturdy shotgun with a longer magazine and a fixed tactical stock designed for non-lethal riot control."
 	icon_state = "riotshotgun"
 	inhand_icon_state = "shotgun"
-	fire_delay = 8
+	fire_delay = 8 DECISECONDS
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE


### PR DESCRIPTION

## About The Pull Request

Converted `fire_delay` and `shot_delay` vars to use time defines

## Why It's Good For The Game

Code readability

## Changelog
:cl:
code: Converted some gun related variables to use time defines, make an issue report if anything shoots abnormally fast/slow.
/:cl:
