### PR TITLE
Weapon rechargers don't wait an extra tick before announcing they're finished

### DIFF
--- a/code/game/objects/items/wind_turbine.dm
+++ b/code/game/objects/items/wind_turbine.dm
@@ -26,8 +26,6 @@
 	var/obj/item/charging = null
 	///Did we put power into "charging" last process()?
 	var/using_power = FALSE
-	///Did we finish recharging the currently inserted item?
-	var/finished_recharging = FALSE
 
 	///Current rotor animation frame. (floating point value).
 	var/rotor_tick = 0
@@ -231,7 +229,6 @@
 	if(is_type_in_typecache(arrived, allowed_devices))
 		charging = arrived
 		START_PROCESSING(SSmachines, src)
-		finished_recharging = FALSE
 		using_power = TRUE
 		update_appearance()
 	return ..()
@@ -313,17 +310,16 @@
 	if(charging_cell)
 		var/wanted_power = min(charging_cell.maxcharge - charging_cell.charge, charging_cell.chargerate)
 		if(wanted_power > 0)
-			using_power = TRUE
 			var/power_to_give = min(available_power, wanted_power) * seconds_per_tick / 2
 			if (power_to_give > 0)
 				charging_cell.give(power_to_give)
 				available_power -= power_to_give
+				if(charging_cell.charge == charging_cell.maxcharge)
+					playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
+					say("[charging] has finished recharging!")
+				else
+					using_power = TRUE
 		update_appearance()
-
-	if(!using_power && !finished_recharging) //Inserted thing is at max charge/ammo, notify those around us
-		finished_recharging = TRUE
-		playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
-		say("[charging] has finished recharging!")
 
 /obj/item/portable_wind_turbine/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Currently they announce they're done if they attempt to recharge and find out that the battery is already full. This PR makes it so that they announce after they perform a successful charge that fills the battery to max. Also gets rid of an unnecessary variable along the way. Also when a battle rifle finishes recalibrating it'll say that it finished recalibrating instead of recharging.

## Why It's Good For The Game

You can already inspect the charger to check the weapon's charge and take the weapon out once it hits 100% even before it alerts you. This just makes it not wait 2 seconds for no reason.

Also spellcheck.

## Changelog

:cl:
qol: weapon rechargers don't wait an extra tick before announcing they've finished recharging
spellcheck: weapon rechargers no longer claim a battle rifle has "finished recharging" when it's finished recalibrating.
/:cl:
