### PR TITLE
Updates silent jaws of recovery

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -119,7 +119,8 @@
 	category = CAT_TOOLS
 
 /datum/crafting_recipe/jaws_of_recovery
-	name = "Modified Jaws of Life"
+	name = "Modified Jaws of Recovery"
+	desc = "This one acts like regular jaws of life, letting you pry any door and doesn't announce doors you're prying open."
 	time = 10 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER)
 	result = /obj/item/crowbar/power/paramedic/silent

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -131,7 +131,7 @@
 
 /obj/item/knife/kitchen/silicon/examine()
 	. = ..()
-	. += " It's fitted with a [tool_behaviour] head."
+	. += "It's fitted with a [tool_behaviour] head."
 
 /obj/item/knife/kitchen/silicon/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/tools/change_drill.ogg', 50, TRUE)

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -329,6 +329,7 @@
 /obj/item/crowbar/power/paramedic/silent
 	desc = "A specialized version of the jaws of life, primarily to be used by paramedics to recover the injured and the recently deceased. Rather than a cutting arm, this tool has a bonesetting apparatus. \
 		This one looks upgraded."
+	w_class = WEIGHT_CLASS_NORMAL // it's a modified, normal jaws
 	limit_jaws_access = FALSE
 	radio_alert = FALSE
 

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -175,7 +175,7 @@
 
 /obj/item/crowbar/power/examine()
 	. = ..()
-	. += " It's fitted with a [tool_behaviour == first_tool_behavior ? inactive_text : active_text] head."
+	. += "It's fitted with a [tool_behaviour == first_tool_behavior ? inactive_text : active_text] head."
 
 /*
  * Signal proc for [COMSIG_TRANSFORMING_ON_TRANSFORM].
@@ -327,8 +327,8 @@
 	)
 
 /obj/item/crowbar/power/paramedic/silent
-	name = "modified jaws of recovery"
-	desc = "Modified version for jaws of life, made to act like jaws of recovery. This one doesn't announce doors you're prying open and lets you pry any door, acting like regular jaws of life"
+	desc = "A specialized version of the jaws of life, primarily to be used by paramedics to recover the injured and the recently deceased. Rather than a cutting arm, this tool has a bonesetting apparatus. \
+		This one looks upgraded."
 	limit_jaws_access = FALSE
 	radio_alert = FALSE
 

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -143,7 +143,7 @@
 
 /obj/item/screwdriver/power/examine()
 	. = ..()
-	. += " It's fitted with a [tool_behaviour == TOOL_SCREWDRIVER ? "screw" : "bolt"] bit."
+	. += "It's fitted with a [tool_behaviour == TOOL_SCREWDRIVER ? "screw" : "bolt"] bit."
 
 /obj/item/screwdriver/power/suicide_act(mob/living/user)
 	if(tool_behaviour == TOOL_SCREWDRIVER)


### PR DESCRIPTION
## About The Pull Request

- Moves the information about the improvements to the silent jaws of recovery to its crafting recipe.
- Modifies silent jaws of recovery tool description
- Updates weight class to match the jaws it's made from
- Fixes some errant additional spaces in power tools descriptions

## Why It's Good For The Game

The modified jaws of recovery shouldn't be so blatantly obvious that it has been 'adjusted' for being a crimer. It should reflect the normal jaws of life that it's modified from, doesn't need to be announced to the world.

Instead, it should be like emagged objects or false walls, where if you're observant you can see the difference, but at a quick glance it looks normal.  Someone looking closely may notice that the modified version lacks the "Cannot access certain high security areas due to safety concerns." and is replaced with "This one looks upgraded."

## Changelog

:cl: LT3
qol: Silent jaws of recovery is now less obvious that it's modified
/:cl: