### PR TITLE
Durability header no longer appears twice when inspecting armor

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -405,7 +405,7 @@
 				continue
 			if(!added_durability_header)
 				readout += "<b><u>DURABILITY (I-X)</u></b>"
-				added_damage_header = TRUE
+				added_durability_header = TRUE
 			readout += "[armor_to_protection_name(durability_key)] [armor_to_protection_class(rating)]"
 
 		if((flags_cover & HEADCOVERSMOUTH) || (flags_cover & PEPPERPROOF))


### PR DESCRIPTION
## About The Pull Request

Small code typo fix. When you inspect the tag on armor, it doesn't put the durability header once before acid and then once again before fire. Atomized from #94190 

<img width="371" height="255" alt="image" src="https://github.com/user-attachments/assets/750f81ee-5b21-4d68-9175-d622d60a81d3" />

If you need a visual this is what it looks like without the PR. With the PR it's the same thing but without the second "DURABILITY (I-X)"

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: Durability header no longer appears twice when inspecting armor
/:cl: