### PR TITLE
Change Runtimestation pistol ammo

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1797,7 +1797,7 @@
 /area/station/command/bridge)
 "BG" = (
 /obj/structure/table,
-/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c9mm,
 /obj/item/gun/ballistic/automatic/pistol,
 /turf/open/floor/iron,
 /area/station/command/bridge)


### PR DESCRIPTION

## About The Pull Request

The pistol on the table is a Makarov that takes 9mm ammo but there's a 10mm box on the table

## Why It's Good For The Game

Correct ammo

## Changelog

N/A
