### PR TITLE
Death moodlets no longer runtime when stacking

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -623,14 +623,14 @@
 		mood_change *= 1.5
 	return ..()
 
-/datum/mood_event/see_death/be_replaced(datum/mood/home, datum/mood_event/new_event, ...)
+/datum/mood_event/see_death/be_replaced(datum/mood/home, datum/mood_event/new_event, mob/dead_mob, ...)
 	// Only be replaced if the incoming event's base mood is worse than our base mood
 	// (IE: replace normal death events with gib events, but not the other way around)
 	if(initial(new_event.mood_change) > initial(mood_change))
 		new_event.mood_change = max(new_event.mood_change, mood_change * 1.5)
 		return ..()
 	// Otherwise if it's equivalent or worse, refresh it instead
-	return be_refreshed(home)
+	return be_refreshed(home, dead_mob)
 
 /// Changes "I saw Joe x" to "I saw the engineer x"
 /datum/mood_event/see_death/proc/get_descriptor(mob/dead_mob)


### PR DESCRIPTION

## About The Pull Request

``be_refreshed`` expects a dead mob which we don't pass down, causing a runtime and preventing the stacking mood debuff

## Changelog
:cl:
fix: Death moodlets no longer runtime when stacking
/:cl:
