### PR TITLE
No more bluespace inhalers

### DIFF
--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -74,7 +74,7 @@
 	var/mob/living/target_mob = interacting_with
 
 	if (!can_puff(target_mob, user))
-		return NONE
+		return ITEM_INTERACT_BLOCKING
 
 	var/puff_timer = 0
 
@@ -110,10 +110,10 @@
 		to_chat(user, pre_use_self_message)
 		if (pre_use_target_message)
 			to_chat(target_mob, pre_use_target_message)
-		if (!do_after(user, puff_timer, src))
-			return NONE
+		if (!do_after(user, puff_timer, target_mob))
+			return ITEM_INTERACT_BLOCKING
 		if (!can_puff(target_mob, user)) // sanity
-			return NONE
+			return ITEM_INTERACT_BLOCKING
 
 	user.visible_message(post_use_visible_message, ignored_mobs = list(user, target_mob))
 	to_chat(user, post_use_self_message)
@@ -121,6 +121,7 @@
 		to_chat(target_mob, post_use_target_message)
 
 	canister.puff(user, target_mob)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/inhaler/attack_self(mob/user, modifiers)
 	try_remove_canister(user, modifiers)


### PR DESCRIPTION
## About The Pull Request

Fixes #94284

When someone walks away from you after you try to put an inhaler to their mouth, it'll cancel the do_after. Currently the do_after is based on the item in your hand and not the mob you're targeting, which leads to that issue. If you're just targeting yourself the effect is the same, so if the bar appearing on the item was a design intention I can revert it if you're only targeting yourself.

Also, the function for using the inhaler returns ITEM_INTERACT_ stuff when it should so you stop whacking yourself and others with the inhaler after using it.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: inhalers no longer have infinite reach
fix: using an inhaler no longer results in whacking the target with it afterwards
/:cl: