### PR TITLE
Makes it so security officers don't spawn in walls

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 			while (length(possible_turfs))
 				var/random_index = rand(1, length(possible_turfs))
 				var/turf/target = possible_turfs[random_index]
-				if (spawning.forceMove(target))
+				if (isopenturf(target) && spawning.forceMove(target))
 					break
 				possible_turfs.Cut(random_index, random_index + 1)
 


### PR DESCRIPTION

## About The Pull Request

Departmental security officers that do not have a departmental outpost spawnpoint will only spawn in open turfs

## Why It's Good For The Game

While security officers being in your walls does provide notable surveillance benefits, Nanotrasen has not yet developed technology that can sustain these officers without air.

## Changelog
:cl:

fix: Departmental security officers will not spawn in walls

/:cl:
