### PR TITLE
Fix no underwear trait not being checked

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -866,7 +866,7 @@ generate/load female uniform sprites matching all previously decided variables
 
 /mob/living/carbon/human/proc/update_underwear()
 	remove_overlay(BODY_LAYER)
-	if(HAS_TRAIT(src, TRAIT_HUSK) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN))
+	if(HAS_TRAIT(src, TRAIT_HUSK) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN) || HAS_TRAIT(src, TRAIT_NO_UNDERWEAR))
 		return
 	// Underwear, Undershirts & Socks
 	var/list/standing = list()


### PR DESCRIPTION
## About The Pull Request

Early return in `/mob/living/carbon/human/update_underwear()` if mob has `TRAIT_NO_UNDERWEAR`

## Why It's Good For The Game

Fixes #94321
Fixes #93922
Fixes #93702 

## Changelog
:cl:
fix: fixed TRAIT_NO_UNDERWEAR not being respected in human rendering
/:cl:
