### PR TITLE
Reduce MULEbot wire chat spam a little

### DIFF
--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -30,7 +30,7 @@
 			if(is_cut(WIRE_MOTOR1) && is_cut(WIRE_MOTOR2))
 				ADD_TRAIT(mule, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 				holder.audible_message(span_hear("The motors of [mule] go silent."), null,  1)
-			else
+			else if(HAS_TRAIT_FROM(mule, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT))
 				REMOVE_TRAIT(mule, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 				holder.audible_message(span_hear("The motors of [mule] whir to life!"), null,  1)
 


### PR DESCRIPTION

## About The Pull Request

Requires the MULEbot to actually be immobile for the "whirs to life" branch to be taken, so it doesn't print every time you cut a motor wire

## Why It's Good For The Game

It's annoyingggg

## Changelog

Nah who cares
