### PR TITLE
Fixes RMB interactions for IV drips

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -42,6 +42,8 @@
 	var/internal_volume_maximum = 100
 	/// If the blood draining tab should be greyed out
 	var/inject_only = FALSE
+	/// Does this IV drip have quick interactions like quick detachment/ejection on right click?
+	var/secondary_interaction = TRUE
 	/// Typecache of containers we accept.
 	var/static/list/drip_containers = typecacheof(list(
 		/obj/item/reagent_containers/blood,
@@ -276,7 +278,7 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
-	if(!ishuman(user))
+	if(!ishuman(user) || !secondary_interaction)
 		return
 	if(attachment)
 		visible_message(span_notice("[attachment.attached_to] is detached from [src]."))

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -42,8 +42,6 @@
 	var/internal_volume_maximum = 100
 	/// If the blood draining tab should be greyed out
 	var/inject_only = FALSE
-	/// Does this IV drip have quick interactions like quick detachment/ejection on right click?
-	var/secondary_interaction = TRUE
 	/// Typecache of containers we accept.
 	var/static/list/drip_containers = typecacheof(list(
 		/obj/item/reagent_containers/blood,
@@ -276,10 +274,12 @@
 
 /obj/machinery/iv_drip/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || !ishuman(user))
 		return
-	if(!ishuman(user) || !secondary_interaction)
-		return
+	if (quick_toggle(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/machinery/iv_drip/proc/quick_toggle(mob/user)
 	if(attachment)
 		visible_message(span_notice("[attachment.attached_to] is detached from [src]."))
 		detach_iv()
@@ -287,7 +287,7 @@
 		eject_beaker(user)
 	else
 		toggle_mode()
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return TRUE
 
 ///called when an IV is attached
 /obj/machinery/iv_drip/proc/attach_iv(atom/target, mob/user)

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -7,17 +7,15 @@
 	density = TRUE
 	use_internal_storage = TRUE
 	processing_flags = START_PROCESSING_MANUALLY
+	secondary_interaction = FALSE
 
 /obj/machinery/iv_drip/plumbing/Initialize(mapload, bolt, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/automated_iv, bolt, layer)
 	AddComponent(/datum/component/simple_rotation)
 
-/obj/machinery/iv_drip/attack_hand_secondary(mob/user, list/modifiers)
-	return FALSE
-
 /obj/machinery/iv_drip/plumbing/click_alt(mob/user)
-	return FALSE
+	return NONE
 
 /obj/machinery/iv_drip/plumbing/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -7,12 +7,14 @@
 	density = TRUE
 	use_internal_storage = TRUE
 	processing_flags = START_PROCESSING_MANUALLY
-	secondary_interaction = FALSE
 
 /obj/machinery/iv_drip/plumbing/Initialize(mapload, bolt, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/automated_iv, bolt, layer)
 	AddComponent(/datum/component/simple_rotation)
+
+/obj/machinery/iv_drip/plumbing/quick_toggle(mob/living/user)
+	return FALSE
 
 /obj/machinery/iv_drip/plumbing/click_alt(mob/user)
 	return NONE


### PR DESCRIPTION

## About The Pull Request

#94058 mistyped plumbing IV drip RMB override and broke all IV drips. Also FALSE is not a valid return, we just need to prevent the child's code from running in that scenario.

## Changelog
:cl:
fix: Fixed RMB interactions for IV drips
/:cl:
