### PR TITLE
Fix typo in 'Departament' to 'Department'

### DIFF
--- a/tgui/packages/tgui/interfaces/MessageMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/MessageMonitor.tsx
@@ -72,7 +72,7 @@ const RequestLogsScreen = (props) => {
               <Table.Cell>Delete</Table.Cell>
               <Table.Cell>Message</Table.Cell>
               <Table.Cell>Stamp</Table.Cell>
-              <Table.Cell>Departament</Table.Cell>
+              <Table.Cell>Department</Table.Cell>
               <Table.Cell>Authentication</Table.Cell>
             </Table.Row>
             {requests?.map((request) => (


### PR DESCRIPTION

## About The Pull Request

fixes a typo in the message monitor console

## Why It's Good For The Game

literally unplayable 

## Changelog
:cl:
spellcheck: Corrected the spelling of department in the message monitor console.
/:cl:
