### PR TITLE
Fix wall mounted sign duplication during placement

### DIFF
--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -198,12 +198,12 @@
 		return NONE
 	var/turf/target_turf = interacting_with
 	var/turf/user_turf = get_turf(user)
-	var/obj/structure/sign/placed_sign = new sign_path(user_turf) //We place the sign on the turf the user is standing, and pixel shift it to the target wall, as below.
-	//This is to mimic how signs and other wall objects are usually placed by mappers, and so they're only visible from one side of a wall.
 	var/dir = get_dir(user_turf, target_turf)
 	if(!(dir in GLOB.cardinals))
 		balloon_alert(user, "stand in line with wall!")
-		return
+		return ITEM_INTERACT_BLOCKING
+	var/obj/structure/sign/placed_sign = new sign_path(user_turf) //We place the sign on the turf the user is standing, and pixel shift it to the target wall, as below.
+	//This is to mimic how signs and other wall objects are usually placed by mappers, and so they're only visible from one side of a wall.
 	if(dir & NORTH)
 		placed_sign.pixel_y = 32
 	else if(dir & SOUTH)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -175,23 +175,23 @@
 		context[SCREENTIP_CONTEXT_LMB] = "Change design"
 		return CONTEXTUAL_SCREENTIP_SET
 
-/obj/item/sign/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	if(is_editable && IS_WRITING_UTENSIL(I))
-		if(!length(GLOB.editable_sign_types))
-			CRASH("GLOB.editable_sign_types failed to populate")
-		var/choice = tgui_input_list(user, "Select a sign type", "Sign Customization", GLOB.editable_sign_types)
-		if(isnull(choice))
-			return
-		if(!Adjacent(user)) //Make sure user is adjacent still.
-			to_chat(user, span_warning("You need to stand next to the sign to change it!"))
-			return
-		user.visible_message(span_notice("You begin changing [src]."))
-		if(!do_after(user, 4 SECONDS, target = src))
-			return
-		set_sign_type(GLOB.editable_sign_types[choice])
-		user.visible_message(span_notice("You finish changing the sign."))
-		return
-	return ..()
+/obj/item/sign/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!is_editable || !IS_WRITING_UTENSIL(tool))
+		return ..()
+	if(!length(GLOB.editable_sign_types))
+		CRASH("GLOB.editable_sign_types failed to populate")
+	var/choice = tgui_input_list(user, "Select a sign type", "Sign Customization", GLOB.editable_sign_types)
+	if(isnull(choice))
+		return ITEM_INTERACT_BLOCKING
+	if(!Adjacent(user)) //Make sure user is adjacent still.
+		to_chat(user, span_warning("You need to stand next to the sign to change it!"))
+		return ITEM_INTERACT_BLOCKING
+	user.visible_message(span_notice("You begin changing [src]."))
+	if(!do_after(user, 4 SECONDS, target = src))
+		return ITEM_INTERACT_BLOCKING
+	set_sign_type(GLOB.editable_sign_types[choice])
+	user.visible_message(span_notice("You finish changing the sign."))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/sign/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!iswallturf(interacting_with) && !istype(interacting_with, /obj/structure/tram))


### PR DESCRIPTION

## About The Pull Request

`/obj/item/sign/interact_with_atom` created the structure instance before it early returned for being at a diagonal so it wouldn't qdel the sign item but it would be there. Also refactor an `attackby` to `item_interaction` while im there

## Why It's Good For The Game

Fixes #93819

## Changelog
:cl:
fix: fixed placing wall signs at diagonals allowing you to duplicate them
/:cl:
