### PR TITLE
Fix MULEbot speeds being swapped

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -500,7 +500,7 @@
 	if(HAS_TRAIT(src, TRAIT_IMMOBILIZED))
 		return
 
-	var/speed = (wires.is_cut(WIRE_MOTOR1) ? 0 : 1) + (wires.is_cut(WIRE_MOTOR2) ? 0 : 2)
+	var/speed = (wires.is_cut(WIRE_MOTOR1) ? 0 : 2) + (wires.is_cut(WIRE_MOTOR2) ? 0 : 1)
 	if(!speed)//Devide by zero man bad
 		return
 	num_steps = round(10/speed) //10, 5, or 3 steps, depending on how many wires we have cut

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -164,18 +164,16 @@
 		return
 	if(!cell)
 		to_chat(user, span_warning("[src] doesn't have a power cell!"))
-		return ITEM_INTERACT_SUCCESS
+		return ITEM_INTERACT_BLOCKING
 	cell.add_fingerprint(user)
-	if(Adjacent(user) && !issilicon(user))
-		user.put_in_hands(cell)
-	else
-		cell.forceMove(drop_location())
 	user.visible_message(
 		span_notice("[user] crowbars [cell] out from [src]."),
 		span_notice("You pry [cell] out of [src]."),
 	)
-	cell = null
-	diag_hud_set_mulebotcell()
+	if(Adjacent(user) && !issilicon(user))
+		user.put_in_hands(cell)
+	else
+		cell.forceMove(drop_location())
 	return ITEM_INTERACT_SUCCESS
 
 /mob/living/simple_animal/bot/mulebot/item_interaction(mob/living/user, obj/item/tool, list/modifiers)


### PR DESCRIPTION

## About The Pull Request

`WIRE_MOTOR1` is the "fast" wire and `WIRE_MOTOR2` is the "average" wire, but a logic error made it so if the fast wire is cut the MULE moves 5 tiles at a time and if the average wire is cut it moves 10 tiles at a time, instead of the other way around. Also moves some `attackby` to `item_interaction` and fixes the name of the cell not showing when popped out

## Why It's Good For The Game

You'd think the fast wire would be the one that makes it go fast

## Changelog
:cl:
fix: fixed mulebot speed wire max steps being swapped
/:cl:
