### PR TITLE
Paperwork storage objects export there paper when saved

### DIFF
--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -26,6 +26,15 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 
+/obj/structure/detectiveboard/on_object_saved()
+	var/data
+
+	for(var/obj/item/case_notes in contents)
+		var/metadata = generate_tgm_metadata(case_notes)
+		data += "[data ? ",\n" : ""][case_notes.type][metadata]"
+
+	return data
+
 /obj/structure/detectiveboard/Initialize(mapload)
 	. = ..()
 

--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -296,8 +296,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 	item = param_item
 	if(!name)
 		name = param_item.name
-	if(!desc)
-		desc = param_item.desc
+	if(!description)
+		description = param_item.desc
 	if(istype(param_item, /obj/item/photo))
 		evidence_type = EVIDENCE_TYPE_PHOTO
 	else

--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -42,7 +42,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 		for(var/obj/item/item in loc)
 			if(!(istype(item, /obj/item/paper) || istype(item, /obj/item/photo)))
 				continue
-			if(!cases[current_case])
+			if(!cases.len)
 				var/datum/case/case = new("Cold Cases", pick(case_colors))
 				cases += case
 				current_case = clamp(cases.len, 1, MAX_CASES)

--- a/code/game/objects/structures/detectiveboard.dm
+++ b/code/game/objects/structures/detectiveboard.dm
@@ -39,6 +39,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 	. = ..()
 
 	if(mapload)
+		var/sprite_dirtied = FALSE
 		for(var/obj/item/item in loc)
 			if(!(istype(item, /obj/item/paper) || istype(item, /obj/item/photo)))
 				continue
@@ -50,6 +51,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/detectiveboard, 32)
 			cases[current_case].notices++
 			var/datum/evidence/evidence = new(null, null, item)
 			cases[current_case].evidences += evidence
+			sprite_dirtied = TRUE
+		if(sprite_dirtied)
 			update_appearance(UPDATE_ICON)
 		find_and_hang_on_atom()
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -257,7 +257,7 @@
 	for(var/C in GLOB.employmentCabinets)
 		var/obj/structure/filingcabinet/employment/employmentCabinet = C
 		if(!employmentCabinet.virgin)
-			employmentCabinet.addFile(employee)
+			employmentCabinet.add_file(employee)
 
 /// Creates, assigns and returns the new_character to spawn as. Assumes a valid mind.assigned_role exists.
 /mob/dead/new_player/proc/create_character(atom/destination)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworks filing cabinets and detective boards to handle exporting there paperwork better.
Generized the population of records so that it saved cabinets will not regenerate (except the employee cabinet because it has extra handling)
Makes it so the det board acctually supports the behavior it has in map load as it used to blindly forcemove notes which you would only be able to get back by deconstructing it (I think). It generates a "Cold Cases" tab for all of these notes, though it unfortuantly doesnt save the evidence datums themselves so no notes or red strings.

<img width="554" height="350" alt="image" src="https://github.com/user-attachments/assets/15de134d-769c-444f-8c21-b97a33a0b121" />

export
<img width="1352" height="811" alt="image" src="https://github.com/user-attachments/assets/0268f534-18fa-42d0-a8aa-3af360b3a21b" />



<img width="786" height="489" alt="image" src="https://github.com/user-attachments/assets/38018702-7a68-4a67-aea2-5f7a58ed25ee" />

export
<img width="847" height="493" alt="image" src="https://github.com/user-attachments/assets/8cb77711-713a-4656-a15f-59840a1b7ea5" />



testing some quickly mapped in stuff for the cold case feature (I manually redeposited them, they spawn stacked in the ui)
<img width="1148" height="812" alt="image" src="https://github.com/user-attachments/assets/176d85b6-33a3-461d-b73d-8219fce9a16b" />

export
<img width="1059" height="572" alt="image" src="https://github.com/user-attachments/assets/f15c64f0-8778-4165-bc1e-569d2de5b9cc" />


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
muh paperwork.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Map exporting filing cabinets or Detective boards now exports its paperwork as well
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
