### PR TITLE
Fixes a oversight on deltastation map

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -77002,12 +77002,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table,
 /obj/machinery/light/directional/west,
-/obj/item/stack/conveyor/thirty,
-/obj/item/boulder_beacon{
-	pixel_x = -5
+/obj/item/food/ready_donk/donkrange_chicken,
+/obj/item/food/ready_donk/donkhiladas{
+	pixel_y = 5
 	},
-/obj/item/conveyor_switch_construct{
-	pixel_x = 10
+/obj/item/food/ready_donk/country_chicken{
+	pixel_y = 10
+	},
+/obj/structure/closet/mini_fridge{
+	name = "mini-fridge"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)


### PR DESCRIPTION
## About The Pull Request
Fixes a oversight of manual boulder collection system still being on the table and replaces it with 3 instant donk meals in a minifridge
<img width="347" height="663" alt="image" src="https://github.com/user-attachments/assets/51727637-2106-40b0-ad0d-997c91c5b6ba" />


## Why It's Good For The Game
Cargo on deltastation already has a boulder collection system set up thus not requiring it to be manually set up anymore and to fill the void i added 3 instant meals because miners have a microwave with nothing microwaveable

## Changelog
:cl: Ezel
fix: Fixes a oversight on deltastation where mining still get a boulder beacon.
map: Nanotrasen now supplies deltastation mining employees with 3 instant meals before doing their workshift
/:cl:
