### PR TITLE
Fixes an oversight with the forked tongue

### DIFF
--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -50,7 +50,7 @@
 		targeted = owner.loc
 		RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
-	if (istype(parent, /obj/item/organ))
+	if (isorgan(parent))
 		RegisterSignal(parent, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_implanted))
 		RegisterSignal(parent, COMSIG_ORGAN_REMOVED, PROC_REF(on_removed))
 	else

--- a/code/datums/components/speechmod.dm
+++ b/code/datums/components/speechmod.dm
@@ -50,10 +50,13 @@
 		targeted = owner.loc
 		RegisterSignal(targeted, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
-	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equipped))
-	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_unequipped))
-	RegisterSignal(parent, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_implanted))
-	RegisterSignal(parent, COMSIG_ORGAN_REMOVED, PROC_REF(on_removed))
+	if (istype(parent, /obj/item/organ))
+		RegisterSignal(parent, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_implanted))
+		RegisterSignal(parent, COMSIG_ORGAN_REMOVED, PROC_REF(on_removed))
+	else
+		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equipped))
+		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_unequipped))
+
 
 /datum/component/speechmod/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -193,12 +193,6 @@
 	. = ..()
 	AddComponent(/datum/component/speechmod, replacements = speech_replacements, should_modify_speech = CALLBACK(src, PROC_REF(should_modify_speech)))
 
-/obj/item/organ/tongue/lizard/should_modify_speech(datum/source, list/speech_args)
-	. = ..()
-
-	if(owner == null || bodypart_owner == null)
-		return FALSE
-
 /obj/item/organ/tongue/lizard/silver
 	name = "silver tongue"
 	desc = "A genetic branch of the high society Silver Scales that gives them their silverizing properties. To them, it is everything, and society traitors have their tongue forcibly revoked. Oddly enough, it itself is just blue."

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -193,6 +193,12 @@
 	. = ..()
 	AddComponent(/datum/component/speechmod, replacements = speech_replacements, should_modify_speech = CALLBACK(src, PROC_REF(should_modify_speech)))
 
+/obj/item/organ/tongue/lizard/should_modify_speech(datum/source, list/speech_args)
+	. = ..()
+
+	if(owner == null || bodypart_owner == null)
+		return FALSE
+
 /obj/item/organ/tongue/lizard/silver
 	name = "silver tongue"
 	desc = "A genetic branch of the high society Silver Scales that gives them their silverizing properties. To them, it is everything, and society traitors have their tongue forcibly revoked. Oddly enough, it itself is just blue."


### PR DESCRIPTION
## About The Pull Request

It was discovered that if a forked tongue is in an inventory slot, be it your hands or pocket it gave you lizard speech. This is likely an oversight that was missed for a long while. It seems likely it is unintended behavior. This PR just adds a check to in the speechmod to check if the items is a organ or not.
<details>
<summary>Screenshots</summary>

<img width="734" height="757" alt="image" src="https://github.com/user-attachments/assets/f42d7993-0fad-4716-a18e-2db168253c98" />

<img width="470" height="631" alt="image" src="https://github.com/user-attachments/assets/c0a4fe07-0e09-4aba-94e5-a62d5c1312ab" />

</details>

## Why It's Good For The Game

Less bugs and no silly behavior with a tongue not being inside of your body.

## Changelog

:cl:
fix: The forked lizard tongue no longer makes you slur your S's if its in your hands or pockets.
/:cl: