### PR TITLE
Partially deployed MODsuits can now be un-deployed with the action

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -50,20 +50,18 @@
 		balloon_alert(user, "currently [active ? "unsealing" : "sealing"]!")
 		playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return FALSE
-	var/deploy = FALSE
+	var/deploy = TRUE
 	for(var/obj/item/part as anything in get_parts())
 		if(part.loc != src)
-			continue
-		deploy = TRUE
-		break
+			deploy = FALSE
+			break
 	wearer.visible_message(span_notice("[wearer]'s [src] [deploy ? "deploys" : "retracts"] its parts with a mechanical hiss."),
 		span_notice("[src] [deploy ? "deploys" : "retracts"] its parts with a mechanical hiss."),
 		span_hear("You hear a mechanical hiss."))
 	playsound(src, 'sound/vehicles/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	for(var/obj/item/part as anything in get_parts())
 		if(deploy && part.loc == src)
-			if(!deploy(null, part))
-				continue
+			deploy(null, part)
 		else if(!deploy && part.loc != src)
 			retract(null, part)
 	if(deploy)


### PR DESCRIPTION

## About The Pull Request

Flips the logic on MOD deploy action RMB click, allowing it to undeploy parts if some of them still aren't deployed. Currently if you're wearing a hat or a suit, trying to use it with your gloves and boots deployed will not do anything, as it will try to deploy parts onto the blocked slots instead of retracting already deployed ones.

## Why It's Good For The Game

Allows people to wear suits and not have to manually undeploy each of their MODsuit parts because the RMB action doesn't work.

## Changelog
:cl:
fix: Fixed partially deployed MODsuits trying to deploy parts onto blocked slots when the deploy action is right clicked, instead of retracting already deployed parts.
/:cl:
