### PR TITLE
Chaplain's Maintenance Adapted eyes no longer burn if you have active welding protection.

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -1177,7 +1177,7 @@
 	return span_danger("[owner.p_Their()] eyes [penlight_message].")
 
 /obj/item/organ/eyes/night_vision/maintenance_adapted/on_life(seconds_per_tick, times_fired)
-	if(!owner.is_blind() && isturf(owner.loc) && owner.has_light_nearby(light_amount=0.5)) //we allow a little more than usual so we can produce light from the adapted eyes
+	if(owner.get_eye_protection() <= FLASH_PROTECTION_SENSITIVE && !owner.is_blind() && isturf(owner.loc) && owner.has_light_nearby(light_amount=0.5)) //we allow a little more than usual so we can produce light from the adapted eyes
 		to_chat(owner, span_danger("Your eyes! They burn in the light!"))
 		apply_organ_damage(10) //blind quickly
 		playsound(owner, 'sound/machines/grill/grillsizzle.ogg', 50)


### PR DESCRIPTION
## About The Pull Request

Chaplain's Maintenance Adapted eyes no longer burn if you have active welding protection. You can also get these eyes from a bioscrambler, it's very annoying. This makes having the eyes slightly less annoying - you'll only be able to walk around in the light while you've got a welding mask on, dimming your vision significantly. But it's better than being intermittently blind.

You'll still eat shit to flashes though; you still need two sets of protection. Eyes are still hypersensitive.

## Why It's Good For The Game

Chaplain sects are already really, really bad - and chaplain's maintenance adapted eyes cost a lot for having an extremely annoying drawback. Rat-infusion eyes in basically every way, too. Though I don't expect anyone to take the maint sect, this should make the downside more bearable. Also makes getting it from a bioscrambler less awful. Now you can walk to medical to get your eyes pulled out.

## Changelog

:cl:
qol: Welding protection now prevents Maintenance Adapted eyes from burning in the light.
/:cl: