### PR TITLE
Standardizes all CI to run on `ubuntu-24.04`

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 jobs:
   auto_changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout

--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   autowiki:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Check for AUTOWIKI_USERNAME"
         id: secrets_set

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -17,7 +17,7 @@ jobs:
   start_gate:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Start Gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Mandatory Empty Step
         run: exit 0
@@ -80,7 +80,7 @@ jobs:
         run_alternate_tests,
         run_linters,
       ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   assign-users:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   collect_data:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}

--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   collect_data:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}

--- a/.github/workflows/compare_screenshots.yml
+++ b/.github/workflows/compare_screenshots.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   compare_screenshots:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Setup directory

--- a/.github/workflows/compare_screenshots.yml
+++ b/.github/workflows/compare_screenshots.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   compare_screenshots:
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Setup directory

--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   compile_all_stations:
     name: Compile All Station Maps
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -31,7 +31,7 @@ jobs:
 
   compile_all_templates:
     name: Compile All Templates
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   compile_all_stations:
     name: Compile All Station Maps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -31,7 +31,7 @@ jobs:
 
   compile_all_templates:
     name: Compile All Templates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   compile:
     name: "Compile changelogs"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   compile:
     name: "Compile changelogs"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/discord_discussions.yml
+++ b/.github/workflows/discord_discussions.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   manage-discord-discussion:
     name: Manage Discord Discussion
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: contains(github.event.pull_request.labels.*.name, 'Discord Discussion')
     steps:
       - name: Fail if vars.DISCORD_DISCUSSIONS_CHANNEL_ID is unset

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Stale' }}
     steps:
       - name: "Check for DISCORD_WEBHOOK"

--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   # labeler must run before gbp because gbp calculates itself based on labels
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.action == 'opened' || github.event.action == 'synchronize'
     permissions:
       pull-requests: write # to apply labels
@@ -27,7 +27,7 @@ jobs:
             });
             console.log(`Labels updated: ${new_labels}`);
   gbp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.action == 'opened' || github.event.action == 'closed'
     steps:
       - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"

--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   gbp_collection:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
         id: value_holder

--- a/.github/workflows/generate_client_storage.yml
+++ b/.github/workflows/generate_client_storage.yml
@@ -10,7 +10,7 @@ jobs:
   dispatch_repo:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Repository Dispatch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate App Token
         id: app-token-generation

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write # for JamesIves/github-pages-deploy-action to push changes in repo
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency: gen-docs
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write # for JamesIves/github-pages-deploy-action to push changes in repo
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency: gen-docs
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -6,7 +6,7 @@ on:
     types: [opened]
 jobs:
   remove_guide_comments:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -6,7 +6,7 @@ on:
       - completed
 jobs:
   rerun_flaky_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
     steps:
       - name: Checkout
@@ -18,7 +18,7 @@ jobs:
             const { rerunFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
             await rerunFlakyTests({ github, context })
   report_flaky_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
     steps:
       - name: Checkout

--- a/.github/workflows/round_id_linker.yml
+++ b/.github/workflows/round_id_linker.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   link_rounds:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tgstation/round_linker@master
         with:

--- a/.github/workflows/round_id_linker.yml
+++ b/.github/workflows/round_id_linker.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   link_rounds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: tgstation/round_linker@master
         with:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -26,7 +26,7 @@ jobs:
     # Otherwise, it will output `Run Tests (map; max)`.
     # For example, `Run Tests (runtimestation; 515)`.
     name: Run Tests (${{ inputs.major && format('{0}.{1}; ', inputs.major, inputs.minor) || '' }}${{ inputs.map }}; ${{ inputs.max_required_byond_client }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linters:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('/tools/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('/tools/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -23,14 +23,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tools/bootstrap/.cache
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/requirements.txt') }}
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('/tools/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
         uses: actions/cache@v4
         with:
           path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ hashFiles('tools/ci/ci_dependencies.sh')}}
+          key: ${{ runner.os }}-rust-${{ hashFiles('/tools/ci/ci_dependencies.sh')}}
           restore-keys: |
             ${{ runner.os }}-rust-
       - name: Restore Cutter cache

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linters:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/setup_build_artifact.yml
+++ b/.github/workflows/setup_build_artifact.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   setup_build_artifact:
     name: Setup build artifact (${{ format('{0}.{1}', inputs.major, inputs.minor) }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/setup_build_artifact.yml
+++ b/.github/workflows/setup_build_artifact.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   setup_build_artifact:
     name: Setup build artifact (${{ format('{0}.{1}', inputs.major, inputs.minor) }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/show_screenshot_test_results.yml
+++ b/.github/workflows/show_screenshot_test_results.yml
@@ -13,7 +13,7 @@ jobs:
   show_screenshot_test_results:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') && github.event.workflow_run.run_attempt == 1 )
     name: Show Screenshot Test Results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Check for ARTIFACTS_FILE_HOUSE_KEY"
         id: secrets_set

--- a/.github/workflows/show_screenshot_test_results.yml
+++ b/.github/workflows/show_screenshot_test_results.yml
@@ -13,7 +13,7 @@ jobs:
   show_screenshot_test_results:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') && github.event.workflow_run.run_attempt == 1 )
     name: Show Screenshot Test Results
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check for ARTIFACTS_FILE_HOUSE_KEY"
         id: secrets_set

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write # for actions/stale to close stale issues
       pull-requests: write # for actions/stale to close stale PRs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/stale@v10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write # for actions/stale to close stale issues
       pull-requests: write # for actions/stale to close stale PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/stale@v10

--- a/.github/workflows/test_merge_bot.yml
+++ b/.github/workflows/test_merge_bot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test_merge_bot:
     name: Test Merge Detector
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check for GET_TEST_MERGES_URL
         id: secrets_set

--- a/.github/workflows/test_merge_bot.yml
+++ b/.github/workflows/test_merge_bot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test_merge_bot:
     name: Test Merge Detector
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check for GET_TEST_MERGES_URL
         id: secrets_set

--- a/.github/workflows/tgs_test.yml
+++ b/.github/workflows/tgs_test.yml
@@ -42,7 +42,7 @@ jobs:
   test_tgs_docker:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Test TGS Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: test_tgs_docker-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/tgs_test.yml
+++ b/.github/workflows/tgs_test.yml
@@ -42,7 +42,7 @@ jobs:
   test_tgs_docker:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Test TGS Docker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: test_tgs_docker-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-dmapi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Update the TGS DMAPI
     permissions:
       contents: write

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-dmapi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Update the TGS DMAPI
     permissions:
       contents: write

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -20,7 +20,7 @@ export BUN_VERSION=1.2.16
 export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.9.0
+export PYTHON_VERSION=3.11.0
 
 #dreamluau repo
 export DREAMLUAU_REPO="tgstation/dreamluau"

--- a/tools/bootstrap/python
+++ b/tools/bootstrap/python
@@ -77,6 +77,7 @@ fi
 # Use pip to install our requirements
 if [ ! -f "$PythonDir/requirements.txt" ] || [ "$(b2sum < "$Sdk/requirements.txt")" != "$(b2sum < "$PythonDir/requirements.txt")" ]; then
 	echo "Updating dependencies..."
+    "$PythonExe" -m ensurepip --default-pip
 	"$PythonExe" -m pip install -U wheel
 	"$PythonExe" -m pip install -U pip -r "$Sdk/requirements.txt"
 	cp "$Sdk/requirements.txt" "$PythonDir/requirements.txt"

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,13 +1,13 @@
-pygit2==1.7.2
-bidict==0.22.0
-Pillow==9.3.0
+pygit2==1.19.0
+bidict==0.23.1
+Pillow==11.1.0
 
 # changelogs
-PyYaml==6.0.1
-beautifulsoup4==4.9.3
+PyYaml==6.0.3
+beautifulsoup4==4.14.3
 
 # ezdb
-mysql-connector-python==8.0.33
+mysql-connector-python==9.5.0
 
 # icon cutter
-numpy==1.26.0
+numpy==2.3.5


### PR DESCRIPTION
## About The Pull Request

<img width="908" height="878" alt="image" src="https://github.com/user-attachments/assets/7262576b-f7d9-4be4-8cff-6662f85698fd" />

Our application of Ubuntu 22.04 versus Ubuntu 24.04 (which is presently the version for `ubuntu-latest`) is pretty inconsistent even within the same suites, I figure we bump it up and set one standard moving forwards. This PR was originally set to autoset it to `ubuntu-latest` but wow the issues are agonizing so let's just bump it up and keep it synchronized

also bumps python to `3.11.0` and whatever dependency versions needed that as that was necessary