### PR TITLE
Different access for tech storage on Catwalk

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -46307,10 +46307,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "muN" = (


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

idk feels weird that you must have construction access to enter tech storage, fucks up over roboticists

## Changelog

:cl:
map: Access changed from "construction" to "tech storage" in respective room entrance on Catwalk.
/:cl:
