### PR TITLE
Fixes Icemoon Comms Agent's secret documents

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_cheap.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_cheap.dmm
@@ -8,11 +8,11 @@
 	pixel_x = -2
 	},
 /obj/item/paper/monitorkey,
-/obj/item/paperwork,
 /obj/item/radio/intercom/syndicate/freerange{
 	dir = 1;
 	pixel_y = 32
 	},
+/obj/item/folder/syndicate/mining,
 /turf/open/floor/plating,
 /area/ruin/comms_agent)
 "b" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_luxury.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_luxury.dmm
@@ -144,11 +144,11 @@
 /area/ruin/comms_agent)
 "M" = (
 /obj/structure/filingcabinet,
-/obj/item/paperwork,
 /obj/item/paper/monitorkey,
 /obj/item/paper/fluff/ruins/listeningstation/briefing{
 	pixel_x = -2
 	},
+/obj/item/folder/syndicate/mining,
 /turf/open/floor/wood/tile,
 /area/ruin/comms_agent)
 "N" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_standard.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent/commsoffice_standard.dmm
@@ -49,11 +49,11 @@
 /area/ruin/comms_agent)
 "u" = (
 /obj/structure/filingcabinet,
-/obj/item/paperwork,
 /obj/item/paper/monitorkey,
 /obj/item/paper/fluff/ruins/listeningstation/briefing{
 	pixel_x = -2
 	},
+/obj/item/folder/syndicate/mining,
 /turf/open/floor/wood/tile,
 /area/ruin/comms_agent)
 "v" = (


### PR DESCRIPTION
## About The Pull Request
Closes #88539 (This issue has been open for almost an entire fucking year now holy moly dude)
This replaces the documents in the comms agent room(s) on Icebox.
It replaces `/obj/item/paperwork` (generic paperwork, no importance at all) with `/obj/item/folder/syndicate/mining` which is ACTUALLY secret. It also makes the traitor objective of stealing any secret documents easier. These documents are also found on the Lavaland equivalent of the comms agent ruin.
## Why It's Good For The Game

Mmmm fixes... More gameplay...
## Changelog
:cl:
fix: Fixes Icebox's comms agent ruin having generic documents, not the secret ones
/:cl:
