### PR TITLE
Makes it so catwalk gravgen apc isn't in the generator room itself

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -7722,6 +7722,7 @@
 	pixel_x = 4;
 	pixel_y = 5
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "cbC" = (
@@ -31181,11 +31182,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
-"iua" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/engineering/gravity_generator)
 "iub" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -36652,7 +36648,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai/satellite/chamber)
 "jRQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
@@ -64635,7 +64630,6 @@
 /area/station/science/xenobiology)
 "rvo" = (
 /obj/structure/table,
-/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -64647,6 +64641,8 @@
 	pixel_y = -9;
 	pixel_x = -3
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "rvs" = (
@@ -76498,6 +76494,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "uFj" = (
@@ -78249,7 +78246,6 @@
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
 "vek" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_large,
@@ -84853,7 +84849,6 @@
 /turf/closed/wall,
 /area/station/security/prison/rec)
 "wVh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
@@ -196673,7 +196668,7 @@ rvv
 unl
 eZC
 wyV
-iua
+eZC
 vek
 wVh
 jVB


### PR DESCRIPTION
## About The Pull Request
This PR changes the apc location from being inside the generator room itself to be outside

From this
<img width="492" height="799" alt="image" src="https://github.com/user-attachments/assets/3305f317-a123-4125-9bc8-cf195488fa89" />

To this
<img width="505" height="791" alt="image" src="https://github.com/user-attachments/assets/bb796399-3891-4ce5-8efa-9f94fb385313" />


## Why It's Good For The Game
I don't like my bones crushed trying to do some simple APC maintenance

## Changelog
:cl: Ezel
map: Changes the location of catwalk gravgen APC to be outside the Generator room
/:cl:
