### PR TITLE
Fixes runtimes caused by auto-observing someone repeatedly

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -408,6 +408,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 		for(var/M in mymob.observers)
 			show_hud(hud_version, M)
 	else if (viewmob.hud_used)
+		viewmob.hide_other_mob_action_buttons(mymob)
 		viewmob.hud_used.plane_masters_update()
 		viewmob.show_other_mob_action_buttons(mymob)
 


### PR DESCRIPTION

## About The Pull Request

show_hud() did not properly unregister the signals which caused stack traces from signal overrides

## Changelog
:cl:
fix: Fixed runtimes caused by auto-observing someone repeatedly
/:cl:
