### PR TITLE
Fix Health Analyzers Freaking Out About Skeletons Not Having Blood

### DIFF
--- a/code/__DEFINES/living.dm
+++ b/code/__DEFINES/living.dm
@@ -20,7 +20,7 @@
 /// Getter for a mob/living's lying angle, otherwise protected
 #define GET_LYING_ANGLE(mob) (UNLINT(mob.lying_angle))
 /// Checks if the mob can have blood
-#define CAN_HAVE_BLOOD(mob) ((mob.living_flags & LIVING_CAN_HAVE_BLOOD) && (!(HAS_TRAIT(mob, TRAIT_NOBLOOD))))
+#define CAN_HAVE_BLOOD(mob) (mob.living_flags & LIVING_CAN_HAVE_BLOOD)
 
 // Used in living mob offset list for determining pixel offsets
 #define PIXEL_W_OFFSET "w"

--- a/code/__DEFINES/living.dm
+++ b/code/__DEFINES/living.dm
@@ -20,7 +20,7 @@
 /// Getter for a mob/living's lying angle, otherwise protected
 #define GET_LYING_ANGLE(mob) (UNLINT(mob.lying_angle))
 /// Checks if the mob can have blood
-#define CAN_HAVE_BLOOD(mob) (mob.living_flags & LIVING_CAN_HAVE_BLOOD)
+#define CAN_HAVE_BLOOD(mob) ((mob.living_flags & LIVING_CAN_HAVE_BLOOD) && (!(HAS_TRAIT(mob, TRAIT_NOBLOOD))))
 
 // Used in living mob offset list for determining pixel offsets
 #define PIXEL_W_OFFSET "w"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1346,5 +1346,4 @@
 	RETURN_TYPE(/datum/blood_type)
 	if(!CAN_HAVE_BLOOD(src))
 		return
-	var/datum/dna/dna = has_dna()
 	return dna?.blood_type

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1344,4 +1344,7 @@
 
 /mob/living/carbon/get_bloodtype()
 	RETURN_TYPE(/datum/blood_type)
-	return dna?.blood_type
+	if(HAS_TRAIT(src, TRAIT_NOBLOOD))
+		return
+	var/datum/dna/dna = has_dna()
+	return dna.blood_type

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1347,4 +1347,4 @@
 	if(HAS_TRAIT(src, TRAIT_NOBLOOD))
 		return
 	var/datum/dna/dna = has_dna()
-	return dna.blood_type
+	return dna?.blood_type

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1344,7 +1344,7 @@
 
 /mob/living/carbon/get_bloodtype()
 	RETURN_TYPE(/datum/blood_type)
-	if(HAS_TRAIT(src, TRAIT_NOBLOOD))
+	if(!CAN_HAVE_BLOOD(src))
 		return
 	var/datum/dna/dna = has_dna()
 	return dna?.blood_type

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -49,7 +49,7 @@
 	///only used by humans.
 	var/obj/item/clothing/ears = null
 
-	/// Carbon, you should really only be accessing this through has_dna() but it's your life
+	/// DNA is carbon-only, and ideally you should be accessing it through has_dna(), but you can access it directly if you know you're working with a carbon mob
 	var/datum/dna/dna = null
 	///last mind to control this mob, for blood-based cloning
 	var/datum/mind/last_mind = null


### PR DESCRIPTION
## About The Pull Request

Changes it so health analysers do not care about blood level in species that have no blood.

## Why It's Good For The Game

I've already had anecdotes of new medical doctors trying to pump plasmamen full of blood packs saline in an effort to fix the problem, to no avail, so I figure this would be appreciated by MDs as one less red herring to ignore.

## Changelog

:cl:
fix: Health analysers will no longer erroneously show a blood level for things that don't have blood.
/:cl: