### PR TITLE
actually makes it so you can arm guncase evidence disposal bombs

### DIFF
--- a/code/game/objects/items/storage/toolboxes/weapons.dm
+++ b/code/game/objects/items/storage/toolboxes/weapons.dm
@@ -122,7 +122,7 @@
 
 	var/i_dont_even_think_once_about_blowing_stuff_up = tgui_alert(user, "Would you like to activate the evidence disposal bomb now?", "BYE BYE", list("Yes","No"))
 
-	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || currently_exploding || QDELETED(user) || QDELETED(src) || user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING))
+	if(i_dont_even_think_once_about_blowing_stuff_up != "Yes" || currently_exploding || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING))
 		return
 
 	explosion_timer = addtimer(CALLBACK(src, PROC_REF(think_fast_chucklenuts)), 5 SECONDS, (TIMER_UNIQUE|TIMER_OVERRIDE))


### PR DESCRIPTION
## About The Pull Request
About what it says on the tin. I don't know how long it's been broken for but now you can finally use this as the funny explosive it was always meant to be.

## Why It's Good For The Game

haha guncase go boom

## Changelog

:cl:
fix: Makarov gun/ammo cases (the ones with the evil red S and the evidence disposal bomb) no longer require you to be stunned to arm the evidence disposal bomb.
/:cl: