### PR TITLE
no more non-virtual blood-drunk caches

### DIFF
--- a/code/modules/bitrunning/util/virtual_megafauna.dm
+++ b/code/modules/bitrunning/util/virtual_megafauna.dm
@@ -6,8 +6,23 @@
 
 	true_spawn = FALSE
 
+	// rebuild the achievement element's arguments to remove it appropriately
+	if (achievement_type || score_achievement_type)
+		var/list/achievements = list(/datum/award/achievement/boss/boss_killer, /datum/award/score/boss_score)
+		if (achievement_type)
+			achievements += achievement_type
+		if (score_achievement_type)
+			achievements += score_achievement_type
+		RemoveElement(/datum/element/kill_achievement, string_list(achievements), crusher_achievement_type, /datum/memory/megafauna_slayer)
+
+	// remove the crusher loot elemet's arguments also to remove it appropriately
+	RemoveElement(\
+		/datum/element/crusher_loot,\
+		trophy_type = crusher_loot,\
+		guaranteed_drop = 0.6,\
+		replace_all = replace_crusher_drop,\
+		drop_immediately = del_on_death,\
+	)
+
 	loot.Cut()
 	loot += /obj/structure/closet/crate/secure/bitrunning/encrypted
-
-	crusher_loot.Cut()
-	crusher_loot += /obj/structure/closet/crate/secure/bitrunning/encrypted

--- a/code/modules/bitrunning/util/virtual_megafauna.dm
+++ b/code/modules/bitrunning/util/virtual_megafauna.dm
@@ -15,7 +15,7 @@
 			achievements += score_achievement_type
 		RemoveElement(/datum/element/kill_achievement, string_list(achievements), crusher_achievement_type, /datum/memory/megafauna_slayer)
 
-	// remove the crusher loot elemet's arguments also to remove it appropriately
+	// remove the crusher loot element's arguments also to remove it appropriately
 	RemoveElement(\
 		/datum/element/crusher_loot,\
 		trophy_type = crusher_loot,\


### PR DESCRIPTION
## About The Pull Request

Adjusts the `make_virtual_megafauna` proc to remove the crusher loot and kill achievement elements so that they no longer grant achievement progression or change the crusher loot for all other instances of the megafauna. The worst offender of this was the blood-drunk miner: before this fix, if the bitrunners ran Sanguine Excavation (the blood-drunk miner domain), this would replace the blood-drunk miner's crusher loot with an encrypted cache for the rest of the round. This presumably carried over to other megafauna who would have been pulped with a crusher.

## Why It's Good For The Game

Please God stop dropping me the encrypted cache when I mulch the blood-drunk miner I really want my cool knife/90% mit trophy back

## Changelog

:cl:
fix: Non-virtual megafauna should no longer be dropping encrypted caches when mulched with a crusher if their matching virtual domain was deployed.
fix: Virtual megafauna no longer count as valid kills for achievement tracking.
/:cl:
