### PR TITLE
Removes Plasmeme innate damage vulnerability, replaces it with demolition vulnerability

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -124,6 +124,8 @@
 #define MOB_MINING (1 << 13)
 ///The mob is a crustacean. Like crabs. Or lobsters.
 #define MOB_CRUSTACEAN (1 << 14)
+///The mob is all boney
+#define MOB_SKELETAL (1 << 15)
 
 //Lung respiration type flags
 #define RESPIRATION_OXYGEN (1 << 0)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -333,7 +333,7 @@
 		), ARMOR_MAX_BLOCK)
 
 	var/final_force = CALCULATE_FORCE(attacking_item, attack_modifiers)
-	if(mob_biotypes & MOB_ROBOTIC)
+	if(mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL))
 		final_force *= attacking_item.get_demolition_modifier(src)
 
 	var/wounding = attacking_item.wound_bonus

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -333,7 +333,7 @@
 		), ARMOR_MAX_BLOCK)
 
 	var/final_force = CALCULATE_FORCE(attacking_item, attack_modifiers)
-	if(mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL))
+	if(mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_SKELETAL)) // this should probably check hit bodypart for humanoids
 		final_force *= attacking_item.get_demolition_modifier(src)
 
 	var/wounding = attacking_item.wound_bonus

--- a/code/modules/mob/living/basic/festivus_pole.dm
+++ b/code/modules/mob/living/basic/festivus_pole.dm
@@ -14,6 +14,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	basic_mob_flags = DEL_ON_DEATH
 	status_flags = CANPUSH
+	mob_biotypes = MOB_MINERAL
 
 	response_help_continuous = "rubs"
 	response_help_simple = "rub"

--- a/code/modules/mob/living/basic/heretic/raw_prophet.dm
+++ b/code/modules/mob/living/basic/heretic/raw_prophet.dm
@@ -15,6 +15,7 @@
 	maxHealth = 65
 	health = 65
 	sight = SEE_MOBS|SEE_OBJS|SEE_TURFS
+	mob_biotypes = MOB_ORGANIC
 	/// List of innate abilities we have to add.
 	var/static/list/innate_abilities = list(
 		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/long = null,

--- a/code/modules/mob/living/basic/heretic/rust_walker.dm
+++ b/code/modules/mob/living/basic/heretic/rust_walker.dm
@@ -13,6 +13,7 @@
 	sight = SEE_TURFS
 	speed = 1
 	ai_controller = /datum/ai_controller/basic_controller/rust_walker
+	mob_biotypes = MOB_ROBOTIC|MOB_MINERAL
 
 /mob/living/basic/heretic_summon/rust_walker/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon.dm
+++ b/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon.dm
@@ -7,6 +7,7 @@
 	icon_gib = "syndicate_gib"
 	mouse_opacity = MOUSE_OPACITY_ICON
 	basic_mob_flags = DEL_ON_DEATH
+	mob_biotypes = MOB_ORGANIC|MOB_MINERAL|MOB_MINING
 	speed = 2
 	maxHealth = 150
 	health = 150

--- a/code/modules/mob/living/basic/lavaland/basilisk/basilisk.dm
+++ b/code/modules/mob/living/basic/lavaland/basilisk/basilisk.dm
@@ -7,6 +7,7 @@
 	icon_dead = "basilisk_dead"
 	speak_emote = list("chimes")
 	damage_coeff = list(BRUTE = 1, BURN = 0.1, TOX = 1, STAMINA = 0, OXY = 1)
+	mob_biotypes = parent_type::mob_biotypes | MOB_MINERAL
 	speed = 20
 	maxHealth = 200
 	health = 200

--- a/code/modules/mob/living/basic/ruin_defender/living_floor.dm
+++ b/code/modules/mob/living/basic/ruin_defender/living_floor.dm
@@ -25,7 +25,7 @@
 	icon_state = "floor"
 	icon_living = "floor"
 	mob_size = MOB_SIZE_HUGE
-	mob_biotypes = MOB_SPECIAL
+	mob_biotypes = MOB_SPECIAL|MOB_MINERAL
 	status_flags = NONE
 	death_message = ""
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
+++ b/code/modules/mob/living/basic/ruin_defender/mimic/mimic.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, typecacheof(list(
 	maxHealth = 250
 	health = 250
 	gender = NEUTER
-	mob_biotypes = NONE
+	mob_biotypes = MOB_MINERAL
 	pass_flags = PASSFLAPS
 	melee_damage_lower = 8
 	melee_damage_upper = 12

--- a/code/modules/mob/living/basic/ruin_defender/skeleton.dm
+++ b/code/modules/mob/living/basic/ruin_defender/skeleton.dm
@@ -3,7 +3,7 @@
 	desc = "A real bonefied skeleton, doesn't seem like it wants to socialize."
 	gender = NEUTER
 	icon = 'icons/mob/simple/simple_human.dmi'
-	mob_biotypes = MOB_UNDEAD|MOB_HUMANOID
+	mob_biotypes = MOB_UNDEAD|MOB_HUMANOID|MOB_SKELETAL
 	speak_emote = list("rattles")
 	maxHealth = 40
 	health = 40

--- a/code/modules/mob/living/basic/space_fauna/statue/statue.dm
+++ b/code/modules/mob/living/basic/space_fauna/statue/statue.dm
@@ -9,7 +9,7 @@
 	icon_dead = "human_male"
 	gender = NEUTER
 	combat_mode = TRUE
-	mob_biotypes = MOB_HUMANOID
+	mob_biotypes = MOB_HUMANOID|MOB_MINERAL
 	gold_core_spawnable = NO_SPAWN
 
 	response_help_continuous = "touches"

--- a/code/modules/mob/living/basic/space_fauna/supermatter_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/supermatter_spider.dm
@@ -10,7 +10,7 @@
 
 	gender = NEUTER
 	status_flags = CANPUSH
-	mob_biotypes = MOB_BUG|MOB_ROBOTIC
+	mob_biotypes = MOB_BUG|MOB_ROBOTIC|MOB_MINERAL
 	speak_emote = list("vibrates")
 
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1674,6 +1674,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			SPECIES_PERK_DESC = "[plural_form] are resilient to being shocked.",
 		))
 
+	if(inherent_biotypes & (MOB_ROBOTIC|MOB_MINERAL))
+		to_add += list(list(
+			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+			SPECIES_PERK_ICON = FA_ICON_HAMMER,
+			SPECIES_PERK_NAME = "Tough Frame",
+			SPECIES_PERK_DESC = "[plural_form] are more resistant to slashing and stabbing, but more vulnerable to impacts.",
+		))
+
 	return to_add
 
 /**

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -16,7 +16,7 @@
 		TRAIT_UNHUSKABLE,
 	)
 
-	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
+	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL|MOB_SKELETAL
 	inherent_respiration_type = RESPIRATION_PLASMA
 	mutantlungs = /obj/item/organ/lungs/plasmaman
 	smoker_lungs = /obj/item/organ/lungs/plasmaman/plasmaman_smoker

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -24,7 +24,7 @@
 		TRAIT_XENO_IMMUNE,
 	)
 	inherent_factions = list(FACTION_SKELETON)
-	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
+	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID|MOB_SKELETAL
 	mutanttongue = /obj/item/organ/tongue/bone
 	mutantstomach = /obj/item/organ/stomach/bone
 	mutantappendix = null

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/clockwork_knight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/clockwork_knight.dm
@@ -23,7 +23,7 @@ I'd rather there be something than the clockwork ruin be entirely empty though s
 	armour_penetration = 40
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	mob_biotypes = MOB_ROBOTIC|MOB_SPECIAL|MOB_MINING
+	mob_biotypes = MOB_ROBOTIC|MOB_SPECIAL|MOB_MINING|MOB_MINERAL
 	vision_range = 9
 	aggro_vision_range = 9
 	speed = 5

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -36,7 +36,7 @@
 	speed = 3
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
-	mob_biotypes = MOB_ROBOTIC|MOB_MINING
+	mob_biotypes = MOB_ROBOTIC|MOB_MINING|MOB_MINERAL
 	death_sound = 'sound/effects/magic/repulse.ogg'
 	death_message = "'s lights flicker, before its top part falls down."
 	loot_drop = /obj/item/clothing/accessory/pandora_hope

--- a/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
@@ -7,8 +7,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	brute_modifier = 1.5 //Plasmemes are weak
-	burn_modifier = 1.5 //Plasmemes are weak
 	head_flags = HEAD_EYESPRITES
 	bodypart_flags = BODYPART_UNHUSKABLE
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)
@@ -22,8 +20,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	brute_modifier = 1.5 //Plasmemes are weak
-	burn_modifier = 1.5 //Plasmemes are weak
 	bodypart_flags = BODYPART_UNHUSKABLE
 	wing_types = null
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)
@@ -39,8 +35,6 @@
 	limb_id = SPECIES_PLASMAMAN
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	brute_modifier = 1.5 //Plasmemes are weak
-	burn_modifier = 1.5 //Plasmemes are weak
 	bodypart_flags = BODYPART_UNHUSKABLE
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)
 
@@ -52,8 +46,6 @@
 	limb_id = SPECIES_PLASMAMAN
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	brute_modifier = 1.5 //Plasmemes are weak
-	burn_modifier = 1.5 //Plasmemes are weak
 	bodypart_flags = BODYPART_UNHUSKABLE
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)
 
@@ -65,8 +57,6 @@
 	limb_id = SPECIES_PLASMAMAN
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	brute_modifier = 1.5 //Plasmemes are weak
-	burn_modifier = 1.5 //Plasmemes are weak
 	bodypart_flags = BODYPART_UNHUSKABLE
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)
 
@@ -78,7 +68,5 @@
 	limb_id = SPECIES_PLASMAMAN
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	brute_modifier = 1.5 //Plasmemes are weak
-	burn_modifier = 1.5 //Plasmemes are weak
 	bodypart_flags = BODYPART_UNHUSKABLE
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)


### PR DESCRIPTION
## About The Pull Request

Splinter of #94324

Plasmamen no longer take 1.5x brute and burn damgae
Plasmamen are now affected by demolition modifier, meaning they take less damage from sharp objects and more damage from blunt objects

Skeletons and golems are also affected by demolition modifier

## Why It's Good For The Game

As a part of #94324 I was making `MINERAL` mobs affected by demo mod
But I realized this would absolutely murder the heck out of Plasmamen! 1.5x brute + another 1.25x brute from blunt objects!
But then I realized "wait that kinda makes sense... a lot *more* sense than the arbitrary damage modifier" 
So here we are

Plasmemes are as vulnerable to being smashed to bits as before, but can now boast a minor resistance to being stabbed due to their lack of fleshy bits

This feels a bit more appropriate to their skeletal nature without completely removing that aspect of their character. It also gives them a very minor upside (they need it) 

## Changelog

:cl: Melbert
balance: Plasmamen no longer take flat 1.5x brute and burn damage
balance: Plasmamen are now affected by weapon demolition modifier, meaning blunt attacks deal more damage but slashing or piercing deal less damage
balance: Skeletons and Golems are also affected by weapon demolition modifier, as well as any mineral type mobs (of which none currently exist) 
/:cl:
