### PR TITLE
Removes rogue decal in a wall of catwalkstation

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -55773,9 +55773,6 @@
 /turf/open/openspace,
 /area/station/engineering/atmos/project)
 "ppa" = (
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/medical/surgery)


### PR DESCRIPTION
## About The Pull Request
Removes decals from inside a wall

## Why It's Good For The Game
We can't admire things covered by walls

## Changelog
:cl: Ezel
fix: Removes rogue decal from catwalk station
/:cl:
