### PR TITLE
You can see if you just locked or unlocked a cyborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return ITEM_INTERACT_BLOCKING
 	locked = !locked
 	update_icons()
-	balloon_alert(user, "chassis cover lock [emagged ? "glitches" : "toggled"]")
+	balloon_alert(user, "chassis cover [emagged ? "lock glitches" : "[locked ? "locked" : "unlocked"]"]")
 	logevent("[emagged ? "ChÃ¥vÃis" : "Chassis"] cover lock has been [locked ? "engaged" : "released"]")
 	return ITEM_INTERACT_SUCCESS
 
@@ -453,7 +453,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		ResetModel()
 		return TRUE
 
-	SetEmagged(1)
+	SetEmagged(TRUE)
 	SetStun(10 SECONDS) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 	lawupdate = FALSE
 	set_connected_ai(null)


### PR DESCRIPTION
## About The Pull Request

Instead of "chassis cover lock toggled" it'll actually tell you what you did. No effect if the cyborg is emagged. Also I changed a 1 to a TRUE somewhere because it annoyed me.

## Why It's Good For The Game

Sometimes you and the borg both try to touch their lock at the same time and then it gets awkward and you gotta swipe your id a second time and that gets pretty annoying.

## Changelog

:cl:
qol: You can see whether you just locked or unlocked a cyborg
/:cl: