### PR TITLE
Stops poster hard deletes

### DIFF
--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -44,8 +44,7 @@
 		icon_state = poster_type::poster_item_icon_state
 
 /obj/item/poster/Destroy(force)
-	if(poster_structure)
-		QDEL_NULL(poster_structure)
+	QDEL_NULL(poster_structure)
 	return ..()
 
 /obj/item/poster/examine(mob/user)

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -151,7 +151,7 @@
 /obj/structure/sign/poster/Destroy(force)
 	var/obj/item/poster/stored_inside = rolled_poster?.resolve()
 	if(!QDELETED(stored_inside))
-		rolled_poster = null
+		stored_inside = null
 	else
 		qdel(stored_inside)
 	return ..()
@@ -258,7 +258,7 @@
 	return rolled_poster
 
 /// Stores a sign obj in a rolled poster's contents, to later be deployed
-/obj/structure/sign/poster/proc/store_sign_in_item(/obj/item/poster/rolled_poster)
+/obj/structure/sign/poster/proc/store_sign_in_item(obj/item/poster/rolled_poster)
 	forceMove(rolled_poster)
 	stored_inside = WEAKREF(rolled_poster)
 

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -149,11 +149,11 @@
 	AddElement(/datum/element/beauty, 300)
 
 /obj/structure/sign/poster/Destroy(force)
-	var/obj/item/poster/stored_inside = rolled_poster?.resolve()
-	if(!QDELETED(stored_inside))
-		stored_inside = null
+	var/obj/item/poster/rolled_poster = stored_inside?.resolve()
+	if(!QDELETED(rolled_poster))
+		rolled_poster = null
 	else
-		qdel(stored_inside)
+		qdel(rolled_poster)
 	return ..()
 
 /// Adds contextual screentips

--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -151,7 +151,7 @@
 /obj/structure/sign/poster/Destroy(force)
 	var/obj/item/poster/rolled_poster = stored_inside?.resolve()
 	if(!QDELETED(rolled_poster))
-		rolled_poster = null
+		stored_inside = null
 	else
 		qdel(rolled_poster)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

<img width="367" height="159" alt="image" src="https://github.com/user-attachments/assets/db4a8f7a-1bf3-4d7c-b726-918b288ba6f7" />

Tin, the signs are stored inside the posters when they get rolled up and this does was not properly manage the refs.

<img width="330" height="80" alt="dreamseeker_avIX76IgGl" src="https://github.com/user-attachments/assets/452ea5d7-44bf-4f23-9743-ed16deabc620" />

Has been tested, and works as expected.

## Why It's Good For The Game

Less hard deletes

## Changelog

Not player facing