### PR TITLE
Fixes malf AI destroy rcds power not fully exploding Mech RCDs

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -610,6 +610,23 @@
 		return gundam.use_energy(amount * MASS_TO_ENERGY)
 	return TRUE
 
+/obj/item/construction/rcd/exosuit/detonate_pulse()
+	var/obj/item/mecha_parts/mecha_equipment/rcd/ourshell = loc
+	if(!istype(ourshell))
+		return
+	ourshell.audible_message(span_danger("<b>[ourshell] begins to vibrate and buzz loudly!</b>"), \
+	span_danger("<b>[ourshell] begins vibrating violently!</b>"))
+	// 5 seconds to get rid of it
+	addtimer(CALLBACK(src, PROC_REF(detonate_pulse_explode)), 5 SECONDS)
+
+/obj/item/construction/rcd/exosuit/detonate_pulse_explode()
+	var/obj/item/mecha_parts/mecha_equipment/rcd/ourshell = loc
+	explosion(ourshell, light_impact_range = 3, flame_range = 1, flash_range = 1)
+	if(owner)
+		ourshell.detach()
+	qdel(ourshell)
+
+
 #undef MASS_TO_ENERGY
 
 #undef FREQUENT_USE_DEBUFF_MULTIPLIER

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -505,10 +505,11 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 	cooldown_period = 10 SECONDS
 
 /datum/action/innate/ai/destroy_rcds/Activate()
-	for(var/I in GLOB.rcd_list)
-		if(!istype(I, /obj/item/construction/rcd/borg)) //Ensures that cyborg RCDs are spared.
-			var/obj/item/construction/rcd/RCD = I
-			RCD.detonate_pulse()
+	for(var/potential_rcd in GLOB.rcd_list)
+		if(istype(potential_rcd, /obj/item/construction/rcd/borg)) //Ensures that cyborg RCDs are spared.
+			continue
+		var/obj/item/construction/rcd/definite_rcd = potential_rcd
+		definite_rcd.detonate_pulse()
 	to_chat(owner, span_danger("RCD detonation pulse emitted."))
 	owner.playsound_local(owner, 'sound/machines/beep/twobeep.ogg', 50, 0)
 


### PR DESCRIPTION

## About The Pull Request

Malf AI blow rcds didnt work right on mech rcd module, because the module isn't an RCD and simply holds an internal real rcd. This led to the rcd "blowing" but remaining intact, just useless as its internal rcd was gone. This modifies the exosuit variant internal RCD's detonation proc such that it properly destroys the fake rcd shell. 

## Why It's Good For The Game

fixes #93921

## Changelog
:cl:

fix: Malf AI "Destroy RCDs" power now properly destroys mech RCDs

/:cl:
