### PR TITLE
Allows you to drop stuff in disposal bins (sort of) 

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -429,7 +429,7 @@
 	for(var/datum/reagent/current_reagent as anything in reagents)
 		. |= current_reagent.expose_atom(src, reagents[current_reagent], methods)
 
-/// Are you allowed to drop this atom
+/// Are you allowed to drop stuff inside this atom
 /atom/proc/AllowDrop()
 	return FALSE
 

--- a/code/game/objects/items/drug_items.dm
+++ b/code/game/objects/items/drug_items.dm
@@ -74,7 +74,6 @@
 	transfer_fingerprints_to(ampoule_shard)
 	splash_reagents(hit_atom, throwingdatum?.get_thrower(), was_thrown = TRUE, allow_closed_splash = FALSE)
 	qdel(src)
-	hit_atom.Bumped(ampoule_shard)
 
 /obj/item/reagent_containers/cup/blastoff_ampoule/Initialize(mapload, vol)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -33,7 +33,6 @@
 	var/obj/item/broken_bottle/B = new (loc)
 	B.mimic_broken(src, target, break_top)
 	qdel(src)
-	target.Bumped(B)
 
 /obj/item/reagent_containers/cup/glass/bullet_act(obj/projectile/proj)
 	. = ..()
@@ -382,7 +381,6 @@
 	var/obj/item/broken_bottle/bottle_shard = new(drop_location())
 	bottle_shard.mimic_broken(src, target)
 	qdel(src)
-	target.Bumped(bottle_shard)
 
 /obj/item/reagent_containers/cup/glass/colocup
 	name = "colo cup"

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -139,7 +139,6 @@
 		message_in_a_bottle.forceMove(drop_location())
 
 	qdel(src)
-	target.Bumped(broken)
 	return TRUE
 
 /obj/item/reagent_containers/cup/glass/bottle/try_splash(mob/user, atom/target)
@@ -263,8 +262,7 @@
 		desc = "A carton with the bottom half burst open. Might give you a papercut."
 	else
 		if(prob(33))
-			var/obj/item/shard/stab_with = new(to_mimic.drop_location())
-			target.Bumped(stab_with)
+			new /obj/item/shard(to_mimic.drop_location())
 		playsound(src, SFX_SHATTER, 70, TRUE)
 	name = "broken [to_mimic.name]"
 	to_mimic.transfer_fingerprints_to(src)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -74,6 +74,9 @@ GLOBAL_VAR_INIT(disposals_animals_spawned, 0)
 
 	return INITIALIZE_HINT_LATELOAD //we need turfs to have air
 
+/obj/machinery/disposal/AllowDrop()
+	return TRUE
+
 /// Checks if there a connecting trunk diposal pipe under the disposal
 /obj/machinery/disposal/proc/trunk_check()
 	var/obj/structure/disposalpipe/trunk/found_trunk = locate() in loc


### PR DESCRIPTION
## About The Pull Request

If you are **within**
(inside)
(as in you climb into a disposal bin)
(like if you're about to be flushed)
a disposal bin or chute, and drop something, the item goes into the bin
(with you)
(inside the bid)
(like if you put an item in a bin like normal)
(it will also be flushed)
rather than onto the floor around the bin

https://github.com/tgstation/tgstation/pull/40723 added a bunch of snowflake `Bumped` calls to mimic this effect - they have been removed.

## Why It's Good For The Game

Seems logical to me. It might break a bunch of stuff but it probably won't.

## Changelog

:cl: Melbert
qol: If you are within a disposal bin or chute, and drop an item, the item will go into the bin, rather than onto the floor outside of the bin.
/:cl:

