### PR TITLE
Splits medical first aid kits in its own crate at cargo

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -99,11 +99,6 @@
 					/obj/item/storage/box/medigels,
 					/obj/item/storage/box/syringes,
 					/obj/item/storage/box/bodybags,
-					/obj/item/storage/medkit/regular,
-					/obj/item/storage/medkit/o2,
-					/obj/item/storage/medkit/toxin,
-					/obj/item/storage/medkit/brute,
-					/obj/item/storage/medkit/fire,
 					/obj/item/defibrillator/loaded,
 					/obj/item/reagent_containers/blood/o_minus,
 					/obj/item/storage/pill_bottle/mining,
@@ -118,6 +113,25 @@
 
 /datum/supply_pack/medical/supplies/fill(obj/structure/closet/crate/C)
 	for(var/i in 1 to 10)
+		var/item = pick(contains)
+		new item(C)
+
+/datum/supply_pack/medical/kits
+	name = "Medical Kits Assortment Crate"
+	desc = "Contains a random assortment of medical first-aid kits."
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/item/storage/medkit/regular,
+					/obj/item/storage/medkit/o2,
+					/obj/item/storage/medkit/toxin,
+					/obj/item/storage/medkit/brute,
+					/obj/item/storage/medkit/fire,
+				)
+	crate_name = "medical kits assortment crate"
+	crate_type = /obj/structure/closet/crate/medical
+	test_ignored = TRUE
+
+/datum/supply_pack/medical/kits/fill(obj/structure/closet/crate/C)
+	for(var/i in 1 to 4)
 		var/item = pick(contains)
 		new item(C)
 


### PR DESCRIPTION
## About The Pull Request
This splits medical first aid kits from medical supplies crate into its own crate

The crate costs 1000 credits and will include 4 random type of medkits.


## Why It's Good For The Game
Medical supplies order is cool but usually its also the most useless one since its randomness affects it alot you could go from getting some medkits to just bodybags and beakers. this is a option to remove the randomness but a little more expensive since its gauranteed medkits make cargo have a better way to spend money(and gives medical a more solid choice aswell when it comes what to order)

## Changelog
:cl: Ezel
balance: Medical first-aid kits are split from medical supplies crate and is now its own order pack
/:cl:
