### PR TITLE
Makes tuberculosis message only tell you to take off your clothes if you have clothes on

### DIFF
--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -62,7 +62,11 @@
 				affected_mob.overeatduration = max(affected_mob.overeatduration - (200 SECONDS), 0)
 				affected_mob.adjust_nutrition(-100)
 			if(SPT_PROB(7.5, seconds_per_tick))
-				to_chat(affected_mob, span_danger("[pick("You feel uncomfortably hot...", "You feel like unzipping your jumpsuit...", "You feel like taking off some clothes...")]"))
+				if(ishuman(affected_mob))
+					var/mob/living/carbon/human/human_victim = affected_mob
+					to_chat(human_victim, span_danger("[human_victim.w_uniform? pick("You feel uncomfortably hot...", "You feel like unzipping your jumpsuit...", "You feel like taking off some clothes...") : "You feel uncomfortably hot..."]"))
+				else
+					to_chat(affected_mob, span_danger("You feel uncomfortably hot..."))
 				affected_mob.adjust_bodytemperature(40)
 			if(need_mob_update)
 				affected_mob.updatehealth()


### PR DESCRIPTION

## About The Pull Request

The clothes-referencing messages within tuberculosis's heating up symptom are only chosen if the person effected has a jumpsuit on

## Why It's Good For The Game

closes #94350

## Changelog
:cl:

spellcheck: Tuberculosis no longer tells naked people to get naked

/:cl:
