### PR TITLE
Antinoblium will decay the station.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -1264,16 +1264,11 @@
 	// Rusts its surroundings.
 	if(SPT_PROB(1, antinoblium_moles / 100) && isturf(holder)) // 1% chance per tick at 100 moles.
 		var/turf/location = holder
-		var/list/turfs = list(location)
+		if(!HAS_TRAIT(location, TRAIT_RUSTY))
+			location.rust_turf()
 		for(var/direction in GLOB.cardinals)
 			var/turf/turf = get_step(location, direction)
-			if(isclosedturf(turf))
-				turfs += turf
-		for(var/turf/turf in turfs)
-			if(!HAS_TRAIT(turf, TRAIT_RUSTY)) // prevents destroying walls
+			if(isclosedturf(turf) && !HAS_TRAIT(turf, TRAIT_RUSTY))
 				turf.rust_turf()
-			for(var/obj/obj in turf)
-				obj.rust_heretic_act()
-
 
 #undef SET_REACTION_RESULTS

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -1262,7 +1262,7 @@
 		air.temperature = max(air.temperature * heat_capacity / new_heat_capacity, TCMB)
 
 	// Rusts its surroundings.
-	if(SPT_PROB(1, antinoblium_moles / 100) && isturf(holder)) // 1% chance per tick at 100 moles.
+	if(prob(100 * (1 - 0.99 ** (antinoblium_moles / 100))) && isturf(holder)) // 1% chance per tick at 100 moles
 		var/turf/location = holder
 		if(!HAS_TRAIT(location, TRAIT_RUSTY))
 			location.rust_turf()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -1261,5 +1261,19 @@
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 		air.temperature = max(air.temperature * heat_capacity / new_heat_capacity, TCMB)
 
+	// Rusts its surroundings.
+	if(SPT_PROB(1, antinoblium_moles / 100) && isturf(holder)) // 1% chance per tick at 100 moles.
+		var/turf/location = holder
+		var/list/turfs = list(location)
+		for(var/direction in GLOB.cardinals)
+			var/turf/turf = get_step(location, direction)
+			if(isclosedturf(turf))
+				turfs += turf
+		for(var/turf/turf in turfs)
+			if(!HAS_TRAIT(turf, TRAIT_RUSTY)) // prevents destroying walls
+				turf.rust_turf()
+			for(var/obj/obj in turf)
+				obj.rust_heretic_act()
+
 
 #undef SET_REACTION_RESULTS


### PR DESCRIPTION

## About The Pull Request
Antinoblium will decay the station by rusting it during reaction. This is halted by hypernoblium as usual. It will not destroy walls.

## Why It's Good For The Game
Makes antinoblium look more dangerous while it spreads around the station. Gives a better impression that this gas decays everything.

## Changelog

:cl:
balance: Antinoblium decays the station.
/:cl:

