### PR TITLE
Makes AB_CHECK_CONSCIOUS checks say you're dead if you're dead

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -178,6 +178,10 @@
 		return FALSE
 	if(action_disabled)
 		return FALSE
+	if((check_flags & AB_CHECK_CONSCIOUS) && owner.stat != CONSCIOUS)
+		if (feedback)
+			owner.balloon_alert(owner, "[owner.stat == DEAD ? "dead" : "unconscious"]!")
+		return FALSE
 	if((check_flags & AB_CHECK_HANDS_BLOCKED) && HAS_TRAIT(owner, TRAIT_HANDS_BLOCKED))
 		if (feedback)
 			owner.balloon_alert(owner, "hands blocked!")
@@ -196,10 +200,6 @@
 			if (feedback)
 				owner.balloon_alert(owner, "must stand up!")
 			return FALSE
-	if((check_flags & AB_CHECK_CONSCIOUS) && owner.stat != CONSCIOUS)
-		if (feedback)
-			owner.balloon_alert(owner, "unconscious!")
-		return FALSE
 	if((check_flags & AB_CHECK_PHASED) && HAS_TRAIT(owner, TRAIT_MAGICALLY_PHASED))
 		if (feedback)
 			owner.balloon_alert(owner, "incorporeal!")


### PR DESCRIPTION

## About The Pull Request

Makes the `AB_CHECK_CONSCIOUS` check in `is_available()` specify you're dead if you're dead, rather than unconcious. Also moves it up to the top of the checks, so that it'll say the much more glaring issue of death before something like "incapacitated' or "hands blocked" or "laying down"

## Why It's Good For The Game

closes #94173

## Changelog
:cl:

spellcheck: abilities that check for consciousness will say you're dead rather than unconscious if you're dead

/:cl:
