### PR TITLE
Removes a fire alarm under poster in meta botany

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7147,14 +7147,6 @@
 	dir = 4
 	},
 /area/station/science/lobby)
-"cyM" = (
-/obj/machinery/firealarm/directional/west{
-	pixel_y = 7;
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/green/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "cyS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -103473,7 +103465,7 @@ cfe
 ddO
 sLE
 cEv
-cyM
+uDr
 eeT
 tUn
 hKV


### PR DESCRIPTION
## About The Pull Request
Removes a duplicate firealarm from under a potion in metastation

## Why It's Good For The Game
Can't press what you can't see (plus its duplicate)

## Changelog
:cl: ezel
fix: Removes a duplicate fire alarm in metastation botany
/:cl:
