### PR TITLE
Fix stunprod harm baton

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -881,9 +881,7 @@
 	user.put_in_hands(brand_new_prod)
 
 /obj/item/melee/baton/security/cattleprod/can_baton(mob/living/target, mob/living/user)
-	if(!sparkler.activate())
-		return FALSE
-	return ..()
+	sparkler?.activate()
 
 /obj/item/melee/baton/security/cattleprod/Destroy()
 	if(sparkler)


### PR DESCRIPTION
## About The Pull Request

Stunprod is tied to an if (!igniter.activate()) return FALSE on can_baton. It results in stunprod melee attack chain being broken.
Fixes that.

## Why It's Good For The Game

Stunprod harm baton has an arbitrary harm baton cooldown due to the above. You can't melee like normal.

## Changelog

:cl: ArchBTW
fix: Fix stunprod harm baton 
/:cl: