### PR TITLE
Cleanup + Logging for Readiness Bugs

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -3,8 +3,8 @@
 //Misc mob defines
 
 //Ready states at roundstart for mob/dead/new_player
-#define PLAYER_NOT_READY 0
-#define PLAYER_READY_TO_PLAY 1
+#define PLAYER_NOT_READY "Not Ready"
+#define PLAYER_READY_TO_PLAY "Ready"
 
 //movement intent defines for the move_intent var
 #define MOVE_INTENT_WALK "walk"

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -248,8 +248,6 @@
 	icon = 'icons/hud/lobby/ready.dmi'
 	icon_state = "not_ready"
 	base_icon_state = "not_ready"
-	///Whether we are readied up for the round or not
-	var/ready = FALSE
 
 /atom/movable/screen/lobby/button/ready/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
@@ -279,14 +277,16 @@
 	if(!.)
 		return
 	var/mob/dead/new_player/new_player = hud.mymob
-	ready = !ready
-	if(ready)
+
+	// switch based on the user, if they aren't ready then we change them to ready, and vice versa
+	if(new_player.ready == PLAYER_NOT_READY)
 		new_player.auto_deadmin_on_ready_or_latejoin()
 		new_player.ready = PLAYER_READY_TO_PLAY
 		base_icon_state = "ready"
 	else
 		new_player.ready = PLAYER_NOT_READY
 		base_icon_state = "not_ready"
+
 	update_appearance(UPDATE_ICON)
 	SEND_SIGNAL(hud, COMSIG_HUD_PLAYER_READY_TOGGLE)
 

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -605,7 +605,7 @@
 	var/blip_icon_state = "ready_blip"
 	if(blip_enabled && hud)
 		var/mob/dead/new_player/new_player = hud.mymob
-		blip_icon_state += "_[new_player.ready ? "" : "not_"]ready"
+		blip_icon_state += "_[new_player.is_ready_to_play() ? "" : "not_"]ready"
 	else
 		blip_icon_state += "_disabled"
 	var/mutable_appearance/ready_blip = mutable_appearance(icon, blip_icon_state)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -216,9 +216,19 @@ SUBSYSTEM_DEF(ticker)
 		return TRUE
 	return FALSE
 
+/// Gets a list of players with their readied state so we can post it as a log
+/datum/controller/subsystem/ticker/proc/get_player_ready_states()
+	var/list/player_states = list()
+	for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
+		player_states += "[player.ckey]: [player.ready]"
+	return player_states
+
 /datum/controller/subsystem/ticker/proc/setup()
 	to_chat(world, span_boldannounce("Starting game..."))
 	var/init_start = world.timeofday
+
+	var/list/players_and_readiness = get_player_ready_states()
+	log_game("Players readied up: [json_encode(players_and_readiness)]", players_and_readiness)
 
 	CHECK_TICK
 	//Configure mode and assign player to antagonists

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -220,7 +220,7 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/get_player_ready_states()
 	var/list/player_states = list()
 	for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
-		player_states += "[player.ckey]: [player.ready]"
+		player_states[player.ckey] = player.ready
 	return player_states
 
 /datum/controller/subsystem/ticker/proc/setup()
@@ -228,7 +228,7 @@ SUBSYSTEM_DEF(ticker)
 	var/init_start = world.timeofday
 
 	var/list/players_and_readiness = get_player_ready_states()
-	log_game("Players readied up: [json_encode(players_and_readiness)]", players_and_readiness)
+	log_game("Players and Readiness: [json_encode(players_and_readiness)]", players_and_readiness)
 
 	CHECK_TICK
 	//Configure mode and assign player to antagonists

--- a/code/modules/mob/dead/new_player/logout.dm
+++ b/code/modules/mob/dead/new_player/logout.dm
@@ -1,5 +1,5 @@
 /mob/dead/new_player/Logout()
-	ready = 0
+	ready = PLAYER_NOT_READY
 	..()
 	if(!spawning)//Here so that if they are spawning and log out, the other procs can play out and they will have a mob to come back to.
 		key = null//We null their key before deleting the mob, so they are properly kicked out.

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -8,7 +8,8 @@
 	hud_type = /datum/hud/new_player
 	hud_possible = list()
 
-	var/ready = FALSE
+	/// Whether the new_player is ready to play or not.
+	var/ready = PLAYER_NOT_READY
 	/// Referenced when you want to delete the new_player later on in the code.
 	var/spawning = FALSE
 	/// For instant transfer once the round is set up

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -8,7 +8,8 @@
 	hud_type = /datum/hud/new_player
 	hud_possible = list()
 
-	/// Whether the new_player is ready to play or not.
+	/// String Values tied to Defines that state whether the new_player is ready to play or not.
+	/// Do try your best to compare this value directly against the defines for certainty but helper procs do exist in bulkier situations.
 	var/ready = PLAYER_NOT_READY
 	/// Referenced when you want to delete the new_player later on in the code.
 	var/spawning = FALSE
@@ -64,6 +65,12 @@
 	if (href_list["votepollref"])
 		var/datum/poll_question/poll = locate(href_list["votepollref"]) in GLOB.polls
 		vote_on_poll_handler(poll, href_list)
+
+/// Quickly gets a boolean of whether the new_player is ready to play or not in places where we would like the boolean logic.
+/// The assertion is that readiness must be an opted in TRUE, while all other states (e.g. not ready, broken, etc) are FALSE.
+/// We organize it this way to ensure the system is extensible for other possible ready states.
+/mob/dead/new_player/proc/is_ready_to_play()
+	return ready == PLAYER_READY
 
 //When you cop out of the round (NB: this HAS A SLEEP FOR PLAYER INPUT IN IT)
 /mob/dead/new_player/proc/make_me_an_observer()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -70,7 +70,7 @@
 /// The assertion is that readiness must be an opted in TRUE, while all other states (e.g. not ready, broken, etc) are FALSE.
 /// We organize it this way to ensure the system is extensible for other possible ready states.
 /mob/dead/new_player/proc/is_ready_to_play()
-	return ready == PLAYER_READY
+	return ready == PLAYER_READY_TO_PLAY
 
 //When you cop out of the round (NB: this HAS A SLEEP FOR PLAYER INPUT IN IT)
 /mob/dead/new_player/proc/make_me_an_observer()


### PR DESCRIPTION

## About The Pull Request

On production, I sign up for rounds (and I know I pushed the button because the auto-deadmin message comes up) but it doesn't inject me in the game and fails without a warning. I have no idea why it's doing this but I shifted some stuff around and added a few logs to hopefully stop this strange consistent failure for me to start a shift.

I just cleaned up a lot of the code and turned the ready defines into strings instead of a boolean (so I could log it more efficiently with little overhead, as well as standardize it to a define without people doing wacky shit everywhere). I don't think this will fix the issue but it will definitely make some things more clear as to why I'm not joining rounds without warning despite clicking ready.
## Why It's Good For The Game

Cleans the code up while trying to resolve a really puzzling bug I've been having.
## Changelog
:cl:
server: The ready/not ready states of new players are logged when a shift starts.
/:cl:
