### PR TITLE
Fix lattice deconstruction to update space areas

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -48,6 +48,10 @@
 		for(var/thing_that_falls in turfloc)
 			turfloc.zFall(thing_that_falls)
 
+	var/area/turf_area = get_area(turfloc)
+	if(isspaceturf(turfloc) && istype(turf_area, /area/space/nearstation))
+		set_turf_to_area(turfloc, GLOB.areas_by_type[/area/space])
+
 /obj/structure/lattice/proc/deconstruction_hints(mob/user)
 	return span_notice("The rods look like they could be <b>cut</b>. There's space for more <i>rods</i> or a <i>tile</i>.")
 


### PR DESCRIPTION

## About The Pull Request
When lattice and catwalks are deconstructed on `/area/space/nearstation` the area should update to `/area/space` since it is now an empty space tile.

## Why It's Good For The Game
Consistency. This is very noticeable when exporting maps and there are chunks of nearstation area markers with empty space.

## Changelog
:cl:
fix: Fix lattice deconstruction to update space areas
/:cl:
