### PR TITLE
Guards against qdeletion in afterattack

### DIFF
--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -69,6 +69,8 @@ GLOBAL_DATUM(bridge_axe, /obj/item/fireaxe)
 		return
 	if(target.resistance_flags & INDESTRUCTIBLE)
 		return
+	if(QDELETED(target))
+		return
 	if(istype(target, /obj/structure/window) || istype(target, /obj/structure/grille))
 		target.atom_destruction("fireaxe")
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -157,7 +157,7 @@
 
 // This is where stun gets applied
 /obj/item/melee/baton/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
-	if(!isliving(target) || !active || !COOLDOWN_FINISHED(src, cooldown_check) || HAS_TRAIT_FROM(target, TRAIT_IWASBATONED, REF(user)))
+	if(!isliving(target) || !active || !COOLDOWN_FINISHED(src, cooldown_check) || HAS_TRAIT_FROM(target, TRAIT_IWASBATONED, REF(user)) || QDELETED(target))
 		return
 	// worst check in the chain but - right click = harmbaton
 	if(LAZYACCESS(modifiers, RIGHT_CLICK) && !stun_on_harmbaton)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -219,7 +219,7 @@
 	return ..()
 
 /obj/item/melee/beesword/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
-	if(iscarbon(target))
+	if(iscarbon(target) && !QDELETED(target))
 		var/mob/living/carbon/carbon_target = target
 		carbon_target.reagents.add_reagent(/datum/reagent/toxin, 4)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1058,6 +1058,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		))
 	AddElement(/datum/element/bane, mob_biotypes = MOB_BUG,  target_type = /mob/living/basic, damage_multiplier = 0, added_damage = 24, requires_combat_mode = FALSE)
 
+/obj/item/melee/flyswatter/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	if(is_type_in_typecache(target, splattable))
 		to_chat(user, span_warning("You easily splat [target]."))
 		if(QDELETED(target))

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1058,9 +1058,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		))
 	AddElement(/datum/element/bane, mob_biotypes = MOB_BUG,  target_type = /mob/living/basic, damage_multiplier = 0, added_damage = 24, requires_combat_mode = FALSE)
 
-/obj/item/melee/flyswatter/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	if(is_type_in_typecache(target, splattable))
 		to_chat(user, span_warning("You easily splat [target]."))
+		if(QDELETED(target))
+			return
 		if(isliving(target))
 			new /obj/effect/decal/cleanable/insectguts(target.drop_location())
 			var/mob/living/bug = target

--- a/code/game/objects/items/wizard_weapons.dm
+++ b/code/game/objects/items/wizard_weapons.dm
@@ -64,7 +64,7 @@
 		return
 
 	charged = FALSE
-	if(isliving(target))
+	if(isliving(target) && !QDELETED(target))
 		var/mob/living/smacked = target
 		smacked.take_bodypart_damage(20, 0)
 	playsound(user, 'sound/items/weapons/marauder.ogg', 50, TRUE)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -227,6 +227,8 @@
 	)
 
 /obj/item/melee/arm_blade/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	if(QDELETED(target))
+		return
 	if(istype(target, /obj/structure/table))
 		var/obj/smash = target
 		smash.deconstruct(FALSE)

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -166,7 +166,7 @@
 
 /obj/item/melee/sickly_blade/dark/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
-	if(!infused || target == user || !isliving(target))
+	if(!infused || target == user || !isliving(target) || QDELETED(target))
 		return
 	var/datum/antagonist/heretic/heretic_datum = GET_HERETIC(user)
 	var/mob/living/living_target = target

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -825,7 +825,7 @@ GLOBAL_LIST_INIT(nullrod_variants, init_nullrod_variants())
 	if(user == living_target)
 		return
 
-	if(living_target.stat == DEAD)
+	if(living_target.stat == DEAD || QDELETED(living_target))
 		return
 
 	sneak_attack(living_target, user)

--- a/code/modules/mapfluff/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/sin_ruins.dm
@@ -38,7 +38,7 @@
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 
 /obj/item/knife/envy/afterattack(atom/target, mob/living/carbon/human/user, list/modifiers, list/attack_modifiers)
-	if(!istype(user) || !ishuman(target))
+	if(!istype(user) || !ishuman(target) || QDELETED(target))
 		return
 
 	var/mob/living/carbon/human/H = target

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -99,6 +99,8 @@
 	return ..()
 
 /obj/item/gun/ballistic/automatic/pistol/clandestine/fisher/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	if(QDELETED(target))
+		return
 	var/obj/projectile/energy/fisher/melee/simulated_hit = new
 	simulated_hit.firer = user
 	simulated_hit.on_hit(target)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -29,11 +29,11 @@
 		return
 	if(bartender_check(target, thrower) && throwingdatum)
 		return
-	splash_reagents(target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
+	splash_reagents(QDELETED(target) ? target.drop_location() : target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
 	var/obj/item/broken_bottle/B = new (loc)
 	B.mimic_broken(src, target, break_top)
 	qdel(src)
-	target.Bumped(B)
+	target?.Bumped(B)
 
 /obj/item/reagent_containers/cup/glass/bullet_act(obj/projectile/proj)
 	. = ..()
@@ -378,11 +378,11 @@
 /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
 	if(bartender_check(target, thrower) && throwingdatum)
 		return
-	splash_reagents(target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
+	splash_reagents(QDELETED(target) ? target.drop_location() : target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
 	var/obj/item/broken_bottle/bottle_shard = new(drop_location())
 	bottle_shard.mimic_broken(src, target)
 	qdel(src)
-	target.Bumped(bottle_shard)
+	target?.Bumped(bottle_shard)
 
 /obj/item/reagent_containers/cup/glass/colocup
 	name = "colo cup"

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -382,7 +382,7 @@
 	var/obj/item/broken_bottle/bottle_shard = new(drop_location())
 	bottle_shard.mimic_broken(src, target)
 	qdel(src)
-	target?.Bumped(bottle_shard)
+	target.Bumped(bottle_shard)
 
 /obj/item/reagent_containers/cup/glass/colocup
 	name = "colo cup"

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -33,7 +33,7 @@
 	var/obj/item/broken_bottle/B = new (loc)
 	B.mimic_broken(src, target, break_top)
 	qdel(src)
-	target?.Bumped(B)
+	target.Bumped(B)
 
 /obj/item/reagent_containers/cup/glass/bullet_act(obj/projectile/proj)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -151,9 +151,8 @@
 	if(!isGlass)
 		return
 
+	var/head_hitter = user.zone_selected == BODY_ZONE_HEAD && isliving(target)
 	if(!QDELETED(target))
-		var/head_hitter = user.zone_selected == BODY_ZONE_HEAD && isliving(target)
-
 		// An attack that targets the head of a living mob will attempt to knock them down
 		if(head_hitter)
 			var/mob/living/living_target = target

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -133,8 +133,6 @@
 	var/obj/item/broken_bottle/broken = new(drop_location())
 	if(!throwingdatum && thrower)
 		thrower.put_in_hands(broken)
-	if(QDELETED(target))
-		target = null
 	broken.mimic_broken(src, target, break_top)
 	broken.inhand_icon_state = broken_inhand_icon_state
 	if(message_in_a_bottle)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -917,10 +917,9 @@
 				firestarter = 1
 				break
 	..()
-	if(QDELETED(target))
-		return
 	if(firestarter && active)
-		target.fire_act()
+		if(!QDELETED(target))
+			target.fire_act()
 		new /obj/effect/hotspot(get_turf(target))
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/item_interaction(mob/living/user, obj/item/item, list/modifiers)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -139,7 +139,7 @@
 		message_in_a_bottle.forceMove(drop_location())
 
 	qdel(src)
-	target?.Bumped(broken)
+	target.Bumped(broken)
 	return TRUE
 
 /obj/item/reagent_containers/cup/glass/bottle/try_splash(mob/user, atom/target)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -151,6 +151,9 @@
 	if(!isGlass)
 		return
 
+	if(QDELETED(target))
+		return
+
 	var/head_hitter = user.zone_selected == BODY_ZONE_HEAD && isliving(target)
 
 	// An attack that targets the head of a living mob will attempt to knock them down

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -267,7 +267,7 @@
 	else
 		if(prob(33))
 			var/obj/item/shard/stab_with = new(to_mimic.drop_location())
-			target?.Bumped(stab_with)
+			target.Bumped(stab_with)
 		playsound(src, SFX_SHATTER, 70, TRUE)
 	name = "broken [to_mimic.name]"
 	to_mimic.transfer_fingerprints_to(src)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -163,18 +163,18 @@
 			if(prob(knockdown_effectiveness))
 				living_target.Knockdown(min(knockdown_effectiveness, 20 SECONDS))
 
-		// Displays a custom message which follows the attack
-		if(target == user)
-			target.visible_message(
-				span_warning("[user] smashes [src] [head_hitter ? "over [user.p_their()] head" : "against [user.p_them()]selves"]!"),
-				span_warning("You smash [src] [head_hitter ? "over your head" : "against yourself"]!"),
-			)
+	// Displays a custom message which follows the attack
+	if(target == user)
+		user.visible_message(
+			span_warning("[user] smashes [src] [head_hitter ? "over [user.p_their()] head" : "against [user.p_them()]selves"]!"),
+			span_warning("You smash [src] [head_hitter ? "over your head" : "against yourself"]!"),
+		)
 
-		else
-			target.visible_message(
-				span_warning("[user] smashes [src] [head_hitter ? "over [target]'s head" : "against [target]"]!"),
-				span_warning("[user] smashes [src] [head_hitter ? "over your head" : "against you"]!"),
-			)
+	else
+		user.visible_message(
+			span_warning("[user] smashes [src] [head_hitter ? "over [target]'s head" : "against [target]"]!"),
+			span_warning("[user] smashes [src] [head_hitter ? "over your head" : "against you"]!"),
+		)
 
 	// Finally, smash the bottle. This kills (del) the bottle and also does all the logging for us
 	smash(target, user)

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -28,8 +28,6 @@ Slimecrossing Weapons
 	damtype = BRUTE
 
 /obj/item/knife/rainbowknife/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
-	if(QDELETED(target))
-		return
 	if(isliving(target))
 		damtype = pick(BRUTE, BURN, TOX, OXY)
 	switch(damtype)

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -28,6 +28,8 @@ Slimecrossing Weapons
 	damtype = BRUTE
 
 /obj/item/knife/rainbowknife/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	if(QDELETED(target))
+		return
 	if(isliving(target))
 		damtype = pick(BRUTE, BURN, TOX, OXY)
 	switch(damtype)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -12,6 +12,8 @@
 	sharpness = SHARP_EDGED
 
 /obj/item/mutant_hand/zombie/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	if(QDELETED(target))
+		return
 	if(ishuman(target))
 		try_to_zombie_infect(target, user, user.zone_selected)
 	else if(isliving(target))


### PR DESCRIPTION
## About The Pull Request

AKA please stop, it's already dead.

A number of items have effects that are applied in afterattack which should run on the mob itself, so afterattack is supposed to always run even if the attacked target was qdeleted.

However there are also a number of effects that run on the target of the attack. Ranging from infecting with a zombie virus, unlocking doors, etc. 

The latter can often lead to a lot of runtimes, timers being added to qdeleted things from balloon alerts, hard deletes potentially if a trait or reagent gets added...etc.

So this PR just adds guards against these cases and stops doing whatever it was we were going if the attacked atom got deleted (if what we were going to do applied to the deleted atom).

## Why It's Good For The Game

Fixes some jankiness

## Changelog


Not really player-facing honestly