### PR TITLE
Fix Stoat Steal Behaviour (and some other AI stuff hopefully)

### DIFF
--- a/code/__DEFINES/ai/ai.dm
+++ b/code/__DEFINES/ai/ai.dm
@@ -76,6 +76,8 @@
 
 //Generic subtree defines
 
+/// default search range (tiles, passed to oview) when using find_and_set
+#define SEARCH_TACTIC_DEFAULT_RANGE 3
 /// probability that the pawn should try resisting out of restraints
 #define RESIST_SUBTREE_PROB 50
 ///macro for whether it's appropriate to resist right now, used by resist subtree

--- a/code/__DEFINES/ai/ai.dm
+++ b/code/__DEFINES/ai/ai.dm
@@ -77,7 +77,7 @@
 //Generic subtree defines
 
 /// default search range (tiles, passed to oview) when using find_and_set
-#define SEARCH_TACTIC_DEFAULT_RANGE 3
+#define SEARCH_TACTIC_DEFAULT_RANGE 7
 /// probability that the pawn should try resisting out of restraints
 #define RESIST_SUBTREE_PROB 50
 ///macro for whether it's appropriate to resist right now, used by resist subtree

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -678,13 +678,15 @@
 
 	return inserted_list
 
-///same as shuffle, but returns nothing and acts on list in place
+///same as shuffle, but acts on list in place, and returns same list
 /proc/shuffle_inplace(list/inserted_list)
 	if(!inserted_list)
 		return
 
 	for(var/i in 1 to inserted_list.len - 1)
 		inserted_list.Swap(i, rand(i, inserted_list.len))
+
+	return inserted_list
 
 ///Return a list with no duplicate entries
 /proc/unique_list(list/inserted_list)

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/climb_tree.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/climb_tree.dm
@@ -1,6 +1,6 @@
 /datum/ai_behavior/find_and_set/valid_tree
 
-/datum/ai_behavior/find_and_set/valid_tree/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/valid_tree/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/valid_trees = list()
 	for (var/obj/structure/flora/tree/tree_target in oview(search_range, controller.pawn))
 		if(istype(tree_target, /obj/structure/flora/tree/dead)) //no died trees

--- a/code/datums/ai/basic_mobs/basic_subtrees/drag_items.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/drag_items.dm
@@ -6,19 +6,19 @@
 		if(prob(controller.blackboard[BB_GUILTY_CONSCIOUS_CHANCE]))
 			controller.queue_behavior(/datum/ai_behavior/stop_dragging)
 		return
-	if(!controller.blackboard[BB_STEAL_CHANCE])
+	if(!prob(controller.blackboard[BB_STEAL_CHANCE]))
 		return
 	if(!controller.blackboard_key_exists(BB_ITEM_TO_STEAL))
-		controller.queue_behavior(/datum/ai_behavior/find_and_set/find_stealable, /obj/item, BB_ITEM_TO_STEAL)
+		controller.queue_behavior(/datum/ai_behavior/find_and_set/find_stealable, BB_ITEM_TO_STEAL, /obj/item)
 		return
-	controller.queue_behavior(/datum/ai_behavior/drag_target)
+	controller.queue_behavior(/datum/ai_behavior/drag_target, BB_ITEM_TO_STEAL)
 	return SUBTREE_RETURN_FINISH_PLANNING
 
 /datum/ai_behavior/find_and_set/find_stealable
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 	action_cooldown = 2 MINUTES
 
-/datum/ai_behavior/find_and_set/find_stealable/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/find_stealable/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 
 	var/list/possible_items = shuffle_inplace(oview(search_range, controller.pawn))
@@ -32,7 +32,7 @@
 /datum/ai_behavior/stop_dragging
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
-/datum/ai_behavior/stop_dragging/perform(seconds_per_tick, datum/ai_controller/controller, target_key)
+/datum/ai_behavior/stop_dragging/perform(seconds_per_tick, datum/ai_controller/controller)
 	var/mob/living/living_pawn = controller.pawn
 	living_pawn.stop_pulling()
 	return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_SUCCEEDED

--- a/code/datums/ai/basic_mobs/basic_subtrees/go_for_swim.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/go_for_swim.dm
@@ -28,7 +28,7 @@
 ///find land if its time to get out of water, otherwise find water
 /datum/ai_behavior/find_and_set/swim_alternate
 
-/datum/ai_behavior/find_and_set/swim_alternate/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/swim_alternate/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 	if(QDELETED(living_pawn))
 		return null

--- a/code/datums/ai/generic/find_and_set.dm
+++ b/code/datums/ai/generic/find_and_set.dm
@@ -37,7 +37,7 @@
 /datum/ai_behavior/find_and_set/food_or_drink
 	var/force_find_drinks = FALSE
 
-/datum/ai_behavior/find_and_set/food_or_drink/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/food_or_drink/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 	var/find_drinks = force_find_drinks || controller.blackboard[BB_IGNORE_DRINKS] || FALSE
 
@@ -92,7 +92,7 @@
  */
 /datum/ai_behavior/find_and_set/in_list
 
-/datum/ai_behavior/find_and_set/in_list/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/search_tactic(datum/ai_controller/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
 	if(length(found))
 		return pick(found)
@@ -112,7 +112,7 @@
  */
 /datum/ai_behavior/find_and_set/animatable
 
-/datum/ai_behavior/find_and_set/animatable/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/animatable/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 
 	var/list/nearby_items = list()
@@ -133,7 +133,7 @@
  */
 /datum/ai_behavior/find_and_set/nearest_wall
 
-/datum/ai_behavior/find_and_set/nearest_wall/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/nearest_wall/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 
 	var/list/nearby_walls = list()
@@ -150,7 +150,7 @@
  */
 /datum/ai_behavior/find_and_set/friendly_corpses
 
-/datum/ai_behavior/find_and_set/friendly_corpses/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/friendly_corpses/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 	var/list/nearby_bodies = list()
 	for (var/mob/living/dead_pal in oview(search_range, controller.pawn))
@@ -172,7 +172,7 @@
  */
 /datum/ai_behavior/find_and_set/conscious_person
 
-/datum/ai_behavior/find_and_set/conscious_person/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/conscious_person/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/customers = list()
 	for(var/mob/living/carbon/human/target in oview(search_range, controller.pawn))
 		if(IS_DEAD_OR_INCAP(target) || !target.mind)
@@ -187,7 +187,7 @@
 /datum/ai_behavior/find_and_set/nearby_friends
 	action_cooldown = 2 SECONDS
 
-/datum/ai_behavior/find_and_set/nearby_friends/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/nearby_friends/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/atom/friend = locate(/mob/living/carbon/human) in oview(search_range, controller.pawn)
 
 	if(isnull(friend))
@@ -200,7 +200,7 @@
 
 /datum/ai_behavior/find_and_set/in_list/turf_types
 
-/datum/ai_behavior/find_and_set/in_list/turf_types/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/turf_types/search_tactic(datum/ai_controller/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/found = RANGE_TURFS(search_range, controller.pawn)
 	shuffle_inplace(found)
 	for(var/turf/possible_turf as anything in found)
@@ -212,7 +212,7 @@
 
 /datum/ai_behavior/find_and_set/in_list/closest_turf
 
-/datum/ai_behavior/find_and_set/in_list/closest_turf/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/closest_turf/search_tactic(datum/ai_controller/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/found = RANGE_TURFS(search_range, controller.pawn)
 	for(var/turf/possible_turf as anything in found)
 		if(!is_type_in_typecache(possible_turf, locate_paths) || !can_see(controller.pawn, possible_turf, search_range))

--- a/code/datums/ai/hunting_behavior/hunting_mouse.dm
+++ b/code/datums/ai/hunting_behavior/hunting_mouse.dm
@@ -49,7 +49,7 @@
 
 /datum/ai_behavior/find_and_set/piano_synth // Disinclude subtypes
 
-/datum/ai_behavior/find_and_set/piano_synth/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/piano_synth/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/obj/item/instrument/piano_synth/synth in oview(search_range, controller.pawn))
 		if(synth.type == /obj/item/instrument/piano_synth)
 			return synth

--- a/code/modules/mob/living/basic/bots/bot_ai.dm
+++ b/code/modules/mob/living/basic/bots/bot_ai.dm
@@ -251,7 +251,7 @@
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 	action_cooldown = BOT_COMMISSIONED_SALUTE_DELAY
 
-/datum/ai_behavior/find_and_set/valid_authority/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/valid_authority/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/mob/living/nearby_mob in oview(search_range, controller.pawn))
 		if(!HAS_TRAIT(nearby_mob, TRAIT_COMMISSIONED))
 			continue

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -69,7 +69,7 @@
 /datum/ai_behavior/find_and_set/in_list/clean_targets
 	action_cooldown = 3 SECONDS
 
-/datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/basic_controller/bot/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/basic_controller/bot/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
 	var/list/ignore_list = controller.blackboard[BB_TEMPORARY_IGNORE_LIST]
 	for(var/atom/found_item in found)
@@ -101,7 +101,7 @@
 	action_cooldown = 30 SECONDS
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
-/datum/ai_behavior/find_and_set/spray_target/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/spray_target/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/ignore_list = controller.blackboard[BB_TEMPORARY_IGNORE_LIST]
 	for(var/mob/living/carbon/human/human_target in oview(search_range, controller.pawn))
 		if(LAZYACCESS(ignore_list, human_target))
@@ -178,7 +178,7 @@
 	action_cooldown = 30 SECONDS
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
-/datum/ai_behavior/find_and_set/friendly_janitor/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/friendly_janitor/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 	for(var/mob/living/carbon/human/human_target in oview(search_range, living_pawn))
 		if(human_target.stat != CONSCIOUS || isnull(human_target.mind))

--- a/code/modules/mob/living/basic/farm_animals/bee/bee_ai_behavior.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/bee_ai_behavior.dm
@@ -64,7 +64,7 @@
 /datum/ai_behavior/find_and_set/bee_hive
 	action_cooldown = 10 SECONDS
 
-/datum/ai_behavior/find_and_set/bee_hive/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/bee_hive/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/valid_hives = list()
 	var/mob/living/bee_pawn = controller.pawn
 

--- a/code/modules/mob/living/basic/farm_animals/goose/goose_ai.dm
+++ b/code/modules/mob/living/basic/farm_animals/goose/goose_ai.dm
@@ -55,7 +55,7 @@
 /// Only set things geese will try to eat
 /datum/ai_behavior/find_and_set/in_list/goose_food
 
-/datum/ai_behavior/find_and_set/in_list/goose_food/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/goose_food/search_tactic(datum/ai_controller/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
 	if(!length(found))
 		return

--- a/code/modules/mob/living/basic/jungle/seedling/seedling_ai.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling_ai.dm
@@ -40,7 +40,7 @@
 /datum/ai_behavior/find_and_set/treatable_hydro
 	action_cooldown = 5 SECONDS
 
-/datum/ai_behavior/find_and_set/treatable_hydro/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/treatable_hydro/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/possible_trays = list()
 	var/mob/living/living_pawn = controller.pawn
 	var/waterlevel_threshold = controller.blackboard[BB_WATERLEVEL_THRESHOLD]
@@ -102,7 +102,7 @@
 /datum/ai_behavior/find_and_set/beamable_hydroplants
 	action_cooldown = 15 SECONDS
 
-/datum/ai_behavior/find_and_set/beamable_hydroplants/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/beamable_hydroplants/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/possible_trays = list()
 
 	for(var/obj/machinery/hydroponics/hydro in oview(search_range, controller.pawn))

--- a/code/modules/mob/living/basic/lavaland/mook/mook_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook_ai.dm
@@ -250,7 +250,7 @@ GLOBAL_LIST_INIT(mook_commands, list(
 
 /datum/ai_behavior/find_and_set/music_audience
 
-/datum/ai_behavior/find_and_set/music_audience/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/music_audience/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/atom/home = controller.blackboard[BB_HOME_VILLAGE]
 	for(var/mob/living/carbon/human/target in oview(search_range, controller.pawn))
 		if(target.stat > UNCONSCIOUS || !target.mind)
@@ -289,7 +289,7 @@ GLOBAL_LIST_INIT(mook_commands, list(
 		return
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/find_chief, BB_MOOK_TRIBAL_CHIEF, /mob/living/basic/mining/mook/worker/tribal_chief)
 
-/datum/ai_behavior/find_and_set/find_chief/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/find_chief/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/chief = locate(locate_path) in oview(search_range, controller.pawn)
 	if(isnull(chief))
 		return null

--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -47,7 +47,7 @@
 
 /datum/ai_behavior/find_and_set/clear_bombing_zone
 
-/datum/ai_behavior/find_and_set/clear_bombing_zone/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/clear_bombing_zone/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/obj/effect/temp_visual/minebot_target/target in oview(search_range, controller.pawn))
 		if(isclosedturf(get_turf(target)))
 			continue
@@ -62,7 +62,7 @@
 
 /datum/ai_behavior/find_and_set/miner_to_befriend
 
-/datum/ai_behavior/find_and_set/miner_to_befriend/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/miner_to_befriend/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/mob/living/carbon/human/target in oview(search_range, controller.pawn))
 		if(HAS_TRAIT(target, TRAIT_ROCK_STONER))
 			return target
@@ -112,7 +112,7 @@
 		return SUBTREE_RETURN_FINISH_PLANNING
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/unconscious_human, BB_NEARBY_DEAD_MINER, /mob/living/carbon/human)
 
-/datum/ai_behavior/find_and_set/unconscious_human/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/unconscious_human/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/mob/living/carbon/human/target in oview(search_range, controller.pawn))
 		if(target.stat >= UNCONSCIOUS && target.mind)
 			return target

--- a/code/modules/mob/living/basic/pets/cat/cat_ai.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat_ai.dm
@@ -44,7 +44,7 @@
 	if(SPT_PROB(reside_chance, seconds_per_tick))
 		controller.queue_behavior(/datum/ai_behavior/find_and_set/valid_home, BB_CAT_HOME, /obj/structure/cat_house)
 
-/datum/ai_behavior/find_and_set/valid_home/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/valid_home/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/obj/structure/cat_house/home in oview(search_range, controller.pawn))
 		if(home.resident_cat)
 			continue
@@ -95,7 +95,7 @@
 
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/cat_tresspasser, BB_TRESSPASSER_TARGET, /mob/living/basic/pet/cat)
 
-/datum/ai_behavior/find_and_set/cat_tresspasser/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/cat_tresspasser/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/ignore_types = controller.blackboard[BB_BABIES_CHILD_TYPES]
 	for(var/mob/living/basic/pet/cat/potential_enemy in oview(search_range, controller.pawn))
 		if(potential_enemy.gender != MALE)
@@ -244,7 +244,7 @@
 
 /datum/ai_behavior/find_and_set/valid_kitten
 
-/datum/ai_behavior/find_and_set/valid_kitten/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/valid_kitten/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/kitten = locate(locate_path) in oview(search_range, controller.pawn)
 	//kitten already has food near it, go feed another hungry kitten
 

--- a/code/modules/mob/living/basic/pets/cat/kitten_ai.dm
+++ b/code/modules/mob/living/basic/pets/cat/kitten_ai.dm
@@ -56,7 +56,7 @@
 
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/human_beg, BB_HUMAN_BEG_TARGET, /mob/living/carbon/human)
 
-/datum/ai_behavior/find_and_set/human_beg/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/human_beg/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/locate_items = controller.blackboard[BB_HUNTABLE_PREY]
 	for(var/mob/living/carbon/human/human_target in oview(search_range, controller.pawn))
 		if(human_target.stat != CONSCIOUS || isnull(human_target.mind))

--- a/code/modules/mob/living/basic/pets/orbie/orbie_ai.dm
+++ b/code/modules/mob/living/basic/pets/orbie/orbie_ai.dm
@@ -42,7 +42,7 @@
 
 /datum/ai_behavior/find_and_set/find_playmate
 
-/datum/ai_behavior/find_and_set/find_playmate/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/find_playmate/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/mob/living/basic/orbie/playmate in oview(search_range, controller.pawn))
 		if(playmate == controller.pawn || playmate.stat == DEAD || isnull(playmate.ai_controller))
 			continue

--- a/code/modules/mob/living/basic/pets/parrot/parrot_ai/parrot_hoarding.dm
+++ b/code/modules/mob/living/basic/pets/parrot/parrot_ai/parrot_hoarding.dm
@@ -27,7 +27,7 @@
 
 /datum/ai_behavior/find_and_set/hoard_location
 
-/datum/ai_behavior/find_and_set/hoard_location/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/hoard_location/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/turf/open/candidate in oview(search_range, controller.pawn))
 		if(is_space_or_openspace(candidate))
 			continue
@@ -41,7 +41,7 @@
 	action_cooldown = 5 SECONDS
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
-/datum/ai_behavior/find_and_set/hoard_item/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/hoard_item/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	if(!controller.blackboard_key_exists(BB_HOARD_LOCATION))
 		return null
 	var/turf/nest_turf = controller.blackboard[BB_HOARD_LOCATION]

--- a/code/modules/mob/living/basic/pets/penguin/penguin_ai.dm
+++ b/code/modules/mob/living/basic/pets/penguin/penguin_ai.dm
@@ -51,7 +51,7 @@
 /datum/ai_planning_subtree/fish/drilled_ice
 	find_fishable_behavior = /datum/ai_behavior/find_and_set/in_list/drilled_ice
 
-/datum/ai_behavior/find_and_set/in_list/drilled_ice/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/drilled_ice/search_tactic(datum/ai_controller/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	for(var/atom/possible_ice as anything in RANGE_TURFS(search_range, controller.pawn))
 		if(!istype(possible_ice, /turf/open/misc/ice))
 			continue

--- a/code/modules/mob/living/basic/pets/pet_cult/pet_cult_ai.dm
+++ b/code/modules/mob/living/basic/pets/pet_cult/pet_cult_ai.dm
@@ -48,7 +48,7 @@
 	action_cooldown = 5 SECONDS
 	behavior_flags = AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
-/datum/ai_behavior/find_and_set/friendly_cultist/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/friendly_cultist/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/mob/living/living_pawn = controller.pawn
 	for(var/mob/living/carbon/possible_cultist in oview(search_range, controller.pawn))
 		if(IS_CULTIST(possible_cultist) && !(living_pawn.faction.Find(REF(possible_cultist))))
@@ -72,7 +72,7 @@
 
 /datum/ai_behavior/find_and_set/occupied_rune
 
-/datum/ai_behavior/find_and_set/occupied_rune/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/occupied_rune/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/datum/team/cult/cult_team = controller.blackboard[BB_CULT_TEAM]
 	if(isnull(cult_team))
 		return null
@@ -140,7 +140,7 @@
 
 /datum/ai_behavior/find_and_set/dead_cultist
 
-/datum/ai_behavior/find_and_set/dead_cultist/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/dead_cultist/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/datum/team/cult/cult_team = controller.blackboard[BB_CULT_TEAM]
 	if(isnull(cult_team))
 		return null

--- a/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_behavior.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_behavior.dm
@@ -1,9 +1,9 @@
 /datum/ai_behavior/find_and_set/hive_partner
 
-/datum/ai_behavior/find_and_set/hive_partner/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/hive_partner/search_tactic(datum/ai_controller/controller, locate_path, search_range = 10)
 	var/mob/living/living_pawn = controller.pawn
 	var/list/hive_partners = list()
-	for(var/mob/living/target in oview(10, living_pawn))
+	for(var/mob/living/target in oview(search_range, living_pawn))
 		if(!istype(target, locate_path))
 			continue
 		if(target.stat == DEAD)

--- a/code/modules/mob/living/basic/space_fauna/paper_wizard/paper_wizard.dm
+++ b/code/modules/mob/living/basic/space_fauna/paper_wizard/paper_wizard.dm
@@ -87,7 +87,7 @@
 /datum/ai_behavior/find_and_set/empty_paper
 	action_cooldown = 10 SECONDS
 
-/datum/ai_behavior/find_and_set/empty_paper/search_tactic(datum/ai_controller/controller, locate_path, search_range)
+/datum/ai_behavior/find_and_set/empty_paper/search_tactic(datum/ai_controller/controller, locate_path, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/empty_papers = list()
 
 	for(var/obj/item/paper/target_paper in oview(search_range, controller.pawn))

--- a/code/modules/mob/living/basic/vermin/mothroach/mothroach_ai.dm
+++ b/code/modules/mob/living/basic/vermin/mothroach/mothroach_ai.dm
@@ -22,7 +22,7 @@
 
 /datum/ai_behavior/find_and_set/in_list/mothroach_food
 
-/datum/ai_behavior/find_and_set/in_list/mothroach_food/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
+/datum/ai_behavior/find_and_set/in_list/mothroach_food/search_tactic(datum/ai_controller/controller, locate_paths, search_range = SEARCH_TACTIC_DEFAULT_RANGE)
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
 	var/mob/living/living_pawn = controller.pawn
 	found -= living_pawn.loc


### PR DESCRIPTION
## About The Pull Request

Two main things. 

Multiple instances of use of a proc in AI controllers seemingly assuming the default behaviour will work for them, but what ends up happening is `search_tactic` gets redefined and redefined with no defaut search range parameter, so nothing ends up passed to the `search_tactic` child procs, so they all call `oview` with `null` and this... somehow doesn't runtime? Has behaviour that works some of the time??? I hate this fucking language. Anyway.

Stoat steal items behaviour was completely broken and apparently was not tested once since it was merged in. I've made the corrections I can, but I haven't figured out why stoat AI never enters idle, so we have a behaviour that leads to the stoat running up to an item, grabbing it, and then just staying there, unmoving. I've sunk too many hours into this, I'm just going to call it fixed and let someone else figure out what exciting additions there need to be to a behaviour that was never functional in the first place.

## Why It's Good For The Game

i don't know man i just want the pain to stop 

okay, generally speaking, when people write AI behaviours, they want those AI behaviours to do something and not just silently fail for six months or longer

## Changelog
:cl:
fix: Stoats have a chance to try and grab items like they always should have.
/:cl:
