### PR TITLE
Standerdizing currency symbols (Part 1?)

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -81,3 +81,14 @@
 #define MARKET_TREND_STABLE 0
 
 #define MARKET_EVENT_PROBABILITY 8 //Probability of a market event firing, in percent. Fires once per material, every stock market tick.
+
+/// The symbol for the default type of money used in the code.
+#define MONEY_SYMBOL "cr"
+/// The name for the default type of money used in the code.
+#define MONEY_NAME "credits"
+#define MONEY_NAME_SINGULAR "credit"
+
+// Used to be "credit" but other parts of the code used "cr" as well so i strongly suspect that was a bug/oversight
+#define CREDIT_TYPE_CREDIT MONEY_SYMBOL
+#define CREDIT_TYPE_MINING "mp"
+#define CREDIT_TYPE_BITRUNNING "np"

--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -88,7 +88,5 @@
 #define MONEY_NAME "credits"
 #define MONEY_NAME_SINGULAR "credit"
 
-// Used to be "credit" but other parts of the code used "cr" as well so i strongly suspect that was a bug/oversight
-#define CREDIT_TYPE_CREDIT MONEY_SYMBOL
-#define CREDIT_TYPE_MINING "mp"
-#define CREDIT_TYPE_BITRUNNING "np"
+#define MONEY_MINING_SYMBOL "mp"
+#define MONEY_BITRUNNING_SYMBOL "np"

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -15,7 +15,7 @@
 	and hopefully get delivered by them.
 	35% cheaper than express delivery."}
 	express_tooltip = @{"Sends your purchases instantly."}
-	credit_type = CREDIT_TYPE_MINING
+	credit_type = MONEY_MINING_SYMBOL
 
 	order_categories = list(
 		CATEGORY_MINING,

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -1,4 +1,4 @@
-#define CREDIT_TYPE_MINING "mp"
+
 
 /obj/machinery/computer/order_console/mining
 	name = "mining equipment order console"
@@ -127,6 +127,5 @@
 			points += amount
 			to_chat(user, span_notice("You transfer [amount] mining points from [attacking_id] to [src]."))
 
-#undef CREDIT_TYPE_MINING
 #undef TO_POINT_CARD
 #undef TO_USER_ID

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
 	var/announcement_line
 
 	///The kind of cash does the console use.
-	var/credit_type = CREDIT_TYPE_CREDIT
+	var/credit_type = MONEY_SYMBOL
 	///Whether the console can only use express mode ONLY
 	var/forced_express = FALSE
 	///Multiplied cost to use for cargo mode

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -1,6 +1,5 @@
 ///List of all items that can be found in the different types of order consoles, to purchase.
 GLOBAL_LIST_EMPTY(order_console_products)
-#define CREDIT_TYPE_CREDIT "credit"
 
 /obj/machinery/computer/order_console
 	name = "Orders Console"
@@ -250,5 +249,3 @@ GLOBAL_LIST_EMPTY(order_console_products)
 		announcement_lines_map["Error"] = "Unknown Error happened, while we tried to procceed an order, please report this to Nanotrasen."
 	. = ..()
 
-
-#undef CREDIT_TYPE_CREDIT

--- a/code/modules/bitrunning/objects/vendor.dm
+++ b/code/modules/bitrunning/objects/vendor.dm
@@ -1,5 +1,3 @@
-#define CREDIT_TYPE_BITRUNNING "np"
-
 /obj/machinery/computer/order_console/bitrunning
 	name = "bitrunning supplies order console"
 	desc = "NexaCache(tm)! Dubiously authentic gear for the digital daredevil."
@@ -84,5 +82,3 @@
 	name = "[purchaser]'s Bitrunning Order"
 	src.cost = cost
 	src.contains = contains
-
-#undef CREDIT_TYPE_BITRUNNING

--- a/code/modules/bitrunning/objects/vendor.dm
+++ b/code/modules/bitrunning/objects/vendor.dm
@@ -13,7 +13,7 @@
 	and hopefully get delivered by them.
 	35% cheaper than express delivery."}
 	express_tooltip = @{"Sends your purchases instantly."}
-	credit_type = CREDIT_TYPE_BITRUNNING
+	credit_type = MONEY_BITRUNNING_SYMBOL
 
 	order_categories = list(
 		CATEGORY_BITRUNNING_FLAIR,

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -317,7 +317,7 @@
 				orderer_rank = GALATIC_MATERIAL_ORDER,
 				orderer_ckey = living_user.ckey,
 				paying_account = is_ordering_private ? account_payable : null,
-				cost_type = CREDIT_TYPE_CREDIT,
+				cost_type = MONEY_SYMBOL,
 				can_be_cancelled = FALSE
 			)
 			//first time order compute the correct cost and compare

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -317,7 +317,7 @@
 				orderer_rank = GALATIC_MATERIAL_ORDER,
 				orderer_ckey = living_user.ckey,
 				paying_account = is_ordering_private ? account_payable : null,
-				cost_type = "cr",
+				cost_type = CREDIT_TYPE_CREDIT,
 				can_be_cancelled = FALSE
 			)
 			//first time order compute the correct cost and compare

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -72,7 +72,7 @@
 	coupon,
 	charge_on_purchase = TRUE,
 	manifest_can_fail = TRUE,
-	cost_type = "cr",
+	cost_type = CREDIT_TYPE_CREDIT,
 	can_be_cancelled = TRUE,
 )
 	id = SSshuttle.order_number++

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -72,7 +72,7 @@
 	coupon,
 	charge_on_purchase = TRUE,
 	manifest_can_fail = TRUE,
-	cost_type = CREDIT_TYPE_CREDIT,
+	cost_type = MONEY_SYMBOL,
 	can_be_cancelled = TRUE,
 )
 	id = SSshuttle.order_number++

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -157,6 +157,9 @@
 				"packs" = get_packs_data(pack.group),
 			)
 
+	data["displayed_currency_full_name"] = " [MONEY_NAME]"
+	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
+
 	return data
 
 /**

--- a/code/modules/mob/living/basic/trader/trader.dm
+++ b/code/modules/mob/living/basic/trader/trader.dm
@@ -23,7 +23,7 @@
 	///Sound used when item sold/bought
 	var/sell_sound = 'sound/effects/cashregister.ogg'
 	///The currency name
-	var/currency_name = "credits"
+	var/currency_name = MONEY_NAME
 	///The spawner we use to create our look
 	var/spawner_path = /obj/effect/mob_spawn/corpse/human/generic_assistant
 	///Our species to create our look

--- a/code/modules/mob/living/basic/trader/trader_data.dm
+++ b/code/modules/mob/living/basic/trader/trader_data.dm
@@ -8,7 +8,7 @@
 	///Sound used when item sold/bought
 	var/sell_sound = 'sound/effects/cashregister.ogg'
 	///The currency name
-	var/currency_name = "credits"
+	var/currency_name = MONEY_NAME
 	///The initial products that the trader offers
 	var/list/initial_products = list(
 		/obj/item/food/burger/ghost = list(PAYCHECK_CREW * 4, INFINITY),

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -50,7 +50,7 @@
 	icon_state = "sustenance_labor"
 	all_products_free = FALSE
 	displayed_currency_icon = "digging"
-	displayed_currency_name = " LP"
+	displayed_currency_name = "LP"
 	allow_custom = FALSE
 
 /obj/machinery/vending/sustenance/labor_camp/proceed_payment(obj/item/card/id/advanced/prisoner/paying_scum_id, mob/living/mob_paying, datum/data/vending_product/product_to_vend, price_to_use)

--- a/code/modules/vending/vendor/_vending.dm
+++ b/code/modules/vending/vendor/_vending.dm
@@ -153,7 +153,7 @@
 	///fontawesome icon name to use in to display the user's balance in the vendor UI
 	var/displayed_currency_icon = "coins"
 	///String of the used currency to display in the vendor UI
-	var/displayed_currency_name = " cr"
+	var/displayed_currency_name = MONEY_SYMBOL
 	///Whether our age check is currently functional
 	var/age_restrictions = TRUE
 	/// How many credits does this vending machine have? 20% of all sales go to this pool, and are given freely when the machine is restocked, or successfully tilted. Lost on deconstruction.

--- a/code/modules/vending/vendor/ui_data.dm
+++ b/code/modules/vending/vendor/ui_data.dm
@@ -70,7 +70,7 @@
 	data["jobDiscount"] = DEPARTMENT_DISCOUNT
 	data["product_records"] = list()
 	data["displayed_currency_icon"] = displayed_currency_icon
-	data["displayed_currency_name"] = displayed_currency_name
+	data["displayed_currency_name"] = " [displayed_currency_name]"
 
 	var/list/categories = list()
 

--- a/tgui/packages/tgui/interfaces/Cargo/CargoButtons.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoButtons.tsx
@@ -6,7 +6,7 @@ import type { CargoData } from './types';
 
 export function CargoCartButtons(props) {
   const { act, data } = useBackend<CargoData>();
-  const { cart = [], requestonly, can_send, can_approve_requests } = data;
+  const { cart = [], requestonly, can_send, can_approve_requests, displayed_currency_name } = data;
 
   let total = 0;
   let amount = 0;
@@ -24,7 +24,7 @@ export function CargoCartButtons(props) {
         {amount === 0 && 'Cart is empty'}
         {amount === 1 && '1 item'}
         {amount >= 2 && `${amount} items`}{' '}
-        {total > 0 && `(${formatMoney(total)} cr)`}
+        {total > 0 && `(${formatMoney(total)}${displayed_currency_name})`}
       </Box>
 
       <Button

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -181,7 +181,7 @@ type CatalogListProps = {
 
 function CatalogList(props: CatalogListProps) {
   const { act, data } = useBackend<CargoData>();
-  const { cart = [], max_order, self_paid, app_cost } = data;
+  const { cart = [], max_order, self_paid, app_cost, displayed_currency_name } = data;
   const { packs = [], openContents } = props;
 
   return (
@@ -258,11 +258,11 @@ function CatalogList(props: CatalogListProps) {
                     opacity={privateBuy && 0.75}
                     style={{ textDecoration: privateBuy && 'red line-through' }}
                   >
-                    {formatMoney(pack.cost)} cr
+                    {formatMoney(pack.cost)}{displayed_currency_name}
                   </Stack.Item>
                   {!!privateBuy && (
                     <Stack.Item>
-                      {formatMoney(Math.round(pack.cost * 1.1))} cr
+                      {formatMoney(Math.round(pack.cost * 1.1))}{displayed_currency_name}
                     </Stack.Item>
                   )}
                 </Stack>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoRequests.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoRequests.tsx
@@ -7,7 +7,7 @@ import type { CargoData } from './types';
 
 export function CargoRequests(props) {
   const { act, data } = useBackend<CargoData>();
-  const { requests = [], requestonly, can_send, can_approve_requests } = data;
+  const { requests = [], requestonly, can_send, can_approve_requests, displayed_currency_name} = data;
 
   return (
     <Section fill scrollable>
@@ -40,7 +40,7 @@ export function CargoRequests(props) {
                 {request.account}
               </Table.Cell>
               <Table.Cell collapsing color="gold">
-                {formatMoney(request.cost)} cr
+                {formatMoney(request.cost)}{displayed_currency_name}
               </Table.Cell>
               {(!requestonly || !!can_send) && !!can_approve_requests && (
                 <Table.Cell collapsing>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoStatus.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoStatus.tsx
@@ -35,7 +35,7 @@ export function CargoStatus(props) {
             value={points}
             format={(value) => formatMoney(value)}
           />
-          {' credits'}
+          {data.displayed_currency_full_name}
         </Box>
       }
     >

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -7,6 +7,8 @@ export type CargoData = {
   can_send: BooleanLike;
   cart: CartEntry[];
   department: string;
+  displayed_currency_full_name: string;
+  displayed_currency_name: string;
   docked: BooleanLike;
   grocery: number;
   loan_dispatched: BooleanLike;


### PR DESCRIPTION

## About The Pull Request
Passes a standardized define into some of the tgui to parody behavior with vending machines.
Adds a few defines for money symbols to make it easier to rework types of money.

If yall are for this I can also go through and find and replace a ton of strings and other tgui with these, but dont want to sink 2 much time into it if not.

<img width="966" height="646" alt="image" src="https://github.com/user-attachments/assets/2d4753be-7e5d-4733-acf8-05f354127a6a" />

Proof of concept if Nanotrasen was not an evil conglomerate and the dollar never went out of style
<img width="1009" height="661" alt="image" src="https://github.com/user-attachments/assets/e68bfcd3-4053-4641-9b28-f384f2cb049b" />

some broken shit here but 99% thats cause minimal runtime station does not support the supply console
<img width="795" height="767" alt="image" src="https://github.com/user-attachments/assets/30dbd625-5338-4dc3-80db-922ff045f0f0" />
## Why It's Good For The Game
In truth, its downstream/fork compatibility, I see no world in which tg actually swaps credits
butttt it would make it really simple to support adding new types of currency to machines (e.g the mining or bitrunning bucks)
## Changelog
:cl:
code: standardized defines for currency symbols
/:cl:
