### PR TITLE
Make evolved lungs resistant to co2

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -1124,7 +1124,7 @@
 	icon_state = "lungs-evolved"
 
 	safe_plasma_max = 8
-	safe_co2_max = 8
+	safe_co2_max = 20
 	maxHealth = 1.2 * STANDARD_ORGAN_THRESHOLD
 	safe_oxygen_min = 8
 


### PR DESCRIPTION
## About The Pull Request
`safe_co2_max` is set to 10 for the default lungs, while the evolved ones have it set to 8. This appears to be an oversight, since #92108 pr description states that evolved lungs should be better at handling CO2 than normal ones.
This PR sets evolved lungs `safe_co2_max` to 20, which makes it as beneficial as having upgraded cybernetic lungs (in terms of CO2 resistance). 
I'm not sure which value is appropriate, but it's surely supposed to be more than the default.
## Why It's Good For The Game
Fix an apparent oversight
## Changelog
:cl:
fix: make evolved lungs actually resistant to co2
/:cl:
