### PR TITLE
[NO GBP] Minor nm oversight

### DIFF
--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -128,13 +128,13 @@
 /datum/element/light_eater/proc/on_interacting_with(obj/item/source, mob/living/user, atom/target)
 	SIGNAL_HANDLER
 	if(eat_lights(target, source))
-		// do a "pretend" attack if we're hitting something that can't normally be
 		if (ismob(target))
 			var/mob/hit_user = target
 			if (hit_user.pulling)
 				var/atom/pulled_thing = hit_user.pulling // potentially dragging a light
 				if (!isliving(pulled_thing)) // we don't want conga lines to be affected
 					eat_lights(pulled_thing, source)
+		// do a "pretend" attack if we're hitting something that can't normally be
 		if(isobj(target))
 			var/obj/smacking = target
 			if(smacking.obj_flags & CAN_BE_HIT)

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -129,6 +129,12 @@
 	SIGNAL_HANDLER
 	if(eat_lights(target, source))
 		// do a "pretend" attack if we're hitting something that can't normally be
+		if (ismob(target))
+			var/mob/hit_user = target
+			if (hit_user.pulling)
+				var/atom/pulled_thing = hit_user.pulling // dragging a light
+				if (!isliving(pulled_thing)) // we don't want conga lines to be affected
+					eat_lights(pulled_thing, source)
 		if(isobj(target))
 			var/obj/smacking = target
 			if(smacking.obj_flags & CAN_BE_HIT)
@@ -138,12 +144,6 @@
 		user.do_attack_animation(target)
 		user.changeNext_move(CLICK_CD_RAPID)
 		target.play_attack_sound()
-	if (ismob(target))
-		var/mob/hit_user = target
-		if (hit_user.pulling)
-			var/atom/pulled_thing = hit_user.pulling // dragging a light
-			if (!isliving(pulled_thing)) // we don't want conga lines to be affected
-				eat_lights(pulled_thing, source)
 	// not particularly picky about what happens afterwards in the attack chain
 	return NONE
 

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -132,7 +132,7 @@
 		if (ismob(target))
 			var/mob/hit_user = target
 			if (hit_user.pulling)
-				var/atom/pulled_thing = hit_user.pulling // dragging a light
+				var/atom/pulled_thing = hit_user.pulling // potentially dragging a light
 				if (!isliving(pulled_thing)) // we don't want conga lines to be affected
 					eat_lights(pulled_thing, source)
 		if(isobj(target))


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/94395

## Why It's Good For The Game

Fix dragged light not getting snuffed out, if the user has another equipped light turned on (light eater works simultaneously, not per hit)

## Changelog

:cl: ArchBTW
fix: Fix nightmare not properly snuffing dragged lights if other lights were turned on simultaneously
/:cl:
