### PR TITLE
Stops overclocked volume pumps from working inside walls.

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -78,7 +78,7 @@
 	if(overclocked)
 		var/turf/turf = loc
 		if(isclosedturf(turf))
-			balloon_alert_to_viewers("jammed! turning on safeties.")
+			balloon_alert_to_viewers("jammed!")
 			overclocked = FALSE
 			update_appearance(UPDATE_ICON)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -69,10 +69,18 @@
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
 
-// Pump mechanism just won't do anything if the pressure is too high/too low unless you overclock it.
+	// Pump mechanism just won't do anything if the pressure is too high/too low unless you overclock it.
 
 	var/input_starting_pressure = air1.return_pressure()
 	var/output_starting_pressure = air2.return_pressure()
+
+	// Requires being able to leak air in order to overclock.
+	if(overclocked)
+		var/turf/turf = loc
+		if(isclosedturf(turf))
+			balloon_alert_to_viewers("jammed! turning on safeties.")
+			overclocked = FALSE
+			update_appearance(UPDATE_ICON)
 
 	if((input_starting_pressure < VOLUME_PUMP_MINIMUM_OUTPUT_PRESSURE) || ((output_starting_pressure > VOLUME_PUMP_MAX_OUTPUT_PRESSURE)) && !overclocked)
 		return


### PR DESCRIPTION
Turns off overclocking when the volume pump is overclocked while inside a wall.

Closes #88513

## About The Pull Request
Overclocked pumps will turn off overclocking when they try to operate inside a closed turf.

## Why It's Good For The Game
Removes an unintended exploit that trivialises the leaking functionality. This makes it consistent with commit ba6d08d5ebf35810eb6f2a44091b48dbf65285be from #57971.

## Changelog

:cl:
fix: Fixes overclocked volume pumps being able to work on walls.
/:cl:

