### PR TITLE
Fix Asclepius again

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -53,7 +53,7 @@
 	if(new_master)
 		thealert.master_ref = master_ref
 		thealert.RegisterSignal(new_master, COMSIG_ATOM_UPDATE_APPEARANCE, TYPE_PROC_REF(/atom/movable/screen/alert, on_master_update_appearance))
-		thealert.update_appearance(UPDATE_OVERLAYS)
+		thealert.update_appearance()
 	else if(severity)
 		thealert.icon_state = "[initial(thealert.icon_state)][severity]"
 		thealert.severity = severity
@@ -125,7 +125,7 @@
 		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
 		mouse_over_pointer = MOUSE_HAND_POINTER
 	if(overlay_state)
-		update_appearance(UPDATE_OVERLAYS)
+		update_appearance()
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()
@@ -137,7 +137,7 @@
 
 /atom/movable/screen/alert/proc/on_master_update_appearance(datum/source)
 	SIGNAL_HANDLER
-	update_appearance(UPDATE_OVERLAYS)
+	update_appearance()
 
 /atom/movable/screen/alert/update_overlays()
 	. = ..()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -158,8 +158,7 @@
 	atom_appearance.pixel_y = atom.base_pixel_y
 	atom_appearance.pixel_w = atom.base_pixel_w
 	atom_appearance.pixel_z = atom.base_pixel_z
-	strip_appearance_underlays(atom_appearance)
-	return atom_appearance
+	return strip_appearance_underlays(atom_appearance)
 
 /atom/movable/screen/alert/Click(location, control, params)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -164,5 +164,6 @@
 	icon_state = "template"
 	use_user_hud_icon = TRUE
 	clickable_glow = TRUE
+	click_master = FALSE
 
 #undef HEAL_EFFECT_COOLDOWN

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -121,7 +121,6 @@
 	for (var/mob/living/candidate as anything in to_heal)
 		if (!current_alerts[candidate])
 			var/atom/movable/screen/alert/aura_healing/alert = candidate.throw_alert(alert_category, /atom/movable/screen/alert/aura_healing, new_master = parent)
-			alert.desc = "You are being healed by [parent]."
 			current_alerts[candidate] = TRUE
 
 		if (should_show_effect && candidate.health < candidate.maxHealth)
@@ -165,5 +164,9 @@
 	use_user_hud_icon = TRUE
 	clickable_glow = TRUE
 	click_master = FALSE
+
+/atom/movable/screen/alert/aura_healing/update_desc(updates)
+	. = ..()
+	desc = "You are being healed by [master_ref?.resolve()]."
 
 #undef HEAL_EFFECT_COOLDOWN

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -120,7 +120,7 @@
 
 	for (var/mob/living/candidate as anything in to_heal)
 		if (!current_alerts[candidate])
-			var/atom/movable/screen/alert/aura_healing/alert = candidate.throw_alert(alert_category, /atom/movable/screen/alert/aura_healing, new_master = parent)
+			candidate.throw_alert(alert_category, /atom/movable/screen/alert/aura_healing, new_master = parent)
 			current_alerts[candidate] = TRUE
 
 		if (should_show_effect && candidate.health < candidate.maxHealth)

--- a/code/datums/status_effects/debuffs/cursed.dm
+++ b/code/datums/status_effects/debuffs/cursed.dm
@@ -184,7 +184,7 @@
 /atom/movable/screen/alert/status_effect/cursed/update_desc()
 	. = ..()
 	var/datum/status_effect/slot_machine_curse/linked_effect = attached_effect
-	var/curses = linked_effect.curse_count
+	var/curses = linked_effect?.curse_count
 	switch(curses)
 		if(2)
 			desc = "Your greed is catching up to you..."

--- a/code/modules/mining/lavaland/mining_loot/equipment.dm
+++ b/code/modules/mining/lavaland/mining_loot/equipment.dm
@@ -40,7 +40,6 @@
 		to_chat(user, span_warning("The snake carving seems to come alive, if only for a moment, before returning to its dormant state, almost as if it finds you incapable of holding its oath."))
 		return
 	var/mob/living/carbon/itemUser = user
-	var/usedHand = itemUser.get_held_index_of_item(src)
 	if(itemUser.has_status_effect(/datum/status_effect/hippocratic_oath))
 		to_chat(user, span_warning("You can't possibly handle the responsibility of more than one rod!"))
 		return
@@ -56,9 +55,12 @@
 		to_chat(itemUser, failText)
 		return
 
-	to_chat(itemUser, span_notice("The snake, satisfied with your oath, attaches itself and the rod to your forearm with an inseparable grip. Your thoughts seem to only revolve around the core idea of helping others, and harm is nothing more than a distant, wicked memory..."))
-	var/datum/status_effect/hippocratic_oath/effect = itemUser.apply_status_effect(/datum/status_effect/hippocratic_oath)
-	effect.hand = usedHand
+	apply_oath(itemUser, usedHand)
+
+/obj/item/rod_of_asclepius/proc/apply_oath(mob/living/carbon/user)
+	to_chat(user, span_notice("The snake, satisfied with your oath, attaches itself and the rod to your forearm with an inseparable grip. Your thoughts seem to only revolve around the core idea of helping others, and harm is nothing more than a distant, wicked memory..."))
+	var/datum/status_effect/hippocratic_oath/effect = user.apply_status_effect(/datum/status_effect/hippocratic_oath)
+	effect.hand = user.get_held_index_of_item(src)
 	activated()
 
 /obj/item/rod_of_asclepius/proc/activated()

--- a/code/modules/mining/lavaland/mining_loot/equipment.dm
+++ b/code/modules/mining/lavaland/mining_loot/equipment.dm
@@ -55,7 +55,7 @@
 		to_chat(itemUser, failText)
 		return
 
-	apply_oath(itemUser, usedHand)
+	apply_oath(itemUser)
 
 /obj/item/rod_of_asclepius/proc/apply_oath(mob/living/carbon/user)
 	to_chat(user, span_notice("The snake, satisfied with your oath, attaches itself and the rod to your forearm with an inseparable grip. Your thoughts seem to only revolve around the core idea of helping others, and harm is nothing more than a distant, wicked memory..."))

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -30,3 +30,28 @@
 /atom/movable/screen/alert/test_alert/Destroy()
 	linked = null
 	return ..()
+
+/datum/unit_test/alert_underlay_stripping
+
+/datum/unit_test/alert_underlay_stripping/Run()
+	var/mob/living/carbon/human/consistent/dummy = EASY_ALLOCATE()
+	dummy.equipOutfit(/datum/outfit/job/assistant/consistent)
+	dummy.mock_client = new /datum/client_interface()
+
+	var/obj/item/flashlight/lantern/on/light = EASY_ALLOCATE()
+	dummy.put_in_hands(light)
+
+	var/obj/item/rod_of_asclepius/asclepius = EASY_ALLOCATE()
+	dummy.put_in_hands(asclepius)
+	asclepius.apply_oath(dummy)
+
+	TEST_ASSERT_NOTNULL(dummy.has_status_effect(/datum/status_effect/hippocratic_oath), "Dummy should have the Hippocratic Oath status effect.")
+	var/atom/movable/screen/alert/aura_healing/alert = locate() in assoc_to_values(dummy.alerts)
+	TEST_ASSERT_NOTNULL(alert, "Dummy should have received the aura healing alert.")
+	TEST_ASSERT(length(alert.overlays) > 0, "Alert should have overlays applied.")
+
+	for(var/mutable_appearance/some_overlay as anything in alert.overlays)
+		var/base_plane = PLANE_TO_TRUE(some_overlay.plane)
+		for(var/mutable_appearance/some_subunderlay as anything in overlay.underlays)
+			if(PLANE_TO_TRUE(some_subunderlay.plane) != base_plane)
+				TEST_FAIL("Alert overlay has a off-plane underlay - it should have been stripped, otherwise it may interfere with screens.")

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -45,7 +45,9 @@
 	dummy.put_in_hands(asclepius)
 	asclepius.apply_oath(dummy)
 
-	TEST_ASSERT_NOTNULL(dummy.has_status_effect(/datum/status_effect/hippocratic_oath), "Dummy should have the Hippocratic Oath status effect.")
+	var/datum/status_effect/hippocratic_oath/oath = dummy.has_status_effect(/datum/status_effect/hippocratic_oath)
+	TEST_ASSERT_NOTNULL(oath, "Dummy should have the Hippocratic Oath status effect.")
+	oath.aura_healing.process(1) // tick it once to apply the alert
 	var/atom/movable/screen/alert/aura_healing/alert = locate() in assoc_to_values(dummy.alerts)
 	TEST_ASSERT_NOTNULL(alert, "Dummy should have received the aura healing alert.")
 	TEST_ASSERT(length(alert.overlays) > 0, "Alert should have overlays applied.")

--- a/code/modules/unit_tests/alerts.dm
+++ b/code/modules/unit_tests/alerts.dm
@@ -52,6 +52,6 @@
 
 	for(var/mutable_appearance/some_overlay as anything in alert.overlays)
 		var/base_plane = PLANE_TO_TRUE(some_overlay.plane)
-		for(var/mutable_appearance/some_subunderlay as anything in overlay.underlays)
+		for(var/mutable_appearance/some_subunderlay as anything in some_overlay.underlays)
 			if(PLANE_TO_TRUE(some_subunderlay.plane) != base_plane)
 				TEST_FAIL("Alert overlay has a off-plane underlay - it should have been stripped, otherwise it may interfere with screens.")


### PR DESCRIPTION
## About The Pull Request

IDK why this didn't work / why this fixes it to be honest

Also this shouldn't be clickable, otherwise you can click them when you otherwise shouldn't be able to 

## Changelog

:cl: Melbert
fix: Fix Asclepius screen alert when the holder has a lantern
fix: You can't click the Asclepius screen alert 
/:cl:
