### PR TITLE
Gives Hos a ID console on catwalk

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -28533,7 +28533,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central/upper)
 "hLC" = (
-/obj/machinery/computer/prisoner/management,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -42514,7 +42513,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lvE" = (
-/obj/machinery/roulette,
+/obj/machinery/modular_computer/preset/id{
+	dir = 4
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
 "lvR" = (


### PR DESCRIPTION
## About The Pull Request
This PR gives HOS a ID modification console in his office in catwalk
Removes prisoner management from his office since thats usually located in the warden office (without turning hos office in its own bridge worth of consoles)
Removes Roulette table not sure if this is a reference to something but it didn't click for me (though the double office hos office is kinda weird.)

## Why It's Good For The Game

So hos can do ID modifications again without downloading a program on their PDA

## Changelog
:cl: Ezel
fix: Hos office on catwalk now includes an ID console
/:cl:
