### PR TITLE
Fix disposal light not turning on when you click drag dump a storage item in

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -366,6 +366,8 @@ GLOBAL_VAR_INIT(disposals_animals_spawned, 0)
 		to_dump.pixel_x = to_dump.base_pixel_x + rand(-5, 5)
 		to_dump.pixel_y = to_dump.base_pixel_y + rand(-5, 5)
 
+	update_appearance()
+
 /obj/machinery/disposal/force_pushed(atom/movable/pusher, force = MOVE_FORCE_DEFAULT, direction)
 	. = ..()
 	visible_message(span_warning("[src] is ripped free from the floor!"))


### PR DESCRIPTION

## About The Pull Request

Call `update_appearance` so that when you click-drag something like a bag or an RPED into a disposal unit the blue "this has stuff in it" light comes on

## Why It's Good For The Game

It makes my eye twitch every time 

## Changelog
:cl:
fix: fixed disposal unit light not turning on when dumping bag contents inside
/:cl:
