### PR TITLE
Fixes mobs not actually befriending their lazarus reviver, and losing all previous friends upon revival

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2761,7 +2761,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 /// Proc called when TARGETED by a lazarus injector
 /mob/living/proc/lazarus_revive(mob/living/reviver, malfunctioning)
 	revive(HEAL_ALL)
-	faction = list(FACTION_NEUTRAL)
+	faction |= FACTION_NEUTRAL
 	if (!malfunctioning)
 		befriend(reviver)
 	var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD) || "The lazarus injector has brought you back to life! You are now friendly to everyone."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2761,8 +2761,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 /// Proc called when TARGETED by a lazarus injector
 /mob/living/proc/lazarus_revive(mob/living/reviver, malfunctioning)
 	revive(HEAL_ALL)
-	befriend(reviver)
-	faction = (malfunctioning) ? list("[REF(reviver)]") : list(FACTION_NEUTRAL)
+	faction = list(FACTION_NEUTRAL)
+	if (!malfunctioning)
+		befriend(reviver)
 	var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD) || "The lazarus injector has brought you back to life! You are now friendly to everyone."
 	if (malfunctioning)
 		reviver.log_message("has revived mob [key_name(src)] with a malfunctioning lazarus injector.", LOG_GAME)


### PR DESCRIPTION

## About The Pull Request

Lazarus'd mobs had their faction assigned to a string ref of their reviver, but check for a raw ref everywhere else. They also didn't get neutral assigned unless the injector was malfunctioning, meaning that they would be hostile to everyone else but the owner.
This PR only *grants* them a neutral faction, and befriends the reviver if the injector is not malfunctioning - this way they don't lose their previous alliances and friends when revived.

Closes #93874

## Changelog
:cl:
fix: Fixed mobs not actually befriending their lazarus reviver, and losing all previous friends upon revival
/:cl:
