### PR TITLE
Retinkers Multikey Message

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -347,7 +347,7 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 				alert_admin_multikey = TRUE
 
 			var/list/concatables = list()
-			concatables += span_danger(span_bold("[double_match ? "MULTIKEY" : "Notice"]"))
+			concatables += span_danger(span_bold("[double_match ? "MULTIKEY" : "Notice"]:"))
 			concatables += "<span class='notice'>Connecting player [key_name_admin(src)] has the same"
 			concatables += double_match ? "!BOTH! [matched_ip] and [matched_cid]" : (!isnull(matched_ip) ? matched_ip : matched_cid)
 			concatables += "as [isnull(potential_match) ? "[joined_player_ckey] (no longer logged in)" : "[key_name_admin(potential_match)]"]"

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -349,7 +349,10 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 			var/list/concatables = list()
 			concatables += span_danger(span_bold("[double_match ? "MULTIKEY" : "Notice"]:"))
 			concatables += "<span class='notice'>Connecting player [key_name_admin(src)] has the same"
-			concatables += double_match ? "!BOTH! [matched_ip] and [matched_cid]" : (!isnull(matched_ip) ? matched_ip : matched_cid)
+			if(double_match)
+				concatables += "!BOTH! [matched_ip] and [matched_cid]"
+			else
+				concatables += (!isnull(matched_ip) ? matched_ip : matched_cid)
 			concatables += "as [isnull(potential_match) ? "[joined_player_ckey] (no longer logged in)" : "[key_name_admin(potential_match)]"]"
 			if(same_round)
 				concatables += span_bold("in the current round")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -352,9 +352,7 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 			concatables += double_match ? "!BOTH! [matched_ip] and [matched_cid]" : (!isnull(matched_ip) ? matched_ip : matched_cid)
 			concatables += "as [isnull(potential_match) ? "[joined_player_ckey] (no longer logged in)" : "[key_name_admin(potential_match)]"]"
 			if(same_round)
-				concatables += span_bold("in the current round.")
-			else
-				concatables += "."
+				concatables += span_bold("in the current round")
 
 			concatables += "</span>"
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -322,30 +322,46 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 			if(!joined_player_preferences)
 				continue //this shouldn't happen.
 
-			var/client/C = GLOB.directory[joined_player_ckey]
-			var/in_round = ""
-			if (joined_players[joined_player_ckey])
-				in_round = " who has played in the current round"
-			var/message_type = "Notice"
+			var/client/potential_match = GLOB.directory[joined_player_ckey]
 
-			var/matches
+			var/matched_ip = null
+			var/matched_cid = null
+			var/same_round = FALSE
+
 			if(joined_player_preferences.last_ip == address)
-				matches += "IP ([address])"
+				matched_ip = "IP [address]"
+
 			if(joined_player_preferences.last_id == computer_id)
-				if(matches)
-					matches = "BOTH [matches] and "
-					alert_admin_multikey = TRUE
-					message_type = "MULTIKEY"
-				matches += "Computer ID ([computer_id])"
+				matched_cid = "Computer ID [computer_id]"
 				alert_mob_dupe_login = TRUE
 
-			if(matches)
-				if(C)
-					message_admins(span_danger("<B>[message_type]: </B></span><span class='notice'>Connecting player [key_name_admin(src)] has the same [matches] as [key_name_admin(C)]<b>[in_round]</b>."))
-					log_admin_private("[message_type]: Connecting player [key_name(src)] has the same [matches] as [key_name(C)][in_round].")
-				else
-					message_admins(span_danger("<B>[message_type]: </B></span><span class='notice'>Connecting player [key_name_admin(src)] has the same [matches] as [joined_player_ckey](no longer logged in)<b>[in_round]</b>. "))
-					log_admin_private("[message_type]: Connecting player [key_name(src)] has the same [matches] as [joined_player_ckey](no longer logged in)[in_round].")
+			if(isnull(matched_ip) && isnull(matched_cid))
+				continue
+
+			if (joined_players[joined_player_ckey])
+				same_round = TRUE
+
+			var/double_match = !isnull(matched_ip) && !isnull(matched_cid)
+
+			if(double_match && same_round)
+				alert_admin_multikey = TRUE
+
+			var/list/concatables = list()
+			concatables += span_danger(span_bold("[double_match ? "MULTIKEY" : "Notice"]"))
+			concatables += "<span class='notice'>Connecting player [key_name_admin(src)] has the same"
+			concatables += double_match ? "!BOTH! [matched_ip] and [matched_cid]" : (!isnull(matched_ip) ? matched_ip : matched_cid)
+			concatables += "as [isnull(potential_match) ? "[joined_player_ckey] (no longer logged in)" : "[key_name_admin(potential_match)]"]"
+			if(same_round)
+				concatables += span_bold("in the current round.")
+			else
+				concatables += "."
+
+			concatables += "</span>"
+
+			var/sendable_string = jointext(concatables, " ")
+
+			message_admins(sendable_string)
+			log_admin_private(strip_html_full(sendable_string, MAX_MESSAGE_LEN))
 
 	. = ..() //calls mob.Login()
 


### PR DESCRIPTION
## About The Pull Request

The slight imperfections of this were getting to me whenever I was testing stuff that required me have two different clients intializied so let's just retinker it a bit to look nicer without losing any functionality of the messaging service (as well as some explicit UX stuff to make it look less syntactically incorrect)

Before:
<img width="781" height="65" alt="image" src="https://github.com/user-attachments/assets/bcd0c44b-8f88-40f6-8d14-ea280f00e084" />

After (colon missing at time of screenshot, fixed later):
<img width="821" height="42" alt="image" src="https://github.com/user-attachments/assets/a0627414-3896-424d-8eb1-250dcfaacf70" />

Logged Version:
```
[2025-12-06 06:29:26.969] ADMINPRIVATE: MULTIKEY: Connecting player San7890 has the same !BOTH! IP 127.0.0.1 and Computer ID *********** as thesan7890 (no longer logged in) in the current round
```
## Why It's Good For The Game

Cleaner message that is still eyecatching for admins, uses string concats so it's less painful to modify in the future as well as reduce duplicated code while overall maintaining a pretty nice flow of message generation rather than be scattered all over the place.

## Changelog
:cl:
admin: Multikeying Notice Messages have taken on a new form factor but should still furnish the same information.
/:cl:
