### PR TITLE
Pathfinder module fixes

### DIFF
--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -121,8 +121,12 @@
 	if(in_transit)
 		balloon_alert(recaller, "suit in transit!")
 		return FALSE
-	if(ismob(get_atom_on_turf(mod)))
-		balloon_alert(recaller, "already worn!")
+	var/atom_on_turf = get_atom_on_turf(mod)
+	if(ismob(atom_on_turf))
+		if(atom_on_turf == recaller)
+			balloon_alert(recaller, "already worn!")
+		else
+			recaller.balloon_alert(recaller, "suit is worn by somebody else!")
 		return FALSE
 
 	in_transit = TRUE
@@ -140,6 +144,7 @@
 	var/container = get_atom_on_turf(mod)
 	if(ismob(container))
 		balloon_alert(recaller, "launch interrupted!")
+		in_transit = FALSE
 		return
 
 	if(iscloset(container))


### PR DESCRIPTION
## About The Pull Request

I love the new pathfinder module but I did notice some tiny little bugs while I was poking through the new code to find out exactly how it worked. Basically if someone picked up the modsuit after it prepared for takeoff it would cancel the launch but not set in_transit back to false so the suit would think it's still flying through the air and you wouldn't be able to recall it ever again.

Also, if the suit is being held by a mob it won't be recalled, but the code kinda just assumes it's you that's holding it so it gives you a balloon alert from the modsuit's position that it's already being worn. Problem is if you're far away from the suit when this happens you won't see the alert, so now it checks for that and instead puts the alert on your position and also tells you it can't be recalled specifically because the suit is being worn by someone else.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: mod pathfinder module no longer gets stuck after an interrupted launch
fix: mod pathfinder module gives you a unique balloon alert on your position if you try to recall a suit that's being held by another mob
/:cl:
