### PR TITLE
Pandemic machine QOL

### DIFF
--- a/code/__HELPERS/logging/virus.dm
+++ b/code/__HELPERS/logging/virus.dm
@@ -11,4 +11,4 @@
 	var/list/name_symptoms = list()
 	for(var/datum/symptom/S in symptoms)
 		name_symptoms += S.name
-	return "[name] - sym: [english_list(name_symptoms)] re:[totalResistance()] st:[totalStealth()] ss:[totalStageSpeed()] tr:[totalTransmittable()]"
+	return "[name] - sym: [english_list(name_symptoms)] re:[totalResistance()] st:[totalStealth()] ss:[totalStageSpeed()] tr:[totalTransmittable()] se:[totalSeverity()]"

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -543,6 +543,9 @@
 /datum/disease/advance/proc/totalTransmittable()
 	return properties["transmittable"]
 
+/datum/disease/advance/proc/totalSeverity()
+	return properties["severity"]
+
 /**
  *  If the disease has an incubation time (such as event diseases) start the timer, let properties determine if there's no timer set.
  */

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -99,12 +99,12 @@
 	if(machine_stat & (NOPOWER|BROKEN))
 		return ..()
 	if(beaker)
-		balloon_alert(user, "pandemic full!")
-		return ..()
-	if(!user.transferItemToLoc(held_item, src))
-		return ..()
+		balloon_alert(user, "beaker swapped")
+		try_put_in_hand(beaker, usr)
+	else
+		balloon_alert(user, "beaker loaded")
+	user.transferItemToLoc(held_item, src)
 	beaker = held_item
-	balloon_alert(user, "beaker loaded")
 	update_appearance()
 	SStgui.update_uis(src)
 
@@ -248,7 +248,7 @@
 	update_appearance()
 	var/turf/source_turf = get_turf(src)
 	log_virus("A culture tube was printed for the virus [adv_disease.admin_details()] at [loc_name(source_turf)] by [key_name(usr)]")
-	addtimer(CALLBACK(src, PROC_REF(reset_replicator_cooldown)), 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(reset_replicator_cooldown)), 1.5 SECONDS)
 	return TRUE
 
 /// Tries to locate a reagent with valid blood_type data
@@ -363,6 +363,7 @@
 			traits["resistance"] = adv_disease.totalResistance()
 			traits["stage_speed"] = adv_disease.totalStageSpeed()
 			traits["stealth"] = adv_disease.totalStealth()
+			traits["severity"] = adv_disease.totalSeverity()
 			traits["symptoms"] = list()
 			for(var/datum/symptom/symptom as anything in adv_disease.symptoms)
 				var/list/this_symptom = list()

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -248,7 +248,7 @@
 	update_appearance()
 	var/turf/source_turf = get_turf(src)
 	log_virus("A culture tube was printed for the virus [adv_disease.admin_details()] at [loc_name(source_turf)] by [key_name(usr)]")
-	addtimer(CALLBACK(src, PROC_REF(reset_replicator_cooldown)), 1.5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(reset_replicator_cooldown)), 5 SECONDS)
 	return TRUE
 
 /// Tries to locate a reagent with valid blood_type data

--- a/tgui/packages/tgui/interfaces/Pandemic/Virus.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Virus.tsx
@@ -78,7 +78,7 @@ const Info = (props) => {
  */
 const Traits = (props) => {
   const {
-    virus: { resistance, stage_speed, stealth, transmission },
+    virus: { resistance, stage_speed, stealth, transmission, severity },
   } = props;
 
   return (
@@ -105,6 +105,14 @@ const Traits = (props) => {
             label="Transmissibility"
           >
             {transmission}
+          </LabeledList.Item>
+        </Tooltip>
+        <Tooltip content="Overall danger posed by the disease.">
+          <LabeledList.Item
+            color={getColor(severity)}
+            label="Severity"
+          >
+            {severity}
           </LabeledList.Item>
         </Tooltip>
       </LabeledList>


### PR DESCRIPTION
## About The Pull Request

You can swap beakers in a pandemic and the overall virus severity is now displayed as a stat.

## Why It's Good For The Game

more convenient

## Changelog

:cl:
qol: you can swap beakers in a pandemic
qol: pandemics now display overall virus severity
admin: virus logs now include severity along with other stats
/:cl: