### PR TITLE
Excepts multiz pipes from mapping verb "check plumbing"

### DIFF
--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -9,9 +9,9 @@ ADMIN_VERB(atmos_debug, R_DEBUG, "Check Plumbing", "Verifies the integrity of th
 
 	//Pipes
 	for(var/obj/machinery/atmospherics/pipe/pipe as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/atmospherics/pipe))
-		if(istype(pipe, /obj/machinery/atmospherics/pipe/smart) || istype(pipe, /obj/machinery/atmospherics/pipe/layer_manifold))
+		if(istype(pipe, /obj/machinery/atmospherics/pipe/smart) || istype(pipe, /obj/machinery/atmospherics/pipe/layer_manifold) || istype(pipe, /obj/machinery/atmospherics/pipe/multiz))
 			continue
-		if(pipe.z && (!pipe.nodes || !pipe.nodes.len || ((null in pipe.nodes) && !istype(pipe, /obj/machinery/atmospherics/pipe/multiz))))
+		if(pipe.z && (!pipe.nodes || !pipe.nodes.len || (null in pipe.nodes)))
 			to_chat(user, "Unconnected [pipe.name] located at [ADMIN_VERBOSEJMP(pipe)]", confidential = TRUE)
 
 	//Nodes

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -11,7 +11,7 @@ ADMIN_VERB(atmos_debug, R_DEBUG, "Check Plumbing", "Verifies the integrity of th
 	for(var/obj/machinery/atmospherics/pipe/pipe as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/atmospherics/pipe))
 		if(istype(pipe, /obj/machinery/atmospherics/pipe/smart) || istype(pipe, /obj/machinery/atmospherics/pipe/layer_manifold))
 			continue
-		if(pipe.z && (!pipe.nodes || !pipe.nodes.len || (null in pipe.nodes)))
+		if(pipe.z && (!pipe.nodes || !pipe.nodes.len || ((null in pipe.nodes) && !istype(pipe, /obj/machinery/atmospherics/pipe/multiz))))
 			to_chat(user, "Unconnected [pipe.name] located at [ADMIN_VERBOSEJMP(pipe)]", confidential = TRUE)
 
 	//Nodes


### PR DESCRIPTION
## About The Pull Request

Multiz pipes will, on any map without 3 z levels, always be "unconnected" to this mapping verb. This is because they're `TRINARY`, and thus must fill `nodes` with three connection points in order to not fail this verb, which they will never do unless they're on the center of three z levels(and have pipes above and below them, which is the case precisely nowhere). They need to keep `TRINARY` in order to keep working, so I'm making an exception in the verb.

## Why It's Good For The Game

Check plumbing will no longer fill your chatbox with one million pipes that are, in fact, connected.
Closes #94378

## Changelog
:cl:

No player facing changes. Or admin facing changes. This is just for us.

/:cl:
