### PR TITLE
Fixes meshes runtiming when the target has a non-burn wound

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -328,7 +328,7 @@
 				break // one at a time
 		affecting.adjustBleedStacks(-1 * stop_bleeding, 0)
 	if(flesh_regeneration || sanitization)
-		for(var/datum/wound/burn/flesh/wound as anything in affecting.wounds)
+		for(var/datum/wound/burn/flesh/wound in affecting.wounds)
 			if(wound.can_be_ointmented_or_meshed())
 				wound.flesh_healing += flesh_regeneration
 				wound.sanitization += sanitization


### PR DESCRIPTION

## About The Pull Request

Wounds other than burns exist, so this would runtime if any non-burn wound was present on the healed part.

## Changelog
:cl:
fix: Fixed meshes runtiming when the target has a non-burn wound
/:cl:
