### PR TITLE
Corrects not being able to sit on all stools

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -329,13 +329,7 @@
 	max_integrity = 300
 
 /obj/structure/chair/stool/post_buckle_mob(mob/living/Mob)
-	var/z_offset = 0
-	if(dir & NORTH)
-		z_offset = 7
-	else
-		z_offset = 3
-
-	Mob.add_offsets(type, z_add = z_offset)
+	Mob.add_offsets(type, z_add = 4)
 	. = ..()
 
 /obj/structure/chair/stool/post_unbuckle_mob(mob/living/Mob)
@@ -373,11 +367,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 	icon_state = "bar"
 	item_chair = /obj/item/chair/stool/bar
 
-/obj/structure/chair/stool/bar/post_buckle_mob(mob/living/M)
-	M.pixel_y += 4
-
-/obj/structure/chair/stool/bar/post_unbuckle_mob(mob/living/M)
-	M.pixel_y -= 4
+/obj/structure/chair/stool/bar/post_buckle_mob(mob/living/Mob)
+	. = ..()
+	Mob.add_offsets(type, z_add = 7)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -324,7 +324,6 @@
 	name = "stool"
 	desc = "Apply butt."
 	icon_state = "stool"
-	can_buckle = FALSE
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool
 	max_integrity = 300
@@ -360,7 +359,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 	desc = "It has some unsavory stains on it..."
 	icon_state = "bar"
 	item_chair = /obj/item/chair/stool/bar
-	can_buckle = TRUE
 
 /obj/structure/chair/stool/bar/post_buckle_mob(mob/living/M)
 	M.pixel_y += 4

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -328,6 +328,19 @@
 	item_chair = /obj/item/chair/stool
 	max_integrity = 300
 
+/obj/structure/chair/stool/post_buckle_mob(mob/living/Mob)
+	var/z_offset = 0
+	if(dir & NORTH)
+		z_offset = 7
+	else
+		z_offset = 3
+
+	Mob.add_offsets(type, z_add = z_offset)
+	. = ..()
+
+/obj/structure/chair/stool/post_unbuckle_mob(mob/living/Mob)
+	Mob.remove_offsets(type)
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool, 0)
 
 /obj/structure/chair/stool/narsie_act()


### PR DESCRIPTION
Corrects not being able to sit on all stools
Since it's a chair

Also fixes a mob's offset when sitting on a stool - if the chair is facing north, the mob should be behind the chair sprite.

## Why It's Good For The Game

Stools are chairs
People sit on chairs
RP level 100

## Changelog

:cl: ArchBTW
fix: Fix sitting on stools (it's a chair)
fix: Fix offset when sitting on a stool
/:cl: