### PR TITLE
security gas masks give pepperspray immunity again

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH
-	visor_flags_cover = MASKCOVERSMOUTH
+	visor_flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	tint = 0
 	fishing_modifier = 0
 	unique_death = 'sound/items/sec_hailer/sec_death.ogg'


### PR DESCRIPTION
## About The Pull Request

when tgstation was doing the weird gas mask nerf thing, the security hailer mask was caught in the crossfire as a compromise for not being FOV restricted. now that FOV restrictions have been removed though, it still hasn't gotten its immunity back. this pr readds the secmask pepper spray immunity, while it's pulled over your mouth and nose of course
## Why It's Good For The Game

both pepper-spray and the sechailer are underused. pepperspray is usually discarded or ignored, and most sec players use the security gas mask like a normal breath mask. pepperspray is cool and criminally underused because the server lagging will make you stun yourself, which is very odd because generally security officers have immunity to all of their own non-baton non-disabler tools (flash, flashbang, pepperspray before the mask was nerfed)

## Changelog
:cl:
balance: the security gas mask is pepper-proof again.
/:cl:
