### PR TITLE
Hearing protection has a tag and is built in to modsuits

### DIFF
--- a/code/datums/components/earprotection.dm
+++ b/code/datums/components/earprotection.dm
@@ -10,7 +10,15 @@
 /datum/component/wearertargeting/earprotection/Initialize(protection_amount = EAR_PROTECTION_NORMAL)
 	. = ..()
 	src.protection_amount = protection_amount
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE_TAGS, PROC_REF(get_examine_tags))
 
 /datum/component/wearertargeting/earprotection/proc/reducebang(datum/source, list/reflist)
 	SIGNAL_HANDLER
 	reflist[EAR_PROTECTION_ARG] += protection_amount
+
+/datum/component/wearertargeting/earprotection/proc/get_examine_tags(atom/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if(protection_amount == EAR_PROTECTION_NORMAL)
+		examine_list["sound-proof"] = "It protects the ears from flashbangs and other loud noises."
+	else if(protection_amount >= EAR_PROTECTION_HEAVY)
+		examine_list["sound-proof"] = "It provides [(protection_amount = EAR_PROTECTION_FULL) ? "full" : "heavy"] protection against flashbangs and other loud noises."

--- a/code/datums/components/earprotection.dm
+++ b/code/datums/components/earprotection.dm
@@ -21,4 +21,4 @@
 	if(protection_amount == EAR_PROTECTION_NORMAL)
 		examine_list["sound-proof"] = "It protects the ears from flashbangs and other loud noises."
 	else if(protection_amount >= EAR_PROTECTION_HEAVY)
-		examine_list["sound-proof"] = "It provides [(protection_amount = EAR_PROTECTION_FULL) ? "full" : "heavy"] protection against flashbangs and other loud noises."
+		examine_list["sound-proof"] = "It provides [protection_amount == EAR_PROTECTION_FULL ? "full" : "heavy"] protection against flashbangs and other loud noises."

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -259,7 +259,7 @@
 		part.heat_protection = initial(part.heat_protection)
 		part.cold_protection = initial(part.cold_protection)
 		part.alternate_worn_layer = part_datum.sealed_layer
-		if((part.slot_flags & ITEM_SLOT_HEAD))
+		if(part.slot_flags & ITEM_SLOT_HEAD)
 			var/datum/component/wearertargeting/protection = part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = src.theme.hearing_protection)
 			protection.on_equip(src, wearer, ITEM_SLOT_HEAD)
 	else

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -259,9 +259,8 @@
 		part.heat_protection = initial(part.heat_protection)
 		part.cold_protection = initial(part.cold_protection)
 		part.alternate_worn_layer = part_datum.sealed_layer
-		if((part.slot_flags & ITEM_SLOT_HEAD) && istype(part, /obj/item/clothing/head/mod))
-			var/obj/item/clothing/head/mod/mod_clothing_part = part
-			var/datum/component/wearertargeting/protection = mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
+		if((part.slot_flags & ITEM_SLOT_HEAD))
+			var/datum/component/wearertargeting/protection = part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = src.theme.hearing_protection)
 			protection.on_equip(src, wearer, ITEM_SLOT_HEAD)
 	else
 		part.icon_state = "[skin]-[part.base_icon_state]"

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -261,8 +261,7 @@
 		part.alternate_worn_layer = part_datum.sealed_layer
 		if((part.slot_flags & ITEM_SLOT_HEAD) && istype(part, /obj/item/clothing/head/mod))
 			var/obj/item/clothing/head/mod/mod_clothing_part = part
-			mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
-			var/datum/component/wearertargeting/earprotection/protection = mod_clothing_part.GetComponent(/datum/component/wearertargeting/earprotection)
+			protection = mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
 			protection.on_equip(src, wearer, ITEM_SLOT_HEAD)
 	else
 		part.icon_state = "[skin]-[part.base_icon_state]"

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -259,6 +259,11 @@
 		part.heat_protection = initial(part.heat_protection)
 		part.cold_protection = initial(part.cold_protection)
 		part.alternate_worn_layer = part_datum.sealed_layer
+		if((part.slot_flags & ITEM_SLOT_HEAD) && istype(part, /obj/item/clothing/head/mod))
+			var/obj/item/clothing/head/mod/mod_clothing_part = part
+			mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
+			var/datum/component/wearertargeting/earprotection/protection = mod_clothing_part.GetComponent(/datum/component/wearertargeting/earprotection)
+			protection.on_equip(src, wearer, ITEM_SLOT_HEAD)
 	else
 		part.icon_state = "[skin]-[part.base_icon_state]"
 		part.flags_cover &= ~part.visor_flags_cover
@@ -267,6 +272,8 @@
 		part.heat_protection = NONE
 		part.cold_protection = NONE
 		part.alternate_worn_layer = part_datum.unsealed_layer
+		if((part.slot_flags & ITEM_SLOT_HEAD) && istype(part, /obj/item/clothing/head/mod))
+			qdel(part.GetComponent(/datum/component/wearertargeting/earprotection))
 	update_speed()
 	wearer.update_clothing(part.slot_flags | slot_flags)
 	wearer.refresh_obscured()

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -261,7 +261,7 @@
 		part.alternate_worn_layer = part_datum.sealed_layer
 		if((part.slot_flags & ITEM_SLOT_HEAD) && istype(part, /obj/item/clothing/head/mod))
 			var/obj/item/clothing/head/mod/mod_clothing_part = part
-			protection = mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
+			var/protection = mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
 			protection.on_equip(src, wearer, ITEM_SLOT_HEAD)
 	else
 		part.icon_state = "[skin]-[part.base_icon_state]"

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -261,7 +261,7 @@
 		part.alternate_worn_layer = part_datum.sealed_layer
 		if((part.slot_flags & ITEM_SLOT_HEAD) && istype(part, /obj/item/clothing/head/mod))
 			var/obj/item/clothing/head/mod/mod_clothing_part = part
-			var/protection = mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
+			var/datum/component/wearertargeting/protection = mod_clothing_part.AddComponent(/datum/component/wearertargeting/earprotection, protection_amount = mod_clothing_part.hearing_protection)
 			protection.on_equip(src, wearer, ITEM_SLOT_HEAD)
 	else
 		part.icon_state = "[skin]-[part.base_icon_state]"

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -9,8 +9,6 @@
 	body_parts_covered = HEAD
 	heat_protection = HEAD
 	cold_protection = HEAD
-	// Whether or not the helmet has hearing protection. This has to go here and not get added as a component because the hearing protection goes away when it's unsealed.
-	var/hearing_protection
 
 // Even without a hat stabilizer, hats can be worn - however, they'll fall off very easily
 /obj/item/clothing/head/mod/Initialize(mapload)

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -9,6 +9,8 @@
 	body_parts_covered = HEAD
 	heat_protection = HEAD
 	cold_protection = HEAD
+	// Whether or not the helmet has hearing protection. This has to go here and not get added as a component because the hearing protection goes away when it's unsealed.
+	var/hearing_protection
 
 // Even without a hat stabilizer, hats can be worn - however, they'll fall off very easily
 /obj/item/clothing/head/mod/Initialize(mapload)

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -114,16 +114,9 @@
 		if(!ispath(path))
 			continue
 		var/obj/item/mod_part = new path(mod)
-		if(isclothing(mod_part))
-			var/obj/item/clothing/clothing_part = mod_part
-			switch(mod_part.slot_flags)
-				if(ITEM_SLOT_OCLOTHING)
-					clothing_part.allowed |= allowed_suit_storage
-				if(ITEM_SLOT_HEAD)
-					if(hearing_protection && istype(clothing_part, /obj/item/clothing/head/mod))
-						var/obj/item/clothing/head/mod/mod_clothing_part = mod_part
-						// This doesn't give us hearing protection, it just tells the helmet to remember that for when it gets activated
-						mod_clothing_part.hearing_protection = hearing_protection
+		if(isclothing(mod_part) && mod_part.slot_flags == ITEM_SLOT_OCLOTHING)
+			var/obj/item/clothing/chestplate = mod_part
+			chestplate.allowed |= allowed_suit_storage
 		var/datum/mod_part/part_datum = new()
 		part_datum.set_item(mod_part)
 		mod.mod_parts["[mod_part.slot_flags]"] = part_datum

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -25,6 +25,8 @@
 	var/datum/armor/armor_type = /datum/armor/mod_theme
 	/// Resistance flags shared across the MOD parts.
 	var/resistance_flags = NONE
+	/// Hearing protection level supplied by the modsuit head
+	var/hearing_protection
 	/// Atom flags shared across the MOD parts.
 	var/atom_flags = NONE
 	/// Max heat protection shared across the MOD parts.
@@ -112,9 +114,16 @@
 		if(!ispath(path))
 			continue
 		var/obj/item/mod_part = new path(mod)
-		if(mod_part.slot_flags == ITEM_SLOT_OCLOTHING && isclothing(mod_part))
-			var/obj/item/clothing/chestplate = mod_part
-			chestplate.allowed |= allowed_suit_storage
+		if(isclothing(mod_part))
+			var/obj/item/clothing/clothing_part = mod_part
+			switch(mod_part.slot_flags)
+				if(ITEM_SLOT_OCLOTHING)
+					clothing_part.allowed |= allowed_suit_storage
+				if(ITEM_SLOT_HEAD)
+					if(hearing_protection && istype(clothing_part, /obj/item/clothing/head/mod))
+						var/obj/item/clothing/head/mod/mod_clothing_part = mod_part
+						// This doesn't give us hearing protection, it just tells the helmet to remember that for when it gets activated
+						mod_clothing_part.hearing_protection = hearing_protection
 		var/datum/mod_part/part_datum = new()
 		part_datum.set_item(mod_part)
 		mod.mod_parts["[mod_part.slot_flags]"] = part_datum
@@ -819,7 +828,8 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	slowdown_deployed = 1.25
-	inbuilt_modules = list(/obj/item/mod/module/reagent_scanner/advanced, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/reagent_scanner/advanced)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/analyzer,
 		/obj/item/dnainjector,
@@ -886,7 +896,7 @@
 	armor_type = /datum/armor/mod_theme_security
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 2
 	slowdown_deployed = 0.5
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
@@ -953,7 +963,8 @@
 	armor_type = /datum/armor/mod_theme_safeguard
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
-	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	slowdown_deployed = 0.25
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
@@ -1026,7 +1037,7 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	slowdown_deployed = 0.25
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1165,7 +1176,8 @@
 	slowdown_deployed = 0
 	ui_theme = "syndicate"
 	resistance_flags = FIRE_PROOF
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1271,7 +1283,8 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1345,7 +1358,8 @@
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.5
 	ui_theme = "syndicate"
 	slot_flags = ITEM_SLOT_BELT
-	inbuilt_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/storage/belt, /obj/item/mod/module/demoralizer, /obj/item/mod/module/hearing_protection, /obj/item/mod/module/night)
+	inbuilt_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/storage/belt, /obj/item/mod/module/demoralizer, /obj/item/mod/module/night)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1414,7 +1428,8 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	slowdown_deployed = -0.5
-	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/assembly/flash,
 		/obj/item/healthanalyzer,
@@ -1501,7 +1516,8 @@
 	complexity_max = DEFAULT_MAX_COMPLEXITY
 	slowdown_deployed = 0
 	ui_theme = "wizard"
-	inbuilt_modules = list(/obj/item/mod/module/anti_magic/wizard, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/anti_magic/wizard)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/teleportation_scroll,
 		/obj/item/highfrequencyblade/wizard,
@@ -1568,7 +1584,8 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	ui_theme = "hackerman"
-	inbuilt_modules = list(/obj/item/mod/module/welding/camera_vision, /obj/item/mod/module/hacker, /obj/item/mod/module/weapon_recall, /obj/item/mod/module/adrenaline_boost, /obj/item/mod/module/energy_net, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/welding/camera_vision, /obj/item/mod/module/hacker, /obj/item/mod/module/weapon_recall, /obj/item/mod/module/adrenaline_boost, /obj/item/mod/module/energy_net)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/gun,
 		/obj/item/melee/baton,
@@ -1704,7 +1721,8 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	ui_theme = "ntos_terminal"
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1772,7 +1790,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_deployed = 0
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1885,7 +1903,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 10
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1956,7 +1974,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_deployed = 0
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -2021,7 +2039,7 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 10
 	slowdown_deployed = 0
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 	)
@@ -2087,7 +2105,7 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.2
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_NORMAL
 	allowed_suit_storage = list(
 		/obj/item/gun,
 	)
@@ -2154,7 +2172,7 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	activation_step_time = MOD_ACTIVATION_STEP_TIME * 0.01
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	hearing_protection = EAR_PROTECTION_FULL
 	allowed_suit_storage = list(
 		/obj/item/gun,
 	)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -1040,25 +1040,3 @@
 	var/datum/effect_system/lightning_spread/sparks = new /datum/effect_system/lightning_spread
 	sparks.set_up(number = 5, cardinals_only = TRUE, location = mod.wearer.loc)
 	sparks.start()
-
-/obj/item/mod/module/hearing_protection
-	name = "MOD hearing protection module"
-	desc = "A module that protects the users ears from loud sounds"
-	complexity = 0
-	removable = FALSE
-	incompatible_modules = list(/obj/item/mod/module/hearing_protection)
-	required_slots = list(ITEM_SLOT_HEAD)
-
-/obj/item/mod/module/hearing_protection/on_part_activation()
-	var/obj/item/clothing/head_cover = mod.get_part_from_slot(ITEM_SLOT_HEAD) || mod.get_part_from_slot(ITEM_SLOT_MASK) || mod.get_part_from_slot(ITEM_SLOT_EYES)
-	if(istype(head_cover))
-		head_cover.AddComponent(/datum/component/wearertargeting/earprotection)
-		var/datum/component/wearertargeting/earprotection/protection = head_cover.GetComponent(/datum/component/wearertargeting/earprotection)
-		protection.on_equip(src, mod.wearer, ITEM_SLOT_HEAD)
-
-/obj/item/mod/module/hearing_protection/on_part_deactivation(deleting = FALSE)
-	if(deleting)
-		return
-	var/obj/item/clothing/head_cover = mod.get_part_from_slot(ITEM_SLOT_HEAD) || mod.get_part_from_slot(ITEM_SLOT_MASK) || mod.get_part_from_slot(ITEM_SLOT_EYES)
-	if(istype(head_cover))
-		qdel(head_cover.GetComponent(/datum/component/wearertargeting/earprotection))


### PR DESCRIPTION
## About The Pull Request
Atomized from #94221

This PR removes the hearing protection module, and instead gives hearing protection properties to all the helmets of the modsuits that previously had it while they're powered on. Also, hearing protection is visible on examine.

## Why It's Good For The Game

The hearing protection module takes up 0 complexity. It cannot be removed, and new ones cannot be printed. So why is it even a module to begin with? It should just be part of the modsuit theme's stats like armor and electrical insulation. That way it doesn't take up space in the UI for no reason.

## Changelog

:cl:
qol: ear protection is visible on examine
qol: hearing protection modsuit module is now built in
/:cl: