### PR TITLE
Welding fuel is no longer ignited by kisses.

### DIFF
--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -78,8 +78,9 @@
 
 /obj/effect/decal/cleanable/fuel_pool/bullet_act(obj/projectile/hit_proj)
 	. = ..()
-	ignite()
-	log_combat(hit_proj.firer, src, "used [hit_proj] to ignite")
+	if(hit_proj.damage)
+		ignite()
+		log_combat(hit_proj.firer, src, "used [hit_proj] to ignite")
 
 /obj/effect/decal/cleanable/fuel_pool/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
 	if(item.ignition_effect(src, user))

--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -78,7 +78,7 @@
 
 /obj/effect/decal/cleanable/fuel_pool/bullet_act(obj/projectile/hit_proj)
 	. = ..()
-	if(hit_proj.damage)
+	if(hit_proj.damage > 0)
 		ignite()
 		log_combat(hit_proj.firer, src, "used [hit_proj] to ignite")
 


### PR DESCRIPTION
Achieves this by requiring the projectile to do damage to ignite.

## About The Pull Request
Achieves this by requiring the projectile to do damage to ignite.

## Why It's Good For The Game
Closes #93990

## Changelog

:cl:
fix: Fixes welding fuel being ignited by kisses.
/:cl:

