### PR TITLE
Places one cable in catwalk maintenance

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -70571,6 +70571,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office/private_investigators_office)
 "tBc" = (


### PR DESCRIPTION

## About The Pull Request

Re-powers the Abandonded Kitchen APC on catwalk, which was missing a cable under an airlock

## Why It's Good For The Game

There's no way this was intentional.

## Changelog
:cl:

map: Catwalk Abandoned Kitchen APC powered by default

/:cl:
