### PR TITLE
Removes advanced health analyzer from CMO

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -84,7 +84,6 @@
 	new /obj/item/radio/headset/heads/cmo(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/defibrillator/compact/loaded(src)
-	new /obj/item/healthanalyzer/advanced(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/autosurgeon/medical_hud(src)
 	new /obj/item/door_remote/chief_medical_officer(src)


### PR DESCRIPTION
## About The Pull Request
This PR removed the health analyzer from cmo roundstart gear

## Why It's Good For The Game
Its a tech bypass and encourages heads to research stuff to the department can do their work better plus cmo like the ce who lost his tools get alot other QoL tools which give them the edge as a head

## Changelog
:cl: Ezel
balance: Cmo no longer starts with a advanced health analyzer
/:cl:
