### PR TITLE
Stops ghosts from (trying to) admire aquariums

### DIFF
--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -697,6 +697,8 @@
 		check_fluid_and_temperature(fish)
 
 /datum/component/aquarium/proc/admire(atom/movable/source, mob/living/user)
+	if(!isliving(user))
+		return
 	source.balloon_alert(user, "admiring aquarium...")
 	if(!do_after(user, 5 SECONDS, target = source))
 		return


### PR DESCRIPTION

## About The Pull Request

Admiring aquariums gives mood events, and nothing is checking for /living before it gets to giving the mood event. No reason for ghosts to be able to do this at all, because it does nothing but mood change.

## Why It's Good For The Game

fixes #94098

## Changelog
:cl:

fix: Ghosts can no longer try and fail to admire aquariums.

/:cl:
