### PR TITLE
Fixes Pun Pun qdel on Monkey Day

### DIFF
--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -50,11 +50,12 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 /mob/living/carbon/human/species/monkey/punpun/Initialize(mapload)
 	. = ..()
 
+	REGISTER_REQUIRED_MAP_ITEM(1, 1) // pun pun is required on maps.
 	if(mapload && (locate(/datum/station_trait/job/pun_pun) in SSstation.station_traits))
 		new /obj/effect/landmark/start/pun_pun(loc) //Pun Pun is a crewmember, and may late-join.
 		return INITIALIZE_HINT_QDEL
 
-	REGISTER_REQUIRED_MAP_ITEM(1, 1)
+	Read_Memory()
 	if(!GLOB.the_one_and_only_punpun && mapload)
 		GLOB.the_one_and_only_punpun = src
 	else if(GLOB.the_one_and_only_punpun)
@@ -132,8 +133,6 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 
 /// Gives pun pun a special name based on various factors
 /mob/living/carbon/human/species/monkey/punpun/proc/give_special_name()
-	Read_Memory()
-
 	var/name_to_use = name
 
 	if(ancestor_name)

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -48,32 +48,19 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 	var/memory_saved = FALSE
 
 /mob/living/carbon/human/species/monkey/punpun/Initialize(mapload)
-	// 1 Pun Pun should exist
-	REGISTER_REQUIRED_MAP_ITEM(1, 1)
+	. = ..()
+
 	if(mapload && (locate(/datum/station_trait/job/pun_pun) in SSstation.station_traits))
 		new /obj/effect/landmark/start/pun_pun(loc) //Pun Pun is a crewmember, and may late-join.
 		return INITIALIZE_HINT_QDEL
-	Read_Memory()
 
-	var/name_to_use = name
-
-	if(ancestor_name)
-		name_to_use = ancestor_name
-		if(ancestor_chain > 1)
-			name_to_use += " \Roman[ancestor_chain]"
-	else if(prob(10))
-		name_to_use = pick(list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky"))
-		if(name_to_use == "Furious George")
-			ai_controller = /datum/ai_controller/monkey/angry //hes always mad
-
-	. = ..()
-
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 	if(!GLOB.the_one_and_only_punpun && mapload)
 		GLOB.the_one_and_only_punpun = src
 	else if(GLOB.the_one_and_only_punpun)
 		ADD_TRAIT(src, TRAIT_DONT_WRITE_MEMORY, INNATE_TRAIT) //faaaaaaake!
 
-	fully_replace_character_name(real_name, name_to_use)
+	give_special_name()
 
 	//These have to be after the parent new to ensure that the monkey
 	//bodyparts are actually created before we try to equip things to
@@ -141,3 +128,22 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 		file_data["relic_mask"] = wear_mask ? wear_mask.type : null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
+
+
+/// Gives pun pun a special name based on various factors
+/mob/living/carbon/human/species/monkey/punpun/proc/give_special_name()
+	Read_Memory()
+
+	var/name_to_use = name
+
+	if(ancestor_name)
+		name_to_use = ancestor_name
+		if(ancestor_chain > 1)
+			name_to_use += " \Roman[ancestor_chain]"
+	else if(prob(10))
+		name_to_use = pick(list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky"))
+		if(name_to_use == "Furious George")
+			qdel(ai_controller)
+			ai_controller = new /datum/ai_controller/monkey/angry(src) //hes always mad
+
+	fully_replace_character_name(real_name, name_to_use)


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/88502

## About The Pull Request

The issue with the current code is that it was returning `INITIALIZE_HINT_QDEL` without going through the whole carbon initialize chain, making it such that we were trying to qdel() the typepath of the `ai_controller` or the `bodypart`s instead of actual datums since those variables pull double duty. I don't think pun pun code should be lackadaisical when it comes to the carbon initialize chain, so I just shifted around a bunch of stuff to retain the same functionality while also making it that we do a full intialize. The tech debt of one monkey shall be infinite.
## Why It's Good For The Game

Less errors on monkey day = ideal.
## Changelog

I don't think this affected the holiday itself so not really player-facing
