### PR TITLE
Makes CE powertools and CMO compact defib head exclusive again removing them from RND

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -55,23 +55,23 @@
 	preload = TRUE
 
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
-	SSwardrobe.provide_type(/obj/item/screwdriver, src)
-	SSwardrobe.provide_type(/obj/item/wrench, src)
-	SSwardrobe.provide_type(/obj/item/weldingtool/hugetank, src)
-	SSwardrobe.provide_type(/obj/item/crowbar, src)
-	SSwardrobe.provide_type(/obj/item/wirecutters, src)
+	SSwardrobe.provide_type(/obj/item/screwdriver/power, src)
+	SSwardrobe.provide_type(/obj/item/crowbar/power, src)
+	SSwardrobe.provide_type(/obj/item/weldingtool/experimental, src)
 	SSwardrobe.provide_type(/obj/item/multitool, src)
 	SSwardrobe.provide_type(/obj/item/stack/cable_coil, src)
+	SSwardrobe.provide_type(/obj/item/extinguisher/mini, src)
+	SSwardrobe.provide_type(/obj/item/analyzer, src)
 
 /obj/item/storage/belt/utility/chief/full/get_types_to_preload()
 	var/list/to_preload = list() //Yes this is a pain. Yes this is the point
-	to_preload += /obj/item/screwdriver
-	to_preload += /obj/item/wrench
-	to_preload += /obj/item/weldingtool/hugetank
-	to_preload += /obj/item/crowbar
-	to_preload += /obj/item/wirecutters
+	to_preload += /obj/item/screwdriver/power
+	to_preload += /obj/item/crowbar/power
+	to_preload += /obj/item/weldingtool/experimental
 	to_preload += /obj/item/multitool
 	to_preload += /obj/item/stack/cable_coil
+	to_preload += /obj/item/extinguisher/mini
+	to_preload += /obj/item/analyzer
 	return to_preload
 
 /obj/item/storage/belt/utility/full/PopulateContents()

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -136,5 +136,6 @@
 	desc = "A wrench designed to grab into airlock's bolting system and raise it regardless of the airlock's power status."
 	icon_state = "bolter_wrench"
 	inhand_icon_state = "bolter_wrench"
+	toolspeed = 0.7
 	icon_angle = -90
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -69,8 +69,6 @@
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 		/obj/item/construction/rcd/ce = 1,
-		/obj/item/extinguisher/mini = 1,
-		/obj/item/analyzer = 1,
 	)
 	belt = /obj/item/storage/belt/utility/chief/full
 	ears = /obj/item/radio/headset/heads/ce

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -224,18 +224,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/defibrillator_compact
-	name = "Compact Defibrillator"
-	desc = "A compact defibrillator that can be worn on a belt."
-	id = "defibrillator_compact"
-	build_type = PROTOLATHE | AWAY_LATHE
-	build_path = /obj/item/defibrillator/compact
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*6, /datum/material/glass = SHEET_MATERIAL_AMOUNT*4, /datum/material/silver = SHEET_MATERIAL_AMOUNT*3, /datum/material/gold =SHEET_MATERIAL_AMOUNT * 1.5)
-	category = list(
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
 /datum/design/genescanner
 	name = "Genetic Sequence Analyzer"
 	desc = "A handy hand-held analyzers for quickly determining mutations and collecting the full sequence."

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -14,31 +14,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
-/datum/design/handdrill
-	name = "Hand Drill"
-	desc = "A small electric hand drill with an interchangeable screwdriver and bolt bit"
-	id = "handdrill"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT*1.75, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/titanium =SHEET_MATERIAL_AMOUNT*1.25)
-	build_path = /obj/item/screwdriver/power
-	category = list(
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
-
-/datum/design/jawsoflife
-	name = "Jaws of Life"
-	desc = "A small, compact Jaws of Life with an interchangeable pry jaws and cutting jaws"
-	id = "jawsoflife" // added one more requirment since the Jaws of Life are a bit OP
-	build_path = /obj/item/crowbar/power
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT*2.25, /datum/material/silver =SHEET_MATERIAL_AMOUNT*1.25, /datum/material/titanium =SHEET_MATERIAL_AMOUNT*1.75)
-	category = list(
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
-	autolathe_exportable = FALSE
-
 /datum/design/exwelder
 	name = "Experimental Welding Tool"
 	desc = "An experimental welder capable of self-fuel generation."

--- a/code/modules/research/techweb/nodes/atmos_nodes.dm
+++ b/code/modules/research/techweb/nodes/atmos_nodes.dm
@@ -98,9 +98,7 @@
 	prereq_ids = list(TECHWEB_NODE_FUSION)
 	design_ids = list(
 		"flatpacker",
-		"handdrill",
 		"exwelder",
-		"jawsoflife",
 		"rangedanalyzer",
 		"rtd_loaded",
 		"mech_rcd",

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -80,7 +80,6 @@
 		"healthanalyzer_advanced",
 		"mod_health_analyzer",
 		"crewpinpointer",
-		"defibrillator_compact",
 		"defibmount",
 		"medicalbed_emergency",
 		"piercesyringe",


### PR DESCRIPTION
## About The Pull Request
This pr returns powertools to the CE with the tradeoff being exclusive to him
This pr also make compact defib unique to the cmo which also makes exclusivity to the item

Alternative solution to #94069

TODO:(Maybe single tool replacements for T2)

## Why It's Good For The Game
Along the year these items got introduced as head exclusive items and they lost their uniqueness when they got added to RnD and printable by everyone in the department.

Jaws of life has some powerscaling to it not only its able to open doors easily it also can cut trough metal handcuffs instantly which is a little more obscure knowledge but for a head item traitors definitly want it. so it adds more value to getting the item stolen from the ce then just printing it out  a vendor.

Compact defib cmo doesn't really use and its really the question of do i want to sacrafice storage space it or just pass it to a person to use this. this doesn't really see alot of use when printed but you are able to emagg it to turn it into a powerfull weapon which adds more steal value from the cmo then just printing it out some dumb autolathe

## Changelog
:cl: Ezel
balance: You can no longer print jaws of life/hand drill/compact defib in the techlathes
balance: CE gets powertools again
balance: Bolter wrench toolspeed buffed
/:cl:
