### PR TITLE
Clowns take a couple of seconds to realise they're about to fall into chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -168,11 +168,24 @@
 		return
 
 	// send to oblivion
-	dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[oblivion_message]"))
+
 	if (isliving(dropped_thing))
 		var/mob/living/falling_mob = dropped_thing
 		ADD_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))
-		falling_mob.Paralyze(20 SECONDS)
+		falling_mob.Stun(20 SECONDS, ignore_canstun = TRUE)
+
+		if (HAS_MIND_TRAIT(falling_mob, TRAIT_NAIVE))
+			falling_mob.do_alert_animation()
+			dropped_thing.visible_message(span_boldwarning("[dropped_thing] kicks [dropped_thing.p_their()] legs in the air, as if running in place!"))
+			dropped_thing.Shake(1, 0, 2 SECONDS, 0.3 SECONDS)
+			sleep(3 SECONDS)
+
+		if (get_turf(falling_mob) != get_turf(parent))
+			REMOVE_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))
+			falling_mob.Paralyze(17 SECONDS, ignore_canstun = TRUE) // Wow nice job
+			return
+
+	dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[oblivion_message]"))
 
 	var/oldtransform = dropped_thing.transform
 	var/oldcolor = dropped_thing.color

--- a/code/modules/mob/living/basic/clown/clown.dm
+++ b/code/modules/mob/living/basic/clown/clown.dm
@@ -42,6 +42,7 @@
 
 /mob/living/basic/clown/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_NAIVE, INNATE_TRAIT)
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_SHOE)
 	AddComponent(/datum/component/ai_retaliate_advanced, CALLBACK(src, PROC_REF(retaliate_callback)))
 	ai_controller.set_blackboard_key(BB_BASIC_MOB_SPEAK_LINES, emotes)


### PR DESCRIPTION
## About The Pull Request

https://github.com/user-attachments/assets/efaddb45-d3f4-4f90-acda-746c2364ac96

If someone with `TRAIT_NAIVE` walks into a chasm they will hang there for 3 seconds before falling.
This does not give them the opportunity to save themselves because they are completely unable to take action at this time, but in the extremely unlikely event that someone throws a bluespace tomato at them then they will miraculously survive.

This is maybe a bit of a stretch for `TRAIT_NAIVE` (although I guess it's naive behaviour to not realise that you walked off a cliff?) which has otherwise remained pretty clean in terms of "it makes you mistake dead things for sleeping things" but I didn't want to make a new trait and apply it to everything that has `TRAIT_NAIVE".

Also this gives clown basic mobs `TRAIT_NAIVE` which they apparently didn't already have, so now sapient clown mutants can happily put the other crew members to sleep instead of killing them.

## Why It's Good For The Game

<img width="700" height="393" alt="image" src="https://github.com/user-attachments/assets/689b9f9a-bc86-4777-947e-e9d8f9fd4eb9" />

It's a classic bit, gives the clown time to say something that isn't very funny.

## Changelog

:cl:
add: It takes a little bit longer for clowns to realise that they're about to die when they enter a chasm
/:cl: