### PR TITLE
Fugitive playable again on Catwalk Map

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -9099,6 +9099,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/effect/mob_spawn/ghost_role/human/fugitive,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "czt" = (
@@ -35569,6 +35570,10 @@
 /obj/effect/turf_decal/tile/dark_blue,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"jHd" = (
+/obj/effect/mob_spawn/ghost_role/human/fugitive,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "jHj" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -74560,6 +74565,10 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
+"uzi" = (
+/obj/effect/mob_spawn/ghost_role/human/fugitive,
+/turf/open/openspace,
+/area/station/hallway/secondary/construction)
 "uzj" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -81847,6 +81856,11 @@
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /turf/open/floor/iron/white,
+/area/station/maintenance/hallway/abandoned_recreation)
+"wwI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/ghost_role/human/fugitive,
+/turf/open/floor/eighties/red,
 /area/station/maintenance/hallway/abandoned_recreation)
 "wwJ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -133195,7 +133209,7 @@ wKb
 wKb
 wKb
 wKb
-eEv
+jHd
 eUr
 wKb
 siG
@@ -175253,7 +175267,7 @@ hRj
 hRj
 gPW
 tbz
-tcb
+wwI
 tcb
 oNc
 gPW
@@ -191258,7 +191272,7 @@ naS
 pFp
 naS
 arT
-ubs
+uzi
 ubs
 gsm
 rFj


### PR DESCRIPTION

## About The Pull Request

Fixes #93908
The player was not able to spawn as fugitive on Catwalk map because there were no fugitive spawn points on the map.
After adding fugitive spawn points, I was able to proc the fugitive antag role.

<img width="1074" height="606" alt="fug1" src="https://github.com/user-attachments/assets/e56efabe-af35-4e9a-90e5-44f6dc240d7e" />

<img width="1568" height="821" alt="FugitiveFix2" src="https://github.com/user-attachments/assets/a7186d91-9243-446d-891f-864896bf34cb" />


And now you can play Where's Waldo again.
 

## Why It's Good For The Game

Allows spawning of Fugitive antag role on Catwalk map.

## Changelog

:cl: Soot-IX

map: Added fugitive spawn points to Catwalk Map so you can find Waldo again.

/:cl: