### PR TITLE
Removes soup pot from technode

### DIFF
--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -190,19 +190,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
-/datum/design/soup_pot
-	name = "Soup Pot"
-	id = "souppot"
-	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT*5, /datum/material/bluespace =SMALL_MATERIAL_AMOUNT*4)
-	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_EQUIPMENT)
-	build_path = /obj/item/reagent_containers/cup/soup_pot
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_KITCHEN,
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
-
 /datum/design/bowl
 	name = "Bowl"
 	id = "bowl"

--- a/code/modules/research/techweb/nodes/service_nodes.dm
+++ b/code/modules/research/techweb/nodes/service_nodes.dm
@@ -146,7 +146,6 @@
 		"oven",
 		"stove",
 		"range",
-		"souppot",
 		"processor",
 		"gibber",
 		"monkey_recycler",


### PR DESCRIPTION
## About The Pull Request
This removes printable soup pots

## Why It's Good For The Game
<img width="915" height="378" alt="image" src="https://github.com/user-attachments/assets/827f193b-56bb-4046-8ffe-eb0c9dfa0626" />
Just get it from the vendor or order restocking units.

## Changelog
:cl: ezel
balance: You can no longer print soup pots
/:cl:
