### PR TITLE
Hulk and infusions no longer texture robotic limbs

### DIFF
--- a/code/datums/elements/organ_set_bonus.dm
+++ b/code/datums/elements/organ_set_bonus.dm
@@ -106,6 +106,8 @@
 	RegisterSignal(carbon_owner, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(untexture_limb))
 
 	for(var/obj/item/bodypart/limb as anything in carbon_owner.bodyparts)
+		if (!(limb.bodytype & BODYTYPE_ORGANIC))
+			continue
 		limb.add_bodypart_overlay(new limb_overlay(), update = FALSE)
 		if (color_overlay_priority)
 			limb.add_color_override(COLOR_WHITE, color_overlay_priority)
@@ -149,6 +151,9 @@
 
 /datum/status_effect/organ_set_bonus/proc/texture_limb(atom/source, obj/item/bodypart/limb)
 	SIGNAL_HANDLER
+
+	if (!(limb.bodytype & BODYTYPE_ORGANIC))
+		return
 
 	// Not updating because enable/disable_bonus(obj/item/organ/removed_organ) call it down the line, and calls coming from comsigs update the owner's body themselves
 	limb.add_bodypart_overlay(new limb_overlay(), update = FALSE)

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -34,11 +34,14 @@
 	if(!.)
 		return
 	for(var/obj/item/bodypart/part as anything in owner.bodyparts)
-		part.add_color_override(bodypart_color, LIMB_COLOR_HULK)
+		if (part.bodytype & BODYTYPE_ORGANIC)
+			part.add_color_override(bodypart_color, LIMB_COLOR_HULK)
 	owner.update_body_parts()
 	owner.add_mood_event("hulk", /datum/mood_event/hulk)
 	RegisterSignal(owner, COMSIG_LIVING_EARLY_UNARMED_ATTACK, PROC_REF(on_attack_hand))
 	RegisterSignal(owner, COMSIG_MOB_CLICKON, PROC_REF(check_swing))
+	RegisterSignal(owner, COMSIG_CARBON_ATTACH_LIMB, PROC_REF(texture_limb))
+	RegisterSignal(owner, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(untexture_limb))
 	owner.add_movespeed_mod_immunities("hulk", /datum/movespeed_modifier/damage_slowdown)
 
 /datum/mutation/hulk/proc/on_attack_hand(mob/living/carbon/human/source, atom/target, proximity, modifiers)
@@ -78,6 +81,15 @@
 	UnregisterSignal(owner, COMSIG_LIVING_EARLY_UNARMED_ATTACK)
 	UnregisterSignal(owner, COMSIG_MOB_CLICKON)
 	owner.remove_movespeed_mod_immunities("hulk", /datum/movespeed_modifier/damage_slowdown)
+
+/datum/mutation/hulk/proc/texture_limb(atom/source, obj/item/bodypart/limb)
+	SIGNAL_HANDLER
+	if (limb.bodytype & BODYTYPE_ORGANIC)
+		limb.add_color_override(bodypart_color, LIMB_COLOR_HULK)
+
+/datum/mutation/hulk/proc/untexture_limb(atom/source, obj/item/bodypart/limb)
+	SIGNAL_HANDLER
+	limb.remove_color_override(LIMB_COLOR_HULK)
 
 /// How many steps it takes to throw the mob
 #define HULK_TAILTHROW_STEPS 28


### PR DESCRIPTION

## About The Pull Request

Closes #94223
Also hulk now tracks your limbs, meaning that new limbs become green and old ones lose their color upon getting detached.

## Changelog
:cl:
fix: Hulk and infusions no longer texture robotic limbs
/:cl:
