### PR TITLE
Fixes runechat offsets for stored mobs

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -270,7 +270,7 @@
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
 	message.pixel_z = starting_height
-	message.pixel_w = -target.base_pixel_w
+	message.pixel_w = -message_loc.base_pixel_w
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight * 1.25 // We add extra because some characters are superscript, like actions
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5


### PR DESCRIPTION

## About The Pull Request

Stored mobs wider than 32 pixels, like worn purple raptors, would have offset runechat messages because they tried to use their own base_pixel_w instead of base_pixel_w of the atom that actually displayed the message

## Changelog
:cl:
fix: Fixed runechat offsets for stored mobs
/:cl:
