### PR TITLE
kills `Debug` and `Debug2` all hail `debugging_enabled`

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -31,19 +31,19 @@
 
 //debug printing macros (for development and testing)
 /// Used for debug messages to the world
-#define debug_world(msg) if (GLOB.Debug2) to_chat(world, \
+#define debug_world(msg) if (GLOB.debugging_enabled) to_chat(world, \
 	type = MESSAGE_TYPE_DEBUG, \
 	text = "DEBUG: [msg]")
 /// Used for debug messages to the player
-#define debug_usr(msg) if (GLOB.Debug2 && usr) to_chat(usr, \
+#define debug_usr(msg) if (GLOB.debugging_enabled && usr) to_chat(usr, \
 	type = MESSAGE_TYPE_DEBUG, \
 	text = "DEBUG: [msg]")
 /// Used for debug messages to the admins
-#define debug_admins(msg) if (GLOB.Debug2) to_chat(GLOB.admins, \
+#define debug_admins(msg) if (GLOB.debugging_enabled) to_chat(GLOB.admins, \
 	type = MESSAGE_TYPE_DEBUG, \
 	text = "DEBUG: [msg]")
 /// Used for debug messages to the server
-#define debug_world_log(msg) if (GLOB.Debug2) log_world("DEBUG: [msg]")
+#define debug_world_log(msg) if (GLOB.debugging_enabled) log_world("DEBUG: [msg]")
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define boxed_message(str) ("<div class='boxed_message'>" + str + "</div>")
 /// Adds a box around whatever message you're sending in chat. Can apply color and/or additional classes. Available colors: red, green, blue, purple. Use it like red_box

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -13,10 +13,10 @@ GLOBAL_VAR_INIT(ooc_allowed, TRUE) // used with admin verbs to disable ooc - not
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
 
 
-// Debug is used exactly once (in living.dm) but is commented out in a lot of places.  It is not set anywhere and only checked.
-// Debug2 is used in conjunction with a lot of admin verbs and therefore is actually legit.
-GLOBAL_VAR_INIT(Debug, FALSE) // global debug switch
-GLOBAL_VAR_INIT(Debug2, FALSE)
+// debugging_enabled is used in conjunction with a lot of admin verbs and therefore is actually legit.
+// im not sure why you would ever add behavoir, likely use a define like TESTING or even checking `Debugger?.enabled`
+/// global debug switch
+GLOBAL_VAR_INIT(debugging_enabled, FALSE)
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
 //Protecting these because the proper way to edit them is with the config/secrets

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -472,8 +472,7 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 	var/took = (REALTIMEOFDAY - started_at) / 10
 
 	//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes to explosion code using this please so we can compare
-	if(GLOB.Debug2)
-		log_world("## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
+	debug_world("Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
 
 	explosion_index += 1
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -229,7 +229,7 @@ SUBSYSTEM_DEF(ticker)
 	can_continue = can_continue && SSjob.divide_occupations() //Distribute jobs
 	CHECK_TICK
 
-	if(!GLOB.Debug2)
+	if(!GLOB.debugging_enabled)
 		if(!can_continue)
 			log_game("Game failed pre_setup")
 			to_chat(world, "<B>Error setting up game.</B> Reverting to pre-game lobby.")

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -287,7 +287,7 @@ Behavior that's still missing from this component that original food items had t
 			else
 				examine_list += span_notice("[owner] was bitten multiple times!")
 
-	if(GLOB.Debug2)
+	if(GLOB.debugging_enabled)
 		examine_list += span_notice("Reagent purities:")
 		for(var/datum/reagent/reagent as anything in owner.reagents.reagent_list)
 			examine_list += span_notice("- [reagent.name] [reagent.volume]u: [round(reagent.purity * 100)]% pure")

--- a/code/game/atom/atom_vv.dm
+++ b/code/game/atom/atom_vv.dm
@@ -214,7 +214,7 @@
  * At the atom level, if you edit a var named "color" it will add the atom colour with
  * admin level priority to the atom colours list
  *
- * Also, if GLOB.Debug2 is FALSE, it sets the [ADMIN_SPAWNED_1] flag on [flags_1][/atom/var/flags_1], which signifies
+ * Also, if GLOB.debugging_enabled is FALSE, it sets the [ADMIN_SPAWNED_1] flag on [flags_1][/atom/var/flags_1], which signifies
  * the object has been admin edited
  */
 /atom/vv_edit_var(var_name, var_value)
@@ -287,7 +287,7 @@
 		datum_flags |= DF_VAR_EDITED
 		return
 
-	if(!GLOB.Debug2)
+	if(!GLOB.debugging_enabled)
 		flags_1 |= ADMIN_SPAWNED_1
 
 	. = ..()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1,6 +1,6 @@
 ADMIN_VERB(toggle_game_debug, R_DEBUG, "Debug-Game", "Toggles game debugging.", ADMIN_CATEGORY_DEBUG)
-	GLOB.Debug2 = !GLOB.Debug2
-	var/message = "toggled debugging [(GLOB.Debug2 ? "ON" : "OFF")]"
+	GLOB.debugging_enabled = !GLOB.debugging_enabled
+	var/message = "toggled debugging [(GLOB.debugging_enabled ? "ON" : "OFF")]"
 	message_admins("[key_name_admin(user)] [message].")
 	log_admin("[key_name(user)] [message].")
 	BLACKBOX_LOG_ADMIN_VERB("Toggle Debug Two")

--- a/code/modules/asset_cache/transports/asset_transport.dm
+++ b/code/modules/asset_cache/transports/asset_transport.dm
@@ -120,7 +120,7 @@
 		if (!keep_local_name)
 			new_asset_name = "asset.[ACI.hash][ACI.ext]"
 		if (client.sent_assets[new_asset_name] == asset_hash)
-			if (GLOB.Debug2)
+			if (GLOB.debugging_enabled)
 				log_asset("DEBUG: Skipping send of `[asset_name]` (as `[new_asset_name]`) for `[client]` because it already exists in the client's sent_assets list")
 			continue
 		unreceived[asset_name] = ACI

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -169,7 +169,7 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		GLOB.current_test.Fail("[main_line]\n[desclines.Join("\n")]", file = E.file, line = E.line)
 #endif
 
-	if(Debugger?.enabled)
+	if(Debugger?.enabled || GLOB.debugging_enabled)
 		to_chat(world, span_alertwarning("[main_line]"), type = MESSAGE_TYPE_DEBUG)
 
 	// This writes the regular format (unwrapping newlines and inserting timestamps as needed).

--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -373,7 +373,7 @@
 		total_step_added += step_add
 
 	#ifdef REAGENTS_TESTING //Kept in so that people who want to write fermireactions can contact me with this log so I can help them
-	if(GLOB.Debug2) //I want my spans for my sanity
+	if(GLOB.debugging_enabled) //I want my spans for my sanity
 		message_admins(span_green("Reaction step active for:[reaction.type]"))
 		message_admins(span_notice("|Reaction conditions| Temp: [holder.chem_temp], pH: [holder.ph], reactions: [length(holder.reaction_list)], awaiting reactions: [length(holder.failed_but_capable_reactions)], no. reagents:[length(holder.reagent_list)], no. prev reagents: [length(holder.previous_reagent_list)]"))
 		message_admins(span_warning("Reaction vars: PreReacted:[reacted_vol] of [step_target_vol] of total [target_vol]. delta_t [delta_t], multiplier [multiplier], delta_chem_factor [delta_chem_factor] Pfactor [product_ratio], purity of [purity] from a delta_ph of [delta_ph]. DeltaTime: [seconds_per_tick]"))

--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -373,10 +373,9 @@
 		total_step_added += step_add
 
 	#ifdef REAGENTS_TESTING //Kept in so that people who want to write fermireactions can contact me with this log so I can help them
-	if(GLOB.debugging_enabled) //I want my spans for my sanity
-		message_admins(span_green("Reaction step active for:[reaction.type]"))
-		message_admins(span_notice("|Reaction conditions| Temp: [holder.chem_temp], pH: [holder.ph], reactions: [length(holder.reaction_list)], awaiting reactions: [length(holder.failed_but_capable_reactions)], no. reagents:[length(holder.reagent_list)], no. prev reagents: [length(holder.previous_reagent_list)]"))
-		message_admins(span_warning("Reaction vars: PreReacted:[reacted_vol] of [step_target_vol] of total [target_vol]. delta_t [delta_t], multiplier [multiplier], delta_chem_factor [delta_chem_factor] Pfactor [product_ratio], purity of [purity] from a delta_ph of [delta_ph]. DeltaTime: [seconds_per_tick]"))
+	debug_admins(span_green("Reaction step active for:[reaction.type]"))
+	debug_admins(span_notice("|Reaction conditions| Temp: [holder.chem_temp], pH: [holder.ph], reactions: [length(holder.reaction_list)], awaiting reactions: [length(holder.failed_but_capable_reactions)], no. reagents:[length(holder.reagent_list)], no. prev reagents: [length(holder.previous_reagent_list)]"))
+	debug_admins(span_warning("Reaction vars: PreReacted:[reacted_vol] of [step_target_vol] of total [target_vol]. delta_t [delta_t], multiplier [multiplier], delta_chem_factor [delta_chem_factor] Pfactor [product_ratio], purity of [purity] from a delta_ph of [delta_ph]. DeltaTime: [seconds_per_tick]"))
 	#endif
 
 	//Apply thermal output of reaction to beaker


### PR DESCRIPTION

## About The Pull Request
renames Debug2 and kills Debug as its last use (atleast the one described in its comment) was removed
added it to the check to print to print stack traces to chat in the instance your debugging without a debugger attached for some reason (if this var is enabled on live it already causes random to_world messages, kinda fuck it we ball at that point)
## Why It's Good For The Game
The first one was ENTIRELY unused now
this name makes more sense
## Changelog
N/A
