### PR TITLE
Let all department protolathes print out a expiri science scanner

### DIFF
--- a/code/modules/research/designs/experisci_designs.dm
+++ b/code/modules/research/designs/experisci_designs.dm
@@ -8,4 +8,4 @@
 	category = list(
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+	departmental_flags = ALL


### PR DESCRIPTION
## About The Pull Request
This PR makes it so you can print expiri science scanner out any departmental protolathe.
(its the tool you do research with)

## Why It's Good For The Game
Currently the whole weight doing expiriments is on science, where we have tasks like make pure halopiridol or scan blood and such normally you have to go science to ask for one of these devices, we also made a standard where heads can research for their department this allows departments work impedentely when it comes to expiriments.

A engineer would likely do stock parts upgrading etc
where medbay would do corpses autospies/pure chem scanning etc

Eitherway i think its intresting for every department being able to control their own research progress instead of being forced to break into science for one of those devices, departments control their own expirimental progress where science itself control the research flow along with the departmental heads.

## Changelog
:cl: Ezel
balance: All protolathes can now print out a expiri science scanner
/:cl:
