### PR TITLE
You can put defib paddles back into defibs using hotkeys

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -187,3 +187,7 @@
 /// From /mob/living/carbon/proc/can_defib() : ()
 /// Return a defib result flag to override default defib brain check
 #define COMSIG_CARBON_DEFIB_BRAIN_CHECK "carbon_defib_brain_check"
+
+/// From /mob/living/carbon/human/proc/smart_equip_targeted(): (obj/item/possible_container)
+/// Return true to stop the transfer from happening
+#define COMSIG_HUMAN_NON_STORAGE_HOTKEY "human_storage_hotkey"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -188,6 +188,7 @@
 /// Return a defib result flag to override default defib brain check
 #define COMSIG_CARBON_DEFIB_BRAIN_CHECK "carbon_defib_brain_check"
 
-/// From /mob/living/carbon/human/proc/smart_equip_targeted(): (obj/item/possible_container)
-/// Return true to stop the transfer from happening
+/// From /mob/living/carbon/human/proc/smart_equip_targeted(): (mob/living/carbon/human/user, obj/item/possible_container)
 #define COMSIG_HUMAN_NON_STORAGE_HOTKEY "human_storage_hotkey"
+	/// Return to prevent the storage fail message
+	#define COMPONENT_STORAGE_HOTKEY_HANDLED (1<<0)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -340,6 +340,7 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob, ITEM_SLOT_BACK)
 	AddComponent(/datum/component/two_handed, force_unwielded=8, force_wielded=12)
+	RegisterSignal(src, COMSIG_HUMAN_NON_STORAGE_HOTKEY, PROC_REF(on_non_storage_hotkey))
 
 /obj/item/shockpaddles/Destroy()
 	defib = null
@@ -667,6 +668,13 @@
 
 /obj/item/shockpaddles/proc/is_wielded()
 	return HAS_TRAIT(src, TRAIT_WIELDED)
+
+/obj/item/shockpaddles/proc/on_non_storage_hotkey(datum/source, obj/item/possible_storage)
+	SIGNAL_HANDLER
+	if(possible_storage == defib)
+		dropped()
+		return TRUE
+	return FALSE
 
 /obj/item/shockpaddles/cyborg
 	name = "cyborg defibrillator paddles"

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -669,11 +669,11 @@
 /obj/item/shockpaddles/proc/is_wielded()
 	return HAS_TRAIT(src, TRAIT_WIELDED)
 
-/obj/item/shockpaddles/proc/on_non_storage_hotkey(datum/source, obj/item/possible_storage)
+/obj/item/shockpaddles/proc/on_non_storage_hotkey(datum/source,  mob/living/carbon/human/user, obj/item/possible_storage)
 	SIGNAL_HANDLER
 	if(possible_storage == defib)
-		dropped()
-		return TRUE
+		user.dropItemToGround(src)
+		return COMPONENT_STORAGE_HOTKEY_HANDLED
 	return FALSE
 
 /obj/item/shockpaddles/cyborg

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -674,7 +674,7 @@
 	if(possible_storage == defib)
 		user.dropItemToGround(src)
 		return COMPONENT_STORAGE_HOTKEY_HANDLED
-	return FALSE
+	return NONE
 
 /obj/item/shockpaddles/cyborg
 	name = "cyborg defibrillator paddles"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -358,7 +358,7 @@
 		return
 	var/obj/item/thing = get_active_held_item()
 	var/obj/item/equipped_item = get_item_by_slot(slot_type)
-	var/thing_reject
+	var/thing_reject = NONE
 	if(thing)
 		thing_reject = SEND_SIGNAL(thing, COMSIG_HUMAN_NON_STORAGE_HOTKEY, src, equipped_item)
 	if(!equipped_item) // We also let you equip an item like this

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -367,6 +367,9 @@
 		return
 	var/datum/storage/storage = equipped_item.atom_storage
 	if(!storage)
+		if(istype(thing, /obj/item/shockpaddles) && istype(equipped_item, /obj/item/defibrillator))
+			thing.dropped()
+			return
 		if(!thing)
 			equipped_item.attack_hand(src)
 		else

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -358,6 +358,9 @@
 		return
 	var/obj/item/thing = get_active_held_item()
 	var/obj/item/equipped_item = get_item_by_slot(slot_type)
+	var/thing_reject
+	if(thing)
+		item_reject = SEND_SIGNAL(thing, COMSIG_HUMAN_NON_STORAGE_HOTKEY, equipped_item)
 	if(!equipped_item) // We also let you equip an item like this
 		if(!thing)
 			to_chat(src, span_warning("You have no [slot_item_name] to take something out of!"))
@@ -367,12 +370,11 @@
 		return
 	var/datum/storage/storage = equipped_item.atom_storage
 	if(!storage)
-		if(istype(thing, /obj/item/shockpaddles) && istype(equipped_item, /obj/item/defibrillator))
-			thing.dropped()
-			return
 		if(!thing)
 			equipped_item.attack_hand(src)
 		else
+			if(thing_reject)
+				return
 			to_chat(src, span_warning("You can't fit [thing] into your [equipped_item.name]!"))
 		return
 	if(!storage.supports_smart_equip)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -360,7 +360,7 @@
 	var/obj/item/equipped_item = get_item_by_slot(slot_type)
 	var/thing_reject
 	if(thing)
-		item_reject = SEND_SIGNAL(thing, COMSIG_HUMAN_NON_STORAGE_HOTKEY, equipped_item)
+		thing_reject = SEND_SIGNAL(thing, COMSIG_HUMAN_NON_STORAGE_HOTKEY, equipped_item)
 	if(!equipped_item) // We also let you equip an item like this
 		if(!thing)
 			to_chat(src, span_warning("You have no [slot_item_name] to take something out of!"))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -360,7 +360,7 @@
 	var/obj/item/equipped_item = get_item_by_slot(slot_type)
 	var/thing_reject
 	if(thing)
-		thing_reject = SEND_SIGNAL(thing, COMSIG_HUMAN_NON_STORAGE_HOTKEY, equipped_item)
+		thing_reject = SEND_SIGNAL(thing, COMSIG_HUMAN_NON_STORAGE_HOTKEY, src, equipped_item)
 	if(!equipped_item) // We also let you equip an item like this
 		if(!thing)
 			to_chat(src, span_warning("You have no [slot_item_name] to take something out of!"))
@@ -373,7 +373,7 @@
 		if(!thing)
 			equipped_item.attack_hand(src)
 		else
-			if(thing_reject)
+			if(thing_reject & COMPONENT_STORAGE_HOTKEY_HANDLED)
 				return
 			to_chat(src, span_warning("You can't fit [thing] into your [equipped_item.name]!"))
 		return


### PR DESCRIPTION
## About The Pull Request

Normally you gotta drop paddles to put them back. If you have a compact defib around your belt and you press your belt hotkey it'll tell you that the paddles don't fit in there because it's just checking to see if the compact defib is a storage container, which it isn't.
This PR makes it specifically check for putting shockpaddles into defibs and makes you drop the item instead. It also adds a signal specifically for this scenario so you can easily add it to other items, like holding a magazine and hotkeying it into a gun in your suit storage.

## Why It's Good For The Game

It's more intuitive.

## Changelog

:cl:
qol: You can hotkey shockpaddles back into their defibs
/:cl:
