### PR TITLE
Fixes runtimes caused by persistent scars trying to save bodyswapped people's scars

### DIFF
--- a/code/controllers/subsystem/persistence/scars.dm
+++ b/code/controllers/subsystem/persistence/scars.dm
@@ -5,7 +5,7 @@
 		if(!istype(ending_human) || !ending_human.mind?.original_character_slot_index || !ending_human.client?.prefs.read_preference(/datum/preference/toggle/persistent_scars))
 			continue
 
-		var/mob/living/carbon/human/original_human = ending_human.mind.original_character.resolve()
+		var/mob/living/carbon/human/original_human = ending_human.mind.original_character?.resolve()
 
 		if(!original_human)
 			continue


### PR DESCRIPTION

## About The Pull Request

Original slot index is preserved upon mind transferring between bodies, but original character isn't, so this could runtime if you bodyswapped, lived until roundend and had persistent scars on.

## Changelog
:cl:
fix: Fixed runtimes caused by persistent scars trying to save bodyswapped people's scars
/:cl:
