### PR TITLE
Tweaks blindness to be more player friendly

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -129,6 +129,11 @@
 /atom/movable/screen/fullscreen/blind/cyborg
 	show_when_dead = TRUE
 
+/atom/movable/screen/fullscreen/blind/noflicker
+	icon_state = "blackimageoverlaystatic"
+	layer = BLIND_LAYER
+	plane = FULLSCREEN_PLANE
+
 /atom/movable/screen/fullscreen/curse
 	icon_state = "curse"
 	layer = CURSE_LAYER

--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -21,45 +21,45 @@
 	)
 
 /datum/status_effect/grouped/blindness/on_apply()
-    if (!CAN_BE_BLIND(owner))
-        return FALSE
+	if (!CAN_BE_BLIND(owner))
+		return FALSE
 
-    RegisterSignals(owner, update_signals, PROC_REF(update_blindness))
-    return ..()
+	RegisterSignals(owner, update_signals, PROC_REF(update_blindness))
+	return ..()
 
 /datum/status_effect/grouped/blindness/source_added(source, ...)
-    update_blindness(source) // new: pass source to update
+	update_blindness(source) // new: pass source to update
 
 /datum/status_effect/grouped/blindness/source_removed(source, removing)
-    if (!removing)
-        update_blindness(source) // new: pass source to update
+	if (!removing)
+		update_blindness(source) // new: pass source to update
 
 /datum/status_effect/grouped/blindness/proc/update_blindness(changed_source)
-    if (!CAN_BE_BLIND(owner)) // future proofing
-        qdel(src)
-        return
+	if (!CAN_BE_BLIND(owner)) // future proofing
+		qdel(src)
+		return
 
-    if (!HAS_TRAIT(owner, TRAIT_SIGHT_BYPASS))
-        make_blind(changed_source) // new: pass source to make_blind
-        return
+	if (!HAS_TRAIT(owner, TRAIT_SIGHT_BYPASS))
+		make_blind(changed_source) // new: pass source to make_blind
+		return
 
-    for (var/blocker in blocking_sources)
-        if (owner.is_blind_from(blocker))
-            make_blind(changed_source) // new: pass source to make_blind
-            return
+	for (var/blocker in blocking_sources)
+		if (owner.is_blind_from(blocker))
+			make_blind(changed_source) // new: pass source to make_blind
+			return
 
-    make_unblind()
+	make_unblind()
 
 /datum/status_effect/grouped/blindness/proc/make_blind(changed_source)
-    // new: have some extra logic to determine what overlay to use
-    // by default we use the noflicker overlay
-    // but if our one and only source is from "temp blindness", use flicker overlay
-    var/overlay_to_use = /atom/movable/screen/fullscreen/blind/noflicker
-    if(changed_source == /datum/status_effect/temporary_blindness::id && length(sources) == 1)
-        overlay_to_use = /atom/movable/screen/fullscreen/blind
-    owner.overlay_fullscreen(id, overlay_to_use )
-    // You are blind - at most, able to make out shapes near you
-    owner.add_client_colour(/datum/client_colour/blindness, REF(src))
+	// new: have some extra logic to determine what overlay to use
+	// by default we use the noflicker overlay
+	// but if our one and only source is from "temp blindness", use flicker overlay
+	var/overlay_to_use = /atom/movable/screen/fullscreen/blind/noflicker
+	if(changed_source == /datum/status_effect/temporary_blindness::id && length(sources) == 1)
+		overlay_to_use = /atom/movable/screen/fullscreen/blind
+	owner.overlay_fullscreen(id, overlay_to_use )
+	// You are blind - at most, able to make out shapes near you
+	owner.add_client_colour(/datum/client_colour/blindness, REF(src))
 
 /datum/status_effect/grouped/blindness/proc/make_unblind()
 	owner.clear_fullscreen(id)

--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -28,11 +28,11 @@
 	return ..()
 
 /datum/status_effect/grouped/blindness/source_added(source, ...)
-	update_blindness(source) // new: pass source to update
+	update_blindness(source)
 
 /datum/status_effect/grouped/blindness/source_removed(source, removing)
 	if (!removing)
-		update_blindness(source) // new: pass source to update
+		update_blindness(source)
 
 /datum/status_effect/grouped/blindness/proc/update_blindness(changed_source)
 	if (!CAN_BE_BLIND(owner)) // future proofing
@@ -40,18 +40,18 @@
 		return
 
 	if (!HAS_TRAIT(owner, TRAIT_SIGHT_BYPASS))
-		make_blind(changed_source) // new: pass source to make_blind
+		make_blind(changed_source)
 		return
 
 	for (var/blocker in blocking_sources)
 		if (owner.is_blind_from(blocker))
-			make_blind(changed_source) // new: pass source to make_blind
+			make_blind(changed_source)
 			return
 
 	make_unblind()
 
 /datum/status_effect/grouped/blindness/proc/make_blind(changed_source)
-	// new: have some extra logic to determine what overlay to use
+	// have some extra logic to determine what overlay to use
 	// by default we use the noflicker overlay
 	// but if our one and only source is from "temp blindness", use flicker overlay
 	var/overlay_to_use = /atom/movable/screen/fullscreen/blind/noflicker

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -170,6 +170,14 @@
 
 // Color types
 
+///we want it to be less harsh for players to take blindness quirk, this adds enough color to not cause too much eye strain
+/datum/client_colour/blindness
+	priority = CLIENT_COLOR_HELMET_PRIORITY
+	split_filters = TRUE
+	color = list(/*R*/ 0.51,0.3,0.3,0, /*G*/ 0.29,0.51,0.29,0, /*B*/ 0.3,0.3,0.61,0, /*A*/ 0,0,0,1, /*C*/ 0,0,0,0) // dim and less saturated
+	fade_in = 2 SECONDS
+	fade_out = 2 SECONDS
+
 ///A client color that makes the screen look a bit more grungy, halloweenesque even.
 /datum/client_colour/halloween_helmet
 	priority = CLIENT_COLOR_HELMET_PRIORITY

--- a/code/modules/unit_tests/blindness.dm
+++ b/code/modules/unit_tests/blindness.dm
@@ -52,14 +52,14 @@
 	// Check for the status effect, duh
 	TEST_ASSERT(dummy.is_blind(), "Dummy, [status_message], did not have the blind status effect.")
 	// Being more technical, we need to check for client color and screen overlays
-	TEST_ASSERT(HAS_CLIENT_COLOR(dummy, /datum/client_colour/monochrome), "Dummy, [status_message], did not have the monochrome client color.")
+	TEST_ASSERT(HAS_CLIENT_COLOR(dummy, /datum/client_colour/blindness), "Dummy, [status_message], did not have the monochrome client color.")
 	TEST_ASSERT(HAS_SCREEN_OVERLAY(dummy, /atom/movable/screen/fullscreen/blind), "Dummy, [status_message], did not have a blind screen overlay in their list of screens.")
 
 /datum/unit_test/blindness/proc/check_if_not_blind(mob/living/carbon/human/dummy, status_message = "after being cured of blindness")
 	// Check for no status effect
 	TEST_ASSERT(!dummy.is_blind(), "Dummy, [status_message], still had the blindness status effect.")
 	// Check that the client color and screen overlay are gone
-	TEST_ASSERT(!HAS_CLIENT_COLOR(dummy, /datum/client_colour/monochrome), "Dummy, [status_message], still had the monochrome client color.")
+	TEST_ASSERT(!HAS_CLIENT_COLOR(dummy, /datum/client_colour/blindness), "Dummy, [status_message], still had the monochrome client color.")
 	TEST_ASSERT(!HAS_SCREEN_OVERLAY(dummy, /atom/movable/screen/fullscreen/blind), "Dummy, [status_message], still had the blind sceen overlay.")
 
 /**


### PR DESCRIPTION
## About The Pull Request

So something i missed from when i played Goonstation a long while ago was my blind characters, i tried recreating them in TGCode but found that the blind quirk here is far more harsh to play visually. So i got some help from Melbert and got a plan goin and here's the results.

![blinds](https://github.com/user-attachments/assets/d12bd5c1-e0cb-4997-835f-279076c6a665)

Players can see colors! But muted, this change is strictly for visual enjoyment as the constant monochrome is just - i cant really describe how much i hate seeing it for more than 15 minutes.

Secondly the flicker is gone from the quirk but remains for all the temporary blindness, this is 100% Melberts code as they're a helluva lot smarter than I am and I just nod and smile before pasting it. This did entail creating a new fulscreen in the dmi, but i just copy/pasted the existing one and took out the animated frames and named it as 'static' so it wouldnt interfere with anything else using it.

## Why It's Good For The Game

Playing a blind character is great, however it causes some serious eyestrain after prolonged playstyle

## Changelog
:cl: MrMelbert, Zergspower
qol: The world is now heavily desaturated while blind, rather than pure monochrome, to give players some visual stimulus 
qol: When blind, the brief flicker of the entire screen now only appears for mobs temporarily blinded - ie, mobs blinded from quirk / trauma / genetic mutation no longer experience it
/:cl:
