### PR TITLE
Fixes syntax error for newer HeidiSQL versions

### DIFF
--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -647,7 +647,7 @@ CREATE TABLE `ticket` (
   KEY `idx_ticket_act_time_rid` (`action`, `timestamp`, `round_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-DELIMITER $$
+DELIMITER //
 CREATE PROCEDURE `set_poll_deleted`(
 	IN `poll_id` INT
 )
@@ -658,16 +658,16 @@ UPDATE `poll_option` SET deleted = 1 WHERE pollid = poll_id;
 UPDATE `poll_vote` SET deleted = 1 WHERE pollid = poll_id;
 UPDATE `poll_textreply` SET deleted = 1 WHERE pollid = poll_id;
 END
-$$
+//
 CREATE TRIGGER `role_timeTlogupdate` AFTER UPDATE ON `role_time` FOR EACH ROW BEGIN INSERT into role_time_log (ckey, job, delta) VALUES (NEW.CKEY, NEW.job, NEW.minutes-OLD.minutes);
 END
-$$
+//
 CREATE TRIGGER `role_timeTloginsert` AFTER INSERT ON `role_time` FOR EACH ROW BEGIN INSERT into role_time_log (ckey, job, delta) VALUES (NEW.ckey, NEW.job, NEW.minutes);
 END
-$$
+//
 CREATE TRIGGER `role_timeTlogdelete` AFTER DELETE ON `role_time` FOR EACH ROW BEGIN INSERT into role_time_log (ckey, job, delta) VALUES (OLD.ckey, OLD.job, 0-OLD.minutes);
 END
-$$
+//
 DELIMITER ;
 
 --

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -646,7 +646,7 @@ CREATE TABLE `SS13_ticket` (
   KEY `idx_ticket_act_time_rid` (`action`, `timestamp`, `round_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-DELIMITER $$
+DELIMITER //
 CREATE PROCEDURE `set_poll_deleted`(
 	IN `poll_id` INT
 )
@@ -657,16 +657,16 @@ UPDATE `SS13_poll_option` SET deleted = 1 WHERE pollid = poll_id;
 UPDATE `SS13_poll_vote` SET deleted = 1 WHERE pollid = poll_id;
 UPDATE `SS13_poll_textreply` SET deleted = 1 WHERE pollid = poll_id;
 END
-$$
+//
 CREATE TRIGGER `SS13_role_timeTlogupdate` AFTER UPDATE ON `SS13_role_time` FOR EACH ROW BEGIN INSERT into SS13_role_time_log (ckey, job, delta) VALUES (NEW.CKEY, NEW.job, NEW.minutes-OLD.minutes);
 END
-$$
+//
 CREATE TRIGGER `SS13_role_timeTloginsert` AFTER INSERT ON `SS13_role_time` FOR EACH ROW BEGIN INSERT into SS13_role_time_log (ckey, job, delta) VALUES (NEW.ckey, NEW.job, NEW.minutes);
 END
-$$
+//
 CREATE TRIGGER `SS13_role_timeTlogdelete` AFTER DELETE ON `SS13_role_time` FOR EACH ROW BEGIN INSERT into SS13_role_time_log (ckey, job, delta) VALUES (OLD.ckey, OLD.job, 0-OLD.minutes);
 END
-$$
+//
 DELIMITER ;
 
 --


### PR DESCRIPTION

## About The Pull Request

Changes the delimiter in that one section of the tgstation_schema(s) from `$$` to `//`
Doesn't really change any of the fields in the schema itself.
## Why It's Good For The Game

Makes sure HeidiSQL (in versions >= 12.12.0.7124) doesn't throw a syntax error™ when you're trying to setup the database.

(See https://www.heidisql.com/forum.php?t=44597#p44598)
