### PR TITLE
Revert replacing T2 tools with T1 tools in the CE toolbelt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -55,23 +55,23 @@
 	preload = TRUE
 
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
-	SSwardrobe.provide_type(/obj/item/screwdriver, src)
-	SSwardrobe.provide_type(/obj/item/wrench, src)
-	SSwardrobe.provide_type(/obj/item/weldingtool/hugetank, src)
-	SSwardrobe.provide_type(/obj/item/crowbar, src)
-	SSwardrobe.provide_type(/obj/item/wirecutters, src)
+	SSwardrobe.provide_type(/obj/item/screwdriver/power, src)
+	SSwardrobe.provide_type(/obj/item/crowbar/power, src)
+	SSwardrobe.provide_type(/obj/item/weldingtool/experimental, src)
 	SSwardrobe.provide_type(/obj/item/multitool, src)
 	SSwardrobe.provide_type(/obj/item/stack/cable_coil, src)
+	SSwardrobe.provide_type(/obj/item/extinguisher/mini, src)
+	SSwardrobe.provide_type(/obj/item/analyzer, src)
 
 /obj/item/storage/belt/utility/chief/full/get_types_to_preload()
 	var/list/to_preload = list() //Yes this is a pain. Yes this is the point
-	to_preload += /obj/item/screwdriver
-	to_preload += /obj/item/wrench
-	to_preload += /obj/item/weldingtool/hugetank
-	to_preload += /obj/item/crowbar
-	to_preload += /obj/item/wirecutters
+	to_preload += /obj/item/screwdriver/power
+	to_preload += /obj/item/crowbar/power
+	to_preload += /obj/item/weldingtool/experimental
 	to_preload += /obj/item/multitool
 	to_preload += /obj/item/stack/cable_coil
+	to_preload += /obj/item/extinguisher/mini
+	to_preload += /obj/item/analyzer
 	return to_preload
 
 /obj/item/storage/belt/utility/full/PopulateContents()

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -69,8 +69,6 @@
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 		/obj/item/construction/rcd/ce = 1,
-		/obj/item/extinguisher/mini = 1,
-		/obj/item/analyzer = 1,
 	)
 	belt = /obj/item/storage/belt/utility/chief/full
 	ears = /obj/item/radio/headset/heads/ce


### PR DESCRIPTION

## About The Pull Request

Reverts #92872, which replaced the advanced tools in the CE's toolbelt with base tools.
## Why It's Good For The Game

This PR reverts the Chief Engineer role back to its long-standing previous state. They are an engineer that leads the engineering department and engages in general command tasks, while also being better at engineering than regular engineers. That's how command roles have worked for a long time, including the CMO, HoS and RD.

The playerbase strongly favors the CE role being a better engineer alongside their role as a member of station command. This is showcased by the clear majority opposition to the tool replacement PR in the form of reactions to #92872:
<img width="176" height="49" alt="image" src="https://github.com/user-attachments/assets/ce5ed515-5bc7-407a-98f6-948893091e26" />

And also the comment thread under that PR.

Historically, roles have always had tech skips. The chemist has dispensers, goggles, chemmasters and a purity scanner. The botanist has hydroponics trays. The medical doctor has cryo tubes and health HUDs. These are all items that are available at roundstart to specific roles, and can be researched later on in the round.

Departmental heads having tech skips is not a problem to the vast majority of the playerbase, and is instead appreciated. The CMOs advanced health analyzer and the CEs advanced toolbelt have never stopped doctors and engineers from going to science to request these items. People ask for advanced tool research extremely often, to the point that science has a culture of researching them without even asking, because it's taken as a given that people want them.

We should have advanced tools as an incentive to play CE. We struggle a lot with staffing command roles, so removing incentives to play them is a bad idea. Competency is already enforced by job bans and department-specific playtime limits, and the tools weren't a major negative driving factor, being outweighed by the positive incentives for good players.

The CE is usually staffed by an experienced engineer that doesn't mind being or wants to be in a command role. That serves the purpose of the CE's role well, and the advanced tools support that by incentivizing these players to pick up the role more often.
## Changelog
:cl:
balance: The CE toolbelt has advanced tools again.
/:cl:
