### PR TITLE
Fix stacking flash assemblies

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -10,6 +10,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
+	assembly_flags = ASSEMBLY_NO_DUPLICATES
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*3, /datum/material/glass = SMALL_MATERIAL_AMOUNT*3)
 	light_system = OVERLAY_LIGHT //Used as a flash here.
 	light_range = FLASH_LIGHT_RANGE


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/94084

One flash allowed on a single assembly

## Why It's Good For The Game

Oversight - https://github.com/tgstation/tgstation/issues/94084
Nightmare instant death
Potential lag machine - See https://github.com/tgstation/tgstation/pull/71264
Probably a result of object paths (flashes are considered assemblies)

## Changelog

:cl: ArchBTW
fix: Fix stacking flash assemblies
/:cl:
