### PR TITLE
More `/living/` `abstract_type`s

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -13,13 +13,10 @@ GLOBAL_LIST_INIT(abstract_mob_types, list(
 	/mob/living/basic/heretic_summon,
 	/mob/living/basic/mimic/copy, // Cannot exist if spawned without being passed an item reference
 	/mob/living/basic/soulscythe, // This is just a way for players to control the soulscythe item
-	/mob/living/carbon/alien,
-	/mob/living/carbon/alien/adult,
 	/mob/living/carbon/human/consistent,
 	/mob/living/carbon/human/dummy,
 	/mob/living/carbon/human/dummy/consistent,
-	/mob/living/carbon/human/species,
-	) + valid_subtypesof(/mob/living))
+	))
 
 
 //Since it didn't really belong in any other category, I'm putting this here

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -8,33 +8,18 @@ GLOBAL_LIST_EMPTY(stealthminID) //reference list with IDs that store ckeys, for 
 
 /// List of types of abstract mob which shouldn't usually exist in the world on its own if we're spawning random mobs
 GLOBAL_LIST_INIT(abstract_mob_types, list(
-	/mob/living/basic,
-	/mob/living/basic/blob_minion,
-	/mob/living/basic/bot,
 	/mob/living/basic/construct,
 	/mob/living/basic/guardian,
 	/mob/living/basic/heretic_summon,
-	/mob/living/basic/mimic, // Cannot exist if spawned without being passed an item reference
-	/mob/living/basic/mining,
-	/mob/living/basic/pet,
-	/mob/living/basic/pet/penguin,
+	/mob/living/basic/mimic/copy, // Cannot exist if spawned without being passed an item reference
 	/mob/living/basic/soulscythe, // This is just a way for players to control the soulscythe item
-	/mob/living/basic/spider,
-	/mob/living/carbon,
 	/mob/living/carbon/alien,
 	/mob/living/carbon/alien/adult,
 	/mob/living/carbon/human/consistent,
 	/mob/living/carbon/human/dummy,
 	/mob/living/carbon/human/dummy/consistent,
 	/mob/living/carbon/human/species,
-	/mob/living/silicon,
-	/mob/living/simple_animal,
-	/mob/living/simple_animal/bot,
-	/mob/living/simple_animal/hostile,
-	/mob/living/simple_animal/hostile/asteroid,
-	/mob/living/simple_animal/hostile/asteroid/elite,
-	/mob/living/simple_animal/hostile/megafauna,
-))
+	) + valid_subtypesof(/mob/living))
 
 
 //Since it didn't really belong in any other category, I'm putting this here

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -111,11 +111,12 @@
 			/mob/living/simple_animal,
 		)
 		for(var/type in mob_subtype_whitelist)
-			possible_mobtypes += subtypesof(type)
+			possible_mobtypes += valid_subtypesof(type)
 
 		var/list/mob_subtype_blacklist = list(
 			/mob/living/simple_animal/hostile/asteroid/elite,
 			/mob/living/simple_animal/hostile/megafauna,
+			/mob/living/basic/boss,
 		)
 		for(var/type in mob_subtype_blacklist)
 			possible_mobtypes -= subtypesof(type)

--- a/code/game/objects/items/soulscythe.dm
+++ b/code/game/objects/items/soulscythe.dm
@@ -258,6 +258,7 @@
 	faction = list()
 	default_blood_volume = MAX_BLOOD_LEVEL
 	hud_type = /datum/hud/soulscythe
+	spawn_blacklisted = TRUE
 
 /mob/living/basic/soulscythe/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/blob_minions/blob_mob.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_mob.dm
@@ -1,5 +1,6 @@
 /// Root of shared behaviour for mobs spawned by blobs, is abstract and should not be spawned
 /mob/living/basic/blob_minion
+	abstract_type = /mob/living/basic/blob_minion
 	name = "Blob Error"
 	desc = "A nonfunctional fungal creature created by bad code or celestial mistake. Point and laugh."
 	icon = 'icons/mob/nonhuman-player/blob.dmi'

--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_INIT(command_strings, list(
 #define SENTIENT_BOT_RESET_TIMER 45 SECONDS
 
 /mob/living/basic/bot
+	abstract_type = /mob/living/basic/bot
 	icon = 'icons/mob/silicon/aibots.dmi'
 	layer = MOB_LAYER
 	gender = NEUTER

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -1,5 +1,6 @@
 ///prototype for mining mobs
 /mob/living/basic/mining
+	abstract_type = /mob/living/basic/mining
 	icon = 'icons/mob/simple/lavaland/lavaland_monsters.dmi'
 	combat_mode = TRUE
 	status_flags = NONE //don't inherit standard basicmob flags

--- a/code/modules/mob/living/basic/pets/penguin/penguin.dm
+++ b/code/modules/mob/living/basic/pets/penguin/penguin.dm
@@ -1,4 +1,5 @@
 /mob/living/basic/pet/penguin
+	abstract_type = /mob/living/basic/pet/penguin
 
 	icon = 'icons/mob/simple/penguins.dmi'
 	gender = FEMALE

--- a/code/modules/mob/living/basic/pets/pet.dm
+++ b/code/modules/mob/living/basic/pets/pet.dm
@@ -1,4 +1,5 @@
 /mob/living/basic/pet
+	abstract_type = /mob/living/basic/pet
 	icon = 'icons/mob/simple/pets.dmi'
 	mob_size = MOB_SIZE_SMALL
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST

--- a/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
+++ b/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 )))
 
 /mob/living/basic/mimic
+	abstract_type = /mob/living/basic/mimic
 	response_help_continuous = "touches"
 	response_help_simple = "touch"
 	response_disarm_continuous = "pushes"

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/alien/adult
+	abstract_type = /mob/living/carbon/alien/adult
 	name = "alien"
 	icon_state = "alien"
 	pass_flags = PASSTABLE

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/alien
+	abstract_type = /mob/living/carbon/alien
 	name = "alien"
 	icon = 'icons/mob/nonhuman-player/alien.dmi'
 	gender = FEMALE //All xenos are girls!!

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1025,6 +1025,7 @@
 	ai_controller = /datum/ai_controller/monkey
 
 /mob/living/carbon/human/species
+	abstract_type = /mob/living/carbon/human/species
 	var/race = null
 	var/use_random_name = TRUE
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1,5 +1,6 @@
 // AI (i.e. game AI, not the AI player) controlled bots
 /mob/living/simple_animal/bot
+	abstract_type = /mob/living/simple_animal/bot
 	icon = 'icons/mob/silicon/aibots.dmi'
 	layer = MOB_LAYER
 	gender = NEUTER


### PR DESCRIPTION
## About The Pull Request
<img width="589" height="186" alt="image" src="https://github.com/user-attachments/assets/52a6caa5-8e3b-4440-82e5-7be49acd2237" />

## Why It's Good For The Game
Less unintended mobs showing up in spawning is good.

## Changelog
:cl:
fix: Less abstract mobs will spawn in random spawners (mostly relating to the summoning prefix) 
fix: "Boss" basic mobs are now exluded from the summoning prefix to parody behavior of them being megafauna
/:cl:
