### PR TITLE
Humanoid creatures can wear pet collars again

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -501,11 +501,6 @@
 	fire = 50
 	acid = 40
 
-/obj/item/clothing/neck/petcollar/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE, indirect_action = FALSE)
-	if(!ismonkey(M))
-		return FALSE
-	return ..()
-
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
 	tagname = sanitize_name(tgui_input_text(user, "Would you like to change the name on the tag?", "Pet Naming", "Spot", MAX_NAME_LEN))
 	if (!tagname || !length(tagname))


### PR DESCRIPTION
## About The Pull Request
Makes humans be able to wear pet collars again

## Why It's Good For The Game

You can wear a cute collar around your neck which is socially accepted in this day and age

## Changelog
:cl: Ezel
qol: Pet collars can be worn by humanoids again
/:cl:
