### PR TITLE
Revolutionaires are happy when heads of staff die

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -583,6 +583,12 @@
 		mood_change *= -0.5
 		description = "More souls for the Geometer!"
 		return
+	if(IS_REVOLUTIONARY(owner))
+		var/datum/job/possible_head_job = dead_mob.mind?.assigned_role
+		if(possible_head_job.job_flags & JOB_HEAD_OF_STAFF)
+			mood_change *= -0.5
+			description = "[possible_head_job.title ? "The [LOWER_TEXT(possible_head_job.title)]" : "Another head of staff"] is dead! Long live the revolution!"
+			return
 
 	var/ispet = istype(dead_mob, /mob/living/basic/pet) || ismonkey(dead_mob)
 	if(HAS_PERSONALITY(owner, /datum/personality/callous) || (ispet && HAS_PERSONALITY(owner, /datum/personality/animal_disliker)))


### PR DESCRIPTION
## About The Pull Request

If you're a rev and you see a head of staff die your moodlet says something different and it's +4 instead of -8.
<img width="379" height="150" alt="image" src="https://github.com/user-attachments/assets/9a9ef652-d734-486e-b65e-47c5b47aad33" />
Closes #94217

## Why It's Good For The Game

revs are brainwashed, they shouldn't feel bad about killing heads of staff

## Changelog

:cl:
qol: Revolutionaires gain a positive moodlet instead of a negative one when they see a dead head of staff
/:cl: