### PR TITLE
[MDB IGNORE] Wawa piping & cabling lookover

### DIFF
--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -8626,6 +8626,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"dcI" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "dcO" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/delivery,
@@ -33544,7 +33553,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "lCR" = (
@@ -40643,10 +40651,10 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/research)
 "ocB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ocF" = (
@@ -41220,6 +41228,8 @@
 	codes_txt = "patrol;next_patrol=P1-Central-Primary";
 	location = "P15-Central-Primary"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "opN" = (
@@ -41416,12 +41426,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "osK" = (
@@ -44797,8 +44807,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/foyer)
 "pyK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "pyO" = (
@@ -64915,12 +64923,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
 "wqU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wqW" = (
@@ -65995,12 +66003,8 @@
 /area/station/service/bar/backroom)
 "wIB" = (
 /obj/structure/railing,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine)
@@ -93098,7 +93102,7 @@ kAg
 ujv
 kmu
 hGE
-nxG
+kmu
 afe
 kmu
 tOm
@@ -93355,7 +93359,7 @@ kAg
 vNH
 kmu
 opH
-knX
+fBz
 fBz
 fBz
 pUW
@@ -93611,7 +93615,7 @@ sWn
 kAg
 veW
 kmu
-tOm
+dcI
 tCE
 tCE
 tCE

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -1089,6 +1089,10 @@
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"asd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "asl" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
@@ -1325,9 +1329,7 @@
 /area/station/science/breakroom)
 "awd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "awf" = (
@@ -3170,6 +3172,7 @@
 "bcm" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured,
 /area/station/engineering/storage/tech)
 "bco" = (
@@ -4051,7 +4054,6 @@
 /area/station/security/armory)
 "buw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -5167,6 +5169,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "bOT" = (
@@ -6318,8 +6321,6 @@
 /area/station/medical/surgery)
 "clG" = (
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Restrooms"
 	},
@@ -7228,7 +7229,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "cEy" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7244,6 +7244,12 @@
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/foyer)
+"cEU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "cEV" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -10411,7 +10417,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
 "dHk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -13172,8 +13177,8 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
 "eEa" = (
@@ -14487,9 +14492,6 @@
 /area/station/hallway/primary/central)
 "feN" = (
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
 "feQ" = (
@@ -15543,12 +15545,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery)
-"fyA" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/security)
 "fyC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -20213,7 +20209,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -21692,14 +21687,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"hBD" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/security)
 "hBF" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -22721,6 +22708,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
 "hTf" = (
@@ -25389,6 +25378,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
 "iRy" = (
@@ -27157,7 +27147,6 @@
 /area/station/security/checkpoint/supply)
 "jyx" = (
 /obj/structure/chair/office,
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
@@ -28504,11 +28493,13 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/office)
 "jUU" = (
@@ -28973,6 +28964,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security)
 "kcB" = (
@@ -29901,6 +29894,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
 "kpD" = (
@@ -31766,6 +31760,11 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"kWC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "kWH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -31876,7 +31875,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -33560,7 +33558,6 @@
 "lCU" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
@@ -36162,7 +36159,6 @@
 /area/station/commons/fitness/recreation)
 "mwc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
@@ -36356,8 +36352,6 @@
 /area/station/medical/pharmacy)
 "mAd" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/office)
 "mAi" = (
@@ -36471,7 +36465,7 @@
 /area/station/engineering/lobby)
 "mBY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
@@ -36805,7 +36799,6 @@
 "mId" = (
 /obj/structure/urinal/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -38359,7 +38352,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
@@ -38913,6 +38906,8 @@
 "ntS" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "nun" = (
@@ -39243,10 +39238,8 @@
 /area/station/maintenance/department/bridge)
 "nAi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/custom_shuttle,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage/tech)
 "nAm" = (
@@ -40294,8 +40287,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "nVm" = (
@@ -42058,6 +42049,8 @@
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "oEB" = (
@@ -42896,7 +42889,6 @@
 "oSd" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -44120,6 +44112,7 @@
 	dir = 8
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "pos" = (
@@ -45754,6 +45747,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"pOQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "pPv" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -46980,6 +46979,12 @@
 "qka" = (
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
+"qkc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/paramedic)
 "qkv" = (
 /obj/machinery/door/airlock/public{
 	name = "Jim Norton's Quebecois Coffee"
@@ -47645,11 +47650,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"qvX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "qwu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -48077,6 +48077,7 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
 "qEm" = (
@@ -49711,6 +49712,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
+"rhs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "rhK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -49941,7 +49949,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -50085,10 +50092,11 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
 "rmi" = (
@@ -51036,7 +51044,6 @@
 /area/station/engineering/storage/tech)
 "rCz" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rCL" = (
@@ -51448,7 +51455,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/cold/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -52707,7 +52713,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -53074,10 +53080,8 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron,
 /area/station/security/office)
 "skw" = (
@@ -54379,7 +54383,7 @@
 "sGk" = (
 /obj/effect/turf_decal/siding/white/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/central)
@@ -54514,11 +54518,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"sIm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "sIv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -55449,7 +55448,7 @@
 "sYZ" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/light/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -57991,11 +57990,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"tRP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "tRX" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -58294,8 +58288,6 @@
 /area/station/asteroid)
 "tXi" = (
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -59599,12 +59591,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
-"utH" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet/restrooms)
 "utM" = (
 /turf/closed/wall/r_wall,
 /area/station/command/eva)
@@ -59706,9 +59692,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "uvN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "uww" = (
@@ -59832,6 +59816,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"uyo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "uyu" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -61545,7 +61534,6 @@
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -66149,6 +66137,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/office)
 "wLu" = (
@@ -67859,6 +67849,7 @@
 /area/station/maintenance/department/science)
 "xqB" = (
 /obj/machinery/light/dim/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured,
 /area/station/engineering/storage/tech)
 "xqE" = (
@@ -68008,7 +67999,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","medbay")
 	},
@@ -69128,7 +69118,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
 "xMY" = (
@@ -69326,6 +69315,8 @@
 "xPH" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "xPL" = (
@@ -69524,8 +69515,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xUW" = (
@@ -70471,6 +70460,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/circuit,
 /area/station/science/robotics/lab)
+"yll" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/security)
 "ylm" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -83581,7 +83580,7 @@ qPN
 xwO
 mHG
 ecy
-sme
+cEU
 rCz
 awj
 dkj
@@ -85914,8 +85913,8 @@ cBb
 hAA
 naZ
 sep
-naZ
-naZ
+qkc
+qkc
 iuV
 sIv
 rnk
@@ -86860,7 +86859,7 @@ dMF
 rrF
 hME
 lvZ
-wUe
+heu
 xPH
 iEO
 sWy
@@ -87117,7 +87116,7 @@ hME
 hME
 hME
 kSm
-wUe
+heu
 eFK
 iEO
 oCR
@@ -89191,8 +89190,8 @@ dPv
 mGG
 mGG
 xQW
-kcA
-fyA
+yll
+qie
 rRK
 gHr
 gHr
@@ -89449,7 +89448,7 @@ sfm
 ecC
 mxv
 hSW
-fyA
+qie
 rRK
 xLR
 lfp
@@ -90732,7 +90731,7 @@ sgW
 cpO
 mAd
 skr
-hBD
+wrx
 gpV
 kaJ
 obc
@@ -102075,7 +102074,7 @@ qdt
 akl
 clG
 tXi
-utH
+cmB
 sYZ
 cmB
 pWR
@@ -117013,7 +117012,7 @@ kEu
 fsQ
 aGC
 vpn
-qvX
+iXR
 uvN
 wQz
 kiW
@@ -117270,9 +117269,9 @@ kEu
 kEu
 aQo
 aQo
-sIm
-sIm
-sIm
+aQo
+aQo
+aQo
 kEu
 uFC
 vaU
@@ -121347,12 +121346,12 @@ cCI
 hbV
 hbV
 qRJ
-rka
+rhs
 nVj
 rka
 xUT
-tRP
-tRP
+hbV
+hbV
 tVV
 jQS
 ucG
@@ -121604,10 +121603,10 @@ bKQ
 hBF
 rYZ
 xay
-xay
-hBF
-hBF
-hBF
+kQa
+pOQ
+pOQ
+kQa
 ulA
 kQa
 baP
@@ -121864,7 +121863,7 @@ cnt
 hbV
 hbV
 hbV
-hbV
+uyo
 kQa
 pJt
 uhz
@@ -176623,8 +176622,8 @@ iZa
 nUb
 jaH
 anN
-gjJ
-gjJ
+ktL
+asd
 uIj
 qVV
 gNZ
@@ -176880,7 +176879,7 @@ elk
 lde
 xtL
 anN
-ktL
+kWC
 gjJ
 qpT
 aYG

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -174,8 +174,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "adc" = (
@@ -326,7 +326,6 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -1581,8 +1580,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "azQ" = (
@@ -1682,6 +1679,14 @@
 	},
 /turf/open/openspace,
 /area/station/security/prison/shower)
+"aCk" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aCp" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -1851,13 +1856,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
-"aEY" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "aFb" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -1875,14 +1873,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
-"aFw" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker)
 "aFz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -2128,7 +2118,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -2185,11 +2174,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"aKd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/parquet,
-/area/station/cargo/boutique)
 "aKg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
@@ -2245,7 +2229,6 @@
 /turf/closed/wall,
 /area/station/security/courtroom)
 "aKP" = (
-/obj/structure/cable,
 /turf/open/floor/iron/half,
 /area/station/service/hydroponics/garden)
 "aKS" = (
@@ -2479,8 +2462,6 @@
 /area/station/command/heads_quarters/qm)
 "aNR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aNV" = (
@@ -2566,7 +2547,6 @@
 	pixel_y = -8;
 	req_access = list("xenobiology")
 	},
-/obj/structure/cable,
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal{
 	icon = 'icons/obj/mining_zones/survival_pod.dmi';
@@ -3274,6 +3254,8 @@
 	dir = 8
 	},
 /obj/item/trash/shrimp_chips,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bej" = (
@@ -3360,7 +3342,6 @@
 /area/station/maintenance/department/science)
 "bfD" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
 	dir = 1
@@ -3472,6 +3453,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"bhG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "bhL" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/door/firedoor/border_only,
@@ -3902,17 +3887,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"bqV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
 "bqX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -4625,9 +4599,7 @@
 "bDN" = (
 /obj/item/stack/tile/iron/white,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/minisat)
 "bDX" = (
@@ -4847,7 +4819,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "bGW" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -4886,7 +4857,6 @@
 /area/station/service/hydroponics)
 "bHc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
@@ -4988,7 +4958,7 @@
 /area/station/maintenance/department/medical/central)
 "bJQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
@@ -5253,8 +5223,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "bQc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/stairs/left{
 	dir = 1
 	},
@@ -5498,7 +5466,6 @@
 "bUJ" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "bUM" = (
@@ -5699,8 +5666,8 @@
 "bYF" = (
 /obj/effect/turf_decal/arrows,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bYP" = (
@@ -5756,7 +5723,7 @@
 "bZH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -5778,6 +5745,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "cax" = (
@@ -5800,9 +5768,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "caP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "caW" = (
@@ -5927,12 +5893,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/large,
 /area/station/cargo/boutique)
-"ccZ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel)
 "cda" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -6091,11 +6051,11 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "cgj" = (
@@ -6174,7 +6134,6 @@
 /area/station/cargo/lobby)
 "chF" = (
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
@@ -6376,7 +6335,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "clM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/item/storage/box/hug/medical,
 /turf/open/floor/iron,
@@ -7115,22 +7073,10 @@
 "cBb" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
-"cBh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "cBj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"cBr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "cBt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -7361,7 +7307,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
@@ -7747,7 +7692,6 @@
 /area/station/cargo/boutique)
 "cOb" = (
 /obj/item/food/grown/banana,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/medical/chemistry)
@@ -8040,7 +7984,6 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "cSy" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
 	},
@@ -8124,12 +8067,14 @@
 /area/station/science/xenobiology)
 "cUk" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "cUm" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
@@ -8329,6 +8274,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine)
+"cXn" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "cXo" = (
 /obj/structure/barricade/wooden/crude,
 /obj/structure/holosign/barrier/atmos,
@@ -8509,6 +8460,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "dbl" = (
@@ -8728,6 +8680,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"deW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "deY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm/directional/east,
@@ -8905,9 +8862,7 @@
 /area/station/maintenance/port/lesser)
 "dhv" = (
 /obj/effect/landmark/start/shaft_miner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "dhN" = (
@@ -8921,6 +8876,7 @@
 	},
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "dhO" = (
@@ -8933,7 +8889,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dhR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/rack,
 /obj/item/wrench,
 /obj/item/knife/kitchen{
@@ -9034,8 +8989,6 @@
 "dko" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "dkq" = (
@@ -9129,7 +9082,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
 "dla" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs/right{
 	dir = 1
 	},
@@ -9231,9 +9183,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "dni" = (
@@ -9626,8 +9575,6 @@
 /area/station/service/janitor)
 "dsY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "dtc" = (
@@ -9691,6 +9638,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"duf" = (
+/obj/item/stack/tile/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/minisat)
 "dum" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/toggleable/justice/escape{
@@ -9846,7 +9799,7 @@
 /area/station/hallway/primary/central)
 "dyb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
@@ -9858,6 +9811,9 @@
 /area/station/science/ordnance)
 "dyv" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "dyA" = (
@@ -10102,7 +10058,6 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "dBn" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/machinery/incident_display/bridge/directional/south,
 /turf/open/floor/iron,
@@ -10537,6 +10492,7 @@
 /obj/structure/disposalpipe/sorting/mail/flip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "dIv" = (
@@ -10908,7 +10864,7 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/exam_room)
@@ -11260,9 +11216,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "dVp" = (
@@ -12156,6 +12109,14 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"ekF" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/commons/locker)
 "ekL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
@@ -12271,7 +12232,7 @@
 /area/station/service/kitchen)
 "enz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
@@ -12283,6 +12244,7 @@
 /obj/effect/spawner/random/structure/chair_comfy{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "eoo" = (
@@ -12448,10 +12410,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"eqQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/robotics/lab)
 "era" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -12935,11 +12893,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
-"ezP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "eAg" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood{
@@ -13058,11 +13011,11 @@
 /area/station/science/ordnance/storage)
 "eBK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "eBY" = (
@@ -13223,11 +13176,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/security)
-"eDV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "eEa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13399,7 +13347,6 @@
 /obj/effect/turf_decal/siding/green,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "eGM" = (
@@ -13507,6 +13454,9 @@
 /area/station/maintenance/department/science)
 "eIY" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "eJi" = (
@@ -14090,7 +14040,6 @@
 	req_access = list("robotics")
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "eWB" = (
@@ -14271,7 +14220,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/mannequin/skeleton,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -14407,7 +14355,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -14418,8 +14365,6 @@
 "fbC" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
@@ -14707,7 +14652,6 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/lobby)
@@ -15061,13 +15005,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fpm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fpo" = (
@@ -15165,11 +15109,6 @@
 	},
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
-"fqF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "frd" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/stripes/line{
@@ -15369,7 +15308,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ftR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
 	},
@@ -15388,13 +15329,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"fun" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "fuo" = (
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office{
@@ -15403,10 +15337,10 @@
 /turf/open/floor/glass/reinforced,
 /area/station/science/genetics)
 "fus" = (
+/obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fux" = (
@@ -15762,7 +15696,6 @@
 /area/station/maintenance/central/greater)
 "fAR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -15972,6 +15905,8 @@
 "fEa" = (
 /obj/structure/railing/corner,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner,
 /area/station/command/meeting_room)
 "fEe" = (
@@ -16086,14 +16021,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"fFz" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "fFE" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/open/misc/asteroid,
@@ -16213,6 +16140,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"fHI" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "fHJ" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -16285,6 +16221,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "fIX" = (
@@ -16365,8 +16303,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "fLe" = (
@@ -16703,7 +16639,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/command/directional/east,
 /obj/machinery/suit_storage_unit/captain{
@@ -16874,9 +16809,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "fSP" = (
@@ -16936,6 +16868,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fTX" = (
@@ -17158,7 +17092,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "fXU" = (
-/obj/structure/cable,
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -17291,7 +17224,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "gak" = (
@@ -17443,6 +17375,8 @@
 /area/station/cargo/storage)
 "gcV" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gcZ" = (
@@ -17635,7 +17569,7 @@
 /obj/item/food/grown/harebell,
 /obj/item/food/grown/harebell,
 /turf/open/floor/iron/chapel{
-	dir = 1
+	dir = 4
 	},
 /area/station/service/chapel)
 "ghp" = (
@@ -17707,7 +17641,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "giv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "giy" = (
@@ -17737,13 +17673,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/lab)
-"giK" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
 "gjt" = (
 /obj/machinery/pdapainter/medbay,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -18271,7 +18200,6 @@
 "gsn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "gsM" = (
@@ -18279,7 +18207,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -18316,10 +18244,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"gtB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
 "gtE" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	dir = 8;
@@ -18354,7 +18278,6 @@
 "gub" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "guk" = (
@@ -18533,9 +18456,8 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "gwA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "gwE" = (
@@ -18979,8 +18901,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 1
 	},
@@ -19242,7 +19162,6 @@
 /turf/open/floor/iron,
 /area/station/security/breakroom)
 "gHX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
@@ -19342,10 +19261,10 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
 "gJC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
 "gJE" = (
@@ -19630,14 +19549,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
-"gOG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "gOY" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -19712,12 +19623,6 @@
 /obj/structure/sign/warning/directional/west,
 /turf/closed/wall/rust,
 /area/station/medical/chemistry/minisat)
-"gQN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
 "gRp" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -19785,8 +19690,8 @@
 /turf/open/floor/holofloor/dark,
 /area/station/command/heads_quarters/cmo)
 "gSJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
 "gSY" = (
@@ -20101,7 +20006,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
@@ -20152,6 +20056,9 @@
 /area/station/engineering/atmos)
 "gZe" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "gZk" = (
@@ -20199,7 +20106,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "gZF" = (
@@ -20763,7 +20669,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -20877,7 +20782,6 @@
 /area/station/science/lobby)
 "hlh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21425,7 +21329,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "htN" = (
@@ -21735,7 +21638,7 @@
 "hAg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
@@ -21778,7 +21681,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/iron/chapel{
-	dir = 4
+	dir = 1
 	},
 /area/station/service/chapel)
 "hBi" = (
@@ -21801,6 +21704,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"hBQ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "hBX" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
@@ -22040,11 +21947,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "hGh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/chapel{
 	dir = 1
@@ -22332,6 +22241,8 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/xenobiology)
 "hLG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -22400,9 +22311,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hNP" = (
@@ -22585,9 +22494,7 @@
 /area/station/cargo/storage)
 "hQy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hQA" = (
@@ -22743,7 +22650,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "hSi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
@@ -23577,6 +23483,7 @@
 "igS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "ihd" = (
@@ -23892,7 +23799,6 @@
 /area/station/service/lawoffice)
 "iom" = (
 /obj/effect/mapping_helpers/dead_body_placer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iov" = (
@@ -23903,7 +23809,6 @@
 /turf/open/floor/carpet/purple,
 /area/station/service/library)
 "iow" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -24020,8 +23925,6 @@
 "ipZ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/iv_drip,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "iqa" = (
@@ -24459,6 +24362,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"iyg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/minisat)
 "iyw" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -24513,7 +24422,7 @@
 "izd" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/wood/large,
 /area/station/cargo/boutique)
@@ -24554,14 +24463,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
-"iAw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
 "iAE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24577,12 +24478,18 @@
 /obj/machinery/computer/security/telescreen/rd/directional/south,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/command/heads_quarters/rd)
+"iAQ" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/minisat)
 "iBe" = (
 /obj/structure/chair/pew/right{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "iBg" = (
@@ -24762,8 +24669,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iEK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
 	dir = 1
@@ -24774,8 +24679,6 @@
 /area/station/security/prison/mess)
 "iEQ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
 "iFb" = (
@@ -24903,9 +24806,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iGK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "iHr" = (
@@ -24934,7 +24835,6 @@
 /area/station/maintenance/solars/port)
 "iHG" = (
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "iHH" = (
@@ -25121,7 +25021,7 @@
 /area/station/medical/patients_rooms/room_a)
 "iJG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -25143,7 +25043,6 @@
 "iJT" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/science/cytology)
 "iJZ" = (
@@ -25251,6 +25150,8 @@
 "iMD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "iMK" = (
@@ -25258,9 +25159,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"iMS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "iMT" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/turf_decal/stripes/corner{
@@ -25428,10 +25333,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
-"iPS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/command/corporate_showroom)
 "iQs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -25733,7 +25634,6 @@
 /area/station/cargo/miningoffice)
 "iWO" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -26002,7 +25902,6 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "jco" = (
@@ -26095,12 +25994,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"jea" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "jer" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/event_spawn,
@@ -26152,7 +26045,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
@@ -26202,8 +26094,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "jge" = (
@@ -26399,14 +26289,14 @@
 /area/station/engineering/supermatter/room)
 "jjQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "jjS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/rack,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/boutique)
 "jka" = (
@@ -26836,7 +26726,6 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -27065,8 +26954,6 @@
 /area/station/ai/satellite/foyer)
 "jui" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
@@ -27130,9 +27017,7 @@
 	},
 /area/station/science/robotics/lab)
 "jvN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage/tech)
 "jvO" = (
@@ -27330,10 +27215,10 @@
 /area/station/engineering/storage/tcomms)
 "jzC" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "jzI" = (
@@ -27427,7 +27312,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "jAG" = (
@@ -27839,10 +27723,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
-"jGK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/cargo/boutique)
 "jGW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -27860,13 +27740,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"jGZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/station/service/chapel)
 "jHn" = (
 /obj/structure/railing{
 	dir = 8
@@ -27961,8 +27834,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -27972,7 +27843,6 @@
 /area/station/command/meeting_room)
 "jIm" = (
 /obj/structure/sign/poster/random/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "jIn" = (
@@ -28093,7 +27963,7 @@
 /area/station/medical/morgue)
 "jKp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
@@ -28503,7 +28373,6 @@
 /obj/structure/chair/office{
 	name = "grimy chair"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -28984,11 +28853,6 @@
 /obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"kaz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "kaJ" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/cable,
@@ -29090,7 +28954,6 @@
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/digital_clock/directional/south,
-/obj/structure/cable,
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","medbay")
 	},
@@ -29198,6 +29061,15 @@
 "kdg" = (
 /turf/closed/wall,
 /area/station/science/research)
+"kdh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "kdo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -29341,6 +29213,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "kfr" = (
@@ -29416,6 +29289,10 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"kgO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/textured_large,
+/area/station/engineering/storage/tech)
 "kgT" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/door/firedoor,
@@ -29568,7 +29445,7 @@
 "kjp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -29705,12 +29582,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/command/vault)
-"kkT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
 "kkU" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/machinery/camera/autoname/directional/south,
@@ -30557,7 +30428,6 @@
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "kyi" = (
@@ -30822,9 +30692,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kCD" = (
@@ -31185,12 +31053,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
-"kJl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/station/service/chapel)
 "kJp" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
@@ -31212,7 +31074,7 @@
 /area/station/maintenance/department/medical/central)
 "kJN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/boutique)
@@ -31348,7 +31210,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "kNk" = (
@@ -31405,6 +31266,8 @@
 "kOl" = (
 /obj/structure/railing,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side,
 /area/station/command/meeting_room)
 "kOn" = (
@@ -31505,6 +31368,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kQF" = (
@@ -31865,13 +31729,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
-"kUW" = (
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/chapel,
-/area/station/service/chapel)
 "kUX" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmospherics_engine)
@@ -32068,12 +31925,6 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"kZg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron,
-/area/station/command/bridge)
 "kZj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32094,8 +31945,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "kZw" = (
@@ -32441,10 +32290,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/department/engine)
 "lfx" = (
-/obj/structure/cable,
 /obj/machinery/light/dim/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lfy" = (
@@ -32635,7 +32481,6 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/stack/rods/two,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -32781,7 +32626,6 @@
 /obj/effect/turf_decal/bot_white,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lmU" = (
@@ -32791,7 +32635,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "lno" = (
@@ -33001,6 +32844,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "lqy" = (
@@ -33016,17 +32861,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"lqM" = (
+/obj/structure/chair/pew{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/station/service/chapel)
 "lqR" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"lrc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/stairs/right{
-	dir = 1
-	},
-/area/station/command/bridge)
 "lrk" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -33053,6 +32901,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/station/science/robotics/lab)
 "lrV" = (
@@ -33223,7 +33072,6 @@
 /area/station/engineering/atmos/project)
 "lvg" = (
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "lvj" = (
@@ -33333,11 +33181,11 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "lwI" = (
@@ -33408,6 +33256,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured,
 /area/station/construction/mining/aux_base)
+"lxX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "lyr" = (
 /obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -33488,6 +33345,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "lzs" = (
@@ -33532,6 +33390,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "lAc" = (
@@ -33591,8 +33451,6 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -33688,6 +33546,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "lCR" = (
@@ -33734,7 +33593,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured,
 /area/station/medical/pharmacy)
 "lDn" = (
@@ -33830,8 +33688,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "lES" = (
@@ -33861,7 +33719,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "lFG" = (
@@ -34109,7 +33966,6 @@
 "lJT" = (
 /obj/machinery/photocopier/prebuilt,
 /obj/machinery/light_switch/directional/east,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/hos)
@@ -34417,7 +34273,9 @@
 /turf/open/floor/engine,
 /area/station/command/corporate_dock)
 "lPz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/dark_blue,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -34611,13 +34469,13 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "lSI" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
 "lSM" = (
@@ -34719,6 +34577,12 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"lUY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "lVj" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 4
@@ -35131,6 +34995,9 @@
 "mcw" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "mcA" = (
@@ -35212,9 +35079,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "meQ" = (
@@ -35390,6 +35254,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"mic" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "mio" = (
 /obj/machinery/computer/station_alert,
 /turf/open/floor/iron,
@@ -35460,6 +35330,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"mjj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "mjq" = (
 /obj/structure/cable/layer3,
 /obj/machinery/camera/autoname/directional/north{
@@ -35469,7 +35343,6 @@
 /area/station/ai/satellite/chamber)
 "mju" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/boutique)
 "mjx" = (
@@ -35885,7 +35758,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "mpP" = (
@@ -35938,6 +35810,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "mra" = (
@@ -36139,6 +36013,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "mut" = (
@@ -36525,7 +36401,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/autoname/directional/south,
@@ -36955,6 +36830,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/cargo/boutique)
+"mIC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "mIH" = (
 /obj/structure/lattice,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -36971,9 +36851,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "mJb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -37015,8 +36892,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "mJL" = (
@@ -38112,6 +37987,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ncZ" = (
@@ -38494,8 +38370,8 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "niQ" = (
@@ -38589,7 +38465,7 @@
 /area/station/maintenance/department/science)
 "nkf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/exam_room)
@@ -38809,11 +38685,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"noi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "nor" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Office"
@@ -39311,11 +39182,6 @@
 "nzk" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central/greater)
-"nzn" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/openspace,
-/area/station/science/lobby)
 "nzw" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/sand/plating,
@@ -39378,9 +39244,9 @@
 "nAi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/custom_shuttle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage/tech)
 "nAm" = (
@@ -39412,14 +39278,11 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"nAx" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "nAG" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "nAR" = (
@@ -39693,6 +39556,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "nHw" = (
@@ -39974,7 +39839,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "nLg" = (
@@ -39995,8 +39859,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "nLz" = (
@@ -40017,6 +39879,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "nLT" = (
@@ -40184,7 +40047,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
 "nOZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "nPf" = (
@@ -40194,7 +40059,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
 "nPm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -40214,7 +40078,9 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "nPV" = (
@@ -40306,22 +40172,14 @@
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
 "nSn" = (
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "nSC" = (
 /turf/closed/wall,
 /area/station/security/prison/shower)
-"nSF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/medical/chemistry/minisat)
 "nSH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -40813,10 +40671,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/central/greater)
 "ocV" = (
-/obj/structure/cable,
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "odg" = (
@@ -41436,13 +41291,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"oqt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/locker)
 "oqz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41779,7 +41627,6 @@
 	},
 /obj/structure/sign/warning/radiation/rad_area/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "oxe" = (
@@ -41828,6 +41675,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
 "oxU" = (
@@ -41891,6 +41740,7 @@
 "ozF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/boutique)
 "ozU" = (
@@ -41990,12 +41840,12 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "oAY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oBe" = (
@@ -42056,6 +41906,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "oBP" = (
@@ -42115,11 +41966,19 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"oDw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry/minisat)
 "oDC" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "oDH" = (
@@ -42162,6 +42021,9 @@
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/tile/blue/full,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "oDZ" = (
@@ -42541,7 +42403,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/chapel{
-	dir = 1
+	dir = 4
 	},
 /area/station/service/chapel)
 "oJU" = (
@@ -42682,6 +42544,7 @@
 /area/station/hallway/primary/fore)
 "oMi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "oMk" = (
@@ -42821,7 +42684,6 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
 "oPl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 1
 	},
@@ -43129,8 +42991,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "oUd" = (
@@ -43273,6 +43133,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "oWg" = (
@@ -43379,7 +43241,7 @@
 "oXz" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
@@ -43536,6 +43398,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "pau" = (
@@ -43670,7 +43533,7 @@
 /area/station/maintenance/department/bridge)
 "pdg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -43726,6 +43589,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -44224,6 +44090,12 @@
 "pnS" = (
 /turf/closed/mineral/random/stationside/asteroid,
 /area/station/asteroid)
+"poe" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pof" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
@@ -44596,7 +44468,6 @@
 	desc = "A memorial wall for pinning mementos upon.";
 	name = "memorial board"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "ptX" = (
@@ -45157,7 +45028,6 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "pCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
@@ -45525,11 +45395,14 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "pJk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
+"pJp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pJt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45562,7 +45435,7 @@
 "pJN" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
@@ -45676,9 +45549,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
 "pLB" = (
@@ -46149,7 +46020,7 @@
 /area/station/engineering/atmos/project)
 "pTC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
@@ -46931,10 +46802,8 @@
 /area/station/security)
 "qgY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage/tech)
 "qhg" = (
@@ -47322,6 +47191,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "qod" = (
@@ -47737,6 +47607,8 @@
 	pixel_x = -32;
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "qvA" = (
@@ -47921,6 +47793,14 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"qyU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qzr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -48080,6 +47960,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk/multiz,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "qCE" = (
@@ -48545,12 +48428,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"qKm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/robotics/lab)
 "qKH" = (
 /turf/open/floor/glass/reinforced,
 /area/station/science/research)
@@ -48743,6 +48620,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/chapel/funeral)
 "qPC" = (
@@ -49210,7 +49088,6 @@
 "qXK" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "qXN" = (
@@ -49390,6 +49267,8 @@
 "raR" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "raT" = (
@@ -49425,8 +49304,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "rbg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -49505,6 +49384,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rcy" = (
@@ -49974,6 +49854,7 @@
 /area/station/maintenance/department/science)
 "rjk" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
 "rjn" = (
@@ -50012,7 +49893,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/interrogation)
@@ -50195,7 +50076,6 @@
 	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "rlw" = (
@@ -50417,7 +50297,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "rqh" = (
@@ -50947,11 +50826,8 @@
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/department/medical/central)
 "rzb" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/camera/autoname/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "rzg" = (
@@ -50975,12 +50851,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"rzF" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "rzI" = (
 /obj/machinery/camera/autoname/directional/south{
 	network = list("ss13","rd")
@@ -51222,6 +51092,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "rDs" = (
@@ -51283,6 +51156,10 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
+"rEw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rEK" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -51341,6 +51218,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "rFZ" = (
@@ -51395,8 +51274,8 @@
 /turf/open/space/basic,
 /area/station/solars/port/fore)
 "rGQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
@@ -51546,7 +51425,6 @@
 /turf/open/floor/iron/textured,
 /area/station/security/processing)
 "rKb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
@@ -51728,7 +51606,6 @@
 /area/station/security/office)
 "rOL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rPe" = (
@@ -52138,14 +52015,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
-"rVu" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/courtroom)
 "rVv" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -52311,7 +52180,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/lawyer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -52592,6 +52460,7 @@
 	dir = 8
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/hos)
 "sas" = (
@@ -52725,7 +52594,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "sbZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -52793,7 +52661,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "sdB" = (
@@ -52902,6 +52769,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/station/science/robotics/lab)
@@ -53143,7 +53011,9 @@
 /area/station/medical/virology)
 "sjJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sjL" = (
@@ -53247,6 +53117,7 @@
 "skV" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "slb" = (
@@ -53454,11 +53325,17 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "soB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage/tech)
+"soC" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "soG" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north{
@@ -54317,8 +54194,9 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "sCO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "sCT" = (
@@ -54771,10 +54649,6 @@
 "sJT" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/uppersouth)
-"sJX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "sKs" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -54935,8 +54809,6 @@
 "sNi" = (
 /obj/machinery/light/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
@@ -55016,6 +54888,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery/theatre)
 "sPD" = (
@@ -55155,19 +55028,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"sRM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/stairs/left{
-	dir = 1
-	},
-/area/station/command/bridge)
 "sRP" = (
 /obj/machinery/photocopier/prebuilt,
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "sRU" = (
@@ -55630,6 +55493,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "sZK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "sZS" = (
@@ -56108,8 +55972,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/pharmacy)
+"tjn" = (
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "tjq" = (
-/obj/structure/cable,
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal{
 	icon = 'icons/obj/mining_zones/survival_pod.dmi';
@@ -56154,6 +56020,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "tkh" = (
@@ -56279,6 +56146,11 @@
 	dir = 1
 	},
 /area/station/medical/pharmacy)
+"tmQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/medical/chemistry/minisat)
 "tmR" = (
 /obj/structure/bed/maint,
 /obj/item/bedsheet/yellow{
@@ -56441,7 +56313,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/chapel{
-	dir = 4
+	dir = 1
 	},
 /area/station/service/chapel)
 "toJ" = (
@@ -57049,7 +56921,7 @@
 /area/station/asteroid)
 "tAr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -57391,8 +57263,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tFa" = (
@@ -57496,7 +57366,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
@@ -57584,18 +57456,14 @@
 "tIH" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"tIN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/command/corporate_showroom)
 "tIO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/minisat)
 "tIS" = (
@@ -57724,8 +57592,8 @@
 	name = "Departure Lounge"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tLH" = (
@@ -58118,7 +57986,6 @@
 "tRp" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/disposal/bin,
-/obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -58170,12 +58037,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"tSH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "tSX" = (
 /obj/item/stack/tile/iron/white/smooth_large,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -58321,13 +58182,13 @@
 /area/station/security/processing)
 "tVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "tVJ" = (
@@ -58381,6 +58242,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tWl" = (
+/obj/item/stack/tile/iron/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/minisat)
 "tWs" = (
 /obj/effect/spawner/random/structure/grille,
 /obj/structure/cable,
@@ -58522,10 +58389,13 @@
 /area/station/command/heads_quarters/hos)
 "tYQ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "tZt" = (
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "tZv" = (
@@ -59023,7 +58893,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/chapel{
-	dir = 4
+	dir = 1
 	},
 /area/station/service/chapel)
 "uin" = (
@@ -59973,6 +59843,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"uyx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/command/bridge)
 "uyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken/directional/east,
@@ -60029,7 +59906,9 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white/herringbone,
 /area/station/science/breakroom)
 "uzB" = (
@@ -60549,7 +60428,9 @@
 /area/station/maintenance/aft/upper)
 "uIU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "uIW" = (
@@ -60639,8 +60520,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "uLi" = (
@@ -60779,6 +60658,7 @@
 "uNc" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/vending_restock,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/boutique)
 "uNd" = (
@@ -61009,13 +60889,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"uSd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
 "uSe" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -61509,7 +61382,6 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "vbY" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/painting/large/library{
 	pixel_y = -35
@@ -61731,8 +61603,6 @@
 /area/station/hallway/primary/central)
 "vgI" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "vgM" = (
@@ -61843,7 +61713,6 @@
 /turf/open/floor/grass,
 /area/station/science/research)
 "vja" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
 	},
@@ -62246,8 +62115,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "vqq" = (
@@ -62485,10 +62352,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"vwb" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "vwd" = (
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/engine,
@@ -63630,10 +63493,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "vQa" = (
@@ -63663,7 +63526,7 @@
 /area/station/command/bridge)
 "vQn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
@@ -63680,8 +63543,6 @@
 /turf/closed/wall,
 /area/station/cargo/boutique)
 "vQT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/official/moth_hardhat/directional/north,
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -63690,6 +63551,9 @@
 "vRi" = (
 /mob/living/basic/bot/cleanbot/medbay,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vRm" = (
@@ -63933,10 +63797,9 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
 "vVj" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/minisat)
 "vVk" = (
@@ -64061,6 +63924,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/cafeteria)
+"vXt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "vXS" = (
 /obj/structure/broken_flooring/side,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -64123,6 +63992,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/theater)
+"vZJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "vZL" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -64140,8 +64015,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "vZX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -64325,7 +64198,7 @@
 "wdc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -65134,6 +65007,7 @@
 "wsi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
@@ -65241,7 +65115,6 @@
 "wtW" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "wtZ" = (
@@ -65296,9 +65169,9 @@
 /turf/open/floor/iron/textured_large,
 /area/station/medical/treatment_center)
 "wus" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/hos)
 "wuS" = (
@@ -65322,8 +65195,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
@@ -65853,8 +65724,6 @@
 "wDo" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/interrogation)
 "wDr" = (
@@ -65889,6 +65758,9 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/science/robotics/lab)
 "wDH" = (
@@ -66269,7 +66141,6 @@
 /area/station/maintenance/department/engine)
 "wLq" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -66377,14 +66248,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured,
 /area/station/science/lobby)
-"wME" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "wMY" = (
 /obj/structure/cable,
 /obj/structure/dresser,
@@ -66554,11 +66417,6 @@
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"wQa" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "wQe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -66892,6 +66750,8 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "wWJ" = (
@@ -66945,7 +66805,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wYc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
@@ -67224,7 +67083,6 @@
 "xbB" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -67255,7 +67113,6 @@
 /area/station/engineering/supermatter/room)
 "xcb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "xch" = (
@@ -67294,6 +67151,7 @@
 /obj/effect/spawner/random/structure/chair_comfy{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "xcC" = (
@@ -67575,6 +67433,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"xiw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "xiy" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -67630,7 +67492,7 @@
 "xje" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -67668,9 +67530,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/landmark/start/chemist,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/textured,
 /area/station/medical/pharmacy)
 "xjq" = (
@@ -68185,7 +68045,6 @@
 "xtA" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "xtB" = (
@@ -68362,8 +68221,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/central/lesser)
 "xwh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "xwm" = (
@@ -68474,6 +68331,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/chapel/funeral)
 "xxV" = (
@@ -68701,6 +68559,11 @@
 "xBS" = (
 /turf/closed/wall,
 /area/station/medical/surgery/theatre)
+"xBU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/station/science/cytology)
 "xBV" = (
 /obj/machinery/atmospherics/components/binary/volume_pump,
 /obj/effect/turf_decal/tile/yellow{
@@ -68865,6 +68728,7 @@
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Art Storage"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "xEr" = (
@@ -69153,7 +69017,6 @@
 	department = "Mining";
 	name = "Mining Requests Console"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "xKo" = (
@@ -69378,6 +69241,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "xOB" = (
@@ -69395,6 +69260,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "xOF" = (
@@ -69452,6 +69318,11 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/plating/elevatorshaft,
 /area/station/ai/satellite/interior)
+"xPp" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "xPH" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -69612,11 +69483,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
-"xUf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "xUx" = (
 /obj/structure/flora/rock/style_random,
 /turf/open/misc/asteroid,
@@ -69637,6 +69503,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"xUJ" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Monkey Pen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/turf/open/floor/grass,
+/area/station/medical/chemistry)
 "xUR" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -69688,6 +69561,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "xVO" = (
@@ -69805,6 +69680,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xXF" = (
@@ -70119,6 +69995,7 @@
 "ycI" = (
 /mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/medical/chemistry)
 "ycN" = (
@@ -70129,6 +70006,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
+"ycT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "ycY" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
@@ -70259,6 +70141,10 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"yfL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured_large,
+/area/station/engineering/storage/tech)
 "ygb" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -83417,8 +83303,8 @@ wsI
 uyL
 umh
 sjJ
-rzF
-bGe
+umh
+uyL
 lmL
 hQy
 icM
@@ -83676,8 +83562,8 @@ icM
 xfN
 rxX
 raR
-wQa
-vwb
+icM
+ijg
 xrU
 fXZ
 sFd
@@ -83930,8 +83816,8 @@ poi
 ahV
 uyL
 hQu
-uyL
-rzF
+bGe
+umh
 nCt
 umh
 uyL
@@ -84187,11 +84073,11 @@ rPA
 mBt
 xnQ
 hQu
-sJX
-rzF
-noi
-jea
-ghU
+oXc
+umh
+xnQ
+hQu
+uSA
 icM
 hoX
 wOU
@@ -84445,7 +84331,7 @@ uyL
 vSt
 umh
 uyL
-fFz
+lmL
 aex
 umh
 uyL
@@ -84702,10 +84588,10 @@ lAL
 heZ
 uyL
 uyL
-ezP
-ezP
-ezP
-ezP
+uyL
+uyL
+uyL
+uyL
 ijg
 hoX
 rXd
@@ -84950,7 +84836,7 @@ bdu
 bWW
 poi
 tAL
-giK
+wBc
 lvg
 lBC
 uDB
@@ -86007,7 +85893,7 @@ bfc
 gok
 rnk
 lpF
-yfl
+kdh
 aNR
 oDC
 meP
@@ -86522,7 +86408,7 @@ xQN
 rnk
 rnk
 vWI
-xUf
+aNR
 taT
 wJy
 wJy
@@ -88081,7 +87967,7 @@ xHY
 rAa
 dgp
 qGB
-fqF
+eYv
 ksU
 tsq
 dgp
@@ -88267,7 +88153,7 @@ jza
 eWC
 jza
 jkv
-kkT
+iHG
 dba
 qLk
 jza
@@ -88338,7 +88224,7 @@ xHY
 wZI
 hQg
 sed
-fqF
+eYv
 nkf
 xzG
 hQg
@@ -88571,7 +88457,7 @@ ksl
 nJs
 fXn
 mDr
-jGK
+fXn
 kJN
 unL
 rnk
@@ -88782,7 +88668,7 @@ fod
 jza
 bSI
 sCO
-bqV
+keQ
 bZf
 jza
 fLv
@@ -89085,7 +88971,7 @@ rWs
 cQm
 fXn
 fXn
-aKd
+cQm
 mju
 wjj
 rnk
@@ -92148,7 +92034,7 @@ wGg
 pLW
 bzH
 bZa
-bZa
+giy
 giy
 ego
 bZa
@@ -92406,7 +92292,7 @@ sid
 mOb
 wEc
 xOg
-rVu
+bLa
 qER
 aUo
 iXj
@@ -95272,7 +95158,7 @@ iEj
 wkf
 hzF
 xEL
-qtP
+deW
 pdg
 iGC
 iGC
@@ -95530,7 +95416,7 @@ hDK
 hzF
 vCy
 czW
-tSH
+hUS
 hUS
 hUS
 hUS
@@ -96031,7 +95917,7 @@ pDP
 umo
 aMR
 ygj
-qrl
+ygj
 ncX
 eQi
 tLI
@@ -96287,7 +96173,7 @@ aGA
 rss
 aGA
 rss
-dbw
+aGA
 aGA
 aGA
 eQi
@@ -96544,7 +96430,7 @@ ruP
 lOE
 mRA
 dlZ
-ygj
+qrl
 pQN
 pQN
 eQi
@@ -96801,7 +96687,7 @@ ruP
 jEr
 qrl
 ffk
-ygj
+qrl
 wKo
 fIX
 eQi
@@ -97004,8 +96890,8 @@ bqX
 ogH
 aeJ
 xcs
-tYQ
-tYQ
+iMS
+iMS
 tYQ
 fID
 nlQ
@@ -97058,7 +96944,7 @@ ruP
 qrl
 vrR
 rej
-ygj
+qrl
 tQt
 efc
 xrV
@@ -97261,8 +97147,8 @@ eKR
 pVC
 yhk
 lPz
-cBh
-cBh
+jTd
+jTd
 rKb
 dla
 kCD
@@ -97315,7 +97201,7 @@ ruP
 pQN
 qrl
 aqR
-ygj
+qrl
 ffk
 ffk
 eQi
@@ -97572,7 +97458,7 @@ ruP
 mSm
 qrl
 gTh
-ygj
+qrl
 qrl
 qrl
 eQi
@@ -97780,13 +97666,13 @@ typ
 ckb
 jlw
 iRB
-gkQ
+uyx
 bGW
 tbH
 alc
 jZj
-nAx
-kaz
+dhl
+jZj
 dbJ
 mMH
 juE
@@ -97829,9 +97715,9 @@ ruP
 ffk
 ohh
 ffk
-ygj
+qrl
 fXU
-eDV
+qrl
 eQi
 vxl
 rjn
@@ -98037,7 +97923,7 @@ typ
 lCK
 aHs
 iRB
-kZg
+uyx
 gbM
 mzI
 cgo
@@ -98100,7 +97986,7 @@ ekL
 hzF
 qDg
 dhO
-tSH
+cSb
 cSb
 cSb
 cSb
@@ -98294,7 +98180,7 @@ rCd
 kNX
 eKR
 tKX
-kZg
+uyx
 nPm
 yjH
 eKR
@@ -98546,10 +98432,10 @@ eKR
 cNQ
 kjs
 ftR
-fun
-fun
+mrq
+mrq
 hSi
-sRM
+bQc
 kZA
 gkQ
 dBn
@@ -99063,7 +98949,7 @@ bCr
 kYU
 jTd
 rkz
-lrc
+dla
 eHa
 ktI
 ita
@@ -99071,7 +98957,7 @@ hOb
 cwq
 cwq
 giv
-iPS
+cwq
 wcp
 juw
 nKt
@@ -99585,7 +99471,7 @@ vCI
 mXY
 mXY
 nPQ
-tIN
+cwq
 euR
 juw
 wUM
@@ -99643,7 +99529,7 @@ loU
 jKy
 iBe
 pOv
-kUW
+gaK
 aRt
 sxk
 azg
@@ -99897,9 +99783,9 @@ nWx
 cRM
 hGo
 dPw
-jGZ
+mQy
 kpj
-kJl
+mQy
 wYc
 hGh
 vSn
@@ -100129,11 +100015,11 @@ xQH
 mcA
 kqD
 jpn
-vOT
-oqt
-oqt
-aFw
-oLH
+uzH
+sgq
+sgq
+pUj
+wWZ
 wWZ
 wWZ
 utY
@@ -100153,10 +100039,10 @@ tCE
 bTm
 jKy
 oeL
-dPw
+cXn
 rGQ
 muf
-pOv
+lqM
 lCO
 umO
 uhD
@@ -100387,9 +100273,9 @@ gLp
 dNh
 gGs
 skV
-uzH
+vOT
 nAG
-pUj
+ekF
 oLH
 gUs
 wWZ
@@ -100412,9 +100298,9 @@ hAV
 hGo
 tki
 iEK
-wsi
+peA
 bfD
-wsi
+peA
 bJQ
 peA
 srj
@@ -100667,8 +100553,8 @@ tCE
 bTm
 gho
 tGZ
-ccZ
-rGQ
+dPw
+jKy
 naO
 pOv
 gaK
@@ -101921,7 +101807,7 @@ usF
 ufr
 kZw
 uIU
-ufr
+kZw
 kZw
 rhP
 fQm
@@ -103704,10 +103590,10 @@ goB
 txy
 tGE
 cUk
-cUk
+vXt
 cUk
 hFY
-wEA
+fHI
 nxG
 sGs
 nTT
@@ -103960,9 +103846,9 @@ eRu
 eRu
 vfJ
 vSv
-grl
-dko
 qXy
+dko
+hBQ
 mJG
 oTX
 tEW
@@ -104223,7 +104109,7 @@ iKc
 rSL
 jbL
 lFE
-cBr
+aQS
 deY
 xMk
 aQS
@@ -104480,7 +104366,7 @@ iKc
 hle
 gvF
 rIb
-iAw
+wEA
 swi
 swi
 swi
@@ -104992,9 +104878,9 @@ rvg
 vuq
 hPH
 iKc
-gtB
-uSd
-gQN
+iKc
+bsw
+wxa
 vks
 yhV
 oYu
@@ -105006,8 +104892,8 @@ xOU
 kBt
 wdz
 nOZ
-xcb
-eqQ
+tld
+tld
 dyb
 qdo
 exQ
@@ -105246,9 +105132,9 @@ kju
 wMB
 jrd
 rvg
-slL
-slL
-slL
+xPp
+xPp
+xPp
 oXz
 bsw
 wxa
@@ -105519,7 +105405,7 @@ uig
 xOU
 kcY
 prg
-qKm
+tld
 rDl
 ylj
 esP
@@ -105776,7 +105662,7 @@ mwW
 xOU
 xOU
 xOU
-qKm
+tld
 wDD
 vRZ
 oQe
@@ -106033,7 +105919,7 @@ exk
 faX
 cya
 vpq
-qKm
+tld
 xVK
 ryy
 ryy
@@ -106061,7 +105947,7 @@ xAy
 pEf
 sbd
 soB
-sbd
+yfL
 bcm
 lHm
 dct
@@ -106575,7 +106461,7 @@ xAy
 rdI
 byj
 jvN
-sbd
+kgO
 xqB
 lHm
 nWu
@@ -107310,7 +107196,7 @@ pdz
 tZF
 wPX
 mlV
-cpw
+dfM
 cpw
 jIm
 xOU
@@ -107825,7 +107711,7 @@ pBn
 cPo
 qii
 owp
-iQZ
+lxX
 ocV
 thf
 qlG
@@ -108083,7 +107969,7 @@ tNR
 oUW
 mnd
 peo
-bWi
+dfM
 thf
 dmM
 pld
@@ -109151,8 +109037,8 @@ eyg
 dUi
 myg
 dyv
-jxd
-jxd
+clx
+clx
 svf
 svf
 pTJ
@@ -109168,7 +109054,7 @@ vPT
 fIW
 mqH
 wCv
-oMi
+vZJ
 wgk
 jKu
 saJ
@@ -109406,9 +109292,9 @@ vME
 gTV
 eyg
 wpn
-cFc
-svf
-svf
+lUY
+jxd
+jxd
 clx
 mJb
 fQO
@@ -109917,7 +109803,7 @@ dpU
 bnK
 wqU
 ocB
-ocB
+mIC
 xot
 xot
 xtY
@@ -111225,8 +111111,8 @@ btl
 qmn
 ryC
 mnU
-lpe
-lpe
+qOY
+qOY
 jKp
 wMt
 ryC
@@ -111484,7 +111370,7 @@ kjI
 vdZ
 rgI
 kyh
-qOY
+lpe
 vAj
 ryC
 cLf
@@ -111699,7 +111585,7 @@ nkA
 com
 cnS
 mSN
-tnp
+pJp
 fCG
 krJ
 oWr
@@ -111956,7 +111842,7 @@ qKj
 jSu
 cnS
 rwF
-fCG
+rEw
 mBb
 atv
 fTX
@@ -111979,7 +111865,7 @@ fTX
 eSm
 rhS
 rhS
-mVi
+bhG
 rhS
 rhS
 rhS
@@ -142544,15 +142430,15 @@ hhX
 urC
 jrm
 pJF
-bcg
-bcg
-bcg
-bcg
-bcg
-nSF
+qyq
+qyq
+qyq
+qyq
+qyq
+wUH
 vVj
-mua
-wJk
+iAQ
+oDw
 wnw
 fYe
 fYe
@@ -142802,18 +142688,18 @@ urC
 jrm
 qyq
 bDN
-sRq
-wqq
-qyq
-wUH
-sRq
+tWl
+iyg
+bcg
+tmQ
+duf
 lSI
 gSJ
 tIO
 wnw
 fYe
 fYe
-hhX
+cLf
 hhX
 hhX
 hhX
@@ -149748,7 +149634,7 @@ mqc
 mfw
 bGk
 bGk
-ncR
+xUJ
 ncR
 bGk
 ahq
@@ -150013,7 +149899,7 @@ vUo
 laf
 kuy
 bVY
-lgA
+tqV
 eXW
 fnh
 mhc
@@ -150772,7 +150658,7 @@ taj
 kYT
 ogL
 cPZ
-rVL
+auB
 rVL
 bGk
 qAU
@@ -151029,8 +150915,8 @@ wWJ
 kYT
 auB
 waT
-rVL
-auB
+xiw
+ycT
 aPC
 jql
 sTj
@@ -151287,7 +151173,7 @@ kYT
 xtb
 fwJ
 ipZ
-auB
+mjj
 aPC
 jql
 sTj
@@ -151543,7 +151429,7 @@ wWJ
 kYT
 auB
 auB
-rVL
+auB
 vQn
 aPC
 eeQ
@@ -151566,7 +151452,7 @@ cNG
 vtv
 lVD
 iom
-dpj
+tjn
 aRZ
 iMq
 vxX
@@ -151822,7 +151708,7 @@ apk
 cNG
 hce
 wLq
-hce
+dpj
 cUm
 tve
 iMq
@@ -152311,7 +152197,7 @@ nGv
 bgY
 bgY
 bgY
-bgY
+dog
 qoN
 fnh
 wnL
@@ -152568,7 +152454,7 @@ fnh
 qoN
 rNJ
 koX
-bgY
+dog
 qoN
 fnh
 igq
@@ -160536,7 +160422,7 @@ lIr
 gcN
 xTZ
 igS
-aEY
+pdp
 jGB
 nRA
 tqJ
@@ -160792,7 +160678,7 @@ pco
 lIr
 mGo
 vqt
-vqt
+mic
 nSn
 jGB
 vyL
@@ -160809,8 +160695,8 @@ lgp
 hzF
 lSM
 gcV
-iGC
-tkD
+swU
+aCk
 uxt
 uxt
 uxt
@@ -161049,7 +160935,7 @@ oxG
 hCs
 jnm
 jKD
-vqt
+mic
 rzb
 jGB
 jGB
@@ -161067,7 +160953,7 @@ hzF
 sNi
 bOi
 iGC
-tkD
+qyU
 uxt
 uxt
 uxt
@@ -161324,7 +161210,7 @@ hzF
 vQT
 clM
 caP
-tkD
+aCk
 uxt
 uxt
 uxt
@@ -161561,7 +161447,7 @@ mnP
 mnP
 dAS
 kdW
-gOG
+gcN
 ffA
 wvc
 gEm
@@ -161836,9 +161722,9 @@ mGW
 iZz
 hzF
 kCu
-jbq
-jbq
-jbq
+poe
+poe
+soC
 jbq
 vnj
 jCr
@@ -170013,7 +169899,7 @@ oAs
 gOc
 gOc
 gOc
-nzn
+oAs
 jqf
 oWg
 gMk
@@ -172590,7 +172476,7 @@ dpp
 gKt
 dVp
 dRh
-fdN
+xBU
 xje
 ipx
 vxX
@@ -172839,7 +172725,7 @@ vRP
 bWi
 bWi
 iHH
-nmj
+dfM
 wPX
 dfM
 xtZ
@@ -173866,7 +173752,7 @@ raz
 obA
 gbR
 omL
-wME
+omL
 acY
 aqa
 vRA
@@ -179563,7 +179449,7 @@ urI
 rAP
 rAP
 rAP
-odk
+urI
 kdE
 xjL
 grz


### PR DESCRIPTION
## About The Pull Request

Goes over Wawa's piping & cabling to correct inefficiencies & deviations from standard design. No scrubbers or vents have been moved beyond rotation. No actual disconnects were found this time around, but there were more inefficiencies than the last two. MDB ignore because it's almost all underfloor. A few changes could be noticeable:

The chapel's floor tiles under their tables were misaligned.

At a few points, piping appeared to deliberately avoid going under holopads, but not at other points. I've taken the opinion that going under holopads is the same as going under chairs - avoid it only if it won't cost extra piping. I have applied this opinion where relevant.

Departures catwalks previously showed one tile of the waste and distro pipes heading directly into their vent/scrubber, these are no longer visible.

A floor tile in chemsat that was "ripped up" previously showed the scrubber pipe under it. This pipe was moved, and the "ripped up" tile moved with it to continue to show the pipe.

## Why It's Good For The Game

More consistent, more efficient piping at no cost. And chapel's tiling looks right.

## Changelog
:cl:

map: Removed some inefficiencies in Wawa's piping and cabling.

/:cl:
