### PR TITLE
Headslugs are now small

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/changeling/headslug.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/headslug.dm
@@ -10,6 +10,9 @@
 	icon_living = "headslug"
 	icon_dead = "headslug_dead"
 	gender = NEUTER
+	pass_flags = PASSTABLE | PASSMOB
+	mob_size = MOB_SIZE_SMALL
+	density = FALSE
 	health = 50
 	maxHealth = 50
 	max_stamina = 120


### PR DESCRIPTION
## About The Pull Request

Headslugs now go under mobs and tables, and mobs walk through them. They were also made small sized, so they can now enter da vim.

I assume this is fix because they are clearly small mobs, but I can see how this might be balance if a maint wants to switch tags.

## Why It's Good For The Game

Like alien larva these are small mobs and I think they should reflect this in not treating them like a full dense mob. Also da vim.

## Changelog

:cl:
fix: Headslugs are now small.
/:cl: