### PR TITLE
New flag for hiding supply packs in the department orders UI

### DIFF
--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -5,6 +5,8 @@
 	var/group = ""
 	/// Is this cargo supply pack visible to the cargo purchasing UI.
 	var/hidden = FALSE
+	/// Is this cargo supply pack visible in the department orders UI.
+	var/hidden_dept_orders = FALSE
 	/// Is this supply pack purchasable outside of the standard purchasing band? Contraband is available by multitooling the cargo purchasing board.
 	var/contraband = FALSE
 	/// Cost of the crate. DO NOT GO ANY LOWER THAN X1.4 the "CARGO_CRATE_VALUE" value if using regular crates, or infinite profit will be possible!

--- a/code/modules/modular_computers/file_system/programs/dept_order.dm
+++ b/code/modules/modular_computers/file_system/programs/dept_order.dm
@@ -113,6 +113,8 @@ GLOBAL_VAR(department_cd_override)
 		return FALSE
 	if(to_check.goody)
 		return FALSE
+	if(to_check.hidden_dept_orders)
+		return FALSE
 	return TRUE
 
 /// Looks through all possible departments and finds one this ID card "corresponds" to.


### PR DESCRIPTION
## About The Pull Request
Added new flag "hidden_dept_orders" for /datum/supply_pack. This flag defines whether the cargo supply pack is visible in the department orders UI (modular computer app)
## Why It's Good For The Game
The initial idea is to provide contributors to the tgstation downstreams with a way to reduce the number of items in the "goodies" tab in the UI of the supply order console. The number of products in this tab sometimes (depends on the downstream) reaches 100-110! Most of these products are related to other sections thematically in some way. This flag allows you to "hide" certain types of orders in the UI of the department's order console, while leaving the option to order this particular pack in the UI of the supply console (privately or using the account of a specific department). 

The current ways of solving this problem aren't so good:

1) "hidden = TRUE" - The supply pack will not be displayed anywhere: neither in the UI of the supply console, nor in the UI of department orders. This parameter is used for mining orders.
2) Use goodies category - This category is already overloaded, and the pack cannot be ordered using the departments' account. This can be changed by adding " goody = FALSE", but in this case, the logic of the goodies section itself falls apart - you can order all the packs only at your own expense, except for the specific one.
3) Use imports section - a good solution to this problem. However, from the point of view of IC logic, all the goods placed in this section are "specialized" developments of companies, not ordinary items that can be obtained on the station. In addition, some downstreams are gradually moving all the packs from the "imports" section to the supply console interface (nova sector).
4) "special = TRUE, special_enabled = FALSE" - This parameter is used only for the station goals crates. It won't work if we need the crate to be displayed in the supply console interface every round.
## Changelog
:cl:
code: Added new flag "hidden_dept_orders". This flag defines whether the cargo supply pack visible in the department orders UI.
/:cl:
