### PR TITLE
Adds missing "require all" type of access for Bitrunning Den

### DIFF
--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -862,6 +862,11 @@
 	access_list += ACCESS_VAULT
 	return access_list
 
+/obj/effect/mapping_helpers/airlock/access/all/supply/bit_den/get_access()
+	var/list/access_list = ..()
+	access_list += ACCESS_BIT_DEN
+	return access_list
+
 // -------------------- Syndicate access helpers
 /obj/effect/mapping_helpers/airlock/access/all/syndicate
 	icon_state = "access_helper_syn"


### PR DESCRIPTION
## About The Pull Request

title

## Changelog

:cl:
fix: Added missing "require all" type of access for Bitrunning Den.
/:cl:
