### PR TITLE
Retypes headgear from /obj/item/clothing to /obj/item

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -10,7 +10,8 @@
 	else
 		return INFINITY //Can't get flashed without eyes
 	if(isclothing(head)) //Adds head protection
-		. += head.flash_protect
+		var/obj/item/clothing/helmet = head
+		. += helmet.flash_protect
 	if(isclothing(glasses)) //Glasses
 		. += glasses.flash_protect
 	if(isclothing(wear_mask)) //Mask

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -38,7 +38,7 @@
 	var/obj/item/tank/internal = null
 	/// "External" air tank. Never set this manually. Not required to stay directly equipped on the mob (i.e. could be a machine or MOD suit module).
 	var/obj/item/tank/external = null
-	var/obj/item/clothing/head = null
+	var/obj/item/head = null
 
 	///only used by humans
 	var/obj/item/clothing/gloves = null

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1349,8 +1349,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/handle_gas_interaction(mob/living/carbon/human/human, datum/gas_mixture/environment, seconds_per_tick, times_fired)
 	/// Some non-clothing items may end up in these slots, e.g. flowers worn on the head, so we should consider clothing_flags as potentially nonexistant as a var.
 	/// Otherwise we will get a very spammy runtime.
-	var/suit_flags = istype(human?.wear_suit, /obj/item/clothing) ? human.wear_suit.clothing_flags : NONE
-	var/head_flags = istype(human?.head, /obj/item/clothing) ? human.head.clothing_flags : NONE
+	var/suit_flags = astype(human?.wear_suit, /obj/item/clothing)?.clothing_flags
+	var/head_flags = astype(human?.head, /obj/item/clothing)?.clothing_flags
 
 	if((suit_flags & STOPSPRESSUREDAMAGE) && (head_flags & STOPSPRESSUREDAMAGE))
 		return

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -262,12 +262,12 @@
 
 /// Returns the helmet if an air tank compatible helmet is equipped.
 /mob/living/carbon/proc/can_breathe_helmet()
-	if (isclothing(head) && (head.clothing_flags & HEADINTERNALS))
+	if (astype(head, /obj/item/clothing)?.clothing_flags & HEADINTERNALS)
 		return head
 
 /// Returns the mask if an air tank compatible mask is equipped.
 /mob/living/carbon/proc/can_breathe_mask()
-	if (isclothing(wear_mask) && (wear_mask.clothing_flags & MASKINTERNALS))
+	if (astype(wear_mask, /obj/item/clothing)?.clothing_flags & MASKINTERNALS)
 		return wear_mask
 
 /// Returns the tube if a breathing tube is equipped.

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -189,7 +189,7 @@
 				if(feedback)
 					to_chat(owner, span_warning("You don't feel strong enough without your robe!"))
 				return FALSE
-			if(!(human_owner.head?.clothing_flags & CASTING_CLOTHES) && !(human_owner.glasses?.clothing_flags & CASTING_CLOTHES))
+			if(!(astype(human_owner.head, /obj/item/clothing)?.clothing_flags & CASTING_CLOTHES) && !(human_owner.glasses?.clothing_flags & CASTING_CLOTHES))
 				if(feedback)
 					to_chat(owner, span_warning("You don't feel strong enough without your hat!"))
 				return FALSE


### PR DESCRIPTION

## About The Pull Request

Headgear hasn't been restricted to clothing for a long while, and some code that attempts to treat it as such will runtime whenever you wear a pet on your head. God bless astype().

## Changelog
:cl:
code: Retyped headgear from /obj/item/clothing to /obj/item, fixing some runtimes in the process
/:cl:
