### PR TITLE
Buffs Polypyrylium Oligomers

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -756,7 +756,7 @@
 /// Spaceman's Trumpet fragile Polypyrylium Oligomers
 /datum/plant_gene/reagent/preset/polypyr
 	reagent_id = /datum/reagent/medicine/polypyr
-	rate = 0.15
+	rate = 0.08
 
 /// Jupitercup's fragile Liquid Electricity
 /datum/plant_gene/reagent/preset/liquidelectricity

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1762,7 +1762,7 @@
 /datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjustOrganLoss(ORGAN_SLOT_LUNGS, -0.25 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjustOrganLoss(ORGAN_SLOT_LUNGS, -2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	need_mob_update += affected_mob.adjustBruteLoss(-0.35 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH


### PR DESCRIPTION
## About The Pull Request

Increases the amount lungs are healed from 0.25 to 2.
Decreases the percentage of Polypyrylium Oligomers from Spaceman's Trumpet Plant's trait from 15% to 8%.

## Why It's Good For The Game

I've been a botany main for years and I don't think I have ever once had med or chem ask me for polypyrylium oligomers. They don't even want it if I just bring it to them. Recently, I asked several knowledgeable chemists and med people their thoughts on the chem, and most of them said it was too weak to bother with, especially since it can force a change on a person's appearance. This buff aims to make it at least somewhat worthwhile.

I've reduced the amount you get from each plant by about half to offset the buff in its effectiveness.

## Changelog

:cl:
balance: Increases the amount lungs are healed by Polypyrylium Oligomers from 0.25 to 2.
balance: Decreases the percentage of Polypyrylium Oligomers from Spaceman's Trumpet Plant's trait from 15% to 8%.
/:cl:
