### PR TITLE
Fixes damp rags not removing reagents other than space cleaner from themselves

### DIFF
--- a/code/modules/reagents/reagent_containers/rag.dm
+++ b/code/modules/reagents/reagent_containers/rag.dm
@@ -177,7 +177,7 @@
 	amount_to_remove = how_dirty * 1.2
 	for(var/datum/reagent/other_reagent as anything in reagents.reagent_list)
 		if((other_reagent.chemical_flags & REAGENT_CLEANS) && other_reagent.volume >= amount_to_remove)
-			reagents.remove_reagent(other_reagent, amount_to_remove)
+			reagents.remove_reagent(other_reagent.type, amount_to_remove)
 			return TRUE
 
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

``remove_reagent`` requires a type, not an instance

## Changelog
:cl:
fix: Fixed damp rags not removing reagents other than space cleaner from themselves
/:cl:
