### PR TITLE
Adds a mapping log to plumbing destroying ducts

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -93193,6 +93193,7 @@
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xbG" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -93193,7 +93193,6 @@
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xbG" = (

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -45,12 +45,6 @@
 
 	set_recipient_reagents_holder(custom_receiver ? custom_receiver : parent_movable.reagents)
 
-#ifdef TESTING
-	var/obj/machinery/duct/duct_on_loc = locate() in parent_movable.loc
-	if(duct_on_loc)
-		log_mapping("[duct_on_loc.name] was found at [AREACOORD(parent_movable)] spawning on top of [parent_movable.name], which should not occur as it takes ducts itself!")
-#endif
-
 	if(start)
 		enable()
 
@@ -250,6 +244,8 @@
 	// Machines disable when they get moved
 	for(var/obj/machinery/duct/duct in parent_movable.loc)
 		if(duct.anchored && (duct.duct_layer & ducting_layer))
+			log_mapping("[duct.name] was found at [AREACOORD(parent_movable)] spawning on top of [parent_movable.name], \
+				which should not occur as it takes ducts itself!")
 			duct.disconnect_duct()
 
 	if(demand_connects)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -45,6 +45,12 @@
 
 	set_recipient_reagents_holder(custom_receiver ? custom_receiver : parent_movable.reagents)
 
+#ifdef TESTING
+	var/obj/machinery/duct/duct_on_loc = locate() in parent_movable.loc
+	if(duct_on_loc)
+		log_mapping("[duct_on_loc.name] was found at [AREACOORDS(parent_movable)] spawning on top of [parent_movable.name], which should not occur as it takes ducts itself!")
+#endif
+
 	if(start)
 		enable()
 

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -48,7 +48,7 @@
 #ifdef TESTING
 	var/obj/machinery/duct/duct_on_loc = locate() in parent_movable.loc
 	if(duct_on_loc)
-		log_mapping("[duct_on_loc.name] was found at [AREACOORDS(parent_movable)] spawning on top of [parent_movable.name], which should not occur as it takes ducts itself!")
+		log_mapping("[duct_on_loc.name] was found at [AREACOORD(parent_movable)] spawning on top of [parent_movable.name], which should not occur as it takes ducts itself!")
 #endif
 
 	if(start)


### PR DESCRIPTION
## About The Pull Request

<img width="1321" height="91" alt="image" src="https://github.com/user-attachments/assets/a50510da-5489-46d3-a56f-b47128f72431" />

This will trigger if you create a plumbing machine on top of a duct, but we're only caring for roundstart here?
I can't use banned neighbors because I don't want to add a list that must be constantly maintained for every machine that uses the component.

## Why It's Good For The Game

Prior to this PR, this is the only error you'd get about this occuring
<img width="944" height="60" alt="image" src="https://github.com/user-attachments/assets/849d86e9-5ea4-4748-aa2a-7cf86386b7f3" />

Very undescriptive and I had to go through every single duct on a map to figure out what was being deleted, turns out it was a single duct being mapped on top of a toilet.

## Changelog

Nothing player-facing.