### PR TITLE
Mending touch changes

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -265,6 +265,7 @@
 	// The total amount of brute and burn we can take on all of our organic limbs, so you can't get a full aug minus one organic limb and only be able to take damage up to that limb's max_damage.
 	for(var/obj/item/bodypart/organic_part in mendicant_organic_parts)
 		damage_we_can_absorb += (organic_part.max_damage - (organic_part.brute_dam + organic_part.burn_dam))
+	damage_we_can_absorb /= pain_multiplier // If we take less damage to our limbs we can afford to heal more
 
 	var/damage_to_heal = min(70 * heal_multiplier, damage_we_can_absorb)
 	var/damage_left = damage_to_heal
@@ -325,7 +326,7 @@
 			var/blood_to_remove = 0
 			if(mendicant_blood > BLOOD_VOLUME_NORMAL) // Reduce blood based on the pain multiplier, but not if it would be helpful
 				blood_to_remove = min(mendicant_blood - BLOOD_VOLUME_NORMAL, blood_we_can_remove)
-				mendicant.adjust_blood_volume(blood_to_remove)
+				mendicant.adjust_blood_volume(-blood_to_remove)
 			if(blood_received)
 				to_chat(hurtguy, span_notice("Your veins don't feel quite so swollen anymore."))
 				. = TRUE

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -256,7 +256,7 @@
 	// Did the transfer work?
 	. = FALSE
 
-	var/mendicant_organic_parts = mendicant.get_damageable_bodyparts(BODYTYPE_ORGANIC) // We need organic limbs that can recieve damage in order to do the transfer
+	var/mendicant_organic_parts = mendicant.get_damageable_bodyparts(BODYTYPE_ORGANIC) // We need organic limbs that can receive damage in order to do the transfer
 	if(!length(mendicant_organic_parts))
 		mendicant.balloon_alert(mendicant, "no organic limbs!")
 		return .
@@ -331,7 +331,7 @@
 				to_chat(hurtguy, span_notice("Your veins don't feel quite so swollen anymore."))
 				. = TRUE
 				// ...Because we do our own spin on it!
-				blood_received -= blood_to_remove // We only update blood_recieved now so a pain_multiplier of 0 will still alert healguy of their new blood
+				blood_received -= blood_to_remove // We only update blood_received now so a pain_multiplier of 0 will still alert healguy of their new blood
 				if(mendicant.get_blood_compatibility(hurtguy) == FALSE)
 					mendicant.adjust_tox_loss((blood_received * 0.1) * pain_multiplier) // 1 dmg per 10 blood
 					to_chat(mendicant, span_notice("Your veins swell and itch!"))

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -265,6 +265,9 @@
 	// The total amount of brute and burn we can take on all of our organic limbs, so you can't get a full aug minus one organic limb and only be able to take damage up to that limb's max_damage.
 	for(var/obj/item/bodypart/organic_part in mendicant_organic_parts)
 		damage_we_can_absorb += (organic_part.max_damage - (organic_part.brute_dam + organic_part.burn_dam))
+	if(damage_we_can_absorb == 0)
+		mendicant.balloon_alert(mendicant, "can't receive any more damage!")
+		return .
 	damage_we_can_absorb /= pain_multiplier // If we take less damage to our limbs we can afford to heal more
 
 	var/damage_to_heal = min(70 * heal_multiplier, damage_we_can_absorb)


### PR DESCRIPTION
## About The Pull Request

This PR changes the do_complicated_heal function of mending touch (using it on a carbon). It fixes bugs and makes some "common sense" balance changes. It's not intended to increase or decrease the overall effectiveness of the mutation though.

## Why It's Good For The Game

It’s like less buggy and more fair. 

## Changelog

:cl:
fix: Mending touch cannot heal more damage than the host can receive
balance: Mending touch self damage is spread among all body parts rather than copying locational damage exactly
balance: Mending touch heals combined brute and burn damage instead of a flat amount of each
fix: Mending touch works on carbons without brute/burn damage that are still injured in other ways (low/high blood and wounds)
balance: Blood loss/gain from mending touch to the mendicant is reduced by the pain_multiplier of that cast, unless they are low on blood and receiving some
fix: The chance for mending touch to transfer severe wounds now increases with the heal_multiplier of that cast instead of decreasing
balance: The chance for mending touch to transfer critical wounds is now 70% of the chance to transfer severe wounds
/:cl:
