### PR TITLE
Adds a key memory for the family heirloom quirk

### DIFF
--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -99,6 +99,30 @@
 /datum/memory/key/quirk_allergy/get_starts()
 	return list("[protagonist_name] sneezing after coming into contact with [allergy_string].")
 
+/// Tracks what kind of item the quirk user's heirloom is
+/datum/memory/key/quirk_heirloom
+	var/heirloom_name
+
+/datum/memory/key/quirk_heirloom/New(
+	datum/mind/memorizer_mind,
+	atom/protagonist,
+	atom/deuteragonist,
+	atom/antagonist,
+	heirloom_name,
+)
+	src.heirloom_name = heirloom_name
+	return ..()
+
+/datum/memory/key/quirk_heirloom/get_names()
+	return list("[protagonist_name]'s heirloom [heirloom_name].")
+
+/datum/memory/key/quirk_heirloom/get_starts()
+	return list(
+		"[protagonist_name] being bequeathed the heirloom [heirloom_name] by a dear relative.",
+		"[protagonist_name] discovering the heirloom [heirloom_name] in some long-forgotten boxes.",
+		"[protagonist_name] stealing the heirloom [heirloom_name] from an undeserving family member.",
+	)
+
 /// Tracks what brand a smoker quirk user likes
 /datum/memory/key/quirk_smoker
 	memory_flags = MEMORY_FLAG_NOLOCATION|MEMORY_FLAG_NOPERSISTENCE|MEMORY_SKIP_UNCONSCIOUS // Does not have nomood

--- a/code/datums/quirks/negative_quirks/family_heirloom.dm
+++ b/code/datums/quirks/negative_quirks/family_heirloom.dm
@@ -52,6 +52,7 @@
 		to_chat(quirk_holder, span_boldnotice("A wave of existential dread runs over you as you realize your precious family heirloom is missing. Perhaps the Gods will show mercy on your cursed soul?"))
 		return
 	family_heirloom.AddComponent(/datum/component/heirloom, quirk_holder.mind, family_name)
+	quirk_holder.add_mob_memory(/datum/memory/key/quirk_heirloom, protagonist = quirk_holder, heirloom_name = initial(family_heirloom.name))
 
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

The real reason I made this is because twice now I've accidentally thrown away my heirloom because it just looked like job equipment, but some other quirks have key memories and I think it's fun flavor to add to something like the heirloom quirk because of the significance of the item to the character.

## Why It's Good For The Game

Carve up the walls with scenes of your character stealing the beloved family lighter from their ungrateful no-good sibling

## Changelog
:cl:
add: Added a key memory to the family heirloom quirk
/:cl:
