### PR TITLE
only stock 10 items for `SSwardrobe` in low memory mode

### DIFF
--- a/code/controllers/subsystem/wardrobe.dm
+++ b/code/controllers/subsystem/wardrobe.dm
@@ -179,6 +179,11 @@ SUBSYSTEM_DEF(wardrobe)
 			master_info[WARDROBE_CACHE_CALL_INSERT] = callback_info[WARDROBE_CALLBACK_INSERT]
 			master_info[WARDROBE_CACHE_CALL_REMOVAL] = callback_info[WARDROBE_CALLBACK_REMOVE]
 		canon_minimum[type_to_stock] = master_info
+#ifdef LOWMEMORYMODE
+	// Allows all wardrobe behavoir to run while tamping down on initing a ton of extra items while the game is only being used for local testing or similar
+	if(master_info[WARDROBE_CACHE_COUNT] >= 5)
+		return
+#endif
 	master_info[WARDROBE_CACHE_COUNT] += 1
 	one_go_master++
 


### PR DESCRIPTION
## About The Pull Request
Normal SSwardrobe sees upwards of 200 items cached for things like backpacks. This caps it to 5 (acctually 10 because its 2x of whatever the stock is set to) if your using the define for the debug maps.

current behavoir
<img width="990" height="230" alt="image" src="https://github.com/user-attachments/assets/328ea121-a304-4d2f-9a82-a3c6d5ac3b42" />

from this pr
<img width="951" height="24" alt="image" src="https://github.com/user-attachments/assets/b6682436-7505-4a7a-9485-79796d58cc7d" />

## Why It's Good For The Game
My idea behind this is if your booting into runtime station or minimal runtime station 99% of the time, you dont need upwards of 200 items of a type preloaded, even if your acctually using up more then the 5 items stocked, the only thing that happens is items need to be inited normally. Nothing really breaks. I still stock 5 so you can still exprience SSwardrobe related behavior.
This however, could be a misuse of the define, its currently only used to control map behavoir
## Changelog
N/A. Only a dev thing.
