### PR TITLE
`log_world()` the Round ID

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -335,6 +335,8 @@ SUBSYSTEM_DEF(dbcore)
 	GLOB.round_id = "[query_round_initialize.last_insert_id]"
 	qdel(query_round_initialize)
 
+	log_world("Round ID: [GLOB.round_id]")
+
 /datum/controller/subsystem/dbcore/proc/SetRoundStart()
 	if(!Connect())
 		return


### PR DESCRIPTION
## About The Pull Request

Better correspondence in higher-level logging files (e.g. TGS's DreamDaemonLog Diagnostic), also helpful in instances where Round ID is not known (like if someone gives you a random log and the round ID has been forgotten), pretty good to have it logged if we know it in all the important stuff like dd.log.
## Why It's Good For The Game

Higher standard of information tracking without having to do infinite amounts of UTC Timezone maths and what-not as it's becoming more common for me to see stuff and then have to pull all sorts of other data in order to make sure what I'm looking at is accurate to what I want (and still having that degree of uncertainty is unideal). 
## Changelog
:cl:
server: Round ID is now output to `log_world()`, so it'll show up stuff like world.log, dd.log, etc.
/:cl:
