### PR TITLE
Fixes kheiral cuff GPS not turning off

### DIFF
--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -72,6 +72,7 @@
 		return
 	balloon_alert(user, "gps de-activated")
 	REMOVE_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
+	qdel(GetComponent(/datum/component/gps/kheiral_cuffs))
 	gps_enabled = FALSE
 
 /// If we're off the Z-level, set far_from_home = TRUE. If being worn, trigger kheiral_network proc


### PR DESCRIPTION

## About The Pull Request
This seems to have been removed by accident
## Why It's Good For The Game
## Changelog
:cl:
fix: The GPS from kheiral cuffs will now turn off when it says it does
/:cl:
