### PR TITLE
Assembling med/repair/secbots will now put their assemblies in your main hand instead of your offhand, and only do so if you held the original item

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -376,11 +376,11 @@
 
 	to_chat(user, span_notice("You add [tool] to [src]."))
 	qdel(tool)
-	if (user.is_holding(src))
-		qdel(src)
-		user.put_in_hands(new /obj/item/bot_assembly/firebot(drop_location()))
-	else
-		qdel(src)
+	var/obj/item/bot_assembly/firebot/assembly = new(drop_location())
+	var/held_index = user.is_holding(src)
+	qdel(src)
+	if (held_index)
+		user.put_in_hand(assembly, held_index)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/extinguisher/anti

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -369,15 +369,19 @@
 		reagents.clear_reagents()
 		user.visible_message(span_notice("[user] empties out [src] onto the floor using the release valve."), span_info("You quietly empty out [src] using its release valve."))
 
-//firebot assembly
-/obj/item/extinguisher/attackby(obj/O, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(O, /obj/item/bodypart/arm/left/robot) || istype(O, /obj/item/bodypart/arm/right/robot))
-		to_chat(user, span_notice("You add [O] to [src]."))
-		qdel(O)
+// Firebot assembly
+/obj/item/extinguisher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if (!istype(tool, /obj/item/bodypart/arm/left/robot) && !istype(tool, /obj/item/bodypart/arm/right/robot))
+		return NONE
+
+	to_chat(user, span_notice("You add [tool] to [src]."))
+	qdel(tool)
+	if (user.is_holding(src))
 		qdel(src)
-		user.put_in_hands(new /obj/item/bot_assembly/firebot)
+		user.put_in_hands(new /obj/item/bot_assembly/firebot(drop_location()))
 	else
-		..()
+		qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/extinguisher/anti
 	name = "fire extender"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -173,12 +173,13 @@
 			if (!M.use(1))
 				to_chat(user, span_warning("You need one sheet of iron to start building ED-209!"))
 				return
-			var/obj/item/bot_assembly/ed209/B = new(drop_location())
+			var/obj/item/bot_assembly/ed209/assembly = new(drop_location())
 			to_chat(user, span_notice("You arm the robot frame."))
-			var/holding_this = user.get_inactive_held_item() == src
+			var/held_index = user.is_holding(src)
 			qdel(src)
-			if (holding_this)
-				user.put_in_hand(B)
+			if (held_index)
+				user.put_in_hand(assembly, held_index)
+
 	else if(istype(W, /obj/item/bodypart/leg/left/robot))
 		if(l_leg)
 			return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -172,7 +172,7 @@
 		if(!l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
 			if (!M.use(1))
 				to_chat(user, span_warning("You need one sheet of iron to start building ED-209!"))
-			return
+				return
 			var/obj/item/bot_assembly/ed209/B = new(drop_location())
 			to_chat(user, span_notice("You arm the robot frame."))
 			var/holding_this = user.get_inactive_held_item() == src

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -170,17 +170,15 @@
 	if(istype(W, /obj/item/stack/sheet/iron))
 		var/obj/item/stack/sheet/iron/M = W
 		if(!l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
-			if (M.use(1))
-				var/obj/item/bot_assembly/ed209/B = new
-				B.forceMove(drop_location())
-				to_chat(user, span_notice("You arm the robot frame."))
-				var/holding_this = user.get_inactive_held_item() == src
-				qdel(src)
-				if (holding_this)
-					user.put_in_inactive_hand(B)
-			else
+			if (!M.use(1))
 				to_chat(user, span_warning("You need one sheet of iron to start building ED-209!"))
-				return
+			return
+			var/obj/item/bot_assembly/ed209/B = new(drop_location())
+			to_chat(user, span_notice("You arm the robot frame."))
+			var/holding_this = user.get_inactive_held_item() == src
+			qdel(src)
+			if (holding_this)
+				user.put_in_hand(B)
 	else if(istype(W, /obj/item/bodypart/leg/left/robot))
 		if(l_leg)
 			return

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -191,11 +191,10 @@
 	qdel(tool)
 	loc.balloon_alert(user, "wheels added, honk!")
 	var/obj/item/bot_assembly/honkbot/assembly = new(drop_location())
-	if (user.is_holding(src))
-		qdel(src)
-		user.put_in_hands(assembly)
-	else
-		qdel(src)
+	var/held_index = user.is_holding(src)
+	qdel(src)
+	if (held_index)
+		user.put_in_hand(assembly, held_index)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/storage/box/clown/suicide_act(mob/living/user)

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -190,9 +190,12 @@
 		return ITEM_INTERACT_BLOCKING
 	qdel(tool)
 	loc.balloon_alert(user, "wheels added, honk!")
-	var/obj/item/bot_assembly/honkbot/A = new
-	qdel(src)
-	user.put_in_hands(A)
+	var/obj/item/bot_assembly/honkbot/assembly = new(drop_location())
+	if (user.is_holding(src))
+		qdel(src)
+		user.put_in_hands(assembly)
+	else
+		qdel(src)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/storage/box/clown/suicide_act(mob/living/user)

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -376,12 +376,12 @@
 
 	var/obj/item/bot_assembly/medbot/medbot_assembly = new()
 	medbot_assembly.set_skin(get_medbot_skin())
-	user.put_in_hands(medbot_assembly)
 	medbot_assembly.balloon_alert(user, "arm added")
 	medbot_assembly.robot_arm = tool.type
 	medbot_assembly.medkit_type = type
 	qdel(tool)
 	qdel(src)
+	user.put_in_hands(medbot_assembly)
 	return ITEM_INTERACT_SUCCESS
 
 /// Gets what skin (icon_state) this medkit uses for a medbot

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -374,14 +374,17 @@
 		balloon_alert(user, "items inside!")
 		return ITEM_INTERACT_BLOCKING
 
-	var/obj/item/bot_assembly/medbot/medbot_assembly = new()
+	var/obj/item/bot_assembly/medbot/medbot_assembly = new(drop_location())
 	medbot_assembly.set_skin(get_medbot_skin())
 	medbot_assembly.balloon_alert(user, "arm added")
 	medbot_assembly.robot_arm = tool.type
 	medbot_assembly.medkit_type = type
 	qdel(tool)
-	qdel(src)
-	user.put_in_hands(medbot_assembly)
+	if(user.is_holding(src))
+		qdel(src)
+		user.put_in_hands(medbot_assembly)
+	else
+		qdel(src)
 	return ITEM_INTERACT_SUCCESS
 
 /// Gets what skin (icon_state) this medkit uses for a medbot

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -380,11 +380,10 @@
 	medbot_assembly.robot_arm = tool.type
 	medbot_assembly.medkit_type = type
 	qdel(tool)
-	if(user.is_holding(src))
-		qdel(src)
-		user.put_in_hands(medbot_assembly)
-	else
-		qdel(src)
+	var/held_index = user.is_holding(src)
+	qdel(src)
+	if (held_index)
+		user.put_in_hand(medbot_assembly, held_index)
 	return ITEM_INTERACT_SUCCESS
 
 /// Gets what skin (icon_state) this medkit uses for a medbot

--- a/code/game/objects/items/storage/toolboxes/_toolbox.dm
+++ b/code/game/objects/items/storage/toolboxes/_toolbox.dm
@@ -153,9 +153,9 @@
 	repair.toolbox = type
 	var/new_color = toolbox_colors[type] || "#445eb3"
 	repair.set_color(new_color)
-	user.put_in_hands(repair)
 	repair.update_appearance()
 	repair.balloon_alert(user, "sensor added!")
 	qdel(tool)
 	qdel(src)
+	user.put_in_hands(repair)
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/storage/toolboxes/_toolbox.dm
+++ b/code/game/objects/items/storage/toolboxes/_toolbox.dm
@@ -156,9 +156,8 @@
 	repair.update_appearance()
 	repair.balloon_alert(user, "sensor added!")
 	qdel(tool)
-	if (user.is_holding(src))
-		qdel(src)
-		user.put_in_hands(repair)
-	else
-		qdel(src)
+	var/held_index = user.is_holding(src)
+	qdel(src)
+	if (held_index)
+		user.put_in_hand(repair, held_index)
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/storage/toolboxes/_toolbox.dm
+++ b/code/game/objects/items/storage/toolboxes/_toolbox.dm
@@ -149,13 +149,16 @@
 		/obj/item/storage/toolbox/crafter = "#9D3282",
 		/obj/item/storage/toolbox/syndicate = "#3d3d3d",
 	)
-	var/obj/item/bot_assembly/repairbot/repair = new
+	var/obj/item/bot_assembly/repairbot/repair = new(drop_location())
 	repair.toolbox = type
 	var/new_color = toolbox_colors[type] || "#445eb3"
 	repair.set_color(new_color)
 	repair.update_appearance()
 	repair.balloon_alert(user, "sensor added!")
 	qdel(tool)
-	qdel(src)
-	user.put_in_hands(repair)
+	if (user.is_holding(src))
+		qdel(src)
+		user.put_in_hands(repair)
+	else
+		qdel(src)
 	return ITEM_INTERACT_SUCCESS

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -62,11 +62,10 @@
 
 		qdel(attached_signaler)
 		var/obj/item/bot_assembly/secbot/secbot_frame = new(drop_location())
-		if (user.is_holding(src))
-			qdel(src)
-			user.put_in_hands(secbot_frame)
-		else
-			qdel(src)
+		var/held_index = user.is_holding(src)
+		qdel(src)
+		if (held_index)
+			user.put_in_hand(secbot_frame, held_index)
 		return TRUE
 
 	return ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -62,9 +62,8 @@
 
 		qdel(attached_signaler)
 		var/obj/item/bot_assembly/secbot/secbot_frame = new(loc)
-		user.put_in_hands(secbot_frame)
-
 		qdel(src)
+		user.put_in_hands(secbot_frame)
 		return TRUE
 
 	return ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -61,9 +61,12 @@
 		to_chat(user, span_notice("You add [attached_signaler] to [src]."))
 
 		qdel(attached_signaler)
-		var/obj/item/bot_assembly/secbot/secbot_frame = new(loc)
-		qdel(src)
-		user.put_in_hands(secbot_frame)
+		var/obj/item/bot_assembly/secbot/secbot_frame = new(drop_location())
+		if (user.is_holding(src))
+			qdel(src)
+			user.put_in_hands(secbot_frame)
+		else
+			qdel(src)
 		return TRUE
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Bot assemblies will only be picked up if you held the item you attached the arm/sensor to, and will be put into the hand which you held the storage item in.
Also changed firebots assemblies to item_interaction

## Why It's Good For The Game

Usually you don't want to pick up the assembly if you're making a bunch of bots on the ground en-masse, and having the assemblies be put in your offhand and not your main hand despite the latter just being freed is weird and clunky.

## Changelog
:cl:
qol: Bot assemblies will only be picked up if you held the medkit/toolbox/helmet/etc in your hands when creating one.
qol: Assembling med/repair/secbots will now put their assemblies in your main hand instead of your offhand
/:cl:
