### PR TITLE
[MDB Ignore] area/noop map lint

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_1.dmm
@@ -63,7 +63,7 @@
 	},
 /obj/modular_map_connector,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "L" = (
 /turf/closed/wall,
 /area/ruin/space/djstation)
@@ -76,7 +76,7 @@
 	name = "Kitchen"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "P" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,

--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_2.dmm
@@ -49,7 +49,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/wooden,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "L" = (
 /turf/closed/wall,
 /area/ruin/space/djstation)
@@ -60,7 +60,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/wooden,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "S" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_4.dmm
@@ -116,7 +116,7 @@
 	name = "Kitchen"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "V" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner{
@@ -140,7 +140,7 @@
 	},
 /obj/modular_map_connector,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 
 (1,1,1) = {"
 e

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_1.dmm
@@ -24,7 +24,7 @@
 	name = "Rest Room"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "u" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/grimy,
@@ -51,7 +51,7 @@
 	},
 /obj/modular_map_connector,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "F" = (
 /obj/structure/curtain,
 /obj/machinery/shower/directional/south,

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_2.dmm
@@ -21,7 +21,7 @@
 	name = "Rest Room"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "v" = (
 /obj/structure/bed/maint,
 /turf/open/floor/iron/dark/textured,
@@ -32,7 +32,7 @@
 	},
 /obj/modular_map_connector,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "J" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_3.dmm
@@ -56,7 +56,7 @@
 	name = "Rest Room"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "s" = (
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/freezer,
@@ -91,7 +91,7 @@
 	},
 /obj/modular_map_connector,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "C" = (
 /obj/machinery/duct,
 /obj/machinery/light/directional/south,

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_4.dmm
@@ -29,7 +29,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/wooden,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "q" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -50,7 +50,7 @@
 "C" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "E" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/airless,
@@ -72,7 +72,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/wooden,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "U" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -85,7 +85,7 @@
 	pixel_y = -1
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Y" = (
 /obj/structure/lattice,
 /obj/effect/spawner/random/structure/grille,

--- a/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
@@ -8,7 +8,7 @@
 "c" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "d" = (
 /obj/structure/frame/computer,
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -66,7 +66,7 @@
 "aK" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -81,7 +81,7 @@
 "aQ" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aT" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/eva,
@@ -211,7 +211,7 @@
 "bK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "bN" = (
 /obj/structure/grille/broken,
 /obj/item/stack/cable_coil/cut,
@@ -227,14 +227,14 @@
 "bP" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "bT" = (
 /obj/structure/grille,
 /obj/item/shard{
@@ -249,7 +249,7 @@
 "bW" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bX" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -319,7 +319,7 @@
 "ly" = (
 /obj/machinery/power/shieldwallgen/unlocked,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "nI" = (
 /obj/structure/alien/resin/wall,
 /obj/machinery/light/floor/broken,

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -218,7 +218,7 @@
 "aY" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aZ" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/derelictoutpost)

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -8,7 +8,7 @@
 "ac" = (
 /obj/item/trash/sosjerky,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "am" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -5,32 +5,32 @@
 "ab" = (
 /obj/structure/girder/displaced,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ac" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ad" = (
 /obj/item/wallframe/camera,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "af" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ag" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/gun/energy/e_gun/mini,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ah" = (
 /obj/structure/lattice/catwalk,
 /mob/living/basic/trooper/pirate/ranged/space{
 	environment_smash = 0
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aj" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -42,15 +42,15 @@
 	width = 22
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ao" = (
 /obj/item/stack/sheet/mineral/titanium,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aD" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bl" = (
 /mob/living/basic/carp,
 /turf/template_noop,
@@ -58,11 +58,11 @@
 "br" = (
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bs" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -115,7 +115,7 @@
 "dc" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -228,7 +228,7 @@
 /obj/structure/lattice,
 /obj/structure/broken_flooring/plating/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "fG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer,
@@ -275,7 +275,7 @@
 	width = 15
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "kG" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -287,7 +287,7 @@
 	width = 9
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "kU" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -299,7 +299,7 @@
 	width = 27
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "kX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -311,7 +311,7 @@
 /obj/structure/lattice,
 /obj/structure/broken_flooring/pile/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lC" = (
 /turf/closed/mineral/random/high_chance,
 /area/ruin/space/has_grav)
@@ -471,7 +471,7 @@
 "re" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "rj" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -656,7 +656,7 @@
 "As" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "AA" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -680,7 +680,7 @@
 "Bq" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Bv" = (
 /obj/structure/chair{
 	dir = 4
@@ -873,7 +873,7 @@
 "Ku" = (
 /obj/structure/broken_flooring/plating/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "KC" = (
 /obj/item/stack/cable_coil{
 	amount = 1
@@ -885,7 +885,7 @@
 /obj/structure/lattice,
 /obj/structure/broken_flooring/plating/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Lx" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide,

--- a/_maps/RandomRuins/SpaceRuins/commsbuoy_nt.dmm
+++ b/_maps/RandomRuins/SpaceRuins/commsbuoy_nt.dmm
@@ -531,7 +531,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ws" = (
 /obj/structure/marker_beacon/cerulean,
 /turf/open/floor/plating/reinforced/airless,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -256,7 +256,7 @@
 "mb" = (
 /obj/item/stack/ore/glass,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "mu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -633,7 +633,7 @@
 "zg" = (
 /obj/item/stack/tile/wood,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "zm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/decoration,
@@ -955,7 +955,7 @@
 "ID" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "IG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
@@ -1028,11 +1028,11 @@
 "KF" = (
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "KO" = (
 /obj/item/light/tube/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ln" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/trimline/brown/line{
@@ -1094,7 +1094,7 @@
 "MC" = (
 /obj/effect/mob_spawn/corpse/human/laborer,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Nc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1309,7 +1309,7 @@
 /obj/item/shard,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Xy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -1654,7 +1654,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/purple,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "uP" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -2018,7 +2018,7 @@
 "zY" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "zZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -2411,7 +2411,7 @@
 "Ey" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "EA" = (
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/dangerous_research/lab)

--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "c" = (
 /obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
@@ -13,7 +13,7 @@
 "d" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "e" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -40,7 +40,7 @@
 "k" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "l" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -76,7 +76,7 @@
 "p" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "q" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,

--- a/_maps/RandomRuins/SpaceRuins/derelict3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict3.dmm
@@ -11,7 +11,7 @@
 "d" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/SpaceRuins/derelict6.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict6.dmm
@@ -6,20 +6,20 @@
 /obj/structure/lattice,
 /obj/structure/broken_flooring/singular/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ac" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ae" = (
 /obj/item/stack/sheet/iron,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "af" = (
 /obj/structure/broken_flooring/pile/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ag" = (
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
@@ -33,7 +33,7 @@
 "aj" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ak" = (
 /obj/item/stack/rods,
 /obj/effect/mapping_helpers/broken_floor,
@@ -43,7 +43,7 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "am" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/airless,
@@ -87,7 +87,7 @@
 "aA" = (
 /obj/structure/broken_flooring/pile/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aB" = (
 /obj/item/stack/tile/iron/base,
 /obj/effect/mapping_helpers/broken_floor,
@@ -203,12 +203,12 @@
 /obj/structure/lattice,
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aZ" = (
 /obj/structure/lattice,
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ba" = (
 /mob/living/basic/ghost,
 /turf/open/floor/iron/cafeteria/airless,
@@ -266,7 +266,7 @@
 "bo" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bp" = (
 /obj/item/stack/sheet/iron,
 /obj/structure/girder,
@@ -291,7 +291,7 @@
 "bv" = (
 /obj/structure/broken_flooring/pile/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bw" = (
 /obj/structure/lattice,
 /obj/structure/broken_flooring/plating/directional/north{
@@ -320,7 +320,7 @@
 "bA" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bC" = (
 /obj/structure/lattice,
 /obj/structure/broken_flooring/corner/directional/north,
@@ -343,7 +343,7 @@
 "bG" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bH" = (
 /obj/structure/broken_flooring/plating/directional/south{
 	name = "broken plating"

--- a/_maps/RandomRuins/SpaceRuins/derelict7.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict7.dmm
@@ -69,7 +69,7 @@
 /obj/item/stack/tile/iron/base,
 /obj/structure/disposalpipe/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "gK" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/pill_bottle/happy,
@@ -79,12 +79,12 @@
 "gX" = (
 /obj/structure/girder/displaced,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "hf" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "iB" = (
 /obj/item/shard,
 /obj/effect/turf_decal/tile/yellow{
@@ -108,7 +108,7 @@
 /obj/structure/lattice,
 /obj/item/stack/tile/iron/base,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lU" = (
 /obj/item/stack/tile/iron/base,
 /obj/effect/mapping_helpers/broken_floor,
@@ -120,7 +120,7 @@
 "or" = (
 /obj/item/stack/tile/iron/base,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "oy" = (
 /obj/structure/table_frame,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -132,7 +132,7 @@
 /obj/structure/lattice,
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "oX" = (
 /obj/structure/door_assembly/door_assembly_med,
 /turf/open/floor/plating/airless,
@@ -146,7 +146,7 @@
 /obj/structure/lattice,
 /obj/structure/girder/displaced,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "pr" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
@@ -170,12 +170,12 @@
 "tj" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "tk" = (
 /obj/structure/lattice,
 /obj/machinery/light/broken/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "tF" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -187,7 +187,7 @@
 /obj/item/stack/tile/iron/base,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "uB" = (
 /obj/structure/disposalpipe/broken{
 	dir = 1
@@ -205,12 +205,12 @@
 /obj/item/stack/tile/iron/base,
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "wJ" = (
 /obj/structure/lattice,
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "wT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -274,11 +274,11 @@
 /obj/structure/lattice,
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "CT" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Di" = (
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/vendor,
@@ -293,7 +293,7 @@
 /obj/structure/lattice,
 /obj/item/vending_refill/assist,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "EE" = (
 /obj/effect/spawner/random/trash/botanical_waste,
 /obj/effect/mapping_helpers/broken_floor,
@@ -302,7 +302,7 @@
 "Fv" = (
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "FQ" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
@@ -321,11 +321,11 @@
 /obj/structure/lattice,
 /obj/item/wallframe/apc,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "HO" = (
 /obj/item/stack/tile/wood,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Il" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass,
@@ -401,7 +401,7 @@
 "NM" = (
 /obj/effect/spawner/random/medical/surgery_tool,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "NN" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -415,7 +415,7 @@
 "Pi" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Pn" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -427,17 +427,17 @@
 /obj/structure/girder/displaced,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Qk" = (
 /obj/structure/lattice,
 /obj/item/stack/tile/wood,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Qw" = (
 /obj/structure/lattice,
 /obj/structure/table_frame,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Qy" = (
 /obj/item/wallframe/airalarm,
 /obj/structure/disposalpipe/segment{
@@ -496,7 +496,7 @@
 /obj/structure/lattice,
 /obj/item/light/tube/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Wr" = (
 /obj/structure/door_assembly/door_assembly_mai,
 /obj/effect/mapping_helpers/broken_floor,
@@ -516,7 +516,7 @@
 /obj/item/wallframe/intercom,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 
 (1,1,1) = {"
 DY

--- a/_maps/RandomRuins/SpaceRuins/derelict8.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict8.dmm
@@ -3,7 +3,7 @@
 /obj/item/stack/tile/iron/base,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ck" = (
 /obj/effect/spawner/random/structure/girder{
 	spawn_loot_chance = 80
@@ -22,7 +22,7 @@
 /obj/structure/lattice,
 /obj/item/stack/tile/iron/base,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/broken/directional/south,
@@ -32,12 +32,12 @@
 "es" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "eu" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "hs" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -119,7 +119,7 @@
 /obj/structure/lattice,
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "yf" = (
 /obj/structure/table,
 /obj/item/food/deadmouse{
@@ -136,11 +136,11 @@
 /obj/item/stack/tile/iron/base,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "zh" = (
 /obj/item/stack/tile/iron/base,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "zt" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
@@ -155,7 +155,7 @@
 "zK" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "BD" = (
 /obj/structure/table,
 /obj/item/gps/spaceruin{
@@ -176,7 +176,7 @@
 /obj/structure/lattice,
 /obj/structure/girder/displaced,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "DQ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/grille,
@@ -242,12 +242,12 @@
 "Of" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "OD" = (
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "OM" = (
 /obj/effect/spawner/random/bureaucracy/paper,
 /obj/structure/table,

--- a/_maps/RandomRuins/SpaceRuins/derelict_construction.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_construction.dmm
@@ -261,12 +261,12 @@
 "DU" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "DY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "DZ" = (
 /obj/structure/frame,
 /turf/open/misc/asteroid,

--- a/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
@@ -410,7 +410,7 @@
 "mC" = (
 /obj/item/stack/tile/iron/smooth_corner,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "na" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/computer/terminal/sulaco/map,
@@ -427,7 +427,7 @@
 /obj/structure/lattice,
 /obj/item/stack/tile/iron/smooth_half,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "nG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks/xeno{
@@ -1127,7 +1127,7 @@
 "KI" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "KS" = (
 /obj/machinery/door/window/brigdoor/left/directional/east,
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
@@ -1234,7 +1234,7 @@
 "Ne" = (
 /obj/item/stack/tile/iron/smooth_half,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ng" = (
 /obj/machinery/camera/directional/south{
 	network = list()
@@ -1311,7 +1311,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "PZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids{
@@ -1375,7 +1375,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Sj" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -1516,7 +1516,7 @@
 /obj/item/stack/tile/iron/smooth_half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "VO" = (
 /obj/structure/alien/weeds,
 /obj/structure/barricade/sandbags,
@@ -1565,7 +1565,7 @@
 	anchored = 1
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "WQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -1583,7 +1583,7 @@
 /obj/structure/lattice,
 /obj/item/stack/tile/iron/smooth_corner,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "XC" = (
 /obj/structure/alien/weeds,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer4{
@@ -1671,7 +1671,7 @@
 "ZZ" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 
 (1,1,1) = {"
 hi

--- a/_maps/RandomRuins/SpaceRuins/dj_station.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dj_station.dmm
@@ -50,7 +50,7 @@
 	key = "radioroom"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "u" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/plating,
@@ -143,7 +143,7 @@
 	key = "solars"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "V" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/effect/spawner/random/maintenance,

--- a/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "c" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav)

--- a/_maps/RandomRuins/SpaceRuins/fasttravel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/fasttravel.dmm
@@ -55,7 +55,7 @@
 	amount = 10
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lq" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -187,7 +187,7 @@
 "CX" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "DZ" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/film_studio.dmm
+++ b/_maps/RandomRuins/SpaceRuins/film_studio.dmm
@@ -31,7 +31,7 @@
 "aG" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "aI" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/curtain/cloth/fancy,
@@ -182,7 +182,7 @@
 /area/ruin/space/has_grav/film_studio/director)
 "dd" = (
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "dg" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/film_studio/starboard)

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -442,7 +442,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bO" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "fscremate"
@@ -922,7 +922,7 @@
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "dj" = (
 /turf/closed/mineral/random/high_chance,
-/area/template_noop)
+/area/space/nearstation)
 "dl" = (
 /obj/machinery/door/password/voice/sfc{
 	password = null

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck1.dmm
@@ -1160,7 +1160,7 @@
 "VL" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Xi" = (
 /obj/item/food/badrecipe/moldy/bacteria,
 /obj/effect/decal/cleanable/food/egg_smudge,

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck2.dmm
@@ -649,7 +649,7 @@
 "VL" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "VV" = (
 /obj/effect/decal/cleanable/blood/gibs/robot_debris/up,
 /obj/structure/frame/computer,

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck3.dmm
@@ -884,7 +884,7 @@
 "VL" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "WK" = (
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/item/clothing/shoes/workboots{

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck4.dmm
@@ -809,7 +809,7 @@
 "VL" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Wl" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
@@ -79,7 +79,7 @@
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bd" = (
 /obj/structure/table/wood,
 /obj/structure/cable/layer1,
@@ -1246,7 +1246,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "kx" = (
 /mob/living/basic/bot/dedbot{
 	bot_mode_flags = 29
@@ -2878,7 +2878,7 @@
 /obj/effect/spawner/random/structure/grille,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "yU" = (
 /obj/item/rack_parts{
 	pixel_y = 8;
@@ -3131,7 +3131,7 @@
 /obj/structure/lattice,
 /obj/effect/spawner/random/structure/grille,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Bj" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/medical/minor_healing,
@@ -4583,7 +4583,7 @@
 "NS" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "NY" = (
 /obj/structure/cable/layer1,
 /obj/machinery/vending/coffee{
@@ -5014,7 +5014,7 @@
 	width = 35
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "RI" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 1
@@ -5278,7 +5278,7 @@
 	name = "external vent"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "TU" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -5986,7 +5986,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ZI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -35,7 +35,7 @@
 "aB" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aV" = (
 /obj/machinery/light/small/red/dim/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -84,7 +84,7 @@
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bD" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gib3-old";
@@ -450,7 +450,7 @@
 "fM" = (
 /obj/structure/door_assembly/door_assembly_ext,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "fX" = (
 /obj/structure/toilet{
 	dir = 4
@@ -463,7 +463,7 @@
 "gG" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "gW" = (
 /obj/effect/turf_decal{
 	dir = 4
@@ -945,7 +945,7 @@
 	pixel_x = 15
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "qb" = (
 /obj/effect/turf_decal{
 	dir = 8
@@ -1014,14 +1014,14 @@
 "qF" = (
 /obj/item/ammo_casing/spent,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "qJ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/clothing/mask/facehugger/toy,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "qR" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/mob_spawn/corpse/human/syndicatecommando/lessenedgear,
@@ -1103,7 +1103,7 @@
 "rO" = (
 /obj/structure/broken_flooring/pile/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "so" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/item/broken_missile,
@@ -1150,7 +1150,7 @@
 "sT" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "sZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -1365,7 +1365,7 @@
 	amount = 25
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "wt" = (
 /obj/effect/turf_decal{
 	icon_state = "warningline_white";
@@ -1448,7 +1448,7 @@
 /obj/effect/spawner/random/trash,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/space/nearstation)
 "xo" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable,
@@ -1651,11 +1651,11 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "zU" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "zV" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal{
@@ -1839,7 +1839,7 @@
 "Eg" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Er" = (
 /obj/effect/turf_decal{
 	icon_state = "arrows_red";
@@ -1879,7 +1879,7 @@
 "EB" = (
 /obj/structure/girder/displaced,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "EL" = (
 /obj/effect/turf_decal{
 	icon_state = "warningline_white"
@@ -2086,12 +2086,12 @@
 "HD" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "HP" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/structure/broken_flooring/pile/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Im" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/plastitanium,
@@ -2325,7 +2325,7 @@
 /obj/item/ammo_casing/spent,
 /obj/structure/alien/weeds,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/space/nearstation)
 "Ln" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/ammo_casing/spent,
@@ -2518,7 +2518,7 @@
 	amount = 23
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ou" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2624,7 +2624,7 @@
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Qm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -2649,7 +2649,7 @@
 "QL" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ru" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -2728,7 +2728,7 @@
 "RY" = (
 /obj/effect/spawner/random/trash,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Sr" = (
 /obj/effect/turf_decal{
 	icon_state = "warningline_white";
@@ -2937,7 +2937,7 @@
 "VR" = (
 /obj/item/tank/internals/oxygen/empty,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "VU" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/vomit/old,
@@ -3004,7 +3004,7 @@
 	amount = 50
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Xc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -689,7 +689,7 @@
 	width = 9
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "KG" = (
 /obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -33,12 +33,12 @@
 "hR" = (
 /obj/item/shard/titanium,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "if" = (
 /obj/structure/lattice,
 /obj/structure/mecha_wreckage/gygax,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "is" = (
 /turf/template_noop,
 /area/template_noop)
@@ -98,12 +98,12 @@
 	pixel_x = 12
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lc" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lB" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -172,7 +172,7 @@
 "wJ" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "xJ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -268,7 +268,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Lk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large/airless,
@@ -298,7 +298,7 @@
 "PG" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Qc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 8
@@ -322,7 +322,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Vl" = (
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -5,7 +5,7 @@
 "ab" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ac" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/tcommsat_oldaisat)
@@ -13,16 +13,16 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ae" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "af" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "ag" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/tcommsat_oldaisat)
@@ -33,7 +33,7 @@
 "ai" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aj" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating/airless,
@@ -78,7 +78,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "au" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -96,7 +96,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ay" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/iron/airless,
@@ -160,7 +160,7 @@
 "aL" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aM" = (
 /obj/item/folder/yellow,
 /turf/open/floor/iron/airless,
@@ -177,14 +177,14 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aP" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aQ" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -194,16 +194,16 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aT" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aU" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/r_wall,
@@ -326,16 +326,16 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "br" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bs" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bt" = (
 /obj/structure/table,
 /obj/item/gps/spaceruin,
@@ -361,7 +361,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bz" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/shard{
@@ -400,7 +400,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bG" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -562,12 +562,12 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ck" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -596,7 +596,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cq" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -649,7 +649,7 @@
 	icon_state = "medium"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cz" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
@@ -657,7 +657,7 @@
 	icon_state = "medium"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
@@ -665,7 +665,7 @@
 "cC" = (
 /obj/structure/grille/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cD" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/iron,

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -206,7 +206,7 @@
 "nv" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "nF" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/blood/old,
@@ -521,7 +521,7 @@
 "Jd" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "JH" = (
 /obj/structure/frame/machine,
 /turf/open/floor/circuit/red/airless,
@@ -544,7 +544,7 @@
 "KM" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Lz" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -644,7 +644,7 @@
 "Tc" = (
 /obj/item/stack/rods/two,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Tx" = (
 /obj/machinery/door/window/brigdoor/right/directional/west{
 	req_access = list("syndicate");
@@ -730,7 +730,7 @@
 "YT" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Zh" = (
 /obj/structure/table,
 /obj/item/storage/medkit/ancient{

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2999,7 +2999,7 @@
 "nr" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ns" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,

--- a/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "c" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/oldteleporter)

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -6,16 +6,16 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ad" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ae" = (
 /obj/item/stack/cable_coil/cut,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ag" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/onehalf/dorms_med)
@@ -106,7 +106,7 @@
 "aw" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ax" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -227,7 +227,7 @@
 /obj/structure/lattice,
 /obj/item/storage/toolbox/syndicate,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aT" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -570,7 +570,7 @@
 "bV" = (
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bW" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
@@ -651,7 +651,7 @@
 	icon_state = "small"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ck" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -705,14 +705,14 @@
 "cr" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cs" = (
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ct" = (
 /obj/structure/lattice,
 /obj/item/shard{
@@ -747,7 +747,7 @@
 "cA" = (
 /obj/item/stack/tile/wood,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cB" = (
 /turf/template_noop,
 /area/ruin/space/has_grav/onehalf/hallway)
@@ -813,7 +813,7 @@
 "cN" = (
 /obj/item/stack/sheet/plasteel,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -875,23 +875,23 @@
 /obj/item/stack/sheet/plasteel,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "di" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dj" = (
 /obj/item/stack/rods,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dl" = (
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ms" = (
 /obj/item/stack/tile/iron/base,
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -5,23 +5,23 @@
 "ab" = (
 /obj/structure/fluff/paper/corner,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ac" = (
 /obj/structure/fluff/paper,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ad" = (
 /obj/structure/fluff/paper/corner{
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ae" = (
 /obj/structure/fluff/paper{
 	dir = 4
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "af" = (
 /turf/closed/indestructible/paper,
 /area/ruin/space/has_grav/powered)
@@ -30,20 +30,20 @@
 	dir = 10
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ah" = (
 /obj/structure/fluff/paper/corner,
 /obj/structure/fluff/paper/corner{
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ai" = (
 /obj/structure/fluff/paper{
 	dir = 6
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aj" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Airlock";
@@ -137,7 +137,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ax" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -375,19 +375,19 @@
 	dir = 9
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bd" = (
 /obj/structure/fluff/paper{
 	dir = 1
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "be" = (
 /obj/structure/fluff/paper/corner{
 	dir = 4
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bf" = (
 /obj/structure/fluff/paper{
 	dir = 4
@@ -454,7 +454,7 @@
 	dir = 10
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bo" = (
 /obj/structure/fluff/paper/corner{
 	dir = 4
@@ -463,7 +463,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bp" = (
 /obj/structure/fluff/paper{
 	dir = 8
@@ -518,13 +518,13 @@
 	dir = 1
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bx" = (
 /obj/structure/fluff/paper{
 	dir = 5
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "by" = (
 /obj/structure/fluff/paper/corner,
 /turf/open/indestructible/paper,

--- a/_maps/RandomRuins/SpaceRuins/prison_shuttle.dmm
+++ b/_maps/RandomRuins/SpaceRuins/prison_shuttle.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/girder/reinforced,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "c" = (
 /obj/structure/girder/reinforced,
 /turf/open/misc/asteroid/airless,

--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -1679,7 +1679,7 @@
 "rd" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "re" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
@@ -6394,7 +6394,7 @@
 /area/ruin/space/ks13/medical/morgue)
 "PG" = (
 /turf/closed/wall/r_wall,
-/area/template_noop)
+/area/space/nearstation)
 "PH" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/power/apc/auto_name/directional/north,

--- a/_maps/RandomRuins/SpaceRuins/space_ghost_restaurant.dmm
+++ b/_maps/RandomRuins/SpaceRuins/space_ghost_restaurant.dmm
@@ -29,7 +29,7 @@
 "eb" = (
 /obj/item/shard,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "en" = (
 /obj/machinery/power/smes/magical{
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
@@ -60,11 +60,11 @@
 "hp" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "iF" = (
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "jd" = (
 /obj/item/stack/sheet/iron,
 /turf/open/floor/plating/airless,
@@ -148,7 +148,7 @@
 "Bv" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "BA" = (
 /obj/effect/decal/cleanable/blood/gibs/robot_debris,
 /obj/effect/decal/cleanable/glass,
@@ -236,7 +236,7 @@
 "Ng" = (
 /obj/item/stack/tile/iron/showroomfloor,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ns" = (
 /obj/item/chair,
 /obj/item/clothing/head/utility/surgerycap,
@@ -272,7 +272,7 @@
 "Rm" = (
 /obj/item/circuitboard/machine/restaurant_portal,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "RI" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/iron/cafeteria/airless,

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -354,7 +354,7 @@
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dK" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -1154,7 +1154,7 @@
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lf" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/shower/directional/south,
@@ -1191,7 +1191,7 @@
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lw" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
@@ -1199,7 +1199,7 @@
 "lB" = (
 /obj/structure/fluff/tram_rail,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "lE" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/grimy,
@@ -1275,7 +1275,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "mj" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
@@ -1537,7 +1537,7 @@
 /obj/structure/fluff/tram_rail,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ot" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/paper_bin,
@@ -1567,7 +1567,7 @@
 	},
 /obj/structure/fluff/tram_rail,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "po" = (
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/misc/beach/sand,
@@ -1660,7 +1660,7 @@
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "qF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1680,7 +1680,7 @@
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "qM" = (
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
@@ -2383,7 +2383,7 @@
 "yB" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "yD" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/firealarm/directional/north,
@@ -2422,7 +2422,7 @@
 "yV" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "yY" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -2892,7 +2892,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "FT" = (
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/hotel/dock)
@@ -3114,7 +3114,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Iq" = (
 /obj/item/kirbyplants/organic/plant16,
 /obj/structure/sign/poster/random/directional/west,
@@ -3167,7 +3167,7 @@
 "IZ" = (
 /obj/structure/fluff/tram_rail/end,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Je" = (
 /obj/structure/cable,
 /obj/item/reagent_containers/cup/bucket,
@@ -4073,7 +4073,7 @@
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "VM" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -4461,7 +4461,7 @@
 	},
 /obj/structure/fluff/tram_rail/end,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Zo" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/showroomfloor,

--- a/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
@@ -534,7 +534,7 @@
 "nM" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "od" = (
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/the_outlet/storefront)
@@ -1566,7 +1566,7 @@
 "LA" = (
 /obj/item/stack/rods/two,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "LL" = (
 /mob/living/basic/construct/proteon/hostile,
 /obj/effect/decal/cleanable/crayon/rune2,

--- a/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
+++ b/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
@@ -234,7 +234,7 @@
 	desc = "An incredibly bad idea."
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "zn" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/food_or_drink/snack,

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -195,7 +195,7 @@
 /obj/structure/lattice,
 /obj/structure/girder,
 /turf/open/floor/plating/rust/airless,
-/area/template_noop)
+/area/space/nearstation)
 "my" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -307,7 +307,7 @@
 "rK" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "sb" = (
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/turretedoutpost)

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "c" = (
 /obj/structure/lattice,
 /turf/open/misc/asteroid/airless,

--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -111,7 +111,7 @@
 "dd" = (
 /obj/structure/broken_flooring/pile/directional/west,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dl" = (
 /obj/machinery/door/airlock/mining/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -561,7 +561,7 @@
 "kn" = (
 /obj/structure/broken_flooring/pile/directional/north,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "ko" = (
 /obj/machinery/door/airlock{
 	name = "Freezer"
@@ -823,7 +823,7 @@
 	width = 35
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "nQ" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -1255,7 +1255,7 @@
 "vi" = (
 /obj/structure/girder,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "vn" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -1323,7 +1323,7 @@
 "wf" = (
 /obj/item/stack/rods/two,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "wj" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/siding/green,
@@ -1379,7 +1379,7 @@
 "xi" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "xq" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2521,7 +2521,7 @@
 "Tl" = (
 /obj/item/shell/airlock,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Tx" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8

--- a/_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/docking_port/stationary/picked/whiteship,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -5,7 +5,7 @@
 	pixel_x = 9
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aw" = (
 /obj/effect/decal/cleanable/glass/plastitanium,
 /turf/open/floor/mineral/titanium/white/airless,
@@ -987,7 +987,7 @@
 	pixel_x = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "FX" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/sleeper{

--- a/_maps/minigame/CTF/cruiser.dmm
+++ b/_maps/minigame/CTF/cruiser.dmm
@@ -479,7 +479,7 @@
 "CA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /turf/template_noop,
-/area/template_noop)
+/area/centcom/ctf)
 "CU" = (
 /obj/structure/window/reinforced/spawner/directional/east{
 	resistance_flags = 64

--- a/_maps/minigame/deathmatch/OSHA_Violator.dmm
+++ b/_maps/minigame/deathmatch/OSHA_Violator.dmm
@@ -2,11 +2,11 @@
 "ac" = (
 /obj/structure/closet/crate/medical,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "ae" = (
 /obj/effect/mob_spawn/corpse/human/cargo_tech,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "ai" = (
 /turf/closed/indestructible/reinforced,
 /area/deathmatch)
@@ -1096,15 +1096,15 @@
 "Zr" = (
 /obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "Zz" = (
 /obj/machinery/power/singularity_beacon/syndicate,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "ZD" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 
 (1,1,1) = {"
 je

--- a/_maps/minigame/deathmatch/arena_station.dmm
+++ b/_maps/minigame/deathmatch/arena_station.dmm
@@ -22,7 +22,7 @@
 "bE" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "bR" = (
 /obj/machinery/computer{
 	dir = 4
@@ -1078,7 +1078,7 @@
 /obj/structure/closet,
 /obj/item/toy/plush/lizard_plushie/green,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "QS" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/indestructible/plating,

--- a/_maps/minigame/deathmatch/maint_mania.dmm
+++ b/_maps/minigame/deathmatch/maint_mania.dmm
@@ -34,7 +34,7 @@
 "ga" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "gJ" = (
 /obj/item/ammo_casing/shotgun/stunslug,
 /turf/open/indestructible,
@@ -170,7 +170,7 @@
 "ur" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "vB" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/indestructible,
@@ -202,7 +202,7 @@
 	desc = "An old, blue toolbox, it looks soulful."
 	},
 /turf/open/space/basic,
-/area/template_noop)
+/area/space/nearstation)
 "Bs" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -220,7 +220,7 @@
 /obj/structure/lattice/catwalk,
 /obj/effect/mob_spawn/corpse/human/engineer/mod,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Dt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
@@ -298,7 +298,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/statue/sandstone/assistant,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Ij" = (
 /turf/open/space/basic,
 /area/template_noop)
@@ -335,7 +335,7 @@
 "MC" = (
 /obj/effect/mob_spawn/corpse/human/assistant,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "Na" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/soda_cans/starkist,
@@ -396,7 +396,7 @@
 "Qr" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "QN" = (
 /obj/item/razor,
 /obj/structure/table/reinforced,

--- a/_maps/minigame/deathmatch/meta_brig.dmm
+++ b/_maps/minigame/deathmatch/meta_brig.dmm
@@ -20,11 +20,7 @@
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
-"an" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/space)
+/area/space/nearstation)
 "aw" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/closed/indestructible/reinforced,
@@ -1444,7 +1440,7 @@
 "vC" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "vD" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -4492,7 +4488,7 @@ IJ
 IJ
 "}
 (32,1,1) = {"
-an
+vC
 Fi
 Fi
 Fi

--- a/tools/maplint/README.md
+++ b/tools/maplint/README.md
@@ -205,3 +205,21 @@ The all node may be added as a child to the when node to specify that it will be
 	required_neighbors:
 	- /obj/dogbed
 ```
+
+### `skip_files`
+
+To skip processing this rule when the current filename start with a given path, either the start of a path, the full path (with extension), or regex matched.
+
+```yml
+/area/template_noop:
+  banned_neighbors:
+    - /turf/open
+    - /obj
+  skip_files:
+    - _maps/templates
+    - _maps/minigame/deathmatch/OSHA_Violator.dmm
+    - pattern: "^_maps/templates/holodeck.*"
+```
+
+In this example, all files in '_maps/templates' (recursively), 'OSHA_Violator.dmm', and any regex matched files for 'temples/holodeck.' will be skipped for any other rules defined in this yml.
+

--- a/tools/maplint/lints/area_noop.yml
+++ b/tools/maplint/lints/area_noop.yml
@@ -1,0 +1,8 @@
+/area/template_noop:
+  banned_neighbors:
+    - /turf/baseturf_bottom
+    - /turf/baseturf_skipover
+    - /turf/closed
+    - /turf/cordon
+    - /turf/open
+    - /obj

--- a/tools/maplint/lints/area_noop.yml
+++ b/tools/maplint/lints/area_noop.yml
@@ -6,3 +6,12 @@
     - /turf/cordon
     - /turf/open
     - /obj
+  skip_files:
+    - _maps/map_files/tramstation/maintenance_modules
+    - _maps/modular_generic
+    - _maps/shuttles/emergency_scrapheap
+    - _maps/templates
+    - _maps/minigame/deathmatch/OSHA_Violator.dmm
+    - _maps/minigame/deathmatch/maint_mania.dmm
+    - _maps/RandomRuins/IceRuins
+    - _maps/RandomRuins/LavaRuins

--- a/tools/mapping_fix_template_noop_areas/fix_template_noop_in_maps.py
+++ b/tools/mapping_fix_template_noop_areas/fix_template_noop_in_maps.py
@@ -1,0 +1,133 @@
+import re
+import sys
+import subprocess
+from pathlib import Path
+
+# ==========================================================
+# REGEX
+# ==========================================================
+KEY_BLOCK_RE = re.compile(
+    r'"([^"]+)"\s*=\s*\((.*?)\)',
+    re.DOTALL
+)
+
+
+# ==========================================================
+# GIT ROOT
+# ==========================================================
+def get_git_root(start_dir: Path) -> Path:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=start_dir,
+            stderr=subprocess.DEVNULL,
+        )
+        return Path(out.decode().strip())
+    except Exception as e:
+        raise SystemExit(f"Failed to determine git repo root: {e}")
+
+
+# ==========================================================
+# LOGIC
+# ==========================================================
+def block_needs_replacement(block: str) -> bool:
+    """
+    A block needs replacement if:
+      - it contains /area/template_noop
+      - AND it has either an /obj OR a /turf that is not /turf/template_noop
+    """
+    if "/area/template_noop" not in block:
+        return False
+
+    has_obj = re.search(r'^\s*/obj/', block, re.MULTILINE) is not None
+
+    has_non_template_turf = False
+    for m in re.finditer(r'^\s*(/turf[^\s,{]*)', block, re.MULTILINE):
+        turf_path = m.group(1)
+        if turf_path != "/turf/template_noop":
+            has_non_template_turf = True
+            break
+
+    return has_obj or has_non_template_turf
+
+
+def process_dmm(path: Path, git_root: Path) -> None:
+    text = path.read_text(encoding="utf8")
+
+    changed = False
+    changed_keys = []
+
+    def repl(match: re.Match) -> str:
+        nonlocal changed
+
+        key_name = match.group(1)
+        block = match.group(2)
+
+        if not block_needs_replacement(block):
+            return match.group(0)
+
+        new_block = block.replace("/area/template_noop", "/area/space/nearstation")
+
+        if new_block == block:
+            return match.group(0)
+
+        changed = True
+        changed_keys.append(key_name)
+
+        return match.group(0).replace(block, new_block)
+
+    new_text = KEY_BLOCK_RE.sub(repl, text)
+
+    if changed:
+        path.write_text(new_text, encoding="utf8")
+        try:
+            rel = path.relative_to(git_root)
+        except ValueError:
+            rel = path
+        print(f"[{rel}] updated keys: {', '.join(changed_keys)}")
+
+
+# ==========================================================
+# MAIN
+# ==========================================================
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python fix_template_noop_areas.py <path-to-search>")
+        print("  <path-to-search> can be:")
+        print("    - relative to the git root (tgstation)")
+        print("    - or an absolute path")
+        sys.exit(1)
+
+    script_dir = Path(__file__).resolve().parent
+    git_root = get_git_root(script_dir)
+    print(f"[INFO] Git root: {git_root}")
+
+    arg_path = Path(sys.argv[1])
+
+    if arg_path.is_absolute():
+        root_dir = arg_path
+    else:
+        root_dir = git_root / arg_path
+
+    print(f"[INFO] Searching under: {root_dir}")
+
+    if not root_dir.is_dir():
+        raise SystemExit(f"[ERROR] Search path does not exist or is not a directory: {root_dir}")
+
+    dmm_files = sorted(root_dir.rglob("*.dmm"))
+    total = len(dmm_files)
+
+    if total == 0:
+        print(f"[INFO] No .dmm files found under {root_dir}")
+        return
+
+    print(f"[INFO] Found {total} .dmm files")
+
+    for idx, dmm in enumerate(dmm_files, start=1):
+        print(f"[INFO] ({idx}/{total}) Processing: {dmm}")
+        process_dmm(dmm, git_root)
+
+    print("[INFO] Done.")
+
+if __name__ == "__main__":
+    main()

--- a/tools/mapping_fix_template_noop_areas/launch_fix_template_noop_in_maps.bat
+++ b/tools/mapping_fix_template_noop_areas/launch_fix_template_noop_in_maps.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+
+set PY_SCRIPT=fix_template_noop_in_maps.py
+
+REM Example: search the SpaceRuins folder relative to git root
+python "%PY_SCRIPT%" "_maps\RandomRuins\SpaceRuins"
+
+endlocal


### PR DESCRIPTION
safeguards against #94132



for downstreams, i've added a bat script in tools\mapping_fix_template_noop_areas that'll iterate over all .dmm in a given folder (set the relative path from the git root in the .bat)

---------

Fixes a bunch of shit getting left in space randomly, as well as flaky tests. 
<img width="1960" height="149" alt="518075345-f003e38f-21ef-4ead-b233-f3a47d1aadcc" src="https://github.com/user-attachments/assets/9a807cd8-0304-4737-bd91-da783c3c8bef" />
