### PR TITLE
Fixes black raptors not hatching from eggs with 6+ color inheritance.

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/_raptor.dm
@@ -280,7 +280,7 @@ GLOBAL_LIST_EMPTY(raptor_population)
 		return partner.raptor_color.guaranteed_crossbreeds[raptor_color.type]
 
 	// We've got all the colors in our family tree and aren't rolling a guarantee, bingo
-	if (length(inherited_stats.parent_colors | partner.inherited_stats.parent_colors | raptor_color.type | partner.raptor_color.type) == length(GLOB.raptor_colors))
+	if (length(inherited_stats.parent_colors | partner.inherited_stats.parent_colors | raptor_color.type | partner.raptor_color.type) >= (length(GLOB.raptor_colors) - 1))
 		return /datum/raptor_color/black
 
 	var/list/prob_list = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue #94484 , where black raptors don't spawn from eggs with 6 or more inherited colors.
The fix is done by changing a check against "== length(GLOB.raptor_colors))" to ">= (length(GLOB.raptor_colors) - 1))".
Let me know if I should go back to the drawing board, here.

Benefits of this approach:
- Fixes the base issue; if red, green, purple, yellow, white, and blue raptors are cross-bred, black raptors can be guaranteed.
- Offspring of black raptors will now also be guaranteed black raptor spawns.

Drawbacks and risks of this approach:
- Doesn't do much for extensibility if more rare raptor colors are to be added.
- May make black raptors too accessible, especially since one black raptor means all future breeding attempts will also result in a black raptor.
- Introduces an issue in which a black raptor can be guaranteed from 5 non-rares and 1 black raptor. I figured this wouldn't be considered a problem from the player perspective.
- I'm not a professional coder, so I may have missed some obvious issues.


## Why It's Good For The Game

If I interpret the description in PR #93564 correctly, black raptors were originally intended to hatch from eggs that had all six raptor colors besides black. (The exception: If there was a color combination that guaranteed a specific resulting color, the guaranteed color would still take precedence.)

This allows Black Raptors to be an achievable goal beyond breeding as many raptors as possible and hoping for the 1/199 chance to hit.


## Proof of Testing

<img width="439" height="133" alt="RaptorFix" src="https://github.com/user-attachments/assets/79507355-34ec-4a97-b586-37653229a2d8" />

Verified:
- Non-guaranteed combos result in a black raptor if the inheritance list is 6 or higher
- Includes the offspring of black raptors hatched in this way
- Same-color pairs, even with 6+ inheritance colors, will result in a hatchling of the same color
- Guaranteed-color pairs, even with 6+ inheritance colors, will result in a hatchling of the guaranteed color
- Black raptors **don't** have guaranteed or likely spawns if the inheritance color list is less than 6 in length


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When all six non-rare colors of raptor are cross-bred, a black raptor now consistently spawns (unless a guaranteed color-combo supersedes it).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
