### PR TITLE
Add ACCESS_CARGO to underfloor nav beacons

### DIFF
--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -25,7 +25,7 @@
 	/// codes as set on map: "tag1;tag2" or "tag1=value;tag2=value"
 	var/codes_txt = ""
 
-	req_one_access = list(ACCESS_ENGINEERING, ACCESS_ROBOTICS)
+	req_one_access = list(ACCESS_CARGO, ACCESS_ENGINEERING, ACCESS_ROBOTICS)
 
 /datum/armor/machinery_navbeacon
 	melee = 70


### PR DESCRIPTION

## About The Pull Request

What the title says

## Why It's Good For The Game

A couple times now as a cargo tech/QM I've wanted to add new mule destinations or move existing ones and I can't because I can't unlock the nav beacons, I think this is silly because mulebots are half the purpose of nav beacons to begin with. I'm marking this as a balance change out of good faith but realistically I don't think it will matter at all

## Changelog
:cl:
balance: cargo techs can now unlock underfloor nav beacons
/:cl:
