### PR TITLE
Changes access for ordnance shutters button on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29036,7 +29036,7 @@
 /obj/machinery/button/door/directional/north{
 	id = "rdordnance";
 	name = "Ordnance Containment Control";
-	req_access = list("rd")
+	req_access = list("science")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)


### PR DESCRIPTION
## About The Pull Request

title. changes from rd to science

## Why It's Good For The Game

because no one from sci except rd can close shutters if ordnance goes spicy

## Changelog

:cl:
map: Changed access for ordnance shutters button on MetaStation (from RD -> Science)
/:cl:
