### PR TITLE
Minor crew monitor fixes and qol

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -258,8 +258,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			continue
 
 		// Current status
-		if (sensor_mode >= SENSOR_LIVING)
+		if (sensor_mode >= SENSOR_VITALS)
 			entry["life_status"] = tracked_living_mob.stat
+		else if (sensor_mode == SENSOR_LIVING)
+			// binary sensors should only report alive or dead
+			entry["life_status"] = (current_status == DEAD) ? DEAD : CONSCIOUS
 
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -262,7 +262,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			entry["life_status"] = tracked_living_mob.stat
 		else if (sensor_mode == SENSOR_LIVING)
 			// binary sensors should only report alive or dead
-			entry["life_status"] = (current_status == DEAD) ? DEAD : CONSCIOUS
+			entry["life_status"] = (tracked_living_mob.stat == DEAD) ? DEAD : CONSCIOUS
 
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -21,53 +21,45 @@ const STAT_DEAD = 4;
 
 const jobIsHead = (jobId: number) => jobId % 10 === 0;
 
-const sortByName = (a: CrewSensor, b: CrewSensor) => {
-  if (a.name > b.name) return 1;
-  if (a.name < b.name) return -1;
-  return 0;
-}
-
-const sortByJob = (a: CrewSensor, b: CrewSensor) => {
-  return a.ijob - b.ijob;
-}
-
-const sortByVitals = (a: CrewSensor, b: CrewSensor) => {
-  if (a.life_status > b.life_status) return -1;
-  if (a.life_status < b.life_status) return 1;
-
-  if (b.oxydam === undefined) return -1;
-  if (a.oxydam === undefined) return 1;
-
-  if (a.health < b.health) return -1;
-  if (a.health > b.health) return 1;
-
-  return 0;
-};
-
-const sortByArea = (a: CrewSensor, b: CrewSensor) => {
-  if (a.area === undefined) return 1;
-  if (b.area === undefined) return -1;
-  if (a.area > b.area) return 1;
-  if (a.area < b.area) return -1;
-  return 0;
-};
-
 const SORT_OPTIONS = [
   {
     name: 'Job',
-    sortingFunction: sortByJob
+    sort: (a: CrewSensor, b: CrewSensor) => {
+      return a.ijob - b.ijob;
+    }
   },
   {
     name: 'Name',
-    sortingFunction: sortByName,
+    sort: (a: CrewSensor, b: CrewSensor) => {
+      if (a.name > b.name) return 1;
+      if (a.name < b.name) return -1;
+      return 0;
+    }
   },
   {
     name: 'Area',
-    sortingFunction: sortByArea,
+    sort: (a: CrewSensor, b: CrewSensor) => {
+      if (a.area === undefined) return 1;
+      if (b.area === undefined) return -1;
+      if (a.area > b.area) return 1;
+      if (a.area < b.area) return -1;
+      return 0;
+    }
   },
   {
     name: 'Vitals',
-    sortingFunction: sortByVitals,
+    sort: (a: CrewSensor, b: CrewSensor) => {
+      if (a.life_status > b.life_status) return -1;
+      if (a.life_status < b.life_status) return 1;
+
+      if (b.oxydam === undefined) return -1;
+      if (a.oxydam === undefined) return 1;
+
+      if (a.health < b.health) return -1;
+      if (a.health > b.health) return 1;
+
+      return 0;
+    }
   }
 ];
 
@@ -182,8 +174,8 @@ const CrewTable = () => {
 
   const sorted = sensors.filter(nameSearch).sort((a, b) =>
     sortAsc
-      ? SORT_OPTIONS[indexOfSortingOption].sortingFunction(a, b)
-      : SORT_OPTIONS[indexOfSortingOption].sortingFunction(b, a)
+      ? SORT_OPTIONS[indexOfSortingOption].sort(a, b)
+      : SORT_OPTIONS[indexOfSortingOption].sort(b, a)
   );
 
   return (

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -32,14 +32,14 @@ const sortByJob = (a: CrewSensor, b: CrewSensor) => {
 }
 
 const sortByVitals = (a: CrewSensor, b: CrewSensor) => {
-  if (a.life_status > b.life_status) return 1;
-  if (a.life_status < b.life_status) return -1;
+  if (a.life_status > b.life_status) return -1;
+  if (a.life_status < b.life_status) return 1;
 
-  if (b.oxydam === undefined) return 1;
-  if (a.oxydam === undefined) return -1;
+  if (b.oxydam === undefined) return -1;
+  if (a.oxydam === undefined) return 1;
 
-  if (a.health < b.health) return 1;
-  if (a.health > b.health) return -1;
+  if (a.health < b.health) return -1;
+  if (a.health > b.health) return 1;
 
   return 0;
 };

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -16,19 +16,60 @@ const HEALTH_COLOR_BY_LEVEL = [
   '#801308',
 ];
 
-const SORT_NAMES = {
-  ijob: 'Job',
-  name: 'Name',
-  area: 'Position',
-  health: 'Vitals',
-};
-
 const STAT_LIVING = 0;
 const STAT_DEAD = 4;
 
-const SORT_OPTIONS = ['health', 'ijob', 'name', 'area'];
-
 const jobIsHead = (jobId: number) => jobId % 10 === 0;
+
+const sortByName = (a: CrewSensor, b: CrewSensor) => {
+  if (a.name > b.name) return 1;
+  if (a.name < b.name) return -1;
+  return 0;
+}
+
+const sortByJob = (a: CrewSensor, b: CrewSensor) => {
+  return a.ijob - b.ijob;
+}
+
+const sortByVitals = (a: CrewSensor, b: CrewSensor) => {
+  if (a.life_status > b.life_status) return 1;
+  if (a.life_status < b.life_status) return -1;
+
+  if (b.oxydam === undefined) return 1;
+  if (a.oxydam === undefined) return -1;
+
+  if (a.health < b.health) return 1;
+  if (a.health > b.health) return -1;
+
+  return 0;
+};
+
+const sortByArea = (a: CrewSensor, b: CrewSensor) => {
+  if (a.area === undefined) return 1;
+  if (b.area === undefined) return -1;
+  if (a.area > b.area) return 1;
+  if (a.area < b.area) return -1;
+  return 0;
+};
+
+const SORT_OPTIONS = [
+  {
+    name: 'Job',
+    sortingFunction: sortByJob
+  },
+  {
+    name: 'Name',
+    sortingFunction: sortByName,
+  },
+  {
+    name: 'Area',
+    sortingFunction: sortByArea,
+  },
+  {
+    name: 'Vitals',
+    sortingFunction: sortByVitals,
+  }
+];
 
 const jobToColor = (jobId: number) => {
   if (jobId === 0) {
@@ -66,22 +107,6 @@ const statToIcon = (life_status: number) => {
       return 'skull';
   }
   return 'heartbeat';
-};
-
-const healthSort = (a: CrewSensor, b: CrewSensor) => {
-  if (a.life_status > b.life_status) return -1;
-  if (a.life_status < b.life_status) return 1;
-  if (a.health < b.health) return -1;
-  if (a.health > b.health) return 1;
-  return 0;
-};
-
-const areaSort = (a: CrewSensor, b: CrewSensor) => {
-  a.area ??= '~';
-  b.area ??= '~';
-  if (a.area < b.area) return -1;
-  if (a.area > b.area) return 1;
-  return 0;
 };
 
 const healthToAttribute = (
@@ -147,36 +172,25 @@ const CrewTable = () => {
 
   const [sortAsc, setSortAsc] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState(SORT_OPTIONS[0]);
+  const [indexOfSortingOption, setIndexOfSortingOption] = useState(0);
 
   const cycleSortBy = () => {
-    let idx = SORT_OPTIONS.indexOf(sortBy) + 1;
-    if (idx === SORT_OPTIONS.length) idx = 0;
-    setSortBy(SORT_OPTIONS[idx]);
+    setIndexOfSortingOption((indexOfSortingOption + 1) % SORT_OPTIONS.length);
   };
 
   const nameSearch = createSearch(searchQuery, (crew: CrewSensor) => crew.name);
 
-  const sorted = sensors.filter(nameSearch).sort((a, b) => {
-    switch (sortBy) {
-      case 'name':
-        return sortAsc ? +(a.name > b.name) : +(b.name > a.name);
-      case 'ijob':
-        return sortAsc ? a.ijob - b.ijob : b.ijob - a.ijob;
-      case 'health':
-        return sortAsc ? healthSort(a, b) : healthSort(b, a);
-      case 'area':
-        return sortAsc ? areaSort(a, b) : areaSort(b, a);
-      default:
-        return 0;
-    }
-  });
+  const sorted = sensors.filter(nameSearch).sort((a, b) =>
+    sortAsc
+      ? SORT_OPTIONS[indexOfSortingOption].sortingFunction(a, b)
+      : SORT_OPTIONS[indexOfSortingOption].sortingFunction(b, a)
+  );
 
   return (
     <Section
       title={
         <>
-          <Button onClick={cycleSortBy}>{SORT_NAMES[sortBy]}</Button>
+          <Button onClick={cycleSortBy}>{SORT_OPTIONS[indexOfSortingOption].name}</Button>
           <Button onClick={() => setSortAsc(!sortAsc)}>
             <Icon
               style={{ marginLeft: '2px' }}


### PR DESCRIPTION
## About The Pull Request

Various minor fixes and qol changes primarly related to sorting on the crew monitor console (See changelog). Also simplifies how the UI cycles the sorting options, as it was a bit bizarre before.
## Why It's Good For The Game

Improves the crew monitor user experience. 

## Changelog

:cl:
fix: binary sensors no longer report exact consciousness status to crew monitor.
fix: crew monitor sort by name now respects ascending vs. descending sorting.
qol: crew monitor sort by vitals now properly treats those with binary sensors as either fully healthy or dead.
/:cl:
