### PR TITLE
NV eyes is an abstract type

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -563,6 +563,7 @@
 #define NIGHTVISION_LIGHT_HIG 3
 
 /obj/item/organ/eyes/night_vision
+	abstract_type = /obj/item/organ/eyes/night_vision
 	actions_types = list(/datum/action/item_action/organ_action/use)
 
 	// These lists are used as the color cutoff for the eye


### PR DESCRIPTION

## About The Pull Request
I belive at some point these functioned on there own but they now dont have any cuttoff values and thus dont acctually function on there own
## Changelog
:cl:
fix basetype for NV eyes are considered abstract
/:cl:
