### PR TITLE
Correctly clears `hanging_support_atom` from atom mounted components

### DIFF
--- a/code/datums/components/atom_mounted.dm
+++ b/code/datums/components/atom_mounted.dm
@@ -20,14 +20,14 @@
 
 /datum/component/atom_mounted/UnregisterFromParent()
 	REMOVE_TRAIT(parent, TRAIT_WALLMOUNTED, REF(src))
+	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
+
+/datum/component/atom_mounted/Destroy(force)
 	UnregisterSignal(hanging_support_atom, list(COMSIG_ATOM_EXAMINE))
 	if(isclosedturf(hanging_support_atom))
 		UnregisterSignal(hanging_support_atom, COMSIG_TURF_CHANGE)
 	else
 		UnregisterSignal(hanging_support_atom, COMSIG_QDELETING)
-	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
-
-/datum/component/atom_mounted/Destroy(force)
 	hanging_support_atom = null
 	return ..()
 

--- a/code/datums/components/atom_mounted.dm
+++ b/code/datums/components/atom_mounted.dm
@@ -26,7 +26,10 @@
 	else
 		UnregisterSignal(hanging_support_atom, COMSIG_QDELETING)
 	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
+
+/datum/component/atom_mounted/Destroy(force)
 	hanging_support_atom = null
+	return ..()
 
 /**
  * When the wall is examined, explains that it's supporting the linked object.

--- a/code/datums/components/atom_mounted.dm
+++ b/code/datums/components/atom_mounted.dm
@@ -8,14 +8,14 @@
 	if(!isobj(parent))
 		return COMPONENT_INCOMPATIBLE
 	hanging_support_atom = target_structure
-
-/datum/component/atom_mounted/RegisterWithParent()
-	ADD_TRAIT(parent, TRAIT_WALLMOUNTED, REF(src))
 	RegisterSignal(hanging_support_atom, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	if(isclosedturf(hanging_support_atom))
 		RegisterSignal(hanging_support_atom, COMSIG_TURF_CHANGE, PROC_REF(on_turf_changing))
 	else
 		RegisterSignal(hanging_support_atom, COMSIG_QDELETING, PROC_REF(on_structure_delete))
+
+/datum/component/atom_mounted/RegisterWithParent()
+	ADD_TRAIT(parent, TRAIT_WALLMOUNTED, REF(src))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 
 /datum/component/atom_mounted/UnregisterFromParent()


### PR DESCRIPTION
## About The Pull Request
- See https://github.com/tgstation/tgstation/pull/94144#issuecomment-3606401934

This should stop hard deletes for all atom mounted atoms in instances where the object is force deleted. Not sure if this will stop the poster hard deleting issue but the change is required

Probably hard delete tag would be appropriate here but nothing player facing

## Changelog
N/A 
/:cl:
