### PR TITLE
Reverts RNG Romerol Nerf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2473,12 +2473,18 @@
 /datum/reagent/romerol/expose_mob(mob/living/carbon/human/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	// Silently add the zombie infection organ to be activated upon death
-	if(exposed_mob.get_organ_slot(ORGAN_SLOT_ZOMBIE))
-		return
-
-	if((methods & (PATCH|INGEST|INJECT|INHALE)) || ((methods & (VAPOR|TOUCH)) && prob(min(reac_volume,100)*(1 - touch_protection))))
+	if(can_infect(exposed_mob, reac_volume, methods))
 		var/obj/item/organ/zombie_infection/nodamage/zombie_infection = new()
 		zombie_infection.Insert(exposed_mob)
+
+/datum/reagent/romerol/proc/can_infect(mob/living/carbon/human/exposed_mob, reac_volume = 5, methods = INGEST)
+	if(exposed_mob.get_organ_slot(ORGAN_SLOT_ZOMBIE))
+		return FALSE
+	if(methods & (PATCH|INGEST|INJECT|INHALE))
+		return TRUE
+	if(reac_volume >= 1)
+		return TRUE
+	return FALSE
 
 /datum/reagent/magillitis
 	name = "Magillitis"


### PR DESCRIPTION
## About The Pull Request

#90241 added touch protection to `TOUCH|VAPOR` reactions of pretty much every chemical, including Romerol

This change also gave Romerol application with `TOUCH|VAPOR` a chance based on the volume applied

Because Romerol is only ever applied in very low volumes, like 1u, this meant it basically never applied with those methods

I reverted that. Now, Romerol will always apply via `PATCH|INGEST|INJECT|INHALE`  and will otherwise always apply if >=1u is applied

## Why It's Good For The Game

I don't see why Romerol, an already difficult chemical to acquire and spread, should have a ~1% chance to actually work, it kind of ruins the fun of the chem. 

It's not even lethal when applied by chem, it does literally nothing until people die. 

## Changelog

:cl: Melbert
balance: Romerol, when applied via touch or vapor, is now guaranteed to infect when using >=1u. (Prior, it had a % chance of infecting equal to the amount of chemicals use - so 1u meant 1% chance to infect.) Other methods of applying Romerol are unaffected (ingesting or injecting any amount is still a guaranteed infection).  
/:cl:

