### PR TITLE
Covering your face stops people from seeing your expression when you're using sign language

### DIFF
--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -310,6 +310,10 @@
 
 /// Send a visible message depending on the tone of the message that the sender is trying to convey to the world.
 /datum/component/sign_language/proc/emote_tone(mob/living/carbon/carbon_parent, emote_tone)
+	if(ishuman(carbon_parent))
+		var/mob/living/carbon/human/human_parent = carbon_parent
+		if(human_parent.get_face_name() == "Unknown")
+			return // You can't see someone's expression if their face is obscured (or disfigured)
 	switch(emote_tone)
 		if(TONE_INQUISITIVE)
 			carbon_parent.visible_message(span_bold("quirks [carbon_parent.p_their()] brows quizzically."), visible_message_flags = EMOTE_MESSAGE|BLOCK_SELF_HIGHLIGHT_MESSAGE)

--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -312,7 +312,7 @@
 /datum/component/sign_language/proc/emote_tone(mob/living/carbon/carbon_parent, emote_tone)
 	if(ishuman(carbon_parent))
 		var/mob/living/carbon/human/human_parent = carbon_parent
-		if(human_parent.get_face_name() == "Unknown")
+		if(human_parent.is_face_obscured())
 			return // You can't see someone's expression if their face is obscured (or disfigured)
 	switch(emote_tone)
 		if(TONE_INQUISITIVE)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -81,14 +81,19 @@
 	return real_name
 
 /mob/living/carbon/human/get_face_name(if_no_face = "Unknown")
-	if(HAS_TRAIT(src, TRAIT_UNKNOWN_APPEARANCE))
-		return if_no_face //We're Unknown, no face information for you
-	if(obscured_slots & HIDEFACE)
-		return if_no_face
-	var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
-	if(isnull(head) || !real_name || HAS_TRAIT(src, TRAIT_DISFIGURED) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN)) //disfigured. use id-name if possible
+	if(!real_name || is_face_obscured())
 		return if_no_face
 	return real_name
+
+/mob/living/carbon/human/proc/is_face_obscured()
+	if(HAS_TRAIT(src, TRAIT_UNKNOWN_APPEARANCE))
+		return TRUE //We're Unknown, no face information for you
+	if(obscured_slots & HIDEFACE)
+		return TRUE
+	var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
+	if(isnull(head) || HAS_TRAIT(src, TRAIT_DISFIGURED) || HAS_TRAIT(src, TRAIT_INVISIBLE_MAN)) //disfigured. use id-name if possible
+		return TRUE
+	return FALSE
 
 /**
  * Gets whatever name is in our ID or PDA


### PR DESCRIPTION
## About The Pull Request

If your face is obscured you won't be quirking your eyes quizzically. Or maybe you will, but nobody will see it.

## Why It's Good For The Game

It's kinda weird that you can see someone's eyebrows through their modsuit helmet or whatever you're wearing that totally obscures your head. The same applies to invisible people. How are they gonna notice you quirked your invisible eyebrows?

## Changelog

:cl:
fix: Obscuring your face prevents people from noticing your facial expression when you're using sign language
/:cl: