### PR TITLE
Fixes the brimdust status alert sprite

### DIFF
--- a/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
+++ b/code/modules/mining/equipment/monster_organs/brimdust_sac.dm
@@ -143,7 +143,7 @@
 
 /datum/status_effect/stacking/brimdust_coating/on_creation(mob/living/new_owner, stacks_to_apply)
 	. = ..()
-	linked_alert?.icon_state = "brimdemon_[stacks]"
+	linked_alert?.overlay_state = "brimdemon_[stacks]"
 
 /datum/status_effect/stacking/brimdust_coating/on_apply()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Otherwise the effect is stuck at the max stacks icon and doesn't have a background.

## Changelog
:cl:
fix: Fixed the brimdust status alert sprite
/:cl:
