### PR TITLE
Hygienebot extinguishes you

### DIFF
--- a/code/modules/mob/living/basic/bots/hygienebot/hygienebot.dm
+++ b/code/modules/mob/living/basic/bots/hygienebot/hygienebot.dm
@@ -115,6 +115,7 @@
 		target.fire_act()
 		return
 	target.wash(CLEAN_WASH)
+	target.extinguish()
 
 /mob/living/basic/bot/hygienebot/on_bot_movement(atom/movable/source, atom/oldloc, dir, forced)
 


### PR DESCRIPTION

## About The Pull Request

Hygiene bots now extinguish mobs when they wash them.

## Why It's Good For The Game

You're being doused with a liquid, how is your cigarette still burning?

## Changelog
:cl:
add: Hygiene bots now extinguish when cleaning.
/:cl: