### PR TITLE
Adds a warning for invalid dynamic config weights

### DIFF
--- a/code/controllers/subsystem/dynamic/_dynamic_ruleset.dm
+++ b/code/controllers/subsystem/dynamic/_dynamic_ruleset.dm
@@ -110,6 +110,7 @@
 	if(new_var in locked_config_values)
 		log_dynamic("Bad config edit rejected: [new_var]")
 		return FALSE
+
 	if(islist(new_val) && (new_var == NAMEOF(src, weight) || new_var == NAMEOF(src, min_pop)))
 		new_val = load_tier_list(new_val)
 
@@ -128,7 +129,16 @@
 	var/alist/tier_list = alist()
 	// loads a list of list("2" = 1, "3" = 3) into an alist(2 = 1, 3 = 3)
 	for(var/tier in incoming_list)
-		tier_list[text2num(tier)] = incoming_list[tier]
+		var/tier_value = text2num(tier)
+		if (tier_value > DYNAMIC_TIER_HIGH)
+			stack_trace("Dynamic config for [name] encountered a tier value exceeding DYNAMIC_TIER_HIGH!")
+			message_admins(span_boldannounce("Dynamic config for [name] encountered a tier value exceeding DYNAMIC_TIER_HIGH!"))
+			tier_value = DYNAMIC_TIER_HIGH
+		else if (tier_value < DYNAMIC_TIER_GREEN)
+			stack_trace("Dynamic config for [name] encountered a negative tier value, below DYNAMIC_TIER_GREEN!")
+			message_admins(span_boldannounce("Dynamic config for [name] encountered a negative tier value, below DYNAMIC_TIER_GREEN!"))
+			tier_value = DYNAMIC_TIER_GREEN
+		tier_list[tier_value] = incoming_list[tier]
 
 	return tier_list
 


### PR DESCRIPTION

## About The Pull Request

Warns admins and clamps values for dynamic weights/pops to ensure that invalid values don't get stored in the list
Should prevent errors like https://github.com/tgstation-operations/server-config/commit/e3c44eebf3de8f6b99a7ddc18268e87b33d793cb from slipping under our radar in the future

## Changelog
:cl:
admin: Added a warning for invalid dynamic config weights
/:cl:
