### PR TITLE
Plum

### DIFF
--- a/code/game/objects/effects/spawners/random/food_or_drink.dm
+++ b/code/game/objects/effects/spawners/random/food_or_drink.dm
@@ -110,7 +110,7 @@
 		/obj/item/food/grown/onion,
 		/obj/item/food/grown/peanut,
 		/obj/item/food/grown/pineapple,
-		/obj/item/seeds/plum,
+		/obj/item/food/grown/plum,
 		/obj/item/food/grown/potato,
 		/obj/item/food/grown/pumpkin,
 		/obj/item/food/grown/carrot,


### PR DESCRIPTION
## About The Pull Request

replaced seed plum item on actually grown plum

## Why It's Good For The Game

pr #92519 introduced new grown food spawner and i believe acidentally placed plum seeds instead of grown plum

## Changelog

:cl:
fix: Plant produce spawner now correctly spawns plum instead of plum seeds.
/:cl:
