### PR TITLE
blood-drunk miner's corpse fades away again

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -129,7 +129,7 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/drop_loot(drop_loc)
 	new /obj/effect/temp_visual/dir_setting/miner_death(loc, dir)
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Move(atom/newloc)
 	if(newloc && newloc.z == z && ischasm(newloc)) //we're not stupid!

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -127,10 +127,9 @@ Difficulty: Medium
 		changeNext_move(adjustment_amount) //attacking it interrupts it attacking, but only briefly
 	. = ..()
 
-/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/death()
+/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/drop_loot(drop_loc)
+	new /obj/effect/temp_visual/dir_setting/miner_death(loc, dir)
 	. = ..()
-	if(.)
-		new /obj/effect/temp_visual/dir_setting/miner_death(loc, dir)
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Move(atom/newloc)
 	if(newloc && newloc.z == z && ischasm(newloc)) //we're not stupid!


### PR DESCRIPTION
## About The Pull Request

exactly what it says on the tin (moves the blood-drunk miner's death-fade effect to `drop_loot()` instead of `death()`)

## Why It's Good For The Game

restoring lost functionality (watching the blood-drunk miner fade away)

## Changelog

:cl:
fix: The blood-drunk miner's corpse now properly appears and fades away again.
/:cl:
