### PR TITLE
A modsuit version of borg hypos

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -635,13 +635,13 @@
 	starting_frequency = MODLINK_FREQ_CENTCOM
 	applied_cell = /obj/item/stock_parts/power_store/cell/hyper
 	applied_modules = list(
-		/obj/item/mod/module/organizer,
 		/obj/item/mod/module/defibrillator,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/health_analyzer,
 		/obj/item/mod/module/injector,
 		/obj/item/mod/module/surgical_processor/emergency,
 		/obj/item/mod/module/storage/large_capacity,
+		/obj/item/mod/module/hypospray,
 	)
 
 /obj/item/mod/control/pre_equipped/emergency_medical/corpsman

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -494,7 +494,7 @@
 
 /obj/item/mod/control/pre_equipped/responsory/medic
 	insignia_type = /obj/item/mod/module/insignia/medic
-	additional_modules = /obj/item/mod/module/quick_carry
+	additional_modules = list(/obj/item/mod/module/quick_carry, /obj/item/mod/module/hypospray)
 
 /obj/item/mod/control/pre_equipped/responsory/janitor
 	insignia_type = /obj/item/mod/module/insignia/janitor
@@ -549,7 +549,7 @@
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/medic
 	insignia_type = /obj/item/mod/module/insignia/medic
-	additional_modules = /obj/item/mod/module/quick_carry
+	additional_modules = list(/obj/item/mod/module/quick_carry, /obj/item/mod/module/hypospray)
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/chaplain
 	insignia_type = /obj/item/mod/module/insignia/chaplain
@@ -646,6 +646,7 @@
 		/obj/item/mod/module/anomaly_locked/kinesis/admin,
 		/obj/item/mod/module/shove_blocker,
 		/obj/item/mod/module/quick_cuff,
+		/obj/item/mod/module/hypospray/advanced
 	)
 	default_pins = list(
 		/obj/item/mod/module/stealth/ninja,

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -123,6 +123,71 @@
 		filling_overlay.color = mix_color_from_reagents(reagents.reagent_list)
 		. += filling_overlay
 
+/// Chemical Synthesizer - A borg hypospray for modsuits.alist
+/obj/item/mod/module/hypospray
+	name = "MOD synthesizer module"
+	desc = "A module inspired by medical cyborgs, \
+		it can create an infinite supply of medicines from energy."
+	icon = 'icons/obj/medical/syringe.dmi'
+	icon_state = "borghypo"
+	module_type = MODULE_ACTIVE
+	complexity = 3
+	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
+	use_energy_cost = DEFAULT_CHARGE_DRAIN
+	device = /obj/item/reagent_containers/borghypo/mod
+	incompatible_modules = list(/obj/item/mod/module/hypospray)
+	cooldown_time = 0.5 SECONDS
+	required_slots = list(ITEM_SLOT_GLOVES)
+
+/obj/item/mod/module/hypospray/Initialize(mapload)
+	. = ..()
+	var/obj/item/reagent_containers/borghypo/mod/hypo = device
+	hypo.module = src
+
+/obj/item/reagent_containers/borghypo/mod
+	name = "modsuit hypospray"
+	desc = "An advanced chemical synthesizer and injection system."
+	default_reagent_types = list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/c2/convermol, /datum/reagent/medicine/granibitaluri, /datum/reagent/toxin/formaldehyde)
+	// The module that we come from, used for drain_power
+	var/obj/item/mod/module/module
+
+/obj/item/reagent_containers/borghypo/mod/regenerate_reagents(list/reagents_to_regen)
+	for(var/reagent in reagents_to_regen)
+		var/datum/reagent/reagent_to_regen = reagent
+		if(!stored_reagents.has_reagent(reagent_to_regen, max_volume_per_reagent))
+			module.drain_power(module.use_energy_cost)
+			stored_reagents.add_reagent(reagent_to_regen, 5, reagtemp = dispensed_temperature, no_react = TRUE)
+
+/obj/item/mod/module/hypospray/advanced
+	name = "MOD expanded synthesizer module"
+	desc = "An upgrade to the original chemical synthesizer, this version can create a greater variety of reagents."
+	device = /obj/item/reagent_containers/borghypo/mod/advanced
+
+/obj/item/reagent_containers/borghypo/mod/advanced
+	name = "modsuit expanded hypospray"
+	bypass_protection = TRUE
+	// All the reagents that upgraded mediborgs get plus the reagents from the normal version.
+	default_reagent_types = list(\
+		/datum/reagent/medicine/c2/aiuri,\
+		/datum/reagent/medicine/c2/convermol,\
+		/datum/reagent/medicine/epinephrine,\
+		/datum/reagent/medicine/c2/libital,\
+		/datum/reagent/medicine/granibitaluri,\
+		/datum/reagent/medicine/c2/multiver,\
+		/datum/reagent/medicine/salglu_solution,\
+		/datum/reagent/medicine/spaceacillin,\
+		/datum/reagent/medicine/haloperidol,\
+		/datum/reagent/medicine/inacusiate,\
+		/datum/reagent/medicine/mannitol,\
+		/datum/reagent/medicine/mutadone,\
+		/datum/reagent/medicine/oculine,\
+		/datum/reagent/medicine/oxandrolone,\
+		/datum/reagent/medicine/pen_acid,\
+		/datum/reagent/medicine/rezadone,\
+		/datum/reagent/medicine/sal_acid,\
+		/datum/reagent/toxin/formaldehyde\
+	)
+
 ///Organizer - Lets you shoot organs, immediately replacing them if the target has the organ manipulation surgery.
 /obj/item/mod/module/organizer
 	name = "MOD organizer module"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -2336,10 +2336,24 @@
 	name = "Injector Module"
 	id = "mod_injector"
 	materials = list(
-		/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/diamond =SMALL_MATERIAL_AMOUNT*5,
 	)
 	build_path = /obj/item/mod/module/injector
+	category = list(
+		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_MEDICAL
+	)
+
+/datum/design/module/mod_hypospray
+	name = "Synthesizer Module"
+	id = "mod_hypospray"
+	materials = list(
+		/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT*4,
+		/datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/diamond = SMALL_MATERIAL_AMOUNT*2,
+	)
+	build_path = /obj/item/mod/module/hypospray
 	category = list(
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_MEDICAL
 	)

--- a/code/modules/research/techweb/nodes/modsuit_nodes.dm
+++ b/code/modules/research/techweb/nodes/modsuit_nodes.dm
@@ -64,6 +64,7 @@
 		"mod_injector",
 		"mod_organizer",
 		"mod_patienttransport",
+		"mod_hypospray",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_MEDICAL)


### PR DESCRIPTION
## About The Pull Request

Adds a new modsuit module, unlocked in the medical modules research node. It's literally just a borg hypo except it has different chemicals and you can't upgrade it to pierce armor.

It can make epinephrine, convermol, spaceacillin, granibitaluri, and formaldehyde. All chems that are already widely available and won't put chemists out of a job. They also aren't good for mid-combat healing so you won't want to install them on like, a security modsuit to inject yourself mid fight (you can't inject through armor anyways). It's meant for paramedics and doctors. 

The granibitaluri is there for anesthesia.

Also ERT medics and centcom paramedics spawn with it in their modsuit (I removed the mod organizer module from emt paramedics for space, why do you need one as a paramed anyways) and there's an upgraded version with armor penetration and all the borg chems in it that spawns in pre-equipped admin modsuits because I thought it would be nice to have for "human ai" type events or deathsquaddies.

## Why It's Good For The Game

More of a reason for medical to use their modsuit and it encourages interaction with robotics.

## Changelog

:cl:
add: Added a new modsuit module that gives you a borg hypospray.
/:cl: