### PR TITLE
Shutters for service area on WawaStation

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -13745,6 +13745,10 @@
 /area/station/command/heads_quarters/cmo)
 "eOY" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics shutters";
+	id = "hydroponics_shutters"
+	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "eOZ" = (
@@ -17639,6 +17643,10 @@
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
 	name = "HoochMaster Deluxe"
 	},
+/obj/machinery/button/door/directional/west{
+	name = "Bar shuttters";
+	id = "bar_shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "ghU" = (
@@ -19886,6 +19894,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/door/directional/north{
+	name = "Hydroponics shutters";
+	id = "hydroponics_shutters"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gUv" = (
@@ -25481,6 +25493,10 @@
 /area/station/commons/fitness/recreation)
 "iRL" = (
 /obj/structure/sink/kitchen/directional/east,
+/obj/machinery/button/door/directional/west{
+	id = "kitchen_counter";
+	name = "Kitchen Shutters"
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iRR" = (
@@ -26416,6 +26432,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bar_shutters";
+	name = "Bar shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "jkG" = (
@@ -27141,6 +27162,11 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bar_shutters";
+	name = "Bar shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -29227,6 +29253,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics shutters";
+	id = "hydroponics_shutters"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ked" = (
@@ -32001,6 +32031,11 @@
 	},
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bar_shutters";
+	name = "Bar shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "kYZ" = (
@@ -32069,6 +32104,10 @@
 	req_access = list("hydroponics")
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics shutters";
+	id = "hydroponics_shutters"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "lac" = (
@@ -41332,6 +41371,11 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bar_shutters";
+	name = "Bar shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "oqj" = (
@@ -56120,6 +56164,10 @@
 	},
 /obj/structure/desk_bell,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics shutters";
+	id = "hydroponics_shutters"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tla" = (
@@ -59766,6 +59814,11 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/effect/spawner/random/entertainment/lighter,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bar_shutters";
+	name = "Bar shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "uwx" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -4875,6 +4875,11 @@
 /obj/item/paper,
 /obj/item/pen,
 /obj/effect/turf_decal/stripes/box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics Shutters";
+	id = "hydroponics_shutters";
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bHc" = (
@@ -13746,7 +13751,7 @@
 "eOY" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
-	name = "Hydroponics shutters";
+	name = "Hydroponics Shutters";
 	id = "hydroponics_shutters"
 	},
 /turf/open/floor/plating,
@@ -26435,7 +26440,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "bar_shutters";
-	name = "Bar shutters"
+	name = "Bar Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -27166,7 +27171,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "bar_shutters";
-	name = "Bar shutters"
+	name = "Bar Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -29254,7 +29259,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/door/poddoor/shutters/preopen{
-	name = "Hydroponics shutters";
+	name = "Hydroponics Shutters";
 	id = "hydroponics_shutters"
 	},
 /turf/open/floor/iron,
@@ -32034,7 +32039,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "bar_shutters";
-	name = "Bar shutters"
+	name = "Bar Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -32105,7 +32110,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	name = "Hydroponics shutters";
+	name = "Hydroponics Shutters";
 	id = "hydroponics_shutters"
 	},
 /turf/open/floor/iron,
@@ -41374,7 +41379,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "bar_shutters";
-	name = "Bar shutters"
+	name = "Bar Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -43617,6 +43622,11 @@
 /area/station/engineering/main)
 "pco" = (
 /obj/machinery/biogenerator,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics Shutters";
+	id = "hydroponics_shutters";
+	dir = 8
+	},
 /turf/closed/wall,
 /area/station/service/hydroponics)
 "pcN" = (
@@ -56165,7 +56175,7 @@
 /obj/structure/desk_bell,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	name = "Hydroponics shutters";
+	name = "Hydroponics Shutters";
 	id = "hydroponics_shutters"
 	},
 /turf/open/floor/iron,
@@ -59817,7 +59827,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "bar_shutters";
-	name = "Bar shutters"
+	name = "Bar Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -62822,6 +62832,11 @@
 /area/station/command/corporate_showroom)
 "vCL" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Hydroponics Shutters";
+	id = "hydroponics_shutters";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "vCQ" = (


### PR DESCRIPTION
## About The Pull Request

adds shutters in bar, hydroponics and a missing button for kitchen shutters.

## Why It's Good For The Game

i feel like service jobs should be able to isolate their workplace from this cruel world..

## Changelog

:cl:
map: Added shutters in some of service areas on WawaStation.
/:cl:
