### PR TITLE
Rescue modsuit suit storage can hold everything the medical modsuit can

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -777,21 +777,22 @@
 	slowdown_deployed = 0.25
 	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced)
 	allowed_suit_storage = list(
+		/obj/item/crowbar/power/paramedic,
+		/obj/item/defibrillator/compact,
 		/obj/item/healthanalyzer,
+		/obj/item/melee/baton/telescopic,
+		/obj/item/reagent_containers/applicator,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/applicator,
 		/obj/item/reagent_containers/syringe,
-		/obj/item/stack/medical,
 		/obj/item/sensor_device,
-		/obj/item/storage/pill_bottle,
+		/obj/item/stack/medical,
 		/obj/item/storage/bag/chemistry,
 		/obj/item/storage/bag/bio,
-		/obj/item/melee/baton/telescopic,
-		/obj/item/defibrillator/compact,
+		/obj/item/storage/pill_bottle,
 	)
 	variants = list(
 		"rescue" = list(

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -783,7 +783,7 @@
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/applicator/pill,
+		/obj/item/reagent_containers/applicator,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/stack/medical,
 		/obj/item/sensor_device,
@@ -791,6 +791,7 @@
 		/obj/item/storage/bag/chemistry,
 		/obj/item/storage/bag/bio,
 		/obj/item/melee/baton/telescopic,
+		/obj/item/defibrillator/compact,
 	)
 	variants = list(
 		"rescue" = list(


### PR DESCRIPTION
## About The Pull Request

Mel forgot to give compact defibs to the rescue suit storage. Also I noticed the medical modsuit can hold other applicators like patches and stuff instead of only pills.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: Rescue modsuit suit storage can hold anything the medical modsuit suit storage can hold
/:cl: