### PR TITLE
tool_flash doesn't flash if strength is 0 (alien welders no longer need flash protection)

### DIFF
--- a/code/datums/elements/tool_flash.dm
+++ b/code/datums/elements/tool_flash.dm
@@ -33,5 +33,5 @@
 /datum/element/tool_flash/proc/flash(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(user && get_dist(get_turf(source), get_turf(user)) <= 1 && flash_strength > 0)
+	if(user && flash_strength > 0 && get_dist(get_turf(source), get_turf(user)) <= 1)
 		user.flash_act(max(flash_strength,1))

--- a/code/datums/elements/tool_flash.dm
+++ b/code/datums/elements/tool_flash.dm
@@ -33,5 +33,5 @@
 /datum/element/tool_flash/proc/flash(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(user && get_dist(get_turf(source), get_turf(user)) <= 1)
+	if(user && get_dist(get_turf(source), get_turf(user)) <= 1 && flash_strength > 0)
 		user.flash_act(max(flash_strength,1))


### PR DESCRIPTION
## About The Pull Request

Makes the `tool_flash` element only flash people if the flash strength is greater than 0. Last PR I could dig up that touched this was tgstation/tgstation#83703, which didn't account for tools that had flash strength 0 (e.g. the alien welder). So now the alien welder no longer burns your eyeballs out if you don't have protection.

## Why It's Good For The Game

<img width="68" height="135" alt="image" src="https://github.com/user-attachments/assets/dc77a0d9-4fdb-4206-8c3d-514ca2432d86" />

Gives the alien welder the ability to be used without flash protection, as it was oh-so-long-ago.

## Changelog

:cl:
fix: Alien welders, as befitting their nature of being Wacky Advanced Tools, no longer sear your eyeballs if you don't have eye protection.
/:cl:
