### PR TITLE
MODsuits without large storages do not get slowdown when undeployed

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -84,6 +84,8 @@
 	COOLDOWN_DECLARE(cooldown_mod_move)
 	/// Person wearing the MODsuit.
 	var/mob/living/carbon/human/wearer
+	/// If the suit will consider the control unit for slowdown
+	var/heavy_storage = FALSE
 
 /obj/item/mod/control/Initialize(mapload, datum/mod_theme/new_theme, new_skin, obj/item/mod/core/new_core)
 	. = ..()
@@ -664,10 +666,11 @@
 	SEND_SIGNAL(src, COMSIG_MOD_UPDATE_SPEED, module_slowdowns, prevent_slowdown)
 	for (var/module_slow in module_slowdowns)
 		total_slowdown += module_slow
-
-	for(var/datum/mod_part/part_datum as anything in get_part_datums(all = TRUE))
+	var/list/part_datums = get_part_datums(all = heavy_storage)
+	var/amount_of_parts = length(part_datums)
+	for(var/datum/mod_part/part_datum as anything in part_datums)
 		var/obj/item/part = part_datum.part_item
-		part.slowdown = total_slowdown / length(mod_parts)
+		part.slowdown = total_slowdown / amount_of_parts
 		if (!part_datum.sealed)
 			part.slowdown = max(part.slowdown, 0)
 	wearer?.update_equipment_speed_mods()

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -17,6 +17,8 @@
 	var/max_items = 7
 	/// Is nesting same-size storage items allowed?
 	var/big_nesting = FALSE
+	/// Will this module make the suit control unit considered for slowdown?
+	var/heavy = FALSE
 
 /obj/item/mod/module/storage/Initialize(mapload)
 	. = ..()
@@ -30,6 +32,8 @@
 	modstorage.set_real_location(src)
 	modstorage.allow_big_nesting = big_nesting
 	atom_storage.set_locked(STORAGE_NOT_LOCKED)
+	mod.heavy_storage = heavy
+	mod.update_speed()
 	var/obj/item/clothing/suit = mod.get_part_from_slot(ITEM_SLOT_OCLOTHING)
 	if(istype(suit))
 		RegisterSignal(suit, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(on_suit_unequip))
@@ -40,6 +44,9 @@
 	QDEL_NULL(mod.atom_storage)
 	if(!deleting)
 		atom_storage.remove_all(mod.drop_location())
+	mod.heavy_storage = FALSE
+	mod.slowdown = 0
+	mod.update_speed()
 	var/obj/item/clothing/suit = mod.get_part_from_slot(ITEM_SLOT_OCLOTHING)
 	if(istype(suit))
 		UnregisterSignal(suit, COMSIG_ITEM_PRE_UNEQUIP)
@@ -62,6 +69,7 @@
 	icon_state = "storage_large"
 	max_combined_w_class = 21
 	max_items = 14
+	heavy = TRUE
 
 /obj/item/mod/module/storage/syndicate
 	name = "MOD syndicate storage module"
@@ -71,6 +79,7 @@
 	icon_state = "storage_syndi"
 	max_combined_w_class = 30
 	max_items = 21
+	heavy = TRUE
 
 /obj/item/mod/module/storage/belt
 	name = "MOD case storage module"

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -64,8 +64,8 @@
 /obj/item/mod/module/storage/large_capacity
 	name = "MOD expanded storage module"
 	desc = "Reverse engineered by Nakamura Engineering from Donk Company designs, this system of hidden compartments \
-		is entirely within the suit, distributing items and weight evenly to ensure a comfortable experience for the user; \
-		whether smuggling, or simply hauling."
+		is entirely within the suit, distributing items and weight evenly to ensure a comfortable experience for the user, \
+		whether smuggling or simply hauling. When undeployed, the many small pockets make it heavier than the standard design."
 	icon_state = "storage_large"
 	max_combined_w_class = 21
 	max_items = 14
@@ -75,7 +75,8 @@
 	name = "MOD syndicate storage module"
 	desc = "A storage system using nanotechnology developed by Cybersun Industries, these compartments use \
 		esoteric technology to compress the physical matter of items put inside of them, \
-		essentially shrinking items for much easier and more portable storage."
+		essentially shrinking items for much easier and more portable storage. \
+		This makes it slightly heavier than the standard design."
 	icon_state = "storage_syndi"
 	max_combined_w_class = 30
 	max_items = 21
@@ -96,7 +97,7 @@
 /obj/item/mod/module/storage/bluespace
 	name = "MOD bluespace storage module"
 	desc = "A storage system developed by Nanotrasen, these compartments employ \
-		miniaturized bluespace pockets for the ultimate in storage technology; regardless of the weight of objects put inside."
+		miniaturized bluespace pockets for the ultimate in storage technology, regardless of the weight of objects put inside."
 	icon_state = "storage_large"
 	max_w_class = WEIGHT_CLASS_GIGANTIC
 	max_combined_w_class = 60
@@ -242,8 +243,8 @@
 /obj/item/mod/module/status_readout
 	name = "MOD status readout module"
 	desc = "A once-common module, this technology unfortunately went out of fashion in the safer regions of space; \
-		and found new life in the research networks of the Periphery. This particular unit hooks into the suit's spine, \
-		capable of capturing and displaying all possible biometric data of the wearer; sleep, nutrition, fitness, fingerprints, \
+		it found new life in the research networks of the Periphery. This particular unit hooks into the suit's spine, \
+		capable of capturing and displaying all possible biometric data of the wearer: sleep, nutrition, fitness, fingerprints, \
 		and even useful information such as their overall health and wellness. The vitals monitor also comes with a speaker, loud enough \
 		to alert anyone nearby that someone has, in fact, died."
 	icon_state = "status"
@@ -581,7 +582,7 @@
 	name = "MOD thermal regulator module"
 	desc = "Advanced climate control, using an inner body glove interwoven with thousands of tiny, \
 		flexible cooling lines. This circulates coolant at various user-controlled temperatures, \
-		ensuring they're comfortable; even if they're some that like it hot."
+		ensuring they're comfortable — even if there's some that like it hot."
 	icon_state = "regulator"
 	module_type = MODULE_TOGGLE
 	complexity = 1


### PR DESCRIPTION
## About The Pull Request

Alternative to #94250 & #94228

A MODsuit that lacks a storage module with `heavy` (a variable applied to expanded and syndicate storage MODules) will not have any slowdown from its control unit alone. The total slowdown is identical, it is only the control unit slowdown that is removed(and spread out among the other parts).

Also changes every improper use of a semicolon in `modules_general` to whatever was correct.

## Why It's Good For The Game

It's the same justification, just a different solution. Currently, expanded storage is a direct upgrade to the normal storage, and one that removes the main downside of a MODsuit entirely. There's no possible reason to take normal storage if expanded is available, and that makes it the worst kind of MODule- one that literally everyone will take without ANY exception. This provides a differentiation between normal and expanded storage that will cause an actual choice to have to be made between them, and one that doesn't mess up complexity balance.

## Changelog
:cl:

balance: Undeployed MODsuits without large storage MODules no longer give slowdown

/:cl:
