### PR TITLE
Fixes fire sound runtimes caused by incorrect arguments

### DIFF
--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -39,6 +39,9 @@
 	var/maxdistance = SOUND_RANGE + extrarange
 	var/source_z = turf_source.z
 
+	if (falloff_distance >= maxdistance)
+		CRASH("playsound(): falloff_distance is equal to or higher than maxdistance! Bump up extrarange or reduce the falloff_distance.")
+
 	if(vary && !frequency)
 		frequency = get_rand_frequency() // skips us having to do it per-sound later. should just make this a macro tbh
 

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -455,11 +455,13 @@
 	var/turf/open/sound_turf = locate(average_x, average_y, average_Z)
 	if(sound)
 		sound.falloff_distance = drop_off_dist
+		sound.extra_range = drop_off_dist
 		if(sound_turf != current_sound_loc)
 			sound.parent = sound_turf
 		return
 	sound = new(sound_turf, TRUE)
 	sound.falloff_distance = drop_off_dist
+	sound.extra_range = drop_off_dist
 	current_sound_loc = sound_turf
 
 #undef MIN_SIZE_SOUND


### PR DESCRIPTION

## About The Pull Request

falloff_distance should never be equal to or higher than maxdistance, which was the case for very large fires, preventing them from playing any sounds

## Changelog
:cl:
fix: Fixed fire sound runtimes caused by incorrect arguments
/:cl:
