### PR TITLE
Prevents Remote Painting Finalization

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -259,7 +259,10 @@
 	LAZYREMOVE(zoom_by_observer, user.key)
 
 /obj/item/canvas/proc/finalize(mob/user)
-	if(painting_metadata.loaded_from_json || finalized)
+	if(finalized || painting_metadata.loaded_from_json)
+		return
+	if(!in_range(src, user))
+		user.balloon_alert(user, "too far away!")
 		return
 	if(!try_rename(user))
 		return


### PR DESCRIPTION

## About The Pull Request

Fixes #94414

Definitely unintended behavior, now you actually have to be next to someone's painting to fuck up their shit
## Why It's Good For The Game

Kinda mean to do this to someone outside of shoving range.
## Changelog
:cl:
fix: Paintings can no longer be finalized if you are not adjacent to the painting.
/:cl:
