### PR TITLE
Fixes xenobiology consoles not being able to use potions

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -442,7 +442,7 @@
 
 	for(var/mob/living/basic/slime/potioned_slime in eye_turf)
 		xeno_console.spit_atom(xeno_console.current_potion, eye_turf)
-		xeno_console.current_potion.interact_with_atom(potioned_slime, living_owner)
+		xeno_console.current_potion.interact_with_slime(potioned_slime, living_owner)
 		xeno_console.xeno_hud.update_potion(xeno_console.current_potion)
 		break
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -442,7 +442,7 @@
 
 	for(var/mob/living/basic/slime/potioned_slime in eye_turf)
 		xeno_console.spit_atom(xeno_console.current_potion, eye_turf)
-		xeno_console.current_potion.attack(potioned_slime, living_owner)
+		xeno_console.current_potion.interact_with_atom(potioned_slime, living_owner)
 		xeno_console.xeno_hud.update_potion(xeno_console.current_potion)
 		break
 


### PR DESCRIPTION

## About The Pull Request

The console called attack() on the potion, which, after the recent refactor, no longer works. This switches it to interact_with_atom. 

## Why It's Good For The Game

fixes #94120

## Changelog
:cl:

fix: xenobio console potions work again

/:cl:
