### PR TITLE
Map-unique technodes is excluded on maps that don't have it.

### DIFF
--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -618,6 +618,12 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
+/datum/design/telescreen_monastery/New()
+	var/has_monastery = CHECK_MAP_JOB_CHANGE(JOB_CHAPLAIN, "has_monastery")
+	if(!has_monastery)
+		id = DESIGN_ID_IGNORE
+	return ..()
+
 /datum/design/entertainment_radio
 	name = "Entertainment Radio"
 	id = "radio_entertainment"

--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -38,17 +38,16 @@
 	var/list/all_designs = list()
 	var/list/exceptions = list(
 		/datum/design/surgery/healing, // Ignored due to the above test
-		/datum/design/telescreen_monastery, // It's map-specific, so it doesn't always have a source.
 	)
 
 	for (var/datum/design/design as anything in subtypesof(/datum/design))
-		var/design_id = design::id
-		if (design_id == DESIGN_ID_IGNORE || (design in exceptions))
+		design = new design()
+		if (design.id == DESIGN_ID_IGNORE || (design.type in exceptions))
 			continue
-		if (design_id in all_designs)
-			TEST_FAIL("Design [design] shares an ID \"[design_id]\" with another design")
+		if (design.id in all_designs)
+			TEST_FAIL("Design [design.type] shares an ID \"[design.id]\" with another design")
 			continue
-		all_designs[design_id] = design
+		all_designs[design.id] = design.type
 
 	for (var/datum/techweb_node/node as anything in subtypesof(/datum/techweb_node))
 		node = new node()


### PR DESCRIPTION
## About The Pull Request

As the title says, this excludes Kilo & Pubby from failing CI due to the design being added while the tech node isn't, now it's only ran if the map has it. This was an oversight of my original PR https://github.com/tgstation/tgstation/pull/94160

## Changelog

Nothing player-facing.