### PR TITLE
Log coordinates of ruin upon successful placement

### DIFF
--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -206,7 +206,11 @@
 									forced_ruins[linked] = SSmapping.get_isolated_ruin_z()
 
 
-			log_mapping("Successfully placed [current_pick.name] ruin.")
+			var/bottom_left_x = placed_turf.x - round(current_pick.width/2)
+			var/bottom_left_y = placed_turf.y - round(current_pick.height/2)
+			var/top_right_x = bottom_left_x + current_pick.width - 1
+			var/top_right_y = bottom_left_y + current_pick.height - 1
+			log_mapping("Successfully placed [current_pick.name] ruin ([bottom_left_x],[bottom_left_y],[placed_turf.z] to [top_right_x],[top_right_y],[placed_turf.z]).")
 
 		//Update the available list
 		for(var/datum/map_template/ruin/R in ruins_available)


### PR DESCRIPTION

## About The Pull Request

A lot of unit tests give coordinates in their failure messages, if the cause of the failure is something in a ruin, not only will the failure be flaky but because placement is random you have no way of matching the coordinates to a given ruin. This adds logging for the bottom left and top right coordinates of a ruin upon placement

## Why It's Good For The Game

Lets you know what ruin was placed at a given set of coordinates for debugging purposes

## Changelog
:cl:
code: ruin loading now logs placement coordinates
/:cl:
