### PR TITLE
Adds a fifty sandbag stack as an object

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -72,6 +72,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	. = ..()
 	. += GLOB.sandbag_recipes
 
+/obj/item/stack/sheet/mineral/sandbags/fifty
+	amount = 50
+
 /obj/item/emptysandbag
 	name = "empty sandbag"
 	desc = "A bag to be filled with sand."

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -327,6 +327,7 @@
 		/obj/item/stack/rods/fifty = null,
 		/obj/item/stack/sheet/mineral/plastitanium = 50,
 		/obj/item/stack/sheet/mineral/abductor = 50,
+		/obj/item/stack/sheet/mineral/sandbags/fifty = null,
 		/obj/item/stack/sheet/cardboard/fifty = null,
 	)
 	for(var/obj/item/stack/stack_type as anything in items_inside)


### PR DESCRIPTION

## About The Pull Request
Title.
You can now spawn in/map in/exist in sandbags in a stack of fifty.
<img width="1004" height="338" alt="изображение" src="https://github.com/user-attachments/assets/3a0bf21c-20b3-4773-b5be-52ca3aca130b" />
<img width="566" height="549" alt="изображение" src="https://github.com/user-attachments/assets/403fa312-1643-4223-b3c6-57e9cb3e8d7c" />
## Why It's Good For The Game
This should prove useful for mappers and admins who'll require sandbags at one or another point.
~~See I needed sandbags for a map I'm making and varediting a stack into a fifty-stack felt wrong.~~
## Changelog
:cl: Stalkeros
add: Stack of fifty sandbags
/:cl:
