### PR TITLE
Makes a bunch of lists lazy

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -692,8 +692,8 @@
 #define GET_TARGETS_FROM(who) (who.targets_from ? who.get_targets_from() : who)
 
 //defines for grad_color and grad_styles list access keys
-#define GRADIENT_HAIR_KEY 1
-#define GRADIENT_FACIAL_HAIR_KEY 2
+#define GRADIENT_HAIR_KEY "1"
+#define GRADIENT_FACIAL_HAIR_KEY "2"
 
 // /datum/sprite_accessory/gradient defines
 #define GRADIENT_APPLIES_TO_HAIR (1<<0)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -93,8 +93,6 @@ Behavior that's still missing from this component that original food items had t
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(UseFromHand))
 		RegisterSignal(parent, COMSIG_ITEM_USED_AS_INGREDIENT, PROC_REF(used_to_customize))
 
-		var/obj/item/item = parent
-
 	else if(isturf(parent) || isstructure(parent))
 		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(TryToEatIt))
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -94,8 +94,6 @@ Behavior that's still missing from this component that original food items had t
 		RegisterSignal(parent, COMSIG_ITEM_USED_AS_INGREDIENT, PROC_REF(used_to_customize))
 
 		var/obj/item/item = parent
-		if(!item.grind_results)
-			item.grind_results = list() //If this doesn't already exist, add it as an empty list. This is needed for the grinder to accept it.
 
 	else if(isturf(parent) || isstructure(parent))
 		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(TryToEatIt))

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -39,11 +39,11 @@ Behavior that's still missing from this component that original food items had t
 	///Last time we checked for food likes
 	var/last_check_time
 	///Assoc list of sources and their foodtypes
-	var/list/foodtypes_by_source = list()
+	var/list/foodtypes_by_source
 	///Assoc list of sources and their food flags
-	var/list/food_flags_by_source = list()
+	var/list/food_flags_by_source
 	///Assoc list of sources and their junkiness
-	var/list/junkiness_by_source = list()
+	var/list/junkiness_by_source
 
 /datum/component/edible/Initialize(
 	list/initial_reagents,
@@ -145,16 +145,16 @@ Behavior that's still missing from this component that original food items had t
 
 	var/recalculate = FALSE
 	if(!isnull(foodtypes))
-		if(foodtypes_by_source[source]) //foodtypes being overriden
+		if(LAZYACCESS(foodtypes_by_source, source)) //foodtypes being overriden
 			recalculate = TRUE
-		foodtypes_by_source[source] = foodtypes
+		LAZYSET(foodtypes_by_source, source, foodtypes)
 	if(!isnull(food_flags))
-		if(food_flags_by_source[source]) //food_flags being overriden
+		if(LAZYACCESS(food_flags_by_source, source)) //food_flags being overridden
 			recalculate = TRUE
-		food_flags_by_source[source] = food_flags
+		LAZYSET(food_flags_by_source, source, food_flags)
 	if(!isnull(junkiness))
-		src.junkiness += junkiness - junkiness_by_source[source]
-		junkiness_by_source[source] = junkiness
+		src.junkiness += junkiness - LAZYACCESS(junkiness_by_source, source)
+		LAZYSET(junkiness_by_source, source, junkiness)
 
 	if(recalculate)
 		recalculate_food_flags()
@@ -194,10 +194,10 @@ Behavior that's still missing from this component that original food items had t
 
 /datum/component/edible/on_source_remove(source)
 	//rebuild the foodtypes and food_flags bitfields without the removed source
-	foodtypes_by_source -= source
-	food_flags_by_source -= source
-	junkiness -= junkiness_by_source[source]
-	junkiness_by_source -= source
+	LAZYREMOVE(foodtypes_by_source, source)
+	LAZYREMOVE(food_flags_by_source, source)
+	junkiness -= LAZYACCESS(junkiness_by_source, source)
+	LAZYREMOVE(junkiness_by_source, source)
 	recalculate_food_flags()
 	return ..()
 
@@ -205,8 +205,8 @@ Behavior that's still missing from this component that original food items had t
 	foodtypes = NONE
 	food_flags = NONE
 	for(var/source_key in foodtypes_by_source)
-		foodtypes |= foodtypes_by_source[source_key]
-		food_flags |= food_flags_by_source[source_key]
+		foodtypes |= LAZYACCESS(foodtypes_by_source, source_key)
+		food_flags |= LAZYACCESS(food_flags_by_source, source_key)
 	if(foodtypes & GORE)
 		ADD_TRAIT(parent, TRAIT_VALID_DNA_INFUSION, REF(src))
 	else

--- a/code/datums/components/seethrough.dm
+++ b/code/datums/components/seethrough.dm
@@ -1,11 +1,9 @@
 ///A component that lets you turn an object invisible when you're standing on certain relative turfs to it, like behind a tree
 /datum/component/seethrough
-	///List of lists that represent relative coordinates to the source atom
-	var/list/relative_turf_coords
 	///A list of turfs on which we make ourself transparent
 	var/list/watched_turfs
 	///Associate list, with client = trickery_image. Track which client is being tricked with which image
-	var/list/tricked_mobs = list()
+	var/list/tricked_mobs
 
 	///Which alpha do we animate towards?
 	var/target_alpha
@@ -15,18 +13,18 @@
 	var/perimeter_reset_timer
 	///Does this object let clicks from players its transparent to pass through it
 	var/clickthrough
+	/// Define for the area which is considered behind
+	var/see_through_map
 
 ///see_through_map is a define pointing to a specific map. It's basically defining the area which is considered behind. See see_through_maps.dm for a list of maps
 /datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS, clickthrough = TRUE)
 	. = ..()
 
-	relative_turf_coords = GLOB.see_through_maps[see_through_map]
-
-	if(!isatom(parent) || !LAZYLEN(relative_turf_coords))
+	//GLOB.see_through_maps[see_through_map is a list of lists that represent relative coordinates to the source atom
+	if(!isatom(parent) || !LAZYLEN(GLOB.see_through_maps[see_through_map]))
 		return COMPONENT_INCOMPATIBLE
 
-	relative_turf_coords = GLOB.see_through_maps[see_through_map]
-	src.relative_turf_coords = relative_turf_coords
+	src.see_through_map = see_through_map
 	src.target_alpha = target_alpha
 	src.animation_time = animation_time
 	src.perimeter_reset_timer = perimeter_reset_timer
@@ -40,7 +38,7 @@
 /datum/component/seethrough/proc/setup_perimeter(atom/parent)
 	watched_turfs = list()
 
-	for(var/list/coordinates as anything in relative_turf_coords)
+	for(var/list/coordinates as anything in GLOB.see_through_maps[see_through_map])
 		var/turf/target = TURF_FROM_COORDS_LIST(list(parent.x + coordinates[1], parent.y + coordinates[2], parent.z + coordinates[3]))
 
 		if(isnull(target))
@@ -90,7 +88,7 @@
 	if(mob in tricked_mobs)
 		var/image/trickery_image = tricked_mobs[mob]
 		animate(trickery_image, alpha = 255, time = animation_time)
-		tricked_mobs.Remove(mob)
+		LAZYREMOVE(tricked_mobs, mob)
 		UnregisterSignal(mob, COMSIG_MOB_LOGOUT)
 
 		//after playing the fade-in animation, remove the screen obj
@@ -119,7 +117,7 @@
 
 	animate(user_overlay, alpha = target_alpha, time = animation_time)
 
-	tricked_mobs[fool] = user_overlay
+	LAZYSET(tricked_mobs, fool, user_overlay)
 	RegisterSignal(fool, COMSIG_MOB_LOGOUT, PROC_REF(on_client_disconnect))
 
 
@@ -150,13 +148,13 @@
 		for(var/atom/movable/screen/plane_master/seethrough in our_hud.get_true_plane_masters(SEETHROUGH_PLANE))
 			seethrough.hide_plane(fool)
 
-	tricked_mobs.Cut()
+	LAZYNULL(tricked_mobs)
 
 ///Image is removed when they log out because client gets deleted, so drop the mob reference
 /datum/component/seethrough/proc/on_client_disconnect(mob/fool)
 	SIGNAL_HANDLER
 
-	tricked_mobs.Remove(fool)
+	LAZYREMOVE(tricked_mobs, fool)
 	UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
 	RegisterSignal(fool, COMSIG_MOB_LOGIN, PROC_REF(trick_mob))
 	var/datum/hud/our_hud = fool.hud_used

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -38,8 +38,9 @@
 	if(length(circuit_components))
 		UnregisterFromParent()
 		should_register = TRUE
-		QDEL_LIST(circuit_components)
-		LAZYNULL(circuit_components)
+		if(circuit_components)
+			QDEL_LIST(circuit_components)
+			circuit_components = null
 
 	for(var/circuit_component in components)
 		var/obj/item/circuit_component/component = circuit_component
@@ -112,7 +113,8 @@
 	on_atom_usb_cable_try_attach(src, cable, null)
 
 /datum/component/usb_port/Destroy()
-	QDEL_LIST(circuit_components)
+	if(circuit_components)
+		QDEL_LIST(circuit_components)
 	QDEL_NULL(usb_cable_beam)
 
 	attached_circuit = null

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -38,9 +38,7 @@
 	if(length(circuit_components))
 		UnregisterFromParent()
 		should_register = TRUE
-		if(circuit_components)
-			QDEL_LIST(circuit_components)
-			circuit_components = null
+		QDEL_LAZYLIST(circuit_components)
 
 	for(var/circuit_component in components)
 		var/obj/item/circuit_component/component = circuit_component
@@ -113,8 +111,7 @@
 	on_atom_usb_cable_try_attach(src, cable, null)
 
 /datum/component/usb_port/Destroy()
-	if(circuit_components)
-		QDEL_LIST(circuit_components)
+	QDEL_LAZYLIST(circuit_components)
 	QDEL_NULL(usb_cable_beam)
 
 	attached_circuit = null

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -29,8 +29,6 @@
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	circuit_components = list()
-
 	src.circuit_component_types = circuit_component_types
 	src.extra_registration_callback = extra_registration_callback
 	src.extra_unregistration_callback = extra_unregistration_callback
@@ -41,6 +39,7 @@
 		UnregisterFromParent()
 		should_register = TRUE
 		QDEL_LIST(circuit_components)
+		LAZYNULL(circuit_components)
 
 	for(var/circuit_component in components)
 		var/obj/item/circuit_component/component = circuit_component
@@ -49,7 +48,7 @@
 		if(!should_register)
 			component.register_usb_parent(parent)
 		RegisterSignal(component, COMSIG_CIRCUIT_COMPONENT_SAVE, PROC_REF(save_component))
-		circuit_components += component
+		LAZYADD(circuit_components, component)
 
 	if(should_register)
 		RegisterWithParent()
@@ -160,7 +159,7 @@
 /datum/component/usb_port/proc/on_atom_usb_cable_try_attach(datum/source, obj/item/usb_cable/connecting_cable, mob/user)
 	SIGNAL_HANDLER
 
-	if (!length(circuit_components))
+	if (!LAZYLEN(circuit_components))
 		set_circuit_components(circuit_component_types)
 
 	var/atom/atom_parent = parent

--- a/code/datums/dna/blocks/dna_identity_block.dm
+++ b/code/datums/dna/blocks/dna_identity_block.dm
@@ -95,7 +95,7 @@
 /datum/dna_block/identity/hair_gradient
 
 /datum/dna_block/identity/hair_gradient/create_unique_block(mob/living/carbon/human/target)
-	return construct_block(SSaccessories.hair_gradients_list.Find(target.grad_style[GRADIENT_HAIR_KEY]), length(SSaccessories.hair_gradients_list))
+	return construct_block(SSaccessories.hair_gradients_list.Find(target.get_hair_gradient_style(GRADIENT_HAIR_KEY)), length(SSaccessories.hair_gradients_list))
 
 /datum/dna_block/identity/hair_gradient/apply_to_mob(mob/living/carbon/human/target, dna_hash)
 	var/gradient_style = SSaccessories.hair_gradients_list[deconstruct_block(get_block(dna_hash), length(SSaccessories.hair_gradients_list))]
@@ -105,7 +105,7 @@
 	block_length = DNA_BLOCK_SIZE_COLOR
 
 /datum/dna_block/identity/hair_gradient_color/create_unique_block(mob/living/carbon/human/target)
-	return sanitize_hexcolor(target.grad_color[GRADIENT_HAIR_KEY], include_crunch = FALSE)
+	return sanitize_hexcolor(target.get_hair_gradient_color(GRADIENT_HAIR_KEY), include_crunch = FALSE)
 
 /datum/dna_block/identity/hair_gradient_color/apply_to_mob(mob/living/carbon/human/target, dna_hash)
 	target.set_hair_gradient_color(sanitize_hexcolor(get_block(dna_hash)), update = FALSE)
@@ -113,7 +113,7 @@
 /datum/dna_block/identity/facial_gradient
 
 /datum/dna_block/identity/facial_gradient/create_unique_block(mob/living/carbon/human/target)
-	return construct_block(SSaccessories.facial_hair_gradients_list.Find(target.grad_style[GRADIENT_FACIAL_HAIR_KEY]), length(SSaccessories.facial_hair_gradients_list))
+	return construct_block(SSaccessories.facial_hair_gradients_list.Find(target.get_hair_gradient_style(GRADIENT_FACIAL_HAIR_KEY)), length(SSaccessories.facial_hair_gradients_list))
 
 /datum/dna_block/identity/facial_gradient/apply_to_mob(mob/living/carbon/human/target, dna_hash)
 	var/gradient_style = SSaccessories.facial_hair_gradients_list[deconstruct_block(get_block(dna_hash), length(SSaccessories.facial_hair_gradients_list))]
@@ -123,7 +123,7 @@
 	block_length = DNA_BLOCK_SIZE_COLOR
 
 /datum/dna_block/identity/facial_gradient_color/create_unique_block(mob/living/carbon/human/target)
-	return sanitize_hexcolor(target.grad_color[GRADIENT_FACIAL_HAIR_KEY], include_crunch = FALSE)
+	return sanitize_hexcolor(target.get_hair_gradient_color(GRADIENT_FACIAL_HAIR_KEY), include_crunch = FALSE)
 
 /datum/dna_block/identity/facial_gradient_color/apply_to_mob(mob/living/carbon/human/target, dna_hash)
 	target.set_facial_hair_gradient_color(sanitize_hexcolor(get_block(dna_hash)), update = FALSE)

--- a/code/datums/elements/beauty.dm
+++ b/code/datums/elements/beauty.dm
@@ -11,7 +11,7 @@
 	  * Assoc list of atoms as keys and number of time the same element instance has been attached to them as assoc value.
 	  * So things don't get odd with same-valued yet dissimilar beauty modifiers being added to the same atom.
 	  */
-	var/beauty_counter = list()
+	var/beauty_counter
 
 /datum/element/beauty/Attach(datum/target, beauty)
 	. = ..()
@@ -19,6 +19,7 @@
 		return ELEMENT_INCOMPATIBLE
 
 	src.beauty = beauty
+	LAZYINITLIST(beauty_counter)
 
 	var/area/current_area = get_area(target)
 	var/beauty_active = TRUE

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -106,7 +106,7 @@
 		var/obj/item/assembly/assembly = LAZYACCESS(assemblies, color)
 		assembly.holder = null
 		assembly.connected = null
-	LAZYCLEARLIST(assemblies)
+	LAZYNULL(assemblies)
 	return ..()
 
 /// Adds a number of wires which do absolutely nothing.

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -22,7 +22,7 @@
 	return FALSE
 
 /atom/proc/attempt_wire_interaction(mob/user)
-	if(!wires)
+	if(isnull(wires))
 		return WIRE_INTERACTION_FAIL
 	if(!IsReachableBy(user))
 		return WIRE_INTERACTION_FAIL
@@ -43,13 +43,13 @@
 	var/wire_behavior = WIRES_INPUT
 
 	/// List of all wires.
-	var/list/wires = list()
+	var/list/wires
 	/// List of cut wires.
-	var/list/cut_wires = list() // List of wires that have been cut.
+	var/list/cut_wires // List of wires that have been cut.
 	/// Dictionary of colours to wire.
-	var/list/colors = list()
+	var/list/colors
 	/// List of attached assemblies.
-	var/list/assemblies = list()
+	var/list/assemblies
 
 	/// If every instance of these wires should be random. Prevents wires from showing up in station blueprints.
 	var/randomize = FALSE
@@ -103,7 +103,7 @@
 	holder = null
 	//properly clear refs to avoid harddels & other problems
 	for(var/color in assemblies)
-		var/obj/item/assembly/assembly = assemblies[color]
+		var/obj/item/assembly/assembly = LAZYACCESS(assemblies, color)
 		assembly.holder = null
 		assembly.connected = null
 	LAZYCLEARLIST(assemblies)
@@ -115,7 +115,7 @@
 		var/dud = WIRE_DUD_PREFIX + "[--duds]"
 		if(dud in wires)
 			continue
-		wires += dud
+		LAZYADD(wires, dud)
 
 ///Called when holder is qdeleted for us to clean ourselves as not to leave any unlawful references.
 /datum/wires/proc/on_holder_qdel(atom/source, force)
@@ -124,7 +124,7 @@
 	qdel(src)
 
 /datum/wires/proc/randomize()
-	if(length(wires) > length(default_possible_colors))
+	if(LAZYLEN(wires) > length(default_possible_colors))
 		stack_trace("Wire type [type] has more wires than possible colors, consider adding more colors or removing wires.")
 
 	var/list/possible_colors = default_possible_colors.Copy()
@@ -132,10 +132,10 @@
 	for(var/wire in shuffle(wires))
 		if(!length(possible_colors))
 			possible_colors = default_possible_colors.Copy()
-		colors[pick_n_take(possible_colors)] = wire
+		LAZYSET(colors, pick_n_take(possible_colors), wire)
 
 /datum/wires/proc/shuffle_wires()
-	colors.Cut()
+	LAZYCLEARLIST(colors)
 	randomize()
 
 /datum/wires/proc/repair()
@@ -143,7 +143,7 @@
 		cut(wire) // I KNOW I KNOW OK
 
 /datum/wires/proc/get_wire(color)
-	return colors[color]
+	return LAZYACCESS(colors, color)
 
 /datum/wires/proc/get_color_of_wire(wire_type)
 	for(var/color in colors)
@@ -152,12 +152,12 @@
 			return color
 
 /datum/wires/proc/get_attached(color)
-	if(assemblies[color])
-		return assemblies[color]
+	if(LAZYACCESS(assemblies, color))
+		return LAZYACCESS(assemblies, color)
 	return null
 
 /datum/wires/proc/is_attached(color)
-	if(assemblies[color])
+	if(LAZYACCESS(assemblies, color))
 		return TRUE
 
 /datum/wires/proc/is_cut(wire)
@@ -167,7 +167,7 @@
 	return is_cut(get_wire(color))
 
 /datum/wires/proc/is_all_cut()
-	if(cut_wires.len == wires.len)
+	if(LAZYLEN(cut_wires) == LAZYLEN(wires))
 		return TRUE
 
 /datum/wires/proc/is_dud(wire)
@@ -178,11 +178,11 @@
 
 /datum/wires/proc/cut(wire, mob/living/source)
 	if(is_cut(wire))
-		cut_wires -= wire
+		LAZYREMOVE(cut_wires, wire)
 		SEND_SIGNAL(src, COMSIG_MEND_WIRE(wire), wire)
 		on_cut(wire, mend = TRUE, source = source)
 	else
-		cut_wires += wire
+		LAZYADD(cut_wires, wire)
 		SEND_SIGNAL(src, COMSIG_CUT_WIRE(wire), wire)
 		on_cut(wire, mend = FALSE, source = source)
 
@@ -190,7 +190,7 @@
 	cut(get_wire(color), source)
 
 /datum/wires/proc/cut_random(source)
-	cut(wires[rand(1, wires.len)], source)
+	cut(LAZYACCESS(wires, rand(1, LAZYLEN(wires))), source)
 
 /datum/wires/proc/cut_all(source)
 	for(var/wire in wires)
@@ -205,26 +205,26 @@
 /datum/wires/proc/pulse_color(color, mob/living/user, force=FALSE)
 	pulse(get_wire(color), user, force)
 
-/datum/wires/proc/pulse_assembly(obj/item/assembly/S)
-	for(var/color in assemblies)
-		if(S == assemblies[color])
+/datum/wires/proc/pulse_assembly(obj/item/assembly/assembly)
+	for(var/color, our_assembly in assemblies)
+		if(assembly == our_assembly)
 			pulse_color(color, force=TRUE)
 			return TRUE
 
-/datum/wires/proc/attach_assembly(color, obj/item/assembly/S)
-	if(S && istype(S) && S.assembly_behavior && !is_attached(color) && !(SEND_SIGNAL(S, COMSIG_ASSEMBLY_PRE_ATTACH, holder) & COMPONENT_CANCEL_ATTACH))
-		assemblies[color] = S
-		S.forceMove(holder)
-		S.connected = src
-		S.on_attach() // Notify assembly that it is attached
-		return S
+/datum/wires/proc/attach_assembly(color, obj/item/assembly/assembly)
+	if(assembly && istype(assembly) && assembly.assembly_behavior && !is_attached(color) && !(SEND_SIGNAL(assembly, COMSIG_ASSEMBLY_PRE_ATTACH, holder) & COMPONENT_CANCEL_ATTACH))
+		LAZYSET(assemblies, color, assembly)
+		assembly.forceMove(holder)
+		assembly.connected = src
+		assembly.on_attach() // Notify assembly that it is attached
+		return assembly
 
 /datum/wires/proc/detach_assembly(color)
-	var/obj/item/assembly/S = get_attached(color)
-	if(S && istype(S))
-		assemblies -= color
-		S.on_detach()		// Notify the assembly.  This should remove the reference to our holder
-		return S
+	var/obj/item/assembly/assembly = get_attached(color)
+	if(assembly && istype(assembly))
+		LAZYREMOVE(assemblies, color)
+		assembly.on_detach()		// Notify the assembly.  This should remove the reference to our holder
+		return assembly
 
 /// Called from [/atom/proc/emp_act]
 /datum/wires/proc/emp_pulse()
@@ -259,9 +259,9 @@
 	if(!interactable(user))
 		return FALSE
 	ui_interact(user)
-	for(var/A in assemblies)
-		var/obj/item/I = assemblies[A]
-		if(istype(I) && I.on_found(user))
+	for(var/color, assembly in assemblies)
+		var/obj/item/assembly_item = assembly
+		if(istype(assembly_item) && assembly_item.on_found(user))
 			break
 	return TRUE
 

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -55,9 +55,10 @@
 		actions += new move_down_action(src)
 	if(add_usb_port)
 		AddComponent(/datum/component/usb_port, \
-			list(
+			typecacheof(list(
 				/obj/item/circuit_component/advanced_camera,
 				/obj/item/circuit_component/advanced_camera_intercept,
+				), \
 			), \
 			extra_registration_callback = PROC_REF(register_usb_port), \
 			extra_unregistration_callback = PROC_REF(unregister_usb_port) \

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -13,9 +13,7 @@
 
 /obj/machinery/computer/crew/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/medical_console_data,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/medical_console_data), only_root_path = TRUE))
 
 /obj/item/circuit_component/medical_console_data
 	display_name = "Crew Monitoring Data"

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -12,9 +12,7 @@
 /obj/machinery/computer/launchpad/Initialize(mapload)
 	launchpads = list()
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/bluespace_launchpad/console,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/bluespace_launchpad/console), only_root_path = TRUE))
 
 /obj/item/circuit_component/bluespace_launchpad/console
 	display_name = "Bluespace Launchpad Console"

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -35,10 +35,12 @@
 
 /obj/machinery/computer/records/security/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/arrest_console_data,
-		/obj/item/circuit_component/arrest_console_arrest,
-	))
+	AddComponent(/datum/component/usb_port, \
+		typecacheof(list(
+			/obj/item/circuit_component/arrest_console_data,
+			/obj/item/circuit_component/arrest_console_arrest,
+		), only_root_path = TRUE) \
+	)
 
 /obj/machinery/computer/records/security/emp_act(severity)
 	. = ..()

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -24,9 +24,7 @@
 	id = "[rand(1000, 9999)]"
 	link_power_station()
 
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/teleporter_control_console,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/teleporter_control_console), only_root_path = TRUE))
 
 /obj/machinery/computer/teleporter/Destroy()
 	if (power_station)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -72,9 +72,7 @@
 	soundloop = new(src, FALSE)
 	set_wires(new /datum/wires/firealarm(src))
 
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/firealarm,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/firealarm), only_root_path = TRUE))
 
 	AddComponent( \
 		/datum/component/redirect_attack_hand_from_turf, \

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -104,9 +104,7 @@
 	update_indicator()
 
 	if(stationary)
-		AddComponent(/datum/component/usb_port, list(
-			/obj/item/circuit_component/bluespace_launchpad,
-		))
+		AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/bluespace_launchpad), only_root_path = TRUE))
 
 /// Whether this launchpad can send or receive.
 /obj/machinery/launchpad/proc/is_available()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -23,9 +23,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 
 	AddComponent(/datum/component/redirect_attack_hand_from_turf)
 
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/light_switch,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/light_switch), only_root_path = TRUE))
 	if(istext(area))
 		area = text2path(area)
 	if(ispath(area))

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -23,9 +23,7 @@
 	if(map_pad_id)
 		mapped_quantum_pads[map_pad_id] = src
 
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/quantumpad,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/quantumpad), only_root_path = TRUE))
 
 /obj/machinery/quantumpad/Destroy()
 	mapped_quantum_pads -= map_pad_id

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -403,9 +403,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 	// register for radio system
 	SSradio.add_object(src, frequency)
 	// Circuit USB
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/status_display,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/status_display), only_root_path = TRUE))
 	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(on_sec_level_change))
 	if(mapload)
 		find_and_hang_on_atom()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -225,7 +225,7 @@
 	///What dye registry should be looked at when dying this item; see washing_machine.dm
 	var/dying_key
 
-	///Grinder var:A reagent list containing the reagents this item produces when ground up in a grinder - this can be an empty list to allow for reagent transferring only
+	/// A lazy reagent list containing the reagents this item produces when ground up in a grinder
 	var/list/grind_results
 	///A reagent the nutriments are converted into when the item is juiced.
 	var/datum/reagent/consumable/juice_typepath
@@ -1089,7 +1089,7 @@
 	PROTECTED_PROC(TRUE)
 
 	. = FALSE
-	if(length(grind_results))
+	if(LAZYLEN(grind_results))
 		target_holder.add_reagent_list(grind_results)
 		. = TRUE
 	if(reagents?.trans_to(target_holder, reagents.total_volume, transferred_by = user))

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -197,7 +197,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throw_speed = 0.5
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_MASK
-	grind_results = list()
 	heat = 1000
 	light_range = 1
 	light_color = LIGHT_COLOR_FIRE

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -30,7 +30,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb_continuous = list("attacks", "colours")
 	attack_verb_simple = list("attack", "colour")
-	grind_results = list()
 	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_IGNORE_MOBILITY
 
 	/// Icon state to use when capped

--- a/code/game/objects/items/dyespray.dm
+++ b/code/game/objects/items/dyespray.dm
@@ -57,7 +57,8 @@
 	if(!user.can_perform_action(src, NEED_DEXTERITY))
 		return
 
-	var/new_grad_color = input(user, "Choose a secondary hair color:", "Character Preference",human_target.grad_color) as color|null
+	var/new_grad_color = input(user, "Choose a secondary hair color:", "Character Preference", human_target.get_hair_gradient_color()) as color|null
+
 	if(!new_grad_color || !user.can_perform_action(src, NEED_DEXTERITY) || !target.IsReachableBy(user))
 		return
 

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -10,7 +10,6 @@
 	righthand_file = 'icons/mob/inhands/items/food_righthand.dmi'
 	abstract_type = /obj/item/food
 	obj_flags = UNIQUE_RENAME
-	grind_results = list()
 	material_flags = MATERIAL_NO_EDIBILITY
 	/**
 	 * A list of material paths. the main material in the custom_materials list is also added on init.

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -623,7 +623,6 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
 	singular_name = "raw durathread ball"
 	icon_state = "sheet-durathreadraw"
 	merge_type = /obj/item/stack/sheet/cotton/durathread
-	grind_results = list()
 	loom_result = /obj/item/stack/sheet/durathread
 
 /obj/item/stack/sheet/cotton/wool
@@ -632,7 +631,6 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
 	singular_name = "raw wool ball"
 	icon_state = "sheet-wool"
 	merge_type = /obj/item/stack/sheet/cotton/wool
-	grind_results = list()
 	loom_result = /obj/item/stack/sheet/cloth
 
 /*

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -191,7 +191,7 @@
 		return FALSE
 
 	//Now transfer the grind results scaled by available_amount
-	var/list/grind_reagents = grind_results.Copy()
+	var/list/grind_reagents = LAZYCOPY(grind_results)
 	for(var/reagent in grind_reagents)
 		grind_reagents[reagent] *= available_amount
 	target_holder.add_reagent_list(grind_reagents)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -36,9 +36,7 @@
 	if(admin)
 		can_rotate = FALSE
 
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/reflector,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/reflector), only_root_path = TRUE))
 
 /obj/structure/reflector/examine(mob/user)
 	. = ..()

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -121,12 +121,14 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	select_mode(src, /datum/air_alarm_mode/filtering, should_apply = FALSE)
 
 	AddElement(/datum/element/connect_loc, atmos_connections)
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/air_alarm_general,
-		/obj/item/circuit_component/air_alarm,
-		/obj/item/circuit_component/air_alarm_scrubbers,
-		/obj/item/circuit_component/air_alarm_vents
-	))
+	AddComponent(/datum/component/usb_port, \
+		typecacheof(list(
+			/obj/item/circuit_component/air_alarm_general,
+			/obj/item/circuit_component/air_alarm,
+			/obj/item/circuit_component/air_alarm_scrubbers,
+			/obj/item/circuit_component/air_alarm_vents
+		), only_root_path = TRUE) \
+	)
 
 	GLOB.air_alarms += src
 	if(mapload)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -24,9 +24,7 @@
 
 /obj/machinery/atmospherics/components/binary/pump/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/atmos_pump,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/atmos_pump), only_root_path = TRUE))
 	register_context()
 
 /obj/machinery/atmospherics/components/binary/pump/add_context(atom/source, list/context, obj/item/held_item, mob/user)

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -87,7 +87,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 
 /obj/machinery/atmospherics/components/binary/valve/digital/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/digital_valve))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/digital_valve), only_root_path = TRUE))
 
 /obj/item/circuit_component/digital_valve
 	display_name = "Digital Valve"

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -28,11 +28,10 @@
 
 /obj/machinery/atmospherics/components/binary/volume_pump/Initialize(mapload)
 	. = ..()
-	AddComponent(
-		/datum/component/usb_port,
+	AddComponent(/datum/component/usb_port, \
 		typecacheof(list(
 			/obj/item/circuit_component/atmos_volume_pump,
-		), only_root_path = TRUE)
+		), only_root_path = TRUE) \
 	)
 	register_context()
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -28,9 +28,12 @@
 
 /obj/machinery/atmospherics/components/binary/volume_pump/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/atmos_volume_pump,
-	))
+	AddComponent(
+		/datum/component/usb_port,
+		typecacheof(list(
+			/obj/item/circuit_component/atmos_volume_pump,
+		), only_root_path = TRUE)
+	)
 	register_context()
 
 /obj/machinery/atmospherics/components/binary/volume_pump/click_ctrl(mob/user)

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -36,11 +36,10 @@
 
 	if(!target)
 		reattach_to_layer()
-	AddComponent(
-		/datum/component/usb_port,
+	AddComponent(/datum/component/usb_port, \
 		typecacheof(list(
 			/obj/item/circuit_component/atmos_meter,
-		), only_root_path = TRUE)
+		), only_root_path = TRUE) \
 	)
 	return ..()
 

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -36,9 +36,12 @@
 
 	if(!target)
 		reattach_to_layer()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/atmos_meter,
-	))
+	AddComponent(
+		/datum/component/usb_port,
+		typecacheof(list(
+			/obj/item/circuit_component/atmos_meter,
+		), only_root_path = TRUE)
+	)
 	return ..()
 
 /obj/machinery/meter/proc/reattach_to_layer()

--- a/code/modules/bitrunning/job.dm
+++ b/code/modules/bitrunning/job.dm
@@ -1,7 +1,6 @@
 /datum/job/bitrunner
 	title = JOB_BITRUNNER
 	description = "Surf the virtual domain for gear and loot. Decrypt your rewards on station."
-	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
 	total_positions = 3
 	spawn_positions = 3

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -207,9 +207,7 @@
 
 /obj/machinery/processor/slime/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/slime_processor,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/slime_processor), only_root_path = TRUE))
 
 /obj/machinery/processor/slime/adjust_item_drop_location(atom/movable/atom_to_drop)
 	var/static/list/slimecores = subtypesof(/obj/item/slime_extract)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -176,7 +176,7 @@
 	. = ..()
 	AddComponent(/datum/component/simple_rotation)
 	AddComponent(/datum/component/plumbing/hydroponics)
-	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/hydroponics), only_root_path = TRUE))
 	AddComponent(/datum/component/fishing_spot, /datum/fish_source/hydro_tray)
 
 /obj/machinery/hydroponics/constructable/RefreshParts()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -11,11 +11,8 @@
 	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a full crew. Format is list(/datum/skill/foo = SKILL_EXP_NOVICE) with exp as an integer or as per code/_DEFINES/skills.dm
 	var/list/minimal_skills
 
-	/// Determines who can demote this position
-	var/department_head = list()
-
 	/// Tells the given channels that the given mob is the new department head. See communications.dm for valid channels.
-	var/list/head_announce = null
+	var/head_announce
 
 	/// Bitflags for the job
 	var/auto_deadmin_role_flags = NONE
@@ -187,7 +184,7 @@
 /// Note the joining mob has no client at this point.
 /datum/job/proc/announce_job(mob/living/joining_mob)
 	if(head_announce)
-		announce_head(joining_mob, head_announce)
+		announce_head(joining_mob, list(head_announce))
 
 
 //Used for a special check of whether to allow a client to latejoin as this job.

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -1,7 +1,6 @@
 /datum/job/atmospheric_technician
 	title = JOB_ATMOSPHERIC_TECHNICIAN
 	description = "Ensure the air is breathable on the station, fill oxygen tanks, fight fires, purify the air."
-	department_head = list(JOB_CHIEF_ENGINEER)
 	faction = FACTION_STATION
 	total_positions = 3
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -1,7 +1,6 @@
 /datum/job/bartender
 	title = JOB_BARTENDER
 	description = "Serve booze, mix drinks, keep the crew drunk."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -1,7 +1,6 @@
 /datum/job/botanist
 	title = JOB_BOTANIST
 	description = "Grow plants for the cook, for medicine, and for recreation."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 3
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -4,7 +4,6 @@
 		keep the crew alive, be prepared to do anything and everything or die \
 		horribly trying."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
-	department_head = list("CentCom")
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -3,7 +3,6 @@
 	description = "Distribute supplies to the departments that ordered them, \
 		collect empty crates, load and unload the supply shuttle, \
 		ship bounty cubes."
-	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
 	total_positions = 5
 	spawn_positions = 3

--- a/code/modules/jobs/job_types/chaplain/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain.dm
@@ -2,7 +2,6 @@
 	title = JOB_CHAPLAIN
 	description = "Hold services and funerals, cremate people, preach your \
 		religion, protect the crew against cults."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -2,7 +2,6 @@
 	title = JOB_CHEMIST
 	description = "Supply the doctors with chemicals, make medicine, as well as \
 		less likable substances in the comfort of a fully reinforced room."
-	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -3,8 +3,7 @@
 	description = "Coordinate engineering, ensure equipment doesn't get stolen, \
 		make sure the Supermatter doesn't blow up, maintain telecommunications."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	department_head = list(JOB_CAPTAIN)
-	head_announce = list("Engineering")
+	head_announce = RADIO_CHANNEL_ENGINEERING
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -2,9 +2,8 @@
 	title = JOB_CHIEF_MEDICAL_OFFICER
 	description = "Coordinate doctors and other medbay employees, ensure they \
 		know how to save lives, check for injuries on the crew monitor."
-	department_head = list(JOB_CAPTAIN)
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	head_announce = list(RADIO_CHANNEL_MEDICAL)
+	head_announce = RADIO_CHANNEL_MEDICAL
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -1,7 +1,6 @@
 /datum/job/clown
 	title = JOB_CLOWN
 	description = "Entertain the crew, make bad jokes, go on a holy quest to find bananium, HONK!"
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -1,7 +1,6 @@
 /datum/job/cook
 	title = JOB_COOK
 	description = "Serve food, cook meat, keep the crew fed."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -2,7 +2,6 @@
 	title = JOB_CORONER
 	description = "Perform Autopsies whenever needed, \
 		Update medical records accordingly, apply formaldehyde."
-	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -2,7 +2,6 @@
 	title = JOB_CURATOR
 	description = "Read and write books and hand them to people, stock \
 		bookshelves, report on station news."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -3,7 +3,6 @@
 	description = "Investigate crimes, gather evidence, perform interrogations, \
 		look badass, smoke cigarettes."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	department_head = list(JOB_HEAD_OF_SECURITY)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -1,7 +1,6 @@
 /datum/job/geneticist
 	title = JOB_GENETICIST
 	description = "Alter genomes, turn monkeys into humans (and vice-versa), and make DNA backups."
-	department_head = list(JOB_RESEARCH_DIRECTOR)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -3,8 +3,7 @@
 	description = "Alter access on ID cards, manage the service department, \
 		protect Ian, run the station when the captain dies."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	department_head = list(JOB_CAPTAIN)
-	head_announce = list(RADIO_CHANNEL_SERVICE)
+	head_announce = RADIO_CHANNEL_SERVICE
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -3,8 +3,7 @@
 	description = "Coordinate security personnel, ensure they are not corrupt, \
 		make sure every department is protected."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
-	department_head = list(JOB_CAPTAIN)
-	head_announce = list(RADIO_CHANNEL_SECURITY)
+	head_announce = RADIO_CHANNEL_SECURITY
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -1,7 +1,6 @@
 /datum/job/janitor
 	title = JOB_JANITOR
 	description = "Clean up trash and blood. Replace broken lights. Slip people over."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -2,7 +2,6 @@
 	title = JOB_LAWYER
 	description = "Advocate for prisoners, create law-binding contracts, \
 		ensure Security is following protocol and Space Law."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -2,7 +2,6 @@
 	title = JOB_MEDICAL_DOCTOR
 	description = "Save lives, run around the station looking for victims, \
 		scan everyone in sight"
-	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
 	faction = FACTION_STATION
 	total_positions = 6
 	spawn_positions = 4

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -1,7 +1,6 @@
 /datum/job/mime
 	title = JOB_MIME
 	description = "..."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -2,7 +2,6 @@
 	title = JOB_PARAMEDIC
 	description = "Run around the station looking for patients, respond to \
 		emergencies, give patients a roller bed ride to medbay."
-	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -1,7 +1,6 @@
 /datum/job/prisoner
 	title = JOB_PRISONER
 	description = "Keep yourself occupied in permabrig."
-	department_head = list("The Security Team")
 	faction = FACTION_STATION
 	total_positions = 0
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -2,7 +2,6 @@
 	title = JOB_PSYCHOLOGIST
 	description = "Advocate sanity, self-esteem, and teamwork in a station \
 		staffed with headcases."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -3,8 +3,7 @@
 	description = "Coordinate cargo technicians and shaft miners, assist with \
 		economical purchasing."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	department_head = list(JOB_CAPTAIN)
-	head_announce = list(RADIO_CHANNEL_SUPPLY)
+	head_announce = RADIO_CHANNEL_SUPPLY
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -4,8 +4,7 @@
 		order, make sure the AI and its Cyborgs aren't rogue, replacing them if \
 		they are."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	department_head = list(JOB_CAPTAIN)
-	head_announce = list("Science")
+	head_announce = RADIO_CHANNEL_SCIENCE
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -1,7 +1,6 @@
 /datum/job/roboticist
 	title = JOB_ROBOTICIST
 	description = "Build and repair the AI and cyborgs, create mechs."
-	department_head = list(JOB_RESEARCH_DIRECTOR)
 	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -1,7 +1,6 @@
 /datum/job/scientist
 	title = JOB_SCIENTIST
 	description = "Do experiments, perform research, feed the slimes, make bombs."
-	department_head = list(JOB_RESEARCH_DIRECTOR)
 	faction = FACTION_STATION
 	total_positions = 5
 	spawn_positions = 3

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -3,7 +3,6 @@
 	description = "Protect company assets, follow the Standard Operating \
 		Procedure, eat donuts."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	department_head = list(JOB_HEAD_OF_SECURITY)
 	faction = FACTION_STATION
 	total_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	spawn_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -2,7 +2,6 @@
 	title = JOB_SHAFT_MINER
 	description = "Travel to strange lands. Mine ores. \
 		Meet strange creatures. Kill them for their gold."
-	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
 	total_positions = 3
 	spawn_positions = 3

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -2,7 +2,6 @@
 	title = JOB_STATION_ENGINEER
 	description = "Start the Supermatter, wire the solars, repair station hull \
 		and wiring damage."
-	department_head = list(JOB_CHIEF_ENGINEER)
 	faction = FACTION_STATION
 	total_positions = 5
 	spawn_positions = 5

--- a/code/modules/jobs/job_types/station_trait/bridge_assistant.dm
+++ b/code/modules/jobs/job_types/station_trait/bridge_assistant.dm
@@ -2,7 +2,6 @@
 	title = JOB_BRIDGE_ASSISTANT
 	description = "Watch over the Bridge, command its consoles, and spend your days brewing coffee for higher-ups."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD //not really a head but close enough
-	department_head = list(JOB_CAPTAIN)
 	faction = FACTION_STATION
 	total_positions = 0
 	spawn_positions = 0

--- a/code/modules/jobs/job_types/station_trait/cargo_gorilla.dm
+++ b/code/modules/jobs/job_types/station_trait/cargo_gorilla.dm
@@ -1,7 +1,6 @@
 /datum/job/cargo_gorilla
 	title = JOB_CARGO_GORILLA
 	description = "Assist the supply department by moving freight and disposing of unwanted fruits."
-	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
 	total_positions = 0
 	spawn_positions = 0

--- a/code/modules/jobs/job_types/station_trait/human_ai.dm
+++ b/code/modules/jobs/job_types/station_trait/human_ai.dm
@@ -2,7 +2,6 @@
 	title = JOB_HUMAN_AI
 	description = "Assist the crew, open airlocks, follow your lawset, and coordinate your cyborgs."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
-	department_head = list(JOB_RESEARCH_DIRECTOR)
 	faction = FACTION_STATION
 	total_positions = 0
 	spawn_positions = 0

--- a/code/modules/jobs/job_types/station_trait/pun_pun.dm
+++ b/code/modules/jobs/job_types/station_trait/pun_pun.dm
@@ -2,7 +2,6 @@
 /datum/job/pun_pun
 	title = JOB_PUN_PUN
 	description = "Assist the service department by serving drinks and food and entertaining the crew."
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
 	total_positions = 0
 	spawn_positions = 0

--- a/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
+++ b/code/modules/jobs/job_types/station_trait/veteran_advisor.dm
@@ -3,7 +3,6 @@
 	description = "Advise HoS, and Captain on matters of Security. Train green Officers. \
 		Lay back in your wheelchair and say \"I told you\" to the HoS when all of the station collapses."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	department_head = list(JOB_HEAD_OF_SECURITY)
 	faction = FACTION_STATION
 	total_positions = 0
 	spawn_positions = 0

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -4,7 +4,6 @@
 		their time is up, issue equipment to security, be a security officer when \
 		they all eventually die."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	department_head = list(JOB_HEAD_OF_SECURITY)
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -30,16 +30,6 @@ GLOBAL_LIST_INIT(exp_specialmap, list(
 ))
 GLOBAL_PROTECT(exp_specialmap)
 
-//this is necessary because antags happen before job datums are handed out, but NOT before they come into existence
-//so I can't simply use job datum.department_head straight from the mind datum, laaaaame.
-/proc/get_department_heads(job_title)
-	if(!job_title)
-		return list()
-
-	for(var/datum/job/job as anything in SSjob.joinable_occupations)
-		if(job.title == job_title)
-			return job.department_head //this is a list
-
 /proc/get_full_job_name(job)
 	var/static/regex/cap_expand = new("cap(?!tain)")
 	var/static/regex/cmo_expand = new("cmo")

--- a/code/modules/lost_crew/character/job_datums.dm
+++ b/code/modules/lost_crew/character/job_datums.dm
@@ -4,30 +4,24 @@
 
 /datum/job/recovered_crew/doctor
 	title = JOB_LOSTCREW_MEDICAL
-	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
 	supervisors = SUPERVISOR_CMO
 
 /datum/job/recovered_crew/engineer
 	title = JOB_LOSTCREW_ENGINEER
-	department_head = list(JOB_CHIEF_ENGINEER)
 	supervisors = SUPERVISOR_CE
 
 /datum/job/recovered_crew/security
 	title = JOB_LOSTCREW_SECURITY
-	department_head = list(JOB_HEAD_OF_SECURITY)
 	supervisors = SUPERVISOR_HOS
 
 /datum/job/recovered_crew/cargo
 	title = JOB_LOSTCREW_CARGO
-	department_head = list(JOB_QUARTERMASTER)
 	supervisors = SUPERVISOR_QM
 
 /datum/job/recovered_crew/scientist
 	title = JOB_LOSTCREW_SCIENCE
-	department_head = list(JOB_RESEARCH_DIRECTOR)
 	supervisors = SUPERVISOR_RD
 
 /datum/job/recovered_crew/civillian
 	title = JOB_LOSTCREW_CIVILLIAN
-	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	supervisors = SUPERVISOR_HOP

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -564,9 +564,10 @@
 		. += "-[facial_hairstyle]"
 		. += "-[override_hair_color || fixed_hair_color || facial_hair_color]"
 		. += "-[facial_hair_alpha]"
-		if(gradient_styles?[GRADIENT_FACIAL_HAIR_KEY])
-			. += "-[gradient_styles[GRADIENT_FACIAL_HAIR_KEY]]"
-			. += "-[gradient_colors[GRADIENT_FACIAL_HAIR_KEY]]"
+		var/facial_hair_gradient_style = get_hair_gradient_style(GRADIENT_FACIAL_HAIR_KEY)
+		if(facial_hair_gradient_style)
+			. += "-[facial_hair_gradient_style]"
+			. += "-[get_hair_gradient_color(GRADIENT_FACIAL_HAIR_KEY)]"
 
 	if(show_eyeless)
 		. += "-SHOW_EYELESS"
@@ -580,9 +581,10 @@
 		. += "-[hairstyle]"
 		. += "-[override_hair_color || fixed_hair_color || hair_color]"
 		. += "-[hair_alpha]"
-		if(gradient_styles?[GRADIENT_HAIR_KEY])
-			. += "-[gradient_styles[GRADIENT_HAIR_KEY]]"
-			. += "-[gradient_colors[GRADIENT_HAIR_KEY]]"
+		var/hair_gradient_style = get_hair_gradient_style(GRADIENT_HAIR_KEY)
+		if(hair_gradient_style)
+			. += "-[hair_gradient_style]"
+			. += "-[get_hair_gradient_color(GRADIENT_HAIR_KEY)]"
 		if(LAZYLEN(hair_masks))
 			. += "-[jointext(hair_masks, "-")]"
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -21,15 +21,9 @@
 	var/hairstyle = "Bald"
 
 	///Colours used for hair and facial hair gradients.
-	var/list/grad_color = list(
-		COLOR_BLACK,	//Hair Gradient Color
-		COLOR_BLACK,	//Facial Hair Gradient Color
-	)
+	var/list/grad_color
 	///Styles used for hair and facial hair gradients.
-	var/list/grad_style = list(
-		"None",	//Hair Gradient Style
-		"None",	//Facial Hair Gradient Style
-	)
+	var/list/grad_style
 
 	//Facial hair colour and style
 	var/facial_hair_color = COLOR_BLACK

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -120,7 +120,7 @@
  * Arguments
  * * [AM][atom] - the atom to grind or juice
  */
-/obj/machinery/plumbing/grinder_chemical/proc/blend(obj/item/I)
+/obj/machinery/plumbing/grinder_chemical/proc/blend(obj/item/item_to_blend)
 	PRIVATE_PROC(TRUE)
 
 	if(!is_operational || !anchored)
@@ -128,14 +128,14 @@
 	if(reagents.holder_full())
 		return
 
-	if((I.item_flags & ABSTRACT) || (I.flags_1 & HOLOGRAM_1))
+	if((item_to_blend.item_flags & ABSTRACT) || (item_to_blend.flags_1 & HOLOGRAM_1))
 		return
-	if(!I.blend_requirements(src))
+	if(!item_to_blend.blend_requirements(src))
 		return
 
 	if(!grinding)
-		I.juice(reagents, usr, src)
-	else if(length(I.grind_results) || I.reagents?.total_volume)
-		I.grind(reagents, usr, src)
+		item_to_blend.juice(reagents, usr, src)
+	else if(LAZYLEN(item_to_blend.grind_results) || item_to_blend.reagents?.total_volume)
+		item_to_blend.grind(reagents, usr, src)
 
 	use_energy(active_power_usage)

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -339,7 +339,7 @@
 				my_atom.visible_message(span_notice("[iconhtml] \The [my_atom]'s power is consumed in the reaction."))
 				extract.name = "used slime extract"
 				extract.desc = "This extract has been used up."
-				extract.grind_results.Cut()
+				LAZYNULL(extract.grind_results)
 
 	//finish the reaction
 	selected_reaction.on_reaction(src, null, multiplier)

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -4,7 +4,6 @@
 	desc = "Report this please."
 	abstract_type = /obj/item/reagent_containers/applicator
 	has_variable_transfer_amount = FALSE
-	grind_results = list()
 	/// Action string displayed in vis_message
 	var/apply_method = "swallow"
 	/// Does the item get its name changed as volume when its produced

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -447,9 +447,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	update_appearance()
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 	set_wires(new /datum/wires/conveyor(src))
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/conveyor_switch,
-	))
+	AddComponent(/datum/component/usb_port, typecacheof(list(/obj/item/circuit_component/conveyor_switch), only_root_path = TRUE))
 	register_context()
 
 /obj/machinery/conveyor_switch/Destroy()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -370,8 +370,8 @@
 		sexy_chad.hair_color = hair_color
 		sexy_chad.facial_hairstyle = facial_hairstyle
 		sexy_chad.facial_hair_color = facial_hair_color
-		sexy_chad.grad_style = gradient_styles.Copy()
-		sexy_chad.grad_color = gradient_colors.Copy()
+		sexy_chad.grad_style = LAZYCOPY(gradient_styles)
+		sexy_chad.grad_color = LAZYCOPY(gradient_colors)
 		sexy_chad.lip_style = lip_style
 		sexy_chad.lip_color = lip_color
 

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -57,15 +57,9 @@
 	var/facial_hair_hidden = FALSE
 
 	/// Gradient styles, if any
-	var/list/gradient_styles = list(
-		"None",	//Hair gradient style
-		"None",	//Facial hair gradient style
-	)
+	var/list/gradient_styles
 	/// Gradient colors, if any
-	var/list/gradient_colors = list(
-		COLOR_BLACK,	//Hair gradient color
-		COLOR_BLACK,	//Facial hair gradient color
-	)
+	var/list/gradient_colors
 
 	/// An override color that can be cleared later, affects both hair and facial hair
 	var/override_hair_color = null

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -56,8 +56,8 @@
 	facial_hair_alpha = target_species.facial_hair_alpha
 	facial_hair_color = target.facial_hair_color
 	fixed_hair_color = target_species.get_fixed_hair_color(target) //Can be null
-	gradient_styles = target.grad_style.Copy()
-	gradient_colors = target.grad_color.Copy()
+	gradient_styles = LAZYCOPY(target.grad_style)
+	gradient_colors = LAZYCOPY(target.grad_color)
 	var/obj/item/organ/eyes/peepers = locate() in src
 	if(peepers)
 		if(overwrite_eyes || isnull(initial(peepers.eye_color_left)))
@@ -114,9 +114,9 @@
 			worn_face_offset?.apply_offset(facial_hair_overlay)
 			. += facial_hair_overlay
 			//Gradients
-			var/facial_hair_gradient_style = gradient_styles[GRADIENT_FACIAL_HAIR_KEY]
+			var/facial_hair_gradient_style = get_hair_gradient_style(GRADIENT_FACIAL_HAIR_KEY)
 			if(facial_hair_gradient_style != "None")
-				var/facial_hair_gradient_color = gradient_colors[GRADIENT_FACIAL_HAIR_KEY]
+				var/facial_hair_gradient_color = get_hair_gradient_color(GRADIENT_FACIAL_HAIR_KEY)
 				var/image/facial_hair_gradient_overlay = get_gradient_overlay(icon(sprite_accessory.icon, sprite_accessory.icon_state), -HAIR_LAYER, SSaccessories.facial_hair_gradients_list[facial_hair_gradient_style], facial_hair_gradient_color, dropped)
 				. += facial_hair_gradient_overlay
 
@@ -150,9 +150,9 @@
 				worn_face_offset?.apply_offset(hair_overlay)
 				. += hair_overlay
 				//Gradients
-				var/hair_gradient_style = gradient_styles[GRADIENT_HAIR_KEY]
+				var/hair_gradient_style = get_hair_gradient_style(GRADIENT_HAIR_KEY)
 				if(hair_gradient_style != "None")
-					var/hair_gradient_color = gradient_colors[GRADIENT_HAIR_KEY]
+					var/hair_gradient_color = get_hair_gradient_color(GRADIENT_HAIR_KEY)
 					var/image/hair_gradient_overlay = get_gradient_overlay(base_icon, hair_overlay.layer, SSaccessories.hair_gradients_list[hair_gradient_style], hair_gradient_color, dropped)
 					hair_gradient_overlay.pixel_z = hair_sprite_accessory.y_offset
 					. += hair_gradient_overlay
@@ -303,6 +303,39 @@
 		update_body_parts()
 
 /**
+ * Get the hair gradient style of a human.
+ * Defaults to "None".
+ * arguments:
+ * * key (optional) - corresponds to hair or facial hair index. If no key is provided returns whole list.
+ **/
+/mob/living/proc/get_hair_gradient_style(key)
+	return
+
+/mob/living/carbon/human/get_hair_gradient_style(key)
+	if(key)
+		return LAZYACCESS(grad_style, key) || "None"
+
+	return grad_style || list(
+		"None",	//Hair Gradient Style
+		"None",	//Facial Hair Gradient Style
+	)
+
+/**
+ * Get the hair gradient style of a head.
+ * Defaults to "None".
+ * arguments:
+ * * key (optional) - corresponds to hair or facial hair index. If no key is provided returns whole list.
+ **/
+/obj/item/bodypart/head/proc/get_hair_gradient_style(key)
+	if(key)
+		return LAZYACCESS(gradient_styles, key) || "None"
+
+	return gradient_styles || list(
+		"None",	//Hair Gradient Style
+		"None",	//Facial Hair Gradient Style
+	)
+
+/**
  * Set the hair gradient style of a human.
  * Update calls update_body_parts().
  **/
@@ -310,16 +343,51 @@
 	return
 
 /mob/living/carbon/human/set_hair_gradient_style(new_style, update = TRUE)
-	if(grad_style[GRADIENT_HAIR_KEY] == new_style)
+	if(LAZYACCESS(grad_style, GRADIENT_HAIR_KEY) == new_style)
 		return
 	var/obj/item/bodypart/head/my_head = get_bodypart(BODY_ZONE_HEAD)
 
-	grad_style[GRADIENT_HAIR_KEY] = new_style
+	LAZYSET(grad_style, GRADIENT_HAIR_KEY, new_style)
 	if(my_head)
-		my_head.gradient_styles[GRADIENT_HAIR_KEY] = new_style
+		LAZYSET(my_head.gradient_styles, GRADIENT_HAIR_KEY, new_style)
 
 	if(update)
 		update_body_parts()
+
+/**
+ * Get the hair gradient color of a human.
+ * Defaults to black.
+ *
+ * arguments:
+ * * key (optional) - corresponds to hair or facial hair index. If no key is provided returns whole list.
+ **/
+/mob/living/proc/get_hair_gradient_color(key)
+	return
+
+/mob/living/carbon/human/get_hair_gradient_color(key)
+	if(key)
+		return LAZYACCESS(grad_color, key) || COLOR_BLACK
+
+	return grad_color || list(
+		COLOR_BLACK,	//Hair Gradient Color
+		COLOR_BLACK,	//Facial Hair Gradient Color
+	)
+
+/**
+ * Get the hair gradient color of a head.
+ * Defaults to black.
+ *
+ * arguments:
+ * * key (optional) - corresponds to hair or facial hair index. If no key is provided returns whole list.
+ **/
+/obj/item/bodypart/head/proc/get_hair_gradient_color(key)
+	if(key)
+		return LAZYACCESS(gradient_colors, key) || COLOR_BLACK
+
+	return gradient_colors || list(
+		COLOR_BLACK,	//Hair Gradient Color
+		COLOR_BLACK,	//Facial Hair Gradient Color
+	)
 
 /**
  * Set the hair gradient color of a human.
@@ -329,13 +397,13 @@
 	return
 
 /mob/living/carbon/human/set_hair_gradient_color(new_color, update = TRUE)
-	if(grad_color[GRADIENT_HAIR_KEY] == new_color)
+	if(LAZYACCESS(grad_color, GRADIENT_HAIR_KEY) == new_color)
 		return
 	var/obj/item/bodypart/head/my_head = get_bodypart(BODY_ZONE_HEAD)
 
-	grad_color[GRADIENT_HAIR_KEY] = new_color
+	LAZYSET(grad_color, GRADIENT_HAIR_KEY, new_color)
 	if(my_head)
-		my_head.gradient_colors[GRADIENT_HAIR_KEY] = new_color
+		LAZYSET(my_head.gradient_colors, GRADIENT_HAIR_KEY, new_color)
 
 	if(update)
 		update_body_parts()
@@ -385,13 +453,13 @@
 	return
 
 /mob/living/carbon/human/set_facial_hair_gradient_style(new_style, update = TRUE)
-	if(grad_style[GRADIENT_FACIAL_HAIR_KEY] == new_style)
+	if(LAZYACCESS(grad_style, GRADIENT_FACIAL_HAIR_KEY) == new_style)
 		return
 	var/obj/item/bodypart/head/my_head = get_bodypart(BODY_ZONE_HEAD)
 
-	grad_style[GRADIENT_FACIAL_HAIR_KEY] = new_style
+	LAZYSET(grad_style, GRADIENT_FACIAL_HAIR_KEY, new_style)
 	if(my_head)
-		my_head.gradient_styles[GRADIENT_FACIAL_HAIR_KEY] = new_style
+		LAZYSET(my_head.gradient_styles, GRADIENT_FACIAL_HAIR_KEY, new_style)
 
 	if(update)
 		update_body_parts()
@@ -404,13 +472,13 @@
 	return
 
 /mob/living/carbon/human/set_facial_hair_gradient_color(new_color, update = TRUE)
-	if(grad_color[GRADIENT_FACIAL_HAIR_KEY] == new_color)
+	if(LAZYACCESS(grad_color, GRADIENT_FACIAL_HAIR_KEY) == new_color)
 		return
 	var/obj/item/bodypart/head/my_head = get_bodypart(BODY_ZONE_HEAD)
 
-	grad_color[GRADIENT_FACIAL_HAIR_KEY] = new_color
+	LAZYSET(grad_color, GRADIENT_FACIAL_HAIR_KEY, new_color)
 	if(my_head)
-		my_head.gradient_colors[GRADIENT_FACIAL_HAIR_KEY] = new_color
+		LAZYSET(my_head.gradient_colors, GRADIENT_FACIAL_HAIR_KEY, new_color)
 
 	if(update)
 		update_body_parts()

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -39,7 +39,7 @@
 	/// Whether the stomach's been repaired with surgery and can be fixed again or not
 	var/operated = FALSE
 	/// List of all atoms within the stomach
-	var/list/atom/movable/stomach_contents = list()
+	var/list/atom/movable/stomach_contents
 	/// Have we been cut open with a scalpel? If so, how much damage from it we still have from it and can be recovered with a cauterizing tool.
 	/// All healing goes towards recovering this.
 	var/cut_open_damage = 0
@@ -215,19 +215,19 @@
 /obj/item/organ/stomach/proc/consume_thing(atom/movable/thing)
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
 	RegisterSignal(thing, COMSIG_QDELETING, PROC_REF(content_deleted))
-	stomach_contents += thing
+	LAZYADD(stomach_contents, thing)
 	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced
 	return TRUE
 
 /obj/item/organ/stomach/proc/content_deleted(atom/movable/source)
 	SIGNAL_HANDLER
-	stomach_contents -= source
+	LAZYREMOVE(stomach_contents, source)
 
 /obj/item/organ/stomach/proc/content_moved(atom/movable/source)
 	SIGNAL_HANDLER
 	if(source.loc == src || source.loc == owner) // not in us? out da list then
 		return
-	stomach_contents -= source
+	LAZYREMOVE(stomach_contents, source)
 	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 
 /obj/item/organ/stomach/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
@@ -248,7 +248,7 @@
 		var/total_chance = chance
 		// If min_amount is set, make sure that we vomit at least some of our contents
 		if (min_amount)
-			total_chance += 100 / (length(stomach_contents) + 1 - min_amount)
+			total_chance += 100 / (LAZYLEN(stomach_contents) + 1 - min_amount)
 		if (!prob(total_chance))
 			continue
 		nugget.forceMove(drop_loc)
@@ -271,7 +271,7 @@
 	if (!owner || SSmobs.times_fired % 3 != 0)
 		return
 
-	if (!length(stomach_contents))
+	if (!LAZYLEN(stomach_contents))
 		return
 
 	var/obj/item/bodypart/chest/chest = owner.get_bodypart(zone)
@@ -305,7 +305,7 @@
 			if (chest && !chest.cavity_item && as_item.w_class <= WEIGHT_CLASS_NORMAL)
 				// Oopsie!
 				chest.cavity_item = as_item
-				stomach_contents -= as_item
+				LAZYREMOVE(stomach_contents, as_item)
 				continue
 
 			owner.apply_damage(as_item.w_class * (as_item.sharpness ? 2 : 1), BRUTE, BODY_ZONE_CHEST, wound_bonus = CANT_WOUND,
@@ -411,7 +411,7 @@
 /// If damage is high enough, we may end up vomiting out whatever we had stored
 /obj/item/organ/stomach/proc/on_punched(datum/source, mob/living/carbon/human/attacker, damage, attack_type, obj/item/bodypart/affecting, final_armor_block, kicking, limb_sharpness)
 	SIGNAL_HANDLER
-	if (!length(stomach_contents) || damage < 9 || final_armor_block || kicking)
+	if (!LAZYLEN(stomach_contents) || damage < 9 || final_armor_block || kicking)
 		return
 	if (owner.vomit(MOB_VOMIT_MESSAGE | MOB_VOMIT_FORCE))
 		// Since we vomited with a force flag, we should've vomited out at least one item

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -53,8 +53,7 @@
 		reagents.flags |= REAGENT_HOLDER_ALIVE
 
 /obj/item/organ/stomach/Destroy()
-	if(stomach_contents)
-		QDEL_LIST(stomach_contents)
+	QDEL_LAZYLIST(stomach_contents)
 	return ..()
 
 /obj/item/organ/stomach/on_life(seconds_per_tick, times_fired)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -53,7 +53,8 @@
 		reagents.flags |= REAGENT_HOLDER_ALIVE
 
 /obj/item/organ/stomach/Destroy()
-	QDEL_LIST(stomach_contents)
+	if(stomach_contents)
+		QDEL_LIST(stomach_contents)
 	return ..()
 
 /obj/item/organ/stomach/on_life(seconds_per_tick, times_fired)

--- a/code/modules/wiremod/components/id/access_checker.dm
+++ b/code/modules/wiremod/components/id/access_checker.dm
@@ -57,7 +57,7 @@
 	return check_access_list(subject_accesses.value)
 
 /obj/item/circuit_component/compare/access/ui_perform_action(mob/user, action)
-	if(length(required_accesses.connected_ports))
+	if(LAZYLEN(required_accesses.connected_ports))
 		balloon_alert(user, "disconnect port before manually configuring!")
 		return
 	interact(user)

--- a/code/modules/wiremod/core/duplicator.dm
+++ b/code/modules/wiremod/core/duplicator.dm
@@ -155,7 +155,7 @@ GLOBAL_LIST_INIT(circuit_dupe_whitelisted_types, list(
 		var/list/input_ports_stored_data = list()
 		for(var/datum/port/input/input as anything in component.input_ports)
 			var/list/connection_data = list()
-			if(!length(input.connected_ports))
+			if(!LAZYLEN(input.connected_ports))
 				if(isnull(input.value) || !(input.datatype in GLOB.circuit_dupe_whitelisted_types))
 					continue
 				connection_data["stored_data"] = input.value

--- a/code/modules/wiremod/core/port.dm
+++ b/code/modules/wiremod/core/port.dm
@@ -141,7 +141,7 @@
 
 /datum/port/input/proc/disconnect(datum/port/output/output)
 	SIGNAL_HANDLER
-	connected_ports -= output
+	LAZYREMOVE(connected_ports, output)
 	UnregisterSignal(output, COMSIG_PORT_SET_VALUE)
 	UnregisterSignal(output, COMSIG_PORT_SET_TYPE)
 	UnregisterSignal(output, COMSIG_PORT_DISCONNECT)
@@ -174,7 +174,6 @@
 	set_value(default)
 	if(trigger)
 		src.trigger = trigger
-	src.connected_ports = list()
 
 /**
  * Connects an input port to an output port.
@@ -185,7 +184,7 @@
 /datum/port/input/proc/connect(datum/port/output/output)
 	if(output in connected_ports)
 		return
-	connected_ports += output
+	LAZYADD(connected_ports, output)
 	RegisterSignal(output, COMSIG_PORT_SET_VALUE, PROC_REF(receive_value))
 	RegisterSignal(output, COMSIG_PORT_SET_TYPE, PROC_REF(check_type))
 	RegisterSignal(output, COMSIG_PORT_DISCONNECT, PROC_REF(disconnect))


### PR DESCRIPTION
## About The Pull Request

Empy lists. There are a lot of 'em.

<img width="981" height="512" alt="image" src="https://github.com/user-attachments/assets/b94b041a-2904-466b-ab89-54bd1de11b4e" />

Going through ways to reduce memory I found a few easy ones here. Wires, the edible component, the seethrough component. None of these are really a concern when it comes to needing lists in memory for performance reasons. Wires aren't going to be cut most of the time for each door. A lot of food does not have any junkiness. Seethrough component lies dormant most of the round. Etc. 

Making lists lazy in these cases should be a no brainer.

Everything I tested still seems to work exactly the same.

## Why It's Good For The Game

Frees memory that is just taking up space a lot of the time.

## Changelog

Not player-facing, this is all under-the-hood stuff.