### PR TITLE
Fixes empty message when ejecting container from biogen

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -440,13 +440,17 @@
 	if(!can_interact(user))
 		return
 
-	if(!silent)
-		to_chat(user, span_notice("You eject [beaker] from [src]."))
+	var/obj/item/ejected_beaker = beaker
 
-	if(!user.put_in_active_hand(beaker))
+	if(user.put_in_hands(beaker))
 		if(!silent)
-			to_chat(user, span_notice("You eject [beaker] from [src] onto the ground."))
-		beaker.forceMove(drop_location())
+			to_chat(user, span_notice("You eject [ejected_beaker] from [src]."))
+
+	else
+		if(!silent)
+			to_chat(user, span_notice("You eject [ejected_beaker] from [src] onto the ground."))
+
+		ejected_beaker.forceMove(drop_location())
 
 	beaker = null
 	update_appearance(UPDATE_ICON)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -440,14 +440,12 @@
 	if(!can_interact(user))
 		return
 
-	if(user.put_in_hands(beaker))
-		if(!silent)
-			to_chat(user, span_notice("You eject [beaker] from [src]."))
+	if(!silent)
+		to_chat(user, span_notice("You eject [beaker] from [src]."))
 
-	else
+	if(!user.put_in_active_hand(beaker))
 		if(!silent)
 			to_chat(user, span_notice("You eject [beaker] from [src] onto the ground."))
-
 		beaker.forceMove(drop_location())
 
 	beaker = null


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

You eject  from the biogenerator.

## Changelog

:cl:
fix: Biogenerator now actually displays name of container that you ejected.
/:cl: