### PR TITLE
Fix signal unregistration in grapple gun on hit

### DIFF
--- a/code/modules/mining/equipment/grapple_gun.dm
+++ b/code/modules/mining/equipment/grapple_gun.dm
@@ -84,7 +84,7 @@
 /obj/item/grapple_gun/proc/on_grapple_hit(datum/source, atom/movable/firer, atom/target, Angle)
 	SIGNAL_HANDLER
 
-	UnregisterSignal(source, list(COMSIG_PROJECTILE_ON_HIT, COMSIG_PREQDELETED))
+	UnregisterSignal(source, list(COMSIG_PROJECTILE_SELF_ON_HIT, COMSIG_PREQDELETED))
 	QDEL_NULL(zipline)
 	var/mob/living/user = zipliner?.resolve()
 	if(isnull(user) || isnull(target))


### PR DESCRIPTION

## About The Pull Request

Changes the unregistering of COMSIG_PROJECTILE_ON_HIT to COMSIG_PROJECTILE_SELF_ON_HIT because COMSIG_PROJECTILE_ON_HIT  isn't used anywhere in grapple code but COMSIG_PROJECTILE_SELF_ON_HIT  is.

See lines 70 and 71 for what I mean.

## Why It's Good For The Game

Fixes good.

## Changelog

:cl: BurgerBB
fix: Fix signal unregistration in grapple gun on hit.
/:cl:
