### PR TITLE
Fixes custom vendor not sanitizing item names

### DIFF
--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -272,8 +272,7 @@
 		return
 	var/obj/item/dispensed_item = params["ref"]
 	for(var/obj/item/product in contents - component_parts)
-		var/thing = ITEM_HASH(product)
-		if(thing == dispensed_item)
+		if(ITEM_HASH(product) == dispensed_item)
 			dispensed_item = product
 			break
 

--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -1,5 +1,5 @@
-///This unique key decides how items are stacked on the UI. We separate them based on name,price & type
-#define ITEM_HASH(item)("[item.name][item.custom_price][item.type]")
+///This unique key decides how items are stacked on the UI. We separate them based on name, price & type
+#define ITEM_HASH(item)(sanitize_css_class_name("[item.name][item.custom_price][item.type]"))
 
 /obj/machinery/vending/custom
 	name = "Custom Vendor"
@@ -272,7 +272,8 @@
 		return
 	var/obj/item/dispensed_item = params["ref"]
 	for(var/obj/item/product in contents - component_parts)
-		if(ITEM_HASH(product) == dispensed_item)
+		var/thing = ITEM_HASH(product)
+		if(thing == dispensed_item)
 			dispensed_item = product
 			break
 	if(QDELETED(dispensed_item))

--- a/code/modules/vending/custom.dm
+++ b/code/modules/vending/custom.dm
@@ -276,8 +276,6 @@
 		if(thing == dispensed_item)
 			dispensed_item = product
 			break
-	if(QDELETED(dispensed_item))
-		return
 
 	var/obj/item/card/id/id_card = user.get_idcard(TRUE)
 	if(QDELETED(id_card))


### PR DESCRIPTION
## About The Pull Request
- Fixes https://github.com/tgstation/tgstation/pull/91987#issuecomment-3573314355

Strings such as `\improper` and other non alphanumeric characters that are stripped out when sent to the UI are now discarded so we don't end up with malformed hashes

## Changelog
:cl:
fix: items such as dna injectors and others that have strange characters in their names can now be dispensed from custom vending machines
/:cl:

