### PR TITLE
Fixes minion blobbernauts never spawning

### DIFF
--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -216,7 +216,7 @@
 		factory.assign_blobbernaut(null)
 		return FALSE
 
-	var/mob_type = /mob/living/basic/blob_minion/spore/minion
+	var/mob_type = /mob/living/basic/blob_minion/blobbernaut/minion
 	var/mob/living/basic/blob_minion/blobbernaut/minion/blobber = new mob_type(get_turf(factory), blob_borne = TRUE)
 	blobber.AddComponent(/datum/component/blob_minion, new_overmind = src, new_death_cloud_size = blobber.death_cloud_size)
 	factory.assign_blobbernaut(blobber)


### PR DESCRIPTION
Broken by #93893

Blob would try to spawn a blob spore when spawning a blobbernaut, obviously fucking shit up

:cl:
fix: Blobs can spawn blobbernauts again
/:cl: