### PR TITLE
Stops hauntium from trying to haunt objects it is incapable of haunting

### DIFF
--- a/code/datums/elements/haunted.dm
+++ b/code/datums/elements/haunted.dm
@@ -24,12 +24,12 @@
 	REMOVE_TRAIT(master, TRAIT_MOVE_FLYING, ELEMENT_TRAIT(type))
 	master.RemoveElement(/datum/element/movetype_handler)
 
-/atom/movable/proc/make_haunted(source, color) //if not haunted, make haunted
+/obj/item/proc/make_haunted(source, color) //if not haunted, make haunted
 	if(!HAS_TRAIT(src, TRAIT_HAUNTED))
 		AddElement(/datum/element/haunted, color)
 	ADD_TRAIT(src, TRAIT_HAUNTED, source)
 
-/atom/movable/proc/remove_haunted(source) //if haunted, make not haunted
+/obj/item/proc/remove_haunted(source) //if haunted, make not haunted
 	REMOVE_TRAIT(src, TRAIT_HAUNTED, source)
 	if(!HAS_TRAIT(src, TRAIT_HAUNTED))
 		RemoveElement(/datum/element/haunted)

--- a/code/datums/materials/hauntium.dm
+++ b/code/datums/materials/hauntium.dm
@@ -42,10 +42,10 @@
 
 /datum/material/hauntium/on_main_removed(atom/source, mat_amount, multiplier)
 	. = ..()
-	if(!isobj(source))
+	if(!isitem(source))
 		return
-	var/obj/obj = source
-	obj.remove_haunted(INNATE_TRAIT)
+	var/obj/item/source_item = source
+	source_item.remove_haunted(INNATE_TRAIT)
 	if(isbodypart(source))
 		var/obj/item/bodypart/bodypart = source
 		if(!(bodypart::bodytype & BODYTYPE_GHOST))

--- a/code/datums/materials/hauntium.dm
+++ b/code/datums/materials/hauntium.dm
@@ -27,10 +27,10 @@
 
 /datum/material/hauntium/on_main_applied(atom/source, mat_amount, multiplier)
 	. = ..()
-	if(!isobj(source))
+	if(!isitem(source))
 		return
-	var/obj/obj = source
-	obj.make_haunted(INNATE_TRAIT, "#f8f8ff")
+	var/obj/item/source_item = source
+	source_item.make_haunted(INNATE_TRAIT, "#f8f8ff")
 	if(isbodypart(source))
 		var/obj/item/bodypart/bodypart = source
 		if(!(bodypart::bodytype & BODYTYPE_GHOST))

--- a/code/datums/status_effects/debuffs/slime/slime_leech.dm
+++ b/code/datums/status_effects/debuffs/slime/slime_leech.dm
@@ -71,7 +71,7 @@
 		if(need_mob_update)
 			owner.updatehealth()
 
-	if(totaldamage >= 0) // AdjustBruteLoss returns a negative value on successful damage adjustment
+	if(totaldamage >= 0) // adjust_brute_loss() returns a negative value on successful damage adjustment
 		our_slime.balloon_alert(our_slime, "not food!")
 		our_slime.stop_feeding()
 		return

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -336,7 +336,7 @@
 	post_heal_effects(max(previous_damage - affecting.get_damage(), 0), patient, user)
 	return TRUE
 
-/// Healing a simple mob, just an adjustbruteloss call
+/// Healing a simple mob, just an adjust_brute_loss() call
 /obj/item/stack/medical/proc/heal_simplemob(mob/living/patient, mob/living/user)
 	patient.adjust_brute_loss(-1 * (heal_brute * patient.maxHealth / 100))
 	user.visible_message(

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3161,7 +3161,7 @@
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-//gives 20 seconds of haunting effect for every unit of it that touches an object
+//gives 20 seconds of haunting effect for every unit of it that touches an item
 /datum/reagent/hauntium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
 	if(!isitem(exposed_obj))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3170,7 +3170,7 @@
 	if(HAS_TRAIT_FROM(exposed_item, TRAIT_HAUNTED, HAUNTIUM_REAGENT_TRAIT))
 		return
 	exposed_item.make_haunted(HAUNTIUM_REAGENT_TRAIT, "#f8f8ff")
-	addtimer(CALLBACK(exposed_item, TYPE_PROC_REF(/atom/movable/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), reac_volume * 20 SECONDS)
+	addtimer(CALLBACK(exposed_item, TYPE_PROC_REF(/obj/item/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), reac_volume * 20 SECONDS)
 
 /datum/reagent/hauntium/on_mob_metabolize(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3166,10 +3166,11 @@
 	. = ..()
 	if(!isitem(exposed_obj))
 		return
-	if(HAS_TRAIT_FROM(exposed_obj, TRAIT_HAUNTED, HAUNTIUM_REAGENT_TRAIT))
+	var/obj/item/exposed_item = exposed_obj
+	if(HAS_TRAIT_FROM(exposed_item, TRAIT_HAUNTED, HAUNTIUM_REAGENT_TRAIT))
 		return
-	exposed_obj.make_haunted(HAUNTIUM_REAGENT_TRAIT, "#f8f8ff")
-	addtimer(CALLBACK(exposed_obj, TYPE_PROC_REF(/atom/movable/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), reac_volume * 20 SECONDS)
+	exposed_item.make_haunted(HAUNTIUM_REAGENT_TRAIT, "#f8f8ff")
+	addtimer(CALLBACK(exposed_item, TYPE_PROC_REF(/atom/movable/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), reac_volume * 20 SECONDS)
 
 /datum/reagent/hauntium/on_mob_metabolize(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

<img width="578" height="377" alt="dreamseeker_Gg1rgahTpr" src="https://github.com/user-attachments/assets/051571f5-5671-40e1-ad94-1607a70f2e71" />

This proc should only work on items since that's the only thing the haunted element works on.

## Why It's Good For The Game

Fixes runtime log spam

## Changelog

Not player-facing
