### PR TITLE
various client storage iframe improvements

### DIFF
--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -77,6 +77,8 @@ class IFrameIndexedDbBackend implements StorageBackend {
     iframe.src = Byond.storageCdn;
 
     const completePromise: Promise<boolean> = new Promise((resolve) => {
+      setTimeout(() => resolve(false), 1000);
+
       window.addEventListener('message', (message) => {
         if (message.data === "ready") {
           resolve(true);

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -77,7 +77,14 @@ class IFrameIndexedDbBackend implements StorageBackend {
     iframe.src = Byond.storageCdn;
 
     const completePromise: Promise<boolean> = new Promise((resolve) => {
-      setTimeout(() => resolve(false), 1000);
+      fetch(Byond.storageCdn, { method: "HEAD" }).then((response) => {
+        if (response.status !== 200) {
+          resolve(false);
+        }
+
+      }).catch(() => {
+        resolve(false);
+      })
 
       window.addEventListener('message', (message) => {
         if (message.data === "ready") {

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -149,7 +149,7 @@ class StorageProxy implements StorageBackend {
       if (!testHubStorage()) {
 
         // If we have an IFrame URL we can use, and we haven't already enabled
-        // hubstorage, we should use the IFrame backend
+        // byondstorage, we should use the IFrame backend
         if (Byond.storageCdn) {
           const iframe = new IFrameIndexedDbBackend();
 

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -93,6 +93,10 @@
         const store = await getStore(READ_WRITE);
         store.clear();
       };
+
+      window.onload = () => {
+        window.parent.postMessage("ready", "*");
+      }
     </script>
   </head>
 </html>


### PR DESCRIPTION
## About The Pull Request

addresses some issues found post-merge about the iframe storage solution

specifically:
- not being able to unset the config to default back to byondstorage
- storage failing back over to byondstorage when it didn't need  to

## Why It's Good For The Game

less bug = more good

fixes https://github.com/tgstation/tgstation/issues/94027

## Changelog

:cl:
fix: chat storage should load more reliably
server: server operators can now properly disable the iframe chat storage solution by unsetting the STORAGE_CDN_IFRAME config
/:cl:

