### PR TITLE
Makes /empty subtypes of full power cells not charge themselfes up before setting their charge to 0

### DIFF
--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -52,10 +52,8 @@
 	if (override_maxcharge)
 		maxcharge = override_maxcharge
 	rating = max(round(maxcharge / (rating_base * 10), 1), 1)
-	if(!charge)
+	if(!empty && !charge)
 		charge = maxcharge
-	if(empty)
-		charge = 0
 	if(ratingdesc)
 		desc += " This one has a rating of [display_energy(maxcharge)][prob(10) ? ", and you should not swallow it" : ""]." //joke works better if it's not on every cell
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request

What it says on the tin, simply makes `power_store` subtypes never set themselfes to full instead of setting themselfes to empty after setting themselfes to full. Saving an uncountably small amount of processing and making the code a lil bit cleaner.

This could theoretically have an issue if something sets its own `charge` and then has a `/empty` subtype since that wont be emptied, those don't exist though and the only cell that even sets its `charge` to something is the ethereal one that should not have an empty subtype

Below be the screenshot of it working, because this 3 line change could truly have disasterous consequences
(admin-spawned in order: high-capacity battery, empty high-capacity battery, potato battery)

<img width="1600" height="858" alt="image" src="https://github.com/user-attachments/assets/6a894e0f-5e59-4b47-bb08-dc9c93d0b3f8" />

## Why It's Good For The Game

Cleaner code

## Changelog
