### PR TITLE
Fixes runtimes from stun batons impacting objects when thrown

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -732,7 +732,7 @@
 
 /obj/item/melee/baton/security/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	if(!. && active && prob(throw_stun_chance) && hit_atom)
+	if(!. && active && prob(throw_stun_chance) && isliving(hit_atom))
 		finalize_baton_attack(hit_atom, throwingdatum?.get_thrower())
 
 /obj/item/melee/baton/security/emp_act(severity)


### PR DESCRIPTION

## About The Pull Request

``finalize_baton_attack`` and subsequently ``baton_effect`` are only meant to be called on living mobs.

## Changelog
:cl:
fix: Fixed runtimes from stun batons impacting objects when thrown
/:cl:
