### PR TITLE
Rag smothering uses INHALE rather than INGEST

### DIFF
--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -86,8 +86,6 @@
 	var/reagentlist = pretty_string_from_reagent_list(reagents.reagent_list)
 	var/log_object = "containing [reagentlist]"
 	if(!carbon_target.is_mouth_covered())
-		if(user.pulling != carbon_target || user.grab_state < GRAB_AGGRESSIVE)
-			return ITEM_INTERACT_BLOCKING
 		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INHALE)
 		carbon_target.visible_message(span_danger("[user] smothers \the [carbon_target] with \the [src]!"), span_userdanger("[user] smothers you with \the [src]!"), span_hear("You hear some struggling and muffled cries of surprise."))
 		log_combat(user, carbon_target, "smothered", src, log_object)

--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -86,9 +86,7 @@
 	var/reagentlist = pretty_string_from_reagent_list(reagents.reagent_list)
 	var/log_object = "containing [reagentlist]"
 	if(!carbon_target.is_mouth_covered())
-		carbon_target.visible_message(span_danger("[user] is trying to smother [carbon_target]!"),\
-		span_danger("[user] is trying to smother you!"))
-		if(!do_after(user, 1 SECONDS, carbon_target))
+		if(user.pulling != carbon_target || user.grab_state < GRAB_AGGRESSIVE)
 			return ITEM_INTERACT_BLOCKING
 		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INHALE)
 		carbon_target.visible_message(span_danger("[user] smothers \the [carbon_target] with \the [src]!"), span_userdanger("[user] smothers you with \the [src]!"), span_hear("You hear some struggling and muffled cries of surprise."))

--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -86,6 +86,10 @@
 	var/reagentlist = pretty_string_from_reagent_list(reagents.reagent_list)
 	var/log_object = "containing [reagentlist]"
 	if(!carbon_target.is_mouth_covered())
+		carbon_target.visible_message(span_danger("[user] is trying to smother [carbon_target]!"),\
+		span_danger("[user] is trying to put smother you!"))
+		if(!do_after(user, 1 SECONDS, carbon_target))
+			return ITEM_INTERACT_BLOCKING
 		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INGEST)
 		carbon_target.visible_message(span_danger("[user] smothers \the [carbon_target] with \the [src]!"), span_userdanger("[user] smothers you with \the [src]!"), span_hear("You hear some struggling and muffled cries of surprise."))
 		log_combat(user, carbon_target, "smothered", src, log_object)

--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -87,7 +87,7 @@
 	var/log_object = "containing [reagentlist]"
 	if(!carbon_target.is_mouth_covered())
 		carbon_target.visible_message(span_danger("[user] is trying to smother [carbon_target]!"),\
-		span_danger("[user] is trying to put smother you!"))
+		span_danger("[user] is trying to smother you!"))
 		if(!do_after(user, 1 SECONDS, carbon_target))
 			return ITEM_INTERACT_BLOCKING
 		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INHALE)

--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -90,7 +90,7 @@
 		span_danger("[user] is trying to put smother you!"))
 		if(!do_after(user, 1 SECONDS, carbon_target))
 			return ITEM_INTERACT_BLOCKING
-		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INGEST)
+		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INHALE)
 		carbon_target.visible_message(span_danger("[user] smothers \the [carbon_target] with \the [src]!"), span_userdanger("[user] smothers you with \the [src]!"), span_hear("You hear some struggling and muffled cries of surprise."))
 		log_combat(user, carbon_target, "smothered", src, log_object)
 	else

--- a/code/modules/unit_tests/damp_rag.dm
+++ b/code/modules/unit_tests/damp_rag.dm
@@ -5,13 +5,13 @@
 /datum/unit_test/damp_rag_smother/Run()
 	var/mob/living/carbon/human/consistent/attacker = EASY_ALLOCATE()
 	var/mob/living/carbon/human/consistent/victim = EASY_ALLOCATE()
-	var/obj/item/organ/stomach/victim_stomach = victim.get_organ_slot(ORGAN_SLOT_STOMACH)
 	var/obj/item/rag/rag = EASY_ALLOCATE()
-
 	attacker.put_in_active_hand(rag, forced = TRUE)
 	attacker.zone_selected = BODY_ZONE_PRECISE_MOUTH
 	attacker.set_combat_mode(TRUE)
 	rag.reagents.add_reagent(/datum/reagent/water, rag.reagents.maximum_volume)
+	attacker.grab(victim)
+	attacker.setGrabState(GRAB_AGGRESSIVE)
 	click_wrapper(attacker, victim)
-	TEST_ASSERT_EQUAL(victim_stomach.reagents.get_reagent_amount(/datum/reagent/water), rag.reagents.maximum_volume, \
+	TEST_ASSERT_EQUAL(victim.reagents.get_reagent_amount(/datum/reagent/water), rag.reagents.maximum_volume, \
 		"The victim should have been smothered by the rag, gaining water reagent.")

--- a/code/modules/unit_tests/damp_rag.dm
+++ b/code/modules/unit_tests/damp_rag.dm
@@ -10,8 +10,6 @@
 	attacker.zone_selected = BODY_ZONE_PRECISE_MOUTH
 	attacker.set_combat_mode(TRUE)
 	rag.reagents.add_reagent(/datum/reagent/water, rag.reagents.maximum_volume)
-	attacker.grab(victim)
-	attacker.setGrabState(GRAB_AGGRESSIVE)
 	click_wrapper(attacker, victim)
 	TEST_ASSERT_EQUAL(victim.reagents.get_reagent_amount(/datum/reagent/water), rag.reagents.maximum_volume, \
 		"The victim should have been smothered by the rag, gaining water reagent.")


### PR DESCRIPTION
## About The Pull Request

Makes the damn rag smother use `INHALE` rather than `INGEST` as its method of transfer.

## Why It's Good For The Game

Of course it's `INHALE`. You're not wringing out the rag into their mouth. The balance implications of this are primarily that it prevents eigenstate instakills with the rag, and that reagents enter the bloodstream rather than the stomach.

## Changelog
:cl:

balance: Smothering someone with a ragmakes the victim inhale the reagents rather than drink them.

/:cl:
