### PR TITLE
Restores Tomas to Catwalk

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -76310,6 +76310,9 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/mob/living/basic/pet/cat/space{
+	name = "Tomas"
+	},
 /turf/open/openspace,
 /area/station/commons/fitness/recreation)
 "uDa" = (


### PR DESCRIPTION

## About The Pull Request

Readds Tomas the space cat to Catwalk, who was recently lost in a dorms remapping. He now lives on the walkway above the holodeck.

## Why It's Good For The Game

I love my accidentally removed stray cat from outer space.

## Changelog
:cl:
map: Tomas once more haunts the dormitories of Catwalk Station
/:cl:
