### PR TITLE
Fix map reader ignoring valid variable names

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -102,7 +102,7 @@
 	/// Matches key formats in TMG (IE: newline after the \()
 	var/static/regex/matches_tgm = new(@'^"[A-z]*"[\s]*=[\s]*\([\s]*\n', "m")
 	/// Pulls out key value pairs for TGM
-	var/static/regex/var_edits_tgm = new(@'^\t([a-zA-Z_][a-zA-Z0-9_]*) = (.*?);?$')
+	var/static/regex/var_edits_tgm = new(@'^\t([A-z0-9]*) = (.*?);?$')
 	/// Pulls out model paths for DMM
 	var/static/regex/model_path = new(@'(\/[^\{]*?(?:\{.*?\})?)(?:,|$)', "g")
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -102,7 +102,7 @@
 	/// Matches key formats in TMG (IE: newline after the \()
 	var/static/regex/matches_tgm = new(@'^"[A-z]*"[\s]*=[\s]*\([\s]*\n', "m")
 	/// Pulls out key value pairs for TGM
-	var/static/regex/var_edits_tgm = new(@'^\t([A-z]*) = (.*?);?$')
+	var/static/regex/var_edits_tgm = new(@'^\t([a-zA-Z_][a-zA-Z0-9_]*) = (.*?);?$')
 	/// Pulls out model paths for DMM
 	var/static/regex/model_path = new(@'(\/[^\{]*?(?:\{.*?\})?)(?:,|$)', "g")
 


### PR DESCRIPTION
## About The Pull Request
Any VV edits to a map that involved numbers in a variable name would get skipped during loading. This is because the regex pattern used to detect variable names did not account for numbers. So for example, if you wanted to VV edit an object's `flags_1` variable, it would get ignored and be replaced by the initial value.

## Why It's Good For The Game
Map VV's for a ton of objects should work now.

## Changelog
:cl:
fix: Fix map reader ignoring valid variable names. If a variable had a number inside the name anywhere the map reader would ignore this value when a map was loaded and use the initial value instead. This was due to a faulty regex pattern that did not properly match variable names.
/:cl:
