### PR TITLE
Wardens can alt-click-reskin their gloves to match their formal attire

### DIFF
--- a/code/datums/components/reskinnable_atom.dm
+++ b/code/datums/components/reskinnable_atom.dm
@@ -62,6 +62,13 @@
 		var/obj/item/item_clear_from = clear_from
 		RESET_INITIAL_IF_SET(item_clear_from, inhand_icon_state, new_icon_state)
 
+/// Gets a preview image for this skin based on the given atom's icon and icon_state
+/datum/atom_skin/proc/get_preview_icon(atom/for_atom)
+	return image(
+		icon = new_icon || for_atom.icon,
+		icon_state = new_icon_state || for_atom.icon_state,
+	)
+
 /**
  * ### Reskinnable atoms
  *
@@ -173,8 +180,7 @@
 
 	var/list/items = list()
 	for(var/reskin_name, reskin_typepath in get_skins_by_name())
-		var/datum/atom_skin/reskin = GLOB.atom_skins[reskin_typepath]
-		items[reskin_name] = image(icon = reskin.new_icon || atom_parent.icon, icon_state = reskin.new_icon_state || atom_parent.icon_state)
+		items[reskin_name] = GLOB.atom_skins[reskin_typepath].get_preview_icon(atom_parent)
 
 	sort_list(items)
 

--- a/code/datums/martial/kaza_ruk.dm
+++ b/code/datums/martial/kaza_ruk.dm
@@ -270,6 +270,34 @@
 	. = ..()
 	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/kaza_ruk)
 
+/datum/atom_skin/kaza_ruk
+	abstract_type = /datum/atom_skin/kaza_ruk
+	reset_missing = FALSE
+	/// Color (/matrix) applied with the skin. If null, no color is applied.
+	var/reskin_color
+
+/datum/atom_skin/kaza_ruk/apply(atom/apply_to)
+	. = ..()
+	if(reskin_color)
+		apply_to.add_atom_colour(color_matrix_filter(reskin_color), FIXED_COLOUR_PRIORITY)
+
+/datum/atom_skin/kaza_ruk/clear_skin(atom/clear_from)
+	. = ..()
+	if(reskin_color)
+		clear_from.remove_atom_colour(FIXED_COLOUR_PRIORITY, reskin_color)
+
+/datum/atom_skin/kaza_ruk/get_preview_icon(atom/for_atom)
+	var/image/generated = ..()
+	generated.add_filter("preview_filter", 1, color_matrix_filter(reskin_color))
+	return generated
+
+/datum/atom_skin/kaza_ruk/red
+	preview_name = "Red"
+
+/datum/atom_skin/kaza_ruk/blue
+	preview_name = "Blue"
+	reskin_color = list(0.33, 0.33, 0.33, 0, 0, 0, 0, 0, 3)
+
 /obj/item/clothing/gloves/kaza_ruk/sec//more obviously named, given to sec
 	name = "kaza ruk gloves"
 	desc = "These gloves seem to guide you through a non-lizardperson friendly variant of the Tiziran martial art, Kaza Ruk. \
@@ -281,6 +309,10 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
+
+/obj/item/clothing/gloves/kaza_ruk/sec/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/reskinable_item, /datum/atom_skin/kaza_ruk, infinite = TRUE)
 
 /obj/item/clothing/gloves/kaza_ruk/combatglovesplus
 	name = "combat gloves plus"

--- a/code/datums/martial/kaza_ruk.dm
+++ b/code/datums/martial/kaza_ruk.dm
@@ -288,7 +288,8 @@
 
 /datum/atom_skin/kaza_ruk/get_preview_icon(atom/for_atom)
 	var/image/generated = ..()
-	generated.add_filter("preview_filter", 1, color_matrix_filter(reskin_color))
+	if(reskin_color)
+		generated.add_filter("preview_filter", 1, color_matrix_filter(reskin_color))
 	return generated
 
 /datum/atom_skin/kaza_ruk/red
@@ -296,7 +297,7 @@
 
 /datum/atom_skin/kaza_ruk/blue
 	preview_name = "Blue"
-	reskin_color = list(0.33, 0.33, 0.33, 0, 0, 0, 0, 0, 3)
+	reskin_color = list(0.33, 0.33, 0.33, 0, 0, 0, 0, 0, 1)
 
 /obj/item/clothing/gloves/kaza_ruk/sec//more obviously named, given to sec
 	name = "kaza ruk gloves"


### PR DESCRIPTION
## About The Pull Request

Adds an alt-click skin to the Kaza Ruk gloves which match their formal attire

<img width="113" height="231" alt="image" src="https://github.com/user-attachments/assets/5f64d09e-a294-423e-b723-bb094ad49fef" />

No new sprites, all it does is apply a color matrix

## Why It's Good For The Game

The only thing that keeps me from taking the formal attire for a spin is that the gloves don't match.
This is already theoretically possibly by just getting a spray can, but I figured it could just be an alt-click thing. Seems appropriate.

## Changelog

:cl: Melbert
add: Wardens can alt-click-reskin their Kaza Ruk gloves to match their formal attire
/:cl:
