### PR TITLE
Significantly increases the explosion radius requirement for anomaly refinement.

### DIFF
--- a/code/modules/research/anomaly/anomaly_refinery.dm
+++ b/code/modules/research/anomaly/anomaly_refinery.dm
@@ -1,5 +1,5 @@
-#define MAX_RADIUS_REQUIRED 20 //maxcap
-#define MIN_RADIUS_REQUIRED 4 //1, 2, 4
+#define MAX_RADIUS_REQUIRED 120 // 30 60 120
+#define MIN_RADIUS_REQUIRED 60 // 15 30 60
 /// How long the compression test can last before the machine just gives up and ejects the items.
 #define COMPRESSION_TEST_TIME (SSOBJ_DT SECONDS * 5)
 

--- a/tgui/packages/tgui/interfaces/AnomalyRefinery.jsx
+++ b/tgui/packages/tgui/interfaces/AnomalyRefinery.jsx
@@ -99,7 +99,7 @@ const CoreCompressorContent = (props) => {
             </LabeledList.Item>
             <LabeledList.Item label={'Required Radius'}>
               {requiredRadius
-                ? `${requiredRadius} tiles`
+                ? `${requiredRadius} meters`
                 : 'Implosion not possible.'}
             </LabeledList.Item>
           </LabeledList>


### PR DESCRIPTION

## About The Pull Request
Increases the minimum radius requirement for anomaly refinery from 4 meters to 60 meters. Increases the maximum radius requirement for anomaly refinery from 20 meters to 120 meters. Improves anomaly refinery RP.

## Why It's Good For The Game
Making tritium for bombs then burning down your department by accident is a core aspect of ordnance. This makes tritium a highly desirable thing to make again for research purposes.

## Changelog

:cl:
balance: The minimum explosion radius requirement for refining anomaly cores increased to 60 meters.
balance: The maximum explosion radius requirement for refining anomaly cores increased to 120 meters.
qol: Improves anomaly core refinery RP.
/:cl:

