### PR TITLE
[TM FIRST] Literally just halves the performance cost of cameras

### DIFF
--- a/code/controllers/subsystem/cameras.dm
+++ b/code/controllers/subsystem/cameras.dm
@@ -25,29 +25,6 @@ SUBSYSTEM_DEF(cameras)
 	/// Tracks current subsystem run
 	var/list/current_run = list()
 
-// TESTING
-/client/verb/update_all_chunks_verb()
-	set name = "Update All Chunks"
-	set category = "Testing"
-
-	SScameras.update_all_chunks()
-
-/datum/controller/subsystem/cameras/proc/update_all_chunks()
-    var/x1 = 1
-    var/y1 = 1
-    var/x2 = world.maxx
-    var/y2 = world.maxy
-
-    var/list/visibleChunks = list()
-    for(var/z_coord in 1 to world.maxz)
-        for(var/x = x1; x <= x2; x += CHUNK_SIZE)
-            for(var/y = y1; y <= y2; y += CHUNK_SIZE)
-                visibleChunks |= generate_chunk(x, y, z_coord)
-
-    for(var/datum/camerachunk/lad in visibleChunks)
-        lad.update()
-// TESTING
-
 /datum/controller/subsystem/cameras/Initialize()
 	update_offsets(SSmapping.max_plane_offset)
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(on_offset_growth))

--- a/code/controllers/subsystem/cameras.dm
+++ b/code/controllers/subsystem/cameras.dm
@@ -25,6 +25,29 @@ SUBSYSTEM_DEF(cameras)
 	/// Tracks current subsystem run
 	var/list/current_run = list()
 
+// TESTING
+/client/verb/update_all_chunks_verb()
+	set name = "Update All Chunks"
+	set category = "Testing"
+
+	SScameras.update_all_chunks()
+
+/datum/controller/subsystem/cameras/proc/update_all_chunks()
+    var/x1 = 1
+    var/y1 = 1
+    var/x2 = world.maxx
+    var/y2 = world.maxy
+
+    var/list/visibleChunks = list()
+    for(var/z_coord in 1 to world.maxz)
+        for(var/x = x1; x <= x2; x += CHUNK_SIZE)
+            for(var/y = y1; y <= y2; y += CHUNK_SIZE)
+                visibleChunks |= generate_chunk(x, y, z_coord)
+
+    for(var/datum/camerachunk/lad in visibleChunks)
+        lad.update()
+// TESTING
+
 /datum/controller/subsystem/cameras/Initialize()
 	update_offsets(SSmapping.max_plane_offset)
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(on_offset_growth))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -401,19 +401,24 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 		return FALSE
 	return TRUE
 
-/// Returns a list of turfs in this camera's view.
-/// This includes turfs that are "obscured by darkness" from the camera's POV.
+/// Returns an alist of turfs in this camera's view. This includes turfs that are "obscured by darkness" from the camera's POV.
+/// Format is "alist[turf] = null", if you need to check individual objects use "length(can_see & list(turf))". Only "&" and "in" work for checking contents, but "in" is much slower.
+/// Always have the return value of can_see as the left-hand operand, otherwise it uses list checks instead of alist checks and your CPU time gets thrown in a blender.
 /obj/machinery/camera/proc/can_see()
-	var/alist/see = null
+	var/alist/see = alist()
 	var/turf/pos = get_turf(src)
 	var/turf/directly_above = GET_TURF_ABOVE(pos)
 	var/check_lower = pos != get_lowest_turf(pos)
 	var/check_higher = directly_above && istransparentturf(directly_above) && (pos != get_highest_turf(pos))
 
 	if(isXRay())
-		see = RANGE_TURFS(view_range, pos)
+		see += RANGE_TURFS(view_range, pos)
 	else
-		see = get_hear_turfs(view_range, pos)
+		var/lum = pos.luminosity
+		pos.luminosity = 6
+		for(var/turf/turf in view(view_range, pos))
+			see += turf
+		pos.luminosity = lum
 
 	if(check_lower || check_higher)
 		// Haha datum var access KILL ME
@@ -429,12 +434,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 					see += RANGE_TURFS(1, above)
 					above = GET_TURF_ABOVE(above)
 
-	var/alist/see_alist = alist()
-
-	for (var/turf/seen as anything in see)
-		see_alist[seen] = TRUE
-
-	return see_alist
+	return see
 
 /obj/machinery/camera/proc/Togglelight(on=0)
 	for(var/mob/living/silicon/ai/A in GLOB.ai_list)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -404,7 +404,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 /// Returns a list of turfs in this camera's view.
 /// This includes turfs that are "obscured by darkness" from the camera's POV.
 /obj/machinery/camera/proc/can_see()
-	var/list/see = null
+	var/alist/see = null
 	var/turf/pos = get_turf(src)
 	var/turf/directly_above = GET_TURF_ABOVE(pos)
 	var/check_lower = pos != get_lowest_turf(pos)
@@ -428,7 +428,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 				while(above && istransparentturf(above))
 					see += RANGE_TURFS(1, above)
 					above = GET_TURF_ABOVE(above)
-	return see
+
+	var/alist/see_alist = alist()
+
+	for (var/turf/seen as anything in see)
+		see_alist[seen] = TRUE
+
+	return see_alist
 
 /obj/machinery/camera/proc/Togglelight(on=0)
 	for(var/mob/living/silicon/ai/A in GLOB.ai_list)

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -103,8 +103,6 @@
 		return
 	update()
 
-GLOBAL_LIST_EMPTY(camera_cost)
-GLOBAL_LIST_EMPTY(camera_count)
 /// The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
 /datum/camerachunk/proc/update()
 	if(SScameras.disable_camera_updates)

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -103,31 +103,50 @@
 		return
 	update()
 
+GLOBAL_LIST_EMPTY(camera_cost)
+GLOBAL_LIST_EMPTY(camera_count)
 /// The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
 /datum/camerachunk/proc/update()
+	INIT_COST(GLOB.camera_cost, GLOB.camera_count)
+	EXPORT_STATS_TO_CSV_LATER("camera chunks.txt", GLOB.camera_cost, GLOB.camera_count)
 	if(SScameras.disable_camera_updates)
 		return
+	SET_COST("Update check")
 
 	update_sources.Cut()
+	SET_COST("Cut sources")
 
 	var/list/updated_visible_turfs = list()
+	SET_COST("List setup")
 
 	for(var/z_level in lower_z to upper_z)
 		for(var/obj/machinery/camera/current_camera as anything in cameras[z_level])
 			if(!current_camera || !current_camera.can_use())
 				continue
+			SET_COST("Validate camera")
 
 			var/turf/point = locate(src.x + (CHUNK_SIZE / 2), src.y + (CHUNK_SIZE / 2), z_level)
+			SET_COST("Locate point")
+
 			if(get_dist(point, current_camera) > CHUNK_SIZE + (CHUNK_SIZE / 2))
 				continue
+			SET_COST("Compare dist")
 
-			for(var/turf/vis_turf as anything in turfs & current_camera.can_see())
+			var/list/can_see = current_camera.can_see()
+			SET_COST("Collect turfs")
+
+			var/list/updating = can_see & turfs
+			SET_COST("The evil & operator")
+
+			for(var/turf/vis_turf as anything in updating)
 				updated_visible_turfs[vis_turf] = vis_turf
+			SET_COST("Updating visible turfs")
 
 	///new turfs that we couldnt see last update but can now
 	var/list/newly_visible_turfs = updated_visible_turfs - visibleTurfs
 	///turfs that we could see last update but cant see now
 	var/list/newly_obscured_turfs = visibleTurfs - updated_visible_turfs
+	SET_COST("Turf list substractions")
 
 	for(var/mob/eye/camera/client_eye as anything in seenby)
 		var/client/client = client_eye.GetViewerClient()
@@ -135,6 +154,7 @@
 			continue
 
 		client.images -= active_static_images
+	SET_COST("Removing old client images")
 
 	for(var/turf/visible_turf as anything in newly_visible_turfs)
 		var/image/static_image = obscuredTurfs[visible_turf]
@@ -143,6 +163,7 @@
 
 		active_static_images -= static_image
 		obscuredTurfs -= visible_turf
+	SET_COST("Removing old static images")
 
 	for(var/turf/obscured_turf as anything in newly_obscured_turfs)
 		if(obscuredTurfs[obscured_turf] || istype(obscured_turf, /turf/open/ai_visible))
@@ -156,6 +177,7 @@
 		obscuredTurfs[obscured_turf] = static_image
 		active_static_images += static_image
 	visibleTurfs = updated_visible_turfs
+	SET_COST("Adding new static images")
 
 	for(var/mob/eye/camera/client_eye as anything in seenby)
 		var/client/client = client_eye.GetViewerClient()
@@ -163,7 +185,7 @@
 			continue
 
 		client.images += active_static_images
-
+	SET_COST("Adding new client images")
 
 /// Create a new camera chunk, since the chunks are made as they are needed.
 /datum/camerachunk/New(x, y, lower_z)

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -174,7 +174,7 @@
 		CRASH("[src] was able to track [target] through /datum/trackable, but was not on a visible turf to cameras.")
 	for(var/obj/machinery/camera/cameras as anything in target_camerachunk.cameras[target.z])
 		// We need to find a particular camera that can see this turf
-		if(!(target_turf in cameras.can_see()))
+		if(length(cameras.can_see() & list(target_turf)))
 			continue
 		var/new_camera = WEAKREF(cameras)
 		if(camera_ref == new_camera)


### PR DESCRIPTION
## About The Pull Request

Title, I used an alist and some inlined list operation tricks to make camera chunk updates twice as fast.

The data in the screenshots is from me updating every single camera chunk on Meta. I did also test on Icebox and it scaled just as well there as it did on Meta, which means that multi-z doesn't cause any issues for these changes.

The correct way to compare these costs is to take the total cost, divide it by the count, and then compare them relatively to see which is higher/lower and by how much.

Before:
<img width="415" height="306" alt="image" src="https://github.com/user-attachments/assets/c3be5986-e405-412d-a9e0-cc34014a7dab" />

After (combined keys):
The value of "update visible turfs" here is just a merged version of "collect turfs" + "the & operator" + "update visible turfs"
<img width="356" height="271" alt="image" src="https://github.com/user-attachments/assets/93ca0e9a-bf17-4b87-a4f0-c70c70148ab0" />

After 2 (separate keys, but fucked up counts):
Not as directly comparable cuz the counts are fucked up, gotta do some math to figure it out.
<img width="414" height="293" alt="image" src="https://github.com/user-attachments/assets/205d4842-4294-4130-a7dd-69d196d318e9" />

The biggest remaining performance bottleneck, which now accounts for ~70% of all the performance cost of camera chunks, is camera.can_see() being slow as balls. You can see this in the After 2 image.

The only cost of doing this is that the format of the list is now "alist[turf] = null" instead of "list[i] = turf", which makes checking for individual turfs cumbersome. Entirely possible and and still relatively performant, but the syntax is just cumbersome. Said single checks are only used by SyndEye as of now.
## Why It's Good For The Game

On live, it seems that camera chunks are consistently the biggest and fattest source of performance loss and overtime in the entire game. Obviously halving that cost is good for the game.
## Changelog
:cl:
fix: Camera chunks, the biggest source of lag in the entire game, now run twice as fast.
/:cl:
