### PR TITLE
Adds jump and search functions to the planecube debugger

### DIFF
--- a/tgui/packages/tgui/interfaces/PlaneMasterDebug/Port.tsx
+++ b/tgui/packages/tgui/interfaces/PlaneMasterDebug/Port.tsx
@@ -14,7 +14,8 @@ export type PortProps = {
 export function Port(props: PortProps) {
   const { connection, source, target_ref } = props;
   const { act } = useBackend();
-  const { setConnectionHighlight } = usePlaneDebugContext();
+  const { setConnectionHighlight, zoomToX, setZoomToX, zoomToY, setZoomToY } =
+    usePlaneDebugContext();
   const sourcePlane: Plane = (
     source ? connection.source : connection.target
   ) as Plane;
@@ -65,8 +66,16 @@ export function Port(props: PortProps) {
             target: connectedPlane.plane,
           });
         }}
-        onMouseLeave={() => {
-          setConnectionHighlight(undefined);
+        onMouseLeave={() => setConnectionHighlight(undefined)}
+        onDoubleClick={() => {
+          setZoomToX(
+            connectedPlane.position.x +
+              (zoomToX === connectedPlane.position.x ? 0.1 : 0),
+          );
+          setZoomToY(
+            connectedPlane.position.y +
+              (zoomToY === connectedPlane.position.y ? 0.1 : 0),
+          );
         }}
       >
         <svg

--- a/tgui/packages/tgui/interfaces/PlaneMasterDebug/index.tsx
+++ b/tgui/packages/tgui/interfaces/PlaneMasterDebug/index.tsx
@@ -1,4 +1,3 @@
-import { timeout } from 'es-toolkit';
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,

--- a/tgui/packages/tgui/interfaces/PlaneMasterDebug/index.tsx
+++ b/tgui/packages/tgui/interfaces/PlaneMasterDebug/index.tsx
@@ -1,3 +1,4 @@
+import { timeout } from 'es-toolkit';
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
@@ -6,7 +7,6 @@ import {
   Stack,
   Tooltip,
 } from 'tgui-core/components';
-
 import { resolveAsset } from '../../assets';
 import { useBackend } from '../../backend';
 import { Window } from '../../layouts';
@@ -507,6 +507,9 @@ export function PlaneMasterDebug() {
   const [connectionOpen, setConnectionOpen] = useState<boolean>(false);
   const [infoOpen, setInfoOpen] = useState<boolean>(false);
   const [planeOpen, setPlaneOpen] = useState<boolean>(false);
+  const [zoomToX, setZoomToX] = useState<number>();
+  const [zoomToY, setZoomToY] = useState<number>();
+  const [zoomToPlane, setZoomToPlane] = useState<string>();
 
   return (
     <PlaneDebugContext.Provider
@@ -522,6 +525,10 @@ export function PlaneMasterDebug() {
         planeOpen,
         setPlaneOpen,
         planesProcessed,
+        zoomToX,
+        setZoomToX,
+        zoomToY,
+        setZoomToY,
       }}
     >
       <Window
@@ -529,7 +536,26 @@ export function PlaneMasterDebug() {
         height={800}
         title={`Plane Debugging: ${mob_name}`}
         buttons={
-          <Stack>
+          <Stack fill>
+            <Stack.Item>
+              <Dropdown
+                options={planes.map((plane) => plane.name).sort()}
+                placeholder="Find Plane"
+                selected={zoomToPlane}
+                onSelected={(value) => {
+                  setZoomToPlane(value);
+                  const locatedPlane = planes.find(
+                    (plane) => plane.name === value,
+                  );
+                  if (locatedPlane) {
+                    const position =
+                      planesProcessed[locatedPlane.plane].position;
+                    setZoomToX(position.x + (zoomToX === position.x ? 0.1 : 0));
+                    setZoomToY(position.y + (zoomToY === position.y ? 0.1 : 0));
+                  }
+                }}
+              />
+            </Stack.Item>
             {!!enable_group_view && (
               <Tooltip
                 content="Plane masters are stored in groups, based off where they came from. MAIN is the main group, but if you open something that displays atoms in a new window, it'll show up here."
@@ -603,6 +629,8 @@ export function PlaneMasterDebug() {
             imageWidth={900}
             initialLeft={500}
             initialTop={-1350}
+            zoomToX={-(zoomToX || 0) + 525}
+            zoomToY={-(zoomToY || 0) + 300}
           >
             {planes.map((plane) => (
               <PlaneMaster

--- a/tgui/packages/tgui/interfaces/PlaneMasterDebug/usePlaneDebug.ts
+++ b/tgui/packages/tgui/interfaces/PlaneMasterDebug/usePlaneDebug.ts
@@ -19,6 +19,10 @@ type PlaneDebug = {
   planeOpen: boolean;
   setPlaneOpen: Dispatch<SetStateAction<boolean>>;
   planesProcessed: PlaneMap;
+  zoomToX: number | undefined;
+  setZoomToX: Dispatch<SetStateAction<number | undefined>>;
+  zoomToY: number | undefined;
+  setZoomToY: Dispatch<SetStateAction<number | undefined>>;
 };
 
 export const PlaneDebugContext = createContext({} as PlaneDebug);


### PR DESCRIPTION

## About The Pull Request

Adds a dropdown listing all planes to the top bar of the planecube debugger which sends the view to the selected plane upon using. Double clicking connection nodes also sends the camera to the plane the other end of the connection is linked to.

## Why It's Good For The Game

Lets us code and debug stuff easier

## Changelog
:cl:
admin: Added jump and search functions to the planecube debugger
/:cl:
