### PR TITLE
Pet collar bugfixes

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -496,15 +496,19 @@
 	desc = "It's for pets."
 	icon_state = "petcollar"
 	var/tagname = null
+	var/human_wearable = FALSE
 
 /datum/armor/large_scarf_syndie
 	fire = 50
 	acid = 40
 
 /obj/item/clothing/neck/petcollar/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE, indirect_action = FALSE)
-	if(!ismonkey(M))
+	if(!ismonkey(M) && !human_wearable)
 		return FALSE
 	return ..()
+
+/obj/item/clothing/neck/petcollar/wearable
+	human_wearable = TRUE
 
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
 	tagname = sanitize_name(tgui_input_text(user, "Would you like to change the name on the tag?", "Pet Naming", "Spot", MAX_NAME_LEN))

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -890,7 +890,7 @@
 	head = /obj/item/clothing/head/soft/rainbow
 	glasses = null
 	ears = /obj/item/radio/headset
-	neck = /obj/item/clothing/neck/petcollar
+	neck = /obj/item/clothing/neck/petcollar/wearable
 	//suit
 	uniform = /obj/item/clothing/under/color/rainbow
 	l_pocket = /obj/item/toy/cattoy


### PR DESCRIPTION
## About The Pull Request

~Since you can't wear pet collars and the bartender doesn't have a pet, I'm not sure why they're in the bartender drobe and bartender clothes locker. I removed them.~

Also, the felinid deathmatch loadout is supposed to spawn with a pet collar equipped but can't since they aren't wearable by humans so now they spawn with an alternate version that is wearable and NOT OBTAINABLE OUTSIDE OF DEATHMATCH.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: Deathmatch felinids now spawn in with pet collars as intended
/:cl: