### PR TITLE
Eigenstate purges stabilizing agent when consumed

### DIFF
--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -73,17 +73,13 @@
 		do_sparks(5,FALSE,living_mob)
 		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
 		do_sparks(5,FALSE,living_mob)
-	var/datum/reagent/stabilizing_agent/stabilizer = living_mob.reagents.has_reagent(/datum/reagent/stabilizing_agent)
-	if(stabilizer)
-		living_mob.reagents.remove_reagent(/datum/reagent/stabilizing_agent, stabilizer.volume)
+	living_mob.reagents.del_reagent(/datum/reagent/stabilizing_agent)
 	if(iscarbon(living_mob))
 		var/mob/living/carbon/carbon_mob = living_mob
 		var/obj/item/organ/stomach/carbonstomach = carbon_mob.get_organ_slot(ORGAN_SLOT_STOMACH)
 		if(!carbonstomach)
 			return ..()
-		stabilizer = carbonstomach.reagents.has_reagent(/datum/reagent/stabilizing_agent)
-		if(stabilizer)
-			carbonstomach.reagents.remove_reagent(/datum/reagent/stabilizing_agent, stabilizer.volume)
+		carbonstomach.reagents.del_reagent(/datum/reagent/stabilizing_agent)
 
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -73,6 +73,17 @@
 		do_sparks(5,FALSE,living_mob)
 		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
 		do_sparks(5,FALSE,living_mob)
+	var/datum/reagent/stabilizing_agent/stabilizer = living_mob.reagents.has_reagent(/datum/reagent/stabilizing_agent)
+	if(stabilizer)
+		living_mob.reagents.remove_reagent(/datum/reagent/stabilizing_agent, stabilizer.volume)
+	if(iscarbon(living_mob))
+		var/mob/living/carbon/carbon_mob = living_mob
+		var/obj/item/organ/stomach/carbonstomach = carbon_mob.get_organ_slot(ORGAN_SLOT_STOMACH)
+		if(!carbonstomach)
+			return ..()
+		stabilizer = carbonstomach.reagents.has_reagent(/datum/reagent/stabilizing_agent)
+		if(stabilizer)
+			carbonstomach.reagents.remove_reagent(/datum/reagent/stabilizing_agent, stabilizer.volume)
 
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

When eigenstate enters your bloodstream, it purges stabilizing agent out of your bloodstream and stomach. This means that unless you take additional stabilizing agent, you will return to the point from whence you came after the eigenstate leaves your bloodstream.

## Why It's Good For The Game

Usescases for eigenstate commonly seen:

Innocuous pills that teleport you directly to places the second(MEDBAY TELEPORT PILL)- Lame, still possible with two pills, genuinely more interesting now because you have the option to either stay or go back.

Teleporting someone directly into a death chamber to instantly kill them- Lame, still possible, but if you don't want them to be recovered you need to rush to their body and give them stabilizing agent, meaning your death box can't be a one million mile away 1x1 box with only walls.

These things are still possible, even automatable. There are many, many ways to get stabilizing agent into people right after you teleport them, even without your input. This just makes "chemical that instantly kills you" require a little more effort than simply going to a lava or plasma river.

The stabilizing agent interaction makes eigenstate into a "teleport to place" chem rather than a "go place then rubberband back" chem. This is why it's so uninteresting and boring. People do not like this chemical, and it's because it's so one-note. This at least makes it required to be two-note.

## Changelog
:cl:

balance: Eigenstate purges stabilizing agent when it enters your bloodstream
/:cl:
