### PR TITLE
[NO GBP] Fix not being able to drag click things on tram floor

### DIFF
--- a/code/modules/transport/tram/tram_floors.dm
+++ b/code/modules/transport/tram/tram_floors.dm
@@ -191,6 +191,10 @@
 	var/floor_tile = /obj/item/stack/thermoplastic
 	var/mutable_appearance/damage_overlay
 
+/obj/structure/thermoplastic/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/force_move_pulled)
+
 /datum/armor/tram_floor
 	melee = 40
 	bullet = 10


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/94200
You can't drag click things on tram floor because its an obj, not a turf.

## Why It's Good For The Game

Fix

## Changelog

:cl: ArchBTW
fix: Fix not being able to drag click things on tram floor
/:cl: