### PR TITLE
[NO GBP] Adding missing interactions for cyborgs

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -254,7 +254,8 @@
 	icon_state = "borg_stack_apparatus"
 	storable = list(/obj/item/stack/sheet,
 					/obj/item/stack/tile,
-					/obj/item/stack/rods)
+					/obj/item/stack/rods,
+					/obj/item/stack/conveyor)
 
 /obj/item/borg/apparatus/sheet_manipulator/Initialize(mapload)
 	update_appearance()
@@ -292,6 +293,7 @@
 		/obj/item/electronics,
 		/obj/item/stock_parts/power_store,
 		/obj/item/light,
+		/obj/item/conveyor_switch_construct,
 	)
 
 /obj/item/borg/apparatus/engineering/Initialize(mapload)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -230,8 +230,7 @@
 	return TRUE
 
 /obj/item/sign/screwdriver_act(mob/living/user, obj/item/tool)
-	if(iscyborg(user))
-		return interact_with_atom(get_step(get_turf(user), user.dir), user)
+	return interact_with_atom(get_step(get_turf(user), user.dir), user)
 
 /obj/item/sign/proc/set_sign_type(obj/structure/sign/fake_type)
 	name = initial(fake_type.name)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -229,6 +229,10 @@
 	atom_integrity = max_integrity
 	return TRUE
 
+/obj/item/sign/screwdriver_act(mob/living/user, obj/item/tool)
+	if(iscyborg(user))
+		return interact_with_atom(get_step(get_turf(user), user.dir), user)
+
 /obj/item/sign/proc/set_sign_type(obj/structure/sign/fake_type)
 	name = initial(fake_type.name)
 	if(fake_type != /obj/structure/sign/blank)


### PR DESCRIPTION
## About The Pull Request

signs now use the same interaction as wallmounts (you can install them with screwdriver while facing the wall)
aswell made cyborg be able to place conveyor belts and switches to them.

## Why It's Good For The Game

plastic signs are technically wallmounts, despite not being subtype of, so it should behave like other wallmounts. made check for cyborgs, because you'd expect everyone else with hands to place signs using those hands.
conveyor belts are sheets so its kinda same consistency as plastic signs.

## Changelog

:cl:
add: Engineering cyborg can now hold conveyor belts and place plastic signs using screwdriver.
/:cl:
