### PR TITLE
Buffs facehuggers a smidge

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -188,7 +188,9 @@
 	if(!sterile)
 		victim.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
 	if(real && !sterile)
-		victim.Knockdown(5 SECONDS)
+		victim.Paralyze(1 SECONDS)
+		victim.adjust_confusion(20 SECONDS)
+		victim.Knockdown(10 SECONDS)
 	GoIdle() //so it doesn't jump the people that tear it off
 
 	addtimer(CALLBACK(src, PROC_REF(Impregnate), victim), rand(MIN_IMPREGNATION_TIME, MAX_IMPREGNATION_TIME))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -24,6 +24,7 @@
 	layer = MOB_LAYER
 	max_integrity = 100
 	slowdown = 2
+	clothing_traits = list(TRAIT_SOFTSPOKEN)
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 
 	var/sterile = FALSE


### PR DESCRIPTION
## About The Pull Request

- Facehugger knockdown 5 seconds -> 10 seconds
- Facehuggers now stun for 1 second 
- Facehuggers now apply 20 seconds of confusion
- You are forced to whisper while a facehugger is applied 

## Why It's Good For The Game

<img width="776" height="155" alt="image" src="https://github.com/user-attachments/assets/a9c5150a-075b-4c82-81ba-9bf3434d6468" />

Xenos have had a significantly harder time getting hosts ever since the massive facehugger nerf 
When I observe Xenos, I usually see the following happen
- Queen yeets a facehugger at someone
- They crawl away
- Queen can't catch up because she's slow AF
- Xenos outed

As a result the Xeno team has a tough time getting their numbers up to fight back against the crew's mechs I mean the crew's mechs I mean the crew's mechs I mean the crew.

By making facehuggers a bit more debilitating again - though not to the degree they used to be - hopefully they'll see a bit more success in getting a foothold.

- The 1 second stun is intended to give Xenos (especially the Queen) a chance to approach without the victim immediately crawling away to a safe distance.
- The confusion effect is intended to make it harder to simply scamper out of an airlock. 
   - Also, it'll affect Hulks. 
- The increased knockdown is intended to keep the victim vulnerable for longer.
- And the forced whisper is mainly just for flavor (since it already muffles), but it might make it a bit harder to out via radio. 

## Changelog

:cl: Melbert
balance: Facehuggers now apply a 1 second stun when initially applied
balance: Facehuggers now apply a 20 second confusion effect
balance: Facehugger knockdown duration has been doubled (to 10 seconds)
balance: While your face is covered by a facehugger, you are forced to whisper
/:cl:
