### PR TITLE
Removes acidentally placed stuff in Catwalk transit tube

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -17654,7 +17654,6 @@
 /area/station/maintenance/starboard/lesser)
 "eUl" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -70041,12 +70040,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"tse" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/transit_tube)
 "tsl" = (
 /obj/machinery/modular_computer/preset/id,
 /obj/machinery/requests_console/auto_name/directional/north,
@@ -198814,7 +198807,7 @@ qcT
 xsS
 ifs
 xsS
-tse
+xsS
 iXH
 vfb
 spb


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

that looks silly no?
<img width="437" height="352" alt="image" src="https://github.com/user-attachments/assets/d65497e9-a6ea-4be2-bbf0-c97c8c7ff697" />


## Changelog

:cl:
fix: Removed hanging fire alarm and decal in Catwalk transit tube.
/:cl: