### PR TITLE
Adds recolorable santa hat to loadout during the festive season

### DIFF
--- a/code/modules/loadout/categories/heads.dm
+++ b/code/modules/loadout/categories/heads.dm
@@ -155,3 +155,8 @@
 /datum/loadout_item/head/wig
 	name = "Natural Wig"
 	item_path = /obj/item/clothing/head/wig/natural
+
+/datum/loadout_item/head/santa
+	name = "Santa Hat"
+	item_path = /obj/item/clothing/head/costume/santa/gags
+	required_holiday = FESTIVE_SEASON

--- a/code/modules/loadout/loadout_categories.dm
+++ b/code/modules/loadout/loadout_categories.dm
@@ -57,6 +57,9 @@
 	var/list/formatted_list = list()
 
 	for(var/datum/loadout_item/item as anything in associated_items)
+		if(item.is_disabled())
+			continue
+
 		var/list/item_data = item.to_ui_data()
 		UNTYPED_LIST_ADD(formatted_list, item_data)
 

--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -27,10 +27,14 @@
 	else
 		CRASH("Invalid outfit passed to equip_outfit_and_loadout ([outfit])")
 
-	var/list/preference_list = preference_source.read_preference(/datum/preference/loadout)
-	var/list/loadout_datums = loadout_list_to_datums(preference_list)
+	var/list/item_details = preference_source.read_preference(/datum/preference/loadout)
+	var/list/loadout_datums = loadout_list_to_datums(item_details)
 	// Slap our things into the outfit given
 	for(var/datum/loadout_item/item as anything in loadout_datums)
+		if(!item.is_equippable(src, item_details?[item.item_path] || list()))
+			loadout_datums -= item
+			continue
+
 		item.insert_path_into_outfit(equipped_outfit, src, visuals_only)
 	// Equip the outfit loadout items included
 	if(!equipped_outfit.equip(src, visuals_only))
@@ -41,7 +45,7 @@
 	for(var/datum/loadout_item/item as anything in loadout_datums)
 		update |= item.on_equip_item(
 			equipped_item = locate(item.item_path) in new_contents,
-			item_details = preference_list?[item.item_path] || list(),
+			item_details = item_details?[item.item_path] || list(),
 			equipper = src,
 			outfit = equipped_outfit,
 			visuals_only = visuals_only,

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -42,6 +42,8 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	var/group = null
 	/// Loadout flags, see LOADOUT_FLAG_* defines
 	var/loadout_flags = NONE
+	/// If set, this item can only be selected during the holiday specified.
+	var/required_holiday
 	/// The actual item path of the loadout item.
 	var/obj/item/item_path
 	/// Icon file (DMI) for the UI to use for preview icons.
@@ -317,6 +319,18 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	return formatted_item
 
 /**
+ * Checks if this item is disabled and cannot be selected or granted
+ */
+/datum/loadout_item/proc/is_disabled()
+	return required_holiday && !check_holidays(required_holiday)
+
+/**
+ * Checks if this item is disabled or unequippable for the given item details.
+ */
+/datum/loadout_item/proc/is_equippable(mob/living/carbon/human/equipper, list/item_details)
+	return !is_disabled()
+
+/**
  * Returns a list of information to display about this item in the loadout UI.
  * Icon -> tooltip displayed when its hovered over
  */
@@ -330,6 +344,9 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(reskin_datum)
 		displayed_text[FA_ICON_SWATCHBOOK] = "Reskinnable"
+
+	if(required_holiday)
+		displayed_text[FA_ICON_CALENDAR_CHECK] = "Only available: [required_holiday]"
 
 	return displayed_text
 

--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -27,7 +27,7 @@
 
 	if(params["deselect"])
 		deselect_item(interacted_item)
-	else
+	else if(!interacted_item.is_disabled())
 		select_item(interacted_item)
 	return TRUE
 

--- a/code/modules/loadout/loadout_preference.dm
+++ b/code/modules/loadout/loadout_preference.dm
@@ -16,7 +16,7 @@
 
 // Sanitize on load to ensure no invalid paths from older saves get in
 /datum/preference/loadout/deserialize(input, datum/preferences/preferences)
-	return sanitize_loadout_list(input, preferences.parent?.mob)
+	return sanitize_loadout_list(input)
 
 // Default value is null - the loadout list is a lazylist
 /datum/preference/loadout/create_default_value(datum/preferences/preferences)
@@ -51,6 +51,10 @@
 					It has been removed, renamed, or is otherwise missing - \
 					You may want to check your loadout settings."))
 			continue
+
+		var/datum/loadout_item/loadout_item = GLOB.all_loadout_datums[real_path]
+		if(loadout_item.is_disabled())
+			continue // this just falls off silently
 
 		// Set into sanitize list using converted path key
 		var/list/data = passed_list[path]

--- a/code/modules/loadout/loadout_preference.dm
+++ b/code/modules/loadout/loadout_preference.dm
@@ -16,7 +16,7 @@
 
 // Sanitize on load to ensure no invalid paths from older saves get in
 /datum/preference/loadout/deserialize(input, datum/preferences/preferences)
-	return sanitize_loadout_list(input)
+	return sanitize_loadout_list(input, preferences.parent?.mob)
 
 // Default value is null - the loadout list is a lazylist
 /datum/preference/loadout/create_default_value(datum/preferences/preferences)


### PR DESCRIPTION
## About The Pull Request

Adds support for holiday-specific loadout items.
They are only visible in the loadout during the holiday. 
When the holiday ends, the item's removed from your loadout list. 

During the entire month of December (IE, During the "Festive Season" holiday) you can equip a recolorable santa hat as a loadout option

## Why It's Good For The Game

Holiday cheer (Also assistants already spawn with one)

## Changelog

:cl: Melbert
add: You can select a recolorable Santa Hat in the loadout during the festive season (December 1st - 31st) 
/:cl:
