### PR TITLE
Fix clicking on things underneath directional firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -743,12 +743,16 @@
 
 /obj/machinery/door/firedoor/border_only/Initialize(mapload)
 	. = ..()
+	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	adjust_lights_starting_offset()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXIT = PROC_REF(on_exit),
 	)
-
 	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/machinery/door/firedoor/border_only/close()
+	. = ..()
+	flags_1 &= ~PREVENT_CLICK_UNDER_1
 
 /obj/machinery/door/firedoor/border_only/adjust_lights_starting_offset()
 	light_xoffset = 0


### PR DESCRIPTION
## About The Pull Request

<img width="87" height="88" alt="image" src="https://github.com/user-attachments/assets/460f4ebe-764f-48e5-8feb-8468be1a91c3" />

You cant pick up items underneath a directional firelock (e.g. this flash), which is odd.

You also can't throw anything on that tile, either.

## Why It's Good For The Game

Fixes the above

## Changelog

:cl: ArchBTW
fix: Fix clicking on things underneath directional firelocks
/:cl: