### PR TITLE
Prevents revenant objectives being targeted at jobs that are not there

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_objectives.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_objectives.dm
@@ -25,11 +25,14 @@
 		"Ensure that any holy weapons are rendered unusable.",
 		"Heed and obey the requests of the dead, provided that carrying them out wouldn't be too inconvenient or self-destructive.",
 		"Impersonate or be worshipped as a God.",
-		"Make the captain as miserable as possible.",
-		"Make the clown as miserable as possible.",
 		"Make the crew as miserable as possible.",
 		"Prevent the use of energy weapons where possible.",
 	)
+	if(SSjob.assigned_captain)
+		explanation_texts += "Make the captain as miserable as possible."
+	var/datum/job/clown/clown_job = SSjob.get_job(JOB_CLOWN)
+	if(clown_job.current_positions)
+		explanation_texts += "Make the clown as miserable as possible."
 	explanation_text = pick(explanation_texts)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Prevents the two specifically-targeted revenant objectives, "Make the [captain/clown] as miserable as possible", from being chosen unless someone holds one of those titles. Acting captains are also allowed.

## Why It's Good For The Game

Your one objective being some guy who may or may not ever be hired is lame. 

## Changelog
:cl:

fix: Revenant objectives can only target people that are actually present

/:cl:
