### PR TITLE
Removes Rock The Vote config entry

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -181,9 +181,6 @@
 /// allow votes to change map
 /datum/config_entry/flag/allow_vote_map
 
-/// allow players to vote to re-do the map vote
-/datum/config_entry/flag/allow_rock_the_vote
-
 /// the number of times we allow players to rock the vote
 /datum/config_entry/number/max_rocking_votes
 	default = 1

--- a/config/config.txt
+++ b/config/config.txt
@@ -119,9 +119,6 @@ RETA_DEPT_COOLDOWN_DS 150
 ## allow players to initiate a map-change vote
 #ALLOW_VOTE_MAP
 
-## allow players to rock the vote, or to vote on the map again if they didn't like the last results
-#ALLOW_ROCK_THE_VOTE
-
 ## the number of times you wish to allow players to rock the vote in a given shift
 MAX_ROCKING_VOTES 1
 


### PR DESCRIPTION
## About The Pull Request

Removes the RTV config entry, as RTV was removed in https://github.com/tgstation/tgstation/pull/86788

## Why It's Good For The Game

Remove leftover useless config entry

## Changelog

:cl: LT3
admin: Removed ability to enable Rock The Vote because RTV is no longer a thing
/:cl: