### PR TITLE
Changes delta engineering delivery to be in the techlathe room

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -68294,16 +68294,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "qUi" = (
-/obj/structure/disposalpipe/sorting/mail{
-	name = "Engineering Junction"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qUu" = (
@@ -96082,11 +96079,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	name = "Engineering Junction"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)


### PR DESCRIPTION
## About The Pull Request
<img width="988" height="1080" alt="image" src="https://github.com/user-attachments/assets/dd06a3c2-d3a1-458d-9398-1616c846e9ac" />


## Why It's Good For The Game

All delivery locations on deltastation brings the crate to techlathe room except engineering, its also kind of out sight which makes it confusing

## Changelog
:cl: Ezel
map: Engineering deliveries now go to the techlathe room on Deltastation
/:cl:
