### PR TITLE
Fixes illusions not fleeing their targets and runtiming in place

### DIFF
--- a/code/modules/mob/living/basic/illusion/illlusion_ai.dm
+++ b/code/modules/mob/living/basic/illusion/illlusion_ai.dm
@@ -20,6 +20,7 @@
 /datum/ai_controller/basic_controller/illusion/escape
 	blackboard = list(
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic, // we don't need the special illusion one here
+		BB_FLEE_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 	)
 
 	ai_traits = DEFAULT_AI_FLAGS


### PR DESCRIPTION
## About The Pull Request

They did not have the fleeing targeting behavior assigned, hence they failed to do anything and runtimed in place

## Changelog
:cl:
fix: Fixed illusions not fleeing their targets and runtiming in place
/:cl:
