### PR TITLE
You can throw items over cardboard crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/cardboard.dm
+++ b/code/game/objects/structures/crates_lockers/crates/cardboard.dm
@@ -1,7 +1,6 @@
 /obj/structure/closet/crate/cardboard
 	name = "cardboard box"
 	desc = "A box, in which you can place things. Revolutionary, I know."
-	pass_flags_self = PASSSTRUCTURE
 	material_drop = /obj/item/stack/sheet/cardboard
 	material_drop_amount = 4
 	custom_materials = list(/datum/material/cardboard = SHEET_MATERIAL_AMOUNT * 4)


### PR DESCRIPTION

## About The Pull Request
Seems like an oversight, just makes it so they inherit normal crate passflags of `pass_flags_self = PASSSTRUCTURE | LETPASSTHROW`
## Why It's Good For The Game
There sprite is smaller then normal crates. why do they block throwing things over them
## Changelog
:cl:
fix: You can toss things over cardboard crates
/:cl:
