### PR TITLE
Fixex pistol cells having too high of a charge speed.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -99,7 +99,7 @@
 
 /obj/item/stock_parts/power_store/cell/laser_pistol
 	name = "laser pistol power cell"
-	chargerate = STANDARD_CELL_RATE * 3
+	chargerate = STANDARD_CELL_RATE * 0.15
 
 /obj/item/stock_parts/power_store/cell/ninja
 	name = "black power cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -99,7 +99,9 @@
 
 /obj/item/stock_parts/power_store/cell/laser_pistol
 	name = "laser pistol power cell"
-	chargerate = STANDARD_CELL_RATE * 0.15
+	chargerate = INFINITY
+	charge = INFINITY
+	emp_damage_modifier = -1
 
 /obj/item/stock_parts/power_store/cell/ninja
 	name = "black power cell"


### PR DESCRIPTION
I assume it was intended for them to be 3 times faster than standard rather than 60.

## About The Pull Request
Fixes pistol cell charging 20 times faster than intended.

## Why It's Good For The Game
Closes #94332

## Changelog

:cl:
fix: Fixes laser pistol charging instantly.
/:cl:

