### PR TITLE
Changes tramstation maintenance mechbay access from maintenance to security

### DIFF
--- a/_maps/map_files/tramstation/maintenance_modules/arrivalsecupper_3.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/arrivalsecupper_3.dmm
@@ -83,7 +83,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/eva)
 "L" = (
@@ -115,7 +115,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva)
 "Y" = (


### PR DESCRIPTION

## About The Pull Request

Changes the access on the tramstation module that puts a maintenance door into sec mechbay from `any/security/maintenance` to `any/security/brig`, preventing those with only maintenance access from entering.

## Why It's Good For The Game

Mechs are very expensive

## Changelog
:cl:

map: Assistants no longer have access to the tramstation security mechbay

/:cl:
