### PR TITLE
Expands expanded storage MODule to 5 complexity

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -951,6 +951,7 @@
 		both corrosive environments and sudden impacts to the user's joints."
 	default_skin = "safeguard"
 	armor_type = /datum/armor/mod_theme_safeguard
+	complexity_max = DEFAULT_MAX_COMPLEXITY + 1
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked, /obj/item/mod/module/hearing_protection)

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -462,7 +462,7 @@
 	resistance_flags = FIRE_PROOF|LAVA_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 2
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 1
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	inbuilt_modules = list(/obj/item/mod/module/ash_accretion, /obj/item/mod/module/sphere_transform)
 	variants = list(

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -951,7 +951,7 @@
 		both corrosive environments and sudden impacts to the user's joints."
 	default_skin = "safeguard"
 	armor_type = /datum/armor/mod_theme_safeguard
-	complexity_max = DEFAULT_MAX_COMPLEXITY + 1
+	complexity_max = DEFAULT_MAX_COMPLEXITY + 2
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked, /obj/item/mod/module/hearing_protection)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -60,6 +60,7 @@
 		is entirely within the suit, distributing items and weight evenly to ensure a comfortable experience for the user; \
 		whether smuggling, or simply hauling."
 	icon_state = "storage_large"
+	complexity = 4
 	max_combined_w_class = 21
 	max_items = 14
 

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -60,7 +60,7 @@
 		is entirely within the suit, distributing items and weight evenly to ensure a comfortable experience for the user; \
 		whether smuggling, or simply hauling."
 	icon_state = "storage_large"
-	complexity = 4
+	complexity = 5
 	max_combined_w_class = 21
 	max_items = 14
 


### PR DESCRIPTION
## About The Pull Request

Alternative to #94228

Makes the Expanded Storage MODule cost 5 complexity to mount rather than 3. No current pre-equipped MODsuits are overfilled by this, except the mining MODsuit and HOS MODsuit, which have been given extra complexity to avoid this. If this is a point of contention, then I'll just remove one of their MODules.

## Why It's Good For The Game

The expanded storage MODule is a straight upgrade, and one that removes what I would identify as the primary(and what I would also identify as the only real) drawback of taking a MODsuit entirely. There is no reason to not to use this MODule if it is available, and this means MODsuits when this MODule is available have no reason to have a downside at all. Now, two extra complexity still isn't much of a hard sell when it does completely remove the drawback of the suit, but it'll at least be something to consider.

To put it simply, the point is to make MODsuits that don't have any drawbacks less powerful because of it.

## Changelog
:cl:

balance: Increased the complexity cost of the expanded storage MODule to 5

/:cl:
