### PR TITLE
Fixes runtimes caused by opportunistic melee AI behaviors

### DIFF
--- a/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
@@ -27,7 +27,7 @@
 /datum/ai_behavior/basic_melee_attack/opportunistic/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	var/atom/movable/atom_pawn = controller.pawn
 	var/atom/atom_target = controller.blackboard[target_key]
-	if (isnull(target))
+	if (QDELETED(target))
 		return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 	if(!atom_target.IsReachableBy(atom_pawn))
 		return AI_BEHAVIOR_INSTANT | AI_BEHAVIOR_SUCCEEDED

--- a/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
@@ -22,11 +22,14 @@
 /datum/ai_behavior/basic_melee_attack/opportunistic/setup(datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	if (!controller.blackboard_key_exists(targeting_strategy_key))
 		CRASH("No target datum was supplied in the blackboard for [controller.pawn]")
+	var/atom/target = controller.blackboard[hiding_location_key] || controller.blackboard[target_key]
+	if(QDELETED(target))
+		return FALSE
 	return controller.blackboard_key_exists(target_key)
 
 /datum/ai_behavior/basic_melee_attack/opportunistic/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	var/atom/movable/atom_pawn = controller.pawn
-	var/atom/atom_target = controller.blackboard[target_key]
+	var/atom/atom_target = controller.blackboard[hiding_location_key] || controller.blackboard[target_key]
 	if(!atom_target.IsReachableBy(atom_pawn))
 		return AI_BEHAVIOR_INSTANT | AI_BEHAVIOR_SUCCEEDED
 	. = ..()

--- a/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
@@ -22,14 +22,13 @@
 /datum/ai_behavior/basic_melee_attack/opportunistic/setup(datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	if (!controller.blackboard_key_exists(targeting_strategy_key))
 		CRASH("No target datum was supplied in the blackboard for [controller.pawn]")
-	var/atom/target = controller.blackboard[hiding_location_key] || controller.blackboard[target_key]
-	if(QDELETED(target))
-		return FALSE
 	return controller.blackboard_key_exists(target_key)
 
 /datum/ai_behavior/basic_melee_attack/opportunistic/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	var/atom/movable/atom_pawn = controller.pawn
-	var/atom/atom_target = controller.blackboard[hiding_location_key] || controller.blackboard[target_key]
+	var/atom/atom_target = controller.blackboard[target_key]
+	if (isnull(target))
+		return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 	if(!atom_target.IsReachableBy(atom_pawn))
 		return AI_BEHAVIOR_INSTANT | AI_BEHAVIOR_SUCCEEDED
 	. = ..()

--- a/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/attack_adjacent_target.dm
@@ -27,7 +27,7 @@
 /datum/ai_behavior/basic_melee_attack/opportunistic/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targeting_strategy_key, hiding_location_key)
 	var/atom/movable/atom_pawn = controller.pawn
 	var/atom/atom_target = controller.blackboard[target_key]
-	if (QDELETED(target))
+	if (QDELETED(atom_target))
 		return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_FAILED
 	if(!atom_target.IsReachableBy(atom_pawn))
 		return AI_BEHAVIOR_INSTANT | AI_BEHAVIOR_SUCCEEDED


### PR DESCRIPTION

## About The Pull Request

Opportunistic melee behavior did not check for target's existence unlike its parent, which means it could runtime if the target got destroyed before the behavior ran

## Changelog
:cl:
fix: Fixes runtimes caused by opportunistic melee AI behaviors
/:cl:
