### PR TITLE
Chatbar now scrolls

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -259,12 +259,13 @@ window "inputwindow"
 	elem "input"
 		type = INPUT
 		pos = 0,0
-		size = 805x20
+		size = 520x20
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
 		border = line
 		saved-params = "command"
+		can-scroll = true
 
 window "inputbuttons"
 	elem "inputbuttons"


### PR DESCRIPTION
## About The Pull Request

ignore my terrible spelling

https://github.com/user-attachments/assets/fe6fd4f1-5b45-44e1-bf5c-60a893ea76bb

god bless https://www.byond.com/docs/ref/skinparams.html (ignore the fact i'm putting it on a non-main window, it just works)

## Why It's Good For The Game

It's very annoying that much of your text is cut off when using the bar

## Changelog

:cl:
fix: The chat bar now scrolls as you type.
/:cl: