### PR TITLE
Warden can open the lethal injection locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -174,7 +174,7 @@
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections locker"
-	req_access = list(ACCESS_HOS)
+	req_access = list(ACCESS_ARMORY)
 
 /obj/structure/closet/secure_closet/injection/PopulateContents()
 	..()


### PR DESCRIPTION
## About The Pull Request

The access of the injection locker matches the rest of the room and warden can open it (not normal officers)

## Why It's Good For The Game

It makes no sense why this one method of execution specifically is only for HOS and captain. Warden can already shoot it open with lasers or shoot the guy being executed with lasers so it's not like it's powercreep or smth.

## Changelog
:cl:
balance: The lethal injection locker is now accessible by the warden.
/:cl:
