### PR TITLE
Buffs MODsuit standard storage, makes expanded storage unprintable

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -12,9 +12,9 @@
 	/// Max weight class of items in the storage.
 	var/max_w_class = WEIGHT_CLASS_NORMAL
 	/// Max combined weight of all items in the storage.
-	var/max_combined_w_class = 15
+	var/max_combined_w_class = 17
 	/// Max amount of items in the storage.
-	var/max_items = 7
+	var/max_items = 14
 	/// Is nesting same-size storage items allowed?
 	var/big_nesting = FALSE
 

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -61,7 +61,6 @@
 		whether smuggling, or simply hauling."
 	icon_state = "storage_large"
 	max_combined_w_class = 21
-	max_items = 14
 
 /obj/item/mod/module/storage/syndicate
 	name = "MOD syndicate storage module"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -2105,15 +2105,6 @@
 	)
 	build_path = /obj/item/mod/module/storage
 
-/datum/design/module/mod_storage_expanded
-	name = "Expanded Storage Module"
-	id = "mod_storage_expanded"
-	materials = list(
-		/datum/material/iron =SHEET_MATERIAL_AMOUNT * 2.5,
-		/datum/material/uranium =SHEET_MATERIAL_AMOUNT,
-	)
-	build_path = /obj/item/mod/module/storage/large_capacity
-
 /datum/design/module/mod_visor_medhud
 	name = "Medical Visor Module"
 	id = "mod_visor_medhud"

--- a/code/modules/research/techweb/nodes/modsuit_nodes.dm
+++ b/code/modules/research/techweb/nodes/modsuit_nodes.dm
@@ -136,7 +136,6 @@
 		"mod_jetpack",
 		"mod_rad_protection",
 		"mod_emp_shield",
-		"mod_storage_expanded",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_ENGINEERING)


### PR DESCRIPTION

## About The Pull Request

Alternative to #94228

Gives MODsuit standard storage modules one more row of max slots, & two additional weight class maximum. This makes them four weight class max / one slot row behind a normal backpack, & four weight class max behind expanded storage.

Drops expanded storage from the techweb entirely, making it effectively head & cargo exclusive.

## Why It's Good For The Game

Directly mentioned in the Non-Goals section of the original MODsuits HackMD was that the suits should be sacrifices. Specifically mentioned in that section was that the suit's users should be sacrificing storage for the utility of the suit. I believe that this is a good idea, a worthwhile tradeoff for the immense utility of the suit. This goal has been lost, though, to the gradual normalization of expanded storage as the standard MODsuit storage, because it's too good to pass up, being a removal of the suit's main downside for no cost. Expanded storage simply existing as a standard MODule makes all MODsuits less interesting by lack of downside(I maintain that undeployed slowdown is so small that it is irrelevant & unnoticeable). Making it a sidegrade isn't desired, reasonably because a large amount of people will take expanded no matter what upside or downside normal or expanded has. The only solution, then, is to return to how expanded originally was- an exclusive MODule just for heads of staff. 

The buff to standard storage is to compensate for the loss of expanded storage for the crew, & is currently set fairly arbitrarily. I'm not even sure it really needs the two additional weight capacity, but I'd like to get opinions on that.

## Changelog
:cl:

balance: Made expanded storage MODule unprintable, buffed standard storage MODule

/:cl:
