### PR TITLE
Lattice ignore slowdown of turf and stop immersive overlay from water

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -16,7 +16,7 @@
 	canSmoothWith = SMOOTH_GROUP_LATTICE + SMOOTH_GROUP_WALLS + SMOOTH_GROUP_OPEN_FLOOR
 	var/number_of_mats = 1
 	var/build_material = /obj/item/stack/rods
-	var/list/give_turf_traits = list(TRAIT_CHASM_STOPPED, TRAIT_HYPERSPACE_STOPPED)
+	var/list/give_turf_traits = list(TRAIT_CHASM_STOPPED, TRAIT_HYPERSPACE_STOPPED, TRAIT_TURF_IGNORE_SLOWDOWN, TRAIT_IMMERSE_STOPPED)
 
 /obj/structure/lattice/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
first part is prob a balance thing but the immersive part feels like an oversight.

Current behavior (catwalks already have both the traits im adding)

https://github.com/user-attachments/assets/2f1b44f3-5942-4e54-9e9a-c6ae9b9bde9e

## Why It's Good For The Game
For the immersive part, it looks bad as its half submersed yet you also sink just as much despite it feeling like something you would stand on.

For a similar logic, lattice seem like something you should be able to walk ontop of. thus ignoring the slowdown of the turf underneath it. It stops you from falling into both chasms and hyperspace. It would likely stop you from dredging through mud or similar turfs that have slowdown

## Changelog
:cl:
balance: Lattice now ignore the slowdowns of turfs
fix: Lattice now stop you from dipping into water
/:cl:
