### PR TITLE
Fix grafting not applying stats when trait is rejected

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -570,7 +570,7 @@
 	if(new_trait?.can_add(src))
 		genes += new_trait
 	else
-		return
+		new_trait = null
 
 	// Adjust stats based on graft stats
 	set_lifespan(round(max(lifespan, (lifespan + (2/3)*(snip.plant_dna.lifespan - lifespan)))))


### PR DESCRIPTION

## About The Pull Request
Instead of stopping the function when the grafted trait is rejected I set `new_trait` to `null`
This allows the stat adjustments to always apply
The function still returns the trait or null so the tray can show the correct message


## Why It's Good For The Game
fix https://github.com/tgstation/tgstation/issues/94060



## Changelog
:cl:
fix: graft stat adjustments now apply even when the trait is rejected
:cl:
