### PR TITLE
Fixes the robot wabbajack weights being broken for 3 years

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1505,23 +1505,23 @@
 			var/static/list/robot_options = list(
 				/mob/living/silicon/robot = 200,
 				/mob/living/basic/drone/polymorphed = 200,
+				/mob/living/silicon/robot/model/syndicate = 100,
+				/mob/living/silicon/robot/model/syndicate/medical = 100,
+				/mob/living/silicon/robot/model/syndicate/saboteur = 100,
+				/mob/living/basic/hivebot/strong = 50,
+				/mob/living/basic/hivebot/mechanic = 50,
 				/mob/living/basic/bot/dedbot = 25,
 				/mob/living/basic/bot/cleanbot = 25,
 				/mob/living/basic/bot/firebot = 25,
 				/mob/living/basic/bot/honkbot = 25,
 				/mob/living/basic/bot/hygienebot = 25,
-				/mob/living/basic/bot/medbot/mysterious = 12,
-				/mob/living/basic/bot/medbot = 13,
 				/mob/living/basic/bot/vibebot = 25,
-				/mob/living/basic/hivebot/strong = 50,
-				/mob/living/basic/hivebot/mechanic = 50,
+				/mob/living/basic/bot/medbot = 13,
+				/mob/living/basic/bot/medbot/mysterious = 12,
 				/mob/living/basic/netguardian = 1,
-				/mob/living/silicon/robot/model/syndicate = 1,
-				/mob/living/silicon/robot/model/syndicate/medical = 1,
-				/mob/living/silicon/robot/model/syndicate/saboteur = 1,
 			)
 
-			var/picked_robot = pick(robot_options)
+			var/picked_robot = pick_weight(robot_options)
 			new_mob = new picked_robot(loc)
 			if(issilicon(new_mob))
 				var/mob/living/silicon/robot/created_robot = new_mob


### PR DESCRIPTION
## About The Pull Request

So this one is gonna be a pain for everyone involved, have fun discussing it maints
Basically 3 years ago https://github.com/tgstation/tgstation/pull/69091 changed the wabbajack robot `pick()` to be a list instead of passing the 5 arguments raw into `pick()`
The same PR also accidentally changed the weights on syndicate borgs to be 1, from 100 (gotta love default byond syntax)
However that PR also didn't make it actually do `pick_weight()`, so it was broken and everything was equal for those 3 years

This PR changes the weights of syndi borgs back to what they were intended to be, fixed the weighted pick and sorted the list from most to least likelly
(and as a consequence of fixing weights, the netguardian chances went from  1 in 16 to 1 in 976, who made these weights?)

## Why It's Good For The Game

Makes the code do what coders expect it to do.

## Changelog

:cl:
balance: wabbajack robot transformations are now weighted like 3 years ago
/:cl:
