### PR TITLE
Adds a bandolier to the warden's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -89,6 +89,7 @@
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/door_remote/head_of_security(src)
+	new /obj/item/storage/belt/bandolier(src)
 
 
 /obj/structure/closet/secure_closet/warden/populate_contents_immediate()


### PR DESCRIPTION

## About The Pull Request

PR title

## Why It's Good For The Game

Warden is the weapons guy and even starts with a super cool unique shotgun. Bandoliers are roundstart items (can be bought from bartender's vendor when they arent using it or arent preset, can be crafted by killing five monkeys which there are plenty of) so this just removes the hastle of having to go get it. 

## Changelog
:cl:
balance: The warden starts with a bandolier in their locker
/:cl:
