### PR TITLE
Science officers landmarks on TramStation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14909,6 +14909,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "eaq" = (
@@ -18294,6 +18295,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fnZ" = (
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "fof" = (
@@ -49578,6 +49580,7 @@
 "qsm" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/sign/poster/official/safety_report/directional/south,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "qsJ" = (
@@ -71510,6 +71513,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "ybZ" = (


### PR DESCRIPTION
## About The Pull Request

adds some missing spawners to prevent this from happening:
<img width="418" height="385" alt="image" src="https://github.com/user-attachments/assets/48cb2372-c366-4e8a-b2a8-f7086191a5e6" />

this is more of a bandaid and in future someone (or maybe me) should remake how security officers spawn in outposts. (atm if theres no spawner for department officer they will spawn in any tile of an outpost area, including walls)

## Changelog

:cl:
fix: Mapped missing security spawners in science outpost on TramStation to prevent spawning in walls.
/:cl:
