### PR TITLE
Quick carry and fastmed traits display on clothing on examine

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -184,7 +184,7 @@
 	VAR_PROTECTED/datum/embedding/embed_data
 
 	///for flags such as [GLASSESCOVERSEYES]
-	var/flags_cover = 0
+	var/flags_cover = NONE
 	var/heat = 0
 	/// All items with sharpness of SHARP_EDGED or higher will automatically get the butchering component.
 	var/sharpness = NONE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -315,18 +315,6 @@
 		. += span_warning("<b>[p_Theyre()] completely shredded and require[p_s()] mending before [p_they()] can be worn again!</b>")
 		return
 
-	if(TRAIT_QUICKER_CARRY in clothing_traits)
-		. += "[src] significantly increase the speed that you carry others."
-
-	else if(TRAIT_QUICK_CARRY in clothing_traits)
-		. += "[src] increase the speed that you carry others."
-
-	if(TRAIT_FASTMED in clothing_traits)
-		. += "[src] increase the speed that you use chemicals on others."
-
-	if(TRAIT_FAST_CUFFING in clothing_traits)
-		. += "[src] increase the speed that you handcuff others."
-
 	for(var/zone in damage_by_parts)
 		var/pct_damage_part = damage_by_parts[zone] / limb_integrity * 100
 		var/zone_name = parse_zone(zone)
@@ -368,7 +356,7 @@
 		.["pressure-proof"] = "Protects the wearer from extremely low or high pressure, such as vacuum of space."
 	if(flags_cover & PEPPERPROOF)
 		.["pepper-proof"] = "Protects the wearer from the effects of pepperspray."
-	if (heat_protection || cold_protection)
+	if(heat_protection || cold_protection)
 		var/heat_desc
 		var/cold_desc
 		switch (max_heat_protection_temperature)
@@ -386,6 +374,12 @@
 			if (0 to 71)
 				cold_desc = "extremely low"
 		.["thermally insulated"] = "Protects the wearer from [jointext(list(heat_desc, cold_desc) - null, " and ")] temperatures."
+	if((TRAIT_QUICK_CARRY in clothing_traits) || (TRAIT_QUICKER_CARRY in clothing_traits))
+		.["tactile"] = "Decreases the time it takes to pick up creatures by [(TRAIT_QUICKER_CARRY in clothing_traits) ? "2 seconds" : "1 second"]."
+	if(TRAIT_FASTMED in clothing_traits)
+		.["sterile"] = "Increases the speed at which reagents are administered to others by [round((1/NITRILE_GLOVES_MULTIPLIER-1)*100, 1)]%."
+	if(TRAIT_FAST_CUFFING in clothing_traits)
+		.["secure"] = "Increases the speed at which you apply restraints."
 
 /obj/item/clothing/examine_descriptor(mob/user)
 	return "clothing"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -315,6 +315,15 @@
 		. += span_warning("<b>[p_Theyre()] completely shredded and require[p_s()] mending before [p_they()] can be worn again!</b>")
 		return
 
+	if(TRAIT_QUICKER_CARRY in clothing_traits)
+		. += "[src] significantly increase the speed that you carry others."
+
+	else if(TRAIT_QUICK_CARRY in clothing_traits)
+		. += "[src] increase the speed that you carry others."
+
+	if(TRAIT_FASTMED in clothing_traits)
+		. += "[src] increase the speed that you use chemicals on others."
+
 	if(TRAIT_FAST_CUFFING in clothing_traits)
 		. += "[src] increase the speed that you handcuff others."
 


### PR DESCRIPTION
## About The Pull Request

It's like with quick cuffing, you can examine the gloves and be able to see if they make you carry people and inject faster

<img width="369" height="204" alt="Screenshot 2025-11-29 143710" src="https://github.com/user-attachments/assets/9018ab18-4fdf-4cfb-a3a1-2a24ab675851" />


## Why It's Good For The Game

Information is already there in the code for all to see

## Changelog

:cl:
qol: Quick carry and fast medicine properties are now visible on gloves
/:cl: