### PR TITLE
Fixes wall mounts prioritizing TABLES

### DIFF
--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -93,8 +93,8 @@
 		msg = "[type] Could not find attachable object at [location.type] "
 
 	var/list/turf/attachable_turfs = list()
+	attachable_turfs += get_step(src, dir)
 	attachable_turfs += get_turf(src)
-	attachable_turfs += get_step(attachable_turfs[1], dir)
 	for(var/turf/target as anything in attachable_turfs)
 		var/atom/attachable_atom
 		if(isclosedturf(target))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -330,6 +330,7 @@
 #include "unit_test.dm"
 #include "verify_config_tags.dm"
 #include "verify_emoji_names.dm"
+#include "wallmount.dm"
 #include "washing.dm"
 #include "weird_food.dm"
 #include "wizard_loadout.dm"

--- a/code/modules/unit_tests/wallmount.dm
+++ b/code/modules/unit_tests/wallmount.dm
@@ -4,6 +4,7 @@
 /datum/unit_test/wallmount/Run()
 	var/obj/structure/table/test_table = EASY_ALLOCATE()
 	var/obj/machinery/light/directional/south/test_light = EASY_ALLOCATE()
+	test_light.find_and_hang_on_atom()
 
 	var/datum/component/atom_mounted/wallmount_component = test_light.GetComponent(/datum/component/atom_mounted)
 	TEST_ASSERT_NOTNULL(wallmount_component, "Wall mount component was not added to the light!")

--- a/code/modules/unit_tests/wallmount.dm
+++ b/code/modules/unit_tests/wallmount.dm
@@ -1,0 +1,10 @@
+/// Ensures wallmouted objects prioritize walls over other mountable objects like tables
+/datum/unit_test/wallmount
+
+/datum/unit_test/wallmount/Run()
+	var/obj/structure/table/test_table = EASY_ALLOCATE()
+	var/obj/machinery/light/directional/south/test_light = EASY_ALLOCATE()
+
+	var/datum/component/atom_mounted/wallmount_component = test_light.GetComponent(/datum/component/atom_mounted)
+	TEST_ASSERT_NOTNULL(wallmount_component, "Wall mount component was not added to the light!")
+	TEST_ASSERT_NOTEQUAL(wallmount_component.hanging_support_atom, test_table, "Wall mount component was mounted on the table rather than the wall!")


### PR DESCRIPTION
## About The Pull Request

It checks its own turf before the turf behind it

## Changelog

:cl: Melbert
fix: Wall mounts no longer stick to tables instead of the wall behind it
/:cl:

