### PR TITLE
Fix cargo manifests sometimes not listing things

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -141,7 +141,7 @@
 	manifest_text += "Contents: <br/>"
 	manifest_text += "<ul>"
 	var/container_contents = list() // Associative list with the format (item_name = nº of occurrences, ...)
-	for(var/atom/movable/stuff in container.contents - manifest_paper)
+	for(var/atom/movable/stuff as anything in container.contents - manifest_paper)
 		if(isstack(stuff))
 			var/obj/item/stack/thing = stuff
 			container_contents[thing.singular_name] += thing.amount

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -141,7 +141,7 @@
 	manifest_text += "Contents: <br/>"
 	manifest_text += "<ul>"
 	var/container_contents = list() // Associative list with the format (item_name = nº of occurrences, ...)
-	for(var/obj/item/stuff in container.contents - manifest_paper)
+	for(var/atom/movable/stuff in container.contents - manifest_paper)
 		if(isstack(stuff))
 			var/obj/item/stack/thing = stuff
 			container_contents[thing.singular_name] += thing.amount


### PR DESCRIPTION

## About The Pull Request

The loop to generate manifest contents only looked for `/obj/item` when you can get `/obj/structure` or even `/mob` in crates, changes the loop to `/atom/movable`

## Why It's Good For The Game

Empty manifests make people red stamp and lose credits because these technically have no errors

## Changelog
:cl:
fix: fixed cargo manifests missing things in certain crates
/:cl:
