### PR TITLE
Replaces CE's belt with powertools for debugging

### DIFF
--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -1023,7 +1023,7 @@
 	},
 /obj/structure/table,
 /obj/item/tank/jetpack/captain,
-/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/full/powertools,
 /obj/item/clothing/gloves/color/yellow{
 	pixel_y = 10
 	},

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -159,7 +159,7 @@
 /obj/structure/table,
 /obj/item/weldingtool/experimental,
 /obj/item/inducer,
-/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/full/powertools,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -427,7 +427,7 @@
 		/obj/item/debug/human_spawner = 1,
 		/obj/item/debug/omnitool = 1,
 )
-	belt = /obj/item/storage/belt/utility/chief/full
+	belt = /obj/item/storage/belt/utility/full/powertools
 	ears = /obj/item/radio/headset/headset_cent/commander
 	glasses = /obj/item/clothing/glasses/debug
 	gloves = /obj/item/clothing/gloves/combat
@@ -459,7 +459,7 @@
 		/obj/item/debug/omnitool = 1,
 		/obj/item/storage/box/stabilized = 1,
 )
-	belt = /obj/item/storage/belt/utility/chief/full
+	belt = /obj/item/storage/belt/utility/full/powertools
 	ears = /obj/item/radio/headset/headset_cent/commander
 	glasses = /obj/item/clothing/glasses/debug
 	gloves = /obj/item/clothing/gloves/combat


### PR DESCRIPTION
## About The Pull Request

Replaces the CE's belt with the powertools belt in the admin outfit, debug outfit, runtime station and multiztesting

## Why It's Good For The Game

Useful in these locations

## Changelog
:cl:
admin: Admins get powertool belts in their special outfits.
/:cl:
