### PR TITLE
Radioactive Resonance grammar

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -617,8 +617,7 @@
 	symptom_delay_max = 1
 	passive_message = span_notice("Your skin glows faintly for a moment.")
 	threshold_descs = list(
-		"Transmission 6" = "Additionally heals cellular damage.",
-		"Resistance 7" = "Increases healing speed.",
+		"Resistance 7" = "Increases healing speed."
 	)
 
 /datum/symptom/heal/radiation/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -617,7 +617,7 @@
 	symptom_delay_max = 1
 	passive_message = span_notice("Your skin glows faintly for a moment.")
 	threshold_descs = list(
-		"Resistance 7" = "Increases healing speed."
+		"Resistance 7" = "Increases healing speed.",
 	)
 
 /datum/symptom/heal/radiation/Start(datum/disease/advance/A)


### PR DESCRIPTION
## About The Pull Request

closes #94197

## Why It's Good For The Game

glorious days of cellular damage are over

## Changelog

:cl:
spellcheck: Removed cellular damage mention from Radioactive Resonance virus description.
/:cl:
