### PR TITLE
[NO GBP] Shards can be embedded in posters again

### DIFF
--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -52,14 +52,13 @@
 	if(!istype(I, /obj/item/shard))
 		return ..()
 
-	if (poster_structure.trap?.resolve())
+	if (locate(/obj/item/shard) in (poster_structure?.contents || contents))
 		balloon_alert(user, "already trapped!")
 		return
 
-	if(!user.transferItemToLoc(I, poster_structure))
+	if(!user.transferItemToLoc(I, src))
 		return
 
-	poster_structure.trap = WEAKREF(I)
 	to_chat(user, span_notice("You conceal \the [I] inside the rolled up poster."))
 
 /obj/item/poster/interact_with_atom(turf/closed/wall_structure, mob/living/user, list/modifiers)
@@ -88,6 +87,9 @@
 	var/obj/structure/sign/poster/placed_poster = poster_structure || new poster_type(src)
 	placed_poster.poster_item_type = type
 	placed_poster.forceMove(wall_structure)
+	var/obj/item/shard/trap = locate() in contents
+	if(trap)
+		trap.forceMove(placed_poster)
 	poster_structure = null
 	flick("poster_being_set", placed_poster)
 	playsound(src, 'sound/items/poster/poster_being_created.ogg', 100, TRUE)
@@ -127,8 +129,6 @@
 	var/poster_item_desc = "This hypothetical poster item should not exist, let's be honest here."
 	var/poster_item_icon_state = "rolled_poster"
 	var/poster_item_type = /obj/item/poster
-	///A sharp shard of material can be hidden inside of a poster, attempts to embed when it is torn down.
-	var/datum/weakref/trap
 
 /obj/structure/sign/poster/Initialize(mapload)
 	. = ..()
@@ -219,7 +219,7 @@
 
 // HO-HO-HOHOHO HU HU-HU HU-HU
 /obj/structure/sign/poster/proc/spring_trap(mob/user)
-	var/obj/item/shard/payload = trap?.resolve()
+	var/obj/item/shard/payload = locate() in contents
 	if (!payload)
 		return
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #94277

## Changelog
:cl:
fix: shards can be embedded in posters again
/:cl:

