### PR TITLE
Fixes arcade machine experiment endlessly winning

### DIFF
--- a/code/modules/experisci/experiment/physical_experiments.dm
+++ b/code/modules/experisci/experiment/physical_experiments.dm
@@ -24,6 +24,7 @@
 /datum/experiment/physical/meat_wall_explosion/proc/check_experiment(datum/source, obj/projectile/proj)
 	SIGNAL_HANDLER
 	if(istype(proj, /obj/projectile/beam/emitter))
+		UnregisterSignal(currently_scanned_atom, COMSIG_ATOM_BULLET_ACT)
 		finish_experiment(linked_experiment_handler)
 
 /datum/experiment/physical/meat_wall_explosion/finish_experiment(datum/component/experiment_handler/experiment_handler, datum/techweb/linked_web_override)
@@ -55,4 +56,5 @@
 
 /datum/experiment/physical/arcade_winner/proc/win_arcade(datum/source)
 	SIGNAL_HANDLER
+	UnregisterSignal(currently_scanned_atom, COMSIG_ARCADE_VICTORY)
 	finish_experiment(linked_experiment_handler)


### PR DESCRIPTION

## About The Pull Request

Physical experiments don't call `unregister_events()` on completion like normal experiments do, due to how they're finished. This led to the arcade experiment never unregistering its victory signal and completing over and over again. This pr unregisters the arcade's signal upon completion, preventing this spam.

This also applies the same fix to the `meat_wall_explosion` experiment, which isn't doable because it isn't referenced anywhere(anybody know what's up with that? seems like a neat experiment), but it'd also have not unregistered its signal upon completion.

## Why It's Good For The Game

fixes #94174

## Changelog
:cl:

fix: Video game winning experiment no longer completes over and over 

/:cl:
